### PR TITLE
[release/8.0-staging] Socket Tests Disable

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -142,6 +142,7 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
+
             // Aborting sync operations for non-owning handles is not supported on Unix.
             if (!owning && UsesSync && !PlatformDetection.IsWindows)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets.Tests
 {
     public abstract class Connect<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
-        public Connect(ITestOutputHelper output) : base(output) { }
+        public Connect(ITestOutputHelper output) : base(output) {}
 
         [OuterLoop]
         [Theory]
@@ -241,27 +241,27 @@ namespace System.Net.Sockets.Tests
 
     public sealed class ConnectSync : Connect<SocketHelperArraySync>
     {
-        public ConnectSync(ITestOutputHelper output) : base(output) { }
+        public ConnectSync(ITestOutputHelper output) : base(output) {}
     }
 
     public sealed class ConnectSyncForceNonBlocking : Connect<SocketHelperSyncForceNonBlocking>
     {
-        public ConnectSyncForceNonBlocking(ITestOutputHelper output) : base(output) { }
+        public ConnectSyncForceNonBlocking(ITestOutputHelper output) : base(output) {}
     }
 
     public sealed class ConnectApm : Connect<SocketHelperApm>
     {
-        public ConnectApm(ITestOutputHelper output) : base(output) { }
+        public ConnectApm(ITestOutputHelper output) : base(output) {}
     }
 
     public sealed class ConnectTask : Connect<SocketHelperTask>
     {
-        public ConnectTask(ITestOutputHelper output) : base(output) { }
+        public ConnectTask(ITestOutputHelper output) : base(output) {}
     }
 
     public sealed class ConnectEap : Connect<SocketHelperEap>
     {
-        public ConnectEap(ITestOutputHelper output) : base(output) { }
+        public ConnectEap(ITestOutputHelper output) : base(output) {}
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -288,7 +288,7 @@ namespace System.Net.Sockets.Tests
             using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
             byte[] buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
-
+            
             var mre = new ManualResetEventSlim(false);
             var saea = new SocketAsyncEventArgs();
             saea.RemoteEndPoint = serverEp;
@@ -302,7 +302,7 @@ namespace System.Net.Sockets.Tests
             {
                 saea.SetBuffer(buffer.AsMemory(2, 4));
             }
-
+            
             saea.Completed += (_, __) => mre.Set();
 
             if (client.ConnectAsync(saea))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets.Tests
 {
     public abstract class Connect<T> : SocketTestHelperBase<T> where T : SocketHelperBase, new()
     {
-        public Connect(ITestOutputHelper output) : base(output) {}
+        public Connect(ITestOutputHelper output) : base(output) { }
 
         [OuterLoop]
         [Theory]
@@ -241,27 +241,27 @@ namespace System.Net.Sockets.Tests
 
     public sealed class ConnectSync : Connect<SocketHelperArraySync>
     {
-        public ConnectSync(ITestOutputHelper output) : base(output) {}
+        public ConnectSync(ITestOutputHelper output) : base(output) { }
     }
 
     public sealed class ConnectSyncForceNonBlocking : Connect<SocketHelperSyncForceNonBlocking>
     {
-        public ConnectSyncForceNonBlocking(ITestOutputHelper output) : base(output) {}
+        public ConnectSyncForceNonBlocking(ITestOutputHelper output) : base(output) { }
     }
 
     public sealed class ConnectApm : Connect<SocketHelperApm>
     {
-        public ConnectApm(ITestOutputHelper output) : base(output) {}
+        public ConnectApm(ITestOutputHelper output) : base(output) { }
     }
 
     public sealed class ConnectTask : Connect<SocketHelperTask>
     {
-        public ConnectTask(ITestOutputHelper output) : base(output) {}
+        public ConnectTask(ITestOutputHelper output) : base(output) { }
     }
 
     public sealed class ConnectEap : Connect<SocketHelperEap>
     {
-        public ConnectEap(ITestOutputHelper output) : base(output) {}
+        public ConnectEap(ITestOutputHelper output) : base(output) { }
 
         [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
@@ -288,7 +288,7 @@ namespace System.Net.Sockets.Tests
             using var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 
             byte[] buffer = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 };
-            
+
             var mre = new ManualResetEventSlim(false);
             var saea = new SocketAsyncEventArgs();
             saea.RemoteEndPoint = serverEp;
@@ -302,7 +302,7 @@ namespace System.Net.Sockets.Tests
             {
                 saea.SetBuffer(buffer.AsMemory(2, 4));
             }
-            
+
             saea.Completed += (_, __) => mre.Set();
 
             if (client.ConnectAsync(saea))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -142,7 +142,7 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
-            
+
             // Aborting sync operations for non-owning handles is not supported on Unix.
             if (!owning && UsesSync && !PlatformDetection.IsWindows)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -142,7 +142,6 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
-
             // Aborting sync operations for non-owning handles is not supported on Unix.
             if (!owning && UsesSync && !PlatformDetection.IsWindows)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -137,6 +137,12 @@ namespace System.Net.Sockets.Tests
         [InlineData("[::ffff:1.1.1.1]", true, false)]
         public async Task ConnectGetsCanceledByDispose(string addressString, bool useDns, bool owning)
         {
+            if (UsesSync && PlatformDetection.IsLinux)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
+                return;
+            }
+            
             // Aborting sync operations for non-owning handles is not supported on Unix.
             if (!owning && UsesSync && !PlatformDetection.IsWindows)
             {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -198,7 +198,6 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
-
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -198,7 +198,7 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
-            
+
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -198,6 +198,7 @@ namespace System.Net.Sockets.Tests
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
+
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -193,6 +193,12 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SocketMethods_WithBools_MemberData))]
         public void EventSource_SocketConnectFailure_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
+            if (connectMethod == "Sync" && PlatformDetection.IsLinux)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
+                return;
+            }
+            
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);


### PR DESCRIPTION
Related to #94149

Test-only change to decrease CI noise.

Disabling tests which started failing due to Linux Kernel regression (tracked by #94149):
- System.Net.Sockets.Tests.ConnectSync.ConnectGetsCanceledByDispose
- System.Net.Sockets.Tests.TelemetryTest.EventSource_SocketConnectFailure_LogsConnectFailed