### PR TITLE
JIT: remove `BBF_DONT_REMOVE` from some blocks that can be removed

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -563,6 +563,9 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         assert(firstHandlerBlock->bbRefs >= 2);
         firstHandlerBlock->bbRefs -= 1;
 
+        // (8) The old try entry no longer needs special protection.
+        firstTryBlock->bbFlags &= ~BBF_DONT_REMOVE;
+
         // Another one bites the dust...
         emptyCount++;
     }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1495,7 +1495,10 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
         bottomBlock              = fgSplitBlockAfterStatement(topBlock, stmtAfter);
         unsigned const baseBBNum = fgBBNumMax;
 
+        // The newly split block is not special so doesn't need to be kept.
         //
+        bottomBlock->bbFlags &= ~BBF_DONT_REMOVE;
+
         // Set the try and handler index and fix the jump types of inlinee's blocks.
         //
         for (BasicBlock* const block : InlineeCompiler->Blocks())


### PR DESCRIPTION
Some blocks marked `BBF_DONT_REMOVE` are in fact perfectly removable.

This fixes the flags for two such cases:
* block was originally a try entry, but the try was removed.
* block was split off from a `BBF_DONT_REMOVE` block during inlining.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=463813&view=ms.vss-build-web.run-extensions-tab)