### PR TITLE
Fix a refleak in the IEnumerator marshalling tests.

### DIFF
--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
@@ -98,6 +98,13 @@ extern "C" DLL_EXPORT HRESULT STDMETHODCALLTYPE VerifyIntegerEnumeration(IDispat
         return hr;
     }
 
+    hr = VariantClear(&result);
+    
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
     hr = VerifyIntegerEnumerator(pEnum, start, count);
 
     pEnum->Release();

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
@@ -92,14 +92,8 @@ extern "C" DLL_EXPORT HRESULT STDMETHODCALLTYPE VerifyIntegerEnumeration(IDispat
     IEnumVARIANT* pEnum;
 
     hr = V_UNKNOWN(&result)->QueryInterface<IEnumVARIANT>(&pEnum);
+    VariantClear(&result);
 
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    hr = VariantClear(&result);
-    
     if (FAILED(hr))
     {
         return hr;

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.csproj
@@ -7,8 +7,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- IEnumerator/IEnumerable marshalling unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- RefCounted handle to System.Runtime.InteropServices.CustomMarshalers.EnumVariantViewOfEnumerator holds the LoaderAllocator alive via System.Linq.Enumerable+RangeIterator -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />


### PR DESCRIPTION
This leak is what was making this test non-unloadable.