### PR TITLE
Disallow inlining Main

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1129,15 +1129,6 @@ namespace Internal.JitInterface
             {
                 result |= CorInfoFlag.CORINFO_FLG_FORCEINLINE;
             }
-#if !READYTORUN
-            else if (method.OwningType is EcmaType ecmaOwningType
-                && ecmaOwningType.EcmaModule.EntryPoint == method)
-            {
-                // Mark entrypoint as NoInlining for better debugging. We don't want it to inline
-                // into startup code because breakpoints won't hit and stack traces won't have Main.
-                result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
-            }
-#endif
 
             if (method.OwningType.IsDelegate && method.Name == "Invoke")
             {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1129,6 +1129,15 @@ namespace Internal.JitInterface
             {
                 result |= CorInfoFlag.CORINFO_FLG_FORCEINLINE;
             }
+#if !READYTORUN
+            else if (method.OwningType is EcmaType ecmaOwningType
+                && ecmaOwningType.EcmaModule.EntryPoint == method)
+            {
+                // Mark entrypoint as NoInlining for better debugging. We don't want it to inline
+                // into startup code because breakpoints won't hit and stack traces won't have Main.
+                result |= CorInfoFlag.CORINFO_FLG_DONT_INLINE;
+            }
+#endif
 
             if (method.OwningType.IsDelegate && method.Name == "Invoke")
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -288,7 +288,7 @@ namespace Internal.IL.Stubs.StartupCode
                     codeStream.MarkDebuggerStepInPoint();
 
                 // This would be tail call eligible but we don't do tail calls
-                // if the method is marked NoOptimization and we just did it above.
+                // if the method is marked NoInlining and we just did it above.
                 codeStream.Emit(ILOpcode.tail);
                 codeStream.Emit(ILOpcode.call, emit.NewToken(WrappedMethod));
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -254,6 +254,25 @@ namespace Internal.IL.Stubs.StartupCode
                 }
             }
 
+            public override bool IsNoOptimization
+            {
+                get
+                {
+                    // Mark as no optimization so that Main doesn't get inlined
+                    // into this method. We want Main to be visible in stack traces.
+                    return true;
+                }
+            }
+
+            public override bool IsNoInlining
+            {
+                get
+                {
+                    // Mark NoInlining so that IsNoOptimization is guaranteed to kick in.
+                    return true;
+                }
+            }
+
             public override MethodIL EmitIL()
             {
                 ILEmitter emit = new ILEmitter();
@@ -268,6 +287,9 @@ namespace Internal.IL.Stubs.StartupCode
                 if (Context.Target.IsWindows)
                     codeStream.MarkDebuggerStepInPoint();
 
+                // This would be tail call eligible but we don't do tail calls
+                // if the method is marked NoOptimization and we just did it above.
+                codeStream.Emit(ILOpcode.tail);
                 codeStream.Emit(ILOpcode.call, emit.NewToken(WrappedMethod));
 
                 codeStream.Emit(ILOpcode.ret);

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -803,8 +803,8 @@ namespace Internal.JitInterface
                 if (caller.OwningType is EcmaType ecmaOwningType
                     && ecmaOwningType.EcmaModule.EntryPoint == caller)
                 {
-                    // We don't want to tailcall the entrypoint for an application; It results in a rather
-                    // confusing debugging experience.
+                    // Do not tailcall from the application entrypoint.
+                    // We want Main to be visible in stack traces.
                     result = false;
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -13,6 +13,7 @@ using Internal.ReadyToRunConstants;
 
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
+using Internal.TypeSystem.Ecma;
 
 #if SUPPORT_JIT
 using MethodCodeNode = Internal.Runtime.JitSupport.JitMethodCodeNode;
@@ -798,6 +799,14 @@ namespace Internal.JitInterface
             if (!fIsTailPrefix)
             {
                 MethodDesc caller = HandleToObject(callerHnd);
+
+                if (caller.OwningType is EcmaType ecmaOwningType
+                    && ecmaOwningType.EcmaModule.EntryPoint == caller)
+                {
+                    // We don't want to tailcall the entrypoint for an application; It results in a rather
+                    // confusing debugging experience.
+                    result = false;
+                }
 
                 if (caller.IsNoInlining)
                 {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8226,9 +8226,8 @@ bool CEEInfo::canTailCall (CORINFO_METHOD_HANDLE hCaller,
     {
         mdMethodDef callerToken = pCaller->GetMemberDef();
 
-        // We don't want to tailcall the entrypoint for an application; JIT64 will sometimes
-        // do this for simple entrypoints and it results in a rather confusing debugging
-        // experience.
+        // Do not tailcall from the application entrypoint.
+        // We want Main to be visible in stack traces.
         if (callerToken == pCaller->GetModule()->GetEntryPointToken())
         {
             result = false;


### PR DESCRIPTION
When we compile managed code, `Main` is not the actual spot where execution of managed code starts. Instead it's the `StartupCodeMain` method that the compiler generates. This method is responsible for initializing the managed environment, calling `Main` and tearing down the environment. If `Main` is short enough, sometimes it gets inlined into `StartupCodeMain` this has bad impact on diagnostics (don't see `Main` in stack traces, can't set breakpoints). Pretend it was marked `NoInlining`.

Cc @dotnet/ilc-contrib 