### PR TITLE
[browser][MT] enable timer tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -122,6 +122,7 @@ namespace System
 
         public static bool IsThreadingSupported => (!IsWasi && !IsBrowser) || IsWasmThreadingSupported;
         public static bool IsWasmThreadingSupported => IsBrowser && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");
+        public static bool IsNotWasmThreadingSupported => !IsWasmThreadingSupported;
         public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
 
         public static bool IsStartingProcessesSupported => !IsiOS && !IstvOS;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Legacy.UnitTests/System/Runtime/InteropServices/JavaScript/TimerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Legacy.UnitTests/System/Runtime/InteropServices/JavaScript/TimerTests.cs
@@ -24,6 +24,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
         [Theory]
         [MemberData(nameof(TestCases))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWasmThreadingSupported))] // this test only makes sense with ST TimerQueue
         public async Task TestTimers(int[] timeouts, int? expectedSetCounter, int? expectedSetCounterAfterCleanUp, int? expectedHitCount)
         {
             int wasCalled = 0;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Legacy.UnitTests/System/Runtime/InteropServices/JavaScript/TimerTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Legacy.UnitTests/System/Runtime/InteropServices/JavaScript/TimerTests.cs
@@ -22,7 +22,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             yield return new object[] { new[] { 800, 600, 400, 200, 100 }, 5, 13, 9 };
         }
 
-        [Theory]
         [MemberData(nameof(TestCases))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWasmThreadingSupported))] // this test only makes sense with ST TimerQueue
         public async Task TestTimers(int[] timeouts, int? expectedSetCounter, int? expectedSetCounterAfterCleanUp, int? expectedHitCount)

--- a/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
@@ -50,7 +50,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.Threading.Timer/tests/TimerDisposeTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerDisposeTests.cs
@@ -50,7 +50,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_DisposeDelayedUntilCallbacksComplete()
         {
             using (var b = new Barrier(2))
@@ -73,7 +72,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_MultipleDisposesBeforeCompletionReturnSameTask()
         {
             using (var b = new Barrier(2))
@@ -99,7 +97,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_AfterDisposeWorks()
         {
             using (var b = new Barrier(2))
@@ -123,7 +120,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_AfterDisposeWaitHandleThrows()
         {
             using (var b = new Barrier(2))
@@ -146,7 +142,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public async Task DisposeAsync_ThenDisposeWaitHandleReturnsFalse()
         {
             using (var b = new Barrier(2))

--- a/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -17,7 +17,6 @@ namespace System.Threading.Tests
         internal const int MaxPositiveTimeoutInMs = 30000;
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_After_DueTime_Ellapses()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -32,7 +31,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_AndPassesStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -49,7 +47,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Fires_AndPassesNullStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -125,7 +122,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_CanDisposeSelfInCallback()
         {
             Timer t = null;
@@ -153,7 +149,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void NonRepeatingTimer_ThatHasAlreadyFired_CanChangeAndFireAgain()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -168,7 +163,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void MultpleTimers_PeriodicTimerIsntBlockedByBlockedCallback()
         {
             int callbacks = 2;
@@ -189,7 +183,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void ManyTimers_EachTimerDoesFire()
         {
             int maxTimers = 10000;
@@ -207,7 +200,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Constructor_CallbackOnly_Change()
         {
             var e = new ManualResetEvent(false);
@@ -225,7 +217,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Timer_Dispose_WaitHandle()
         {
             int tickCount = 0;
@@ -371,7 +362,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91545", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TimersCreatedConcurrentlyOnDifferentThreadsAllFire()
         {
             int processorCount = Environment.ProcessorCount;


### PR DESCRIPTION
after we switched to portable timer in https://github.com/dotnet/runtime/pull/94180