### PR TITLE
[browser] Enable TCValidateAfterAddInvalidSchema.AddValid_Import_Include_Redefine and TC_SchemaSet_Add_URL.v4 for single thread

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -64,7 +64,7 @@ namespace System.Xml.XmlSchemaTests
 
         //-----------------------------------------------------------------------------------
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75123", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75123", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         //[Variation(Desc = "v4 - ns = valid, URL = invalid")]
         public void v4()
         {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -419,7 +419,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
         [InlineData("SCHEMA", "schB1_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schM2_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schH2_a.xsd", 1, 3, 3)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/75132", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/75132", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void AddValid_Import_Include_Redefine(string testDir, string testFile, int expCount, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(path, testDir, testFile);


### PR DESCRIPTION
It is not necessary to block the test for browser in general. It passes with single threaded runtime. Multithreaded runtime runs only for browser, so the change blocks only the failing configuration.