### PR TITLE
Additional QuicConnectionOptions

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -41,7 +41,13 @@ namespace System.Net.Quic
         internal QuicConnectionOptions() { }
         public long DefaultCloseErrorCode { get { throw null; } set { } }
         public long DefaultStreamErrorCode { get { throw null; } set { } }
+        public System.TimeSpan HandshakeTimeout { get { throw null; } set { } }
         public System.TimeSpan IdleTimeout { get { throw null; } set { } }
+        public int InitialConnectionWindowSize { get { throw null; } set { } }
+        public int InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
+        public int InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
+        public int InitialUnidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
+        public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
         public int MaxInboundBidirectionalStreams { get { throw null; } set { } }
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
     }
@@ -64,8 +70,8 @@ namespace System.Net.Quic
     {
         public QuicException(System.Net.Quic.QuicError error, long? applicationErrorCode, string message) { }
         public long? ApplicationErrorCode { get { throw null; } }
-        public long? TransportErrorCode { get { throw null; } }
         public System.Net.Quic.QuicError QuicError { get { throw null; } }
+        public long? TransportErrorCode { get { throw null; } }
     }
     public sealed partial class QuicListener : System.IAsyncDisposable
     {

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -43,10 +43,7 @@ namespace System.Net.Quic
         public long DefaultStreamErrorCode { get { throw null; } set { } }
         public System.TimeSpan HandshakeTimeout { get { throw null; } set { } }
         public System.TimeSpan IdleTimeout { get { throw null; } set { } }
-        public int InitialConnectionWindowSize { get { throw null; } set { } }
-        public int InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
-        public int InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
-        public int InitialUnidirectionalStreamReceiveWindowSize { get { throw null; } set { } }
+        public System.Net.Quic.QuicReceiveWindowSizes InitialReceiveWindowSizes { get { throw null; } set { } }
         public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
         public int MaxInboundBidirectionalStreams { get { throw null; } set { } }
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
@@ -90,6 +87,14 @@ namespace System.Net.Quic
         public System.Func<System.Net.Quic.QuicConnection, System.Net.Security.SslClientHelloInfo, System.Threading.CancellationToken, System.Threading.Tasks.ValueTask<System.Net.Quic.QuicServerConnectionOptions>> ConnectionOptionsCallback { get { throw null; } set { } }
         public int ListenBacklog { get { throw null; } set { } }
         public System.Net.IPEndPoint ListenEndPoint { get { throw null; } set { } }
+    }
+    public sealed partial class QuicReceiveWindowSizes
+    {
+        public QuicReceiveWindowSizes() { }
+        public int Connection { get { throw null; } set { } }
+        public int LocallyInitiatedBidirectionalStream { get { throw null; } set { } }
+        public int RemotelyInitiatedBidirectionalStream { get { throw null; } set { } }
+        public int UnidirectionalStream { get { throw null; } set { } }
     }
     public sealed partial class QuicServerConnectionOptions : System.Net.Quic.QuicConnectionOptions
     {

--- a/src/libraries/System.Net.Quic/src/ExcludeApiList.PNSE.txt
+++ b/src/libraries/System.Net.Quic/src/ExcludeApiList.PNSE.txt
@@ -2,5 +2,6 @@ P:System.Net.Quic.QuicConnection.IsSupported
 P:System.Net.Quic.QuicListener.IsSupported
 C:System.Net.Quic.QuicListenerOptions
 C:System.Net.Quic.QuicConnectionOptions
+C:System.Net.Quic.QuicReceiveWindowSizes
 C:System.Net.Quic.QuicClientConnectionOptions
 C:System.Net.Quic.QuicServerConnectionOptions

--- a/src/libraries/System.Net.Quic/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Quic/src/Resources/Strings.resx
@@ -142,7 +142,10 @@
     <value>Writing is not allowed on stream.</value>
   </data>
   <data name="net_quic_in_range" xml:space="preserve">
-    <value>'{0}'' should be within [0, {1}) range.</value>
+    <value>'{0}' should be within [0, {1}) range.</value>
+  </data>
+  <data name="net_quic_power_of_2" xml:space="preserve">
+    <value>'{0}' must be a power of 2.</value>
   </data>
   <data name="net_quic_not_null_listener" xml:space="preserve">
     <value>'{0}' must be specified to start the listener.</value>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -18,7 +18,6 @@ internal sealed unsafe partial class MsQuicApi
 {
     private static readonly Version s_minWindowsVersion = new Version(10, 0, 20145, 1000);
 
-    // TODO: update after https://github.com/microsoft/msquic/pull/3948 is released
     private static readonly Version s_minMsQuicVersion = new Version(2, 2, 2);
 
     private static readonly delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> MsQuicOpenVersion;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -18,6 +18,7 @@ internal sealed unsafe partial class MsQuicApi
 {
     private static readonly Version s_minWindowsVersion = new Version(10, 0, 20145, 1000);
 
+    // TODO: update after https://github.com/microsoft/msquic/pull/3948 is released
     private static readonly Version s_minMsQuicVersion = new Version(2, 2, 2);
 
     private static readonly delegate* unmanaged[Cdecl]<uint, QUIC_API_TABLE**, int> MsQuicOpenVersion;
@@ -154,7 +155,7 @@ internal sealed unsafe partial class MsQuicApi
 
             if (version < s_minMsQuicVersion)
             {
-                NotSupportedReason =  $"Incompatible MsQuic library version '{version}', expecting higher than '{s_minMsQuicVersion}'.";
+                NotSupportedReason = $"Incompatible MsQuic library version '{version}', expecting higher than '{s_minMsQuicVersion}'.";
                 if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(null, NotSupportedReason);
@@ -178,7 +179,7 @@ internal sealed unsafe partial class MsQuicApi
                 // Implies windows platform, check TLS1.3 availability
                 if (!IsWindowsVersionSupported())
                 {
-                    NotSupportedReason =  $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {s_minWindowsVersion}.";
+                    NotSupportedReason = $"Current Windows version ({Environment.OSVersion}) is not supported by QUIC. Minimal supported version is {s_minWindowsVersion}.";
                     if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(null, NotSupportedReason);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -117,14 +117,48 @@ internal static class MsQuicConfiguration
 #pragma warning restore SYSLIB0040
 
         QUIC_SETTINGS settings = default(QUIC_SETTINGS);
+
         settings.IsSet.PeerUnidiStreamCount = 1;
         settings.PeerUnidiStreamCount = (ushort)options.MaxInboundUnidirectionalStreams;
+
         settings.IsSet.PeerBidiStreamCount = 1;
         settings.PeerBidiStreamCount = (ushort)options.MaxInboundBidirectionalStreams;
+
         if (options.IdleTimeout != TimeSpan.Zero)
         {
             settings.IsSet.IdleTimeoutMs = 1;
             settings.IdleTimeoutMs = options.IdleTimeout != Timeout.InfiniteTimeSpan ? (ulong)options.IdleTimeout.TotalMilliseconds : 0;
+        }
+
+        if (options.KeepAliveInterval != TimeSpan.Zero)
+        {
+            settings.IsSet.KeepAliveIntervalMs = 1;
+            settings.KeepAliveIntervalMs = (uint)options.KeepAliveInterval.TotalMilliseconds;
+        }
+
+        if (options.InitialConnectionWindowSize > 0)
+        {
+            settings.IsSet.ConnFlowControlWindow = 1;
+            settings.ConnFlowControlWindow = (uint)options.InitialConnectionWindowSize;
+        }
+
+        // todo: these values need all to be powers of 2
+        if (options.InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize > 0)
+        {
+            settings.IsSet.StreamRecvWindowBidiLocalDefault = 1;
+            settings.StreamRecvWindowBidiLocalDefault = (uint)options.InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize;
+        }
+
+        if (options.InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize > 0)
+        {
+            settings.IsSet.StreamRecvWindowBidiRemoteDefault = 1;
+            settings.StreamRecvWindowBidiRemoteDefault = (uint)options.InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize;
+        }
+
+        if (options.InitialUnidirectionalStreamReceiveWindowSize > 0)
+        {
+            settings.IsSet.StreamRecvWindowUnidiDefault = 1;
+            settings.StreamRecvWindowUnidiDefault = (uint)options.InitialUnidirectionalStreamReceiveWindowSize;
         }
 
         QUIC_HANDLE* handle;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -132,27 +132,33 @@ internal static class MsQuicConfiguration
                 : 0; // 0 disables the timeout
         }
 
-        settings.IsSet.KeepAliveIntervalMs = 1;
-        settings.KeepAliveIntervalMs = options.KeepAliveInterval != Timeout.InfiniteTimeSpan
-            ? (uint)options.KeepAliveInterval.TotalMilliseconds
-            : 0; // 0 disables the keepalive
+        if (options.KeepAliveInterval != TimeSpan.Zero)
+        {
+            settings.IsSet.KeepAliveIntervalMs = 1;
+            settings.KeepAliveIntervalMs = options.KeepAliveInterval != Timeout.InfiniteTimeSpan
+                ? (uint)options.KeepAliveInterval.TotalMilliseconds
+                : 0; // 0 disables the keepalive
+        }
 
         settings.IsSet.ConnFlowControlWindow = 1;
-        settings.ConnFlowControlWindow = (uint)options.InitialReceiveWindowSizes.Connection;
+        settings.ConnFlowControlWindow = (uint)(options._initialRecieveWindowSizes?.Connection ?? QuicDefaults.DefaultConnectionMaxData);
 
         settings.IsSet.StreamRecvWindowBidiLocalDefault = 1;
-        settings.StreamRecvWindowBidiLocalDefault = (uint)options.InitialReceiveWindowSizes.LocallyInitiatedBidirectionalStream;
+        settings.StreamRecvWindowBidiLocalDefault = (uint)(options._initialRecieveWindowSizes?.LocallyInitiatedBidirectionalStream ?? QuicDefaults.DefaultStreamMaxData);
 
         settings.IsSet.StreamRecvWindowBidiRemoteDefault = 1;
-        settings.StreamRecvWindowBidiRemoteDefault = (uint)options.InitialReceiveWindowSizes.RemotelyInitiatedBidirectionalStream;
+        settings.StreamRecvWindowBidiRemoteDefault = (uint)(options._initialRecieveWindowSizes?.RemotelyInitiatedBidirectionalStream ?? QuicDefaults.DefaultStreamMaxData);
 
         settings.IsSet.StreamRecvWindowUnidiDefault = 1;
-        settings.StreamRecvWindowUnidiDefault = (uint)options.InitialReceiveWindowSizes.UnidirectionalStream;
+        settings.StreamRecvWindowUnidiDefault = (uint)(options._initialRecieveWindowSizes?.UnidirectionalStream ?? QuicDefaults.DefaultStreamMaxData);
 
-        settings.IsSet.HandshakeIdleTimeoutMs = 1;
-        settings.HandshakeIdleTimeoutMs = options.HandshakeTimeout != Timeout.InfiniteTimeSpan
-                ? (ulong)options.HandshakeTimeout.TotalMilliseconds
-                : 0; // 0 disables the timeout
+        if (options.HandshakeTimeout != TimeSpan.Zero)
+        {
+            settings.IsSet.HandshakeIdleTimeoutMs = 1;
+            settings.HandshakeIdleTimeoutMs = options.HandshakeTimeout != Timeout.InfiniteTimeSpan
+                    ? (ulong)options.HandshakeTimeout.TotalMilliseconds
+                    : 0; // 0 disables the timeout
+        }
 
         QUIC_HANDLE* handle;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -124,17 +124,18 @@ internal static class MsQuicConfiguration
         settings.IsSet.PeerBidiStreamCount = 1;
         settings.PeerBidiStreamCount = (ushort)options.MaxInboundBidirectionalStreams;
 
-        if (options.IdleTimeout != Timeout.InfiniteTimeSpan)
+        if (options.IdleTimeout != TimeSpan.Zero)
         {
             settings.IsSet.IdleTimeoutMs = 1;
-            settings.IdleTimeoutMs = (uint)options.IdleTimeout.TotalMilliseconds;
+            settings.IdleTimeoutMs = options.IdleTimeout != Timeout.InfiniteTimeSpan
+                ? (ulong)options.IdleTimeout.TotalMilliseconds
+                : 0; // 0 disables the timeout
         }
 
-        if (options.KeepAliveInterval != Timeout.InfiniteTimeSpan)
-        {
-            settings.IsSet.KeepAliveIntervalMs = 1;
-            settings.KeepAliveIntervalMs = (uint)options.KeepAliveInterval.TotalMilliseconds;
-        }
+        settings.IsSet.KeepAliveIntervalMs = 1;
+        settings.KeepAliveIntervalMs = options.KeepAliveInterval != Timeout.InfiniteTimeSpan
+            ? (uint)options.KeepAliveInterval.TotalMilliseconds
+            : 0; // 0 disables the keepalive
 
         settings.IsSet.ConnFlowControlWindow = 1;
         settings.ConnFlowControlWindow = (uint)options.InitialReceiveWindowSizes.Connection;
@@ -147,6 +148,11 @@ internal static class MsQuicConfiguration
 
         settings.IsSet.StreamRecvWindowUnidiDefault = 1;
         settings.StreamRecvWindowUnidiDefault = (uint)options.InitialReceiveWindowSizes.UnidirectionalStream;
+
+        settings.IsSet.HandshakeIdleTimeoutMs = 1;
+        settings.HandshakeIdleTimeoutMs = options.HandshakeTimeout != Timeout.InfiniteTimeSpan
+                ? (ulong)options.HandshakeTimeout.TotalMilliseconds
+                : 0; // 0 disables the timeout
 
         QUIC_HANDLE* handle;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -124,42 +124,29 @@ internal static class MsQuicConfiguration
         settings.IsSet.PeerBidiStreamCount = 1;
         settings.PeerBidiStreamCount = (ushort)options.MaxInboundBidirectionalStreams;
 
-        if (options.IdleTimeout != TimeSpan.Zero)
+        if (options.IdleTimeout != Timeout.InfiniteTimeSpan)
         {
             settings.IsSet.IdleTimeoutMs = 1;
-            settings.IdleTimeoutMs = options.IdleTimeout != Timeout.InfiniteTimeSpan ? (ulong)options.IdleTimeout.TotalMilliseconds : 0;
+            settings.IdleTimeoutMs = (uint)options.IdleTimeout.TotalMilliseconds;
         }
 
-        if (options.KeepAliveInterval != TimeSpan.Zero)
+        if (options.KeepAliveInterval != Timeout.InfiniteTimeSpan)
         {
             settings.IsSet.KeepAliveIntervalMs = 1;
             settings.KeepAliveIntervalMs = (uint)options.KeepAliveInterval.TotalMilliseconds;
         }
 
-        if (options.InitialConnectionWindowSize > 0)
-        {
-            settings.IsSet.ConnFlowControlWindow = 1;
-            settings.ConnFlowControlWindow = (uint)options.InitialConnectionWindowSize;
-        }
+        settings.IsSet.ConnFlowControlWindow = 1;
+        settings.ConnFlowControlWindow = (uint)options.InitialReceiveWindowSizes.Connection;
 
-        // todo: these values need all to be powers of 2
-        if (options.InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize > 0)
-        {
-            settings.IsSet.StreamRecvWindowBidiLocalDefault = 1;
-            settings.StreamRecvWindowBidiLocalDefault = (uint)options.InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize;
-        }
+        settings.IsSet.StreamRecvWindowBidiLocalDefault = 1;
+        settings.StreamRecvWindowBidiLocalDefault = (uint)options.InitialReceiveWindowSizes.LocallyInitiatedBidirectionalStream;
 
-        if (options.InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize > 0)
-        {
-            settings.IsSet.StreamRecvWindowBidiRemoteDefault = 1;
-            settings.StreamRecvWindowBidiRemoteDefault = (uint)options.InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize;
-        }
+        settings.IsSet.StreamRecvWindowBidiRemoteDefault = 1;
+        settings.StreamRecvWindowBidiRemoteDefault = (uint)options.InitialReceiveWindowSizes.RemotelyInitiatedBidirectionalStream;
 
-        if (options.InitialUnidirectionalStreamReceiveWindowSize > 0)
-        {
-            settings.IsSet.StreamRecvWindowUnidiDefault = 1;
-            settings.StreamRecvWindowUnidiDefault = (uint)options.InitialUnidirectionalStreamReceiveWindowSize;
-        }
+        settings.IsSet.StreamRecvWindowUnidiDefault = 1;
+        settings.StreamRecvWindowUnidiDefault = (uint)options.InitialReceiveWindowSizes.UnidirectionalStream;
 
         QUIC_HANDLE* handle;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic_generated.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Interop/msquic_generated.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Quic
         NONE = 0x0000,
         UNIDIRECTIONAL = 0x0001,
         ZERO_RTT = 0x0002,
-        DELAY_FC_UPDATES = 0x0004,
+        DELAY_ID_FC_UPDATES = 0x0004,
     }
 
     [System.Flags]
@@ -211,6 +211,7 @@ namespace Microsoft.Quic
     {
         NONE = 0x0000,
         QTIP = 0x0001,
+        RIO = 0x0002,
     }
 
     internal unsafe partial struct QUIC_EXECUTION_CONFIG
@@ -764,17 +765,31 @@ namespace Microsoft.Quic
             }
         }
 
-        [NativeTypeName("uint32_t : 26")]
-        internal uint RESERVED
+        [NativeTypeName("uint32_t : 1")]
+        internal uint EncryptionOffloaded
         {
             get
             {
-                return (_bitfield >> 6) & 0x3FFFFFFu;
+                return (_bitfield >> 6) & 0x1u;
             }
 
             set
             {
-                _bitfield = (_bitfield & ~(0x3FFFFFFu << 6)) | ((value & 0x3FFFFFFu) << 6);
+                _bitfield = (_bitfield & ~(0x1u << 6)) | ((value & 0x1u) << 6);
+            }
+        }
+
+        [NativeTypeName("uint32_t : 25")]
+        internal uint RESERVED
+        {
+            get
+            {
+                return (_bitfield >> 7) & 0x1FFFFFFu;
+            }
+
+            set
+            {
+                _bitfield = (_bitfield & ~(0x1FFFFFFu << 7)) | ((value & 0x1FFFFFFu) << 7);
             }
         }
 
@@ -1231,6 +1246,15 @@ namespace Microsoft.Quic
         [NativeTypeName("QUIC_SETTINGS::(anonymous union)")]
         internal _Anonymous2_e__Union Anonymous2;
 
+        [NativeTypeName("uint32_t")]
+        internal uint StreamRecvWindowBidiLocalDefault;
+
+        [NativeTypeName("uint32_t")]
+        internal uint StreamRecvWindowBidiRemoteDefault;
+
+        [NativeTypeName("uint32_t")]
+        internal uint StreamRecvWindowUnidiDefault;
+
         internal ref ulong IsSetFlags
         {
             get
@@ -1265,6 +1289,45 @@ namespace Microsoft.Quic
             set
             {
                 Anonymous2.Anonymous.HyStartEnabled = value;
+            }
+        }
+
+        internal ulong EncryptionOffloadAllowed
+        {
+            get
+            {
+                return Anonymous2.Anonymous.EncryptionOffloadAllowed;
+            }
+
+            set
+            {
+                Anonymous2.Anonymous.EncryptionOffloadAllowed = value;
+            }
+        }
+
+        internal ulong ReliableResetEnabled
+        {
+            get
+            {
+                return Anonymous2.Anonymous.ReliableResetEnabled;
+            }
+
+            set
+            {
+                Anonymous2.Anonymous.ReliableResetEnabled = value;
+            }
+        }
+
+        internal ulong OneWayDelayEnabled
+        {
+            get
+            {
+                return Anonymous2.Anonymous.OneWayDelayEnabled;
+            }
+
+            set
+            {
+                Anonymous2.Anonymous.OneWayDelayEnabled = value;
             }
         }
 
@@ -1786,17 +1849,101 @@ namespace Microsoft.Quic
                     }
                 }
 
-                [NativeTypeName("uint64_t : 29")]
-                internal ulong RESERVED
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong StreamRecvWindowBidiLocalDefault
                 {
                     get
                     {
-                        return (_bitfield >> 35) & 0x1FFFFFFFUL;
+                        return (_bitfield >> 35) & 0x1UL;
                     }
 
                     set
                     {
-                        _bitfield = (_bitfield & ~(0x1FFFFFFFUL << 35)) | ((value & 0x1FFFFFFFUL) << 35);
+                        _bitfield = (_bitfield & ~(0x1UL << 35)) | ((value & 0x1UL) << 35);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong StreamRecvWindowBidiRemoteDefault
+                {
+                    get
+                    {
+                        return (_bitfield >> 36) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 36)) | ((value & 0x1UL) << 36);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong StreamRecvWindowUnidiDefault
+                {
+                    get
+                    {
+                        return (_bitfield >> 37) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 37)) | ((value & 0x1UL) << 37);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong EncryptionOffloadAllowed
+                {
+                    get
+                    {
+                        return (_bitfield >> 38) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 38)) | ((value & 0x1UL) << 38);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong ReliableResetEnabled
+                {
+                    get
+                    {
+                        return (_bitfield >> 39) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 39)) | ((value & 0x1UL) << 39);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong OneWayDelayEnabled
+                {
+                    get
+                    {
+                        return (_bitfield >> 40) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 40)) | ((value & 0x1UL) << 40);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 23")]
+                internal ulong RESERVED
+                {
+                    get
+                    {
+                        return (_bitfield >> 41) & 0x7FFFFFUL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x7FFFFFUL << 41)) | ((value & 0x7FFFFFUL) << 41);
                     }
                 }
             }
@@ -1831,17 +1978,59 @@ namespace Microsoft.Quic
                     }
                 }
 
-                [NativeTypeName("uint64_t : 63")]
-                internal ulong ReservedFlags
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong EncryptionOffloadAllowed
                 {
                     get
                     {
-                        return (_bitfield >> 1) & 0x7FFFFFFFUL;
+                        return (_bitfield >> 1) & 0x1UL;
                     }
 
                     set
                     {
-                        _bitfield = (_bitfield & ~(0x7FFFFFFFUL << 1)) | ((value & 0x7FFFFFFFUL) << 1);
+                        _bitfield = (_bitfield & ~(0x1UL << 1)) | ((value & 0x1UL) << 1);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong ReliableResetEnabled
+                {
+                    get
+                    {
+                        return (_bitfield >> 2) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 2)) | ((value & 0x1UL) << 2);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 1")]
+                internal ulong OneWayDelayEnabled
+                {
+                    get
+                    {
+                        return (_bitfield >> 3) & 0x1UL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0x1UL << 3)) | ((value & 0x1UL) << 3);
+                    }
+                }
+
+                [NativeTypeName("uint64_t : 60")]
+                internal ulong ReservedFlags
+                {
+                    get
+                    {
+                        return (_bitfield >> 4) & 0xFFFFFFFUL;
+                    }
+
+                    set
+                    {
+                        _bitfield = (_bitfield & ~(0xFFFFFFFUL << 4)) | ((value & 0xFFFFFFFUL) << 4);
                     }
                 }
             }
@@ -2123,6 +2312,8 @@ namespace Microsoft.Quic
         RESUMED = 13,
         RESUMPTION_TICKET_RECEIVED = 14,
         PEER_CERTIFICATE_RECEIVED = 15,
+        RELIABLE_RESET_NEGOTIATED = 16,
+        ONE_WAY_DELAY_NEGOTIATED = 17,
     }
 
     internal partial struct QUIC_CONNECTION_EVENT
@@ -2260,6 +2451,22 @@ namespace Microsoft.Quic
             }
         }
 
+        internal ref _Anonymous_e__Union._RELIABLE_RESET_NEGOTIATED_e__Struct RELIABLE_RESET_NEGOTIATED
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.RELIABLE_RESET_NEGOTIATED, 1));
+            }
+        }
+
+        internal ref _Anonymous_e__Union._ONE_WAY_DELAY_NEGOTIATED_e__Struct ONE_WAY_DELAY_NEGOTIATED
+        {
+            get
+            {
+                return ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Anonymous.ONE_WAY_DELAY_NEGOTIATED, 1));
+            }
+        }
+
         [StructLayout(LayoutKind.Explicit)]
         internal partial struct _Anonymous_e__Union
         {
@@ -2326,6 +2533,14 @@ namespace Microsoft.Quic
             [FieldOffset(0)]
             [NativeTypeName("struct (anonymous struct)")]
             internal _PEER_CERTIFICATE_RECEIVED_e__Struct PEER_CERTIFICATE_RECEIVED;
+
+            [FieldOffset(0)]
+            [NativeTypeName("struct (anonymous struct)")]
+            internal _RELIABLE_RESET_NEGOTIATED_e__Struct RELIABLE_RESET_NEGOTIATED;
+
+            [FieldOffset(0)]
+            [NativeTypeName("struct (anonymous struct)")]
+            internal _ONE_WAY_DELAY_NEGOTIATED_e__Struct ONE_WAY_DELAY_NEGOTIATED;
 
             internal unsafe partial struct _CONNECTED_e__Struct
             {
@@ -2440,6 +2655,9 @@ namespace Microsoft.Quic
             {
                 [NativeTypeName("uint16_t")]
                 internal ushort IdealProcessor;
+
+                [NativeTypeName("uint16_t")]
+                internal ushort PartitionIndex;
             }
 
             internal partial struct _DATAGRAM_STATE_CHANGED_e__Struct
@@ -2497,6 +2715,21 @@ namespace Microsoft.Quic
 
                 [NativeTypeName("QUIC_CERTIFICATE_CHAIN *")]
                 internal void* Chain;
+            }
+
+            internal partial struct _RELIABLE_RESET_NEGOTIATED_e__Struct
+            {
+                [NativeTypeName("BOOLEAN")]
+                internal byte IsNegotiated;
+            }
+
+            internal partial struct _ONE_WAY_DELAY_NEGOTIATED_e__Struct
+            {
+                [NativeTypeName("BOOLEAN")]
+                internal byte SendNegotiated;
+
+                [NativeTypeName("BOOLEAN")]
+                internal byte ReceiveNegotiated;
             }
         }
     }
@@ -2895,6 +3128,9 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_MAX_RESUMPTION_APP_DATA_LENGTH 1000")]
         internal const uint QUIC_MAX_RESUMPTION_APP_DATA_LENGTH = 1000;
 
+        [NativeTypeName("#define QUIC_STATELESS_RESET_KEY_LENGTH 32")]
+        internal const uint QUIC_STATELESS_RESET_KEY_LENGTH = 32;
+
         [NativeTypeName("#define QUIC_EXECUTION_CONFIG_MIN_SIZE (uint32_t)FIELD_OFFSET(QUIC_EXECUTION_CONFIG, ProcessorList)")]
         internal static readonly uint QUIC_EXECUTION_CONFIG_MIN_SIZE = unchecked((uint)((int)(Marshal.OffsetOf<QUIC_EXECUTION_CONFIG>("ProcessorList"))));
 
@@ -2960,6 +3196,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_PARAM_GLOBAL_TLS_PROVIDER 0x0100000A")]
         internal const uint QUIC_PARAM_GLOBAL_TLS_PROVIDER = 0x0100000A;
+
+        [NativeTypeName("#define QUIC_PARAM_GLOBAL_STATELESS_RESET_KEY 0x0100000B")]
+        internal const uint QUIC_PARAM_GLOBAL_STATELESS_RESET_KEY = 0x0100000B;
 
         [NativeTypeName("#define QUIC_PARAM_CONFIGURATION_SETTINGS 0x03000000")]
         internal const uint QUIC_PARAM_CONFIGURATION_SETTINGS = 0x03000000;
@@ -3054,6 +3293,9 @@ namespace Microsoft.Quic
         [NativeTypeName("#define QUIC_PARAM_CONN_STATISTICS_V2_PLAT 0x05000017")]
         internal const uint QUIC_PARAM_CONN_STATISTICS_V2_PLAT = 0x05000017;
 
+        [NativeTypeName("#define QUIC_PARAM_CONN_ORIG_DEST_CID 0x05000018")]
+        internal const uint QUIC_PARAM_CONN_ORIG_DEST_CID = 0x05000018;
+
         [NativeTypeName("#define QUIC_PARAM_TLS_HANDSHAKE_INFO 0x06000000")]
         internal const uint QUIC_PARAM_TLS_HANDSHAKE_INFO = 0x06000000;
 
@@ -3083,6 +3325,9 @@ namespace Microsoft.Quic
 
         [NativeTypeName("#define QUIC_PARAM_STREAM_STATISTICS 0X08000004")]
         internal const uint QUIC_PARAM_STREAM_STATISTICS = 0X08000004;
+
+        [NativeTypeName("#define QUIC_PARAM_STREAM_RELIABLE_OFFSET 0x08000005")]
+        internal const uint QUIC_PARAM_STREAM_RELIABLE_OFFSET = 0x08000005;
 
         [NativeTypeName("#define QUIC_API_VERSION_2 2")]
         internal const uint QUIC_API_VERSION_2 = 2;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -76,8 +76,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
-                // connect timeout elapsed, since handshake is not done yet, application error code
-                // is not applied yet.
+                // handshake timeout elapsed, tear down the connection.
+                // Note that since handshake is not done yet, application error code is not sent.
                 await connection.DisposeAsync().ConfigureAwait(false);
 
                 throw new QuicException(QuicError.ConnectionTimeout, null, SR.Format(SR.net_quic_handshake_timeout, options.HandshakeTimeout));

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -105,6 +105,9 @@ public sealed partial class QuicConnection : IAsyncDisposable
     private readonly ValueTaskSource _connectedTcs = new ValueTaskSource();
     private readonly ValueTaskSource _shutdownTcs = new ValueTaskSource();
 
+    private readonly CancellationTokenSource _shutdownCancellationTokenSource = new CancellationTokenSource();
+    internal CancellationToken ShutdownCancellationToken => _shutdownCancellationTokenSource.Token;
+
     private readonly Channel<QuicStream> _acceptQueue = Channel.CreateUnbounded<QuicStream>(new UnboundedChannelOptions()
     {
         SingleWriter = true
@@ -509,6 +512,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _acceptQueue.Writer.TryComplete(exception);
         _connectedTcs.TrySetException(exception);
         _shutdownTcs.TrySetResult();
+        _shutdownCancellationTokenSource.Cancel();
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventLocalAddressChanged(ref LOCAL_ADDRESS_CHANGED_DATA data)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -523,7 +523,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             return QUIC_STATUS_SUCCESS;
         }
 
-        data.Flags |= QUIC_STREAM_OPEN_FLAGS.DELAY_FC_UPDATES;
+        data.Flags |= QUIC_STREAM_OPEN_FLAGS.DELAY_ID_FC_UPDATES;
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventPeerCertificateReceived(ref PEER_CERTIFICATE_RECEIVED_DATA data)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -55,6 +55,42 @@ public abstract class QuicConnectionOptions
     public long DefaultCloseErrorCode { get; set; } = -1;
 
     /// <summary>
+    /// The interval at which keep alive packets are sent on the connection.
+    /// Default <see cref="TimeSpan.Zero"/> means underlying implementation default interval.
+    /// </summary>
+    public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// The initial flow-control window size for the connection.
+    /// Default 0 to leave the window size to the implementation.
+    /// </summary>
+    public int InitialConnectionWindowSize { get; set; } = 0;
+
+    /// <summary>
+    /// The initial flow-control window size for locally initiated bidirectional streams.
+    /// Default 0 to leave the window size to the implementation.
+    /// </summary>
+    public int InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize { get; set; } = 0;
+
+    /// <summary>
+    /// The initial flow-control window size for remotely initiated bidirectional streams.
+    /// Default 0 to leave the window size to the implementation.
+    /// </summary>
+    public int InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize { get; set; } = 0;
+
+    /// <summary>
+    /// The initial flow-control window size for (remotely initiated) unidirectional streams.
+    /// Default 0 to leave the window size to the implementation.
+    /// </summary>
+    public int InitialUnidirectionalStreamReceiveWindowSize { get; set; } = 0;
+
+    /// <summary>
+    /// The initial flow-control window size for (remotely initiated) unidirectional streams.
+    /// Default 0 to leave the window size to the implementation.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
     /// Validates the options and potentially sets platform specific defaults.
     /// </summary>
     /// <param name="argumentName">Name of the from the caller.</param>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -85,8 +85,8 @@ public abstract class QuicConnectionOptions
     public int InitialUnidirectionalStreamReceiveWindowSize { get; set; } = 0;
 
     /// <summary>
-    /// The initial flow-control window size for (remotely initiated) unidirectional streams.
-    /// Default 0 to leave the window size to the implementation.
+    /// The upper bound on time when the handshake must complete. If the handshake does not
+    /// complete in this time, the connection is aborted.
     /// </summary>
     public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.Zero;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -2,9 +2,52 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Net.Quic;
+
+/// <summary>
+/// Collection of receive window sizes for <see cref="QuicConnection"/> as a whole and individual <see cref="QuicStream"/> types.
+/// </summary>
+public sealed class QuicReceiveWindowSizes
+{
+    /// <summary>
+    /// The initial flow-control window size for the connection.
+    /// </summary>
+    public int Connection { get; set; } = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// The initial flow-control window size for locally initiated bidirectional streams.
+    /// </summary>
+    public int LocallyInitiatedBidirectionalStream { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// The initial flow-control window size for remotely initiated bidirectional streams.
+    /// </summary>
+    public int RemotelyInitiatedBidirectionalStream { get; set; } = 64 * 1024;
+
+    /// <summary>
+    /// The initial flow-control window size for (remotely initiated) unidirectional streams.
+    /// </summary>
+    public int UnidirectionalStream { get; set; } = 64 * 1024;
+
+    internal void Validate(string argumentName)
+    {
+        ValidatePowerOf2(argumentName, Connection);
+        ValidatePowerOf2(argumentName, LocallyInitiatedBidirectionalStream);
+        ValidatePowerOf2(argumentName, RemotelyInitiatedBidirectionalStream);
+        ValidatePowerOf2(argumentName, UnidirectionalStream);
+
+        static void ValidatePowerOf2(string argumentName, int value, [CallerArgumentExpression(nameof(value))] string? propertyName = null)
+        {
+            if (value <= 0 || ((value - 1) & value) != 0)
+            {
+                throw new ArgumentOutOfRangeException(argumentName, value, SR.Format(SR.net_quic_power_of_2, $"{nameof(QuicConnectionOptions.InitialReceiveWindowSizes)}.{propertyName}"));
+            }
+        }
+    }
+}
 
 /// <summary>
 /// Shared options for both client (outbound) and server (inbound) <see cref="QuicConnection" />.
@@ -54,41 +97,27 @@ public abstract class QuicConnectionOptions
     // We can safely use this to distinguish if user provided value during validation.
     public long DefaultCloseErrorCode { get; set; } = -1;
 
+    private QuicReceiveWindowSizes? _initialRecieveWindowSizes;
+
+    /// <summary>
+    /// The initial receive window sizes for the connection and individual stream types.
+    /// </summary>
+    public QuicReceiveWindowSizes InitialReceiveWindowSizes
+    {
+        get => _initialRecieveWindowSizes ??= new QuicReceiveWindowSizes();
+        set => _initialRecieveWindowSizes = value;
+    }
+
     /// <summary>
     /// The interval at which keep alive packets are sent on the connection.
-    /// Default <see cref="TimeSpan.Zero"/> means underlying implementation default interval.
     /// </summary>
-    public TimeSpan KeepAliveInterval { get; set; } = TimeSpan.Zero;
-
-    /// <summary>
-    /// The initial flow-control window size for the connection.
-    /// Default 0 to leave the window size to the implementation.
-    /// </summary>
-    public int InitialConnectionWindowSize { get; set; } = 0;
-
-    /// <summary>
-    /// The initial flow-control window size for locally initiated bidirectional streams.
-    /// Default 0 to leave the window size to the implementation.
-    /// </summary>
-    public int InitialLocallyInitiatedBidirectionalStreamReceiveWindowSize { get; set; } = 0;
-
-    /// <summary>
-    /// The initial flow-control window size for remotely initiated bidirectional streams.
-    /// Default 0 to leave the window size to the implementation.
-    /// </summary>
-    public int InitialRemotelyInitiatedBidirectionalStreamReceiveWindowSize { get; set; } = 0;
-
-    /// <summary>
-    /// The initial flow-control window size for (remotely initiated) unidirectional streams.
-    /// Default 0 to leave the window size to the implementation.
-    /// </summary>
-    public int InitialUnidirectionalStreamReceiveWindowSize { get; set; } = 0;
+    public TimeSpan KeepAliveInterval { get; set; } = Timeout.InfiniteTimeSpan;
 
     /// <summary>
     /// The upper bound on time when the handshake must complete. If the handshake does not
     /// complete in this time, the connection is aborted.
     /// </summary>
-    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.Zero;
+    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Validates the options and potentially sets platform specific defaults.
@@ -96,25 +125,30 @@ public abstract class QuicConnectionOptions
     /// <param name="argumentName">Name of the from the caller.</param>
     internal virtual void Validate(string argumentName)
     {
-        if (MaxInboundBidirectionalStreams < 0 || MaxInboundBidirectionalStreams > ushort.MaxValue)
+        ValidateInRange(argumentName, MaxInboundBidirectionalStreams, ushort.MaxValue);
+        ValidateInRange(argumentName, MaxInboundUnidirectionalStreams, ushort.MaxValue);
+        ValidateTimespan(argumentName, IdleTimeout);
+        ValidateTimespan(argumentName, KeepAliveInterval);
+        ValidateInRange(argumentName, DefaultCloseErrorCode, QuicDefaults.MaxErrorCodeValue);
+        ValidateInRange(argumentName, DefaultStreamErrorCode, QuicDefaults.MaxErrorCodeValue);
+        ValidateTimespan(argumentName, HandshakeTimeout);
+
+        _initialRecieveWindowSizes?.Validate(argumentName);
+
+        static void ValidateInRange(string argumentName, long value, long max, [CallerArgumentExpression(nameof(value))] string? propertyName = null)
         {
-            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundBidirectionalStreams), ushort.MaxValue), argumentName);
+            if (value < 0 || value > max)
+            {
+                throw new ArgumentOutOfRangeException(argumentName, value, SR.Format(SR.net_quic_in_range, propertyName, max));
+            }
         }
-        if (MaxInboundUnidirectionalStreams < 0 || MaxInboundUnidirectionalStreams > ushort.MaxValue)
+
+        static void ValidateTimespan(string argumentName, TimeSpan value, [CallerArgumentExpression(nameof(value))] string? propertyName = null)
         {
-            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.MaxInboundUnidirectionalStreams), ushort.MaxValue), argumentName);
-        }
-        if (IdleTimeout < TimeSpan.Zero && IdleTimeout != Timeout.InfiniteTimeSpan)
-        {
-            throw new ArgumentOutOfRangeException(nameof(QuicConnectionOptions.IdleTimeout), SR.net_quic_timeout_use_gt_zero);
-        }
-        if (DefaultStreamErrorCode < 0 || DefaultStreamErrorCode > QuicDefaults.MaxErrorCodeValue)
-        {
-            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultStreamErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
-        }
-        if (DefaultCloseErrorCode < 0 || DefaultCloseErrorCode > QuicDefaults.MaxErrorCodeValue)
-        {
-            throw new ArgumentOutOfRangeException(SR.Format(SR.net_quic_in_range, nameof(QuicConnectionOptions.DefaultCloseErrorCode), QuicDefaults.MaxErrorCodeValue), argumentName);
+            if (value < TimeSpan.Zero && value != Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentOutOfRangeException(argumentName, value, SR.Format(SR.net_quic_timeout_use_gt_zero, propertyName));
+            }
         }
     }
 }
@@ -159,13 +193,15 @@ public sealed class QuicClientConnectionOptions : QuicConnectionOptions
         base.Validate(argumentName);
 
         // The content of ClientAuthenticationOptions gets validate in MsQuicConfiguration.Create.
-        if (ClientAuthenticationOptions is null)
+        ValidateNotNull(argumentName, ClientAuthenticationOptions);
+        ValidateNotNull(argumentName, RemoteEndPoint);
+
+        static void ValidateNotNull(string argumentName, object value, [CallerArgumentExpression(nameof(value))] string? propertyName = null)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_not_null_open_connection, nameof(QuicClientConnectionOptions.ClientAuthenticationOptions)), argumentName);
-        }
-        if (RemoteEndPoint is null)
-        {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_not_null_open_connection, nameof(QuicClientConnectionOptions.RemoteEndPoint)), argumentName);
+            if (value is null)
+            {
+                throw new ArgumentNullException(argumentName, SR.Format(SR.net_quic_not_null_open_connection, propertyName));
+            }
         }
     }
 }
@@ -199,9 +235,14 @@ public sealed class QuicServerConnectionOptions : QuicConnectionOptions
         base.Validate(argumentName);
 
         // The content of ServerAuthenticationOptions gets validate in MsQuicConfiguration.Create.
-        if (ServerAuthenticationOptions is null)
+        ValidateNotNull(argumentName, ServerAuthenticationOptions);
+
+        static void ValidateNotNull(string argumentName, object value, [CallerArgumentExpression(nameof(value))] string? propertyName = null)
         {
-            throw new ArgumentNullException(SR.Format(SR.net_quic_not_null_accept_connection, nameof(QuicServerConnectionOptions.ServerAuthenticationOptions)), argumentName);
+            if (value is null)
+            {
+                throw new ArgumentNullException(argumentName, SR.Format(SR.net_quic_not_null_accept_connection, propertyName));
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -8,29 +8,29 @@ using System.Threading;
 namespace System.Net.Quic;
 
 /// <summary>
-/// Collection of receive window sizes for <see cref="QuicConnection"/> as a whole and individual <see cref="QuicStream"/> types.
+/// Collection of receive window sizes for <see cref="QuicConnection"/> as a whole and for individual <see cref="QuicStream"/> types.
 /// </summary>
 public sealed class QuicReceiveWindowSizes
 {
     /// <summary>
     /// The initial flow-control window size for the connection.
     /// </summary>
-    public int Connection { get; set; } = 16 * 1024 * 1024;
+    public int Connection { get; set; } = QuicDefaults.DefaultConnectionMaxData;
 
     /// <summary>
     /// The initial flow-control window size for locally initiated bidirectional streams.
     /// </summary>
-    public int LocallyInitiatedBidirectionalStream { get; set; } = 64 * 1024;
+    public int LocallyInitiatedBidirectionalStream { get; set; } = QuicDefaults.DefaultStreamMaxData;
 
     /// <summary>
     /// The initial flow-control window size for remotely initiated bidirectional streams.
     /// </summary>
-    public int RemotelyInitiatedBidirectionalStream { get; set; } = 64 * 1024;
+    public int RemotelyInitiatedBidirectionalStream { get; set; } = QuicDefaults.DefaultStreamMaxData;
 
     /// <summary>
     /// The initial flow-control window size for (remotely initiated) unidirectional streams.
     /// </summary>
-    public int UnidirectionalStream { get; set; } = 64 * 1024;
+    public int UnidirectionalStream { get; set; } = QuicDefaults.DefaultStreamMaxData;
 
     internal void Validate(string argumentName)
     {
@@ -110,12 +110,16 @@ public abstract class QuicConnectionOptions
 
     /// <summary>
     /// The interval at which keep alive packets are sent on the connection.
+    /// Value <see cref="TimeSpan.Zero"/> means underlying implementation default timeout.
+    /// Default <see cref="Timeout.InfiniteTimeSpan"/> means never sending keep alive packets.
     /// </summary>
     public TimeSpan KeepAliveInterval { get; set; } = Timeout.InfiniteTimeSpan;
 
     /// <summary>
     /// The upper bound on time when the handshake must complete. If the handshake does not
     /// complete in this time, the connection is aborted.
+    /// Value <see cref="TimeSpan.Zero"/> means underlying implementation default timeout.
+    /// Default timeout is 10 seconds.
     /// </summary>
     public TimeSpan HandshakeTimeout { get; set; } = QuicDefaults.HandshakeTimeout;
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -97,7 +97,7 @@ public abstract class QuicConnectionOptions
     // We can safely use this to distinguish if user provided value during validation.
     public long DefaultCloseErrorCode { get; set; } = -1;
 
-    private QuicReceiveWindowSizes? _initialRecieveWindowSizes;
+    internal QuicReceiveWindowSizes? _initialRecieveWindowSizes;
 
     /// <summary>
     /// The initial receive window sizes for the connection and individual stream types.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -117,7 +117,7 @@ public abstract class QuicConnectionOptions
     /// The upper bound on time when the handshake must complete. If the handshake does not
     /// complete in this time, the connection is aborted.
     /// </summary>
-    public TimeSpan HandshakeTimeout { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan HandshakeTimeout { get; set; } = QuicDefaults.HandshakeTimeout;
 
     /// <summary>
     /// Validates the options and potentially sets platform specific defaults.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
@@ -37,4 +37,14 @@ internal static partial class QuicDefaults
     /// Default handshake timeout (same default as MsQuic)
     /// </summary>
     public static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Default initial_max_data value.
+    /// </summary>
+    public static int DefaultConnectionMaxData = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// Default initial_max_stream_data_* value.
+    /// </summary>
+    public static int DefaultStreamMaxData = 64 * 1024;
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
@@ -34,7 +34,7 @@ internal static partial class QuicDefaults
     public const long MaxErrorCodeValue = (1L << 62) - 1;
 
     /// <summary>
-    /// Our own imposed timeout in the handshake process, since in certain cases MsQuic will not impose theirs, see <see href="https://github.com/microsoft/msquic/discussions/2705"/>.
+    /// Default handshake timeout (same default as MsQuic)
     /// </summary>
     public static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(10);
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicDefaults.cs
@@ -34,7 +34,7 @@ internal static partial class QuicDefaults
     public const long MaxErrorCodeValue = (1L << 62) - 1;
 
     /// <summary>
-    /// Default handshake timeout (same default as MsQuic)
+    /// Default handshake timeout.
     /// </summary>
     public static readonly TimeSpan HandshakeTimeout = TimeSpan.FromSeconds(10);
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -213,12 +213,13 @@ public sealed partial class QuicListener : IAsyncDisposable
 
         // In certain cases MsQuic will not impose the handshake idle timeout on their side, see
         // https://github.com/microsoft/msquic/discussions/2705.
-        // This will be assigned to before the linkec CTS is cancelled
+        // This will be assigned to before the linked CTS is cancelled
         TimeSpan handshakeTimeout = QuicDefaults.HandshakeTimeout;
         try
         {
             using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token);
             cancellationToken = linkedCts.Token;
+            // initial timeout for retrieving connection options
             linkedCts.CancelAfter(handshakeTimeout);
 
             wrapException = true;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -218,7 +218,7 @@ public sealed partial class QuicListener : IAsyncDisposable
         TimeSpan handshakeTimeout = QuicDefaults.HandshakeTimeout;
         try
         {
-            using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, connection.ShutdownCancellationToken);
+            using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, connection.ConnectionShutdownToken);
             cancellationToken = linkedCts.Token;
             // initial timeout for retrieving connection options
             linkedCts.CancelAfter(handshakeTimeout);
@@ -240,7 +240,7 @@ public sealed partial class QuicListener : IAsyncDisposable
                 await connection.DisposeAsync().ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException) when (connection.ShutdownCancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException) when (connection.ConnectionShutdownToken.IsCancellationRequested)
         {
             // Connection closed by peer
             if (NetEventSource.Log.IsEnabled())


### PR DESCRIPTION
Closes #72984.
Closes #70090.

Adds:
- KeepAliveInterval - sending ping frames to prevent the connection from idling out. (we may want to add the same property on QuicConnection itself so that users can turn pings on/off according to their needs)
- flow-control limits (max_data) - stream-level limits will have effect only with newer MsQuic having https://github.com/microsoft/msquic/pull/3948. 2.4+ should be it
- HandshakeTimeout - kills the connection if the handshake is not established in the given amount of time
  -  ServerOptionsCallback still has 10s timeout as before, once the callback returns, the timeout value from the options is applied. 
  The client times out as well.
  - Timeouts lead to peer receiving UserCanceled TLS Alert which is weird but is not against the spec, although getting CONNECTION_CLOSE with APPLICATION_ERROR would be more expected.
 
Other improvements:
- if the client terminates the connection during the handshake, CancellationToken passed to ServerOptionsCallback fires as well.
- Fix property names in ArgumentExceptions thrown from connection options validation (previously it put the message instead of the parameter name)