### PR TITLE
Fixed xml-doc comments in OptionsServiceCollectionExtensions.AddOptionsWithValidateOnStart

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TOptions">The options type to be configured.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <param name="name">The name of the options instance.</param>
-        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that configure calls can be chained in it.</returns>
         public static OptionsBuilder<TOptions> AddOptionsWithValidateOnStart<
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions>(
             this IServiceCollection services,
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TValidateOptions">The <see cref="IValidateOptions{TOptions}"/> validator type.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
         /// <param name="name">The name of the options instance.</param>
-        /// <returns>The <see cref="IServiceCollection"/> so that additional calls can be chained.</returns>
+        /// <returns>The <see cref="OptionsBuilder{TOptions}"/> so that configure calls can be chained in it.</returns>
         public static OptionsBuilder<TOptions> AddOptionsWithValidateOnStart<
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] TOptions,
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TValidateOptions>(


### PR DESCRIPTION
In the xml-doc comments the wrong return-type was specified.
Most likely this was a copy & paste fault.

---

Is there a PR needed for dotnet-api-docs project or does the change flow over there?
(I could create that PR to update [a](https://github.com/dotnet/dotnet-api-docs/blob/172de5c3f03b5faecd8418092d977d23555bd2c2/xml/Microsoft.Extensions.DependencyInjection/OptionsServiceCollectionExtensions.xml#L209) and [b](https://github.com/dotnet/dotnet-api-docs/blob/172de5c3f03b5faecd8418092d977d23555bd2c2/xml/Microsoft.Extensions.DependencyInjection/OptionsServiceCollectionExtensions.xml#L269))