### PR TITLE
Fix the type of handle constants replacing TYP_REF expressions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2649,6 +2649,13 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                 if (!opts.compReloc)
                 {
                     conValTree = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
+
+                    // The generated constant node will have TYP_I_IMPL. However, we might be replacing a TYP_REF
+                    // node. If so, make it a TYP_REF.
+                    if (tree->TypeIs(TYP_REF))
+                    {
+                        conValTree->gtType = TYP_REF;
+                    }
                 }
             }
             else
@@ -2705,6 +2712,13 @@ GenTree* Compiler::optVNConstantPropOnTree(BasicBlock* block, GenTree* tree)
                 if (!opts.compReloc)
                 {
                     conValTree = gtNewIconHandleNode(value, vnStore->GetHandleFlags(vnCns));
+
+                    // The generated constant node will have TYP_I_IMPL. However, we might be replacing a TYP_REF
+                    // node. If so, make it a TYP_REF.
+                    if (tree->TypeIs(TYP_REF))
+                    {
+                        conValTree->gtType = TYP_REF;
+                    }
                 }
             }
             else


### PR DESCRIPTION
`optVNConstantPropOnTree` will propagate a constant handle value into a tree node currently typed as TYP_REF, where the new constant node is TYP_I_IMPL. This leads to trees like:

```
*  STORE_LCL_VAR ref   (AX) V08 tmp6
\--*  CNS_INT(h) long   $181
```

This seems like an undesired type mismatch. In another change, code was asserting because of this.

Change the type of the substituted constant node to be TYP_REF if necessary, to match the type of the node being replaced.

This change causes diffs: the constant is GC reported.