### PR TITLE
Make Deflate/GZip/ZlibStream empty writes have the same impact as no writes

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/Deflater.cs
@@ -122,10 +122,7 @@ namespace System.IO.Compression
         internal unsafe void SetInput(ReadOnlyMemory<byte> inputBuffer)
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
-            if (0 == inputBuffer.Length)
-            {
-                return;
-            }
+            Debug.Assert(!inputBuffer.IsEmpty);
 
             lock (SyncLock)
             {
@@ -140,11 +137,7 @@ namespace System.IO.Compression
         {
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
             Debug.Assert(inputBufferPtr != null);
-
-            if (count == 0)
-            {
-                return;
-            }
+            Debug.Assert(count > 0);
 
             lock (SyncLock)
             {

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Gzip.cs
@@ -55,6 +55,65 @@ namespace System.IO.Compression
         {
         }
 
+        [Fact]
+        public async Task ConcatenatedEmptyGzipStreams()
+        {
+            const int copyToBufferSizeRequested = 0x8000;
+
+            // we'll request a specific size buffer, but we cannot guarantee that's the size
+            // that will be used since CopyTo will rent from the array pool
+            // take advantage of this knowledge to find out what size it will actually use
+            var rentedBuffer = ArrayPool<byte>.Shared.Rent(copyToBufferSizeRequested);
+            int actualBufferSize = rentedBuffer.Length;
+            ArrayPool<byte>.Shared.Return(rentedBuffer);
+
+            // use 3 buffers-full so that we can prime the stream with the first buffer-full,
+            // test that CopyTo successfully flushes this at the beginning of the operation,
+            // then populates the second buffer-full and reads its entirety despite every
+            // payload being 0 length before it reads the final buffer-full.
+            int minCompressedSize = 3 * actualBufferSize;
+
+            // A single empty chunk in a GZIP header/footer. This is writing the bytes directly
+            // as the implementation now avoids writing 0-length chunks.
+            byte[] payload = [31, 139, 8, 0, 0, 0, 0, 0, 2, 10, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+            using (Stream compressedStream = new DerivedMemoryStream())
+            {
+                using (var gz = new GZipStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                {
+                    // write one byte in order to allow us to prime the inflater buffer
+                    gz.WriteByte(3);
+                }
+
+                while (compressedStream.Length < minCompressedSize)
+                {
+                    compressedStream.Write(payload);
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater buffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    gz.CopyTo(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+
+                compressedStream.Seek(0, SeekOrigin.Begin);
+                using (Stream gz = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true))
+                using (Stream decompressedData = new DerivedMemoryStream())
+                {
+                    // read one byte in order to fill the inflater buffer before copy
+                    Assert.Equal(3, gz.ReadByte());
+
+                    await gz.CopyToAsync(decompressedData, copyToBufferSizeRequested);
+                    Assert.Equal(0, decompressedData.Length);
+                }
+            }
+        }
+
         [Theory]
         [InlineData(1000, TestScenario.Read, 1000, 1)]
         [InlineData(1000, TestScenario.ReadByte, 0, 1)]


### PR DESCRIPTION
If you create such a compression stream, don't write to it, and close it, it won't write out any bytes.  But today if you perform an empty write, it'll result in the stream thinking data was written, and it'll end up writing out an empty chunk, which will result in several bytes of output.  Logically it's strange that there's such a difference between an empty write and no write; this seeks to make them the same.

This changed back in 2015, in https://github.com/dotnet/corefx/pull/4917, I _think_ unintentionally.

@ericstj, this removes a test you added in https://github.com/dotnet/corefx/pull/41190 (the test relies on an empty write resulting in a non-empty compressed payload).  Do you have concerns with this change? Is there reason to believe folks depend on this?  In general with compression we make no guarantees version to version about generated bytes other than that they'll roundtrip, but this change obviously breaks that test you added, which will now loop forever because it assumes the number of bytes written will not be 0.