### PR TITLE
ElapsedEventArgs: public constructor + sealed

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/ref/System.ComponentModel.TypeConverter.cs
@@ -2366,9 +2366,9 @@ namespace System.Security.Authentication.ExtendedProtection
 }
 namespace System.Timers
 {
-    public partial class ElapsedEventArgs : System.EventArgs
+    public sealed partial class ElapsedEventArgs : System.EventArgs
     {
-        internal ElapsedEventArgs() { }
+        public ElapsedEventArgs(System.DateTime signalTime) { }
         public System.DateTime SignalTime { get { throw null; } }
     }
     public delegate void ElapsedEventHandler(object? sender, System.Timers.ElapsedEventArgs e);

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
@@ -3,13 +3,22 @@
 
 namespace System.Timers
 {
-    public class ElapsedEventArgs : EventArgs
+    /// <summary>
+    /// Provides data for the <see cref='System.Timers.Timer.Elapsed'/> event.
+    /// </summary>
+    public sealed class ElapsedEventArgs : EventArgs
     {
-        internal ElapsedEventArgs(DateTime localTime)
+        /// <summary>
+        /// Initializes a new instance of the <see cref='System.Timers.ElapsedEventArgs'/> class.
+        /// </summary>
+        public ElapsedEventArgs(DateTime signalTime)
         {
-            SignalTime = localTime;
+            SignalTime = signalTime;
         }
 
+        /// <summary>
+        /// Gets the time when the timer elapsed.
+        /// </summary>
         public DateTime SignalTime { get; }
     }
 }

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/Timers/ElapsedEventArgs.cs
@@ -11,6 +11,7 @@ namespace System.Timers
         /// <summary>
         /// Initializes a new instance of the <see cref='System.Timers.ElapsedEventArgs'/> class.
         /// </summary>
+        /// <param name="signalTime">Time when the timer elapsed</param>
         public ElapsedEventArgs(DateTime signalTime)
         {
             SignalTime = signalTime;

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/TimerTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/TimerTests.cs
@@ -94,6 +94,14 @@ namespace System.Timers.Tests
             }
         }
 
+        [Fact]
+        public void ElapsedEventArgs_Ctor_SignalTime()
+        {
+            DateTime now = DateTime.Now;
+            ElapsedEventArgs args = new ElapsedEventArgs(now);
+            Assert.Equal(now, args.SignalTime);
+        }
+
         [Theory]
         [InlineData(int.MaxValue)]
         [InlineData(0.5D)]


### PR DESCRIPTION
Changed the internal ElapsedEventArgs constructor to be public, sealed the class, and renamed constructor argument to match property name.

Fix #31204