### PR TITLE
JIT: Print finally clone stats with JitTimeLogCsv

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1884,7 +1884,9 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
         // Initialize all the per-method statistics gathering data structures.
         //
 
-        optLoopsCloned = 0;
+        optFinallyCount  = 0;
+        optFinallyCloned = 0;
+        optLoopsCloned   = 0;
 
 #if LOOP_HOIST_STATS
         m_loopsConsidered             = 0;
@@ -8914,6 +8916,8 @@ void JitTimer::PrintCsvHeader()
             fprintf(s_csvFile, "\"IL Bytes\",");
             fprintf(s_csvFile, "\"Basic Blocks\",");
             fprintf(s_csvFile, "\"Min Opts\",");
+            fprintf(s_csvFile, "\"Finally Clone Candidates\",");
+            fprintf(s_csvFile, "\"Finally Blocks Cloned\",");
             fprintf(s_csvFile, "\"Loops\",");
             fprintf(s_csvFile, "\"Loops Cloned\",");
 #if FEATURE_LOOP_ALIGN
@@ -8991,6 +8995,8 @@ void JitTimer::PrintCsvMethodStats(Compiler* comp)
     fprintf(s_csvFile, "%u,", comp->info.compILCodeSize);
     fprintf(s_csvFile, "%u,", comp->fgBBcount);
     fprintf(s_csvFile, "%u,", comp->opts.MinOpts());
+    fprintf(s_csvFile, "%u,", comp->optFinallyCount);
+    fprintf(s_csvFile, "%u,", comp->optFinallyCloned);
     fprintf(s_csvFile, "%u,", comp->optLoopCount);
     fprintf(s_csvFile, "%u,", comp->optLoopsCloned);
 #if FEATURE_LOOP_ALIGN

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6643,6 +6643,8 @@ protected:
     unsigned optCallCount;         // number of calls made in the method
     unsigned optIndirectCallCount; // number of virtual, interface and indirect calls made in the method
     unsigned optNativeCallCount;   // number of Pinvoke/Native calls made in the method
+    unsigned optFinallyCount;      // number of finally blocks considered for cloning in the current method
+    unsigned optFinallyCloned;     // number of finally blocks cloned in the current method
     unsigned optLoopsCloned;       // number of loops cloned in the current method.
 
 #ifdef DEBUG


### PR DESCRIPTION
For each method, print the number of finally handlers considered for cloning and the number of finally handlers that were cloned when logging with `DOTNET_JitTimeLogCsv`.

CC @dotnet/jit-contrib, @EgorBo PTAL. Note that if `Compiler::fgCloneFinally` doesn't try to do any cloning, both metrics ("Finally Clone Candidates" and "Finally Blocks Cloned") will be zero. Would we ever be interested in how many finally handlers there are if we didn't do any cloning?