### PR TITLE
Fix class construction recursion issue in `Lock` on NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/SynchronizedMethodHelpers.cs
@@ -26,7 +26,7 @@ namespace Internal.Runtime.CompilerHelpers
                 ObjectHeader.GetLockObject(obj) :
                 SyncTable.GetLockObject(resultOrIndex);
 
-            lck.TryEnterSlow(Timeout.Infinite, currentThreadID, obj);
+            lck.TryEnterSlow(Timeout.Infinite, currentThreadID);
             lockTaken = true;
         }
         private static void MonitorExit(object obj, ref bool lockTaken)
@@ -55,7 +55,7 @@ namespace Internal.Runtime.CompilerHelpers
                 ObjectHeader.GetLockObject(obj) :
                 SyncTable.GetLockObject(resultOrIndex);
 
-            lck.TryEnterSlow(Timeout.Infinite, currentThreadID, obj);
+            lck.TryEnterSlow(Timeout.Infinite, currentThreadID);
             lockTaken = true;
         }
         private static unsafe void MonitorExitStatic(MethodTable* pMT, ref bool lockTaken)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -178,6 +178,7 @@ namespace System.Threading
 
                 // Also initialize some types that are used later to prevent potential class construction cycles
                 NativeRuntimeEventSource.Log.IsEnabled();
+                using (new Monitor.DebugBlockingScope(null, Monitor.DebugBlockingItemType.MonitorCriticalSection, 0, out _)) { }
             }
             catch
             {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -54,12 +54,8 @@ namespace System.Threading
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private ThreadId TryEnterSlow(int timeoutMs, ThreadId currentThreadId) =>
-            TryEnterSlow(timeoutMs, currentThreadId, this);
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryEnterSlow(int timeoutMs, int currentManagedThreadId, object associatedObject) =>
-            TryEnterSlow(timeoutMs, new ThreadId((uint)currentManagedThreadId), associatedObject).IsInitialized;
+        internal bool TryEnterSlow(int timeoutMs, int currentManagedThreadId) =>
+            TryEnterSlow(timeoutMs, new ThreadId((uint)currentManagedThreadId)).IsInitialized;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool GetIsHeldByCurrentThread(int currentManagedThreadId)
@@ -178,7 +174,6 @@ namespace System.Threading
 
                 // Also initialize some types that are used later to prevent potential class construction cycles
                 NativeRuntimeEventSource.Log.IsEnabled();
-                using (new Monitor.DebugBlockingScope(null, Monitor.DebugBlockingItemType.MonitorCriticalSection, 0, out _)) { }
             }
             catch
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -290,11 +290,7 @@ namespace System.Threading
         private static bool IsAdaptiveSpinEnabled(short minSpinCount) => minSpinCount <= 0;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-#if !NATIVEAOT
         private ThreadId TryEnterSlow(int timeoutMs, ThreadId currentThreadId)
-#else
-        private ThreadId TryEnterSlow(int timeoutMs, ThreadId currentThreadId, object associatedObject)
-#endif
         {
             Debug.Assert(timeoutMs >= -1);
 
@@ -462,15 +458,6 @@ namespace System.Threading
             // exceptional paths.
             try
             {
-#if NATIVEAOT
-                using var debugBlockingScope =
-                    new Monitor.DebugBlockingScope(
-                        associatedObject,
-                        Monitor.DebugBlockingItemType.MonitorCriticalSection,
-                        timeoutMs,
-                        out _);
-#endif
-
                 Interlocked.Increment(ref s_contentionCount);
 
                 long waitStartTimeTicks = 0;


### PR DESCRIPTION
- The `Monitor` type was being constructed due to the use of `Monitor.DebugBlockingScope`, added that to the initialization phase so that the relevant type is initialized before it's used on the wait path
- A better alternative may be to move `DebugBlockingScope` to be under `Lock`, it would probably make more sense for `Monitor` to refer to `Lock` as it already does, than the inverse. Based on the comments the thread-static field is apparently bound-to in debugging scenarios currently. Something to look into, for now this should unblock the CI.
- Fixes https://github.com/dotnet/runtime/issues/94227