### PR TITLE
Fix for a stress crash in ComAwareWeakReferenceNative::HasInteropInfo

### DIFF
--- a/src/coreclr/vm/weakreferencenative.cpp
+++ b/src/coreclr/vm/weakreferencenative.cpp
@@ -172,8 +172,7 @@ FCIMPL1(FC_BOOL_RET, ComAwareWeakReferenceNative::HasInteropInfo, Object* pObjec
     _ASSERTE(pObject != nullptr);
 
     SyncBlock* pSyncBlock = pObject->PassiveGetSyncBlock();
-    _ASSERTE(pSyncBlock != nullptr);
-    return pSyncBlock->GetInteropInfoNoCreate() != nullptr;
+    return pSyncBlock != nullptr && pSyncBlock->GetInteropInfoNoCreate() != nullptr;
 }
 FCIMPLEND
 


### PR DESCRIPTION
In rare cases it is possible for a syncblock to be collected in the time after we detected its presence and before we get into `ComAwareWeakReferenceNative::HasInteropInfo`, so we should not assume the syncblock is still there and must null-check before looking inside it. 

Fixes: https://github.com/dotnet/runtime/issues/94579