### PR TITLE
[mono] catch the case of updated methods in mono_debug_lookup_source_location

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/NewMethodThrows.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/NewMethodThrows.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class NewMethodThrows
+    {
+        public string ExistingMethod(string x)
+	{
+            return x;
+        }
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/NewMethodThrows_v1.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/NewMethodThrows_v1.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+
+
+namespace System.Reflection.Metadata.ApplyUpdate.Test
+{
+    public class NewMethodThrows
+    {
+        public string ExistingMethod(string x)
+	{
+            return NewMethod(x);
+        }
+
+        public string NewMethod(string x)
+        {
+            throw new InvalidOperationException (x);
+        }
+
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TestRuntime>true</TestRuntime>
+    <DeltaScript>deltascript.json</DeltaScript>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NewMethodThrows.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/deltascript.json
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdate/System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows/deltascript.json
@@ -1,0 +1,6 @@
+{
+    "changes": [
+        {"document": "NewMethodThrows.cs", "update": "NewMethodThrows_v1.cs"},
+    ]
+}
+

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -969,11 +969,9 @@ namespace System.Reflection.Metadata
 
                 Assert.Equal(newMethod, throwingMethod);
 
-                // CoreCLR doesn't have file info after ApplyUpdate
-                if (ApplyUpdateUtil.IsMonoRuntime)
-                {
-                    Assert.Contains("NewMethodThrows.cs", frames[0].GetFileName());
-                }
+                // We don't have the filename on all runtimes and platforms
+                var frame0Name = frames[0].GetFileName();
+                Assert.True(frame0Name == null || frame0Name.Contains("NewMethodThrows.cs"));
 
                 var existingMethod = typeof (System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows).GetMethod("ExistingMethod");
 
@@ -981,10 +979,8 @@ namespace System.Reflection.Metadata
 
                 Assert.Equal(existingMethod, throwingMethodCaller);
 
-                if (ApplyUpdateUtil.IsMonoRuntime)
-                {
-                    Assert.Contains("NewMethodThrows.cs", frames[1].GetFileName());
-                }
+                var frame1Name = frames[0].GetFileName();
+                Assert.True(frame1Name == null || frame1Name.Contains("NewMethodThrows.cs"));
             });
         }
     }       

--- a/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ApplyUpdateTest.cs
@@ -969,7 +969,11 @@ namespace System.Reflection.Metadata
 
                 Assert.Equal(newMethod, throwingMethod);
 
-                Assert.Contains("NewMethodThrows.cs", frames[0].GetFileName());
+                // CoreCLR doesn't have file info after ApplyUpdate
+                if (ApplyUpdateUtil.IsMonoRuntime)
+                {
+                    Assert.Contains("NewMethodThrows.cs", frames[0].GetFileName());
+                }
 
                 var existingMethod = typeof (System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows).GetMethod("ExistingMethod");
 
@@ -977,7 +981,10 @@ namespace System.Reflection.Metadata
 
                 Assert.Equal(existingMethod, throwingMethodCaller);
 
-                Assert.Contains("NewMethodThrows.cs", frames[1].GetFileName());
+                if (ApplyUpdateUtil.IsMonoRuntime)
+                {
+                    Assert.Contains("NewMethodThrows.cs", frames[1].GetFileName());
+                }
             });
         }
     }       

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -64,6 +64,7 @@
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod\System.Reflection.Metadata.ApplyUpdate.Test.ReflectionAddNewMethod.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddStaticField\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddStaticField.csproj" />
     <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddInstanceField\System.Reflection.Metadata.ApplyUpdate.Test.GenericAddInstanceField.csproj" />
+    <ProjectReference Include="ApplyUpdate\System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows\System.Reflection.Metadata.ApplyUpdate.Test.NewMethodThrows.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetOS)' == 'browser'">
     <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />

--- a/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/HotReloadTests.cs
@@ -627,6 +627,68 @@ namespace DebuggerTests
             await StepAndCheck(StepKind.Into, $"dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 119, 12, "ApplyUpdateReferencedAssembly.MethodBody10.StaticMethod1");
         }
 
+        [ConditionalFact(nameof(RunningOnChrome))]
+        public async Task DebugHotReloadMethod_AddingNewMethodAndThrowException()
+        {
+            //await SetPauseOnException("all");
+            string asm_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.dll");
+            string pdb_file = Path.Combine(DebuggerTestAppPath, "ApplyUpdateReferencedAssembly.pdb");
+            string asm_file_hot_reload = Path.Combine(DebuggerTestAppPath, "../wasm/ApplyUpdateReferencedAssembly.dll");
+
+            var bp_notchanged = await SetBreakpoint(".*/MethodBody1.cs$", 129, 12, use_regex: true);
+            var bp_invalid = await SetBreakpoint(".*/MethodBody1.cs$", 133, 12, use_regex: true);
+
+            var pause_location = await LoadAssemblyAndTestHotReloadUsingSDBWithoutChanges(
+                    asm_file, pdb_file, "MethodBody11", "StaticMethod1", expectBpResolvedEvent: true, sourcesToWait: new string [] { "MethodBody0.cs", "MethodBody1.cs" });
+
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 129, 12, scripts, pause_location["callFrames"]?[0]["location"]);
+            //apply first update
+            pause_location = await LoadAssemblyAndTestHotReloadUsingSDB(
+                    asm_file_hot_reload, "MethodBody11", "NewMethodStaticWithThrow", 1);
+
+            JToken top_frame = pause_location["callFrames"]?[0];
+            AssertEqual("ApplyUpdateReferencedAssembly.MethodBody11.NewMethodStaticWithThrow", top_frame?["functionName"]?.Value<string>(), top_frame?.ToString());
+            CheckLocation("dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 133, 12, scripts, top_frame["location"]);
+            await StepAndCheck(StepKind.Over, "dotnet://ApplyUpdateReferencedAssembly.dll/MethodBody1.cs", 134, 12, "ApplyUpdateReferencedAssembly.MethodBody11.NewMethodStaticWithThrow",
+            locals_fn: async (locals) =>
+                {
+                    CheckNumber(locals, "i", 20);
+                    await Task.CompletedTask;
+                }
+            );
+
+            await SetPauseOnException("all");
+
+            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", null, 0, 0, null);
+
+            await CheckValue(pause_location["data"], JObject.FromObject(new
+            {
+                type = "object",
+                subtype = "error",
+                className = "System.Exception",
+                uncaught = false
+            }), "exception0.data");
+
+            pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", null, 0, 0, null);
+            try
+            {
+                pause_location = await SendCommandAndCheck(JObject.FromObject(new { }), "Debugger.resume", null, 0, 0, null);
+            }
+            catch (System.Exception ae)
+            {
+                System.Console.WriteLine(ae);
+                var eo = JObject.Parse(ae.Message);
+
+                AssertEqual("Uncaught", eo["exceptionDetails"]?["text"]?.Value<string>(), "text");
+
+                await CheckValue(eo["exceptionDetails"]?["exception"], JObject.FromObject(new
+                {
+                    type = "object",
+                    subtype = "error",
+                    className = "Error"
+                }), "exception");
+            }
+        }
         // Enable this test when https://github.com/dotnet/hotreload-utils/pull/264 flows into dotnet/runtime repo
         // [ConditionalFact(nameof(RunningOnChrome))]
         // public async Task DebugHotReloadMethod_ChangeParameterName()

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1.cs
@@ -112,4 +112,23 @@ namespace ApplyUpdateReferencedAssembly
     //         return M1(1, 2);
     //     }
     // }
+
+
+
+
+
+
+
+
+
+
+
+
+
+    public class MethodBody11 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v1.cs
@@ -124,4 +124,18 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine($"do not step into here");
         }
     }
+
+    public class MethodBody11 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+        public static void NewMethodStaticWithThrow () {
+            int i = 20;
+            Console.WriteLine($"add a breakpoint in the new static method, look at locals {i}");
+            throw new Exception("my exception");
+            /*var newvar = new MethodBody6();
+            newvar.NewMethodInstance (10);*/
+        }
+    }
 }

--- a/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
+++ b/src/mono/wasm/debugger/tests/ApplyUpdateReferencedAssembly/MethodBody1_v2.cs
@@ -124,4 +124,18 @@ namespace ApplyUpdateReferencedAssembly
             Console.WriteLine($"do not step into here");
         }
     }
+
+    public class MethodBody11 {
+        public static void StaticMethod1 () {
+            Console.WriteLine("breakpoint in a line that will not be changed");
+            Console.WriteLine("original");
+        }
+        public static void NewMethodStaticWithThrow () {
+            int i = 20;
+            Console.WriteLine($"add a breakpoint in the new static method, look at locals {i}");
+            throw new Exception("my exception");
+            /*var newvar = new MethodBody6();
+            newvar.NewMethodInstance (10);*/
+        }
+    }
 }


### PR DESCRIPTION
If a newly added method is in a stack trace, look it up in the EnC debug information, if available.

Related to #93860 

