### PR TITLE
Update Marshal.QueryInterface() argument modifier (take 2)

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -56,7 +56,7 @@ namespace System.Runtime.InteropServices
             }
 
             wrapperId = wrapper._comWrappers.id;
-            return Marshal.QueryInterface(wrapper._externalComObject, in iid, out unknown) == HResults.S_OK;
+            return Marshal.QueryInterface(wrapper._externalComObject, iid, out unknown) == HResults.S_OK;
         }
 
         public static unsafe bool TryGetComInstance(object obj, out IntPtr unknown)
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices
                 return false;
             }
 
-            return Marshal.QueryInterface(wrapper._externalComObject, in IID_IUnknown, out unknown) == HResults.S_OK;
+            return Marshal.QueryInterface(wrapper._externalComObject, IID_IUnknown, out unknown) == HResults.S_OK;
         }
 
         public static unsafe bool TryGetObject(IntPtr unknown, [NotNullWhen(true)] out object? obj)
@@ -512,7 +512,7 @@ namespace System.Runtime.InteropServices
             public static NativeObjectWrapper Create(IntPtr externalComObject, IntPtr inner, ComWrappers comWrappers, object comProxy, CreateObjectFlags flags)
             {
                 if (flags.HasFlag(CreateObjectFlags.TrackerObject) &&
-                    Marshal.QueryInterface(externalComObject, in IID_IReferenceTracker, out IntPtr trackerObject) == HResults.S_OK)
+                    Marshal.QueryInterface(externalComObject, IID_IReferenceTracker, out IntPtr trackerObject) == HResults.S_OK)
                 {
                     return new ReferenceTrackerNativeObjectWrapper(externalComObject, inner, comWrappers, comProxy, flags, trackerObject);
                 }
@@ -854,7 +854,7 @@ namespace System.Runtime.InteropServices
             {
                 // It is possible the user has defined their own IUnknown impl so
                 // we fallback to the tagged interface approach to be sure.
-                if (0 != Marshal.QueryInterface(comObject, in IID_TaggedImpl, out nint implMaybe))
+                if (0 != Marshal.QueryInterface(comObject, IID_TaggedImpl, out nint implMaybe))
                 {
                     return null;
                 }
@@ -888,7 +888,7 @@ namespace System.Runtime.InteropServices
             bool refTrackerInnerScenario = flags.HasFlag(CreateObjectFlags.TrackerObject)
                 && flags.HasFlag(CreateObjectFlags.Aggregation);
             if (refTrackerInnerScenario &&
-                Marshal.QueryInterface(externalComObject, in IID_IReferenceTracker, out IntPtr referenceTrackerPtr) == HResults.S_OK)
+                Marshal.QueryInterface(externalComObject, IID_IReferenceTracker, out IntPtr referenceTrackerPtr) == HResults.S_OK)
             {
                 // We are checking the supplied external value
                 // for IReferenceTracker since in .NET 5 API usage scenarios
@@ -900,11 +900,11 @@ namespace System.Runtime.InteropServices
                 // be the true identity.
                 using ComHolder referenceTracker = new ComHolder(referenceTrackerPtr);
                 checkForIdentity = referenceTrackerPtr;
-                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(checkForIdentity, in IID_IUnknown, out identity));
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(checkForIdentity, IID_IUnknown, out identity));
             }
             else
             {
-                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, in IID_IUnknown, out identity));
+                Marshal.ThrowExceptionForHR(Marshal.QueryInterface(externalComObject, IID_IUnknown, out identity));
             }
 
             // Set the inner if scenario dictates an update.
@@ -1463,7 +1463,7 @@ namespace System.Runtime.InteropServices
                 return HResults.E_INVALIDARG;
             }
 
-            if (Marshal.QueryInterface(punk, in IID_IUnknown, out IntPtr ppv) != HResults.S_OK)
+            if (Marshal.QueryInterface(punk, IID_IUnknown, out IntPtr ppv) != HResults.S_OK)
             {
                 return HResults.COR_E_INVALIDCAST;
             }
@@ -1472,7 +1472,7 @@ namespace System.Runtime.InteropServices
             {
                 using ComHolder identity = new ComHolder(ppv);
                 using ComHolder trackerTarget = new ComHolder(GetOrCreateTrackerTarget(identity.Ptr));
-                return Marshal.QueryInterface(trackerTarget.Ptr, in IID_IReferenceTrackerTarget, out *ppNewReference);
+                return Marshal.QueryInterface(trackerTarget.Ptr, IID_IReferenceTrackerTarget, out *ppNewReference);
             }
             catch (Exception e)
             {
@@ -1594,7 +1594,7 @@ namespace System.Runtime.InteropServices
                 targetPtr != IntPtr.Zero)
             {
                 using ComHolder target = new ComHolder(targetPtr);
-                if (Marshal.QueryInterface(target.Ptr, in IID_IUnknown, out IntPtr targetIdentityPtr) == HResults.S_OK)
+                if (Marshal.QueryInterface(target.Ptr, IID_IUnknown, out IntPtr targetIdentityPtr) == HResults.S_OK)
                 {
                     using ComHolder targetIdentity = new ComHolder(targetIdentityPtr);
                     return GetOrCreateObjectFromWrapper(wrapperId, targetIdentity.Ptr);

--- a/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
@@ -37,8 +37,7 @@ namespace System.Data.OleDb
         {
             Debug.Assert(flags == CreateObjectFlags.UniqueInstance);
 
-            Guid errorInfoIID = IID_IErrorInfo;
-            int hr = Marshal.QueryInterface(externalComObject, ref errorInfoIID, out IntPtr comObject);
+            int hr = Marshal.QueryInterface(externalComObject, IID_IErrorInfo, out IntPtr comObject);
             if (hr == S_OK)
             {
                 return new ErrorInfoWrapper(comObject);

--- a/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbComWrappers.cs
@@ -37,7 +37,10 @@ namespace System.Data.OleDb
         {
             Debug.Assert(flags == CreateObjectFlags.UniqueInstance);
 
-            int hr = Marshal.QueryInterface(externalComObject, IID_IErrorInfo, out IntPtr comObject);
+            Guid errorInfoIID = IID_IErrorInfo;
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+            int hr = Marshal.QueryInterface(externalComObject, ref errorInfoIID, out IntPtr comObject);
+#pragma warning restore CS9191
             if (hr == S_OK)
             {
                 return new ErrorInfoWrapper(comObject);

--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -675,7 +675,9 @@ namespace System.Data.OleDb
             finally
             {
                 Guid IID_IChapteredRowset = typeof(System.Data.Common.UnsafeNativeMethods.IChapteredRowset).GUID;
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, IID_IChapteredRowset, out var pChapteredRowset);
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_IChapteredRowset, out var pChapteredRowset);
+#pragma warning restore CS9191
                 if (pChapteredRowset != IntPtr.Zero)
                 {
                     var chapteredRowset = (System.Data.Common.UnsafeNativeMethods.IChapteredRowset)Marshal.GetObjectForIUnknown(pChapteredRowset);
@@ -695,7 +697,10 @@ namespace System.Data.OleDb
             { }
             finally
             {
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, typeof(ITransactionLocal).GUID, out var pTransaction);
+                Guid IID_ITransactionLocal = typeof(ITransactionLocal).GUID;
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_ITransactionLocal, out var pTransaction);
+#pragma warning restore CS9191
                 if (pTransaction != IntPtr.Zero)
                 {
                     ITransactionLocal transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);
@@ -715,7 +720,10 @@ namespace System.Data.OleDb
             { }
             finally
             {
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, typeof(ITransactionLocal).GUID, out var pTransaction);
+                Guid IID_ITransactionLocal = typeof(ITransactionLocal).GUID;
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_ITransactionLocal, out var pTransaction);
+#pragma warning restore CS9191
                 if (pTransaction != IntPtr.Zero)
                 {
                     ITransactionLocal transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);

--- a/src/libraries/System.Data.OleDb/src/SafeHandles.cs
+++ b/src/libraries/System.Data.OleDb/src/SafeHandles.cs
@@ -675,7 +675,7 @@ namespace System.Data.OleDb
             finally
             {
                 Guid IID_IChapteredRowset = typeof(System.Data.Common.UnsafeNativeMethods.IChapteredRowset).GUID;
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_IChapteredRowset, out var pChapteredRowset);
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, IID_IChapteredRowset, out var pChapteredRowset);
                 if (pChapteredRowset != IntPtr.Zero)
                 {
                     var chapteredRowset = (System.Data.Common.UnsafeNativeMethods.IChapteredRowset)Marshal.GetObjectForIUnknown(pChapteredRowset);
@@ -695,8 +695,7 @@ namespace System.Data.OleDb
             { }
             finally
             {
-                Guid IID_ITransactionLocal = typeof(ITransactionLocal).GUID;
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_ITransactionLocal, out var pTransaction);
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, typeof(ITransactionLocal).GUID, out var pTransaction);
                 if (pTransaction != IntPtr.Zero)
                 {
                     ITransactionLocal transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);
@@ -716,8 +715,7 @@ namespace System.Data.OleDb
             { }
             finally
             {
-                Guid IID_ITransactionLocal = typeof(ITransactionLocal).GUID;
-                hr = (OleDbHResult)Marshal.QueryInterface(ptr, ref IID_ITransactionLocal, out var pTransaction);
+                hr = (OleDbHResult)Marshal.QueryInterface(ptr, typeof(ITransactionLocal).GUID, out var pTransaction);
                 if (pTransaction != IntPtr.Zero)
                 {
                     ITransactionLocal transactionLocal = (ITransactionLocal)Marshal.GetObjectForIUnknown(pTransaction);

--- a/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
+++ b/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Runtime.Serialization;
@@ -1343,7 +1344,9 @@ namespace System.Management
                     return false;
 
                 // If we CAN get to the IObjectContext interface, we have a 'context'
-                if (0 == Marshal.QueryInterface(pComThreadingInfo, IID_IObjectContext, out pObjectContext))
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                if (0 == Marshal.QueryInterface(pComThreadingInfo, ref Unsafe.AsRef(in IID_IObjectContext), out pObjectContext))
+#pragma warning restore CS9191
                     return false;
             }
             finally

--- a/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
+++ b/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
@@ -1299,8 +1299,8 @@ namespace System.Management
         }
 
         // Interfaces that we need to use
-        private static Guid IID_IObjectContext = new Guid("51372AE0-CAE7-11CF-BE81-00AA00A2FA25");
-        private static Guid IID_IComThreadingInfo = new Guid("000001ce-0000-0000-C000-000000000046");
+        private static readonly Guid IID_IObjectContext = new Guid("51372AE0-CAE7-11CF-BE81-00AA00A2FA25");
+        private static readonly Guid IID_IComThreadingInfo = new Guid("000001ce-0000-0000-C000-000000000046");
 
         // A variable that is initialized once to tell us if we are on
         // a Win2k platform or above.
@@ -1343,7 +1343,7 @@ namespace System.Management
                     return false;
 
                 // If we CAN get to the IObjectContext interface, we have a 'context'
-                if (0 == Marshal.QueryInterface(pComThreadingInfo, ref IID_IObjectContext, out pObjectContext))
+                if (0 == Marshal.QueryInterface(pComThreadingInfo, IID_IObjectContext, out pObjectContext))
                     return false;
             }
             finally

--- a/src/libraries/System.Management/src/System/Management/wmiutil.cs
+++ b/src/libraries/System.Management/src/System/Management/wmiutil.cs
@@ -33,7 +33,7 @@ namespace System.Management
             if (IntPtr.Zero != pErrorInfo && new IntPtr(-1) != pErrorInfo)
             {
                 IntPtr pIWbemClassObject;
-                Marshal.QueryInterface(pErrorInfo, ref IWbemClassObjectFreeThreaded.IID_IWbemClassObject, out pIWbemClassObject);
+                Marshal.QueryInterface(pErrorInfo, IWbemClassObjectFreeThreaded.IID_IWbemClassObject, out pIWbemClassObject);
                 Marshal.Release(pErrorInfo);
 
                 // The IWbemClassObjectFreeThreaded instance will own reference count on pIWbemClassObject

--- a/src/libraries/System.Management/src/System/Management/wmiutil.cs
+++ b/src/libraries/System.Management/src/System/Management/wmiutil.cs
@@ -33,7 +33,9 @@ namespace System.Management
             if (IntPtr.Zero != pErrorInfo && new IntPtr(-1) != pErrorInfo)
             {
                 IntPtr pIWbemClassObject;
-                Marshal.QueryInterface(pErrorInfo, IWbemClassObjectFreeThreaded.IID_IWbemClassObject, out pIWbemClassObject);
+#pragma warning disable CS9191 // The 'ref' modifier for argument 1 corresponding to 'in' parameter is equivalent to 'in'. Consider using 'in' instead.
+                Marshal.QueryInterface(pErrorInfo, ref IWbemClassObjectFreeThreaded.IID_IWbemClassObject, out pIWbemClassObject);
+#pragma warning restore CS9191
                 Marshal.Release(pErrorInfo);
 
                 // The IWbemClassObjectFreeThreaded instance will own reference count on pIWbemClassObject

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -130,7 +130,7 @@ namespace System.Runtime.InteropServices
             return SizeOfHelper(t, throwIfNotMarshalable: true);
         }
 
-        public static unsafe int QueryInterface(IntPtr pUnk, ref readonly Guid iid, out IntPtr ppv)
+        public static unsafe int QueryInterface(IntPtr pUnk, in Guid iid, out IntPtr ppv)
         {
             ArgumentNullException.ThrowIfNull(pUnk);
 

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -1121,7 +1121,7 @@ namespace System.Runtime.InteropServices
         public static object? PtrToStructure(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors| System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)] System.Type structureType) { throw null; }
         public static T? PtrToStructure<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]T>(System.IntPtr ptr) { throw null; }
         public static void PtrToStructure<T>(System.IntPtr ptr, [System.Diagnostics.CodeAnalysis.DisallowNullAttribute] T structure) { }
-        public static int QueryInterface(System.IntPtr pUnk, ref readonly System.Guid iid, out System.IntPtr ppv) { throw null; }
+        public static int QueryInterface(System.IntPtr pUnk, in System.Guid iid, out System.IntPtr ppv) { throw null; }
         public static byte ReadByte(System.IntPtr ptr) { throw null; }
         public static byte ReadByte(System.IntPtr ptr, int ofs) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Marshalling code for the object might not be available")]

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/FreeThreadedStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/FreeThreadedStrategy.cs
@@ -18,7 +18,7 @@ namespace System.Runtime.InteropServices.Marshalling
 
         unsafe int IIUnknownStrategy.QueryInterface(void* thisPtr, in Guid handle, out void* ppObj)
         {
-            int hr = Marshal.QueryInterface((nint)thisPtr, in handle, out nint ppv);
+            int hr = Marshal.QueryInterface((nint)thisPtr, handle, out nint ppv);
             if (hr < 0)
             {
                 ppObj = null;

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/IIUnknownStrategy.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/IIUnknownStrategy.cs
@@ -32,7 +32,7 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="iid">The IID (Interface ID) to query for.</param>
         /// <param name="ppObj">The resulting interface.</param>
         /// <returns>Returns an HRESULT represents the success of the operation.</returns>
-        /// <seealso cref="Marshal.QueryInterface(nint, ref readonly Guid, out nint)"/>
+        /// <seealso cref="Marshal.QueryInterface(nint, in Guid, out nint)"/>
         public int QueryInterface(void* instancePtr, in Guid iid, out void* ppObj);
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/GeneratedComClassTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Tests/GeneratedComClassTests.cs
@@ -46,8 +46,7 @@ namespace ComInterfaceGenerator.Tests
             StrategyBasedComWrappers wrappers = new();
             nint ptr = wrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.None);
             Assert.NotEqual(0, ptr);
-            var iid = typeof(IGetAndSetInt).GUID;
-            Assert.Equal(0, Marshal.QueryInterface(ptr, in iid, out nint iComInterface));
+            Assert.Equal(0, Marshal.QueryInterface(ptr, typeof(IGetAndSetInt).GUID, out nint iComInterface));
             Assert.NotEqual(0, iComInterface);
             Marshal.Release(iComInterface);
             Marshal.Release(ptr);
@@ -60,8 +59,7 @@ namespace ComInterfaceGenerator.Tests
             StrategyBasedComWrappers wrappers = new();
             nint ptr = wrappers.GetOrCreateComInterfaceForObject(obj, CreateComInterfaceFlags.None);
             Assert.NotEqual(0, ptr);
-            var iid = typeof(IGetAndSetInt).GUID;
-            Assert.Equal(0, Marshal.QueryInterface(ptr, in iid, out nint iComInterface));
+            Assert.Equal(0, Marshal.QueryInterface(ptr, typeof(IGetAndSetInt).GUID, out nint iComInterface));
             Assert.NotEqual(0, iComInterface);
             Marshal.Release(iComInterface);
             Marshal.Release(ptr);

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/QueryInterfaceTests.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/QueryInterfaceTests.Windows.cs
@@ -47,7 +47,7 @@ namespace System.Runtime.InteropServices.Tests
             try
             {
                 Guid guid = new Guid(iidString);
-                Assert.Equal(0, Marshal.QueryInterface(ptr, in guid, out IntPtr ppv));
+                Assert.Equal(0, Marshal.QueryInterface(ptr, guid, out IntPtr ppv));
                 Assert.NotEqual(IntPtr.Zero, ppv);
                 try
                 {
@@ -103,7 +103,7 @@ namespace System.Runtime.InteropServices.Tests
             try
             {
                 Guid iid = new Guid(iidString);
-                Assert.Equal(E_NOINTERFACE, Marshal.QueryInterface(ptr, in iid, out IntPtr ppv));
+                Assert.Equal(E_NOINTERFACE, Marshal.QueryInterface(ptr, iid, out IntPtr ppv));
                 Assert.Equal(IntPtr.Zero, ppv);
                 Assert.Equal(new Guid(iidString), iid);
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/QueryInterfaceTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/QueryInterfaceTests.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.InteropServices.Tests
             try
             {
                 Guid guid = new Guid(iidString);
-                Assert.Equal(0, Marshal.QueryInterface(ptr, in guid, out IntPtr ppv));
+                Assert.Equal(0, Marshal.QueryInterface(ptr, guid, out IntPtr ppv));
                 Assert.NotEqual(IntPtr.Zero, ppv);
                 try
                 {
@@ -64,7 +64,7 @@ namespace System.Runtime.InteropServices.Tests
             try
             {
                 Guid iid = new Guid(iidString);
-                Assert.Equal(E_NOINTERFACE, Marshal.QueryInterface(ptr, in iid, out IntPtr ppv));
+                Assert.Equal(E_NOINTERFACE, Marshal.QueryInterface(ptr, iid, out IntPtr ppv));
                 Assert.Equal(IntPtr.Zero, ppv);
                 Assert.Equal(new Guid(iidString), iid);
             }
@@ -77,8 +77,7 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void QueryInterface_ZeroPointer_ThrowsArgumentNullException()
         {
-            Guid iid = Guid.Empty;
-            AssertExtensions.Throws<ArgumentNullException>("pUnk", () => Marshal.QueryInterface(IntPtr.Zero, in iid, out IntPtr ppv));
+            AssertExtensions.Throws<ArgumentNullException>("pUnk", () => Marshal.QueryInterface(IntPtr.Zero, Guid.Empty, out IntPtr ppv));
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaces.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaces.cs
@@ -23,7 +23,7 @@ public static unsafe class ComInterfaces
 
         public void SetData(int x);
 
-        public static Guid IID = new Guid("2c3f9903-b586-46b1-881b-adfce9af47b1");
+        public static readonly Guid IID = new Guid("2c3f9903-b586-46b1-881b-adfce9af47b1");
     }
 
     // Call from another assembly to get a ptr to make an RCW
@@ -100,7 +100,7 @@ public static unsafe class ComInterfaces
         }
         protected override object CreateObject(nint ptr, CreateObjectFlags flags)
         {
-            int hr = Marshal.QueryInterface(ptr, in IComInterface1.IID, out IntPtr IComInterfaceImpl);
+            int hr = Marshal.QueryInterface(ptr, IComInterface1.IID, out IntPtr IComInterfaceImpl);
             if (hr != 0)
             {
                 return null;

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionInterop.cs
@@ -442,7 +442,7 @@ namespace System.Transactions
                 unsafe
                 {
                     nint unknown = Marshal.GetIUnknownForObject(transactionNative);
-                    if (Marshal.QueryInterface(unknown, in Guids.IID_ITransaction_Guid, out IntPtr transactionNativePtr) == 0)
+                    if (Marshal.QueryInterface(unknown, Guids.IID_ITransaction_Guid, out IntPtr transactionNativePtr) == 0)
                     {
                         Marshal.Release(unknown);
                         myTransactionNative = ComInterfaceMarshaller<ITransaction>.ConvertToManaged((void*)transactionNativePtr)!;

--- a/src/tests/Interop/COM/ComWrappers/API/Program.cs
+++ b/src/tests/Interop/COM/ComWrappers/API/Program.cs
@@ -85,16 +85,14 @@ namespace ComWrappersTests
 
             protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
             {
-                var iTrackerObjectIid = typeof(ITrackerObject).GUID;
                 IntPtr iTrackerComObject;
-                int hr = Marshal.QueryInterface(externalComObject, in iTrackerObjectIid, out iTrackerComObject);
+                int hr = Marshal.QueryInterface(externalComObject, typeof(ITrackerObject).GUID, out iTrackerComObject);
                 if (hr == 0)
                 {
                     return new ITrackerObjectWrapper(iTrackerComObject);
                 }
-                var iTestIid = typeof(ITest).GUID;
                 IntPtr iTest;
-                hr = Marshal.QueryInterface(externalComObject, in iTestIid, out iTest);
+                hr = Marshal.QueryInterface(externalComObject, typeof(ITest).GUID, out iTest);
                 if (hr == 0)
                 {
                     return new ITestObjectWrapper(iTest);
@@ -324,9 +322,8 @@ namespace ComWrappersTests
                 IntPtr nativeInstance = wrappers.GetOrCreateComInterfaceForObject(testInstance, CreateComInterfaceFlags.None);
                 Assert.NotEqual(IntPtr.Zero, nativeInstance);
 
-                var iid = typeof(ITest).GUID;
                 nint itestPtr;
-                Assert.Equal(0, Marshal.QueryInterface(nativeInstance, in iid, out itestPtr));
+                Assert.Equal(0, Marshal.QueryInterface(nativeInstance, typeof(ITest).GUID, out itestPtr));
 
                 var inst = (ComWrappers.ComInterfaceDispatch*)itestPtr;
                 var vtbl = (ITestVtbl*)(inst->Vtable);
@@ -380,9 +377,8 @@ namespace ComWrappersTests
                 IntPtr nativeInstance = wrappers.GetOrCreateComInterfaceForObject(Test.Resurrected, CreateComInterfaceFlags.None);
                 Assert.NotEqual(IntPtr.Zero, nativeInstance);
 
-                var iid = typeof(ITest).GUID;
                 nint itestPtr;
-                Assert.Equal(0, Marshal.QueryInterface(nativeInstance, in iid, out itestPtr));
+                Assert.Equal(0, Marshal.QueryInterface(nativeInstance, typeof(ITest).GUID, out itestPtr));
 
                 var inst = (ComWrappers.ComInterfaceDispatch*)itestPtr;
                 var vtbl = (ITestVtbl*)(inst->Vtable);
@@ -419,12 +415,12 @@ namespace ComWrappersTests
             IntPtr result;
             var anyGuid = new Guid("1E42439C-DCB5-4701-ACBD-87FE92E785DE");
             testObj.ICustomQueryInterface_GetInterfaceIID = anyGuid;
-            int hr = Marshal.QueryInterface(comWrapper, in anyGuid, out result);
+            int hr = Marshal.QueryInterface(comWrapper, anyGuid, out result);
             Assert.Equal(0, hr);
             Assert.Equal(testObj.ICustomQueryInterface_GetInterfaceResult, result);
 
             var anyGuid2 = new Guid("7996D0F9-C8DD-4544-B708-0F75C6FF076F");
-            hr = Marshal.QueryInterface(comWrapper, in anyGuid2, out result);
+            hr = Marshal.QueryInterface(comWrapper, anyGuid2, out result);
             const int E_NOINTERFACE = unchecked((int)0x80004002);
             Assert.Equal(E_NOINTERFACE, hr);
             Assert.Equal(IntPtr.Zero, result);
@@ -513,7 +509,7 @@ namespace ComWrappersTests
 
             // Create a wrapper for the unmanaged instance
             IntPtr unmanagedObj = MockReferenceTrackerRuntime.CreateTrackerObject();
-            Assert.Equal(0, Marshal.QueryInterface(unmanagedObj, in IUnknownVtbl.IID_IUnknown, out IntPtr unmanagedObjIUnknown));
+            Assert.Equal(0, Marshal.QueryInterface(unmanagedObj, IUnknownVtbl.IID_IUnknown, out IntPtr unmanagedObjIUnknown));
             var unmanagedWrapper = cw.GetOrCreateObjectForComInstance(unmanagedObj, CreateObjectFlags.None);
 
             // Also allocate a unique instance to validate looking from an uncached instance
@@ -601,9 +597,8 @@ namespace ComWrappersTests
             IntPtr trackerObjRaw = MockReferenceTrackerRuntime.CreateTrackerObject();
 
             // Manually create a wrapper
-            var iid = typeof(ITrackerObject).GUID;
             IntPtr iTestComObject;
-            int hr = Marshal.QueryInterface(trackerObjRaw, in iid, out iTestComObject);
+            int hr = Marshal.QueryInterface(trackerObjRaw, typeof(ITrackerObject).GUID, out iTestComObject);
             Assert.Equal(0, hr);
             var nativeWrapper = new ITrackerObjectWrapper(iTestComObject);
 
@@ -666,9 +661,8 @@ namespace ComWrappersTests
             static WeakReference<ITrackerObjectWrapper> CreateAndRegisterWrapper(ComWrappers cw, IntPtr trackerObjRaw)
             {
                 // Manually create a wrapper
-                var iid = typeof(ITrackerObject).GUID;
                 IntPtr iTestComObject;
-                int hr = Marshal.QueryInterface(trackerObjRaw, in iid, out iTestComObject);
+                int hr = Marshal.QueryInterface(trackerObjRaw, typeof(ITrackerObject).GUID, out iTestComObject);
                 Assert.Equal(0, hr);
                 var nativeWrapper = new ITrackerObjectWrapper(iTestComObject);
 
@@ -884,9 +878,8 @@ namespace ComWrappersTests
             // the wrapper lifetime has been extended. However, the QueryInterface may fail
             // if the associated managed object was collected. The failure here is an important
             // part of the contract for a Reference Tracker runtime.
-            var iid = typeof(ITest).GUID;
             IntPtr iTestComObject;
-            int hr = Marshal.QueryInterface(refTrackerTarget, in iid, out iTestComObject);
+            int hr = Marshal.QueryInterface(refTrackerTarget, typeof(ITest).GUID, out iTestComObject);
 
             const int COR_E_ACCESSING_CCW = unchecked((int)0x80131544);
             Assert.Equal(COR_E_ACCESSING_CCW, hr);

--- a/src/tests/Interop/COM/ComWrappers/Common.cs
+++ b/src/tests/Interop/COM/ComWrappers/Common.cs
@@ -325,7 +325,7 @@ namespace ComWrappersTests.Common
             const int S_OK = 0;
             const int E_NOINTERFACE = unchecked((int)0x80004002);
 
-            int hr = Marshal.QueryInterface(this.classNative.Inner, in iid, out ppv);
+            int hr = Marshal.QueryInterface(this.classNative.Inner, iid, out ppv);
             if (hr == S_OK)
             {
                 return CustomQueryInterfaceResult.Handled;
@@ -402,7 +402,7 @@ namespace ComWrappersTests.Common
                 // it should answer immediately without going through the outer. Either way
                 // the reference count will go to the new instance.
                 IntPtr queryForTracker = isAggregation ? classNative.Inner : classNative.Instance;
-                int hr = Marshal.QueryInterface(queryForTracker, in IID_IReferenceTracker, out classNative.ReferenceTracker);
+                int hr = Marshal.QueryInterface(queryForTracker, IID_IReferenceTracker, out classNative.ReferenceTracker);
                 if (hr != 0)
                 {
                     classNative.ReferenceTracker = default;

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
@@ -158,9 +158,8 @@ namespace ComWrappersTests.GlobalInstance
 
                 for (var i = 0; i < iids.Length; i++)
                 {
-                    var iid = iids[i];
                     IntPtr comObject;
-                    int hr = Marshal.QueryInterface(externalComObject, in iid, out comObject);
+                    int hr = Marshal.QueryInterface(externalComObject, iids[i], out comObject);
                     if (hr == 0)
                         return new FakeWrapper(comObject);
                 }


### PR DESCRIPTION
> [!NOTE]
> This reverts commit a60b66da4a1f1087ea5504599c960da8c1c7636e (from #91983)

Follow up from a conversation with @AaronRobinsonMSFT offline. Now that .NET 8 is done and we're early in the .NET 9 cycle (and most importantly, all tooling is already updated to correctly handle `ref readonly`), we can attempt again to change `Marshal.QueryInterface` to use `in` for the `Guid` parameter (as approved in #85911). I've also updated most `Marshal.QueryInterface` callsites through libraries and tests to leverage the new `in` parameter modifier.

F# also just got a fix to handle `ref readonly` method parameters: https://github.com/dotnet/fsharp/pull/16232.

cc. @tannergooding @vzarytovskii