### PR TITLE
Disable the Jitted Methods Counting Test When SSE2 is Disabled

### DIFF
--- a/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
+++ b/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
@@ -15,12 +15,12 @@ public class JittedMethodsCountingTest
     public static int TestEntryPoint()
     {
         // If either of DOTNET_ReadyToRun, DOTNET_EnableHWIntrinsics, or
-        // DOTNET_EnableSSE2 are disabled (i.e. set to "0"), then this test
+        // DOTNET_EnableSSE(2) are disabled (i.e. set to "0"), then this test
         // ought to be skipped.
-        if (!IsReadyToRunEnabled() || !IsHardwareIntrinsicsEnabled() || !IsSSE2Enabled())
+        if (!IsReadyToRunEnabled() || !IsHardwareIntrinsicsEnabled() || !IsSSEEnabled())
         {
             Console.WriteLine("\nThis test is only supported in ReadyToRun scenarios"
-                              + " with Hardware Intrinsics and SSE2 enabled."
+                              + " with Hardware Intrinsics and SSE(2) enabled."
                               + " Skipping...\n");
             return 100;
         }
@@ -51,9 +51,12 @@ public class JittedMethodsCountingTest
                 || dotnetEnableHWIntrinsics != "0");
     }
 
-    private static bool IsSSE2Enabled()
+    private static bool IsSSEEnabled()
     {
+        string? dotnetSSE = Environment.GetEnvironmentVariable("DOTNET_EnableSSE");
         string? dotnetSSE2 = Environment.GetEnvironmentVariable("DOTNET_EnableSSE2");
-        return (string.IsNullOrEmpty(dotnetSSE2) || dotnetSSE2 != "0");
+
+        return ((string.IsNullOrEmpty(dotnetSSE) || dotnetSSE != "0")
+                && (string.IsNullOrEmpty(dotnetSSE2) || dotnetSSE2 != "0"));
     }
 }

--- a/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
+++ b/src/tests/readytorun/JittedMethodsCountingTest/JittedMethodsCountingTest.cs
@@ -14,12 +14,14 @@ public class JittedMethodsCountingTest
     [Fact]
     public static int TestEntryPoint()
     {
-        // If either DOTNET_ReadyToRun or DOTNET_EnableHWIntrinsics are disabled
-        // (i.e. set to "0"), then this test ought to be skipped.
-        if (!IsReadyToRunEnabled() || !IsHardwareIntrinsicsEnabled())
+        // If either of DOTNET_ReadyToRun, DOTNET_EnableHWIntrinsics, or
+        // DOTNET_EnableSSE2 are disabled (i.e. set to "0"), then this test
+        // ought to be skipped.
+        if (!IsReadyToRunEnabled() || !IsHardwareIntrinsicsEnabled() || !IsSSE2Enabled())
         {
             Console.WriteLine("\nThis test is only supported in ReadyToRun scenarios"
-                              + " with Hardware Intrinsics enabled. Skipping...\n");
+                              + " with Hardware Intrinsics and SSE2 enabled."
+                              + " Skipping...\n");
             return 100;
         }
 
@@ -47,5 +49,11 @@ public class JittedMethodsCountingTest
 
         return (string.IsNullOrEmpty(dotnetEnableHWIntrinsics)
                 || dotnetEnableHWIntrinsics != "0");
+    }
+
+    private static bool IsSSE2Enabled()
+    {
+        string? dotnetSSE2 = Environment.GetEnvironmentVariable("DOTNET_EnableSSE2");
+        return (string.IsNullOrEmpty(dotnetSSE2) || dotnetSSE2 != "0");
     }
 }


### PR DESCRIPTION
Fixes #93163. When `DOTNET_EnableSSE2=0` is set, we are testing a different scenario than what the Jitted Methods Counting Test aims for. So, we ought to disable it because it makes those specific pipelines incorrectly fail.