### PR TITLE
[JIT] Fixes use of msvcdis

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -14,7 +14,11 @@
 #include "regset.h"
 #include "jitgcinfo.h"
 
+#ifdef LATE_DISASM
+class CodeGen : public CodeGenInterface
+#else // LATE_DISASM
 class CodeGen final : public CodeGenInterface
+#endif // !LATE_DISASM
 {
     friend class emitter;
     friend class DisAssembler;
@@ -33,6 +37,11 @@ public:
     // move it to Lower
     virtual bool genCreateAddrMode(
         GenTree* addr, bool fold, bool* revPtr, GenTree** rv1Ptr, GenTree** rv2Ptr, unsigned* mulPtr, ssize_t* cnsPtr);
+
+#ifdef LATE_DISASM
+    virtual const char* siStackVarName(size_t offs, size_t size, unsigned reg, unsigned stkOffs);
+    virtual const char* siRegVarName(size_t offs, size_t size, unsigned reg);
+#endif // LATE_DISASM
 
 private:
 #if defined(TARGET_XARCH)

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -14,11 +14,7 @@
 #include "regset.h"
 #include "jitgcinfo.h"
 
-#ifdef LATE_DISASM
-class CodeGen : public CodeGenInterface
-#else // LATE_DISASM
 class CodeGen final : public CodeGenInterface
-#endif // !LATE_DISASM
 {
     friend class emitter;
     friend class DisAssembler;

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2927,7 +2927,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
 
 #ifdef LATE_DISASM
-        if (JitConfig.JitLateDisasm().contains(info.compMethodName, info.compClassName, &info.compMethodInfo->args))
+        if (JitConfig.JitLateDisasm().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args))
             opts.doLateDisasm = true;
 #endif // LATE_DISASM
 


### PR DESCRIPTION
We have this option in the JIT, called `LATE_DISASM`, that enables use of MSVC's disassembly tool to disassemble the raw bytecode. We should enable this for our work on SVE2 so we can verify that we are emitting the right instructions.