### PR TITLE
enable two HTTP POST tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -671,14 +671,6 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task PostAsync_RedirectWith307_LargePayload(Configuration.Http.RemoteServer remoteServer)
         {
-            if (remoteServer.HttpVersion == new Version(2, 0))
-            {
-                // This is occasionally timing out in CI with SocketsHttpHandler and HTTP2, particularly on Linux
-                // Likely this is just a very slow test and not a product issue, so just increasing the timeout may be the right fix.
-                // Disable until we can investigate further.
-                return;
-            }
-
             await PostAsync_Redirect_LargePayload_Helper(remoteServer, 307, true);
         }
 
@@ -722,7 +714,9 @@ namespace System.Net.Http.Functional.Tests
                     content.Headers.ContentMD5 = TestHelper.ComputeMD5Hash(contentBytes);
                 }
 
-                using (HttpClient client = CreateHttpClientForRemoteServer(remoteServer))
+                using HttpClient client = CreateHttpClientForRemoteServer(remoteServer);
+                client.Timeout = TimeSpan.FromMinutes(10);
+
                 using (HttpResponseMessage response = await client.PostAsync(redirectUri, content))
                 {
                     try

--- a/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/PostScenarioTest.cs
@@ -165,11 +165,9 @@ namespace System.Net.Http.Functional.Tests
         [Theory, MemberData(nameof(RemoteServersMemberData))]
         public async Task PostRewindableContentUsingAuth_NoPreAuthenticate_Success(Configuration.Http.RemoteServer remoteServer)
         {
-            if (remoteServer.HttpVersion == new Version(2, 0))
+            // Sync API supported only up to HTTP/1.1
+            if (!TestAsync && remoteServer.HttpVersion.Major >= 2)
             {
-                // This is occasionally timing out in CI with SocketsHttpHandler and HTTP2, particularly on Linux
-                // Likely this is just a very slow test and not a product issue, so just increasing the timeout may be the right fix.
-                // Disable until we can investigate further.
                 return;
             }
 


### PR DESCRIPTION
fixes  #1580

I have capture where the big upload took ~ 5minutes to complete. I don't know if that is my ISP, server load or infrastructure. So I enabled the tests and increased the default utmost for large posts. 
While it may seems excessive this is also OuterLoop test doing very large post to remote server so the actual performance may vary. I was running tests overnight in loop and I did not see failure after bumping the timeout up. 