### PR TITLE
JIT: Use post order computed by SSA in VN

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4493,6 +4493,8 @@ public:
     unsigned     fgBBNumMax;           // The max bbNum that has been assigned to basic blocks
     unsigned     fgDomBBcount;         // # of BBs for which we have dominator and reachability information
     BasicBlock** fgBBReversePostorder; // Blocks in reverse postorder
+    BasicBlock** fgSSAPostOrder;       // Blocks in postorder, computed during SSA
+    unsigned     fgSSAPostOrderCount;  // Number of blocks in fgSSAPostOrder
 
     // After the dominance tree is computed, we cache a DFS preorder number and DFS postorder number to compute
     // dominance queries in O(1). fgDomTreePreOrder and fgDomTreePostOrder are arrays giving the block's preorder and
@@ -5057,7 +5059,7 @@ public:
 
     // The value numbers for this compilation.
     ValueNumStore* vnStore;
-    struct ValueNumberState* vnVisitState;
+    class ValueNumberState* vnState;
 
 public:
     ValueNumStore* GetValueNumStore()
@@ -5723,7 +5725,7 @@ public:
 
 protected:
     friend class SsaBuilder;
-    friend struct ValueNumberState;
+    friend class ValueNumberState;
 
     //--------------------- Detect the basic blocks ---------------------------
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -769,7 +769,6 @@ bool Compiler::fgRemoveDeadBlocks()
 // Notes:
 //   Each block's `bbPreorderNum` and `bbPostorderNum` is set.
 //   The `fgBBReversePostorder` array is filled in with the `BasicBlock*` in reverse post-order.
-//   This algorithm only pays attention to the actual blocks. It ignores any imaginary entry block.
 //
 //   Unreachable blocks will have higher pre and post order numbers than reachable blocks.
 //   Hence they will appear at lower indices in the fgBBReversePostorder array.

--- a/src/coreclr/jit/ssabuilder.h
+++ b/src/coreclr/jit/ssabuilder.h
@@ -33,6 +33,12 @@ public:
     // variable are stored in the "per SSA data" on the local descriptor.
     void Build();
 
+    BasicBlock** GetPostOrder(unsigned* count)
+    {
+        *count = m_postOrderCount;
+        return m_postOrder;
+    }
+
 private:
     // Ensures that the basic block graph has a root for the dominator graph, by ensuring
     // that there is a first block that is not in a try region (adding an empty block for that purpose
@@ -44,7 +50,7 @@ private:
     // the blocks in post order (i.e., a node's children first) in the array. Returns the
     // number of nodes visited while sorting the graph. In other words, valid entries in
     // the output array.
-    int TopologicalSort(BasicBlock** postOrder, int count);
+    unsigned TopologicalSort(BasicBlock** postOrder, int count);
 
     // Requires "postOrder" to hold the blocks of the flowgraph in topologically sorted
     // order. Requires count to be the valid entries in the "postOrder" array. Computes
@@ -101,4 +107,6 @@ private:
     BitVec       m_visited;
 
     SsaRenameState m_renameStack;
+    BasicBlock**   m_postOrder      = nullptr;
+    unsigned       m_postOrderCount = 0;
 };


### PR DESCRIPTION
VN tries hard to dynamically compute a reverse post-order to visit the flow graph in. However, SSA has already computed such an order, so simply pass this along to VN instead.

A few positive diffs are expected. As [Andy has pointed out recently](https://github.com/dotnet/runtime/issues/93246#issuecomment-1787432449) the "dynamic RPO" VN was doing does not necessarily result in an actual RPO, so using SSA's order is expected to be a better order than what VN ends up with today.