### PR TITLE
[mono] Fix GetCustomAttributes `System.Reflection` API with a custom attribute provider

### DIFF
--- a/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -114,13 +114,7 @@ namespace System.Reflection
         // FIXME: Callers are explicitly passing in null for attributeType, but GetCustomAttributes prohibits null attributeType arguments
         internal static object[] GetCustomAttributesBase(ICustomAttributeProvider obj, Type? attributeType, bool inheritedOnly)
         {
-            object[] attrs;
-
-            if (IsUserCattrProvider(obj))
-                attrs = obj.GetCustomAttributes(attributeType!, true);
-            else
-                attrs = GetCustomAttributesInternal(obj, attributeType!, false);
-
+            object[] attrs = GetCustomAttributesInternal(obj, attributeType!, pseudoAttrs: false);
             //
             // All pseudo custom attributes are Inherited = false hence we can avoid
             // building attributes array which would be discarded by inherited checks
@@ -155,6 +149,9 @@ namespace System.Reflection
             if (!attributeType.IsSubclassOf(typeof(Attribute)) && !attributeType.IsInterface
                 && attributeType != typeof(Attribute) && attributeType != typeof(CustomAttribute) && attributeType != typeof(object))
                 throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
+
+            if (IsUserCattrProvider(obj))
+                return obj.GetCustomAttributes(attributeType, inherit);
 
             // FIXME: GetCustomAttributesBase doesn't like being passed a null attributeType
             if (attributeType == typeof(CustomAttribute))
@@ -305,6 +302,9 @@ namespace System.Reflection
         internal static object[] GetCustomAttributes(ICustomAttributeProvider obj, bool inherit)
         {
             ArgumentNullException.ThrowIfNull(obj);
+
+            if (IsUserCattrProvider(obj))
+                return obj.GetCustomAttributes(typeof(Attribute), inherit);
 
             if (!inherit)
                 return (object[])GetCustomAttributesBase(obj, null, false).Clone();


### PR DESCRIPTION
### Description

This PR fixes issues when using `GetCustomAttributes` API with a custom attribute provider with Mono.

The problem comes from the fact that entry points of the `GetCustomAttributes` API in the Mono implementation, do not check early if the custom attribute provider is derived from the base type, but rather call back to the custom override after some problematic "workarounds" are done like: 
https://github.com/dotnet/runtime/blob/952ac21a0e89569c923f8597a0441138e3ddf89a/src/mono/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs#L159-L165
causing `ArgumentNullException`

### Changes

This has been fixed by lifting up the check for the user-defined custom attribute provider and the call to the adequate overrides.

It seems that such usage is not covered with our unit tests, however it is used in ASP.NET test suite (reported here: https://github.com/dotnet/runtime/issues/93770 and here: https://github.com/dotnet/runtime/pull/94437#issuecomment-1799757995)

To verify the fix and to increase our test coverage I have added a unit test in this PR inspired by: https://github.com/dotnet/aspnetcore/blob/402e7fc10aa304775f50d318c8a4dafbf46dbfe0/src/Shared/PropertyAsParameterInfo.cs#L15

NOTE: It is possible I did not place the unit test in the right location.

---
Fixes: https://github.com/dotnet/runtime/issues/94488