### PR TITLE
[release/6.0-staging] Socket Tests Disable

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -131,6 +131,12 @@ namespace System.Net.Sockets.Tests
         [InlineData("[::ffff:1.1.1.1]", true)]
         public async Task ConnectGetsCanceledByDispose(string addressString, bool useDns)
         {
+            if (UsesSync && PlatformDetection.IsLinux)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
+                return;
+            }
+
             IPAddress address = IPAddress.Parse(addressString);
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -158,6 +158,12 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SocketMethods_WithBools_MemberData))]
         public void EventSource_SocketConnectFailure_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
+            if (connectMethod == "Sync" && PlatformDetection.IsLinux)
+            {
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
+                return;
+            }
+
             RemoteExecutor.Invoke(async (connectMethod, useDnsEndPointString) =>
             {
                 EndPoint endPoint = await GetRemoteEndPointAsync(useDnsEndPointString, port: 12345);


### PR DESCRIPTION
Backport of #94243 to release/6.0-staging

Related to https://github.com/dotnet/runtime/issues/94149

## Customer Impact

Disabling tests which started failing due to Linux Kernel regression (tracked by https://github.com/dotnet/runtime/issues/94149):

- System.Net.Sockets.Tests.ConnectSync.ConnectGetsCanceledByDispose
- System.Net.Sockets.Tests.TelemetryTest.EventSource_SocketConnectFailure_LogsConnectFailed

## Testing

CI

## Risk

Test-only change.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
