### PR TITLE
[Android] Fix SslStream on Android API 21-23

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -86,6 +86,7 @@ jmethodID g_SSLParametersSetServerNames;
 // com/android/org/conscrypt/OpenSSLEngineImpl
 jclass    g_ConscryptOpenSSLEngineImplClass;
 jfieldID  g_ConscryptOpenSSLEngineImplSslParametersField;
+jfieldID  g_ConscryptOpenSSLEngineImplHandshakeSessionField;
 
 // com/android/org/conscrypt/SSLParametersImpl
 jclass    g_ConscryptSSLParametersImplClass;
@@ -627,6 +628,17 @@ jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, co
     return fid;
 }
 
+jfieldID GetOptionalField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig)
+{
+    jfieldID fid = isStatic ? (*env)->GetStaticFieldID(env, klass, name, sig) : (*env)->GetFieldID(env, klass, name, sig);
+    if (!fid) {
+        LOG_INFO("optional field %s %s was not found", name, sig);
+        // Failing to find an optional field causes an exception state, which we need to clear.
+        TryClearJNIExceptions(env);
+    }
+    return fid;
+}
+
 static void DetachThreadFromJNI(void* unused)
 {
     LOG_DEBUG("Detaching thread from JNI");
@@ -761,6 +773,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     if (g_ConscryptOpenSSLEngineImplClass != NULL)
     {
         g_ConscryptOpenSSLEngineImplSslParametersField =  GetField(env, false,  g_ConscryptOpenSSLEngineImplClass, "sslParameters", "Lcom/android/org/conscrypt/SSLParametersImpl;");
+        g_ConscryptOpenSSLEngineImplHandshakeSessionField = GetOptionalField(env, false,  g_ConscryptOpenSSLEngineImplClass, "handshakeSession", "Lcom/android/org/conscrypt/OpenSSLSessionImpl;");
 
         g_ConscryptSSLParametersImplClass = GetClassGRef(env, "com/android/org/conscrypt/SSLParametersImpl");
         g_ConscryptSSLParametersImplSetUseSni = GetMethod(env, false,  g_ConscryptSSLParametersImplClass, "setUseSni", "(Z)V");

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -98,6 +98,7 @@ extern jmethodID g_SSLParametersSetServerNames;
 // com/android/org/conscrypt/OpenSSLEngineImpl
 extern jclass    g_ConscryptOpenSSLEngineImplClass;
 extern jfieldID  g_ConscryptOpenSSLEngineImplSslParametersField;
+extern jfieldID  g_ConscryptOpenSSLEngineImplHandshakeSessionField;
 
 // com/android/org/conscrypt/SSLParametersImpl
 extern jclass    g_ConscryptSSLParametersImplClass;
@@ -590,6 +591,7 @@ bool TryGetJNIException(JNIEnv* env, jthrowable *ex, bool printException) ARGS_N
 jmethodID GetMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
+jfieldID GetOptionalField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 JNIEnv* GetJNIEnv(void);
 
 int GetEnumAsInt(JNIEnv *env, jobject enumObj) ARGS_NON_NULL_ALL;


### PR DESCRIPTION
The `SSLEngine.getHandshakeSession` java method isn't available on Android API 21-23 (we don't support older API levels). As a workaround, we can access the private field that contains the handshake session directly. Since this change only affects very old Android versions which won't receive any updates (not even security updates), I think accessing the private field is OK.

This PR will have to be backported to .NET 8 once it's merged. These changes should be reverted once we drop support for Android API 23.

Ref #94230