### PR TITLE
[browser] improve promise resolve marshaling after exit

### DIFF
--- a/src/mono/wasm/runtime/marshal-to-cs.ts
+++ b/src/mono/wasm/runtime/marshal-to-cs.ts
@@ -22,6 +22,7 @@ import { stringToMonoStringRoot } from "./strings";
 import { JSMarshalerArgument, JSMarshalerArguments, JSMarshalerType, MarshalerToCs, MarshalerToJs, BoundMarshalerToCs, MarshalerType } from "./types/internal";
 import { TypedArray } from "./types/emscripten";
 import { addUnsettledPromise, settleUnsettledPromise } from "./pthreads/shared/eventloop";
+import { mono_log_warn } from "./logging";
 
 export const jsinteropDoc = "For more information see https://aka.ms/dotnet-wasm-jsinterop";
 
@@ -318,8 +319,11 @@ function _marshal_task_to_cs(arg: JSMarshalerArgument, value: Promise<any>, _?: 
         addUnsettledPromise();
 
     value.then(data => {
+        if (!loaderHelpers.is_runtime_running()) {
+            mono_log_warn("This promise can't be propagated to managed code, mono runtime already exited.");
+            return;
+        }
         try {
-            loaderHelpers.assert_runtime_running();
             mono_assert(!holder.isDisposed, "This promise can't be propagated to managed code, because the Task was already freed.");
             if (MonoWasmThreads)
                 settleUnsettledPromise();
@@ -330,8 +334,11 @@ function _marshal_task_to_cs(arg: JSMarshalerArgument, value: Promise<any>, _?: 
             runtimeHelpers.abort(ex);
         }
     }).catch(reason => {
+        if (!loaderHelpers.is_runtime_running()) {
+            mono_log_warn("This promise can't be propagated to managed code, mono runtime already exited.", reason);
+            return;
+        }
         try {
-            loaderHelpers.assert_runtime_running();
             mono_assert(!holder.isDisposed, "This promise can't be propagated to managed code, because the Task was already freed.");
             if (MonoWasmThreads)
                 settleUnsettledPromise();

--- a/src/mono/wasm/runtime/marshal-to-cs.ts
+++ b/src/mono/wasm/runtime/marshal-to-cs.ts
@@ -22,7 +22,7 @@ import { stringToMonoStringRoot } from "./strings";
 import { JSMarshalerArgument, JSMarshalerArguments, JSMarshalerType, MarshalerToCs, MarshalerToJs, BoundMarshalerToCs, MarshalerType } from "./types/internal";
 import { TypedArray } from "./types/emscripten";
 import { addUnsettledPromise, settleUnsettledPromise } from "./pthreads/shared/eventloop";
-import { mono_log_warn } from "./logging";
+import { mono_log_debug } from "./logging";
 
 export const jsinteropDoc = "For more information see https://aka.ms/dotnet-wasm-jsinterop";
 
@@ -320,7 +320,7 @@ function _marshal_task_to_cs(arg: JSMarshalerArgument, value: Promise<any>, _?: 
 
     value.then(data => {
         if (!loaderHelpers.is_runtime_running()) {
-            mono_log_warn("This promise can't be propagated to managed code, mono runtime already exited.");
+            mono_log_debug("This promise can't be propagated to managed code, mono runtime already exited.");
             return;
         }
         try {
@@ -335,7 +335,7 @@ function _marshal_task_to_cs(arg: JSMarshalerArgument, value: Promise<any>, _?: 
         }
     }).catch(reason => {
         if (!loaderHelpers.is_runtime_running()) {
-            mono_log_warn("This promise can't be propagated to managed code, mono runtime already exited.", reason);
+            mono_log_debug("This promise can't be propagated to managed code, mono runtime already exited.", reason);
             return;
         }
         try {


### PR DESCRIPTION
Scenario:
- after WS or HTTP unit tests we call `forceDisposeProxies`
- that will abort pending WebSockets and reject pending promises
- some of the pending promises only propagate to the marshaling to C# only after next tick of the browser loop
- at which point, the emscripten/mono is already exited and can't marshal rejections
   - also, those handles are already disposed

Solution, don't try to marshal promise resolutions after runtime exit.

Related issue https://github.com/dotnet/runtime/issues/89425