### PR TITLE
Arm64/SVE: Add Uzp1

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -6703,11 +6703,11 @@ void CodeGen::genArm64EmitterUnitTests()
     theEmitter->emitIns_R_R_R(INS_rorv, EA_4BYTE, REG_R8, REG_R9, REG_R10);
 
     // TODO-SVE: Fix once we add predicate registers
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
                               INS_OPTS_8B); // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
                               INS_OPTS_8B); // UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
                               INS_OPTS_8B); // UZP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -6703,9 +6703,12 @@ void CodeGen::genArm64EmitterUnitTests()
     theEmitter->emitIns_R_R_R(INS_rorv, EA_4BYTE, REG_R8, REG_R9, REG_R10);
 
     // TODO-SVE: Fix once we add predicate registers
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
-    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+                              INS_OPTS_8B); // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+                              INS_OPTS_8B); // UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2,
+                              INS_OPTS_8B); // UZP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -6702,6 +6702,11 @@ void CodeGen::genArm64EmitterUnitTests()
     theEmitter->emitIns_R_R_R(INS_asrv, EA_4BYTE, REG_R8, REG_R9, REG_R10);
     theEmitter->emitIns_R_R_R(INS_rorv, EA_4BYTE, REG_R8, REG_R9, REG_R10);
 
+    // TODO-SVE: Fix once we add predicate registers
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q
+    theEmitter->emitIns_R_R_R(INS_uzp1, EA_8BYTE, REG_R0, REG_R1, REG_R2, INS_OPTS_8B);  // UZP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>
+
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS
 
 #ifdef ALL_ARM64_EMITTER_UNIT_TESTS

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -946,24 +946,24 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
             elemsize = id->idOpSize();
             assert(insOptsNone(id->idInsOpt()));
-            assert(isVectorRegister(id->idReg1())); // ddddd
-            assert(isVectorRegister(id->idReg2())); // nnnnn
-            assert(isVectorRegister(id->idReg3())); // mmmmm
+            assert(isVectorRegister(id->idReg1()));  // ddddd
+            assert(isVectorRegister(id->idReg2()));  // nnnnn
+            assert(isVectorRegister(id->idReg3()));  // mmmmm
             assert(isValidVectorElemsize(elemsize)); // xx
 
-        case IF_SVE_BR_3B:   // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
+        case IF_SVE_BR_3B: // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
             assert(insOptsNone(id->idInsOpt()));
             assert(isVectorRegister(id->idReg1())); // ddddd
             assert(isVectorRegister(id->idReg2())); // nnnnn
             assert(isVectorRegister(id->idReg3())); // mmmmm
 
-        case IF_SVE_CI_3A:   // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
+        case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
             elemsize = id->idOpSize();
             assert(insOptsNone(id->idInsOpt()));
             assert(isPredicateRegister(id->idReg1())); // DDDD
             assert(isPredicateRegister(id->idReg2())); // NNNN
             assert(isPredicateRegister(id->idReg3())); // MMMM
-            assert(isValidVectorElemsize(elemsize));    // xx
+            assert(isValidVectorElemsize(elemsize));   // xx
             break;
 
         default:
@@ -13404,7 +13404,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             code |= insEncodeReg_Vd(id->idReg1()); // ddddd
             code |= insEncodeReg_Vn(id->idReg2()); // nnnnn
             code |= insEncodeReg_Vm(id->idReg3()); // mmmmm
-            code |= insEncodeElemsize(elemsize);    // xx
+            code |= insEncodeElemsize(elemsize);   // xx
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -13422,7 +13422,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             code |= insEncodeReg_Pd(id->idReg1()); // DDDD
             code |= insEncodeReg_Pn(id->idReg2()); // NNNN
             code |= insEncodeReg_Pm(id->idReg3()); // MMMM
-            code |= insEncodeElemsize(elemsize);    // xx
+            code |= insEncodeElemsize(elemsize);   // xx
             dst += emitOutput_Instr(dst, code);
             break;
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1044,6 +1044,10 @@ bool emitter::emitInsMayWriteToGCReg(instrDesc* id)
         case IF_DV_3F:  // DV_3F   .Q......XX.mmmmm ......nnnnnddddd      Vd Vn Vm   (vector)
         case IF_DV_3G:  // DV_3G   .Q.........mmmmm .iiii.nnnnnddddd      Vd Vn Vm imm (vector)
         case IF_DV_4A:  // DV_4A   .........X.mmmmm .aaaaannnnnddddd      Vd Va Vn Vm (scalar)
+
+        case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+        case IF_SVE_EF_3A: // ...........mmmmm ......nnnnnddddd -- SVE two-way dot product
+        case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
             // Tracked GC pointers cannot be placed into the SIMD registers.
             return false;
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1443,6 +1443,25 @@ const char* emitter::emitVectorRegName(regNumber reg)
     return vRegNames[index];
 }
 
+//------------------------------------------------------------------------
+// emitPredicateRegName: Returns a predicate register name.
+//
+// Arguments:
+//    reg - A predicate register.
+//
+// Return value:
+//    A string that represents a predicate register name.
+//
+const char* emitter::emitPredicateRegName(regNumber reg)
+{
+    // TODO-SVE: Fix once we add predicate registers
+    assert((reg >= REG_V0) && (reg <= REG_V31));
+
+    int index = (int)reg - (int)REG_V0;
+
+    return vRegNames[index];
+}
+
 /*****************************************************************************
  *
  *  Returns the base encoding of the given CPU instruction.
@@ -13942,6 +13961,20 @@ void emitter::emitDispVectorElemList(
 }
 
 //------------------------------------------------------------------------
+// emitDispPredicateReg: Display a predicate register name with with an arrangement suffix
+//
+void emitter::emitDispPredicateReg(regNumber reg, insOpts opt, bool addComma)
+{
+    // TODO-SVE: Fix once we add predicate registers
+    assert(isPredicateRegister(reg));
+    printf(emitVectorRegName(reg));
+    emitDispArrangement(opt);
+
+    if (addComma)
+        emitDispComma();
+}
+
+//------------------------------------------------------------------------
 // emitDispArrangement: Display a SIMD vector arrangement suffix
 //
 void emitter::emitDispArrangement(insOpts opt)
@@ -15534,6 +15567,24 @@ void emitter::emitDispInsHelp(
             {
                 emitDispReg(id->idReg1(), size, false);
             }
+            break;
+
+        case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+            emitDispVectorReg(id->idReg1(), id->idInsOpt(), true); // ddddd
+            emitDispVectorReg(id->idReg2(), id->idInsOpt(), true); // nnnnn
+            emitDispVectorReg(id->idReg3(), id->idInsOpt(), true); // mmmmm
+            break;
+
+        case IF_SVE_BR_3B: // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
+            emitDispVectorReg(id->idReg1(), id->idInsOpt(), true); // ddddd
+            emitDispVectorReg(id->idReg2(), id->idInsOpt(), true); // nnnnn
+            emitDispVectorReg(id->idReg3(), id->idInsOpt(), true); // mmmmm
+            break;
+
+        case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
+            emitDispPredicateReg(id->idReg1(), id->idInsOpt(), true); // DDDD
+            emitDispPredicateReg(id->idReg2(), id->idInsOpt(), true); // NNNN
+            emitDispPredicateReg(id->idReg3(), id->idInsOpt(), true); // MMMM
             break;
 
         default:

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -950,12 +950,14 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             assert(isVectorRegister(id->idReg2()));  // nnnnn
             assert(isVectorRegister(id->idReg3()));  // mmmmm
             assert(isValidVectorElemsize(elemsize)); // xx
+            break;
 
         case IF_SVE_BR_3B: // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
             assert(insOptsNone(id->idInsOpt()));
             assert(isVectorRegister(id->idReg1())); // ddddd
             assert(isVectorRegister(id->idReg2())); // nnnnn
             assert(isVectorRegister(id->idReg3())); // mmmmm
+            break;
 
         case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
             elemsize = id->idOpSize();
@@ -17769,26 +17771,26 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
                     result.insLatency    = PERFSCORE_LATENCY_3C;
                     break;
 
-                case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-                    result.insLatency    = PERFSCORE_LATENCY_2C;
-                    break;
-
-                case IF_SVE_BR_3B: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-                    result.insLatency    = PERFSCORE_LATENCY_2C;
-                    break;
-
-                case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-                    result.insLatency    = PERFSCORE_LATENCY_2C;
-                    break;
-
                 default:
                     // all other instructions
                     perfScoreUnhandledInstruction(id, &result);
                     break;
             }
+            break;
+
+        case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            break;
+
+        case IF_SVE_BR_3B: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            break;
+
+        case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
+            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            result.insLatency    = PERFSCORE_LATENCY_2C;
             break;
 
         default:

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -943,6 +943,29 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             assert(datasize == EA_8BYTE);
             break;
 
+        case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+            elemsize = id->idOpSize();
+            assert(insOptsNone(id->idInsOpt()));
+            assert(isVectorRegister(id->idReg1())); // ddddd
+            assert(isVectorRegister(id->idReg2())); // nnnnn
+            assert(isVectorRegister(id->idReg3())); // mmmmm
+            assert(isValidVectorElemsize(elemsize)); // xx
+
+        case IF_SVE_BR_3B:   // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
+            assert(insOptsNone(id->idInsOpt()));
+            assert(isVectorRegister(id->idReg1())); // ddddd
+            assert(isVectorRegister(id->idReg2())); // nnnnn
+            assert(isVectorRegister(id->idReg3())); // mmmmm
+
+        case IF_SVE_CI_3A:   // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
+            elemsize = id->idOpSize();
+            assert(insOptsNone(id->idInsOpt()));
+            assert(isPredicateRegister(id->idReg1())); // DDDD
+            assert(isPredicateRegister(id->idReg2())); // NNNN
+            assert(isPredicateRegister(id->idReg3())); // MMMM
+            assert(isValidVectorElemsize(elemsize));    // xx
+            break;
+
         default:
             printf("unexpected format %s\n", emitIfName(id->idInsFmt()));
             assert(!"Unexpected format");

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -17714,6 +17714,21 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
                     result.insLatency    = PERFSCORE_LATENCY_3C;
                     break;
 
+                case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    break;
+
+                case IF_SVE_BR_3B: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    break;
+
+                case IF_SVE_CI_3A: // ........xx..MMMM .......NNNN.DDDD -- SVE permute predicate elements
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    break;
+
                 default:
                     // all other instructions
                     perfScoreUnhandledInstruction(id, &result);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -20,6 +20,7 @@ static bool strictArmAsm;
 /************************************************************************/
 
 const char* emitVectorRegName(regNumber reg);
+const char* emitPredicateRegName(regNumber reg);
 
 void emitDispInsHelp(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig);
@@ -42,6 +43,7 @@ void emitDispVectorReg(regNumber reg, insOpts opt, bool addComma);
 void emitDispVectorRegIndex(regNumber reg, emitAttr elemsize, ssize_t index, bool addComma);
 void emitDispVectorRegList(regNumber firstReg, unsigned listSize, insOpts opt, bool addComma);
 void emitDispVectorElemList(regNumber firstReg, unsigned listSize, emitAttr elemsize, unsigned index, bool addComma);
+void emitDispPredicateReg(regNumber reg, insOpts opt, bool addComma);
 void emitDispArrangement(insOpts opt);
 void emitDispElemsize(emitAttr elemsize);
 void emitDispShiftedReg(regNumber reg, insOpts opt, ssize_t imm, emitAttr attr);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -312,6 +312,15 @@ static code_t insEncodeReg_Vm(regNumber reg);
 // Returns an encoding for the specified register used in the 'Va' position
 static code_t insEncodeReg_Va(regNumber reg);
 
+// Returns an encoding for the specified register used in the 'Pd' position
+static code_t insEncodeReg_Pd(regNumber reg);
+
+// Returns an encoding for the specified register used in the 'Pn' position
+static code_t insEncodeReg_Pn(regNumber reg);
+
+// Returns an encoding for the specified register used in the 'Pm' position
+static code_t insEncodeReg_Pm(regNumber reg);
+
 // Returns an encoding for the imm which represents the condition code.
 static code_t insEncodeCond(insCond cond);
 
@@ -662,6 +671,12 @@ inline static bool isVectorRegister(regNumber reg)
 inline static bool isFloatReg(regNumber reg)
 {
     return isVectorRegister(reg);
+}
+
+inline static bool isPredicateRegister(regNumber reg)
+{
+    //TODO-SVE: Fix once we add predicate registers
+    return (reg >= REG_FP_FIRST && reg <= REG_FP_LAST);
 }
 
 inline static bool insOptsNone(insOpts opt)

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -677,7 +677,7 @@ inline static bool isFloatReg(regNumber reg)
 
 inline static bool isPredicateRegister(regNumber reg)
 {
-    //TODO-SVE: Fix once we add predicate registers
+    // TODO-SVE: Fix once we add predicate registers
     return (reg >= REG_FP_FIRST && reg <= REG_FP_LAST);
 }
 


### PR DESCRIPTION
This is similar to #93067, except that most of the code added in this PR was generated by the tool, the same tool that generated encodings in https://github.com/dotnet/runtime/pull/94285. The only thing that I realized the tool does not generate is the entries in `emitInsMayWriteToGCReg()`. I could add it, but I think it is easier to do it manually.

I have also added method placeholders for predicate registes which will need to be fixed once we add predicate register support in LSRA. I think the next step for this PR would be to make sure the encodings are correctly generated by comparing it with cordistool or lldb. That won't be possible until we add the actual Z and predicate registers.

Another TODO would be to fix the PerfScore numbers, not sure where to check that information though.

Contributes to https://github.com/dotnet/runtime/issues/93095