### PR TITLE
Tests build fix with BuildAsStandalone

### DIFF
--- a/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
+++ b/src/tests/baseservices/callconvs/CallFunctionPointers.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="CallFunctionPointers.il" />
   </ItemGroup>

--- a/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
+++ b/src/tests/baseservices/compilerservices/RuntimeWrappedException/StringThrower.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="StringThrower.il" />
   </ItemGroup>

--- a/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
+++ b/src/tests/baseservices/compilerservices/modulector/moduleCctor.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="moduleCctor.il" />
   </ItemGroup>

--- a/src/tests/baseservices/exceptions/simple/ILHelper.ilproj
+++ b/src/tests/baseservices/exceptions/simple/ILHelper.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ILHelper.il" />

--- a/src/tests/baseservices/exceptions/simple/VT.ilproj
+++ b/src/tests/baseservices/exceptions/simple/VT.ilproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="VT.il" />

--- a/src/tests/baseservices/typeequivalence/impl/PunningLib.ilproj
+++ b/src/tests/baseservices/typeequivalence/impl/PunningLib.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="PunningLib.il" />
     <ProjectReference Include="TypeImpl.csproj" />

--- a/src/tests/baseservices/typeequivalence/signatures/basetestclassesil.ilproj
+++ b/src/tests/baseservices/typeequivalence/signatures/basetestclassesil.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="basetestclassesil.il" />
   </ItemGroup>

--- a/src/tests/baseservices/typeequivalence/signatures/testclassesil.ilproj
+++ b/src/tests/baseservices/typeequivalence/signatures/testclassesil.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="testclassesil.il" />
   </ItemGroup>


### PR DESCRIPTION
Without this patch build of these tests fails with "No entry point declared for executable" with BuildAsStandalone.
Before #91560 they were built as OutputType=Library and these are actually not launched during testing, but are used as libs.

cc @trylek @t-mustafin @clamp03 