### PR TITLE
Update trim/aot analyzer to run on generated code

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/CompatibilitySuppressions.xml
@@ -321,7 +321,85 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.BinaryOperationBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.ConvertBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.CreateInstanceBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.DeleteIndexBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.DeleteMemberBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
     <Target>T:System.Dynamic.DynamicMetaObjectBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.DynamicObject:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.GetIndexBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.GetMemberBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.InvokeBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.InvokeMemberBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.SetIndexBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.SetMemberBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.UnaryOperationBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
     <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
     <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
   </Suppression>

--- a/src/libraries/System.Linq.Expressions/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Linq.Expressions/src/CompatibilitySuppressions.xml
@@ -99,6 +99,48 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.DynamicExpression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression,System.String,System.Type[],System.Linq.Expressions.Expression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
     <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
     <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
@@ -106,6 +148,96 @@
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:System.Linq.Expressions.Expression.Call(System.Type,System.String,System.Type[],System.Linq.Expressions.Expression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Dynamic(System.Runtime.CompilerServices.CallSiteBinder,System.Type,System.Linq.Expressions.Expression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.GetActionType(System.Type[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.GetDelegateType(System.Type[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.GetFuncType(System.Type[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.Boolean,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.Boolean,System.Linq.Expressions.ParameterExpression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.Linq.Expressions.ParameterExpression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.String,System.Boolean,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.Lambda(System.Linq.Expressions.Expression,System.String,System.Collections.Generic.IEnumerable{System.Linq.Expressions.ParameterExpression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
     <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
     <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
   </Suppression>
@@ -135,7 +267,61 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Collections.Generic.IEnumerable{System.Linq.Expressions.Expression}):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Linq.Expressions.Expression,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Linq.Expressions.Expression):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.MakeDynamic(System.Type,System.Runtime.CompilerServices.CallSiteBinder,System.Linq.Expressions.Expression[]):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.TryGetActionType(System.Type[],System.Type@):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>M:System.Linq.Expressions.Expression.TryGetFuncType(System.Type[],System.Type@):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:System.Runtime.CompilerServices.CallSite`1.Create(System.Runtime.CompilerServices.CallSiteBinder):[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
+    <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
+    <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:System.Dynamic.DynamicMetaObjectBinder:[T:System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute]</Target>
     <Left>ref/net9.0/System.Linq.Expressions.dll</Left>
     <Right>lib/net9.0/System.Linq.Expressions.dll</Right>
   </Suppression>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/BinaryOperationBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/BinaryOperationBinder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 
@@ -9,6 +10,7 @@ namespace System.Dynamic
     /// <summary>
     /// Represents the binary dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class BinaryOperationBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/ConvertBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/ConvertBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the convert dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class ConvertBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/CreateInstanceBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/CreateInstanceBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the create dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class CreateInstanceBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/DeleteIndexBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/DeleteIndexBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic delete index operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class DeleteIndexBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/DeleteMemberBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/DeleteMemberBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic delete member operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class DeleteMemberBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObjectBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/DynamicMetaObjectBinder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
@@ -19,6 +20,7 @@ namespace System.Dynamic
     /// as input. On the other hand, the <see cref="DynamicMetaObjectBinder"/> participates in the <see cref="DynamicMetaObject"/>
     /// binding protocol.
     /// </remarks>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class DynamicMetaObjectBinder : CallSiteBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/DynamicObject.cs
@@ -23,6 +23,7 @@ namespace System.Dynamic
     /// If a method is not overridden then the <see cref="DynamicObject"/> does not directly support
     /// that behavior and the call site will determine how the binding should be performed.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public class DynamicObject : IDynamicMetaObjectProvider
     {
         /// <summary>
@@ -205,6 +206,7 @@ namespace System.Dynamic
 
         #region MetaDynamic
 
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         private sealed class MetaDynamic : DynamicMetaObject
         {
             internal MetaDynamic(Expression expression, DynamicObject value)
@@ -855,6 +857,7 @@ namespace System.Dynamic
             // is only used by DynamicObject.GetMember--it is not expected to
             // (and cannot) implement binding semantics. It is just so the DO
             // can use the Name and IgnoreCase properties.
+            [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
             private sealed class GetBinderAdapter : GetMemberBinder
             {
                 internal GetBinderAdapter(InvokeMemberBinder binder)

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/GetIndexBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/GetIndexBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic get index operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class GetIndexBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/GetMemberBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/GetMemberBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic get member operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class GetMemberBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/InvokeBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/InvokeBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the invoke dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class InvokeBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/InvokeMemberBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/InvokeMemberBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the invoke member dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class InvokeMemberBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/SetIndexBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/SetIndexBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic set index operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class SetIndexBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/SetMemberBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/SetMemberBinder.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
+using System.Linq.Expressions;
 
 namespace System.Dynamic
 {
     /// <summary>
     /// Represents the dynamic set member operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class SetMemberBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/UnaryOperationBinder.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/UnaryOperationBinder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Linq.Expressions;
 
@@ -9,6 +10,7 @@ namespace System.Dynamic
     /// <summary>
     /// Represents the unary dynamic operation at the call site, providing the binding semantic and the details about the operation.
     /// </summary>
+    [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
     public abstract class UnaryOperationBinder : DynamicMetaObjectBinder
     {
         /// <summary>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/UpdateDelegates.Generated.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
 namespace System.Dynamic
@@ -8,6 +10,7 @@ namespace System.Dynamic
     internal static partial class UpdateDelegates
     {
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute1<T0, TRet>(CallSite site, T0 arg0)
         {
             //
@@ -153,6 +156,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute2<T0, T1, TRet>(CallSite site, T0 arg0, T1 arg1)
         {
             //
@@ -298,6 +302,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute3<T0, T1, T2, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
             //
@@ -443,6 +448,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute4<T0, T1, T2, T3, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
             //
@@ -588,6 +594,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute5<T0, T1, T2, T3, T4, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             //
@@ -733,6 +740,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute6<T0, T1, T2, T3, T4, T5, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             //
@@ -878,6 +886,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute7<T0, T1, T2, T3, T4, T5, T6, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             //
@@ -1023,6 +1032,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute8<T0, T1, T2, T3, T4, T5, T6, T7, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             //
@@ -1168,6 +1178,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute9<T0, T1, T2, T3, T4, T5, T6, T7, T8, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             //
@@ -1313,6 +1324,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static TRet UpdateAndExecute10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, TRet>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             //
@@ -1458,6 +1470,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid1<T0>(CallSite site, T0 arg0)
         {
             //
@@ -1602,6 +1615,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid2<T0, T1>(CallSite site, T0 arg0, T1 arg1)
         {
             //
@@ -1746,6 +1760,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid3<T0, T1, T2>(CallSite site, T0 arg0, T1 arg1, T2 arg2)
         {
             //
@@ -1890,6 +1905,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid4<T0, T1, T2, T3>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3)
         {
             //
@@ -2034,6 +2050,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid5<T0, T1, T2, T3, T4>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             //
@@ -2178,6 +2195,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid6<T0, T1, T2, T3, T4, T5>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             //
@@ -2322,6 +2340,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid7<T0, T1, T2, T3, T4, T5, T6>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             //
@@ -2466,6 +2485,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid8<T0, T1, T2, T3, T4, T5, T6, T7>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
             //
@@ -2610,6 +2630,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid9<T0, T1, T2, T3, T4, T5, T6, T7, T8>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             //
@@ -2754,6 +2775,7 @@ namespace System.Dynamic
 
 
         [Obsolete("pregenerated CallSite<T>.Update delegate", error: true)]
+        [RequiresDynamicCode(Expression.CallSiteRequiresDynamicCode)]
         internal static void UpdateAndExecuteVoid10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(CallSite site, T0 arg0, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
             //

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.Generated.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 
 namespace System.Linq.Expressions.Compiler
@@ -14,6 +15,7 @@ namespace System.Linq.Expressions.Compiler
         /// We use the cache to avoid copying the array, and to cache the
         /// created delegate type
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type MakeDelegateType(Type[] types)
         {
             lock (_DelegateCache)
@@ -90,6 +92,7 @@ namespace System.Linq.Expressions.Compiler
         public delegate object VBCallSiteDelegate6<T>(T callSite, object instance, ref object arg1, ref object arg2, ref object arg3, ref object arg4, ref object arg5, ref object arg6);
         public delegate object VBCallSiteDelegate7<T>(T callSite, object instance, ref object arg1, ref object arg2, ref object arg3, ref object arg4, ref object arg5, ref object arg6, ref object arg7);
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static Type TryMakeVBStyledCallSite(Type[] types)
         {
             // Shape of VB CallSiteDelegates is CallSite * (instance : obj) * [arg-n : byref obj] -> obj
@@ -127,6 +130,7 @@ namespace System.Linq.Expressions.Compiler
         /// Creates a new delegate, or uses a func/action
         /// Note: this method does not cache
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type MakeNewDelegate(Type[] types)
         {
             Debug.Assert(types != null && types.Length > 0);
@@ -180,6 +184,7 @@ namespace System.Linq.Expressions.Compiler
             return result;
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type GetFuncType(Type[] types)
         {
             switch (types.Length)
@@ -224,6 +229,7 @@ namespace System.Linq.Expressions.Compiler
             }
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type GetActionType(Type[] types)
         {
             switch (types.Length)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic;
 using System.Dynamic.Utils;
 using System.Reflection;
@@ -18,6 +19,7 @@ namespace System.Linq.Expressions.Compiler
         /// We take the read-only collection of Expression explicitly to avoid allocating memory (an array
         /// of types) on lookup of delegate types.
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type MakeCallSiteDelegate(ReadOnlyCollection<Expression> types, Type returnType)
         {
             lock (_DelegateCache)
@@ -52,6 +54,7 @@ namespace System.Linq.Expressions.Compiler
         /// We take the array of MetaObject explicitly to avoid allocating memory (an array of types) on
         /// lookup of delegate types.
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         internal static Type MakeDeferredSiteDelegate(DynamicMetaObject[] args, Type returnType)
         {
             lock (_DelegateCache)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.cs
@@ -462,7 +462,8 @@ namespace System.Linq.Expressions.Compiler
             return cr.Finish(expr);
         }
 
-        [RequiresDynamicCode(Expression.NewArrayRequiresDynamicCode)]
+        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL3050:RequiresDynamicCode",
+            Justification = "A NewArrayExpression has already been created. The original creator will get a warning that it is not trim compatible.")]
         private Result RewriteNewArrayExpression(Expression expr, Stack stack)
         {
             var node = (NewArrayExpression)expr;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
@@ -2,17 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace System.Linq.Expressions.Compiler
 {
     internal static class TypeInfoExtensions
     {
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static Type MakeDelegateType(this DelegateHelpers.TypeInfo info, Type retType, params Expression[] args)
         {
             return info.MakeDelegateType(retType, (IList<Expression>)args);
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static Type MakeDelegateType(this DelegateHelpers.TypeInfo info, Type retType, IList<Expression> args)
         {
             // nope, go ahead and create it and spend the

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -240,6 +240,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, params Expression[] arguments)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arguments);
@@ -261,6 +262,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arguments);
@@ -282,6 +284,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arg0);
@@ -304,6 +307,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arg0, arg1);
@@ -327,6 +331,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arg0, arg1, arg2);
@@ -351,6 +356,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DelegateType">DelegateType</see> property of the result will be inferred
         /// from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
             return ExpressionExtension.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
@@ -369,6 +375,7 @@ namespace System.Linq.Expressions
         /// <see cref="Binder">Binder</see>, and
         /// <see cref="Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static new DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression>? arguments)
         {
             return ExpressionExtension.MakeDynamic(delegateType, binder, arguments);
@@ -1026,6 +1033,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, params Expression[] arguments)
         {
             return Dynamic(binder, returnType, (IEnumerable<Expression>)arguments);
@@ -1047,6 +1055,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0)
         {
             ArgumentNullException.ThrowIfNull(binder);
@@ -1082,6 +1091,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1)
         {
             ArgumentNullException.ThrowIfNull(binder);
@@ -1122,6 +1132,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2)
         {
             ArgumentNullException.ThrowIfNull(binder);
@@ -1167,6 +1178,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
             ArgumentNullException.ThrowIfNull(binder);
@@ -1213,6 +1225,7 @@ namespace System.Linq.Expressions
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments)
         {
             ArgumentNullException.ThrowIfNull(arguments);
@@ -1223,6 +1236,7 @@ namespace System.Linq.Expressions
             return MakeDynamic(binder, returnType, args);
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static DynamicExpression MakeDynamic(CallSiteBinder binder, Type returnType, ReadOnlyCollection<Expression> arguments)
         {
             ArgumentNullException.ThrowIfNull(binder);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Dynamic.Utils;
 using System.Globalization;
 using System.Reflection;
@@ -25,6 +26,7 @@ namespace System.Linq.Expressions
         internal const string LambdaCompilerRequiresDynamicCode = "Compiling a lambda expression requires dynamic code generation.";
         internal const string StrongBoxRequiresDynamicCode = "Creating a StrongBox requires dynamic code generation.";
         internal const string NewArrayRequiresDynamicCode = "Creating arrays at runtime requires dynamic code generation.";
+        internal const string DelegateCreationRequiresDynamicCode = "Delegate creation requires dynamic code generation.";
 
         private static readonly CacheDict<Type, MethodInfo> s_lambdaDelegateCache = new CacheDict<Type, MethodInfo>(40);
         private static volatile CacheDict<Type, Func<Expression, string?, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression>>? s_lambdaFactories;
@@ -298,6 +300,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments) =>
             DynamicExpression.Dynamic(binder, returnType, arguments);
 
@@ -317,6 +320,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0) =>
             DynamicExpression.Dynamic(binder, returnType, arg0);
 
@@ -337,6 +341,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1) =>
             DynamicExpression.Dynamic(binder, returnType, arg0, arg1);
 
@@ -358,6 +363,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2) =>
             DynamicExpression.Dynamic(binder, returnType, arg0, arg1, arg2);
 
@@ -380,6 +386,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3) =>
             DynamicExpression.Dynamic(binder, returnType, arg0, arg1, arg2, arg3);
 
@@ -399,6 +406,7 @@ comparand: null
         /// The <see cref="DynamicExpression.DelegateType">DelegateType</see> property of the
         /// result will be inferred from the types of the arguments and the specified return type.
         /// </remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, params Expression[] arguments) =>
             DynamicExpression.Dynamic(binder, returnType, arguments);
 
@@ -415,6 +423,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression>? arguments) =>
             DynamicExpression.MakeDynamic(delegateType, binder, arguments);
 
@@ -431,6 +440,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0) =>
             DynamicExpression.MakeDynamic(delegateType, binder, arg0);
 
@@ -448,6 +458,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1) =>
             DynamicExpression.MakeDynamic(delegateType, binder, arg0, arg1);
 
@@ -466,6 +477,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2) =>
             DynamicExpression.MakeDynamic(delegateType, binder, arg0, arg1, arg2);
 
@@ -485,6 +497,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3) =>
             DynamicExpression.MakeDynamic(delegateType, binder, arg0, arg1, arg2, arg3);
 
@@ -501,6 +514,7 @@ comparand: null
         /// <see cref="DynamicExpression.Binder">Binder</see>, and
         /// <see cref="DynamicExpression.Arguments">Arguments</see> set to the specified values.
         /// </returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, params Expression[]? arguments) =>
             MakeDynamic(delegateType, binder, (IEnumerable<Expression>?)arguments);
     }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.Generated.cs
@@ -32,6 +32,7 @@ namespace System.Linq.Expressions.Interpreter
         /// One relaxation is that for return types which are non-primitive types
         /// we can fall back to object due to relaxed delegates.
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static CallInstruction FastCreate(MethodInfo target, ParameterInfo[] pi)
         {
             Type t = TryGetParameterOrReturnType(target, pi, 0);
@@ -71,6 +72,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static CallInstruction FastCreate<T0>(MethodInfo target, ParameterInfo[] pi)
         {
             Type t = TryGetParameterOrReturnType(target, pi, 1);
@@ -114,6 +116,7 @@ namespace System.Linq.Expressions.Interpreter
             }
         }
 
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static CallInstruction FastCreate<T0, T1>(MethodInfo target, ParameterInfo[] pi)
         {
             Type t = TryGetParameterOrReturnType(target, pi, 2);
@@ -157,6 +160,7 @@ namespace System.Linq.Expressions.Interpreter
 #endif
 
         [return: DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes.PublicConstructors)]
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static Type GetHelperType(MethodInfo info, Type[] arrTypes)
         {
             Type t;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -50,6 +50,8 @@ namespace System.Linq.Expressions.Interpreter
             if (!CanCreateArbitraryDelegates)
                 return new MethodInfoCallInstruction(info, argumentCount);
 
+            // This code should be unreachable in AOT. The analyzer currently doesn't understand feature switches
+#pragma warning disable IL3050
             if (!info.IsStatic && info.DeclaringType!.IsValueType)
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
@@ -81,11 +83,11 @@ namespace System.Linq.Expressions.Interpreter
             try
             {
 #if FEATURE_FAST_CREATE
-                if (argumentCount < MaxArgs)
-                {
-                    res = FastCreate(info, parameters);
-                }
-                else
+            if (argumentCount < MaxArgs)
+            {
+                res = FastCreate(info, parameters);
+            }
+            else
 #endif
                 {
                     res = SlowCreate(info, parameters);
@@ -113,6 +115,7 @@ namespace System.Linq.Expressions.Interpreter
             s_cache[info] = res;
 
             return res;
+#pragma warning restore IL3050
         }
 
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)
@@ -205,6 +208,7 @@ namespace System.Linq.Expressions.Interpreter
         /// <summary>
         /// Uses reflection to create new instance of the appropriate ReflectedCaller
         /// </summary>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         private static CallInstruction SlowCreate(MethodInfo info, ParameterInfo[] pis)
         {
             List<Type> types = new List<Type>();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -83,11 +83,11 @@ namespace System.Linq.Expressions.Interpreter
             try
             {
 #if FEATURE_FAST_CREATE
-            if (argumentCount < MaxArgs)
-            {
-                res = FastCreate(info, parameters);
-            }
-            else
+                if (argumentCount < MaxArgs)
+                {
+                    res = FastCreate(info, parameters);
+                }
+                else
 #endif
                 {
                     res = SlowCreate(info, parameters);

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -742,6 +742,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, params ParameterExpression[]? parameters)
         {
             return Lambda(body, false, (IEnumerable<ParameterExpression>?)parameters);
@@ -754,6 +755,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An array that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, bool tailCall, params ParameterExpression[]? parameters)
         {
             return Lambda(body, tailCall, (IEnumerable<ParameterExpression>?)parameters);
@@ -765,6 +767,7 @@ namespace System.Linq.Expressions
         /// <param name="body">An <see cref="Expression"/> to set the <see cref="LambdaExpression.Body"/> property equal to.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, IEnumerable<ParameterExpression>? parameters)
         {
             return Lambda(body, null, false, parameters);
@@ -777,6 +780,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, bool tailCall, IEnumerable<ParameterExpression>? parameters)
         {
             return Lambda(body, null, tailCall, parameters);
@@ -839,6 +843,7 @@ namespace System.Linq.Expressions
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <param name="name">The name for the lambda. Used for emitting debug information.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, string? name, IEnumerable<ParameterExpression>? parameters)
         {
             return Lambda(body, name, false, parameters);
@@ -852,6 +857,7 @@ namespace System.Linq.Expressions
         /// <param name="tailCall">A <see cref="bool"/> that indicates if tail call optimization will be applied when compiling the created expression.</param>
         /// <param name="parameters">An <see cref="IEnumerable{T}"/> that contains <see cref="ParameterExpression"/> objects to use to populate the <see cref="LambdaExpression.Parameters"/> collection.</param>
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="ExpressionType.Lambda"/> and the <see cref="LambdaExpression.Body"/> and <see cref="LambdaExpression.Parameters"/> properties set to the specified values.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static LambdaExpression Lambda(Expression body, string? name, bool tailCall, IEnumerable<ParameterExpression>? parameters)
         {
             ArgumentNullException.ThrowIfNull(body);
@@ -1026,6 +1032,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="typeArgs">An array of <see cref="System.Type"/> objects that specify the type arguments for the System.Func delegate type.</param>
         /// <returns>The type of a System.Func delegate that has the specified type arguments.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static Type GetFuncType(params Type[]? typeArgs)
         {
             switch (ValidateTryGetFuncActionArgs(typeArgs))
@@ -1055,6 +1062,7 @@ namespace System.Linq.Expressions
         /// <param name="typeArgs">An array of <see cref="System.Type"/> objects that specify the type arguments for the System.Func delegate type.</param>
         /// <param name="funcType">When this method returns, contains the generic System.Func delegate type that has specific type arguments. Contains null if there is no generic System.Func delegate that matches the <paramref name="typeArgs"/>.This parameter is passed uninitialized.</param>
         /// <returns>true if generic System.Func delegate type was created for specific <paramref name="typeArgs"/>; false otherwise.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static bool TryGetFuncType(Type[] typeArgs, [NotNullWhen(true)] out Type? funcType)
         {
             if (ValidateTryGetFuncActionArgs(typeArgs) == TryGetFuncActionArgsResult.Valid)
@@ -1071,6 +1079,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="typeArgs">An array of <see cref="System.Type"/> objects that specify the type arguments for the System.Action delegate type.</param>
         /// <returns>The type of a System.Action delegate that has the specified type arguments.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static Type GetActionType(params Type[]? typeArgs)
         {
             switch (ValidateTryGetFuncActionArgs(typeArgs))
@@ -1099,6 +1108,7 @@ namespace System.Linq.Expressions
         /// <param name="typeArgs">An array of <see cref="System.Type"/> objects that specify the type arguments for the System.Action delegate type.</param>
         /// <param name="actionType">When this method returns, contains the generic System.Action delegate type that has specific type arguments. Contains null if there is no generic System.Action delegate that matches the <paramref name="typeArgs"/>.This parameter is passed uninitialized.</param>
         /// <returns>true if generic System.Action delegate type was created for specific <paramref name="typeArgs"/>; false otherwise.</returns>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static bool TryGetActionType(Type[] typeArgs, [NotNullWhen(true)] out Type? actionType)
         {
             if (ValidateTryGetFuncActionArgs(typeArgs) == TryGetFuncActionArgsResult.Valid)
@@ -1120,6 +1130,7 @@ namespace System.Linq.Expressions
         /// <remarks>
         /// As with Func, the last argument is the return type. It can be set
         /// to <see cref="System.Void"/> to produce an Action.</remarks>
+        [RequiresDynamicCode(Expression.DelegateCreationRequiresDynamicCode)]
         public static Type GetDelegateType(params Type[] typeArgs)
         {
             ContractUtils.RequiresNotEmpty(typeArgs, nameof(typeArgs));

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/COMAnalyzer.cs
@@ -26,9 +26,11 @@ namespace ILLink.RoslynAnalyzer
 
 		public override void Initialize (AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			if (!System.Diagnostics.Debugger.IsAttached)
 				context.EnableConcurrentExecution ();
-			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			context.RegisterCompilationStartAction (context => {
 				var compilation = context.Compilation;
 				if (!context.Options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, compilation))

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DynamicallyAccessedMembersAnalyzer.cs
@@ -68,9 +68,11 @@ namespace ILLink.RoslynAnalyzer
 
 		public override void Initialize (AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			if (!System.Diagnostics.Debugger.IsAttached)
 				context.EnableConcurrentExecution ();
-			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			context.RegisterCompilationStartAction (context => {
 				if (!context.Options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableTrimAnalyzer, context.Compilation))
 					return;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -33,9 +33,11 @@ namespace ILLink.RoslynAnalyzer
 
 		public override void Initialize (AnalysisContext context)
 		{
+			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			if (!System.Diagnostics.Debugger.IsAttached)
 				context.EnableConcurrentExecution ();
-			context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
 			context.RegisterCompilationStartAction (context => {
 				var compilation = context.Compilation;
 				if (!IsAnalyzerEnabled (context.Options, compilation))


### PR DESCRIPTION
Also fixes problems in System.Linq.Expressions as a result.

Fixes https://github.com/dotnet/runtime/issues/93785