### PR TITLE
Implement frozen object heap

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -153,7 +153,7 @@ namespace Internal.Runtime.CompilerHelpers
 
         private static unsafe void InitializeModuleFrozenObjectSegment(IntPtr segmentStart, int length)
         {
-            if (RuntimeImports.RhpRegisterFrozenSegment(segmentStart, (IntPtr)length) == IntPtr.Zero)
+            if (RuntimeImports.RhRegisterFrozenSegment((void*)segmentStart, (nuint)length, (nuint)length, (nuint)length) == IntPtr.Zero)
             {
                 // This should only happen if we ran out of memory.
                 RuntimeExceptionHelpers.FailFast("Failed to register frozen object segment for the module.");

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeImports.cs
@@ -13,14 +13,6 @@ namespace System.Runtime
     {
         private const string RuntimeLibrary = "*";
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpRegisterFrozenSegment")]
-        internal static extern IntPtr RhpRegisterFrozenSegment(IntPtr pSegmentStart, IntPtr length);
-
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpUnregisterFrozenSegment")]
-        internal static extern void RhpUnregisterFrozenSegment(IntPtr pSegmentHandle);
-
         [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern IntPtr RhGetModuleSection(ref TypeManagerHandle module, ReadyToRunSectionType section, out int length);

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -356,12 +356,17 @@ EXTERN_C NATIVEAOT_API int32_t __cdecl RhpGetCurrentThreadStackTrace(void* pOutp
     return RhpCalculateStackTraceWorker(pOutputBuffer, outputBufferLength, pAddressInCurrentFrame);
 }
 
-COOP_PINVOKE_HELPER(void*, RhpRegisterFrozenSegment, (void* pSegmentStart, size_t length))
+COOP_PINVOKE_HELPER(void*, RhRegisterFrozenSegment, (void * pSection, size_t allocSize, size_t commitSize, size_t reservedSize))
 {
-    return RedhawkGCInterface::RegisterFrozenSegment(pSegmentStart, length);
+    return RedhawkGCInterface::RegisterFrozenSegment(pSection, allocSize, commitSize, reservedSize);
 }
 
-COOP_PINVOKE_HELPER(void, RhpUnregisterFrozenSegment, (void* pSegmentHandle))
+COOP_PINVOKE_HELPER(void, RhUpdateFrozenSegment, (void* pSegmentHandle, uint8_t* allocated, uint8_t* committed))
+{
+    RedhawkGCInterface::UpdateFrozenSegment((GcSegmentHandle)pSegmentHandle, allocated, committed);
+}
+
+COOP_PINVOKE_HELPER(void, RhUnregisterFrozenSegment, (void* pSegmentHandle))
 {
     RedhawkGCInterface::UnregisterFrozenSegment((GcSegmentHandle)pSegmentHandle);
 }

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -356,17 +356,17 @@ EXTERN_C NATIVEAOT_API int32_t __cdecl RhpGetCurrentThreadStackTrace(void* pOutp
     return RhpCalculateStackTraceWorker(pOutputBuffer, outputBufferLength, pAddressInCurrentFrame);
 }
 
-COOP_PINVOKE_HELPER(void*, RhRegisterFrozenSegment, (void * pSection, size_t allocSize, size_t commitSize, size_t reservedSize))
+EXTERN_C NATIVEAOT_API void* __cdecl RhRegisterFrozenSegment(void * pSection, size_t allocSize, size_t commitSize, size_t reservedSize)
 {
     return RedhawkGCInterface::RegisterFrozenSegment(pSection, allocSize, commitSize, reservedSize);
 }
 
-COOP_PINVOKE_HELPER(void, RhUpdateFrozenSegment, (void* pSegmentHandle, uint8_t* allocated, uint8_t* committed))
+EXTERN_C NATIVEAOT_API void __cdecl RhUpdateFrozenSegment(void* pSegmentHandle, uint8_t* allocated, uint8_t* committed)
 {
     RedhawkGCInterface::UpdateFrozenSegment((GcSegmentHandle)pSegmentHandle, allocated, committed);
 }
 
-COOP_PINVOKE_HELPER(void, RhUnregisterFrozenSegment, (void* pSegmentHandle))
+EXTERN_C NATIVEAOT_API void __cdecl RhUnregisterFrozenSegment(void* pSegmentHandle)
 {
     RedhawkGCInterface::UnregisterFrozenSegment((GcSegmentHandle)pSegmentHandle);
 }

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -368,21 +368,33 @@ void RedhawkGCInterface::BulkEnumGcObjRef(PTR_RtuObjectRef pRefs, uint32_t cRefs
 }
 
 // static
-GcSegmentHandle RedhawkGCInterface::RegisterFrozenSegment(void * pSection, size_t SizeSection)
+GcSegmentHandle RedhawkGCInterface::RegisterFrozenSegment(void * pSection, size_t allocSize, size_t commitSize, size_t reservedSize)
 {
+    ASSERT(allocSize <= commitSize);
+    ASSERT(commitSize <= reservedSize);
+    ASSERT(allocSize >= MIN_OBJECT_SIZE);
+
 #ifdef FEATURE_BASICFREEZE
     segment_info seginfo;
 
     seginfo.pvMem           = pSection;
     seginfo.ibFirstObject   = sizeof(ObjHeader);
-    seginfo.ibAllocated     = SizeSection;
-    seginfo.ibCommit        = seginfo.ibAllocated;
-    seginfo.ibReserved      = seginfo.ibAllocated;
+    seginfo.ibAllocated     = allocSize;
+    seginfo.ibCommit        = commitSize;
+    seginfo.ibReserved      = reservedSize;
 
     return (GcSegmentHandle)GCHeapUtilities::GetGCHeap()->RegisterFrozenSegment(&seginfo);
 #else // FEATURE_BASICFREEZE
     return NULL;
 #endif // FEATURE_BASICFREEZE
+}
+
+// static
+void RedhawkGCInterface::UpdateFrozenSegment(GcSegmentHandle seg, uint8_t* allocated, uint8_t* committed)
+{
+    ASSERT(allocated <= committed);
+
+    GCHeapUtilities::GetGCHeap()->UpdateFrozenSegment((segment_handle)seg, allocated, committed);
 }
 
 // static

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -372,7 +372,6 @@ GcSegmentHandle RedhawkGCInterface::RegisterFrozenSegment(void * pSection, size_
 {
     ASSERT(allocSize <= commitSize);
     ASSERT(commitSize <= reservedSize);
-    ASSERT(allocSize >= MIN_OBJECT_SIZE);
 
 #ifdef FEATURE_BASICFREEZE
     segment_info seginfo;

--- a/src/coreclr/nativeaot/Runtime/gcrhinterface.h
+++ b/src/coreclr/nativeaot/Runtime/gcrhinterface.h
@@ -129,7 +129,8 @@ public:
                                                  void * pfnEnumCallback,
                                                  void * pvCallbackData);
 
-    static GcSegmentHandle RegisterFrozenSegment(void * pSection, size_t SizeSection);
+    static GcSegmentHandle RegisterFrozenSegment(void * pSection, size_t allocSize, size_t commitSize, size_t reservedSize);
+    static void UpdateFrozenSegment(GcSegmentHandle seg, uint8_t* allocated, uint8_t* committed);
     static void UnregisterFrozenSegment(GcSegmentHandle segment);
 
 #ifdef FEATURE_GC_STRESS

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Unix.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
 
 namespace Internal.Runtime
 {
@@ -15,7 +15,7 @@ namespace Internal.Runtime
                 size,
                 Interop.Sys.MemoryMappedProtections.PROT_NONE,
                 Interop.Sys.MemoryMappedFlags.MAP_PRIVATE | Interop.Sys.MemoryMappedFlags.MAP_ANONYMOUS,
-                new SafeFileHandle(-1, false),
+                -1,
                 0);
 
         }
@@ -32,6 +32,7 @@ namespace Internal.Runtime
 
         static void ClrVirtualFree(void* pBase, nuint size)
         {
+            Debug.Assert(size != 0);
             Interop.Sys.MUnmap((nint)pBase, size);
         }
     }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Unix.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Unix.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Runtime
+{
+    internal unsafe partial class FrozenObjectHeapManager
+    {
+        static void* ClrVirtualReserve(nuint size)
+        {
+            // The shim will return null for failure
+            return (void*)Interop.Sys.MMap(
+                0,
+                size,
+                Interop.Sys.MemoryMappedProtections.PROT_NONE,
+                Interop.Sys.MemoryMappedFlags.MAP_PRIVATE | Interop.Sys.MemoryMappedFlags.MAP_ANONYMOUS,
+                new SafeFileHandle(-1, false),
+                0);
+
+        }
+
+        static void* ClrVirtualCommit(void* pBase, nuint size)
+        {
+            int result = Interop.Sys.MProtect(
+                (nint)pBase,
+                size,
+                Interop.Sys.MemoryMappedProtections.PROT_READ | Interop.Sys.MemoryMappedProtections.PROT_WRITE);
+
+            return result == 0 ? pBase : null;
+        }
+
+        static void ClrVirtualFree(void* pBase, nuint size)
+        {
+            Interop.Sys.MUnmap((nint)pBase, size);
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Windows.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace Internal.Runtime
 {
     internal unsafe partial class FrozenObjectHeapManager
@@ -17,7 +19,13 @@ namespace Internal.Runtime
 
         static void ClrVirtualFree(void* pBase, nuint size)
         {
-            Interop.Kernel32.VirtualFree(pBase, size, Interop.Kernel32.MemOptions.MEM_RELEASE);
+            // We require the size parameter for Unix implementation sake.
+            // The Win32 API ignores this parameter because we must pass zero.
+            // If the caller passed zero, this is going to be broken on Unix
+            // so let's at least assert that.
+            Debug.Assert(size != 0);
+
+            Interop.Kernel32.VirtualFree(pBase, 0, Interop.Kernel32.MemOptions.MEM_RELEASE);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.Windows.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Internal.Runtime
+{
+    internal unsafe partial class FrozenObjectHeapManager
+    {
+        static void* ClrVirtualReserve(nuint size)
+        {
+            return Interop.Kernel32.VirtualAlloc(null, size, Interop.Kernel32.MemOptions.MEM_RESERVE, Interop.Kernel32.PageOptions.PAGE_READWRITE);
+        }
+
+        static void* ClrVirtualCommit(void* pBase, nuint size)
+        {
+            return Interop.Kernel32.VirtualAlloc(pBase, size, Interop.Kernel32.MemOptions.MEM_COMMIT, Interop.Kernel32.PageOptions.PAGE_READWRITE);
+        }
+
+        static void ClrVirtualFree(void* pBase, nuint size)
+        {
+            Interop.Kernel32.VirtualFree(pBase, size, Interop.Kernel32.MemOptions.MEM_RELEASE);
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -1,0 +1,269 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace Internal.Runtime
+{
+    internal unsafe partial class FrozenObjectHeapManager
+    {
+        public static FrozenObjectHeapManager Instance = new FrozenObjectHeapManager();
+
+        private readonly LowLevelLock m_Crst = new LowLevelLock();
+        private readonly LowLevelLock m_SegmentRegistrationCrst = new LowLevelLock();
+        private ArrayBuilder<FrozenObjectSegment> m_FrozenSegments;
+        private FrozenObjectSegment m_CurrentSegment;
+
+        // Default size to reserve for a frozen segment
+        private const nuint FOH_SEGMENT_DEFAULT_SIZE = 4 * 1024 * 1024;
+        // Size to commit on demand in that reserved space
+        private const nuint FOH_COMMIT_SIZE = 64 * 1024;
+
+        public T? TryAllocateObject<T>() where T : class
+        {
+            MethodTable* pMT = MethodTable.Of<T>();
+            return Unsafe.As<T?>(TryAllocateObject(pMT, pMT->BaseSize));
+        }
+
+        private object? TryAllocateObject(MethodTable* type, nuint objectSize)
+        {
+            HalfBakedObject* obj = null;
+            FrozenObjectSegment? curSeg = null;
+            byte* curSegmentCurrent = null;
+            nuint curSegSizeCommitted = 0;
+
+            m_Crst.Acquire();
+
+            try
+            {
+                Debug.Assert(type != null);
+                // _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
+
+                // Currently we don't support frozen objects with special alignment requirements
+                // TODO: We should also give up on arrays of doubles on 32-bit platforms.
+                // (we currently never allocate them on frozen segments)
+#if FEATURE_64BIT_ALIGNMENT
+                if (type->RequiresAlign8)
+                {
+                    // Align8 objects are not supported yet
+                    return nullptr;
+                }
+#endif
+
+                // NOTE: objectSize is expected be the full size including header
+                // _ASSERT(objectSize >= MIN_OBJECT_SIZE);
+
+                if (objectSize > FOH_COMMIT_SIZE)
+                {
+                    // The current design doesn't allow objects larger than FOH_COMMIT_SIZE and
+                    // since FrozenObjectHeap is just an optimization, let's not fill it with huge objects.
+                    return null;
+                }
+
+                obj = m_CurrentSegment == null ? null : m_CurrentSegment.TryAllocateObject(type, objectSize);
+                // obj is nullptr if the current segment is full or hasn't been allocated yet
+                if (obj == null)
+                {
+                    nuint newSegmentSize = FOH_SEGMENT_DEFAULT_SIZE;
+                    if (m_CurrentSegment != null)
+                    {
+                        // Double the reserved size to reduce the number of frozen segments in apps with lots of frozen objects
+                        // Use the same size in case if prevSegmentSize*2 operation overflows.
+                        nuint prevSegmentSize = m_CurrentSegment.m_Size;
+                        newSegmentSize = Math.Max(prevSegmentSize, prevSegmentSize * 2);
+                    }
+
+                    m_CurrentSegment = new FrozenObjectSegment(newSegmentSize);
+                    m_FrozenSegments.Add(m_CurrentSegment);
+
+                    // Try again
+                    obj = m_CurrentSegment.TryAllocateObject(type, objectSize);
+
+                    // This time it's not expected to be null
+                    Debug.Assert(obj != null);
+                }
+
+                curSeg = m_CurrentSegment;
+                curSegSizeCommitted = curSeg.m_SizeCommitted;
+                curSegmentCurrent = curSeg.m_pCurrent;
+            } // end of m_Crst lock
+            finally
+            {
+                m_Crst.Release();
+            }
+
+            // Let GC know about the new segment or changes in it.
+            // We do it under a new lock because the main one (m_Crst) can be used by Profiler in a GC's thread
+            // and that might cause deadlocks since RegisterFrozenSegment may stuck on GC's lock.
+            m_SegmentRegistrationCrst.Acquire();
+            try
+            {
+                curSeg.RegisterOrUpdate(curSegmentCurrent, curSegSizeCommitted);
+            }
+            finally
+            {
+                m_SegmentRegistrationCrst.Release();
+            }
+
+            //PublishFrozenObject(obj);
+
+            IntPtr result = (IntPtr)obj;
+
+            return Unsafe.As<IntPtr, object>(ref result);
+        }
+
+        private class FrozenObjectSegment
+        {
+            // Start of the reserved memory, the first object starts at "m_pStart + sizeof(ObjHeader)" (its pMT)
+            byte* m_pStart;
+
+            // NOTE: To handle potential race conditions, only m_[x]Registered fields should be accessed
+            // externally as they guarantee that GC is aware of the current state of the segment.
+
+            // Pointer to the end of the current segment, ready to be used as a pMT for a new object
+            // meaning that "m_pCurrent - sizeof(ObjHeader)" is the actual start of the new object (header).
+            //
+            // m_pCurrent <= m_SizeCommitted
+            public byte* m_pCurrent;
+
+            // Last known value of m_pCurrent that GC is aware of.
+            //
+            // m_pCurrentRegistered <= m_pCurrent
+            byte* m_pCurrentRegistered;
+
+            // Memory committed in the current segment
+            //
+            // m_SizeCommitted <= m_pStart + FOH_SIZE_RESERVED
+            public nuint m_SizeCommitted;
+
+            // Total memory reserved for the current segment
+            public nuint m_Size;
+
+            IntPtr m_SegmentHandle;
+
+            public FrozenObjectSegment(nuint sizeHint)
+            {
+                m_Size = sizeHint;
+
+                Debug.Assert(m_Size > FOH_COMMIT_SIZE);
+                Debug.Assert(m_Size % FOH_COMMIT_SIZE == 0);
+
+                void* alloc = ClrVirtualReserve(m_Size);
+                if (alloc == null)
+                {
+                    // Try again with the default FOH size
+                    if (m_Size > FOH_SEGMENT_DEFAULT_SIZE)
+                    {
+                        m_Size = FOH_SEGMENT_DEFAULT_SIZE;
+                        Debug.Assert(m_Size > FOH_COMMIT_SIZE);
+                        Debug.Assert(m_Size % FOH_COMMIT_SIZE == 0);
+                        alloc = ClrVirtualReserve(m_Size);
+                    }
+
+                    if (alloc == null)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                }
+
+                // Commit a chunk in advance
+                void* committedAlloc = ClrVirtualCommit(alloc, FOH_COMMIT_SIZE);
+                if (committedAlloc == null)
+                {
+                    ClrVirtualFree(alloc, 0);
+                    throw new OutOfMemoryException();
+                }
+
+                m_pStart = (byte*)committedAlloc;
+                m_pCurrent = m_pStart + sizeof(ObjHeader);
+                m_SizeCommitted = FOH_COMMIT_SIZE;
+
+                // ClrVirtualAlloc is expected to be PageSize-aligned so we can expect
+                // DATA_ALIGNMENT alignment as well
+                // _ASSERT(IS_ALIGNED(committedAlloc, DATA_ALIGNMENT));
+            }
+
+            public void RegisterOrUpdate(byte* current, nuint sizeCommited)
+            {
+                if (m_pCurrentRegistered == null)
+                {
+                    Debug.Assert(current >= m_pStart);
+
+                    // NOTE: RegisterFrozenSegment may take a GC lock inside.
+                    m_SegmentHandle = RuntimeImports.RhRegisterFrozenSegment(m_pStart, (nuint)current - (nuint)m_pStart, sizeCommited, m_Size);
+                    if (m_SegmentHandle == IntPtr.Zero)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                    m_pCurrentRegistered = current;
+                }
+                else
+                {
+                    if (current > m_pCurrentRegistered)
+                    {
+                        RuntimeImports.RhUpdateFrozenSegment(
+                            m_SegmentHandle, current, m_pStart + sizeCommited);
+                        m_pCurrentRegistered = current;
+                    }
+                    else
+                    {
+                        // Some other thread already advanced it.
+                    }
+                }
+            }
+
+            public HalfBakedObject* TryAllocateObject(MethodTable* type, nuint objectSize)
+            {
+                Debug.Assert((m_pStart != null) && (m_Size > 0));
+                //_ASSERT(IS_ALIGNED(m_pCurrent, DATA_ALIGNMENT));
+                //_ASSERT(IS_ALIGNED(objectSize, DATA_ALIGNMENT));
+                Debug.Assert(objectSize <= FOH_COMMIT_SIZE);
+                Debug.Assert(m_pCurrent >= m_pStart + sizeof(ObjHeader));
+
+                nuint spaceUsed = (nuint)(m_pCurrent - m_pStart);
+                nuint spaceLeft = m_Size - spaceUsed;
+
+                Debug.Assert(spaceUsed >= (nuint)sizeof(ObjHeader));
+                Debug.Assert(spaceLeft >= (nuint)sizeof(ObjHeader));
+
+                // Test if we have a room for the given object (including extra sizeof(ObjHeader) for next object)
+                if (spaceLeft - (nuint)sizeof(ObjHeader) < objectSize)
+                {
+                    return null;
+                }
+
+                // Check if we need to commit a new chunk
+                if (spaceUsed + objectSize + (nuint)sizeof(ObjHeader) > m_SizeCommitted)
+                {
+                    // Make sure we don't go out of bounds during this commit
+                    Debug.Assert(m_SizeCommitted + FOH_COMMIT_SIZE <= m_Size);
+
+                    if (ClrVirtualCommit(m_pStart + m_SizeCommitted, FOH_COMMIT_SIZE) == null)
+                    {
+                        throw new OutOfMemoryException();
+                    }
+                    m_SizeCommitted += FOH_COMMIT_SIZE;
+                }
+
+                HalfBakedObject* obj = (HalfBakedObject*)m_pCurrent;
+                obj->SetMethodTable(type);
+
+                m_pCurrent += objectSize;
+
+                return obj;
+            }
+        }
+
+        private struct HalfBakedObject
+        {
+            private MethodTable* _methodTable;
+            public void SetMethodTable(MethodTable* methodTable) => _methodTable = methodTable;
+        }
+    }
+}

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Debug = System.Diagnostics.Debug;
+// Rewrite of src\coreclr\vm\frozenobjectheap.cpp in C#
 
 namespace Internal.Runtime
 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 using Debug = System.Diagnostics.Debug;
+
 // Rewrite of src\coreclr\vm\frozenobjectheap.cpp in C#
 
 namespace Internal.Runtime

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -94,6 +94,7 @@
     <Compile Include="$(AotCommonPath)\Internal\Runtime\TypeLoader\ExternalReferencesTable.cs">
       <Link>Common\src\Internal\Runtime\TypeLoader\ExternalReferencesTable.cs</Link>
     </Compile>
+    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.cs" />
     <Compile Include="Internal\Runtime\ThreadStatics.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\StartupCode\StartupCodeHelpers.Extensions.cs" />
     <Compile Include="Internal\Runtime\CompilerHelpers\ArrayHelpers.cs" />
@@ -252,6 +253,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.Windows.cs" />
     <Compile Include="System\Runtime\InteropServices\NativeLibrary.NativeAot.Windows.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Windows.cs" />
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\BuiltInVariantExtensions.cs">
@@ -291,6 +293,7 @@
     <Compile Include="System\Threading\ThreadPoolCallbackWrapper.NativeAot.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)'=='true'">
+    <Compile Include="Internal\Runtime\FrozenObjectHeapManager.Unix.cs" />
     <Compile Include="System\Environment.NativeAot.Unix.cs" />
     <Compile Include="System\Runtime\InteropServices\NativeLibrary.NativeAot.Unix.cs" />
     <Compile Include="System\Runtime\InteropServices\PInvokeMarshal.Unix.cs" />
@@ -301,6 +304,15 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Exit.cs">
       <Link>Interop\Unix\System.Native\Interop.Exit.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MMap.cs">
+      <Link>Interop\Unix\System.Native\Interop.MMap.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MProtect.cs">
+      <Link>Interop\Unix\System.Native\Interop.MProtect.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MUnmap.cs">
+      <Link>Interop\Unix\System.Native\Interop.MUnmap.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/GC.NativeAot.cs
@@ -741,14 +741,14 @@ namespace System
             return size;
         }
 
-        private static IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, IntPtr sectionSize)
+        private static unsafe IntPtr _RegisterFrozenSegment(IntPtr sectionAddress, IntPtr sectionSize)
         {
-            return RuntimeImports.RhpRegisterFrozenSegment(sectionAddress, sectionSize);
+            return RuntimeImports.RhRegisterFrozenSegment((void*)sectionAddress, (nuint)sectionSize, (nuint)sectionSize, (nuint)sectionSize);
         }
 
         private static void _UnregisterFrozenSegment(IntPtr segmentHandle)
         {
-            RuntimeImports.RhpUnregisterFrozenSegment(segmentHandle);
+            RuntimeImports.RhUnregisterFrozenSegment(segmentHandle);
         }
 
         public static long GetAllocatedBytesForCurrentThread()

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -166,12 +166,15 @@ namespace System.Runtime
         internal static extern long RhGetLastGCDuration(int generation);
 
         [LibraryImport(RuntimeLibrary)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         internal static unsafe partial IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
         [LibraryImport(RuntimeLibrary)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         internal static unsafe partial void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
 
         [LibraryImport(RuntimeLibrary)]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvCdecl) })]
         internal static partial void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -166,13 +166,13 @@ namespace System.Runtime
         internal static extern long RhGetLastGCDuration(int generation);
 
         [LibraryImport(RuntimeLibrary)]
-        internal static extern unsafe IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
+        internal static unsafe partial IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
         [LibraryImport(RuntimeLibrary)]
         internal static unsafe partial void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
 
         [LibraryImport(RuntimeLibrary)]
-        internal static extern void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
+        internal static partial void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhRegisterForFullGCNotification")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -165,13 +165,14 @@ namespace System.Runtime
         [RuntimeImport(RuntimeLibrary, "RhGetLastGCDuration")]
         internal static extern long RhGetLastGCDuration(int generation);
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpRegisterFrozenSegment")]
-        internal static extern IntPtr RhpRegisterFrozenSegment(IntPtr pSegmentStart, IntPtr length);
+        [LibraryImport(RuntimeLibrary)]
+        internal static extern unsafe IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpUnregisterFrozenSegment")]
-        internal static extern void RhpUnregisterFrozenSegment(IntPtr pSegmentHandle);
+        [LibraryImport(RuntimeLibrary)]
+        internal static unsafe partial void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
+
+        [LibraryImport(RuntimeLibrary)]
+        internal static extern void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhRegisterForFullGCNotification")]

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -40,13 +40,13 @@ namespace System.Runtime
             return h;
         }
 
-        [DllImport(RuntimeLibrary)]
+        [DllImport(RuntimeLibrary, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
-        [DllImport(RuntimeLibrary)]
+        [DllImport(RuntimeLibrary, CallingConvention = CallingConvention.Cdecl)]
         internal static extern unsafe void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
 
-        [DllImport(RuntimeLibrary)]
+        [DllImport(RuntimeLibrary, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -40,16 +40,13 @@ namespace System.Runtime
             return h;
         }
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhRegisterFrozenSegment")]
+        [DllImport(RuntimeLibrary)]
         internal static extern unsafe IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhUpdateFrozenSegment")]
+        [DllImport(RuntimeLibrary)]
         internal static extern unsafe void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
 
-        [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhUnregisterFrozenSegment")]
+        [DllImport(RuntimeLibrary)]
         internal static extern void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]

--- a/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/Test.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -41,12 +41,16 @@ namespace System.Runtime
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpRegisterFrozenSegment")]
-        internal static extern IntPtr RhpRegisterFrozenSegment(IntPtr pSegmentStart, IntPtr length);
+        [RuntimeImport(RuntimeLibrary, "RhRegisterFrozenSegment")]
+        internal static extern unsafe IntPtr RhRegisterFrozenSegment(void* pSegmentStart, nuint allocSize, nuint commitSize, nuint reservedSize);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RuntimeImport(RuntimeLibrary, "RhpUnregisterFrozenSegment")]
-        internal static extern void RhpUnregisterFrozenSegment(IntPtr pSegmentHandle);
+        [RuntimeImport(RuntimeLibrary, "RhUpdateFrozenSegment")]
+        internal static extern unsafe void RhUpdateFrozenSegment(IntPtr seg, void* allocated, void* committed);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        [RuntimeImport(RuntimeLibrary, "RhUnregisterFrozenSegment")]
+        internal static extern void RhUnregisterFrozenSegment(IntPtr pSegmentHandle);
 
         [RuntimeImport(RuntimeLibrary, "RhpGetModuleSection")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
@@ -33,5 +33,12 @@ internal static partial class Interop
             IntPtr addr, ulong len,
             MemoryMappedProtections prot, MemoryMappedFlags flags,
             SafeFileHandle fd, long offset);
+
+        // NOTE: Shim returns null pointer on failure, not non-null MAP_FAILED sentinel.
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_MMap", SetLastError = true)]
+        internal static partial IntPtr MMap(
+            IntPtr addr, ulong len,
+            MemoryMappedProtections prot, MemoryMappedFlags flags,
+            IntPtr fd, long offset);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MProtect.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MProtect.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_MProtect", SetLastError = true)]
+        internal static partial int MProtect(IntPtr addr, ulong len, MemoryMappedProtections prot);
+    }
+}

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -93,6 +93,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_MksTemps)
     DllImportEntry(SystemNative_MMap)
     DllImportEntry(SystemNative_MUnmap)
+    DllImportEntry(SystemNative_MProtect);
     DllImportEntry(SystemNative_MAdvise)
     DllImportEntry(SystemNative_MSync)
     DllImportEntry(SystemNative_SysConf)

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -93,7 +93,7 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_MksTemps)
     DllImportEntry(SystemNative_MMap)
     DllImportEntry(SystemNative_MUnmap)
-    DllImportEntry(SystemNative_MProtect);
+    DllImportEntry(SystemNative_MProtect)
     DllImportEntry(SystemNative_MAdvise)
     DllImportEntry(SystemNative_MSync)
     DllImportEntry(SystemNative_SysConf)

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1019,6 +1019,19 @@ int32_t SystemNative_MUnmap(void* address, uint64_t length)
     return munmap(address, (size_t)length);
 }
 
+int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t protection)
+{
+    if (length > SIZE_MAX)
+    {
+        errno =  ERANGE;
+        return -1;
+    }
+
+    protection = ConvertMMapProtection(protection);
+
+    return mprotect(address, (size_t)length, protection);
+}
+
 int32_t SystemNative_MAdvise(void* address, uint64_t length, int32_t advice)
 {
     if (length > SIZE_MAX)

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -601,6 +601,13 @@ PALEXPORT void* SystemNative_MMap(void* address,
 PALEXPORT int32_t SystemNative_MUnmap(void* address, uint64_t length);
 
 /**
+ * Change the access protections for the specified memory pages.
+ *
+ * Returns 0 for success, -1 for failure. Sets errno on failure.
+ */
+PALEXPORT int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t protection);
+
+/**
  * Give advice about use of memory. Implemented as shim to madvise(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.


### PR DESCRIPTION
When allocating a RuntimeType instances, we were creating an object on the pinned object heap, creating a handle to it, and purposefully leaked the handle. The RuntimeTypes live forever. This fragments the pinned object heap. So instead of doing that, port frozen object heap from CoreCLR. This is a line-by-line port. Frozen object heap is a segmented bump memory allocator that interacts with the GC to tell it the boundaries of the segments.

cc @dotnet/ilc-contrib 