### PR TITLE
[ILLink analyzer] Move dynamic object logic into dataflow analysis

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -27,8 +27,6 @@ namespace ILLink.RoslynAnalyzer
 		private protected abstract DiagnosticDescriptor RequiresAttributeMismatch { get; }
 		private protected abstract DiagnosticDescriptor RequiresOnStaticCtor { get; }
 
-		private protected virtual ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions { get; } = ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)>.Empty;
-
 		private protected virtual ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)> ExtraSyntaxNodeActions { get; } = ImmutableArray<(Action<SyntaxNodeAnalysisContext> Action, SyntaxKind[] SyntaxKind)>.Empty;
 		private protected virtual ImmutableArray<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)> ExtraSymbolActions { get; } = ImmutableArray<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)>.Empty;
 
@@ -102,10 +100,6 @@ namespace ILLink.RoslynAnalyzer
 						}
 					}
 				}, SyntaxKind.GenericName);
-
-				// Register any extra operation actions supported by the analyzer.
-				foreach (var extraOperationAction in ExtraOperationActions)
-					context.RegisterOperationAction (extraOperationAction.Action, extraOperationAction.OperationKind);
 
 				foreach (var extraSyntaxNodeAction in ExtraSyntaxNodeActions)
 					context.RegisterSyntaxNodeAction (extraSyntaxNodeAction.Action, extraSyntaxNodeAction.SyntaxKind);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresUnreferencedCodeAnalyzer.cs
@@ -19,23 +19,11 @@ namespace ILLink.RoslynAnalyzer
 
 		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode);
 		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeAttributeMismatch = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeAttributeMismatch);
-		static readonly DiagnosticDescriptor s_dynamicTypeInvocationRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCode,
-			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationTitle), SharedStrings.ResourceManager, typeof (SharedStrings)),
-			new LocalizableResourceString (nameof (SharedStrings.DynamicTypeInvocationMessage), SharedStrings.ResourceManager, typeof (SharedStrings)));
 		static readonly DiagnosticDescriptor s_makeGenericTypeRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericType);
 		static readonly DiagnosticDescriptor s_makeGenericMethodRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.MakeGenericMethod);
 		static readonly DiagnosticDescriptor s_requiresUnreferencedCodeOnStaticCtor = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnStaticConstructor);
 
 		static readonly DiagnosticDescriptor s_typeDerivesFromRucClassRule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.RequiresUnreferencedCodeOnBaseClass);
-
-		static readonly Action<OperationAnalysisContext> s_dynamicTypeInvocation = operationContext => {
-			if (FindContainingSymbol (operationContext, DiagnosticTargets.All) is ISymbol containingSymbol &&
-				containingSymbol.IsInRequiresScope (RequiresUnreferencedCodeAttribute, out _))
-				return;
-
-			operationContext.ReportDiagnostic (Diagnostic.Create (s_dynamicTypeInvocationRule,
-				operationContext.Operation.Syntax.GetLocation ()));
-		};
 
 		private Action<SymbolAnalysisContext> typeDerivesFromRucBase {
 			get {
@@ -56,7 +44,7 @@ namespace ILLink.RoslynAnalyzer
 		}
 
 		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-			ImmutableArray.Create (s_dynamicTypeInvocationRule, s_makeGenericMethodRule, s_makeGenericTypeRule, s_requiresUnreferencedCodeRule, s_requiresUnreferencedCodeAttributeMismatch, s_typeDerivesFromRucClassRule, s_requiresUnreferencedCodeOnStaticCtor);
+			ImmutableArray.Create (s_makeGenericMethodRule, s_makeGenericTypeRule, s_requiresUnreferencedCodeRule, s_requiresUnreferencedCodeAttributeMismatch, s_typeDerivesFromRucClassRule, s_requiresUnreferencedCodeOnStaticCtor);
 
 		private protected override string RequiresAttributeName => RequiresUnreferencedCodeAttribute;
 
@@ -89,11 +77,6 @@ namespace ILLink.RoslynAnalyzer
 		}
 		private protected override ImmutableArray<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)> ExtraSymbolActions =>
 			ImmutableArray.Create<(Action<SymbolAnalysisContext> Action, SymbolKind[] SymbolKind)> ((typeDerivesFromRucBase, new SymbolKind[] { SymbolKind.NamedType }));
-
-
-
-		private protected override ImmutableArray<(Action<OperationAnalysisContext> Action, OperationKind[] OperationKind)> ExtraOperationActions =>
-				ImmutableArray.Create ((s_dynamicTypeInvocation, new OperationKind[] { OperationKind.DynamicInvocation }));
 
 		protected override bool VerifyAttributeArguments (AttributeData attribute) =>
 			RequiresUnreferencedCodeUtils.VerifyRequiresUnreferencedCodeAttributeArguments (attribute);

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -33,13 +33,14 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		const int MaxTrackedArrayValues = 32;
 
 		public TrimAnalysisVisitor (
+			Compilation compilation,
 			LocalStateLattice<MultiValue, ValueSetLattice<SingleValue>> lattice,
 			ISymbol owningSymbol,
 			ControlFlowGraph methodCFG,
 			ImmutableDictionary<CaptureId, FlowCaptureKind> lValueFlowCaptures,
 			TrimAnalysisPatternStore trimAnalysisPatterns,
 			InterproceduralState<MultiValue, ValueSetLattice<SingleValue>> interproceduralState
-		) : base (lattice, owningSymbol, methodCFG, lValueFlowCaptures, interproceduralState)
+		) : base (compilation, lattice, owningSymbol, methodCFG, lValueFlowCaptures, interproceduralState)
 		{
 			_multiValueLattice = lattice.Lattice.ValueLattice;
 			TrimAnalysisPatterns = trimAnalysisPatterns;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
@@ -39,7 +39,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			ControlFlowGraph methodCFG,
 			ImmutableDictionary<CaptureId, FlowCaptureKind> lValueFlowCaptures,
 			InterproceduralState<MultiValue, ValueSetLattice<SingleValue>> interproceduralState)
-		 => new (Lattice, owningSymbol, methodCFG, lValueFlowCaptures, TrimAnalysisPatterns, interproceduralState);
+		 => new (Context.Compilation, Lattice, owningSymbol, methodCFG, lValueFlowCaptures, TrimAnalysisPatterns, interproceduralState);
 
 #if DEBUG
 #pragma warning disable CA1805 // Do not initialize unnecessarily

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicObjects.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicObjects.cs
@@ -14,6 +14,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[Reference ("Microsoft.CSharp.dll")]
 	public class DynamicObjects
 	{
+		// Note on discrepancies between analyzer and NativeAot:
+		// Analyzer doesn't produce RequiresDynamicCode warnings for dynamic invocations.
+		// Tracked by https://github.com/dotnet/runtime/issues/94427.
 		public static void Main ()
 		{
 			InvocationOnDynamicType.Test ();
@@ -26,7 +29,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class InvocationOnDynamicType
 		{
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void DynamicArgument ()
 			{
 				dynamic dynamicObject = "Some string";
@@ -45,15 +48,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void MethodWithDynamicParameter (dynamic arg)
 			{
 				arg.MethodWithDynamicParameter (arg);
 			}
 
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeConstructor")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
-			// TODO: analyzer hole!
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void ObjectCreationDynamicArgument ()
 			{
 				dynamic dynamicObject = "Some string";
@@ -78,14 +80,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class DynamicMemberReference
 		{
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetMember")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void Read (dynamic d)
 			{
 				var x = d.Member;
 			}
 
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetMember")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void Write (dynamic d)
 			{
 				d.Member = 0;
@@ -101,14 +103,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 		class DynamicIndexerAccess
 		{
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetIndex")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void Read (dynamic d)
 			{
 				var x = d[0];
 			}
 
 			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetIndex")]
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 			static void Write (dynamic d)
 			{
 				d[0] = 0;
@@ -126,7 +128,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RequiresUnreferencedCode("message")]
 			class ClassWithRequires
 			{
-				[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
+				[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)] // https://github.com/dotnet/runtime/issues/94427
 				public static void MethodWithDynamicArg (dynamic arg)
 				{
 					arg.DynamicInvocation ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicObjects.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/DynamicObjects.cs
@@ -25,9 +25,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class InvocationOnDynamicType
 		{
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Invoking members on dynamic types is not trimming-compatible.", ProducedBy = Tool.Analyzer)]
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void DynamicArgument ()
 			{
@@ -46,16 +44,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Invoking members on dynamic types is not trimming-compatible.", ProducedBy = Tool.Analyzer)]
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void MethodWithDynamicParameter (dynamic arg)
 			{
 				arg.MethodWithDynamicParameter (arg);
 			}
 
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeConstructor", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.InvokeConstructor")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			// TODO: analyzer hole!
 			static void ObjectCreationDynamicArgument ()
@@ -81,16 +77,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class DynamicMemberReference
 		{
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetMember", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetMember")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void Read (dynamic d)
 			{
 				var x = d.Member;
 			}
 
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetMember", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetMember")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void Write (dynamic d)
 			{
@@ -106,16 +100,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class DynamicIndexerAccess
 		{
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetIndex", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.GetIndex")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void Read (dynamic d)
 			{
 				var x = d[0];
 			}
 
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
-			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetIndex", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "Microsoft.CSharp.RuntimeBinder.Binder.SetIndex")]
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 			static void Write (dynamic d)
 			{
@@ -134,7 +126,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[RequiresUnreferencedCode("message")]
 			class ClassWithRequires
 			{
-				// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
 				[ExpectedWarning ("IL3050", ProducedBy = Tool.NativeAot)]
 				public static void MethodWithDynamicArg (dynamic arg)
 				{
@@ -151,7 +142,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		class InvocationOnDynamicTypeInMethodWithRUCDoesNotWarnTwoTimes ()
 		{
-			// Analyzer hole: https://github.com/dotnet/runtime/issues/94057
 			[RequiresUnreferencedCode ("We should only see the warning related to this annotation, and none about the dynamic type.")]
 			[RequiresDynamicCode ("We should only see the warning related to this annotation, and none about the dynamic type.")]
 			static void MethodWithRequires ()


### PR DESCRIPTION
Moves analysis of dynamic object invocations and related operations from the attribute analyzer into the dataflow analyzer. This lowers dynamic object operations into calls to methods on `Microsoft.CSharp.RuntimeBinder.Binder`, which have `RequiresUnreferencedCode` annotations, so that the analyzer produces the same warnings as ILLink.

Adds handling of previously unimplemented operations on dynamic objects.  Fixes https://github.com/dotnet/runtime/issues/94057

