### PR TITLE
Fix compilation of Synchronized method combined with generics

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/TypeLoaderCallbacks.cs
@@ -14,6 +14,7 @@ namespace Internal.Runtime.Augments
     [CLSCompliant(false)]
     public abstract class TypeLoaderCallbacks
     {
+        public abstract bool TryGetOwningTypeForMethodDictionary(IntPtr dictionary, out RuntimeTypeHandle owningType);
         public abstract TypeManagerHandle GetModuleForMetadataReader(MetadataReader reader);
         public abstract bool TryGetConstructedGenericTypeForComponents(RuntimeTypeHandle genericTypeDefinitionHandle, RuntimeTypeHandle[] genericTypeArgumentHandles, out RuntimeTypeHandle runtimeTypeHandle);
         public abstract IntPtr GetThreadStaticGCDescForDynamicType(TypeManagerHandle handle, int index);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
@@ -4,6 +4,10 @@
 using System;
 using System.Threading;
 
+using Internal.Runtime.Augments;
+
+using Debug = System.Diagnostics.Debug;
+
 namespace Internal.Runtime.CompilerHelpers
 {
     /// <summary>
@@ -72,6 +76,15 @@ namespace Internal.Runtime.CompilerHelpers
         private static unsafe RuntimeType GetStaticLockObject(MethodTable* pMT)
         {
             return Type.GetTypeFromMethodTable(pMT);
+        }
+
+        private static unsafe MethodTable* GetSyncFromClassHandle(MethodTable* pMT) => pMT;
+
+        private static unsafe MethodTable* GetClassFromMethodParam(IntPtr pDictionary)
+        {
+            bool success = RuntimeAugments.TypeLoaderCallbacks.TryGetOwningTypeForMethodDictionary(pDictionary, out RuntimeTypeHandle th);
+            Debug.Assert(success);
+            return th.ToMethodTable();
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -22,6 +22,12 @@ namespace Internal.Runtime.TypeLoader
 {
     internal class Callbacks : TypeLoaderCallbacks
     {
+        public override bool TryGetOwningTypeForMethodDictionary(IntPtr dictionary, out RuntimeTypeHandle owningType)
+        {
+            // PERF: computing NameAndSignature and the instantiation (that we discard) was useless
+            return TypeLoaderEnvironment.Instance.TryGetGenericMethodComponents(dictionary, out owningType, out _, out _);
+        }
+
         public override TypeManagerHandle GetModuleForMetadataReader(MetadataReader reader)
         {
             return ModuleList.Instance.GetModuleForMetadataReader(reader);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -391,6 +391,12 @@ namespace ILCompiler
                 dependencies ??= new DependencyList();
                 dependencies.Add(factory.GenericMethodsHashtableEntry(method), "Reflection visible dictionary");
             }
+
+            if (method.Signature.IsStatic && method.IsSynchronized)
+            {
+                dependencies ??= new DependencyList();
+                dependencies.Add(factory.GenericMethodsHashtableEntry(method), "Will need to look up owning type from dictionary");
+            }
         }
 
         public IEnumerable<CombinedDependencyListEntry> GetConditionalDependenciesDueToGenericDictionary(NodeFactory factory, MethodDesc method)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -153,6 +153,14 @@ namespace Internal.IL
                     {
                         _dependencies.Add(_factory.NecessaryTypeSymbol(method.OwningType), reason);
                     }
+
+                    if (_canonMethod.IsCanonicalMethod(CanonicalFormKind.Any))
+                    {
+                        _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(_compilation.NodeFactory.TypeSystemContext.GetHelperEntryPoint("SynchronizedMethodHelpers", "GetSyncFromClassHandle")), reason);
+
+                        if (_canonMethod.RequiresInstMethodDescArg())
+                            _dependencies.Add(_compilation.NodeFactory.MethodEntrypoint(_compilation.NodeFactory.TypeSystemContext.GetHelperEntryPoint("SynchronizedMethodHelpers", "GetClassFromMethodParam")), reason);
+                    }
                 }
                 else
                 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1257,6 +1257,8 @@ namespace Internal.JitInterface
 
                 case CorInfoHelpFunc.CORINFO_HELP_INITCLASS:
                 case CorInfoHelpFunc.CORINFO_HELP_INITINSTCLASS:
+                case CorInfoHelpFunc.CORINFO_HELP_GETSYNCFROMCLASSHANDLE:
+                case CorInfoHelpFunc.CORINFO_HELP_GETCLASSFROMMETHODPARAM:
                 case CorInfoHelpFunc.CORINFO_HELP_THROW_ARGUMENTEXCEPTION:
                 case CorInfoHelpFunc.CORINFO_HELP_THROW_ARGUMENTOUTOFRANGEEXCEPTION:
                 case CorInfoHelpFunc.CORINFO_HELP_THROW_PLATFORM_NOT_SUPPORTED:

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -726,6 +726,11 @@ namespace Internal.JitInterface
                     id = ReadyToRunHelper.MonitorExitStatic;
                     break;
 
+                case CorInfoHelpFunc.CORINFO_HELP_GETSYNCFROMCLASSHANDLE:
+                    return _compilation.NodeFactory.MethodEntrypoint(_compilation.NodeFactory.TypeSystemContext.GetHelperEntryPoint("SynchronizedMethodHelpers", "GetSyncFromClassHandle"));
+                case CorInfoHelpFunc.CORINFO_HELP_GETCLASSFROMMETHODPARAM:
+                    return _compilation.NodeFactory.MethodEntrypoint(_compilation.NodeFactory.TypeSystemContext.GetHelperEntryPoint("SynchronizedMethodHelpers", "GetClassFromMethodParam"));
+
                 case CorInfoHelpFunc.CORINFO_HELP_GVMLOOKUP_FOR_SLOT:
                     id = ReadyToRunHelper.GVMLookupForSlot;
                     break;

--- a/src/tests/JIT/Generics/Fields/getclassfrommethodparam.cs
+++ b/src/tests/JIT/Generics/Fields/getclassfrommethodparam.cs
@@ -11,8 +11,7 @@ namespace Sandbox3
     {
         public static string Value;
 
-        // [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
         public static void Action<T>(T value)
         {
             Value = value.ToString();

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -13,6 +13,7 @@ class Generics
         TestDictionaryDependencyTracking.Run();
         TestStaticBaseLookups.Run();
         TestInitThisClass.Run();
+        TestSynchronizedMethods.Run();
         TestDelegateFatFunctionPointers.Run();
         TestDelegateToCanonMethods.Run();
         TestVirtualMethodUseTracking.Run();
@@ -599,6 +600,54 @@ class Generics
 
             if (NonGeneric.Get<object>(new object[0]) != "Hi there")
                 throw new Exception();
+        }
+    }
+
+    class TestSynchronizedMethods
+    {
+        static class Gen<T>
+        {
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public static int Synchronize() => 42;
+        }
+
+        static class NonGen
+        {
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public static int Synchronize<T>() => 42;
+        }
+
+        static class GenReflected<T>
+        {
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public static int Synchronize() => 42;
+        }
+
+        static class NonGenReflected
+        {
+            [MethodImpl(MethodImplOptions.Synchronized)]
+            public static int Synchronize<T>() => 42;
+        }
+
+        static Type s_genReflectedType = typeof(GenReflected<>);
+        static MethodInfo s_nonGenReflectedSynchronizeMethod = typeof(NonGenReflected).GetMethod("Synchronize");
+
+        public static void Run()
+        {
+            Gen<object>.Synchronize();
+            NonGen.Synchronize<object>();
+            Gen<int>.Synchronize();
+            NonGen.Synchronize<int>();
+
+            {
+                var mi = (MethodInfo)s_genReflectedType.MakeGenericType(typeof(object)).GetMemberWithSameMetadataDefinitionAs(typeof(GenReflected<>).GetMethod("Synchronize"));
+                mi.Invoke(null, Array.Empty<object>());
+            }
+
+            {
+                var mi = s_nonGenReflectedSynchronizeMethod.MakeGenericMethod(typeof(object));
+                mi.Invoke(null, Array.Empty<object>());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #77093.

As I was looking at the bug, I realized it got miscategorized as native AOT, but the customer filed it for ReadyToRun. The bug is in both native AOT and ReadyToRun. I'm fixing it for both.

We clearly didn't have any pre-existing test coverage, but as I was looking around the test tree, getclassfrommethodparam.cs was obviously testing this. For unexplained reasons, the Synchronized part got commented out. When I compared the file with the original in TFS at `$/DevDiv/FX/Feature/NetFXDev1/QA/CLR/testsrc/jit/Generics/Fields/getclassfrommethodparam.cs`, the commented out line is not commented out. So I'm fixing it. I've also added dedicated native aot test because this has dependency analysis implications that we need to be careful about.

Cc @dotnet/ilc-contrib 