### PR TITLE
Do not release frozen segment if we failed extending it

### DIFF
--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -237,7 +237,6 @@ Object* FrozenObjectSegment::TryAllocateObject(PTR_MethodTable type, size_t obje
 
         if (ClrVirtualAlloc(m_pStart + m_SizeCommitted, FOH_COMMIT_SIZE, MEM_COMMIT, PAGE_READWRITE) == nullptr)
         {
-            ClrVirtualFree(m_pStart, 0, MEM_RELEASE);
             ThrowOutOfMemory();
         }
         m_SizeCommitted += FOH_COMMIT_SIZE;


### PR DESCRIPTION
Maybe I'm missing something, but if we try to commit more of the reserved segment and this fails, it doesn't feel right to release the whole thing. The previously committed part of the segment is still in use.