### PR TITLE
More general VN const casting

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12155,9 +12155,10 @@ ValueNum ValueNumStore::VNForCast(ValueNum  srcVN,
                                   bool      hasOverflowCheck) /* = false */
 {
 
-    if ((castFromType == TYP_I_IMPL) && (castToType == TYP_BYREF) && IsVNHandle(srcVN))
+    if ((castFromType == TYP_I_IMPL) && varTypeIsGC(castToType) && IsVNConstant(srcVN))
     {
-        // Omit cast for (h)CNS_INT [TYP_I_IMPL -> TYP_BYREF]
+        // Omit cast for CNS_INT [TYP_I_IMPL -> TYP_BYREF/TYP_REF]
+        // We can't check `IsVNHandle(srcVN)` because we may have lost handle information with shared const CSEs.
         return srcVN;
     }
 


### PR DESCRIPTION
When creating a VN cast, skip the cast if the target type is any GC type (not just TYP_BYREF) if the source operand is any TYP_I_IMPL constant (not just handle constant). We can lose track of whether a value is a handle due to shared const CSE.