### PR TITLE
[release/8.0-staging][wasm] WBT Stop taking latest sdk in release/8.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -258,7 +258,7 @@
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
     <!-- installer version, for testing workloads -->
-    <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23478.7</MicrosoftDotnetSdkInternalVersion>
-    <!-- <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting> -->
+    <MicrosoftDotnetSdkInternalVersion>8.0.100-rtm.23527.6</MicrosoftDotnetSdkInternalVersion>
+    <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting>
   </PropertyGroup>
 </Project>

--- a/src/mono/wasi/Wasi.Build.Tests/data/nuget8.config
+++ b/src/mono/wasi/Wasi.Build.Tests/data/nuget8.config
@@ -9,6 +9,11 @@
     <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="nuget.org"  value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+
+    <!-- work around illink needing a stable version for now -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-pub-dotnet-runtime-488a8a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-488a8a35/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
   </packageSources>
     <disabledPackageSources>
     <clear />

--- a/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/NonWasmTemplateBuildTests.cs
@@ -67,8 +67,11 @@ public class NonWasmTemplateBuildTests : TestMainJsTestBase
         )
         .MultiplyWithSingleArgs
         (
+            // Disable net6 and net7 tests for now, as the latest versions aren't in the feeds yet
+            /*
             "net6.0",
             s_previousTargetFramework,
+            */
             s_latestTargetFramework
         )
         .UnwrapItemsAsArrays().ToList();

--- a/src/mono/wasm/Wasm.Build.Tests/data/nuget8.config
+++ b/src/mono/wasm/Wasm.Build.Tests/data/nuget8.config
@@ -9,6 +9,11 @@
     <!-- TEST_RESTORE_SOURCES_INSERTION_LINE -->
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="nuget.org"  value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+
+    <!-- work around illink needing a stable version for now -->
+    <!--  Begin: Package sources from dotnet-runtime -->
+    <add key="darc-pub-dotnet-runtime-488a8a3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-488a8a35/nuget/v3/index.json" />
+    <!--  End: Package sources from dotnet-runtime -->
   </packageSources>
     <disabledPackageSources>
     <clear />


### PR DESCRIPTION
It looks like wasm build tests have started picking up 8.0.2xx sdks after being unpinned.  This pins the WBT sdk to a recent 8.0.1xx sdk which should be new enough for testing and not contain the workload set changes.  We could probably set the channel correctly for 1xx and unpin but that can happen later.

We will need to fix wbt for the workload set changes but that definitely doesn't need to happen before 8.0.0.

Fixes https://github.com/dotnet/runtime/issues/93900 