### PR TITLE
[release/8.0-staging] Use live M.Bcl.AsyncInterfaces dependency

### DIFF
--- a/src/libraries/Microsoft.Bcl.TimeProvider/ref/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/ref/Microsoft.Bcl.TimeProvider.csproj
@@ -13,6 +13,6 @@
     <Compile Include="Microsoft.Bcl.TimeProvider.Common.cs" />
   </ItemGroup>
  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+   <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\ref\Microsoft.Bcl.AsyncInterfaces.csproj" />
  </ItemGroup>
 </Project>

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
@@ -31,7 +31,7 @@ System.ITimer</PackageDescription>
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
+    <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Bcl.AsyncInterfaces\src\Microsoft.Bcl.AsyncInterfaces.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
@@ -14,6 +14,8 @@ System.TimeProvider
 System.ITimer</PackageDescription>
     <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/src/Microsoft.Bcl.TimeProvider.csproj
@@ -15,7 +15,7 @@ System.ITimer</PackageDescription>
     <!-- This library uses IsPartialFacadeAssembly for which the compiler doesn't produce any XML documentation. -->
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>1</ServicingVersion
+    <ServicingVersion>1</ServicingVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/94451

## Customer Impact
Customers who reference the `Microsoft.Bcl.TimeProvider` polyfill package, transitively reference the 6.0.0 version of the `Microsoft.Bcl.AsyncInterfaces` package instead of the 8.0.0 version.

Not brining in the old 6.0.0 version is especially important for the .NET deprecation effort. At the time when we will deprecate our 6.0.x packages, we would need to keep AsyncInterfaces un-deprecated as it is referenced by the TimeProvider package.

## Testing
Manually produced the package and now seeing the correct 8.0.0 version in the package / nuspec.

## Risk
Low. Two msbuild project files are changed. No code changes aside from that.