### PR TITLE
Fix fgOptimizeAddition opt for AOT

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11113,16 +11113,15 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
         GenTreeOp*     addOne   = op1->AsOp();
         GenTreeOp*     addTwo   = op2->AsOp();
         GenTreeIntCon* constOne = addOne->gtGetOp2()->AsIntCon();
-        GenTreeIntCon* constTwo = addTwo->gtGetOp2()->AsIntCon();
 
+        // addOne is now "x + y"
         addOne->gtOp2 = addTwo->gtGetOp1();
         addOne->SetAllEffectsFlags(addOne->gtGetOp1(), addOne->gtGetOp2());
-        DEBUG_DESTROY_NODE(addTwo);
 
-        constOne->SetValueTruncating(constOne->IconValue() + constTwo->IconValue());
-        op2        = constOne;
-        add->gtOp2 = constOne;
-        DEBUG_DESTROY_NODE(constTwo);
+        // addTwo is now "icon1 + icon2" so we can fold it using gtFoldExprConst
+        addTwo->gtOp1 = constOne;
+        add->gtOp2 = gtFoldExprConst(add->gtOp2);
+        op2        = add->gtGetOp2();
     }
 
     // Fold (x + 0) - given it won't change the tree type.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11120,8 +11120,8 @@ GenTree* Compiler::fgOptimizeAddition(GenTreeOp* add)
 
         // addTwo is now "icon1 + icon2" so we can fold it using gtFoldExprConst
         addTwo->gtOp1 = constOne;
-        add->gtOp2 = gtFoldExprConst(add->gtOp2);
-        op2        = add->gtGetOp2();
+        add->gtOp2    = gtFoldExprConst(add->gtOp2);
+        op2           = add->gtGetOp2();
     }
 
     // Fold (x + 0) - given it won't change the tree type.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94332

Thanks @MichalStrehovsky for finding the root cause, indeed, a Morph optimization folded "CNS1 + CNS2" where it wasn't legal. `gtFoldExprConst` cares about such cases so I am just forwarding the folding to that.