### PR TITLE
[wasm] make it easy to exclude browser-bench measurements

### DIFF
--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -68,7 +68,7 @@
   </Target>
   <Target Name="RunSampleWithBrowserAndSimpleServer" DependsOnTargets="BuildSampleInTree">
     <Exec Command="$(_Dotnet) build -c $(Configuration) ..\simple-server\HttpServer.csproj" />
-    <Exec WorkingDirectory="bin/$(Configuration)/AppBundle" Command="..\..\..\..\simple-server\bin\$(Configuration)\net6.0\HttpServer" />
+    <Exec WorkingDirectory="bin/$(Configuration)/AppBundle" Command="$(_Dotnet) run --configuration $(Configuration) --project ..\..\..\..\simple-server\HttpServer.csproj -s &quot;$(SimpleServerURLSuffix)&quot;" />
   </Target>
 
   <Target Name="TriggerGenerateRunScript"

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -7,6 +7,7 @@ import { dotnet, exit } from './_framework/dotnet.js'
 
 let runBenchmark;
 let setTasks;
+let setExclusions;
 let getFullJsonResults;
 let legacyExportTargetInt;
 let jsExportTargetInt;
@@ -68,6 +69,7 @@ class MainApp {
         _jiterpreter_dump_stats = INTERNAL.jiterpreter_dump_stats.bind(INTERNAL);
         runBenchmark = exports.Sample.Test.RunBenchmark;
         setTasks = exports.Sample.Test.SetTasks;
+        setExclusions = exports.Sample.Test.SetExclusions;
         getFullJsonResults = exports.Sample.Test.GetFullJsonResults;
 
         legacyExportTargetInt = BINDING.bind_static_method("[Wasm.Browser.Bench.Sample]Sample.ImportsExportsHelper:LegacyExportTargetInt");
@@ -96,6 +98,10 @@ class MainApp {
         let tasks = url.searchParams.getAll('task');
         if (tasks != '') {
             setTasks(tasks.join(','));
+        }
+        let exclusions = url.searchParams.getAll('exclusions');
+        if (exclusions != '') {
+            setExclusions(exclusions.join(','));
         }
 
         const r = await fetch("/bootstrap.flag", {

--- a/src/mono/sample/wasm/simple-server/HttpServer.csproj
+++ b/src/mono/sample/wasm/simple-server/HttpServer.csproj
@@ -2,10 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>major</RollForward>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
+  </ItemGroup>
 </Project>

--- a/src/mono/sample/wasm/simple-server/Program.cs
+++ b/src/mono/sample/wasm/simple-server/Program.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System;
 using System.Security.Cryptography;
+using Mono.Options;
 
 namespace HttpServer
 {
@@ -21,17 +22,54 @@ namespace HttpServer
 
     public sealed class Program
     {
-        private bool Verbose = false;
+        private static bool Verbose = false;
+        private static string URLSuffix = "";
         private ConcurrentDictionary<string, Session> Sessions = new ConcurrentDictionary<string, Session>();
         private Dictionary<string, FileContent> cache = new(StringComparer.OrdinalIgnoreCase);
 
-        public static int Main()
+        static List<string> ProcessArguments(string[] args)
+        {
+            var help = false;
+            var options = new OptionSet {
+                $"Usage: HttpServer OPTIONS*",
+                "",
+                "Simple http server for browser-bench sample",
+                "",
+                "Copyright 2022, 2023 Microsoft Corporation",
+                "",
+                "Options:",
+                { "h|help|?",
+                    "Show this message and exit",
+                    v => help = v != null },
+                { "s=",
+                    "URL {suffix}",
+                    v => URLSuffix =  v },
+                { "v|verbose",
+                    "Output more information during the run of the server.",
+                    v => Verbose = true },
+            };
+
+            var remaining = options.Parse(args);
+
+            if (help)
+            {
+                options.WriteOptionDescriptions(Console.Out);
+
+                Environment.Exit(0);
+            }
+
+            return remaining;
+        }
+
+        public static int Main(string[] args)
         {
             if (!HttpListener.IsSupported)
             {
                 Console.WriteLine("error: HttpListener is not supported.");
                 return -1;
             }
+
+            ProcessArguments(args);
 
             // retry upto 9 times to find free port
             for (int i = 0; i < 10; i++)
@@ -60,7 +98,7 @@ namespace HttpServer
             }
 
             Console.WriteLine($"Listening on {url}");
-            OpenUrl(url);
+            OpenUrl(url + URLSuffix);
 
             while (true)
                 HandleRequest(listener);


### PR DESCRIPTION
Add options to the simple server, including the URL suffix

Add exclusions URL option to the browser-bench

This way we can exclude selected measurements. This can be used for MT measurements, where we are hitting few crashes.