### PR TITLE
Fixes the build when IlcStandaloneGCSupport is specified

### DIFF
--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -1114,6 +1114,11 @@ void GCToEEInterface::UpdateGCEventStatus(int currentPublicLevel, int currentPub
     // TODO: Linux LTTng
 }
 
+void GCToEEInterface::LogStressMsg(unsigned level, unsigned facility, const StressLogMsg& msg)
+{
+    // TODO: Implementation
+}
+
 uint32_t GCToEEInterface::GetCurrentProcessCpuCount()
 {
     return PalGetProcessCpuCount();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94618