### PR TITLE
[wasm][AOT] Disable Hybrid Globalization tests on Calendars

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -74,6 +74,9 @@
 
     <!-- Normally run with HighAOT, but disabling there, and for AOT - https://github.com/dotnet/runtime/issues/86164 -->
     <!-- <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" /> -->
+
+    <!-- https://github.com/dotnet/runtime/issues/94225 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\Hybrid\System.Globalization.Calendars.Hybrid.WASM.Tests.csproj" />
   </ItemGroup>
 
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/runtime/issues/94225.