### PR TITLE
[browser][mt] Enable `TestProducerConsumerAsyncEnumerable`

### DIFF
--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.IAsyncEnumerable.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.IAsyncEnumerable.cs
@@ -166,7 +166,6 @@ namespace System.Threading.Tasks.Dataflow.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75389", TestPlatforms.Browser)]
         public async Task TestProducerConsumerAsyncEnumerable()
         {
             foreach (TaskScheduler scheduler in new[] { TaskScheduler.Default, new ConcurrentExclusiveSchedulerPair().ConcurrentScheduler })


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/75389.