### PR TITLE
improve debuging HTTP/2 tests

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -799,12 +799,14 @@ internal static partial class Interop
         {
             Debug.Assert(s_fileStream != null);
             ReadOnlySpan<byte> data = MemoryMarshal.CreateReadOnlySpanFromNullTerminated((byte*)line);
+
             if (data.Length > 0)
             {
                 lock (s_fileStream)
                 {
                     s_fileStream.Write(data);
                     s_fileStream.WriteByte((byte)'\n');
+                    s_fileStream.Flush();
                 }
             }
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -799,7 +799,6 @@ internal static partial class Interop
         {
             Debug.Assert(s_fileStream != null);
             ReadOnlySpan<byte> data = MemoryMarshal.CreateReadOnlySpanFromNullTerminated((byte*)line);
-
             if (data.Length > 0)
             {
                 lock (s_fileStream)

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -94,8 +94,8 @@ namespace System.Net.Test.Common
             CloseWebSocket();
         }
 
-        public EndPoint? LocalEndPoint => _socket.LocalEndPoint;
-        public EndPoint? RemoteEndPoint => _socket.RemoteEndPoint;
+        public EndPoint? LocalEndPoint => _socket?.LocalEndPoint;
+        public EndPoint? RemoteEndPoint => _socket?.RemoteEndPoint;
 
         public async Task WaitForCloseAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs
@@ -94,6 +94,9 @@ namespace System.Net.Test.Common
             CloseWebSocket();
         }
 
+        public EndPoint? LocalEndPoint => _socket.LocalEndPoint;
+        public EndPoint? RemoteEndPoint => _socket.RemoteEndPoint;
+
         public async Task WaitForCloseAsync(CancellationToken cancellationToken)
         {
             while (_websocket != null

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -43,6 +43,11 @@ namespace System.Net.Test.Common
             _transparentPingResponse = transparentPingResponse;
         }
 
+        public override string ToString()
+        {
+            return $"{this.GetType().Name} {_connectionSocket.LocalEndPoint} <-> {_connectionSocket.RemoteEndPoint}";
+        }
+
         public static Task<Http2LoopbackConnection> CreateAsync(SocketWrapper socket, Stream stream, Http2Options httpOptions)
         {
             return CreateAsync(socket, stream, httpOptions, Http2LoopbackServer.Timeout);


### PR DESCRIPTION
I bump to two issue while working on  #94112
1) I was using the SSLKEYLOG environment so I can decrypt TLS and peek at the HTTP/2 exchange. 
However, often the sessions keys were not there and I failed to decrypt the transaction. It seems like when the handshake happens and the process exist immediately not everything is written. Adding `Flush` seems to fix this.
It may come with some perf cost but this is Debug only feature so it should not matter as much. 

2) The issue would happen only when running whole test suite. I wanted to instrument the test to spit out the IPEndPoints so I can find the connection among many in the capture file. So I added `ToString` that can giver me something like
`  Http2LoopbackConnection 127.0.0.1:42543 <-> 127.0.0.1:60302`

with that I can set filer in Wireshark as `tcp.port==42543` and get

<img width="1462" alt="failTest" src="https://github.com/dotnet/runtime/assets/14356188/c5686925-52d1-4dcc-b4fd-3a5f6bfc918d">

