### PR TITLE
Enable SA1136: Enum values should be on separate lines #94098

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1269,7 +1269,7 @@ dotnet_diagnostic.SA1134.severity = none
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = error
+dotnet_diagnostic.SA1136.severity = warning
 
 # SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none

--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1269,7 +1269,7 @@ dotnet_diagnostic.SA1134.severity = none
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = none
+dotnet_diagnostic.SA1136.severity = error
 
 # SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1264,7 +1264,7 @@ dotnet_diagnostic.SA1134.severity = none
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = warning
+dotnet_diagnostic.SA1136.severity = none
 
 # SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1264,7 +1264,7 @@ dotnet_diagnostic.SA1134.severity = none
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = none
+dotnet_diagnostic.SA1136.severity = error
 
 # SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1264,7 +1264,7 @@ dotnet_diagnostic.SA1134.severity = none
 dotnet_diagnostic.SA1135.severity = none
 
 # SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = error
+dotnet_diagnostic.SA1136.severity = warning
 
 # SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none

--- a/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
+++ b/src/coreclr/tools/Common/Internal/NativeFormat/NativeFormatWriter.cs
@@ -627,7 +627,12 @@ namespace Internal.NativeFormat
 #endif
     class VertexBag : Vertex
     {
-        private enum EntryType { Vertex, Unsigned, Signed }
+        private enum EntryType
+        {
+            Vertex,
+            Unsigned,
+            Signed
+        }
 
         private struct Entry
         {

--- a/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
+++ b/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
@@ -17,7 +17,12 @@ internal static partial class Interop
         // For disambiguation, see https://systemd.io/CGROUP_DELEGATION/#three-different-tree-setups-
 
         /// <summary>The supported versions of cgroup.</summary>
-        internal enum CGroupVersion { None, CGroup1, CGroup2 };
+        internal enum CGroupVersion
+        {
+            None,
+            CGroup1,
+            CGroup2
+        };
 
         /// <summary>Path to cgroup filesystem that tells us which version of cgroup is in use.</summary>
         private const string SysFsCgroupFileSystemPath = "/sys/fs/cgroup";

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -187,7 +187,13 @@ namespace System.IO.Compression
         /// </summary>
         public sealed class ZLibStreamHandle : SafeHandle
         {
-            public enum State { NotInitialized, InitializedForDeflate, InitializedForInflate, Disposed }
+            public enum State
+            {
+                NotInitialized,
+                InitializedForDeflate,
+                InitializedForInflate,
+                Disposed
+            }
 
             private ZStream _zStream;
 

--- a/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/UnixCommandLinePing.cs
@@ -50,7 +50,12 @@ namespace System.Net.NetworkInformation
             return false;
         }
 
-        public enum PingFragmentOptions { Default, Do, Dont };
+        public enum PingFragmentOptions
+        {
+            Default,
+            Do,
+            Dont
+        };
 
         /// <summary>
         /// The location of the IPv4 ping utility on the current machine.

--- a/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/ObjectStorage.cs
@@ -15,7 +15,14 @@ namespace System.Data.Common
 {
     internal sealed class ObjectStorage : DataStorage
     {
-        private enum Families { DATETIME, NUMBER, STRING, BOOLEAN, ARRAY };
+        private enum Families
+        {
+            DATETIME,
+            NUMBER,
+            STRING,
+            BOOLEAN,
+            ARRAY
+        };
 
         private object?[] _values = default!; // Late-initialized
         private readonly bool _implementsIXmlSerializable;

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -13,7 +13,6 @@ using System.Diagnostics;
 
 namespace BasicEventSourceTests
 {
-#pragma warning disable SA1136 // Enum values should be on separate lines
     internal enum Color { Red, Blue, Green };
     internal enum ColorUInt32 : uint { Red, Blue, Green };
     internal enum ColorByte : byte { Red, Blue, Green };
@@ -22,7 +21,6 @@ namespace BasicEventSourceTests
     internal enum ColorUInt16 : ushort { Red, Blue, Green };
     internal enum ColorInt64 : long { Red, Blue, Green };
     internal enum ColorUInt64 : ulong { Red, Blue, Green };
-#pragma warning restore
 
     public partial class TestsWrite
     {

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 
 namespace BasicEventSourceTests
 {
+#pragma warning disable SA1136 // Enum values should be on separate lines
     internal enum Color { Red, Blue, Green };
     internal enum ColorUInt32 : uint { Red, Blue, Green };
     internal enum ColorByte : byte { Red, Blue, Green };
@@ -21,6 +22,7 @@ namespace BasicEventSourceTests
     internal enum ColorUInt16 : ushort { Red, Blue, Green };
     internal enum ColorInt64 : long { Red, Blue, Green };
     internal enum ColorUInt64 : ulong { Red, Blue, Green };
+#pragma warning restore
 
     public partial class TestsWrite
     {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1309,8 +1309,20 @@ namespace System.IO.Compression
         }
 
         [Flags]
-        internal enum BitFlagValues : ushort { IsEncrypted = 0x1, DataDescriptor = 0x8, UnicodeFileNameAndComment = 0x800 }
+        internal enum BitFlagValues : ushort
+        {
+            IsEncrypted = 0x1,
+            DataDescriptor = 0x8,
+            UnicodeFileNameAndComment = 0x800
+        }
 
-        internal enum CompressionMethodValues : ushort { Stored = 0x0, Deflate = 0x8, Deflate64 = 0x9, BZip2 = 0xC, LZMA = 0xE }
+        internal enum CompressionMethodValues : ushort
+        {
+            Stored = 0x0,
+            Deflate = 0x8,
+            Deflate64 = 0x9,
+            BZip2 = 0xC,
+            LZMA = 0xE
+        }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -13,7 +13,11 @@ namespace System.Net.Mail
     [Flags]
     public enum DeliveryNotificationOptions
     {
-        None = 0, OnSuccess = 1, OnFailure = 2, Delay = 4, Never = (int)0x08000000
+        None = 0,
+        OnSuccess = 1,
+        OnFailure = 2,
+        Delay = 4,
+        Never = (int)0x08000000
     }
 
     public class MailMessage : IDisposable

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -74,7 +74,12 @@ namespace System.Net.Sockets
         private unsafe NativeOverlapped* _pendingOverlappedForCancellation;
 
         private PinState _pinState;
-        private enum PinState : byte { None = 0, MultipleBuffer, SendPackets }
+        private enum PinState : byte
+        {
+            None = 0,
+            MultipleBuffer,
+            SendPackets
+        }
 
         [MemberNotNull(nameof(_preAllocatedOverlapped))]
         private void InitializeInternals()

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
@@ -99,7 +99,12 @@ namespace System.Globalization
             return new string(destination.Slice(0, charsWritten));
         }
 
-        internal enum StandardFormat { C, G, g }
+        internal enum StandardFormat
+        {
+            C,
+            G,
+            g
+        }
 
         internal static unsafe bool TryFormatStandard<TChar>(TimeSpan value, StandardFormat format, ReadOnlySpan<TChar> decimalSeparator, Span<TChar> destination, out int written) where TChar : unmanaged, IUtfChar<TChar>
         {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/EncodingStreamWrapper.cs
@@ -20,7 +20,13 @@ namespace System.Xml
     //                      during construction.
     internal sealed class EncodingStreamWrapper : Stream
     {
-        private enum SupportedEncoding { UTF8, UTF16LE, UTF16BE, None }
+        private enum SupportedEncoding
+        {
+            UTF8,
+            UTF16LE,
+            UTF16BE,
+            None
+        }
         private const int BufferLength = 128;
 
         // UTF-8 is fastpath, so that's how these are stored

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/PrefixHandle.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/PrefixHandle.cs
@@ -11,7 +11,9 @@ namespace System.Xml
     internal enum PrefixHandleType
     {
         Empty,
+#pragma warning disable SA1136 // Enum values should be on separate lines
         A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+#pragma warning restore SA1136
         Buffer,
         Max,
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/IteratorDescriptor.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/IteratorDescriptor.cs
@@ -35,7 +35,12 @@ namespace System.Xml.Xsl.IlGen
     /// True--Branch if boolean expression evaluates to true
     /// False--Branch if boolean expression evaluates to false
     /// </summary>
-    internal enum BranchingContext { None, OnTrue, OnFalse };
+    internal enum BranchingContext
+    {
+        None,
+        OnTrue,
+        OnFalse
+    };
 
     /// <summary>
     /// Describes the Clr type and location of items returned by an iterator.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Runtime/XsltLibrary.cs
@@ -324,10 +324,14 @@ namespace System.Xml.Xsl.Runtime
         #region Comparisons
         internal enum ComparisonOperator
         {
-            /*Equality  */
-            Eq, Ne,
-            /*Relational*/
-            Lt, Le, Gt, Ge,
+            /* Equality */
+            Eq,
+            Ne,
+            /* Relational */
+            Lt,
+            Le,
+            Gt,
+            Ge,
         }
 
         // Returns TypeCode of the given atomic value

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1311,7 +1311,12 @@ namespace System.Numerics
         }
 
         /// <summary>Mode used to enable sharing <see cref="TryGetBytes(GetBytesMode, Span{byte}, bool, bool, ref int)"/> for multiple purposes.</summary>
-        private enum GetBytesMode { AllocateArray, Count, Span }
+        private enum GetBytesMode
+        {
+            AllocateArray,
+            Count,
+            Span
+        }
 
         /// <summary>Shared logic for <see cref="ToByteArray(bool, bool)"/>, <see cref="TryWriteBytes(Span{byte}, out int, bool, bool)"/>, and <see cref="GetByteCount"/>.</summary>
         /// <param name="mode">Which entry point is being used.</param>

--- a/src/libraries/System.Speech/src/Internal/AlphabetConverter.cs
+++ b/src/libraries/System.Speech/src/Internal/AlphabetConverter.cs
@@ -12,7 +12,9 @@ namespace System.Speech.Internal
 {
     internal enum AlphabetType
     {
-        Sapi, Ipa, Ups
+        Sapi,
+        Ipa,
+        Ups
     }
 
     /// <summary>

--- a/src/libraries/System.Speech/src/Internal/SrgsCompiler/SRGSCompiler.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsCompiler/SRGSCompiler.cs
@@ -195,6 +195,7 @@ namespace System.Speech.Internal.SrgsCompiler
 
     internal enum RuleScope
     {
-        PublicRule, PrivateRule
+        PublicRule,
+        PrivateRule
     }
 }

--- a/src/libraries/System.Speech/src/Internal/SrgsParser/IGrammar.cs
+++ b/src/libraries/System.Speech/src/Internal/SrgsParser/IGrammar.cs
@@ -31,6 +31,7 @@ namespace System.Speech.Internal.SrgsParser
 
     internal enum GrammarType
     {
-        VoiceGrammar, DtmfGrammar
+        VoiceGrammar,
+        DtmfGrammar
     }
 }

--- a/src/libraries/System.Speech/src/Internal/Synthesis/EngineSite.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/EngineSite.cs
@@ -364,7 +364,9 @@ namespace System.Speech.Internal.Synthesis
     {
         public enum PhonemeConversion
         {
-            IpaToSapi, SapiToIpa, NoConversion
+            IpaToSapi,
+            SapiToIpa,
+            NoConversion
         }
 
         internal PhonemeEventMapper(ITtsEventSink sink, PhonemeConversion conversion, AlphabetConverter alphabetConverter) : base(sink)

--- a/src/libraries/System.Speech/src/Internal/Synthesis/PcmConverter.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/PcmConverter.cs
@@ -439,7 +439,12 @@ namespace System.Speech.Internal.Synthesis
 
         #region private Fields
 
-        private enum Block { First, Middle, Last };
+        private enum Block
+        {
+            First,
+            Middle,
+            Last
+        };
 
         private WAVEFORMATEX _inWavFormat;
         private WAVEFORMATEX _outWavFormat;

--- a/src/libraries/System.Text.Json/gen/Model/JsonPrimitiveTypeKind.cs
+++ b/src/libraries/System.Text.Json/gen/Model/JsonPrimitiveTypeKind.cs
@@ -5,6 +5,10 @@ namespace System.Text.Json.SourceGeneration
 {
     public enum JsonPrimitiveTypeKind
     {
-        String, Boolean, ByteArray, Char, Number
+        String,
+        Boolean,
+        ByteArray,
+        Char,
+        Number
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs
@@ -617,7 +617,12 @@ namespace System.Text.Json.Serialization.Metadata
         internal bool IsConfigured => _configurationState == ConfigurationState.Configured;
         internal bool IsConfigurationStarted => _configurationState is not ConfigurationState.NotConfigured;
         private volatile ConfigurationState _configurationState;
-        private enum ConfigurationState : byte { NotConfigured = 0, Configuring = 1, Configured = 2 };
+        private enum ConfigurationState : byte
+        {
+            NotConfigured = 0,
+            Configuring = 1,
+            Configured = 2
+        };
 
         private ExceptionDispatchInfo? _cachedConfigureError;
 

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -174,10 +174,10 @@ namespace Mono.Linker
 			Context.LogError (null, DiagnosticId.MissingArgumentForCommanLineOptionName, optionName);
 		}
 
-		public enum DependenciesFileFormat 
-		{ 
-			Xml, 
-			Dgml 
+		public enum DependenciesFileFormat
+		{
+			Xml,
+			Dgml
 		};
 
 		// Perform setup of the LinkContext and parse the arguments.

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -174,7 +174,11 @@ namespace Mono.Linker
 			Context.LogError (null, DiagnosticId.MissingArgumentForCommanLineOptionName, optionName);
 		}
 
-		public enum DependenciesFileFormat { Xml, Dgml };
+		public enum DependenciesFileFormat 
+		{ 
+			Xml, 
+			Dgml 
+		};
 
 		// Perform setup of the LinkContext and parse the arguments.
 		// Return values:


### PR DESCRIPTION
Fixes #94098, enabling another style rule.

Includes a couple places where the rule does not make sense, but otherwise, this includes all the code clean-up as well. 

Style updates were done by hand. 