### PR TITLE
JIT: Fix `EvalHWIntrinsicFunBinary` for ARM `MultiplyByScalar`

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7826,7 +7826,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
                 }
                 break;
             }
-#else
+#endif
 
 #ifdef TARGET_ARM64
             case NI_AdvSimd_Multiply:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7810,10 +7810,13 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 
                 assert((TypeOfVN(arg0VN) == type) && (TypeOfVN(arg1VN) == TYP_SIMD8));
 
-                // Handle x * 1 => x, but only if the scalar RHS is 1.
-                if (arg1VN == VNOneForSimdType(TYP_SIMD8, baseType))
+                // Handle x * 1 => x, but only if the scalar RHS is <1, ...>.
+                if (IsVNConstant(arg1VN))
                 {
-                    return arg0VN;
+                    if (EvaluateSimdGetElement(this, TYP_SIMD8, baseType, arg1VN, 0) == VNOneForType(baseType))
+                    {
+                        return arg0VN;
+                    }
                 }
                 break;
             }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7808,20 +7808,11 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
                     }
                 }
 
-                // Handle x * 1 => x, but only if the scalar RHS is 1.
-                ValueNum oneVN;
-                if (varTypeIsSIMD(TypeOfVN(arg1VN)))
-                {
-                    oneVN = VNOneForSimdType(TypeOfVN(arg1VN), baseType);
-                }
-                else
-                {
-                    oneVN = VNOneForType(baseType);
-                }
+                assert((TypeOfVN(arg0VN) == type) && (TypeOfVN(arg1VN) == TYP_SIMD8));
 
-                if (arg1VN == oneVN)
+                // Handle x * 1 => x, but only if the scalar RHS is 1.
+                if (arg1VN == VNOneForSimdType(TYP_SIMD8, baseType))
                 {
-                    assert(TypeOfVN(arg0VN) == type);
                     return arg0VN;
                 }
                 break;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7819,7 +7819,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 
                     if (cnsVN == zeroVN)
                     {
-                        return zeroVN;
+                        return VNZeroForType(type);
                     }
                 }
 
@@ -7836,7 +7836,7 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
                     oneVN = VNOneForType(baseType);
                 }
 
-                if (cnsVN == oneVN)
+                if ((cnsVN == oneVN) && (TypeOfVN(argVN) == type))
                 {
                     return argVN;
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_92201/Runtime_92201.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_92201/Runtime_92201.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 using System.Numerics;
 using Xunit;
 
@@ -12,8 +13,13 @@ public static class Runtime_93876
     {
         Vector4 v = Mul(0, 1);
         Assert.Equal(Vector4.One, v);
+        Vector64<float> v64 = Mul64(0, 1);
+        Assert.Equal(Vector64<float>.One, v64);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static Vector4 Mul(float a, float b) => Vector4.Multiply(a + b, Vector4.One);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<float> Mul64(float a, float b) => Vector64.Multiply(a + b, Vector64<float>.One);
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Numerics;
+using Xunit;
+
+public static class Runtime_93876
+{
+    [Fact]
+    public static void Problem()
+    {
+        Vector4 v = Mul(0, 1);
+        Assert.Equal(Vector4.One, v);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector4 Mul(float a, float b) => Vector4.Multiply(a + b, Vector4.One);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-    <!-- Needed for CLRTestEnvironmentVariable -->
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
-    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MAKE_CSE STRESS_SPLIT_TREES_REMOVE_COMMAS" />
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MAKE_CSE STRESS_SPLIT_TREES_REMOVE_COMMAS" />
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <CLRTestEnvironmentVariable Include="DOTNET_JitStressModeNames" Value="STRESS_MAKE_CSE STRESS_SPLIT_TREES_REMOVE_COMMAS" />


### PR DESCRIPTION
`MultiplyByScalar` on ARM/ARM64 can have differently typed operands, so we cannot fold multiplications by one/zero without ensuring that we get the proper result type.

Fix #93876