### PR TITLE
Allow preinitializing RuntimeType instances

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -8989,6 +8989,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         FALLTHROUGH;
                     case CORINFO_FIELD_STATIC_SHARED_STATIC_HELPER:
                     case CORINFO_FIELD_STATIC_ADDRESS:
+                    case CORINFO_FIELD_STATIC_RELOCATABLE:
                         // Replace static read-only fields with constant if possible
                         if ((aflags & CORINFO_ACCESS_GET) && (fieldInfo.fieldFlags & CORINFO_FLG_FIELD_FINAL))
                         {
@@ -9005,7 +9006,6 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     case CORINFO_FIELD_STATIC_RVA_ADDRESS:
                     case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
                     case CORINFO_FIELD_STATIC_READYTORUN_HELPER:
-                    case CORINFO_FIELD_STATIC_RELOCATABLE:
                         op1 = impImportStaticFieldAddress(&resolvedToken, (CORINFO_ACCESS_FLAGS)aflags, &fieldInfo,
                                                           lclTyp, &indirFlags);
                         break;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -1237,6 +1237,13 @@ namespace ILCompiler.DependencyAnalysis
             return _frozenObjectNodes.GetOrAdd(new SerializedFrozenObjectKey(owningType, allocationSiteId, data));
         }
 
+        public FrozenRuntimeTypeNode SerializedMaximallyConstructableRuntimeTypeObject(TypeDesc type)
+        {
+            if (ConstructedEETypeNode.CreationAllowed(type))
+                return SerializedConstructedRuntimeTypeObject(type);
+            return SerializedNecessaryRuntimeTypeObject(type);
+        }
+
         private NodeCache<TypeDesc, FrozenRuntimeTypeNode> _frozenConstructedRuntimeTypeNodes;
 
         public FrozenRuntimeTypeNode SerializedConstructedRuntimeTypeObject(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -375,7 +375,7 @@ namespace ILCompiler
                                 if (value is ValueTypeValue)
                                     stack.PushFromLocation(field.FieldType, value);
                                 else if (value is ReferenceTypeValue referenceType)
-                                    stack.PushFromLocation(field.FieldType, referenceType.ToForeignInstance(baseInstructionCounter));
+                                    stack.PushFromLocation(field.FieldType, referenceType.ToForeignInstance(baseInstructionCounter, this));
                                 else
                                     return Status.Fail(methodIL.OwningMethod, opcode);
                             }
@@ -2388,7 +2388,7 @@ namespace ILCompiler
             }
         }
 
-        private sealed class RuntimeTypeValue : ReferenceTypeValue, IInternalModelingOnlyValue
+        private sealed class RuntimeTypeValue : ReferenceTypeValue
         {
             public TypeDesc TypeRepresented { get; }
 
@@ -2400,11 +2400,21 @@ namespace ILCompiler
 
             public override bool GetRawData(NodeFactory factory, out object data)
             {
-                data = null;
-                return false;
+                data = factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented);
+                return true;
             }
-            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) => this;
-            public override void WriteFieldData(ref ObjectDataBuilder builder, NodeFactory factory) => throw new NotImplementedException();
+            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext)
+            {
+                if (!preinitContext._internedTypes.TryGetValue(TypeRepresented, out RuntimeTypeValue result))
+                {
+                    preinitContext._internedTypes.Add(TypeRepresented, result = new RuntimeTypeValue(TypeRepresented));
+                }
+                return result;
+            }
+            public override void WriteFieldData(ref ObjectDataBuilder builder, NodeFactory factory)
+            {
+                builder.EmitPointerReloc(factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented));
+            }
         }
 
         private sealed class ReadOnlySpanValue : BaseValueTypeValue, IInternalModelingOnlyValue
@@ -2641,7 +2651,7 @@ namespace ILCompiler
                 return this == value;
             }
 
-            public abstract ReferenceTypeValue ToForeignInstance(int baseInstructionCounter);
+            public abstract ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext);
         }
 
         private struct AllocationSite
@@ -2669,7 +2679,7 @@ namespace ILCompiler
                 AllocationSite = allocationSite;
             }
 
-            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) =>
+            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext) =>
                 new ForeignTypeInstance(
                     Type,
                     new AllocationSite(AllocationSite.OwningType, AllocationSite.InstructionCounter - baseInstructionCounter),
@@ -2889,7 +2899,7 @@ namespace ILCompiler
                 }
             }
 
-            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) => this;
+            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext) => this;
         }
 
         private sealed class StringInstance : ReferenceTypeValue, IHasInstanceFields
@@ -2947,7 +2957,15 @@ namespace ILCompiler
                 return true;
             }
 
-            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter) => this;
+            public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext)
+            {
+                string value = ValueAsString;
+                if (!preinitContext._internedStrings.TryGetValue(value, out StringInstance result))
+                {
+                    preinitContext._internedStrings.Add(value, result = new StringInstance(Type, value));
+                }
+                return result;
+            }
             Value IHasInstanceFields.GetField(FieldDesc field) => new FieldAccessor(_value).GetField(field);
             void IHasInstanceFields.SetField(FieldDesc field, Value value) => ThrowHelper.ThrowInvalidProgramException();
             ByRefValue IHasInstanceFields.GetFieldAddress(FieldDesc field) => new FieldAccessor(_value).GetFieldAddress(field);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/RyuJitCompilation.cs
@@ -83,8 +83,8 @@ namespace ILCompiler
         {
             bool canPotentiallyConstruct = _devirtualizationManager == null
                 ? true : _devirtualizationManager.CanConstructType(type);
-            if (canPotentiallyConstruct && ConstructedEETypeNode.CreationAllowed(type))
-                return _nodeFactory.SerializedConstructedRuntimeTypeObject(type);
+            if (canPotentiallyConstruct)
+                return _nodeFactory.SerializedMaximallyConstructableRuntimeTypeObject(type);
 
             return _nodeFactory.SerializedNecessaryRuntimeTypeObject(type);
         }

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -657,6 +657,7 @@ class TestInitFromOtherClass
     static int s_intValue = OtherClass.IntValue;
     static string s_stringValue = OtherClass.StringValue;
     static object s_objectValue = OtherClass.ObjectValue;
+    static bool s_areStringsSame = Object.ReferenceEquals(OtherClass.StringValue, "Hello");
 
     public static void Run()
     {
@@ -664,6 +665,7 @@ class TestInitFromOtherClass
         Assert.AreEqual(OtherClass.IntValue, s_intValue);
         Assert.AreSame(OtherClass.StringValue, s_stringValue);
         Assert.AreSame(OtherClass.ObjectValue, s_objectValue);
+        Assert.True(s_areStringsSame);
     }
 }
 
@@ -1282,8 +1284,8 @@ class TestTypeHandles
         Assert.True(!Foo<bool>.IsChar);
         Assert.True(Foo<bool>.IsBool);
 
-        Assert.IsLazyInitialized(typeof(CharHolder));
-        Assert.IsLazyInitialized(typeof(IsChar));
+        Assert.IsPreinitialized(typeof(CharHolder));
+        Assert.IsPreinitialized(typeof(IsChar));
         Assert.True(IsChar.Is);
     }
 }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -689,7 +689,7 @@ public class Interfaces
         static IInterface<object> s_c3a = new C3<object>();
         static IInterface s_c3b = new C3<object>();
 
-        // Works around https://github.com/dotnet/runtime/pull/94342
+        // Works around https://github.com/dotnet/runtime/issues/94399
         [MethodImpl(MethodImplOptions.NoOptimization)]
         public static void Run()
         {

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -689,6 +689,8 @@ public class Interfaces
         static IInterface<object> s_c3a = new C3<object>();
         static IInterface s_c3b = new C3<object>();
 
+        // Works around https://github.com/dotnet/runtime/pull/94342
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         public static void Run()
         {
             if (s_c1.Method(null) != "Method(object)")


### PR DESCRIPTION
Unblock serializing `RuntimeType` instances from the static constructor interpreter.

With this we can now preinitialize `static readonly Type s_foo = typeof(Foo)` and RyuJIT will optimize reads of `s_foo` into loading a constant value.

Contributes to #91704.

Cc @dotnet/ilc-contrib 