### PR TITLE
fixed doc comment copy mistake

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -253,7 +253,7 @@ namespace System
 
         /// <summary>Indicates whether a character is categorized as an uppercase ASCII letter.</summary>
         /// <param name="c">The character to evaluate.</param>
-        /// <returns>true if <paramref name="c"/> is a lowercase ASCII letter; otherwise, false.</returns>
+        /// <returns>true if <paramref name="c"/> is a uppercase ASCII letter; otherwise, false.</returns>
         /// <remarks>
         /// This determines whether the character is in the range 'a' through 'z', inclusive.
         /// </remarks>


### PR DESCRIPTION
On the `char.IsAsciiLetterUpper(Char c)` documentation comment, there is a mistake in the `return` tag. It conflicts the `summary` tags contents.