### PR TITLE
Fix Comvariant Failure on s390x

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -47,8 +47,13 @@ namespace System.Runtime.InteropServices.Marshalling
         [StructLayout(LayoutKind.Sequential)]
         private struct TypeUnion
         {
+#if BIGENDIAN
+            public ushort _wReserved1;
+            public ushort _vt;
+#else
             public ushort _vt;
             public ushort _wReserved1;
+#endif
             public ushort _wReserved2;
             public ushort _wReserved3;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -47,6 +47,7 @@ namespace System.Runtime.InteropServices.Marshalling
         [StructLayout(LayoutKind.Sequential)]
         private struct TypeUnion
         {
+            // The layout of _wReserved1 and _vt fields needs to match Decimal._flags
 #if BIGENDIAN
             public ushort _wReserved1;
             public ushort _vt;


### PR DESCRIPTION
The CI Reported two test failure on S390x
```
System.Runtime.InteropServices.Tests.ComVariantMarshallerTests.Decimal_Marshals_To_DECIMAL [FAIL]
System.Runtime.InteropServices.Tests.ComVariantTests.Decimal [FAIL]
```
cc: @uweigand 