### PR TITLE
ARM64: Fix Vector64x2/3/4 API comments. Minor cleanup in AdvSimd.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
@@ -1553,152 +1553,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndInsertScalar((Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndInsertScalar((Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndInsertScalar((Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndInsertScalar((Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndInsertScalar((Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             /// float64x2_t vld1q_dup_f64 (float64_t const * ptr)
@@ -1721,152 +1721,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LDP Dt1, Dt2, [Xn]
@@ -2251,152 +2251,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadVector128x2(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadVector128x2(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadVector128x2(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadVector128x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadVector128x2(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadVector128x2(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadVector128x2(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadVector128x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadVector128x2(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadVector128x2(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadVector128x2(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadVector128x2(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadVector128x2(long* address)  { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadVector128x2(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadVector128x2(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadVector128x2(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadVector128x2(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadVector128x2(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadVector128x2(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadVector128x2(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadVector128x3(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadVector128x3(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadVector128x3(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadVector128x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadVector128x3(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadVector128x3(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadVector128x3(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadVector128x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadVector128x3(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadVector128x3(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadVector128x3(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadVector128x3(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadVector128x3(long* address)  { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadVector128x3(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadVector128x3(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadVector128x3(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadVector128x3(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadVector128x3(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadVector128x3(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadVector128x3(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadVector128x4(byte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadVector128x4(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadVector128x4(sbyte* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadVector128x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadVector128x4(short* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadVector128x4(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadVector128x4(ushort* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadVector128x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadVector128x4(int* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadVector128x4(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadVector128x4(uint* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadVector128x4(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadVector128x4(long* address)  { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadVector128x4(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D}, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadVector128x4(ulong* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadVector128x4(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadVector128x4(float* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadVector128x4(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadVector128x4(double* address) { throw new PlatformNotSupportedException(); }
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadVector128x4(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             /// float64x2_t vmaxq_f64 (float64x2_t a, float64x2_t b)
@@ -8742,107 +8742,107 @@ namespace System.Runtime.Intrinsics.Arm
         /// <summary>
         ///   A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndInsertScalar((Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndInsertScalar((Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndInsertScalar((Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// uint8x8_t vld1_dup_u8 (uint8_t const * ptr)
@@ -8945,107 +8945,107 @@ namespace System.Runtime.Intrinsics.Arm
         /// <summary>
         ///   A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// uint8x8_t vld1_u8 (uint8_t const * ptr)
@@ -9188,214 +9188,214 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadVector64x2AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadVector64x2AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadVector64x2AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadVector64x2AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadVector64x2AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadVector64x2AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadVector64x2AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadVector64x3AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadVector64x3AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadVector64x3AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadVector64x3AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadVector64x3AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadVector64x3AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadVector64x3AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadVector64x4AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadVector64x4AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadVector64x4AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadVector64x4AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadVector64x4AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadVector64x4AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadVector64x4AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadVector64x2(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadVector64x2(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadVector64x2(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadVector64x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadVector64x2(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadVector64x2(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadVector64x2(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadVector64x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadVector64x2(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadVector64x2(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadVector64x2(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadVector64x2(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadVector64x2(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadVector64x2(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadVector64x3(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadVector64x3(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadVector64x3(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadVector64x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadVector64x3(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadVector64x3(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadVector64x3(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadVector64x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadVector64x3(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadVector64x3(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadVector64x3(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadVector64x3(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadVector64x3(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadVector64x3(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
+        ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadVector64x4(byte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadVector64x4(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
+        ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadVector64x4(sbyte* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadVector64x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
+        ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadVector64x4(short* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadVector64x4(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
+        ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadVector64x4(ushort* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadVector64x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadVector64x4(int* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadVector64x4(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadVector64x4(uint* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadVector64x4(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadVector64x4(float* address) { throw new PlatformNotSupportedException(); }
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadVector64x4(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// uint8x8_t vmax_u8 (uint8x8_t a, uint8x8_t b)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -1551,152 +1551,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndInsertScalar((Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndInsertScalar((Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndInsertScalar((Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndInsertScalar((Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndInsertScalar((Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             /// float64x2_t vld1q_dup_f64 (float64_t const * ptr)
@@ -1719,152 +1719,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) => LoadAndReplicateToVector128x2(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) => LoadAndReplicateToVector128x3(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) => LoadAndReplicateToVector128x4(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>
             ///   A64: LDP Dt1, Dt2, [Xn]
@@ -2249,152 +2249,152 @@ namespace System.Runtime.Intrinsics.Arm
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadVector128x2(byte* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadVector128x2(byte* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadVector128x2(sbyte* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadVector128x2(sbyte* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadVector128x2(short* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadVector128x2(short* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadVector128x2(ushort* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadVector128x2(ushort* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadVector128x2(int* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadVector128x2(int* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadVector128x2(uint* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadVector128x2(uint* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadVector128x2(long* address)  => LoadVector128x2(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadVector128x2(long* address)  => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadVector128x2(ulong* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadVector128x2(ulong* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadVector128x2(float* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadVector128x2(float* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadVector128x2(double* address) => LoadVector128x2(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadVector128x2(double* address) => LoadVector128x2(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadVector128x3(byte* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadVector128x3(byte* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadVector128x3(sbyte* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadVector128x3(sbyte* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadVector128x3(short* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadVector128x3(short* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadVector128x3(ushort* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadVector128x3(ushort* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadVector128x3(int* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadVector128x3(int* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadVector128x3(uint* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadVector128x3(uint* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadVector128x3(long* address)  => LoadVector128x3(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadVector128x3(long* address)  => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadVector128x3(ulong* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadVector128x3(ulong* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadVector128x3(float* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadVector128x3(float* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadVector128x3(double* address) => LoadVector128x3(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadVector128x3(double* address) => LoadVector128x3(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadVector128x4(byte* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadVector128x4(byte* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadVector128x4(sbyte* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadVector128x4(sbyte* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadVector128x4(short* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadVector128x4(short* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadVector128x4(ushort* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadVector128x4(ushort* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadVector128x4(int* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadVector128x4(int* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadVector128x4(uint* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadVector128x4(uint* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadVector128x4(long* address)  => LoadVector128x4(address);
+            public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadVector128x4(long* address)  => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D}, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadVector128x4(ulong* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadVector128x4(ulong* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadVector128x4(float* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadVector128x4(float* address) => LoadVector128x4(address);
 
             /// <summary>
             ///   A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]
             /// </summary>
-            public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadVector128x4(double* address) => LoadVector128x4(address);
+            public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadVector128x4(double* address) => LoadVector128x4(address);
 
             /// <summary>
             /// float64x2_t vmaxq_f64 (float64x2_t a, float64x2_t b)
@@ -8739,107 +8739,107 @@ namespace System.Runtime.Intrinsics.Arm
         /// <summary>
         ///   A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndInsertScalar((Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndInsertScalar((Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndInsertScalar((Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
         /// uint8x8_t vld1_dup_u8 (uint8_t const * ptr)
@@ -8942,107 +8942,107 @@ namespace System.Runtime.Intrinsics.Arm
         /// <summary>
         ///   A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) => LoadAndReplicateToVector64x2(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) => LoadAndReplicateToVector64x3(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         ///   A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) => LoadAndReplicateToVector64x4(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
         /// uint8x8_t vld1_u8 (uint8_t const * ptr)
@@ -9185,214 +9185,214 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) => LoadVector128(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadVector64x2AndUnzip(byte* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadVector64x2AndUnzip(sbyte* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadVector64x2AndUnzip(short* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadVector64x2AndUnzip(ushort* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadVector64x2AndUnzip(int* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadVector64x2AndUnzip(uint* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadVector64x2AndUnzip(float* address) => LoadVector64x2AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadVector64x3AndUnzip(byte* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadVector64x3AndUnzip(sbyte* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadVector64x3AndUnzip(short* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadVector64x3AndUnzip(ushort* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadVector64x3AndUnzip(int* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadVector64x3AndUnzip(uint* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadVector64x3AndUnzip(float* address) => LoadVector64x3AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadVector64x4AndUnzip(byte* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadVector64x4AndUnzip(sbyte* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadVector64x4AndUnzip(short* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4h }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadVector64x4AndUnzip(ushort* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadVector64x4AndUnzip(int* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadVector64x4AndUnzip(uint* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.2S }, [Xn]
         /// </summary>
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadVector64x4AndUnzip(float* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadVector64x2(byte* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadVector64x2(byte* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]
+        ///   A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadVector64x2(sbyte* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadVector64x2(sbyte* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadVector64x2(short* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadVector64x2(short* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]
+        ///   A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadVector64x2(ushort* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadVector64x2(ushort* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadVector64x2(int* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadVector64x2(int* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]128x4
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadVector64x2(uint* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadVector64x2(uint* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]
+        ///   A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadVector64x2(float* address) => LoadVector64x2(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadVector64x2(float* address) => LoadVector64x2(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadVector64x3(byte* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadVector64x3(byte* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]
+        ///   A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadVector64x3(sbyte* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadVector64x3(sbyte* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadVector64x3(short* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadVector64x3(short* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]
+        ///   A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadVector64x3(ushort* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadVector64x3(ushort* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadVector64x3(int* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadVector64x3(int* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadVector64x3(uint* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadVector64x3(uint* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]
+        ///   A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadVector64x3(float* address) => LoadVector64x3(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadVector64x3(float* address) => LoadVector64x3(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
+        ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadVector64x4(byte* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadVector64x4(byte* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]
+        ///   A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadVector64x4(sbyte* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadVector64x4(sbyte* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
+        ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadVector64x4(short* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadVector64x4(short* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]
+        ///   A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadVector64x4(ushort* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadVector64x4(ushort* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadVector64x4(int* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadVector64x4(int* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadVector64x4(uint* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadVector64x4(uint* address) => LoadVector64x4(address);
 
         /// <summary>
-        ///   A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]
+        ///   A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]
         /// </summary>
-        public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadVector64x4(float* address) => LoadVector64x4(address);
+        public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadVector64x4(float* address) => LoadVector64x4(address);
 
         /// <summary>
         /// uint8x8_t vmax_u8 (uint8x8_t a, uint8x8_t b)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -9270,7 +9270,7 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadVector64x4AndUnzip(short* address) => LoadVector64x4AndUnzip(address);
 
         /// <summary>
-        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4h }, [Xn]
+        ///   A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]
         /// </summary>
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadVector64x4AndUnzip(ushort* address) => LoadVector64x4AndUnzip(address);
 


### PR DESCRIPTION
This is a non-functional change. It fixes a few comments in the recent VectorLoad APIs that we added, and does some minor cleanup in AdvSimd by removing the fully qualified use of Vector64 and Vector128.