### PR TITLE
[RISC-V] Floating NaN overflow test fix

### DIFF
--- a/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/ByteTests.GenericMath.cs
@@ -13,6 +13,15 @@ namespace System.Tests
         // IAdditionOperators
         //
 
+        private static byte NaNConversionOverflowValue()
+        {
+            if(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.RiscV64)
+            {
+                return (byte)0xFF;
+            }
+            return (byte)0x00;
+        }
+
         [Fact]
         public static void op_AdditionTest()
         {
@@ -1571,7 +1580,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<double>(double.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<double>(double.MinValue));
                                      
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateSaturating<double>(double.NaN));
         }
 
         [Fact]
@@ -1595,7 +1604,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<Half>(Half.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<Half>(Half.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateSaturating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1680,7 +1689,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<NFloat>(NFloat.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateSaturating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1714,7 +1723,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateSaturating<float>(float.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateSaturating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateSaturating<float>(float.NaN));
         }
 
         [Fact]
@@ -1831,7 +1840,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<double>(double.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateTruncating<double>(double.NaN));
         }
 
         [Fact]
@@ -1855,7 +1864,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<Half>(Half.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<Half>(Half.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateTruncating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1940,7 +1949,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<NFloat>(NFloat.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateTruncating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1974,7 +1983,7 @@ namespace System.Tests
             Assert.Equal((byte)0xFF, NumberBaseHelper<byte>.CreateTruncating<float>(float.MaxValue));
             Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal((byte)0x00, NumberBaseHelper<byte>.CreateTruncating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<byte>.CreateTruncating<float>(float.NaN));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.GenericMath.cs
@@ -12,6 +12,15 @@ namespace System.Tests
         // IAdditionOperators
         //
 
+        private static char NaNConversionOverflowValue()
+        {
+            if(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.RiscV64)
+            {
+                return (char)0xFFFF;
+            }
+            return (char)0x0000;
+        }
+
         [Fact]
         public static void op_AdditionTest()
         {
@@ -1569,7 +1578,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<double>(double.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateSaturating<double>(double.NaN));
         }
 
         [Fact]
@@ -1590,7 +1599,7 @@ namespace System.Tests
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<Half>(Half.NegativeInfinity));
 
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<Half>(Half.MinValue));
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateSaturating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1675,7 +1684,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<NFloat>(NFloat.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateSaturating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1709,7 +1718,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateSaturating<float>(float.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateSaturating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateSaturating<float>(float.NaN));
         }
 
         [Fact]
@@ -1827,7 +1836,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<double>(double.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateTruncating<double>(double.NaN));
         }
 
         [Fact]
@@ -1848,7 +1857,7 @@ namespace System.Tests
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<Half>(Half.NegativeInfinity));
 
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<Half>(Half.MinValue));
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateTruncating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1933,7 +1942,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<NFloat>(NFloat.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateTruncating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1967,7 +1976,7 @@ namespace System.Tests
             Assert.Equal((char)0xFFFF, NumberBaseHelper<char>.CreateTruncating<float>(float.MaxValue));
             Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal((char)0x0000, NumberBaseHelper<char>.CreateTruncating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<char>.CreateTruncating<float>(float.NaN));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt16Tests.GenericMath.cs
@@ -13,6 +13,15 @@ namespace System.Tests
         // IAdditionOperators
         //
 
+        private static ushort NaNConversionOverflowValue()
+        {
+            if(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.RiscV64)
+            {
+                return (ushort)0xFFFF;
+            }
+            return (ushort)0x0000;
+        }
+
         [Fact]
         public static void op_AdditionTest()
         {
@@ -1571,7 +1580,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<double>(double.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateSaturating<double>(double.NaN));
         }
 
         [Fact]
@@ -1677,7 +1686,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<NFloat>(NFloat.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateSaturating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1711,7 +1720,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateSaturating<float>(float.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateSaturating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateSaturating<float>(float.NaN));
         }
 
         [Fact]
@@ -1829,7 +1838,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<double>(double.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateTruncating<double>(double.NaN));
         }
 
         [Fact]
@@ -1850,7 +1859,7 @@ namespace System.Tests
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<Half>(Half.NegativeInfinity));
 
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<Half>(Half.MinValue));
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateTruncating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1935,7 +1944,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<NFloat>(NFloat.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateTruncating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1969,7 +1978,7 @@ namespace System.Tests
             Assert.Equal((ushort)0xFFFF, NumberBaseHelper<ushort>.CreateTruncating<float>(float.MaxValue));
             Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal((ushort)0x0000, NumberBaseHelper<ushort>.CreateTruncating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<ushort>.CreateTruncating<float>(float.NaN));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UInt32Tests.GenericMath.cs
@@ -13,6 +13,15 @@ namespace System.Tests
         // IAdditionOperators
         //
 
+        private static uint NaNConversionOverflowValue()
+        {
+            if(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.RiscV64)
+            {
+                return (uint)0xFFFF_FFFF;
+            }
+            return (uint)0x0000_0000;
+        }
+
         [Fact]
         public static void op_AdditionTest()
         {
@@ -1583,7 +1592,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateSaturating<double>(double.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateSaturating<double>(double.NaN));
         }
 
         [Fact]
@@ -1604,7 +1613,7 @@ namespace System.Tests
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<Half>(Half.NegativeInfinity));
 
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<Half>(Half.MinValue));
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateSaturating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1700,7 +1709,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateSaturating<NFloat>(NFloat.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateSaturating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -1734,7 +1743,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateSaturating<float>(float.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateSaturating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateSaturating<float>(float.NaN));
         }
 
         [Fact]
@@ -1852,7 +1861,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateTruncating<double>(double.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateTruncating<double>(double.NaN));
         }
 
         [Fact]
@@ -1873,7 +1882,7 @@ namespace System.Tests
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<Half>(Half.NegativeInfinity));
 
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<Half>(Half.MinValue));
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateTruncating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -1969,7 +1978,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateTruncating<NFloat>(NFloat.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateTruncating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -2003,7 +2012,7 @@ namespace System.Tests
             Assert.Equal((uint)0xFFFF_FFFF, NumberBaseHelper<uint>.CreateTruncating<float>(float.MaxValue));
             Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal((uint)0x0000_0000, NumberBaseHelper<uint>.CreateTruncating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<uint>.CreateTruncating<float>(float.NaN));
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System/UIntPtrTests.GenericMath.cs
@@ -13,6 +13,15 @@ namespace System.Tests
         // IAdditionOperators
         //
 
+        private static nuint NaNConversionOverflowValue()
+        {
+            if(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.RiscV64)
+            {
+                return nuint.MaxValue;
+            }
+            return nuint.MinValue;
+        }
+
         [Fact]
         public static void op_AdditionTest()
         {
@@ -2220,7 +2229,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateSaturating<double>(double.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<double>(double.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateSaturating<double>(double.NaN));
         }
 
         [Fact]
@@ -2241,7 +2250,7 @@ namespace System.Tests
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<Half>(Half.NegativeInfinity));
 
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<Half>(Half.MinValue));
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateSaturating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -2348,7 +2357,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateSaturating<NFloat>(NFloat.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateSaturating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -2393,7 +2402,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateSaturating<float>(float.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<float>(float.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateSaturating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateSaturating<float>(float.NaN));
         }
 
         [Fact]
@@ -2532,7 +2541,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateTruncating<double>(double.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<double>(double.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<double>(double.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateTruncating<double>(double.NaN));
         }
 
         [Fact]
@@ -2553,7 +2562,7 @@ namespace System.Tests
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<Half>(Half.NegativeInfinity));
 
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<Half>(Half.MinValue));
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<Half>(Half.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateTruncating<Half>(Half.NaN));
         }
 
         [Fact]
@@ -2682,7 +2691,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateTruncating<NFloat>(NFloat.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<NFloat>(NFloat.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<NFloat>(NFloat.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateTruncating<NFloat>(NFloat.NaN));
         }
 
         [Fact]
@@ -2738,7 +2747,7 @@ namespace System.Tests
             Assert.Equal(nuint.MaxValue, NumberBaseHelper<nuint>.CreateTruncating<float>(float.MaxValue));
             Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<float>(float.MinValue));
 
-            Assert.Equal(nuint.MinValue, NumberBaseHelper<nuint>.CreateTruncating<float>(float.NaN));
+            Assert.Equal(NaNConversionOverflowValue(), NumberBaseHelper<nuint>.CreateTruncating<float>(float.NaN));
         }
 
         [Fact]


### PR DESCRIPTION
There are differences between results of floating NaN conversions overflow on X64 or ARM64 and RISC-V. As I suppose it is caused by runtime using some sort of `flush-to-zero` option for X64 and ARM64 which replace such overflowing values with zero.  
But RISC-V specification does not provide such option.  
Thus I suggest to change expected result of NaN overflow tests on RISC-V.

Part of https://github.com/dotnet/runtime/issues/84834
cc @gbalykov @t-mustafin @clamp03 @tomeksowi 