### PR TITLE
[wasm] WasmAppHost: Fix passing message as paramName

### DIFF
--- a/src/mono/wasm/host/CommonConfiguration.cs
+++ b/src/mono/wasm/host/CommonConfiguration.cs
@@ -125,18 +125,18 @@ internal sealed class CommonConfiguration
     public static void CheckPathOrInAppPath(string appPath, string? path, string argName)
     {
         if (string.IsNullOrEmpty(path))
-            throw new ArgumentNullException($"Missing value for {argName}");
+            throw new CommandLineException($"Missing value for {argName}");
 
         if (Path.IsPathRooted(path))
         {
             if (!File.Exists(path))
-                throw new ArgumentException($"Cannot find {argName}: {path}");
+                throw new CommandLineException($"Cannot find {argName}: {path}");
         }
         else
         {
             string fullPath = Path.Combine(appPath, path);
             if (!File.Exists(fullPath))
-                throw new ArgumentException($"Cannot find {argName} {path} in app directory {appPath}");
+                throw new CommandLineException($"Cannot find {argName} {path} in app directory {appPath}");
         }
     }
 }


### PR DESCRIPTION
The [`ArgumentNullException`](https://learn.microsoft.com/en-us/dotnet/api/system.argumentnullexception.-ctor#system-argumentnullexception-ctor(system-string)) constructor with one parameter takes a parameter name, not a message.  ~~Since it throws for empty as well as `null`, I changed it to throw `ArgumentException` instead.~~

As per feedback, it now throws `CommandLineException`.