### PR TITLE
[browser] Disable AOT Hybrid Globalization wbt

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/HybridGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/HybridGlobalizationTests.cs
@@ -22,6 +22,7 @@ namespace Wasm.Build.Tests
                 .WithRunHosts(host)
                 .UnwrapItemsAsArrays();
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/94212")]
         [Theory]
         [MemberData(nameof(HybridGlobalizationTestData), parameters: new object[] { /*aot*/ false, RunHost.All })]
         [MemberData(nameof(HybridGlobalizationTestData), parameters: new object[] { /*aot*/ true, RunHost.All })]


### PR DESCRIPTION
The wbt with HG and AOT is failing with error `The type initializer for 'System.Globalization.CultureInfo' threw an exception.`  after exposing `Lock` type (= after merging in https://github.com/dotnet/runtime/pull/87672). I do not see direct reason for the failure yet, disabling for the time of investigation.

Active issue: https://github.com/dotnet/runtime/issues/94212