### PR TITLE
Combine rootDir with relative file names

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -46,16 +46,24 @@ namespace Microsoft.Extensions.FileSystemGlobbing
             else
             {
                 var fileList = new List<string>(files.Count());
+                string normalizedRoot = Path.GetFullPath(rootDir.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
 
                 // normalize
                 foreach (string file in files)
                 {
-                    fileList.Add(Path.GetFullPath(file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                    if (Path.IsPathRooted(file))
+                    {
+                        fileList.Add(Path.GetFullPath(file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                    }
+                    else
+                    {
+                        fileList.Add(Path.Combine(normalizedRoot, file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                    }
                 }
 
                 _files = fileList;
 
-                FullName = Path.GetFullPath(rootDir.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+                FullName = normalizedRoot;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -372,12 +372,11 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         public void StemCorrectWithDifferentWildCards_WithInMemory()
         {
             var matcher = new Matcher();
-            matcher.AddInclude("sub/*.cs");
-            matcher.AddInclude("**/*.cs");
+            matcher.AddInclude("src/project/sub/*.cs");
+            matcher.AddInclude("src/project/**/*.cs");
 
             var files = GetFileList();
-            var directoryPath = "src/project";
-            var results = matcher.Match(directoryPath, files);
+            var results = matcher.Match("./", files);
 
             var actual = results.Files.Select(match => match.Stem);
             var expected = new string[]
@@ -425,11 +424,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         public void MultipleSubDirsAfterFirstWildcardMatch_HasCorrectStem_WithInMemory()
         {
             var matcher = new Matcher();
-            matcher.AddInclude("compiler/**/*.cs");
+            matcher.AddInclude("src/project/compiler/**/*.cs");
 
             var files = GetFileList();
-            var directoryPath = "src/project";
-            var results = matcher.Match(directoryPath, files);
+            var results = matcher.Match("./", files);
 
             var actual = results.Files.Select(match => match.Stem);
             var expected = new string[]
@@ -450,12 +448,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         [InlineData(@"root", @"**/*.0",      @"test.0")]
         public void PathIncludesAllSegmentsFromPattern_RootDirectory(string root, string includePattern, string expectedPath)
         {
-            var fileToFind = @"root/test.0";
-
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
 
-            var results = matcher.Match(root, new[] { fileToFind });
+            var results = matcher.Match(root, new[] { expectedPath });
             var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -464,7 +460,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             matcher = new Matcher();
             matcher.AddInclude("./" + includePattern);
 
-            results = matcher.Match(root, new[] { fileToFind });
+            results = matcher.Match(root, new[] { expectedPath });
             actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -480,12 +476,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         [InlineData(@"root",      @"**/*.1",         @"dir1/test.1")]
         public void PathIncludesAllSegmentsFromPattern_OneDirectoryDeep(string root, string includePattern, string expectedPath)
         {
-            var fileToFind = @"root/dir1/test.1";
-
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
 
-            var results = matcher.Match(root, new[] { fileToFind });
+            var results = matcher.Match(root, new[] { expectedPath });
             var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -494,7 +488,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             matcher = new Matcher();
             matcher.AddInclude("./" + includePattern);
 
-            results = matcher.Match(root, new[] { fileToFind });
+            results = matcher.Match(root, new[] { expectedPath });
             actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -520,12 +514,10 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         [InlineData(@"root",           @"**/*.2",                 @"dir1/dir2/test.2")]
         public void PathIncludesAllSegmentsFromPattern_TwoDirectoriesDeep(string root, string includePattern, string expectedPath)
         {
-            var fileToFind = @"root/dir1/dir2/test.2";
-
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
 
-            var results = matcher.Match(root, new[] { fileToFind });
+            var results = matcher.Match(root, new[] { expectedPath });
             var actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -534,7 +526,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             matcher = new Matcher();
             matcher.AddInclude("./" + includePattern);
 
-            results = matcher.Match(root, new[] { fileToFind });
+            results = matcher.Match(root, new[] { expectedPath });
             actualPath = results.Files.Select(file => file.Path).SingleOrDefault();
 
             Assert.Equal(expectedPath, actualPath);
@@ -545,7 +537,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         [InlineData(@"root", @"**/*.0",      @"test.0")]
         public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_RootDirectory(string root, string includePattern, string expectedStem)
         {
-            var fileToFind = @"root/test.0";
+            string fileToFind = "test.0";
 
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
@@ -565,18 +557,16 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             Assert.Equal(expectedStem, actualStem);
         }
 
-        [Theory] // rootDir,      includePattern,    expectedStem
-        [InlineData(@"root/dir1", @"*.1",            @"test.1")]
-        [InlineData(@"root/dir1", @"**/*.1",         @"test.1")]
-        [InlineData(@"root",      @"dir1/*.1",       @"test.1")]
-        [InlineData(@"root",      @"dir1/**/*.1",    @"test.1")]
-        [InlineData(@"root",      @"**/dir1/*.1",    @"dir1/test.1")]
-        [InlineData(@"root",      @"**/dir1/**/*.1", @"dir1/test.1")]
-        [InlineData(@"root",      @"**/*.1",         @"dir1/test.1")]
-        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_OneDirectoryDeep(string root, string includePattern, string expectedStem)
+        [Theory] // rootDir,      includePattern,    fileToFind      expectedStem
+        [InlineData(@"root/dir1", @"*.1",            @"test.1",      @"test.1")]
+        [InlineData(@"root/dir1", @"**/*.1",         @"test.1",      @"test.1")]
+        [InlineData(@"root",      @"dir1/*.1",       @"dir1/test.1", @"test.1")]
+        [InlineData(@"root",      @"dir1/**/*.1",    @"dir1/test.1", @"test.1")]
+        [InlineData(@"root",      @"**/dir1/*.1",    @"dir1/test.1", @"dir1/test.1")]
+        [InlineData(@"root",      @"**/dir1/**/*.1", @"dir1/test.1", @"dir1/test.1")]
+        [InlineData(@"root",      @"**/*.1",         @"dir1/test.1", @"dir1/test.1")]
+        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_OneDirectoryDeep(string root, string includePattern, string fileToFind, string expectedStem)
         {
-            var fileToFind = @"root/dir1/test.1";
-
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
 
@@ -595,28 +585,26 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             Assert.Equal(expectedStem, actualStem);
         }
 
-        [Theory] // rootDir,           includePattern,            expectedStem
-        [InlineData(@"root/dir1/dir2", @"*.2",                    @"test.2")]
-        [InlineData(@"root/dir1/dir2", @"**/*.2",                 @"test.2")]
-        [InlineData(@"root/dir1",      @"dir2/*.2",               @"test.2")]
-        [InlineData(@"root/dir1",      @"dir2/**/*.2",            @"test.2")]
-        [InlineData(@"root/dir1",      @"**/dir2/*.2",            @"dir2/test.2")]
-        [InlineData(@"root/dir1",      @"**/dir2/**/*.2",         @"dir2/test.2")]
-        [InlineData(@"root/dir1",      @"**/*.2",                 @"dir2/test.2")]
-        [InlineData(@"root",           @"dir1/dir2/*.2",          @"test.2")]
-        [InlineData(@"root",           @"dir1/dir2/**/*.2",       @"test.2")]
-        [InlineData(@"root",           @"**/dir1/dir2/**/*.2",    @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"**/dir1/**/dir2/*.2",    @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"**/dir1/**/dir2/**/*.2", @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"dir1/**/*.2",            @"dir2/test.2")]
-        [InlineData(@"root",           @"**/dir1/**/*.2",         @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"**/dir2/*.2",            @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"**/dir2/**/*.2",         @"dir1/dir2/test.2")]
-        [InlineData(@"root",           @"**/*.2",                 @"dir1/dir2/test.2")]
-        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_TwoDirectoriesDeep(string root, string includePattern, string expectedStem)
+        [Theory] // rootDir,           includePattern,            fileToFind           expectedStem
+        [InlineData(@"root/dir1/dir2", @"*.2",                    @"test.2",           @"test.2")]
+        [InlineData(@"root/dir1/dir2", @"**/*.2",                 @"test.2",           @"test.2")]
+        [InlineData(@"root/dir1",      @"dir2/*.2",               @"dir2/test.2",      @"test.2")]
+        [InlineData(@"root/dir1",      @"dir2/**/*.2",            @"dir2/test.2",      @"test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/*.2",            @"dir2/test.2",      @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/dir2/**/*.2",         @"dir2/test.2",      @"dir2/test.2")]
+        [InlineData(@"root/dir1",      @"**/*.2",                 @"dir2/test.2",      @"dir2/test.2")]
+        [InlineData(@"root",           @"dir1/dir2/*.2",          @"dir1/dir2/test.2", @"test.2")]
+        [InlineData(@"root",           @"dir1/dir2/**/*.2",       @"dir1/dir2/test.2", @"test.2")]
+        [InlineData(@"root",           @"**/dir1/dir2/**/*.2",    @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/*.2",    @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/dir2/**/*.2", @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"dir1/**/*.2",            @"dir1/dir2/test.2", @"dir2/test.2")]
+        [InlineData(@"root",           @"**/dir1/**/*.2",         @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/*.2",            @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/dir2/**/*.2",         @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        [InlineData(@"root",           @"**/*.2",                 @"dir1/dir2/test.2", @"dir1/dir2/test.2")]
+        public void StemIncludesAllSegmentsFromPatternStartingAtWildcard_TwoDirectoriesDeep(string root, string includePattern, string fileToFind, string expectedStem)
         {
-            var fileToFind = @"root/dir1/dir2/test.2";
-
             var matcher = new Matcher();
             matcher.AddInclude(includePattern);
 
@@ -844,7 +832,6 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         }
 
         [Fact] // https://github.com/dotnet/runtime/issues/36415
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/50648")]
         public void VerifyInMemoryDirectoryInfo_IsNotEmpty()
         {
             IEnumerable<string> files = new[] { @"pagefile.sys" };


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/50648

Using `Path.GetFullPath` on relative file names causes that the in-memory `Matcher.Match` to treat files as relative to the CWD blocking scenarios that are using a rootDir in a different drive as the one discussed in #50648. We should combine the rootDir with the relative file names instead. This is also what's described in the [documentation](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.inmemorydirectoryinfo.-ctor).

> files IEnumerable\<String\>
> Collection of file names. If relative paths rootDir will be prepended to the paths.

However, this is a (massive?) breaking change as there's already a lot of tests showing that filenames are relative to CWD and not to rootDir, and in the wild, there will be most likely use cases that depend in this bug (need to check).
