### PR TITLE
Small cleanup for Lock in Mono

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Monitor.CoreCLR.cs
@@ -183,12 +183,10 @@ namespace System.Threading
             ObjPulseAll(obj);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         /// <summary>
         /// Gets the number of times there was contention upon trying to take a <see cref="Monitor"/>'s lock so far.
         /// </summary>
         public static long LockContentionCount => GetLockContentionCount() + Lock.ContentionCount;
-#pragma warning restore CA2252
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ObjectNative_GetMonitorLockContentionCount")]
         private static partial long GetLockContentionCount();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -3,8 +3,6 @@
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <!-- AD0001 : https://github.com/dotnet/runtime/issues/90356 -->
     <NoWarn>$(NoWarn);AD0001</NoWarn>
-    <!-- CA2252: Opt in to preview features before using them (Lock) -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -4,6 +4,9 @@
     <SharedGUID>c5ed3c1d-b572-46f1-8f96-522a85ce1179</SharedGUID>
     <StringResourcesName Condition="'$(StringResourcesName)' == ''">System.Private.CoreLib.Strings</StringResourcesName>
     <GenerateResourcesSubstitutions>true</GenerateResourcesSubstitutions>
+
+    <!-- CA2252: Opt in to preview features before using them (for System.Threading.Lock) -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <Import_RootNamespace />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -83,11 +83,9 @@ namespace System.Diagnostics.Tracing
             LogContentionLockCreated(LockID, AssociatedObjectID, ClrInstanceID);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionLockCreated(Lock lockObj) => ContentionLockCreated(lockObj.LockIdForEvents, lockObj.ObjectIdForEvents);
-#pragma warning restore CA2252
 
         [Event(81, Level = EventLevel.Informational, Message = Messages.ContentionStart, Task = Tasks.Contention, Opcode = EventOpcode.Start, Version = 2, Keywords = Keywords.ContentionKeyword)]
         private void ContentionStart(
@@ -101,7 +99,6 @@ namespace System.Diagnostics.Tracing
             LogContentionStart(ContentionFlags, ClrInstanceID, LockID, AssociatedObjectID, LockOwnerThreadID);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionStart(Lock lockObj) =>
@@ -111,7 +108,6 @@ namespace System.Diagnostics.Tracing
                 lockObj.LockIdForEvents,
                 lockObj.ObjectIdForEvents,
                 lockObj.OwningThreadId);
-#pragma warning restore CA2252
 
         [Event(91, Level = EventLevel.Informational, Message = Messages.ContentionStop, Task = Tasks.Contention, Opcode = EventOpcode.Stop, Version = 1, Keywords = Keywords.ContentionKeyword)]
         private void ContentionStop(ContentionFlagsMap ContentionFlags, ushort ClrInstanceID, double DurationNs)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -95,11 +95,9 @@ namespace System.Diagnostics.Tracing
             WriteEventCore(90, 3, data);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionLockCreated(Lock lockObj) => ContentionLockCreated(lockObj.LockIdForEvents, lockObj.ObjectIdForEvents);
-#pragma warning restore CA2252
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern", Justification = "Parameters to this method are primitive and are trimmer safe")]
         [Event(81, Level = EventLevel.Informational, Message = Messages.ContentionStart, Task = Tasks.Contention, Opcode = EventOpcode.Start, Version = 2, Keywords = Keywords.ContentionKeyword)]
@@ -131,7 +129,6 @@ namespace System.Diagnostics.Tracing
             WriteEventCore(81, 3, data);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionStart(Lock lockObj) =>
@@ -141,7 +138,6 @@ namespace System.Diagnostics.Tracing
                 lockObj.LockIdForEvents,
                 lockObj.ObjectIdForEvents,
                 lockObj.OwningThreadId);
-#pragma warning restore CA2252
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern", Justification = "Parameters to this method are primitive and are trimmer safe")]
         [Event(91, Level = EventLevel.Informational, Message = Messages.ContentionStop, Task = Tasks.Contention, Opcode = EventOpcode.Stop, Version = 1, Keywords = Keywords.ContentionKeyword)]

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -13,9 +13,6 @@
     <Platforms>x64;x86;arm;armv6;arm64;riscv64;s390x;wasm;ppc64le</Platforms>
 
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-
-    <!-- CA2252: Opt in to preview features before using them (Lock) -->
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->

--- a/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -13,6 +13,9 @@
     <Platforms>x64;x86;arm;armv6;arm64;riscv64;s390x;wasm;ppc64le</Platforms>
 
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+
+    <!-- CA2252: Opt in to preview features before using them (Lock) -->
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <!-- Note that various places in SPCL depend on this resource name i.e. TplEventSource -->

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
@@ -145,9 +145,7 @@ namespace System.Threading
             try_enter_with_atomic_var(obj, timeout, true, ref lockTaken);
         }
 
-#pragma warning disable CA2252 // Opt in to preview features before using them (Lock)
         public static long LockContentionCount => Monitor_get_lock_contention_count() + Lock.ContentionCount;
-#pragma warning restore CA2252
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern long Monitor_get_lock_contention_count();

--- a/src/mono/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.Mono.cs
@@ -16,7 +16,7 @@ namespace System.Threading
     //
     internal partial class TimerQueue
     {
-        public static long TickCount64 => Environment.TickCount64;
+        private static long TickCount64 => Environment.TickCount64;
         private static List<TimerQueue>? s_scheduledTimers;
         private static List<TimerQueue>? s_scheduledTimersToFire;
         private static long s_shortestDueTimeMs = long.MaxValue;


### PR DESCRIPTION
- Used the project property instead of disabling the compiler warning. Probably a bit cleaner, and would enable using Lock in other libraries to try it out.
- Undid an unnecessary change from https://github.com/dotnet/runtime/pull/87672