### PR TITLE
[RISC-V] Add branch label offset to disasm

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7139,16 +7139,9 @@ unsigned emitter::emitEndCodeGen(Compiler* comp,
                 printf("\n%s:", emitLabelString(ig));
                 if (!emitComp->opts.disDiffable)
                 {
-#ifdef DEBUG
                     if (emitComp->opts.disAddr)
-                    {
-                        printf("              ;; offset=0x%04X", emitCurCodeOffs(cp));
-                    }
-                    else
-#endif // DEBUG
-                    {
-                        printf("  ;; offset=0x%04X", emitCurCodeOffs(cp));
-                    }
+                        printf("            ");
+                    printf("  ;; offset=0x%04X", emitCurCodeOffs(cp));
                 }
                 printf("\n");
             }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2209,7 +2209,7 @@ public:
     UNATIVE_OFFSET emitTotalHotCodeSize;
     UNATIVE_OFFSET emitTotalColdCodeSize;
 
-    UNATIVE_OFFSET emitCurCodeOffs(BYTE* dst)
+    UNATIVE_OFFSET emitCurCodeOffs(const BYTE* dst)
     {
         size_t distance;
         if ((dst >= emitCodeBlock) && (dst <= (emitCodeBlock + emitTotalHotCodeSize)))

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2901,7 +2901,7 @@ static const char* const RegNames[] =
 //    id   - The instrDesc of the code if needed.
 //
 // Note:
-//    The length of the instruction's name include aligned space is 13.
+//    The length of the instruction's name include aligned space is 15.
 //
 
 void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
@@ -3223,7 +3223,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     return;
             }
         }
-        case 0x63:
+        case 0x63: // BRANCH
         {
             unsigned int opcode2 = (code >> 12) & 0x7;
             const char*  rs1     = RegNames[(code >> 15) & 0x1f];
@@ -3236,28 +3236,42 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             }
             switch (opcode2)
             {
-                case 0: // BEQ
-                    printf("beq            %s, %s, %d\n", rs1, rs2, offset);
-                    return;
-                case 1: // BNE
-                    printf("bne            %s, %s, %d\n", rs1, rs2, offset);
-                    return;
-                case 4: // BLT
-                    printf("blt            %s, %s, %d\n", rs1, rs2, offset);
-                    return;
-                case 5: // BGE
-                    printf("bge            %s, %s, %d\n", rs1, rs2, offset);
-                    return;
-                case 6: // BLTU
-                    printf("bltu           %s, %s, %d\n", rs1, rs2, offset);
-                    return;
-                case 7: // BGEU
-                    printf("bgeu           %s, %s, %d\n", rs1, rs2, offset);
-                    return;
+                case 0:
+                    printf("beq ");
+                    break;
+                case 1:
+                    printf("bne ");
+                    break;
+                case 4:
+                    printf("blt ");
+                    break;
+                case 5:
+                    printf("bge ");
+                    break;
+                case 6:
+                    printf("bltu");
+                    break;
+                case 7:
+                    printf("bgeu");
+                    break;
                 default:
                     printf("RISCV64 illegal instruction: 0x%08X\n", code);
                     return;
             }
+            static const int MAX_LEN = 32;
+            int len = printf("           %s, %s, %d", rs1, rs2, offset);
+            if (len <= 0 || len > MAX_LEN)
+                return;
+
+            if (!emitComp->opts.disDiffable)
+            {
+                printf("%*s;; offset=0x%04X\n", MAX_LEN - len, "", emitCurCodeOffs(insAdr) + offset);
+            }
+            else
+            {
+                printf("\n");
+            }
+            return;
         }
         case 0x03:
         {

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3259,6 +3259,7 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                     return;
             }
             static const int MAX_LEN = 32;
+
             int len = printf("           %s, %s, %d", rs1, rs2, offset);
             if (len <= 0 || len > MAX_LEN)
                 return;

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3265,13 +3265,8 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
                 return;
 
             if (!emitComp->opts.disDiffable)
-            {
-                printf("%*s;; offset=0x%04X\n", MAX_LEN - len, "", emitCurCodeOffs(insAdr) + offset);
-            }
-            else
-            {
-                printf("\n");
-            }
+                printf("%*s;; offset=0x%04X", MAX_LEN - len, "", emitCurCodeOffs(insAdr) + offset);
+            printf("\n");
             return;
         }
         case 0x03:


### PR DESCRIPTION
Label offset is easier to look for than raw instruction offset.

Sample disassembly with this PR:
```asm
  000FC863  blt            t6, zero, 16         ;; offset=0x00AC
  01000513  addi           a0, zero, 16
  02A42223  sw             a0, 36(fp)
  00C0006F  jal            zero, 12
                                                ;; size=48 bbWeight=1 PerfScore 0.00
G_M14667_IG07:  ;; offset=0x00AC
  00F00513  addi           a0, zero, 15
```
Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @sirntar @yurai007 @Bajtazar