### PR TITLE
Re-use status flag inside Ping

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -92,7 +92,7 @@ namespace System.Net.NetworkInformation
                 {
                     pingProcess.Kill();
                 }
-                if (_status == Cancelled)
+                if (_status == Canceled)
                 {
                     throw;
                 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.PingUtility.cs
@@ -92,7 +92,7 @@ namespace System.Net.NetworkInformation
                 {
                     pingProcess.Kill();
                 }
-                if (_canceled)
+                if (_status == Cancelled)
                 {
                     throw;
                 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -327,7 +327,7 @@ namespace System.Net.NetworkInformation
             {
                 return CreatePingReply(IPStatus.PacketTooBig);
             }
-            catch (OperationCanceledException) when (!_canceled)
+            catch (OperationCanceledException) when (_status != Cancelled)
             {
             }
 

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -327,7 +327,7 @@ namespace System.Net.NetworkInformation
             {
                 return CreatePingReply(IPStatus.PacketTooBig);
             }
-            catch (OperationCanceledException) when (_status != Cancelled)
+            catch (OperationCanceledException) when (_status != Canceled)
             {
             }
 

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -273,7 +273,7 @@ namespace System.Net.NetworkInformation
             {
                 lock (_lockObject)
                 {
-                    canceled = _canceled;
+                    canceled = _status == Canceled;
 
                     reply = CreatePingReply();
                 }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -118,7 +118,7 @@ namespace System.Net.NetworkInformation
         {
             lock (_lockObject)
             {
-                Debug.Assert(_status == InProgress, $"Invalid status: {_status}");
+                Debug.Assert(_status == InProgress || _status == Canceled, $"Invalid status: {_status}");
                 _status = Free;
                 if (!_timeoutOrCancellationSource!.TryReset())
                 {

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -26,7 +26,7 @@ namespace System.Net.NetworkInformation
         private const int InProgress = 1;
         private new const int Disposed = 2;
         // Used to differentiate between timeout and cancellation when _timeoutOrCancellationSource triggers
-        private const int Cancelled = 3;
+        private const int Canceled = 3;
         private const int DisposeRequested = 4;
 
         private int _status = Free;
@@ -679,7 +679,7 @@ namespace System.Net.NetworkInformation
 
         private void SetCanceled()
         {
-            _status = Cancelled;
+            _status = Canceled;
             _timeoutOrCancellationSource?.Cancel();
         }
 
@@ -724,7 +724,7 @@ namespace System.Net.NetworkInformation
                 _timeoutOrCancellationSource.CancelAfter(timeout);
                 return await pingTask.ConfigureAwait(false);
             }
-            catch (Exception e) when (e is not PlatformNotSupportedException && !(e is OperationCanceledException && _status == Cancelled))
+            catch (Exception e) when (e is not PlatformNotSupportedException && !(e is OperationCanceledException && _status == Canceled))
             {
                 throw new PingException(SR.net_ping, e);
             }

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -20,12 +20,12 @@ namespace System.Net.NetworkInformation
         private SendOrPostCallback? _onPingCompletedDelegate;
         private byte[]? _defaultSendBuffer;
         private CancellationTokenSource? _timeoutOrCancellationSource;
-        // Used to differentiate between timeout and cancellation when _timeoutOrCancellationSource triggers
 
         // Thread safety:
         private const int Free = 0;
         private const int InProgress = 1;
         private new const int Disposed = 2;
+        // Used to differentiate between timeout and cancellation when _timeoutOrCancellationSource triggers
         private const int Cancelled = 3;
         private const int DisposeRequested = 4;
 


### PR DESCRIPTION
Similar idea as https://github.com/dotnet/runtime/pull/81251 and a couple of other examples described in [the blog post](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#http). Instead of storing these flags in separate booleans, re-use the existing mechanism that stores them as separate values for the existing integer. 

I expect this to result in a smaller `Ping` object, presumably 16 bytes due to padding, but I'm not confident about that.

I created a small benchmark in dotnet/performance (locally):

```cs
[BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
public class PingTests
{
    [Benchmark]
    public void Ping() => new Ping();
}
```

Which gives me the following results (top is `main`, bottom is PR):

| Method | Job        | Toolchain                                                                                                        | Mean     | Error    | StdDev   | Median   | Min      | Max      | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------- |----------- |----------------------------------------------------------------------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| Ping   | Job-EIVJMB | \dotnet\runtime\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe | 57.24 ns | 1.697 ns | 1.954 ns | 57.16 ns | 54.48 ns | 60.11 ns |  1.04 |    0.03 | 0.0218 |     184 B |        1.00 |
| Ping   | Job-ATHUQO | \runtime\artifacts\bin\testhost\net9.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe        | 55.29 ns | 1.128 ns | 1.298 ns | 55.28 ns | 53.62 ns | 58.42 ns |  1.00 |    0.00 | 0.0218 |     184 B |        1.00 |

A small improvement in time but no change in allocation so I'd be interested to hear takes on why I'm not seeing the expected reduction in allocation.