### PR TITLE
[wasm] Implement initial support for WasmImportLinkage in the AppBuilders

### DIFF
--- a/src/mono/sample/wasi/native/Makefile
+++ b/src/mono/sample/wasi/native/Makefile
@@ -1,0 +1,15 @@
+TOP=../../../../..
+
+include ../wasi.mk
+
+ifneq ($(AOT),)
+override MSBUILD_ARGS+=/p:RunAOTCompilation=true
+endif
+
+ifneq ($(V),)
+DOTNET_MONO_LOG_LEVEL=--setenv=MONO_LOG_LEVEL=debug
+endif
+
+PROJECT_NAME=Wasi.Console.Sample.csproj
+
+run: run-console

--- a/src/mono/sample/wasi/native/Program.cs
+++ b/src/mono/sample/wasi/native/Program.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+public unsafe class Test
+{
+    [UnmanagedCallersOnly(EntryPoint = "ManagedFunc")]
+    public static int MyExport(int number)
+    {
+        // called from MyImport aka UnmanagedFunc
+        Console.WriteLine($"MyExport({number}) -> 42");
+        return 42;
+    }
+
+    [DllImport("*", EntryPoint = "UnmanagedFunc")]
+    public static extern void MyImport(); // calls ManagedFunc aka MyExport
+
+    [DllImport("*")]
+    public static unsafe extern void ReferenceFuncPtr(delegate* unmanaged<int,int> funcPtr);
+
+    static bool AlwaysFalse(string [] args) => false;
+
+    public unsafe static int Main(string[] args)
+    {
+        Console.WriteLine($"main: {args.Length}");
+        MyImport();
+
+        if (AlwaysFalse(args))
+        {
+            // never called (would an error on wasm) and doesn't actually do anything
+            // but required for wasm_native_to_interp_ftndesc initialization
+            // the lookup happens before main when this is here
+            ReferenceFuncPtr(&MyExport);
+        }
+
+        return 0;
+    }
+}

--- a/src/mono/sample/wasi/native/Program.cs
+++ b/src/mono/sample/wasi/native/Program.cs
@@ -17,24 +17,15 @@ public unsafe class Test
     [DllImport("*", EntryPoint = "UnmanagedFunc")]
     public static extern void MyImport(); // calls ManagedFunc aka MyExport
 
-    [DllImport("*")]
-    public static unsafe extern void ReferenceFuncPtr(delegate* unmanaged<int,int> funcPtr);
-
-    static bool AlwaysFalse(string [] args) => false;
-
     public unsafe static int Main(string[] args)
     {
         Console.WriteLine($"main: {args.Length}");
-        MyImport();
-
-        if (AlwaysFalse(args))
-        {
-            // never called (would an error on wasm) and doesn't actually do anything
-            // but required for wasm_native_to_interp_ftndesc initialization
-            // the lookup happens before main when this is here
-            ReferenceFuncPtr(&MyExport);
+        // workaround to force the interpreter to initialize wasm_native_to_interp_ftndesc for MyExport
+        if (args.Length > 10000) {
+            ((IntPtr)(delegate* unmanaged<int,int>)&MyExport).ToString();
         }
 
+        MyImport();
         return 0;
     }
 }

--- a/src/mono/sample/wasi/native/Wasi.Native.Sample.csproj
+++ b/src/mono/sample/wasi/native/Wasi.Native.Sample.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
+    
+    <TargetOs>wasi</TargetOs>
+    <WasmBuildNative>true</WasmBuildNative>
+    <WasmNativeStrip>false</WasmNativeStrip>
+    <IsBrowserWasmProject>false</IsBrowserWasmProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <NativeFileReference Include="local.c" />
+  </ItemGroup>
+  <Target Name="RunSample" DependsOnTargets="RunSampleWithWasmtime" />
+</Project>

--- a/src/mono/sample/wasi/native/Wasi.Native.Sample.csproj
+++ b/src/mono/sample/wasi/native/Wasi.Native.Sample.csproj
@@ -7,6 +7,7 @@
     <WasmBuildNative>true</WasmBuildNative>
     <WasmNativeStrip>false</WasmNativeStrip>
     <IsBrowserWasmProject>false</IsBrowserWasmProject>
+    <WasmSingleFileBundle>true</WasmSingleFileBundle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/mono/sample/wasi/native/local.c
+++ b/src/mono/sample/wasi/native/local.c
@@ -9,18 +9,3 @@ void UnmanagedFunc()
     ret = ManagedFunc(123);
     printf("ManagedFunc returned %d\n", ret);
 }
-
-
-#ifdef PARSING_FUNCTION_POINTERS_IS_SUPPORTED
-/*
- warning WASM0001: Could not get pinvoke, or callbacks for method 'Test::ReferenceFuncPtr' because 'Parsing function pointe
-r types in signatures is not supported.'
-warning WASM0001: Skipping pinvoke 'Test::ReferenceFuncPtr' because 'Parsing function pointer types in signatures is not s
-upported.'
-*/
-typedef int (*ManagedFuncPtr)(int);
-
-void ReferenceFuncPtr(ManagedFuncPtr funcPtr) {
-    printf("ReferenceFuncPtr %p\n", funcPtr);
-}
-#endif

--- a/src/mono/sample/wasi/native/local.c
+++ b/src/mono/sample/wasi/native/local.c
@@ -1,0 +1,26 @@
+#include <stdio.h>
+
+int ManagedFunc(int number);
+
+void UnmanagedFunc()
+{
+    int ret = 0;
+    printf("UnmanagedFunc calling ManagedFunc\n");
+    ret = ManagedFunc(123);
+    printf("ManagedFunc returned %d\n", ret);
+}
+
+
+#ifdef PARSING_FUNCTION_POINTERS_IS_SUPPORTED
+/*
+ warning WASM0001: Could not get pinvoke, or callbacks for method 'Test::ReferenceFuncPtr' because 'Parsing function pointe
+r types in signatures is not supported.'
+warning WASM0001: Skipping pinvoke 'Test::ReferenceFuncPtr' because 'Parsing function pointer types in signatures is not s
+upported.'
+*/
+typedef int (*ManagedFuncPtr)(int);
+
+void ReferenceFuncPtr(ManagedFuncPtr funcPtr) {
+    printf("ReferenceFuncPtr %p\n", funcPtr);
+}
+#endif

--- a/src/tasks/WasmAppBuilder/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeCollector.cs
@@ -15,17 +15,20 @@ using Microsoft.Build.Tasks;
 internal sealed class PInvoke : IEquatable<PInvoke>
 #pragma warning restore CA1067
 {
-    public PInvoke(string entryPoint, string module, MethodInfo method)
+    public PInvoke(string entryPoint, string module, MethodInfo method, bool wasmLinkage)
     {
         EntryPoint = entryPoint;
         Module = module;
         Method = method;
+        WasmLinkage = wasmLinkage;
     }
 
     public string EntryPoint;
     public string Module;
     public MethodInfo Method;
     public bool Skip;
+    public bool WasmLinkage;
+
 
     public bool Equals(PInvoke? other)
         => other != null &&
@@ -100,9 +103,10 @@ internal sealed class PInvokeCollector {
             if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
             {
                 var dllimport = method.CustomAttributes.First(attr => attr.AttributeType.Name == "DllImportAttribute");
+                var wasmLinkage = method.CustomAttributes.Any(attr => attr.AttributeType.Name == "WasmImportLinkageAttribute");
                 var module = (string)dllimport.ConstructorArguments[0].Value!;
                 var entrypoint = (string)dllimport.NamedArguments.First(arg => arg.MemberName == "EntryPoint").TypedValue.Value!;
-                pinvokes.Add(new PInvoke(entrypoint, module, method));
+                pinvokes.Add(new PInvoke(entrypoint, module, method, wasmLinkage));
 
                 string? signature = SignatureMapper.MethodToSignature(method);
                 if (signature == null)

--- a/src/tasks/WasmAppBuilder/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeCollector.cs
@@ -245,8 +245,22 @@ internal sealed class PInvokeCallback
     public PInvokeCallback(MethodInfo method)
     {
         Method = method;
+        foreach (var attr in method.CustomAttributes)
+        {
+            if (attr.AttributeType.Name == "UnmanagedCallersOnlyAttribute")
+            {
+                foreach(var arg in attr.NamedArguments)
+                {
+                    if (arg.MemberName == "EntryPoint")
+                    {
+                        EntryPoint = arg.TypedValue.Value!.ToString();
+                    }
+                }
+            }
+        }
     }
 
+    public string? EntryPoint;
     public MethodInfo Method;
     public string? EntryName;
 }

--- a/src/tasks/WasmAppBuilder/PInvokeCollector.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeCollector.cs
@@ -29,7 +29,6 @@ internal sealed class PInvoke : IEquatable<PInvoke>
     public bool Skip;
     public bool WasmLinkage;
 
-
     public bool Equals(PInvoke? other)
         => other != null &&
             string.Equals(EntryPoint, other.EntryPoint, StringComparison.Ordinal) &&
@@ -254,6 +253,7 @@ internal sealed class PInvokeCallback
                     if (arg.MemberName == "EntryPoint")
                     {
                         EntryPoint = arg.TypedValue.Value!.ToString();
+                        return;
                     }
                 }
             }

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -132,7 +132,7 @@ internal sealed class PInvokeTableGenerator
                 Where(l => l.Module == module && !l.Skip).
                 OrderBy(l => l.EntryPoint).
                 GroupBy(d => d.EntryPoint).
-                Select(l => "{\"" + _fixupSymbolName(l.Key) + "\", " + TransformEntryPoint(l.First()) + "}, " +
+                Select(l => "{\"" + l.Key + "\", " + TransformEntryPoint(l.First()) + "}, " +
                                 "// " + string.Join(", ", l.Select(c => c.Method.DeclaringType!.Module!.Assembly!.GetName()!.Name!).Distinct().OrderBy(n => n)));
 
             foreach (var pinvoke in assemblies_pinvokes)

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -67,7 +67,8 @@ internal sealed class PInvokeTableGenerator
     private void EmitPInvokeTable(StreamWriter w, Dictionary<string, string> modules, List<PInvoke> pinvokes)
     {
 
-        foreach (var pinvoke in pinvokes) {
+        foreach (var pinvoke in pinvokes)
+        {
             if (modules.ContainsKey(pinvoke.Module))
                 continue;
             // Handle special modules, and add them to the list of modules

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -252,7 +252,7 @@ internal sealed class PInvokeTableGenerator
         }
 
         if (pinvoke.WasmLinkage) {
-            sb.Append($"__attribute__((weak,import_module(\"{EscapeLiteral(pinvoke.Module)}\"), import_name(\"{EscapeLiteral(pinvoke.EntryPoint)}\")))\nextern ");
+            sb.Append($"__attribute__((import_module(\"{EscapeLiteral(pinvoke.Module)}\"), import_name(\"{EscapeLiteral(pinvoke.EntryPoint)}\")))\nextern ");
         }
 
         sb.Append($"{MapType(method.ReturnType)} {TransformEntryPoint(pinvoke)} ({string.Join(", ", method.GetParameters().Select(p => MapType(p.ParameterType)))});");

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -244,7 +244,7 @@ internal sealed class PInvokeTableGenerator
         return
             $$"""
             {{(pinvoke.WasmLinkage ? $"__attribute__((import_module(\"{EscapeLiteral(pinvoke.Module)}\"),import_name(\"{EscapeLiteral(pinvoke.EntryPoint)}\")))" : "")}}
-            {{(pinvoke.WasmLinkage ? "extern " : "")}} {{MapType(method.ReturnType)}} {{CEntryPoint(pinvoke)}} ({{
+            {{(pinvoke.WasmLinkage ? "extern " : "")}}{{MapType(method.ReturnType)}} {{CEntryPoint(pinvoke)}} ({{
                 string.Join(", ", method.GetParameters().Select(p => MapType(p.ParameterType)))
             }});
             """;
@@ -265,15 +265,15 @@ internal sealed class PInvokeTableGenerator
     {
         // FIXME: this is a hack, we need to encode this better
         // and allow reflection in the interp case but either way
-        // it needs to match the key passed to get_native_to_interp
+        // it needs to match the key generated in get_native_to_interp
         var method = export.Method;
         string module_symbol = method.DeclaringType!.Module!.Assembly!.GetName()!.Name!;
         return $"\"{module_symbol}_{method.DeclaringType.Name}_{method.Name}\"".Replace('.', '_');
     }
 
-    #pragma warning disable SYSLIB1045 // framework doesn't support GeneratedRegexAttribute
+#pragma warning disable SYSLIB1045 // framework doesn't support GeneratedRegexAttribute
     private static string EscapeLiteral(string s) => Regex.Replace(s, @"(\\|\"")", @"\$1");
-    #pragma warning restore SYSLIB1045
+#pragma warning restore SYSLIB1045
 
     private void EmitNativeToInterp(StreamWriter w, List<PInvokeCallback> callbacks)
     {
@@ -365,7 +365,7 @@ internal sealed class PInvokeTableGenerator
                 {{string.Join(", ", callbacks.Select(cb => cb.EntryName))}}
             };
 
-            // need to match the key passed to get_native_to_interp
+            // these strings need to match the keys generated in get_native_to_interp
             static const char *wasm_native_to_interp_map[] = {
                 {{string.Join(", ", callbacks.Select(DelegateKey))}}
             };


### PR DESCRIPTION
In response to https://github.com/dotnet/runtime/pull/93823 this is a rough partial fix for https://github.com/dotnet/runtime/issues/94513, https://github.com/dotnet/runtime/issues/86984, and https://github.com/dotnet/runtime/issues/86985
With the default settings this works in wasi-wasm but emscripten will complain if you don't enable unresolved symbols on browser-wasm

Using
```csharp
    [WasmImportLinkage]
    [DllImport("extism:host/user")]
    public static extern void do_something();
```

Will generate
```wat
(type $i64_i32_=>_i64 (func (param i64 i32) (result i64)))
 (type $i32_i64_i64_i32_=>_none (func (param i32 i64 i64 i32)))
 (import "wasi_snapshot_preview1" "sock_accept" (func $fimport$0 (param i32 i32 i32) (result i32)))
 (import "extism:host/user" "do_something" (func $fimport$1))
 (import "wasi_snapshot_preview1" "args_get" (func $fimport$2 (param i32 i32) (result i32)))
```