### PR TITLE
Fix test returning 100 unconditionally

### DIFF
--- a/src/tests/Loader/classloader/regressions/GitHub_93770/GitHub_93770.cs
+++ b/src/tests/Loader/classloader/regressions/GitHub_93770/GitHub_93770.cs
@@ -20,12 +20,11 @@ namespace ReproGH93770;
 public class ReproGH93770
 {
     [Fact]
-    public static int TestEntryPoint()
+    public static void TestEntryPoint()
     {
         C c = new C();
         I1 i1 = c;
         Helper(i1);
-        return 100;
     }
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void Helper(I1 i1)


### PR DESCRIPTION
Xunit error XUW1002: Tests should not unconditionally return 100. Convert to a void return.

Related change: https://github.com/dotnet/runtime/pull/94437

cc @lambdageek @clamp03 @t-mustafin