### PR TITLE
[release/8.0] Calculate PackageVersionNet7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
-    <PackageVersionNet7>7.0.12</PackageVersionNet7>
+    <PackageVersionNet7>7.0.$([MSBuild]::Add($(PatchVersion),14))</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>


### PR DESCRIPTION
Since 8.0 is GA, we'll be able to calculate the net7 version based on PatchVersion