### PR TITLE
[wasm][AOT] Disable general Hybrid Globalization tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -77,6 +77,7 @@
 
     <!-- https://github.com/dotnet/runtime/issues/94225 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\Hybrid\System.Globalization.Calendars.Hybrid.WASM.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\Hybrid\System.Globalization.Hybrid.WASM.Tests.csproj" />
   </ItemGroup>
 
   <!-- Projects that don't support code coverage measurement. -->


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/runtime/issues/94225. Not only Calendars fail but also all the other globalization tests. This PR disables them.