### PR TITLE
JIT: stop computing dom start nodes for morph RPO

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5330,13 +5330,14 @@ protected:
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 
     void fgDfsReversePostorder();
+    unsigned fgDfsReversePostorderCore(BlockSet_ValArg_T startBlocks);
     void fgDfsReversePostorderHelper(BasicBlock* block,
                                      BlockSet&   visited,
                                      unsigned&   preorderIndex,
                                      unsigned&   reversePostorderIndex);
 
-    BlockSet_ValRet_T fgDomFindStartNodes(); // Computes which basic blocks don't have incoming edges in the flow graph.
-                                             // Returns this as a set.
+    BlockSet_ValRet_T fgDomFindStartBlocks(); // Computes which basic blocks don't have incoming edges in the flow graph.
+                                              // Returns this as a set.
 
     INDEBUG(void fgDispDomTree(DomTreeNode* domTree);) // Helper that prints out the Dominator Tree in debug builds.
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5329,15 +5329,11 @@ protected:
 
     BasicBlock* fgIntersectDom(BasicBlock* a, BasicBlock* b); // Intersect two immediate dominator sets.
 
-    void fgDfsReversePostorder();
-    unsigned fgDfsReversePostorderCore(BlockSet_ValArg_T startBlocks);
+    unsigned fgDfsReversePostorder();
     void fgDfsReversePostorderHelper(BasicBlock* block,
                                      BlockSet&   visited,
                                      unsigned&   preorderIndex,
                                      unsigned&   reversePostorderIndex);
-
-    BlockSet_ValRet_T fgDomFindStartBlocks(); // Computes which basic blocks don't have incoming edges in the flow graph.
-                                              // Returns this as a set.
 
     INDEBUG(void fgDispDomTree(DomTreeNode* domTree);) // Helper that prints out the Dominator Tree in debug builds.
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -819,9 +819,11 @@ unsigned Compiler::fgDfsReversePostorder()
                     assert(finallyPredBlock->KindIs(BBJ_CALLFINALLY));
                     assert(finallyPredBlock->isBBCallAlwaysPair());
 
-                    if (!BlockSetOps::IsMember(this, visited, finallyPredBlock->bbNum))
+                    BasicBlock* const pairTailBlock = finallyPredBlock->Next();
+
+                    if (!BlockSetOps::IsMember(this, visited, pairTailBlock->bbNum))
                     {
-                        fgDfsReversePostorderHelper(finallyPredBlock, visited, preorderIndex, postorderIndex);
+                        fgDfsReversePostorderHelper(pairTailBlock, visited, preorderIndex, postorderIndex);
                     }
                 }
             }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -816,9 +816,13 @@ unsigned Compiler::fgDfsReversePostorder()
             {
                 for (BasicBlock* const finallyPredBlock : handlerBlock->PredBlocks())
                 {
-                    assert(finallyPredBlock->KindIs(BBJ_CALLFINALLY));
+                    // In some rare cases the finally is a loop entry.
+                    //
+                    if (!finallyPredBlock->KindIs(BBJ_CALLFINALLY))
+                    {
+                        continue;
+                    }
                     assert(finallyPredBlock->isBBCallAlwaysPair());
-
                     BasicBlock* const pairTailBlock = finallyPredBlock->Next();
 
                     if (!BlockSetOps::IsMember(this, visited, pairTailBlock->bbNum))

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -814,7 +814,7 @@ unsigned Compiler::fgDfsReversePostorder()
             //
             if (HBtab->HasFinallyHandler())
             {
-                for (BasicBlock* const finallyPredBlock : handlerBlock->Preds())
+                for (BasicBlock* const finallyPredBlock : handlerBlock->PredBlocks())
                 {
                     assert(finallyPredBlock->KindIs(BBJ_CALLFINALLY));
                     assert(finallyPredBlock->isBBCallAlwaysPair());

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -790,7 +790,6 @@ void ProfileSynthesis::RandomizeLikelihoods()
 void ProfileSynthesis::BuildReversePostorder()
 {
     m_comp->EnsureBasicBlockEpoch();
-    m_comp->fgComputeEnterBlocksSet();
     m_comp->fgDfsReversePostorder();
 
     // Build map from bbNum to Block*.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13869,9 +13869,7 @@ PhaseStatus Compiler::fgMorphBlocks()
         // We are optimizing. Process in RPO.
         //
         fgRenumberBlocks();
-        EnsureBasicBlockEpoch();
-        fgComputeEnterBlocksSet();
-        const unsigned lastReachablePostorderNumber = fgDfsReversePostorderCore(fgEnterBlks);
+        fgDfsReversePostorder();
 
         // Disallow general creation of new blocks or edges as it
         // would invalidate RPO.
@@ -13896,20 +13894,11 @@ PhaseStatus Compiler::fgMorphBlocks()
 
         // Remember this so we can sanity check that no new blocks will get created.
         //
-        INDEBUG(unsigned const bbNumMax = fgBBNumMax;);
-
-        // Todo: verify enter block set is sufficient to allow actual removal here.
-        // Likely need to add genReturnBB, fgEntryBB (for OSR), and perhaps more.
-        //
-        if (lastReachablePostorderNumber < fgBBNumMax)
-        {
-            JITDUMP("Method has %u unreachable blocks, consider removing them\n",
-                    fgBBNumMax - lastReachablePostorderNumber);
-        }
+        unsigned const bbNumMax = fgBBNumMax;
 
         // Morph the blocks in RPO.
         //
-        for (unsigned i = 1; i <= fgBBNumMax; i++)
+        for (unsigned i = 1; i <= bbNumMax; i++)
         {
             BasicBlock* const block = fgBBReversePostorder[i];
             fgMorphBlock(block);


### PR DESCRIPTION
Remove the up-front computation of enter blocks and dom
start nodes from the DFS computations used for RPO.

Also lay the groundwork for removing unreachable blocks, by tracking
the postorder number of the last reachable block.
