### PR TITLE
[mono-debug] refactor access to MonoDebugInformationEnc

### DIFF
--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -775,7 +775,7 @@ get_method_enc_debug_info (MonoMethod *method, MonoDebugInformationEnc **mdie_ou
 			*mdie_out = mdie;
 			return TRUE;
 		} else {
-			/// added method without EnC info, maybe the delta came in without a PDB delta
+			/// an added method without debug info; maybe the delta came in without a PDB delta
 			gboolean added_method = idx >= table_info_get_rows (&img->tables[MONO_TABLE_METHOD]);
 			if (added_method)
 				return TRUE;

--- a/src/mono/mono/metadata/mono-debug.c
+++ b/src/mono/mono/metadata/mono-debug.c
@@ -758,6 +758,34 @@ mono_debug_il_offset_from_address (MonoMethod *method, MonoDomain *domain, guint
 	return res;
 }
 
+/* returns TRUE if the method is involved in an EnC update and the baseline debug info may not be valid.
+ *   writes the enc debug info, if available to *mdie_out
+ * returns FALSE if the method is part of the baseline image
+ */
+static gboolean
+get_method_enc_debug_info (MonoMethod *method, MonoDebugInformationEnc **mdie_out)
+{
+	g_assert (mdie_out != NULL);
+	*mdie_out = NULL;
+	MonoImage *img = m_class_get_image (method->klass);
+	if (G_UNLIKELY (img->has_updates)) {
+		guint32 idx = mono_metadata_token_index (method->token);
+		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+		if (mdie != NULL) {
+			*mdie_out = mdie;
+			return TRUE;
+		} else {
+			/// added method without EnC info, maybe the delta came in without a PDB delta
+			gboolean added_method = idx >= table_info_get_rows (&img->tables[MONO_TABLE_METHOD]);
+			if (added_method)
+				return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+
+
 /**
  * mono_debug_lookup_source_location:
  * \param address Native offset within the \p method's machine code.
@@ -777,10 +805,8 @@ mono_debug_lookup_source_location (MonoMethod *method, guint32 address, MonoDoma
 	if (mono_debug_format == MONO_DEBUG_FORMAT_NONE)
 		return NULL;
 
-	MonoImage *img = m_class_get_image (method->klass);
-	if (G_UNLIKELY (img->has_updates)) {
-		guint32 idx = mono_metadata_token_index (method->token);
-		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+	MonoDebugInformationEnc *mdie = NULL;
+	if (G_UNLIKELY (get_method_enc_debug_info (method, &mdie))) {
 		if (mdie != NULL) {
 			offset = il_offset_from_address (method, address);
 			if (offset < 0) {
@@ -792,10 +818,7 @@ mono_debug_lookup_source_location (MonoMethod *method, guint32 address, MonoDoma
 			if (ret)
 				return ret;
 		} else {
-			/// added method without EnC info, maybe the delta came in without a PDB delta
-			gboolean added_method = idx >= table_info_get_rows (&img->tables[MONO_TABLE_METHOD]);
-			if (added_method)
-				return NULL;
+			return NULL;
 		}
 	}
 
@@ -862,18 +885,14 @@ mono_debug_lookup_source_location_by_il (MonoMethod *method, guint32 il_offset, 
 MonoDebugSourceLocation *
 mono_debug_method_lookup_location (MonoDebugMethodInfo *minfo, int il_offset)
 {
-	MonoImage* img = m_class_get_image (minfo->method->klass);
-	if (img->has_updates) {
-		guint32 idx = mono_metadata_token_index (minfo->method->token);
-		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+	MonoDebugInformationEnc *mdie = NULL;
+	if (G_UNLIKELY (get_method_enc_debug_info (minfo->method, &mdie))) {
 		if (mdie != NULL) {
 			MonoDebugSourceLocation * ret = mono_ppdb_lookup_location_enc (mdie->ppdb_file, mdie->idx, il_offset);
-			if (ret)
-				return ret;
+			g_assert (ret); // FIXME: when can this be null?
+			return ret;
 		} else {
-			gboolean added_method = idx >= table_info_get_rows (&img->tables[MONO_TABLE_METHOD]);
-			if (added_method)
-				return NULL;
+			return NULL;
 		}
 	}
 
@@ -900,14 +919,14 @@ mono_debug_lookup_locals (MonoMethod *method)
 	MonoDebugMethodInfo *minfo;
 	MonoDebugLocalsInfo *res;
 
-	MonoImage* img = m_class_get_image (method->klass);
-	if (img->has_updates) {
-		int idx = mono_metadata_token_index (method->token);
-		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+	MonoDebugInformationEnc *mdie = NULL;
+	if (G_UNLIKELY (get_method_enc_debug_info (method, &mdie))) {
 		if (mdie != NULL) {
 			res = mono_ppdb_lookup_locals_enc (mdie->ppdb_file->image, mdie->idx);
-			if (res != NULL)
-				return res;
+			g_assert (res != NULL);
+			return res;
+		} else {
+			return NULL;
 		}
 	}
 
@@ -1154,10 +1173,8 @@ mono_debug_enabled (void)
 mono_bool
 mono_debug_generate_enc_seq_points_without_debug_info (MonoDebugMethodInfo *minfo)
 {
-	MonoImage* img = m_class_get_image (minfo->method->klass);
-	if (G_UNLIKELY (img->has_updates)) {
-		guint32 idx = mono_metadata_token_index (minfo->method->token);
-		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+	MonoDebugInformationEnc *mdie = NULL;
+	if (G_UNLIKELY (get_method_enc_debug_info (minfo->method, &mdie))) {
 		if (mdie == NULL)
 			return TRUE;
 	}
@@ -1167,21 +1184,18 @@ mono_debug_generate_enc_seq_points_without_debug_info (MonoDebugMethodInfo *minf
 void
 mono_debug_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrArray **source_file_list, int **source_files, MonoSymSeqPoint **seq_points, int *n_seq_points)
 {
-	MonoImage* img = m_class_get_image (minfo->method->klass);
-	if (img->has_updates) {
-		guint32 idx = mono_metadata_token_index (minfo->method->token);
-		MonoDebugInformationEnc *mdie = (MonoDebugInformationEnc *) mono_metadata_update_get_updated_method_ppdb (img, idx);
+	MonoDebugInformationEnc *mdie = NULL;
+	if (G_UNLIKELY (get_method_enc_debug_info (minfo->method, &mdie))) {
 		if (mdie != NULL) {
 			if (mono_ppdb_get_seq_points_enc (minfo, mdie->ppdb_file, mdie->idx, source_file, source_file_list, source_files, seq_points, n_seq_points))
 				return;
-		}
+		} else {
 		/*
 		 * dotnet watch sometimes sends us updated with PPDB deltas, but the baseline
 		 * project has debug info (and we use it for seq points?).  In tht case, just say
 		 * the added method has no sequence points.  N.B. intentionally, comparing idx to
 		 * the baseline tables.  For methods that already existed, use their old seq points.
 		 */
-		if (idx >= table_info_get_rows (&img->tables[MONO_TABLE_METHOD])) {
 			if (source_file)
 				*source_file = NULL;
 			if (source_file_list)


### PR DESCRIPTION
Small follow-up to https://github.com/dotnet/runtime/pull/94540 to remove some of the duplicated logic for accesing the EnC debug info.