### PR TITLE
Reenable runtime-richnav pipeline

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -30,6 +30,8 @@ parameters:
   extraVariablesTemplates: []
   isManualCodeQLBuild: false
   preBuildSteps: []
+  enableRichCodeNavigation: false
+  richCodeNavigationLanguage: 'csharp'
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -46,6 +48,9 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     enablePublishTestResults: ${{ parameters.enablePublishTestResults }}
     testResultsFormat: ${{ parameters.testResultsFormat }}
+
+    enableRichCodeNavigation: ${{ parameters.enableRichCodeNavigation }}
+    richCodeNavigationLanguage: ${{ parameters.richCodeNavigationLanguage }}
 
     # Component governance does not work on musl machines
     ${{ if eq(parameters.osSubGroup, '_musl') }}:

--- a/eng/pipelines/runtime-richnav.yml
+++ b/eng/pipelines/runtime-richnav.yml
@@ -1,33 +1,25 @@
-# disabled until https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1746670 is fixed
-trigger: none
-
-# trigger:
-#   batch: true
-#   branches:
-#     include:
-#       - main
-#       - release/*.*
-#   paths:
-#     include:
-#     - '*'
-#     exclude:
-#     - '**.md'
-#     - eng/Version.Details.xml
-#     - .devcontainer/*
-#     - .github/*
-#     - docs/*
-#     - LICENSE.TXT
-#     - PATENTS.TXT
-#     - THIRD-PARTY-NOTICES.TXT
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+  paths:
+    include:
+    - '*'
+    exclude:
+    - '**.md'
+    - eng/Version.Details.xml
+    - .devcontainer/*
+    - .github/*
+    - docs/*
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - THIRD-PARTY-NOTICES.TXT
 
 pr: none
 
 variables:
   - template: /eng/pipelines/common/variables.yml
-  - name: CodeIndex.Enabled
-    value: true
-  - name: CodeIndex.Languages
-    value: csharp,cpp
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -43,8 +35,14 @@ extends:
           platforms:
             - windows_x64
           jobParameters:
+            enableRichCodeNavigation: true
+            richCodeNavigationLanguage: "csharp"
+            nameSuffix: Libs
             timeoutInMinutes: 240
             buildArgs: -s libs.sfx+libs.oob -allConfigurations
+            preBuildSteps:
+              - script: dotnet.cmd nuget add source -n richnav "https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json"
+                displayName: Add richnav NuGet feed
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -53,5 +51,11 @@ extends:
           platforms:
             - windows_x64
           jobParameters:
-            nameSuffix: Mono
-            buildArgs: -s mono -c debug
+            enableRichCodeNavigation: true
+            richCodeNavigationLanguage: "csharp,cpp"
+            nameSuffix: Runtimes
+            timeoutInMinutes: 240
+            buildArgs: -s clr+mono
+            preBuildSteps:
+              - script: dotnet.cmd nuget add source -n richnav "https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json"
+                displayName: Add richnav NuGet feed

--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -6,6 +6,7 @@ include(../../eng/native/configurepaths.cmake)
 include(${CLR_ENG_NATIVE_DIR}/functions.cmake)
 include(${CLR_ENG_NATIVE_DIR}/configuretools.cmake)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
The pipeline was disabled because the code indexing failed earlier, but it works now: https://dev.azure.com/dnceng-public/public/_build/results?buildId=467649&view=results