### PR TITLE
Console.Unix: for echoing, write back to the terminal instead of writing to Console.Out.

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetWindowWidth.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetWindowWidth.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -18,7 +19,7 @@ internal static partial class Interop
         };
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetWindowSize", SetLastError = true)]
-        internal static partial int GetWindowSize(out WinSize winSize);
+        internal static partial int GetWindowSize(SafeFileHandle terminalHandle, out WinSize winSize);
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetWindowSize", SetLastError = true)]
         internal static partial int SetWindowSize(in WinSize winSize);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InitializeTerminalAndSignalHandling.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.InitializeTerminalAndSignalHandling.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -12,6 +13,6 @@ internal static partial class Interop
         internal static partial bool InitializeTerminalAndSignalHandling();
 
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetKeypadXmit", StringMarshalling = StringMarshalling.Utf8)]
-        internal static partial void SetKeypadXmit(string terminfoString);
+        internal static partial void SetKeypadXmit(SafeFileHandle terminalHandle, string terminfoString);
     }
 }

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.ConsoleStream.cs
@@ -47,7 +47,7 @@ namespace System
                     ConsolePal.Read(_handle, buffer);
 
             public override void Write(ReadOnlySpan<byte> buffer) =>
-                ConsolePal.Write(_handle, buffer);
+                ConsolePal.WriteFromConsoleStream(_handle, buffer);
 
             public override void Flush()
             {

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -243,7 +243,7 @@ namespace System
                 if (!string.IsNullOrEmpty(cursorAddressFormat))
                 {
                     string ansiStr = TermInfo.ParameterizedStrings.Evaluate(cursorAddressFormat, top, left);
-                    WriteStringToTerminal(terminalHandle, ansiStr);
+                    WriteTerminalAnsiString(terminalHandle, ansiStr);
                 }
 
                 SetCachedCursorPosition(left, top);
@@ -1094,7 +1094,7 @@ namespace System
             Volatile.Write(ref s_invalidateCachedSettings, 1);
         }
 
-        internal static void WriteStringToTerminal(SafeFileHandle terminalHandle, string? value, bool mayChangeCursorPosition = true)
+        internal static void WriteTerminalAnsiString(SafeFileHandle terminalHandle, string? value, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;
@@ -1120,7 +1120,7 @@ namespace System
         /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
         /// <param name="value">The string to write.</param>
         /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
-       internal static void WriteStdoutAnsiString(string? value, bool mayChangeCursorPosition = true)
-            => WriteStringToTerminal(Interop.Sys.FileDescriptors.STDOUT_FILENO, value, mayChangeCursorPosition);
+       private static void WriteStdoutAnsiString(string? value, bool mayChangeCursorPosition = true)
+            => WriteTerminalAnsiString(Interop.Sys.FileDescriptors.STDOUT_FILENO, value, mayChangeCursorPosition);
     }
 }

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -82,8 +82,8 @@ namespace System
 
                     SyncTextReader reader = SyncTextReader.GetSynchronizedTextReader(
                                                 new StdInReader(
-                                                    encoding: Console.InputEncoding,
-                                                    isTerminal: !Console.IsInputRedirected));
+                                                    encoding: Console.InputEncoding
+                                                ));
 
                     // Don't overwrite a set reader.
                     // The reader doesn't own resources, so we don't need to dispose

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1103,6 +1103,9 @@ namespace System
             Volatile.Write(ref s_invalidateCachedSettings, 1);
         }
 
+        /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
+        /// <param name="value">The string to write.</param>
+        /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
         internal static void WriteTerminalAnsiString(string? value, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -969,6 +969,9 @@ namespace System
         }
 
         /// <summary>Writes data from the buffer into the file descriptor.</summary>
+        /// <param name="fd">The file descriptor.</param>
+        /// <param name="buffer">The buffer from which to write data.</param>
+        /// <param name="mayChangeCursorPosition">Writing this buffer may change the cursor position.</param>
         private static unsafe void Write(SafeFileHandle fd, ReadOnlySpan<byte> buffer, bool mayChangeCursorPosition = true)
         {
             fixed (byte* p = buffer)

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -411,8 +411,10 @@ namespace System
 
         public static (int Left, int Top) GetCursorPosition()
         {
-            if (Console.IsOutputRedirected)
+            if (Console.IsInputRedirected || Console.IsOutputRedirected)
+            {
                 return (0, 0);
+            }
 
             TryGetCursorPosition(out int left, out int top);
             return (left, top);
@@ -438,6 +440,8 @@ namespace System
         /// <param name="reinitializeForRead">Indicates whether this method is called as part of a on-going Read operation.</param>
         internal static bool TryGetCursorPosition(out int left, out int top, bool reinitializeForRead = false)
         {
+            Debug.Assert(!Console.IsInputRedirected);
+
             left = top = 0;
 
             int cursorVersion;

--- a/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
@@ -304,7 +304,7 @@ namespace System
             }
         }
 
-        internal static void WriteTerminalAnsiString(SafeFileHandle terminalHandle, string? value, bool mayChangeCursorPosition = true)
+        internal static void WriteTerminalAnsiString(string? value, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;
@@ -323,7 +323,7 @@ namespace System
 
             lock (Console.Out) // synchronize with other writers
             {
-                Write(terminalHandle, data, mayChangeCursorPosition);
+                Write(data, mayChangeCursorPosition);
             }
         }
     }

--- a/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
@@ -304,10 +304,7 @@ namespace System
             }
         }
 
-        /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
-        /// <param name="value">The string to write.</param>
-        /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
-        internal static void WriteStdoutAnsiString(string? value, bool mayChangeCursorPosition = true)
+        internal static void WriteTerminalAnsiString(SafeFileHandle terminalHandle, string? value, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;
@@ -326,7 +323,7 @@ namespace System
 
             lock (Console.Out) // synchronize with other writers
             {
-                Write(Interop.Sys.FileDescriptors.STDOUT_FILENO, data, mayChangeCursorPosition);
+                Write(terminalHandle, data, mayChangeCursorPosition);
             }
         }
     }

--- a/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
@@ -264,7 +264,7 @@ namespace System
         /// <param name="fd">The file descriptor.</param>
         /// <param name="buffer">The buffer from which to write data.</param>
         /// <param name="mayChangeCursorPosition">Writing this buffer may change the cursor position.</param>
-        private static unsafe void Write(SafeFileHandle fd, ReadOnlySpan<byte> buffer, bool mayChangeCursorPosition = true)
+        private static unsafe void Write(SafeFileHandle fd, ReadOnlySpan<byte> buffer)
         {
             fixed (byte* p = buffer)
             {
@@ -272,8 +272,6 @@ namespace System
                 int count = buffer.Length;
                 while (count > 0)
                 {
-                    int cursorVersion = mayChangeCursorPosition ? Volatile.Read(ref s_cursorVersion) : -1;
-
                     int bytesWritten = Interop.Sys.Write(fd, bufPtr, count);
                     if (bytesWritten < 0)
                     {
@@ -299,13 +297,6 @@ namespace System
                         {
                             // Something else... fail.
                             throw Interop.GetExceptionForIoErrno(errorInfo);
-                        }
-                    }
-                    else
-                    {
-                        if (mayChangeCursorPosition)
-                        {
-                            UpdatedCachedCursorPosition(bufPtr, bytesWritten, cursorVersion);
                         }
                     }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Wasi.cs
@@ -263,7 +263,6 @@ namespace System
         /// <summary>Writes data from the buffer into the file descriptor.</summary>
         /// <param name="fd">The file descriptor.</param>
         /// <param name="buffer">The buffer from which to write data.</param>
-        /// <param name="mayChangeCursorPosition">Writing this buffer may change the cursor position.</param>
         private static unsafe void Write(SafeFileHandle fd, ReadOnlySpan<byte> buffer)
         {
             fixed (byte* p = buffer)

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -31,8 +31,6 @@ namespace System.IO
         private int _startIndex; // First unprocessed index in the buffer;
         private int _endIndex; // Index after last unprocessed index in the buffer;
 
-        private static SafeFileHandle StdInHandle => Interop.Sys.FileDescriptors.STDIN_FILENO;
-
         internal StdInReader(Encoding encoding)
         {
             Debug.Assert(!Console.IsInputRedirected); // stdin is a terminal.
@@ -215,9 +213,9 @@ namespace System.IO
                                 s_clearToEol ??= ConsolePal.TerminalFormatStringsInstance.ClrEol ?? string.Empty;
 
                                 // Move to end of previous line
-                                ConsolePal.SetCursorPosition(StdInHandle, ConsolePal.WindowWidth - 1, top - 1);
+                                ConsolePal.SetTerminalCursorPosition(ConsolePal.WindowWidth - 1, top - 1);
                                 // Clear from cursor to end of the line
-                                ConsolePal.WriteTerminalAnsiString(StdInHandle, s_clearToEol, mayChangeCursorPosition: false);
+                                ConsolePal.WriteTerminalAnsiString(s_clearToEol, mayChangeCursorPosition: false);
                             }
                             else
                             {
@@ -227,7 +225,7 @@ namespace System.IO
                                     s_moveLeftString = !string.IsNullOrEmpty(moveLeft) ? moveLeft + " " + moveLeft : string.Empty;
                                 }
 
-                                ConsolePal.WriteTerminalAnsiString(StdInHandle, s_moveLeftString);
+                                ConsolePal.WriteTerminalAnsiString(s_moveLeftString);
                             }
                         }
                     }
@@ -247,7 +245,7 @@ namespace System.IO
                         _readLineSB.Clear();
                         if (freshKeys)
                         {
-                            ConsolePal.WriteTerminalAnsiString(StdInHandle, ConsolePal.TerminalFormatStringsInstance.Clear);
+                            ConsolePal.WriteTerminalAnsiString(ConsolePal.TerminalFormatStringsInstance.Clear);
                         }
                     }
                     else if (keyInfo.KeyChar != '\0')
@@ -386,10 +384,7 @@ namespace System.IO
                 return;
             }
 
-            lock (Console.Out) // synchronize with other writers
-            {
-                ConsolePal.Write(StdInHandle, bytes.Slice(0, bytesWritten));
-            }
+            ConsolePal.WriteToTerminal(bytes.Slice(0, bytesWritten));
         }
     }
 }

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -32,7 +32,7 @@ namespace System.IO
         private int _startIndex; // First unprocessed index in the buffer;
         private int _endIndex; // Index after last unprocessed index in the buffer;
 
-        private SafeFileHandle StdInHandle => Interop.Sys.FileDescriptors.STDIN_FILENO;
+        private static SafeFileHandle StdInHandle => Interop.Sys.FileDescriptors.STDIN_FILENO;
 
         internal StdInReader(Encoding encoding, bool isTerminal)
         {

--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -20,11 +20,11 @@ namespace System.IO
             }
         }
 
-        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
+        public ConsoleKeyInfo ReadKey(bool intercept)
         {
             lock (this)
             {
-                return Inner.ReadKey(out previouslyProcessed);
+                return Inner.ReadKey(intercept);
             }
         }
 

--- a/src/native/libs/System.Native/pal_console.c
+++ b/src/native/libs/System.Native/pal_console.c
@@ -33,6 +33,7 @@ int32_t SystemNative_GetWindowSize(intptr_t fd, WinSize* windowSize)
 
     return error;
 #else
+    (void)fd;
     memset(windowSize, 0, sizeof(WinSize)); // managed out param must be initialized
     errno = ENOTSUP;
     return -1;

--- a/src/native/libs/System.Native/pal_console.c
+++ b/src/native/libs/System.Native/pal_console.c
@@ -19,12 +19,12 @@
 #include <pthread.h>
 #include <signal.h>
 
-int32_t SystemNative_GetWindowSize(WinSize* windowSize)
+int32_t SystemNative_GetWindowSize(intptr_t fd, WinSize* windowSize)
 {
     assert(windowSize != NULL);
 
 #if HAVE_IOCTL && HAVE_TIOCGWINSZ
-    int error = ioctl(STDOUT_FILENO, TIOCGWINSZ, windowSize);
+    int error = ioctl(ToFileDescriptor(fd), TIOCGWINSZ, windowSize);
 
     if (error != 0)
     {
@@ -61,6 +61,7 @@ int32_t SystemNative_IsATty(intptr_t fd)
 }
 
 static char* g_keypadXmit = NULL; // string used to enable application mode, from terminfo
+static int g_keypadXmitFd = -1;
 
 static void WriteKeypadXmit(void)
 {
@@ -69,12 +70,12 @@ static void WriteKeypadXmit(void)
     if (g_keypadXmit != NULL)
     {
         ssize_t ret;
-        while (CheckInterrupted(ret = write(STDOUT_FILENO, g_keypadXmit, (size_t)(sizeof(char) * strlen(g_keypadXmit)))));
-        assert(ret >= 0); // failure to change the mode should not prevent app from continuing
+        while (CheckInterrupted(ret = write(g_keypadXmitFd, g_keypadXmit, (size_t)(sizeof(char) * strlen(g_keypadXmit)))));
+        assert(ret >= 0 || (errno == EBADF && g_keypadXmitFd == 0)); // failure to change the mode should not prevent app from continuing
     }
 }
 
-void SystemNative_SetKeypadXmit(const char* terminfoString)
+void SystemNative_SetKeypadXmit(intptr_t fd, const char* terminfoString)
 {
     assert(terminfoString != NULL);
 
@@ -85,6 +86,7 @@ void SystemNative_SetKeypadXmit(const char* terminfoString)
     }
 
     // Store the string to use to enter application mode, then enter
+    g_keypadXmitFd = ToFileDescriptor(fd);
     g_keypadXmit = strdup(terminfoString);
     WriteKeypadXmit();
 }
@@ -108,7 +110,6 @@ static bool g_reading = false;                // tracks whether the application 
 static bool g_childUsesTerminal = false;      // tracks whether a child process is using the terminal
 static bool g_terminalUninitialized = false;  // tracks whether the application is terminating
 static bool g_terminalConfigured = false;     // tracks whether the application configured the terminal.
-
 static bool g_hasTty = false;                  // cache we are not a tty
 
 static volatile bool g_receivedSigTtou = false;

--- a/src/native/libs/System.Native/pal_console.h
+++ b/src/native/libs/System.Native/pal_console.h
@@ -46,7 +46,7 @@ typedef struct
  *
  * Returns 0 on success; otherwise, returns -1 and sets errno.
  */
-PALEXPORT int32_t SystemNative_GetWindowSize(WinSize* windowsSize);
+PALEXPORT int32_t SystemNative_GetWindowSize(intptr_t fd, WinSize* windowsSize);
 
 /**
  * Sets the windows size of the terminal
@@ -76,7 +76,7 @@ PALEXPORT int32_t SystemNative_InitializeTerminalAndSignalHandling(void);
  *
  * Returns 1 on success; otherwise returns 0 and sets errno.
  */
-PALEXPORT void SystemNative_SetKeypadXmit(const char* terminfoString);
+PALEXPORT void SystemNative_SetKeypadXmit(intptr_t fd, const char* terminfoString);
 
 /**
  * Gets the special control character codes for the requested control characters.

--- a/src/native/libs/System.Native/pal_console_wasi.c
+++ b/src/native/libs/System.Native/pal_console_wasi.c
@@ -25,6 +25,7 @@
 
 int32_t SystemNative_GetWindowSize(intptr_t fd, WinSize* windowSize)
 {
+    (void)fd;
     assert(windowSize != NULL);
     memset(windowSize, 0, sizeof(WinSize)); // managed out param must be initialized
     errno = ENOTSUP;
@@ -46,6 +47,7 @@ int32_t SystemNative_IsATty(intptr_t fd)
 DEBUGNOTRETURN
 void SystemNative_SetKeypadXmit(intptr_t fd, const char* terminfoString)
 {
+    (void)fd;
     assert(terminfoString != NULL);
     assert_msg(false, "Not supported on WASI", 0);
 }

--- a/src/native/libs/System.Native/pal_console_wasi.c
+++ b/src/native/libs/System.Native/pal_console_wasi.c
@@ -23,7 +23,7 @@
 #define DEBUGNOTRETURN
 #endif
 
-int32_t SystemNative_GetWindowSize(WinSize* windowSize)
+int32_t SystemNative_GetWindowSize(intptr_t fd, WinSize* windowSize)
 {
     assert(windowSize != NULL);
     memset(windowSize, 0, sizeof(WinSize)); // managed out param must be initialized
@@ -44,7 +44,7 @@ int32_t SystemNative_IsATty(intptr_t fd)
 }
 
 DEBUGNOTRETURN
-void SystemNative_SetKeypadXmit(const char* terminfoString)
+void SystemNative_SetKeypadXmit(intptr_t fd, const char* terminfoString)
 {
     assert(terminfoString != NULL);
     assert_msg(false, "Not supported on WASI", 0);


### PR DESCRIPTION
On Unix .NET implements its own echo to make Console behave similar to Windows.

The echo implementation was writing to standard output, which has the unintended effect of writing the echo characters into a redirected standard output.

This changes to write the echo to the stdin terminal where they were read from.

Fixes https://github.com/dotnet/runtime/issues/22314.

@adamsitnik @stephentoub ptal.