### PR TITLE
Remove [EditorBrowsable(Never)] from [InlineArray], add XML docs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
@@ -6,14 +6,37 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates that the instance's storage is sequentially replicated "length" times.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This attribute can be used to annotate a <see langword="struct"/> type with a single field.
+    /// The runtime will replicate that field as many times as specified in the actual type layout.
+    /// </para>
+    /// <para>
+    /// Here's an example of how an inline array type with 8 <see cref="float"/> values can be declared:
+    /// <code lang="csharp">
+    /// [InlineArray(8)]
+    /// struct Float8InlineArray
+    /// {
+    ///     private float _value;
+    /// }
+    /// </code>
+    /// </para>
+    /// <para>
+    /// The compiler will also automatically generate an indexer property, and support casting the type
+    /// to <see cref="Span{T}"/> and <see cref="ReadOnlySpan{T}"/> for safe enumeration of all elements.
+    /// </para>
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
     public sealed class InlineArrayAttribute : Attribute
     {
+        /// <summary>Creates a new <see cref="InlineArrayAttribute"/> instance with the specified parameters.</summary>
+        /// <param name="length">The number of sequential fields to replicate in the inline array type.</param>
         public InlineArrayAttribute(int length)
         {
             Length = length;
         }
 
+        /// <summary>Gets the number of sequential fields to replicate in the inline array type.</summary>
         public int Length { get; }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
     /// Indicates that the instance's storage is sequentially replicated "length" times.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
     [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
     public sealed class InlineArrayAttribute : Attribute
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArrayAttribute.cs
@@ -9,7 +9,7 @@ namespace System.Runtime.CompilerServices
     /// <remarks>
     /// <para>
     /// This attribute can be used to annotate a <see langword="struct"/> type with a single field.
-    /// The runtime will replicate that field as many times as specified in the actual type layout.
+    /// The runtime will replicate that field in the actual type layout as many times as is specified.
     /// </para>
     /// <para>
     /// Here's an example of how an inline array type with 8 <see cref="float"/> values can be declared:
@@ -21,15 +21,11 @@ namespace System.Runtime.CompilerServices
     /// }
     /// </code>
     /// </para>
-    /// <para>
-    /// The compiler will also automatically generate an indexer property, and support casting the type
-    /// to <see cref="Span{T}"/> and <see cref="ReadOnlySpan{T}"/> for safe enumeration of all elements.
-    /// </para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
     public sealed class InlineArrayAttribute : Attribute
     {
-        /// <summary>Creates a new <see cref="InlineArrayAttribute"/> instance with the specified parameters.</summary>
+        /// <summary>Creates a new <see cref="InlineArrayAttribute"/> instance with the specified length.</summary>
         /// <param name="length">The number of sequential fields to replicate in the inline array type.</param>
         public InlineArrayAttribute(int length)
         {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12905,7 +12905,6 @@ namespace System.Runtime.CompilerServices
         public InterpolatedStringHandlerAttribute() { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Struct, AllowMultiple = false)]
-    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
     public sealed partial class InlineArrayAttribute : System.Attribute
     {
         public InlineArrayAttribute(int length) { }


### PR DESCRIPTION
### Closes #94283

### Overview

This PR includes two changes to `[InlineArray]`:
- Removes `[EditorBrowsable(EditorBrowsableState.Never)]`
- Adds some XML remarks, as well as all missing XML docs