### PR TITLE
Ensure that a native code version only ever gets one entry point that doesn't change

### DIFF
--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3311,13 +3311,7 @@ BOOL MethodDesc::SetNativeCodeInterlocked(PCODE addr, PCODE pExpected /*=NULL*/)
         }
 #endif
 
-        PTR_PCODE pSlot = GetAddrOfNativeCodeSlot();
-        NativeCodeSlot expected;
-
-        expected = *pSlot;
-
-        return InterlockedCompareExchangeT(reinterpret_cast<TADDR*>(pSlot),
-            (TADDR&)addr, (TADDR&)expected) == (TADDR&)expected;
+        return InterlockedCompareExchangeT(GetAddrOfNativeCodeSlot(), addr, pExpected) == pExpected;
     }
 
     _ASSERTE(pExpected == NULL);


### PR DESCRIPTION
- Fixed `MethodDesc::SetNativeCodeInterlocked` to use the passed-in expected entry point instead of the current entry point. It seems this is how it used to work before https://github.com/dotnet/runtime/pull/57707.
- It's possible for a method to get jitted multiple times on the same thread due to reentry through class construction. Once a native code version is updated with an entry point, it can run and there are times when it's necessary to look up the native code version corresponding to the currently running code, such as when installing patchpoints. That would be impossible if the entry point is changed meanwhile to a different entry point.

Fixes https://github.com/dotnet/runtime/issues/93849