### PR TITLE
make Http2_RequestFailsWithAppropriateHttpProtocolException test more deterministic

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -139,7 +139,8 @@ namespace System.Net.Http.Functional.Tests
 
                 Http2LoopbackConnection connection = await server.AcceptConnectionAsync(timeout: null);
                 _ = await connection.ReadSettingsAsync();
-
+                // Wait until client starts sending request
+                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
                 GoAwayFrame goAwayFrame = new GoAwayFrame(lastStreamId: 0, (int)ProtocolErrors.HTTP_1_1_REQUIRED, additionalDebugData: Array.Empty<byte>(), streamId: 0);
                 await connection.WriteFrameAsync(goAwayFrame);
 
@@ -319,6 +320,8 @@ namespace System.Net.Http.Functional.Tests
 
                 Http2LoopbackConnection connection = await server.AcceptConnectionAsync();
                 await connection.ReadSettingsAsync();
+                // Wait until client starts sending request
+                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
                 await connection.SendGoAway(0, ProtocolErrors.INTERNAL_ERROR);
 
                 await AssertProtocolErrorAsync(sendTask, ProtocolErrors.INTERNAL_ERROR);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -140,7 +140,7 @@ namespace System.Net.Http.Functional.Tests
                 Http2LoopbackConnection connection = await server.AcceptConnectionAsync(timeout: null);
                 _ = await connection.ReadSettingsAsync();
                 // Wait until client starts sending request
-                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
+                _ = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
                 GoAwayFrame goAwayFrame = new GoAwayFrame(lastStreamId: 0, (int)ProtocolErrors.HTTP_1_1_REQUIRED, additionalDebugData: Array.Empty<byte>(), streamId: 0);
                 await connection.WriteFrameAsync(goAwayFrame);
 
@@ -321,7 +321,7 @@ namespace System.Net.Http.Functional.Tests
                 Http2LoopbackConnection connection = await server.AcceptConnectionAsync();
                 await connection.ReadSettingsAsync();
                 // Wait until client starts sending request
-                Frame frame = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
+                _ = await connection.ReadFrameAsync(TestHelper.PassingTestTimeout);
                 await connection.SendGoAway(0, ProtocolErrors.INTERNAL_ERROR);
 
                 await AssertProtocolErrorAsync(sendTask, ProtocolErrors.INTERNAL_ERROR);


### PR DESCRIPTION
When I look at the normal passing run I see something like

<img width="1486" alt="passingTest" src="https://github.com/dotnet/runtime/assets/14356188/9f788df1-2bc3-4025-815b-4b3a837f8715">

when it fails, the exchange looks like 
<img width="1462" alt="failTest" src="https://github.com/dotnet/runtime/assets/14356188/c5686925-52d1-4dcc-b4fd-3a5f6bfc918d">

So it seems like if the GOAWAY is sent before the client even start making request the test fails with  ` Couldn't find HttpProtocolException with matching error code in exception: System.Net.Http.HttpRequestException: An HTTP/2 connection could not be established because the server did not complete the HTTP/2 handshake.`

This may (or may not) be caused by the connection pool refactor. Since the requests are now detached, the connection can be closed by the 'GOAWAY` and the request does not fail with protocol error. 

To minimize risk, I only changed the test to wait for beginning of the request to arrive so when `HttpClient` process the response it would produce deterministic result. I was running tests in loop with this change and I did not see failure. It was failing for me before frequently with less than 20-50 iterations. 
 
fixes #92647