### PR TITLE
[ILLink analyzer] Fix dataflow tracking for nested finally regions

### DIFF
--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -218,22 +218,7 @@ namespace ILLink.Shared.DataFlow
 					foreach (var predecessor in cfg.GetPredecessors (block)) {
 						TValue predecessorState = cfgState.Get (predecessor.Block).Current;
 
-						// Propagate state through all finally blocks.
-						foreach (var exitedFinally in predecessor.FinallyRegions) {
-							TValue oldFinallyInputState = cfgState.GetFinallyInputState (exitedFinally);
-							TValue finallyInputState = lattice.Meet (oldFinallyInputState, predecessorState);
-
-							cfgState.SetFinallyInputState (exitedFinally, finallyInputState);
-
-							// Note: the current approach here is inefficient for long chains of finally regions because
-							// the states will not converge until we have visited each block along the chain
-							// and propagated the new states along this path.
-							if (!changed && !finallyInputState.Equals (oldFinallyInputState))
-								changed = true;
-
-							TBlock lastFinallyBlock = cfg.LastBlock (exitedFinally);
-							predecessorState = cfgState.Get (lastFinallyBlock).Current;
-						}
+						FlowStateThroughExitedFinallys (predecessor, ref predecessorState);
 
 						currentState = lattice.Meet (currentState, predecessorState);
 					}
@@ -268,18 +253,7 @@ namespace ILLink.Shared.DataFlow
 							var isPredecessorInFinally = cfgState.TryGetExceptionFinallyState (predecessor.Block, out TValue predecessorState);
 							Debug.Assert (isPredecessorInFinally);
 
-							// Propagate state through all finally blocks.
-							foreach (var exitedFinally in predecessor.FinallyRegions) {
-								TValue oldFinallyInputState = cfgState.GetFinallyInputState (exitedFinally);
-								TValue finallyInputState = lattice.Meet (oldFinallyInputState, predecessorState);
-
-								cfgState.SetFinallyInputState (exitedFinally, finallyInputState);
-								if (!changed && !finallyInputState.Equals (oldFinallyInputState))
-									changed = true;
-
-								TBlock lastFinallyBlock = cfg.LastBlock (exitedFinally);
-								predecessorState = cfgState.Get (lastFinallyBlock).Current;
-							}
+							FlowStateThroughExitedFinallys (predecessor, ref predecessorState);
 
 							exceptionFinallyState = lattice.Meet (exceptionFinallyState.Value, predecessorState);
 						}
@@ -362,6 +336,27 @@ namespace ILLink.Shared.DataFlow
 					}
 
 					TraceBlockOutput (state.Current, exceptionState?.Value, exceptionFinallyState);
+				}
+			}
+
+			void FlowStateThroughExitedFinallys (
+				IControlFlowGraph<TBlock, TRegion>.Predecessor predecessor,
+				ref TValue predecessorState)
+			{
+				foreach (var exitedFinally in predecessor.FinallyRegions) {
+					TValue oldFinallyInputState = cfgState.GetFinallyInputState (exitedFinally);
+					TValue finallyInputState = lattice.Meet (oldFinallyInputState, predecessorState);
+
+					cfgState.SetFinallyInputState (exitedFinally, finallyInputState);
+
+					// Note: the current approach here is inefficient for long chains of finally regions because
+					// the states will not converge until we have visited each block along the chain
+					// and propagated the new states along this path.
+					if (!changed && !finallyInputState.Equals (oldFinallyInputState))
+						changed = true;
+
+					TBlock lastFinallyBlock = cfg.LastBlock (exitedFinally);
+					predecessorState = cfgState.Get (lastFinallyBlock).Current;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes a bug I encountered while adding some new tests for feature checks.

While analyzing finally regions in the mode where they will not exit normally, we weren't correctly propagating dataflow states through nested finally regions. See https://github.com/dotnet/linker/pull/2481 for original context around the analysis done here.
