### PR TITLE
update IServiceProvider.GetServices return value nullability

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/ref/Microsoft.Extensions.DependencyInjection.Abstractions.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static object GetRequiredService(this System.IServiceProvider provider, System.Type serviceType) { throw null; }
         public static T GetRequiredService<T>(this System.IServiceProvider provider) where T : notnull { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("The native code for an IEnumerable<serviceType> might not be available at runtime.")]
-        public static System.Collections.Generic.IEnumerable<object?> GetServices(this System.IServiceProvider provider, System.Type serviceType) { throw null; }
+        public static System.Collections.Generic.IEnumerable<object> GetServices(this System.IServiceProvider provider, System.Type serviceType) { throw null; }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this System.IServiceProvider provider) { throw null; }
         public static T? GetService<T>(this System.IServiceProvider provider) { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="serviceType">An object that specifies the type of service object to get.</param>
         /// <returns>An enumeration of services of type <paramref name="serviceType"/>.</returns>
         [RequiresDynamicCode("The native code for an IEnumerable<serviceType> might not be available at runtime.")]
-        public static IEnumerable<object?> GetServices(this IServiceProvider provider, Type serviceType)
+        public static IEnumerable<object> GetServices(this IServiceProvider provider, Type serviceType)
         {
             ThrowHelper.ThrowIfNull(provider);
             ThrowHelper.ThrowIfNull(serviceType);


### PR DESCRIPTION
update `IServiceProvider.GetServices` return value nullability

update to `IEnumerable<object>` to align with the method return value type

https://github.com/dotnet/runtime/blob/b4823d05c38d7eb44de0db41ba9ba6c6a2df4e46/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderServiceExtensions.cs#L88-L95