### PR TITLE
Add `-repeatCount` in superpmi.exe to repeat method compilation

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.h
@@ -136,6 +136,9 @@ public:
     MethodContextBuffer GetNextMethodContext();
     // No C++ exceptions, so the constructor has to always succeed...
     bool   isValid();
+
+    double Progress();
+    double TotalWork();
     double PercentComplete();
 
     // Returns the index of the last MethodContext read by GetNextMethodContext

--- a/src/coreclr/tools/superpmi/superpmi/commandline.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.cpp
@@ -117,6 +117,10 @@ void CommandLine::DumpHelp(const char* program)
     printf(" -skipCleanup\n");
     printf("     Skip deletion of temporary files created by child SuperPMI processes with -parallel.\n");
     printf("\n");
+    printf(" -repeatCount <repetition count>\n");
+    printf("     Number of times compilation should repeat for each method context. Usually used when\n");
+    printf("     trying to measure JIT throughput for a specific set of methods. Default=1.\n");
+    printf("\n");
     printf(" -target <target>\n");
     printf("     Used by the assembly differences calculator. This specifies the target\n");
     printf("     architecture for cross-compilation. Currently allowed <target> values: x64, x86, arm, arm64\n");
@@ -525,6 +529,40 @@ bool CommandLine::Parse(int argc, char* argv[], /* OUT */ Options* o)
             else if ((_stricmp(&argv[i][1], "skipCleanup") == 0))
             {
                 o->skipCleanup = true;
+            }
+            else if ((_stricmp(&argv[i][1], "repeatCount") == 0))
+            {
+                if (++i >= argc)
+                {
+                    DumpHelp(argv[0]);
+                    return false;
+                }
+
+                bool isValidRepeatCount = true;
+                size_t nextlen          = strlen(argv[i]);
+                for (size_t j = 0; j < nextlen; j++)
+                {
+                    if (!isdigit(argv[i][j]))
+                    {
+                        isValidRepeatCount = false;
+                        break;
+                    }
+                }
+                if (isValidRepeatCount)
+                {
+                    o->repeatCount = atoi(argv[i]);
+                    if (o->repeatCount < 1)
+                    {
+                        isValidRepeatCount = false;
+                    }
+                }
+
+                if (!isValidRepeatCount)
+                {
+                    LogError("Invalid repeat count specified. Repeat count must be between 1 and INT_MAX.");
+                    DumpHelp(argv[0]);
+                    return false;
+                }
             }
             else if ((_strnicmp(&argv[i][1], "stride", argLen) == 0))
             {

--- a/src/coreclr/tools/superpmi/superpmi/commandline.h
+++ b/src/coreclr/tools/superpmi/superpmi/commandline.h
@@ -34,6 +34,7 @@ public:
         int   workerCount = -1; // Number of workers to use for /parallel mode. -1 (or 1) means don't use parallel mode.
         int   indexCount = -1;  // If indexCount is -1 and hash points to nullptr it means compile all.
         int   failureLimit = -1; // Number of failures after which bail out the replay/asmdiffs.
+        int   repeatCount = 1;   // Number of times given methods should be compiled.
         int*  indexes = nullptr;
         char* hash = nullptr;
         char* methodStatsTypes = nullptr;

--- a/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/parallelsuperpmi.cpp
@@ -426,6 +426,14 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
         bytesWritten += sprintf_s(spmiArgs + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " %s %s", arg, s);         \
     }
 
+    // Only pass through an integer argument if it is not the same as the default (which must be specified here).
+    // (This is a proxy for "did the command-line parser actually parse something for this argument".)
+#define ADDARG_INT(i, arg, defaultValue)                                                                               \
+    if (i != defaultValue)                                                                                             \
+    {                                                                                                                  \
+        bytesWritten += sprintf_s(spmiArgs + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " %s %d", arg, i);         \
+    }
+
     // We don't pass through:
     //
     //    -parallel
@@ -438,7 +446,6 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
     //    -diffMetricsSummary
     //    -failingMCList
     //    -diffMCList
-    //    -failureLimit
     //
     // Everything else we need to reconstruct and pass through.
     //
@@ -457,6 +464,8 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
     ADDARG_STRING(o.hash, "-matchHash");
     ADDARG_STRING(o.targetArchitecture, "-target");
     ADDARG_STRING(o.compileList, "-compile");
+    ADDARG_INT(o.failureLimit, "-failureLimit", -1);
+    ADDARG_INT(o.repeatCount, "-repeatCount", 1);
 
     addJitOptionArgument(o.forceJitOptions, bytesWritten, spmiArgs, "jitoption force");
     addJitOptionArgument(o.forceJit2Options, bytesWritten, spmiArgs, "jit2option force");
@@ -471,6 +480,7 @@ char* ConstructChildProcessArgs(const CommandLine::Options& o)
 #undef ADDSTRING
 #undef ADDARG_BOOL
 #undef ADDARG_STRING
+#undef ADDARG_INT
 
     return spmiArgs;
 }
@@ -582,12 +592,6 @@ int doParallelSuperPMI(CommandLine::Options& o)
         {
             bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -details %s",
                                       wd.detailsPath);
-        }
-
-        if (o.failureLimit > 0)
-        {
-            bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -failureLimit %d",
-                                      o.failureLimit);
         }
 
         bytesWritten += sprintf_s(cmdLine + bytesWritten, MAX_CMDLINE_SIZE - bytesWritten, " -v ewmin %s", spmiArgs);

--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -327,8 +327,17 @@ int __cdecl main(int argc, char* argv[])
         }
     }
 
+    // This doesn't change in the work loop below, so compute it once.
+    double totalWork = reader->TotalWork() * o.repeatCount;
+
     while (true)
     {
+        // Read the progress before doing the method context read. This is because when we output progress below,
+        // we output a sum of this plus the per-repeatCount progress for the currently read MC.
+        double progressBeforeCurrentMC = reader->Progress() * o.repeatCount;
+
+        // Read the Method Context data from the file.
+
         MethodContextBuffer mcb = reader->GetNextMethodContext();
         if (mcb.Error())
         {
@@ -338,23 +347,6 @@ int __cdecl main(int argc, char* argv[])
         {
             LogDebug("Done processing method contexts");
             break;
-        }
-        if ((loadedCount % 500 == 0) && (loadedCount > 0))
-        {
-            st1.Stop();
-            if (o.applyDiff)
-            {
-                LogVerbose(" %2.1f%% - Loaded %d  Jitted %d  Diffs %d  FailedCompile %d at %d per second",
-                           reader->PercentComplete(), loadedCount, jittedCount, diffsCount,
-                           failToReplayCount, (int)((double)500 / st1.GetSeconds()));
-            }
-            else
-            {
-                LogVerbose(" %2.1f%% - Loaded %d  Jitted %d  FailedCompile %d at %d per second",
-                           reader->PercentComplete(), loadedCount, jittedCount, failToReplayCount,
-                           (int)((double)500 / st1.GetSeconds()));
-            }
-            st1.Start();
         }
 
         // Now read the data into a MethodContext. This could throw if the method context data is corrupt.
@@ -380,334 +372,367 @@ int __cdecl main(int argc, char* argv[])
             continue;
         }
 
-        if (jit == nullptr)
-        {
-            SimpleTimer stInitJit;
+        // Save the stored CompileResult
+        mc->originalCR = mc->cr;
 
-            jit = JitInstance::InitJit(o.nameOfJit, o.breakOnAssert, &stInitJit, mc, o.forceJitOptions, o.jitOptions);
+        // Compile this method context as many times as we have been asked to (default is once).
+        for (int iter = 0; iter < o.repeatCount; iter++)
+        {
             if (jit == nullptr)
             {
-                // InitJit already printed a failure message
-                return (int)SpmiResult::JitFailedToInit;
-            }
+                SimpleTimer stInitJit;
 
-            if (o.nameOfJit2 != nullptr)
-            {
-                jit2 = JitInstance::InitJit(o.nameOfJit2, o.breakOnAssert, &stInitJit, mc, o.forceJit2Options,
-                                            o.jit2Options);
-                if (jit2 == nullptr)
+                jit = JitInstance::InitJit(o.nameOfJit, o.breakOnAssert, &stInitJit, mc, o.forceJitOptions, o.jitOptions);
+                if (jit == nullptr)
                 {
                     // InitJit already printed a failure message
                     return (int)SpmiResult::JitFailedToInit;
                 }
-            }
-        }
 
-        // I needed to reason about what crl contains at any point in time
-        // Here is my guess based on reading the code so far
-        // crl initially contains the CompileResult from the MCH file
-        // However if we have a second jit it has the CompileResult from Jit1
-        CompileResult* crl = mc->cr;
-
-        mc->cr         = new CompileResult();
-        mc->originalCR = crl;
-
-        if (mc->WasEnvironmentChanged(jit->getEnvironment()))
-        {
-            if (!jit->resetConfig(mc))
-            {
-                LogError("JIT can't reset environment");
-            }
-            if (o.nameOfJit2 != nullptr)
-            {
-                if (!jit2->resetConfig(mc))
+                if (o.nameOfJit2 != nullptr)
                 {
-                    LogError("JIT2 can't reset environment");
+                    jit2 = JitInstance::InitJit(o.nameOfJit2, o.breakOnAssert, &stInitJit, mc, o.forceJit2Options,
+                                                o.jit2Options);
+                    if (jit2 == nullptr)
+                    {
+                        // InitJit already printed a failure message
+                        return (int)SpmiResult::JitFailedToInit;
+                    }
                 }
             }
-        }
 
-        jittedCount++;
-        st3.Start();
-        ReplayResults res = jit->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
-        st3.Stop();
-        LogDebug("Method %d compiled%s in %fms, result %d",
-            reader->GetMethodContextIndex(), (o.nameOfJit2 == nullptr) ? "" : " by JIT1", st3.GetMilliseconds(), res);
-
-        if (res.Result == ReplayResult::Success)
-        {
-            if (Logger::IsLogLevelEnabled(LOGLEVEL_DEBUG))
-            {
-                mc->cr->dumpToConsole(); // Dump the compile results if doing debug logging
-            }
-        }
-        else if (res.Result == ReplayResult::Error)
-        {
-            errorCount++;
-            LogError("Method %d of size %d failed to load and compile correctly%s (%s).",
-                        reader->GetMethodContextIndex(), mc->methodSize,
-                        (o.nameOfJit2 == nullptr) ? "" : " by JIT1", o.nameOfJit);
-            if (errorCount == o.failureLimit)
-            {
-                LogError("More than %d methods failed%s. Skip compiling remaining methods.",
-                    o.failureLimit, (o.nameOfJit2 == nullptr) ? "" : " by JIT1");
-                break;
-            }
-            if ((o.reproName != nullptr) && (o.indexCount == -1))
-            {
-                char buff[500];
-                sprintf_s(buff, 500, "%s-%d.mc", o.reproName, reader->GetMethodContextIndex());
-                HANDLE hFileOut = CreateFileA(buff, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
-                                                FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-                if (hFileOut == INVALID_HANDLE_VALUE)
-                {
-                    LogError("Failed to open output '%s'. GetLastError()=%u", buff, GetLastError());
-                    return (int)SpmiResult::GeneralFailure;
-                }
-                mc->saveToFile(hFileOut);
-                if (CloseHandle(hFileOut) == 0)
-                {
-                    LogError("CloseHandle for output file failed. GetLastError()=%u", GetLastError());
-                    return (int)SpmiResult::GeneralFailure;
-                }
-                LogInfo("Wrote out repro to '%s'", buff);
-            }
-            if (o.breakOnError)
-            {
-                if (o.indexCount == -1)
-                    LogInfo("HINT: to repro add '-c %d' to cmdline", reader->GetMethodContextIndex());
-                __debugbreak();
-            }
-        }
-
-        ReplayResults res2;
-        res2.Result = ReplayResult::Success;
-        if (o.nameOfJit2 != nullptr)
-        {
-            // Lets get the results for the 2nd JIT
-            // We will save the first JIT's CR to save space for the 2nd JIT CR
-            // Note that the recorded CR is still stored in MC->originalCR
-            crl    = mc->cr;
+            // Create a new CompileResult for this compilation (the CompileResult from the stored file is
+            // in originalCR if necessary).
             mc->cr = new CompileResult();
 
-            st4.Start();
-            res2 = jit2->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
-            st4.Stop();
-            LogDebug("Method %d compiled by JIT2 in %fms, result %d", reader->GetMethodContextIndex(),
-                     st4.GetMilliseconds(), res2);
+            // For asm diffs, we need to store away the CompileResult generated by the first JIT when compiling
+            // with the 2nd JIT.
+            CompileResult* crl = nullptr;
 
-            if (res2.Result == ReplayResult::Success)
+            if (mc->WasEnvironmentChanged(jit->getEnvironment()))
+            {
+                if (!jit->resetConfig(mc))
+                {
+                    LogError("JIT can't reset environment");
+                }
+                if (o.nameOfJit2 != nullptr)
+                {
+                    if (!jit2->resetConfig(mc))
+                    {
+                        LogError("JIT2 can't reset environment");
+                    }
+                }
+            }
+
+            jittedCount++;
+            st3.Start();
+            ReplayResults res = jit->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
+            st3.Stop();
+            LogDebug("Method %d compiled%s in %fms, result %d",
+                reader->GetMethodContextIndex(), (o.nameOfJit2 == nullptr) ? "" : " by JIT1", st3.GetMilliseconds(), res);
+
+            if (res.Result == ReplayResult::Success)
             {
                 if (Logger::IsLogLevelEnabled(LOGLEVEL_DEBUG))
                 {
                     mc->cr->dumpToConsole(); // Dump the compile results if doing debug logging
                 }
             }
-            else if (res2.Result == ReplayResult::Error)
+            else if (res.Result == ReplayResult::Error)
             {
-                errorCount2++;
-                LogError("Method %d of size %d failed to load and compile correctly by JIT2 (%s).",
-                         reader->GetMethodContextIndex(), mc->methodSize, o.nameOfJit2);
-                if (errorCount2 == o.failureLimit)
+                errorCount++;
+                LogError("Method %d of size %d failed to load and compile correctly%s (%s).",
+                            reader->GetMethodContextIndex(), mc->methodSize,
+                            (o.nameOfJit2 == nullptr) ? "" : " by JIT1", o.nameOfJit);
+                if (errorCount == o.failureLimit)
                 {
-                    LogError("More than %d methods compilation failed by JIT2. Skip compiling remaining methods.", o.failureLimit);
+                    LogError("More than %d methods failed%s. Skip compiling remaining methods.",
+                        o.failureLimit, (o.nameOfJit2 == nullptr) ? "" : " by JIT1");
                     break;
                 }
-            }
-        }
-
-        if ((res.Result == ReplayResult::Success) && (res2.Result == ReplayResult::Success))
-        {
-            if (collectThroughput)
-            {
-                if ((o.nameOfJit2 != nullptr) && (res2.Result == ReplayResult::Success))
+                if ((o.reproName != nullptr) && (o.indexCount == -1))
                 {
-                    // TODO-Bug?: bug in getting the lowest cycle time??
-                    ULONGLONG dif1, dif2, dif3, dif4;
-                    dif1 = (jit->times[0] - jit2->times[0]) * (jit->times[0] - jit2->times[0]);
-                    dif2 = (jit->times[0] - jit2->times[1]) * (jit->times[0] - jit2->times[1]);
-                    dif3 = (jit->times[1] - jit2->times[0]) * (jit->times[1] - jit2->times[0]);
-                    dif4 = (jit->times[1] - jit2->times[1]) * (jit->times[1] - jit2->times[1]);
-
-                    if (dif1 < dif2)
+                    char buff[500];
+                    sprintf_s(buff, 500, "%s-%d.mc", o.reproName, reader->GetMethodContextIndex());
+                    HANDLE hFileOut = CreateFileA(buff, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
+                                                    FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+                    if (hFileOut == INVALID_HANDLE_VALUE)
                     {
-                        if (dif3 < dif4)
+                        LogError("Failed to open output '%s'. GetLastError()=%u", buff, GetLastError());
+                        return (int)SpmiResult::GeneralFailure;
+                    }
+                    mc->saveToFile(hFileOut);
+                    if (CloseHandle(hFileOut) == 0)
+                    {
+                        LogError("CloseHandle for output file failed. GetLastError()=%u", GetLastError());
+                        return (int)SpmiResult::GeneralFailure;
+                    }
+                    LogInfo("Wrote out repro to '%s'", buff);
+                }
+                if (o.breakOnError)
+                {
+                    if (o.indexCount == -1)
+                        LogInfo("HINT: to repro add '-c %d' to cmdline", reader->GetMethodContextIndex());
+                    __debugbreak();
+                }
+            }
+
+            ReplayResults res2;
+            res2.Result = ReplayResult::Success;
+            if (o.nameOfJit2 != nullptr)
+            {
+                // Lets get the results for the 2nd JIT.
+                // We will save the first JIT's CR to save space for the 2nd JIT CR
+                crl    = mc->cr;
+                mc->cr = new CompileResult();
+
+                st4.Start();
+                res2 = jit2->CompileMethod(mc, reader->GetMethodContextIndex(), collectThroughput);
+                st4.Stop();
+                LogDebug("Method %d compiled by JIT2 in %fms, result %d", reader->GetMethodContextIndex(),
+                         st4.GetMilliseconds(), res2);
+
+                if (res2.Result == ReplayResult::Success)
+                {
+                    if (Logger::IsLogLevelEnabled(LOGLEVEL_DEBUG))
+                    {
+                        mc->cr->dumpToConsole(); // Dump the compile results if doing debug logging
+                    }
+                }
+                else if (res2.Result == ReplayResult::Error)
+                {
+                    errorCount2++;
+                    LogError("Method %d of size %d failed to load and compile correctly by JIT2 (%s).",
+                             reader->GetMethodContextIndex(), mc->methodSize, o.nameOfJit2);
+                    if (errorCount2 == o.failureLimit)
+                    {
+                        LogError("More than %d methods compilation failed by JIT2. Skip compiling remaining methods.", o.failureLimit);
+                        break;
+                    }
+                }
+            }
+
+            if ((res.Result == ReplayResult::Success) && (res2.Result == ReplayResult::Success))
+            {
+                if (collectThroughput)
+                {
+                    if ((o.nameOfJit2 != nullptr) && (res2.Result == ReplayResult::Success))
+                    {
+                        // TODO-Bug?: bug in getting the lowest cycle time??
+                        ULONGLONG dif1, dif2, dif3, dif4;
+                        dif1 = (jit->times[0] - jit2->times[0]) * (jit->times[0] - jit2->times[0]);
+                        dif2 = (jit->times[0] - jit2->times[1]) * (jit->times[0] - jit2->times[1]);
+                        dif3 = (jit->times[1] - jit2->times[0]) * (jit->times[1] - jit2->times[0]);
+                        dif4 = (jit->times[1] - jit2->times[1]) * (jit->times[1] - jit2->times[1]);
+
+                        if (dif1 < dif2)
                         {
-                            if (dif1 < dif3)
+                            if (dif3 < dif4)
                             {
-                                crl->clockCyclesToCompile    = jit->times[0];
-                                mc->cr->clockCyclesToCompile = jit2->times[0];
+                                if (dif1 < dif3)
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[0];
+                                    mc->cr->clockCyclesToCompile = jit2->times[0];
+                                }
+                                else
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[1];
+                                    mc->cr->clockCyclesToCompile = jit2->times[0];
+                                }
                             }
                             else
                             {
-                                crl->clockCyclesToCompile    = jit->times[1];
-                                mc->cr->clockCyclesToCompile = jit2->times[0];
+                                if (dif1 < dif4)
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[0];
+                                    mc->cr->clockCyclesToCompile = jit2->times[0];
+                                }
+                                else
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[1];
+                                    mc->cr->clockCyclesToCompile = jit2->times[1];
+                                }
                             }
                         }
                         else
                         {
-                            if (dif1 < dif4)
+                            if (dif3 < dif4)
                             {
-                                crl->clockCyclesToCompile    = jit->times[0];
-                                mc->cr->clockCyclesToCompile = jit2->times[0];
+                                if (dif2 < dif3)
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[0];
+                                    mc->cr->clockCyclesToCompile = jit2->times[1];
+                                }
+                                else
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[1];
+                                    mc->cr->clockCyclesToCompile = jit2->times[0];
+                                }
                             }
                             else
                             {
-                                crl->clockCyclesToCompile    = jit->times[1];
-                                mc->cr->clockCyclesToCompile = jit2->times[1];
+                                if (dif2 < dif4)
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[0];
+                                    mc->cr->clockCyclesToCompile = jit2->times[1];
+                                }
+                                else
+                                {
+                                    crl->clockCyclesToCompile    = jit->times[1];
+                                    mc->cr->clockCyclesToCompile = jit2->times[1];
+                                }
                             }
+                        }
+
+                        if (methodStatsEmitter != nullptr)
+                        {
+                            methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, crl->clockCyclesToCompile,
+                                                     mc->cr->clockCyclesToCompile);
                         }
                     }
                     else
                     {
-                        if (dif3 < dif4)
-                        {
-                            if (dif2 < dif3)
-                            {
-                                crl->clockCyclesToCompile    = jit->times[0];
-                                mc->cr->clockCyclesToCompile = jit2->times[1];
-                            }
-                            else
-                            {
-                                crl->clockCyclesToCompile    = jit->times[1];
-                                mc->cr->clockCyclesToCompile = jit2->times[0];
-                            }
-                        }
+                        if (jit->times[0] > jit->times[1])
+                            mc->cr->clockCyclesToCompile = jit->times[1];
                         else
+                            mc->cr->clockCyclesToCompile = jit->times[0];
+                        if (methodStatsEmitter != nullptr)
                         {
-                            if (dif2 < dif4)
-                            {
-                                crl->clockCyclesToCompile    = jit->times[0];
-                                mc->cr->clockCyclesToCompile = jit2->times[1];
-                            }
-                            else
-                            {
-                                crl->clockCyclesToCompile    = jit->times[1];
-                                mc->cr->clockCyclesToCompile = jit2->times[1];
-                            }
+                            methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, mc->cr->clockCyclesToCompile, 0);
+                        }
+                    }
+                }
+
+                if (!collectThroughput && methodStatsEmitter != nullptr)
+                {
+                    // We have a separate call to Emit for collectThroughput
+                    methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, -1, -1);
+                }
+
+                if (o.applyDiff)
+                {
+                    NearDifferResult diffResult = NearDifferResult::Failure;
+                    // We need at least two compile results to diff: they can either both come from JIT
+                    // invocations, or one can be loaded from the method context file.
+
+                    // We need to check both CompileResults to ensure we have a valid CR
+                    if (crl->AllocMem == nullptr || mc->cr->AllocMem == nullptr)
+                    {
+                        LogError("method %d is missing a compileResult, cannot do diffing",
+                                 reader->GetMethodContextIndex());
+                    }
+                    else
+                    {
+                        diffResult = InvokeNearDiffer(&nearDiffer, &mc, &crl, &reader);
+
+                        switch (diffResult)
+                        {
+                            case NearDifferResult::SuccessWithDiff:
+                                diffsCount++;
+                                // This is a difference in ASM outputs from Jit1 & Jit2 and not a playback failure
+                                // We will add this MC to the details if there is one below.
+                                // Otherwise add it in the failingMCList here.
+                                if (o.details == nullptr)
+                                {
+                                    failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+                                }
+
+                                break;
+                            case NearDifferResult::SuccessWithoutDiff:
+                                break;
+                            case NearDifferResult::Failure:
+                                if (o.mclFilename != nullptr)
+                                    failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+
+                                break;
                         }
                     }
 
-                    if (methodStatsEmitter != nullptr)
+                    if (o.details != nullptr)
                     {
-                        methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, crl->clockCyclesToCompile,
-                                                 mc->cr->clockCyclesToCompile);
+                        PrintDiffsCsvRow(
+                            detailsCsv,
+                            reader->GetMethodContextIndex(),
+                            mcb.size,
+                            res, res2,
+                            /* hasDiff */ diffResult != NearDifferResult::SuccessWithoutDiff);
                     }
                 }
                 else
                 {
-                    if (jit->times[0] > jit->times[1])
-                        mc->cr->clockCyclesToCompile = jit->times[1];
-                    else
-                        mc->cr->clockCyclesToCompile = jit->times[0];
-                    if (methodStatsEmitter != nullptr)
+                    if (o.details != nullptr)
                     {
-                        methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, mc->cr->clockCyclesToCompile, 0);
+                        PrintReplayCsvRow(
+                            detailsCsv,
+                            reader->GetMethodContextIndex(),
+                            mcb.size,
+                            res);
                     }
-                }
-            }
-
-            if (!collectThroughput && methodStatsEmitter != nullptr)
-            {
-                // We have a separate call to Emit for collectThroughput
-                methodStatsEmitter->Emit(reader->GetMethodContextIndex(), mc, -1, -1);
-            }
-
-            if (o.applyDiff)
-            {
-                NearDifferResult diffResult = NearDifferResult::Failure;
-                // We need at least two compile results to diff: they can either both come from JIT
-                // invocations, or one can be loaded from the method context file.
-
-                // We need to check both CompileResults to ensure we have a valid CR
-                if (crl->AllocMem == nullptr || mc->cr->AllocMem == nullptr)
-                {
-                    LogError("method %d is missing a compileResult, cannot do diffing",
-                             reader->GetMethodContextIndex());
-                }
-                else
-                {
-                    diffResult = InvokeNearDiffer(&nearDiffer, &mc, &crl, &reader);
-
-                    switch (diffResult)
-                    {
-                        case NearDifferResult::SuccessWithDiff:
-                            diffsCount++;
-                            // This is a difference in ASM outputs from Jit1 & Jit2 and not a playback failure
-                            // We will add this MC to the details if there is one below.
-                            // Otherwise add it in the failingMCList here.
-                            if (o.details == nullptr)
-                            {
-                                failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
-                            }
-
-                            break;
-                        case NearDifferResult::SuccessWithoutDiff:
-                            break;
-                        case NearDifferResult::Failure:
-                            if (o.mclFilename != nullptr)
-                                failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
-
-                            break;
-                    }
-                }
-
-                if (o.details != nullptr)
-                {
-                    PrintDiffsCsvRow(
-                        detailsCsv,
-                        reader->GetMethodContextIndex(),
-                        mcb.size,
-                        res, res2,
-                        /* hasDiff */ diffResult != NearDifferResult::SuccessWithoutDiff);
                 }
             }
             else
             {
+                failToReplayCount++;
+
+                // Methods that don't compile due to missing JIT-EE information
+                // should still be added to the failing MC list but we don't create MC repro for them.
+                if (o.mclFilename != nullptr)
+                {
+                    failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
+                }
+
+                if ((res.Result == ReplayResult::Miss) || (res2.Result == ReplayResult::Miss))
+                {
+                    missingCount++;
+                }
+
                 if (o.details != nullptr)
                 {
-                    PrintReplayCsvRow(
-                        detailsCsv,
-                        reader->GetMethodContextIndex(),
-                        mcb.size,
-                        res);
+                    if (o.applyDiff)
+                    {
+                        PrintDiffsCsvRow(
+                            detailsCsv,
+                            reader->GetMethodContextIndex(), mcb.size,
+                            res, res2,
+                            /* hasDiff */ false);
+                    }
+                    else
+                    {
+                        PrintReplayCsvRow(detailsCsv, reader->GetMethodContextIndex(), mcb.size, res);
+                    }
                 }
             }
-        }
-        else
-        {
-            failToReplayCount++;
 
-            // Methods that don't compile due to missing JIT-EE information
-            // should still be added to the failing MC list but we don't create MC repro for them.
-            if (o.mclFilename != nullptr)
+            // Write a progress message if necessary.
+            const int progressInterval = 500;
+            if ((jittedCount > 0) && (jittedCount % progressInterval == 0))
             {
-                failingToReplayMCL.AddMethodToMCL(reader->GetMethodContextIndex());
-            }
+                // Note that if progress is measured in terms of bytes of method contexts, instead of a method
+                // context count, then adding `iter` here will be wildly inaccurate. However, in that case --
+                // when we don't have a TOC or index list -- we have no idea how many method contexts are in
+                // the file nor the "average size" of any single method context.
+                double currentProgress = progressBeforeCurrentMC + iter;
+                double percentComplete = 100.0 * currentProgress / totalWork;
 
-            if ((res.Result == ReplayResult::Miss) || (res2.Result == ReplayResult::Miss))
-            {
-                missingCount++;
-            }
-
-            if (o.details != nullptr)
-            {
+                st1.Stop();
                 if (o.applyDiff)
                 {
-                    PrintDiffsCsvRow(
-                        detailsCsv,
-                        reader->GetMethodContextIndex(), mcb.size,
-                        res, res2,
-                        /* hasDiff */ false);
+                    LogVerbose(" %2.1f%% - Loaded %d  Jitted %d  Diffs %d  FailedCompile %d at %d per second",
+                               percentComplete, loadedCount, jittedCount, diffsCount,
+                               failToReplayCount, (int)((double)progressInterval / st1.GetSeconds()));
                 }
                 else
                 {
-                    PrintReplayCsvRow(detailsCsv, reader->GetMethodContextIndex(), mcb.size, res);
+                    LogVerbose(" %2.1f%% - Loaded %d  Jitted %d  FailedCompile %d at %d per second",
+                               percentComplete, loadedCount, jittedCount, failToReplayCount,
+                               (int)((double)progressInterval / st1.GetSeconds()));
                 }
+                st1.Start();
             }
+
+            delete crl;
         }
 
-        delete crl;
         delete mc;
     }
     delete reader;


### PR DESCRIPTION
Passing `-repeatCount N` for some integer `N > 0` will compile each function `N` times. This is true for each function in the MCH file, by default, or each one specified by a `-c` argument or .mcl file.

This can be used to help investigate the JIT throughput for compilation of a particular function or set of functions.

This is based on #93417.