### PR TITLE
JIT: SELECT(COND, 11, 10) -> ADD(COND, 10)

### DIFF
--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -713,6 +713,7 @@ bool OptIfConversionDsc::optIfConvert()
     //
     // SELECT(COND, 10, 11) -> ADD(COND, 10)
     //
+    // Conservatively give up on relops with NaNs (we won't be able to reverse them).
     if (selectTrueInput->IsCnsIntOrI() && selectFalseInput->IsCnsIntOrI() &&
         ((m_cond->gtFlags & GTF_RELOP_NAN_UN) == 0))
     {
@@ -726,7 +727,7 @@ bool OptIfConversionDsc::optIfConvert()
                 m_cond->ChangeOper(GenTree::ReverseRelop(m_cond->OperGet()));
                 cns = selectTrueInput;
             }
-            select = m_comp->gtNewOperNode(GT_ADD, m_cond->TypeGet(), m_cond, cns);
+            select = m_comp->gtNewOperNode(GT_ADD, selectType, m_cond, cns);
         }
     }
 

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -727,7 +727,16 @@ bool OptIfConversionDsc::optIfConvert()
                 m_cond->ChangeOper(GenTree::ReverseRelop(m_cond->OperGet()));
                 cns = selectTrueInput;
             }
-            select = m_comp->gtNewOperNode(GT_ADD, selectType, m_cond, cns);
+
+            if (!cns->IsIntegralConst(0))
+            {
+                select = m_comp->gtNewOperNode(GT_ADD, selectType, m_cond, cns);
+            }
+            else
+            {
+                // ADD(COND, 0) -> COND
+                select = m_cond;
+            }
         }
     }
 

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -711,7 +711,8 @@ bool OptIfConversionDsc::optIfConvert()
     // For SELECT(COND, CNS1, CNS2) check if we can fold it into ADD(COND, MIN(CNS1, CNS2)) if
     // the difference between CNS1 and CNS2 is exactly 1. E.g.:
     //
-    // SELECT(COND, 10, 11) -> ADD(COND, 10)
+    // SELECT(COND, 2, 1) -> ADD(COND, 1)
+    // SELECT(COND, 1, 2) -> ADD(REVERSED_COND, 1)
     //
     // Conservatively give up on relops with NaNs (we won't be able to reverse them).
     if (selectTrueInput->IsCnsIntOrI() && selectFalseInput->IsCnsIntOrI() &&

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -713,26 +713,20 @@ bool OptIfConversionDsc::optIfConvert()
     //
     // SELECT(COND, 10, 11) -> ADD(COND, 10)
     //
-    if (selectTrueInput->IsCnsIntOrI() && selectFalseInput->IsCnsIntOrI() && m_cond->TypeIs(TYP_INT))
+    if (selectTrueInput->IsCnsIntOrI() && selectFalseInput->IsCnsIntOrI() &&
+        ((m_cond->gtFlags & GTF_RELOP_NAN_UN) == 0))
     {
         const ssize_t selectTrueVal  = selectTrueInput->AsIntConCommon()->IconValue();
         const ssize_t selectFalseVal = selectFalseInput->AsIntConCommon()->IconValue();
         if (abs(selectTrueVal - selectFalseVal) == 1)
         {
+            GenTree* cns = selectFalseInput;
             if (selectTrueVal < selectFalseVal)
             {
-                // if selectTrueVal is less than selectFalseVal then we need to reverse the condition
-                if (m_cond->OperIsCompare() && ((m_cond->gtFlags & GTF_RELOP_NAN_UN) == 0))
-                {
-                    m_cond->ChangeOper(GenTree::ReverseRelop(m_cond->OperGet()));
-                    select = m_comp->gtNewOperNode(GT_ADD, m_cond->TypeGet(), m_cond, selectTrueInput);
-                }
-                // or wrap it with GT_NEG but that seems to lead to worse diffs
+                m_cond->ChangeOper(GenTree::ReverseRelop(m_cond->OperGet()));
+                cns = selectTrueInput;
             }
-            else
-            {
-                select = m_comp->gtNewOperNode(GT_ADD, m_cond->TypeGet(), m_cond, selectFalseInput);
-            }
+            select = m_comp->gtNewOperNode(GT_ADD, m_cond->TypeGet(), m_cond, cns);
         }
     }
 


### PR DESCRIPTION
```cs
int Test(int x) => x == 42 ? 1 : 2;
```
```diff
; Method Benchmarks:Test(int):int:this (FullOpts)
-      mov      eax, 1
-      mov      ecx, 2
-      cmp      edx, 42
-      cmovne   eax, ecx
+      xor      eax, eax
+      cmp      edx, 42
+      setne    al
+      inc      eax
       ret      
-; Total bytes of code: 17
+; Total bytes of code: 11
```

We can do the same for `SELECT(COND, X, X+1)` if this pattern is popular.