### PR TITLE
JIT: Sparse conditional propagation in value numbering

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5057,6 +5057,7 @@ public:
 
     // The value numbers for this compilation.
     ValueNumStore* vnStore;
+    struct ValueNumberState* vnVisitState;
 
 public:
     ValueNumStore* GetValueNumStore()

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9853,7 +9853,7 @@ struct ValueNumberState
         GenTree* lastTree = predBlock->lastStmt()->GetRootNode();
         assert(lastTree->OperIs(GT_JTRUE));
 
-        GenTree* cond     = lastTree->gtGetOp1();
+        GenTree* cond = lastTree->gtGetOp1();
         // TODO-Cleanup: Using liberal VNs here is a bit questionable as it add
         // a cross-phase dependency on RBO to definitely fold this branch away.
         ValueNum normalVN = m_comp->vnStore->VNNormalValue(cond->GetVN(VNK_Liberal));

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9854,8 +9854,9 @@ struct ValueNumberState
         assert(lastTree->OperIs(GT_JTRUE));
 
         GenTree* cond = lastTree->gtGetOp1();
-        // TODO-Cleanup: Using liberal VNs here is a bit questionable as it add
-        // a cross-phase dependency on RBO to definitely fold this branch away.
+        // TODO-Cleanup: Using liberal VNs here is a bit questionable as it
+        // adds a cross-phase dependency on RBO to definitely fold this branch
+        // away.
         ValueNum normalVN = m_comp->vnStore->VNNormalValue(cond->GetVN(VNK_Liberal));
         if (!m_comp->vnStore->IsVNConstant(normalVN))
         {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9854,7 +9854,9 @@ struct ValueNumberState
         assert(lastTree->OperIs(GT_JTRUE));
 
         GenTree* cond     = lastTree->gtGetOp1();
-        ValueNum normalVN = m_comp->vnStore->VNNormalValue(cond->GetVN(VNK_Conservative));
+        // TODO-Cleanup: Using liberal VNs here is a bit questionable as it add
+        // a cross-phase dependency on RBO to definitely fold this branch away.
+        ValueNum normalVN = m_comp->vnStore->VNNormalValue(cond->GetVN(VNK_Liberal));
         if (!m_comp->vnStore->IsVNConstant(normalVN))
         {
             return true;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9658,6 +9658,8 @@ struct ValueNumberState
         BVB_complete     = 0x1,
         BVB_onAllDone    = 0x2,
         BVB_onNotAllDone = 0x4,
+        // Set for statically reachable blocks that we have proven unreachable.
+        BVB_provenUnreachable = 0x8,
     };
 
     bool GetVisitBit(unsigned bbNum, BlockVisitBits bvb)
@@ -9787,7 +9789,8 @@ struct ValueNumberState
             JITDUMP("     Not yet completed.\n");
 #endif // DEBUG_VN_VISIT
 
-            bool allPredsVisited = true;
+            bool allPredsVisited   = true;
+            bool provenUnreachable = true;
             for (FlowEdge* pred = m_comp->BlockPredsWithEH(succ); pred != nullptr; pred = pred->getNextPredEdge())
             {
                 BasicBlock* predBlock = pred->getSourceBlock();
@@ -9795,6 +9798,12 @@ struct ValueNumberState
                 {
                     allPredsVisited = false;
                     break;
+                }
+
+                if (provenUnreachable && !GetVisitBit(predBlock->bbNum, BVB_provenUnreachable) &&
+                    IsReachableFromPred(predBlock, succ))
+                {
+                    provenUnreachable = false;
                 }
             }
 
@@ -9808,6 +9817,11 @@ struct ValueNumberState
                 assert(!GetVisitBit(succ->bbNum, BVB_onAllDone));
                 m_toDoAllPredsDone.Push(succ);
                 SetVisitBit(succ->bbNum, BVB_onAllDone);
+
+                if (provenUnreachable)
+                {
+                    SetVisitBit(succ->bbNum, BVB_provenUnreachable);
+                }
             }
             else
             {
@@ -9827,6 +9841,28 @@ struct ValueNumberState
 
             return BasicBlockVisit::Continue;
         });
+    }
+
+    bool IsReachableFromPred(BasicBlock* predBlock, BasicBlock* block)
+    {
+        if (!predBlock->KindIs(BBJ_COND) || predBlock->JumpsToNext())
+        {
+            return true;
+        }
+
+        GenTree* lastTree = predBlock->lastStmt()->GetRootNode();
+        assert(lastTree->OperIs(GT_JTRUE));
+
+        GenTree* cond     = lastTree->gtGetOp1();
+        ValueNum normalVN = m_comp->vnStore->VNNormalValue(cond->GetVN(VNK_Liberal));
+        if (!m_comp->vnStore->IsVNConstant(normalVN))
+        {
+            return true;
+        }
+
+        bool        isTaken         = normalVN != m_comp->vnStore->VNZeroForType(TYP_INT);
+        BasicBlock* unreachableSucc = isTaken ? predBlock->Next() : predBlock->GetJumpDest();
+        return block != unreachableSucc;
     }
 
     bool ToDoExists()
@@ -9965,6 +10001,8 @@ PhaseStatus Compiler::fgValueNumber()
 
     ValueNumberState vs(this);
 
+    vnVisitState = &vs;
+
     // Push the first block.  This has no preds.
     vs.m_toDoAllPredsDone.Push(fgFirstBB);
 
@@ -9973,7 +10011,13 @@ PhaseStatus Compiler::fgValueNumber()
         while (vs.m_toDoAllPredsDone.Size() > 0)
         {
             BasicBlock* toDo = vs.m_toDoAllPredsDone.Pop();
+
+            // TODO-TP: We can skip VN'ing blocks we have proven unreachable
+            // here. However, currently downstream phases are not prepared to
+            // handle the fact that some blocks that are seemingly reachable
+            // have not been VN'd.
             fgValueNumberBlock(toDo);
+
             // Record that we've visited "toDo", and add successors to the right sets.
             vs.FinishVisit(toDo);
         }
@@ -10008,10 +10052,11 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 {
     compCurBB = blk;
 
+    bool isReachableBlock = !vnVisitState->GetVisitBit(blk->bbNum, ValueNumberState::BVB_provenUnreachable);
+
     Statement* stmt = blk->firstStmt();
 
-    // First: visit phi's.  If "newVNForPhis", give them new VN's.  If not,
-    // first check to see if all phi args have the same value.
+    // First: visit phis and check to see if all phi args have the same value.
     for (; (stmt != nullptr) && stmt->IsPhiDefnStmt(); stmt = stmt->GetNextStmt())
     {
         GenTreeLclVar* newSsaDef = stmt->GetRootNode()->AsLclVar();
@@ -10021,9 +10066,17 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
 
         for (GenTreePhi::Use& use : phiNode->Uses())
         {
-            GenTreePhiArg* phiArg         = use.GetNode()->AsPhiArg();
-            ValueNum       phiArgSsaNumVN = vnStore->VNForIntCon(phiArg->GetSsaNum());
-            ValueNumPair   phiArgVNP      = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum())->m_vnPair;
+            GenTreePhiArg* phiArg = use.GetNode()->AsPhiArg();
+            if (isReachableBlock &&
+                vnVisitState->GetVisitBit(phiArg->gtPredBB->bbNum, ValueNumberState::BVB_provenUnreachable))
+            {
+                JITDUMP("  Skipping phi arg [%06u]; pred " FMT_BB " was proven unreachable\n", dspTreeID(phiArg),
+                        phiArg->gtPredBB->bbNum);
+                continue;
+            }
+
+            ValueNum     phiArgSsaNumVN = vnStore->VNForIntCon(phiArg->GetSsaNum());
+            ValueNumPair phiArgVNP      = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum())->m_vnPair;
 
             phiArg->gtVNPair = phiArgVNP;
 
@@ -10049,12 +10102,12 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
             }
         }
 
-#ifdef DEBUG
-        // There should be at least to 2 PHI arguments so phiVN's VNs should always be VNF_Phi functions.
-        VNFuncApp phiFunc;
-        assert(vnStore->GetVNFunc(phiVNP.GetLiberal(), &phiFunc) && (phiFunc.m_func == VNF_Phi));
-        assert(vnStore->GetVNFunc(phiVNP.GetConservative(), &phiFunc) && (phiFunc.m_func == VNF_Phi));
-#endif
+        // We should have visited at least one phi arg in the loop above
+        // 1. For reachable blocks, at least one pred should be reachable or we would have proven this block to be
+        // unreachable too
+        // 2. For unreachable blocks we build for all phi args.
+        assert(phiVNP.GetLiberal() != ValueNumStore::NoVN);
+        assert(phiVNP.GetConservative() != ValueNumStore::NoVN);
 
         ValueNumPair newSsaDefVNP;
 
@@ -10117,6 +10170,8 @@ void Compiler::fgValueNumberBlock(BasicBlock* blk)
             else
             {
                 // Are all the VN's the same?
+                // TODO-CQ: Skip proven unreachable blocks. Do we have any way to look up the pred block for memory
+                // PHIs?
                 BasicBlock::MemoryPhiArg* phiArgs = blk->bbMemorySsaPhiFunc[memoryKind];
                 assert(phiArgs != BasicBlock::EmptyMemoryPhiDef);
                 // There should be > 1 args to a phi.


### PR DESCRIPTION
Utilize the fact that VN is able to decide whether many non-trivial branches will be taken or not taken to prove basic blocks dynamically unreachable. Take this into account when building PHIs.

Fix #94559

There are some additional improvements to make:
1. I'm not sure if we see statically unreachable blocks, but if we do, we should try to handle them similarly. Currently it seems like we pessimize PHIs if these are present.
2. We should fully skip VN'ing the blocks that are proven unreachable, but downstream phases currently are not prepared to handle that. We should maybe eliminate the proven unreachable blocks as part of VN to make sure downstream phases see a consistent view. (This is also necessary to make VN correct on its own when it is utilizing liberal VNs to prove the reachability.)
3. ~~I couldn't figure out how to look up the predecessor corresponding to a memory PHI arg, so currently we do not do this for memory PHIs.~~ Adding the pred blocks for these and making use of them has almost no diffs, so doesn't seem worth it.

Codegen of the example from #94559 before:
```asm
       mov      rcx, 0xD1FFAB1E      ; ubyte[]
       mov      edx, 128
       call     CORINFO_HELP_NEWARR_1_VC
       add      rax, 16
       mov      ecx, 128
       xor      rdx, rdx
       test     ecx, ecx
       cmovne   rdx, rax
       mov      bword ptr [rsp+0x20], rdx
       mov      rcx, rdx
       call     [Program:DoSomething(ulong)]
       xor      eax, eax
       mov      bword ptr [rsp+0x20], rax
```

Codegen after:
```asm
       mov      rcx, 0xD1FFAB1E      ; ubyte[]
       mov      edx, 128
       call     CORINFO_HELP_NEWARR_1_VC
       add      rax, 16
       mov      rcx, rax
       mov      bword ptr [rsp+0x20], rcx
       call     [Program:DoSomething(ulong)]
       xor      eax, eax
       mov      bword ptr [rsp+0x20], rax
```