### PR TITLE
Ensure that `JsonSerializerOptions.CacheContext` is a singleton.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Threading;
 
 namespace System.Text.Json
 {
@@ -24,7 +25,13 @@ namespace System.Text.Json
             get
             {
                 Debug.Assert(IsReadOnly);
-                return _cachingContext ??= TrackedCachingContexts.GetOrCreate(this);
+                return _cachingContext ?? GetOrCreate();
+
+                CachingContext GetOrCreate()
+                {
+                    CachingContext ctx = TrackedCachingContexts.GetOrCreate(this);
+                    return Interlocked.CompareExchange(ref _cachingContext, ctx, null) ?? ctx;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a race condition wherein the `JsonSerializerOptions.CacheContext` property could be returning multiple instances, which can occasionally make this assertion fail:

https://github.com/dotnet/runtime/blob/0ad3723332c37f6423a725fbd4ad889b8e0f3d7c/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.cs#L672

Fix #88102.