### PR TITLE
Implement straightforward ServicePoint(Manager) properties in HttpWebRequest

### DIFF
--- a/src/libraries/System.Net.Requests/src/System.Net.Requests.csproj
+++ b/src/libraries/System.Net.Requests/src/System.Net.Requests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="System\Net\ServicePoint\SecurityProtocolType.cs" />
     <Compile Include="System\Net\ServicePoint\ServicePoint.cs" />
     <Compile Include="System\Net\ServicePoint\ServicePointManager.cs" />
+    <Compile Include="System\Net\ServicePoint\TcpKeepAlive.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs"

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1183,6 +1183,8 @@ namespace System.Net
                     request.Headers.ConnectionClose = true;
                 }
 
+                request.Headers.ExpectContinue = _servicePoint?.Expect100Continue ?? true;
+
                 request.Version = ProtocolVersion;
 
                 _sendRequestTask = async ?

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1183,7 +1183,10 @@ namespace System.Net
                     request.Headers.ConnectionClose = true;
                 }
 
-                request.Headers.ExpectContinue = _servicePoint?.Expect100Continue ?? true;
+                if (_servicePoint?.Expect100Continue == true)
+                {
+                    request.Headers.ExpectContinue = true;
+                }
 
                 request.Version = ProtocolVersion;
 

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1679,10 +1679,8 @@ namespace System.Net
                                 socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, parameters.ServicePoint.KeepAlive.Value.Interval);
                             }
                         }
-                        else
-                        {
-                            socket.NoDelay = true;
-                        }
+
+                        socket.NoDelay = true;
 
                         if (parameters.Async)
                         {

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -166,7 +166,8 @@ namespace System.Net
                     && ReferenceEquals(Proxy, DefaultWebProxy)
                     && ServerCertificateValidationCallback == null
                     && ClientCertificates == null
-                    && CookieContainer == null;
+                    && CookieContainer == null
+                    && ServicePoint == null;
             }
         }
 
@@ -1665,18 +1666,18 @@ namespace System.Net
 
                     try
                     {
-                        if (parameters.ServicePoint is not null)
+                        if (parameters.ServicePoint is { } servicePoint)
                         {
-                            if (parameters.ServicePoint.ReceiveBufferSize != -1)
+                            if (servicePoint.ReceiveBufferSize != -1)
                             {
-                                socket.ReceiveBufferSize = parameters.ServicePoint.ReceiveBufferSize;
+                                socket.ReceiveBufferSize = servicePoint.ReceiveBufferSize;
                             }
 
-                            if (parameters.ServicePoint.KeepAlive is not null)
+                            if (servicePoint.KeepAlive is { } keepAlive)
                             {
                                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, parameters.ServicePoint.KeepAlive.Time);
-                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, parameters.ServicePoint.KeepAlive.Interval);
+                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, keepAlive.Time);
+                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, keepAlive.Interval);
                             }
                         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1687,8 +1687,6 @@ namespace System.Net
                             socket.NoDelay = true;
                         }
 
-                        socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.ReuseUnicastPort, parameters.ReusePort);
-
                         if (parameters.Async)
                         {
                             await socket.ConnectAsync(context.DnsEndPoint, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -1675,8 +1675,8 @@ namespace System.Net
                             if (parameters.ServicePoint.KeepAlive is not null)
                             {
                                 socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, parameters.ServicePoint.KeepAlive.Value.Time);
-                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, parameters.ServicePoint.KeepAlive.Value.Interval);
+                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, parameters.ServicePoint.KeepAlive.Time);
+                                socket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, parameters.ServicePoint.KeepAlive.Interval);
                             }
                         }
 

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/ServicePoint.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/ServicePoint.cs
@@ -14,6 +14,8 @@ namespace System.Net
         private int _receiveBufferSize = -1;
         private int _connectionLimit;
 
+        internal TcpKeepAlive? KeepAlive { get; set; }
+
         internal ServicePoint(Uri address)
         {
             Debug.Assert(address != null);
@@ -87,11 +89,20 @@ namespace System.Net
 
         public void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
         {
-            if (enabled)
+            if (!enabled)
             {
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveTime);
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveInterval);
+                KeepAlive = null;
+                return;
             }
+
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveTime);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveInterval);
+
+            KeepAlive = new TcpKeepAlive
+            {
+                Time = keepAliveTime,
+                Interval = keepAliveInterval
+            };
         }
     }
 }

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/ServicePointManager.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/ServicePointManager.cs
@@ -46,6 +46,8 @@ namespace System.Net
             }
         }
 
+        internal static TcpKeepAlive? KeepAlive { get; private set; }
+
         public static int MaxServicePoints
         {
             get { return s_maxServicePoints; }
@@ -153,7 +155,8 @@ namespace System.Net
                     ConnectionLimit = DefaultConnectionLimit,
                     IdleSince = DateTime.Now,
                     Expect100Continue = Expect100Continue,
-                    UseNagleAlgorithm = UseNagleAlgorithm
+                    UseNagleAlgorithm = UseNagleAlgorithm,
+                    KeepAlive = KeepAlive
                 };
                 s_servicePointTable[tableKey] = new WeakReference<ServicePoint>(sp);
 
@@ -208,11 +211,20 @@ namespace System.Net
 
         public static void SetTcpKeepAlive(bool enabled, int keepAliveTime, int keepAliveInterval)
         {
-            if (enabled)
+            if (!enabled)
             {
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveTime);
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveInterval);
+                KeepAlive = null;
+                return;
             }
+
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveTime);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(keepAliveInterval);
+
+            KeepAlive = new TcpKeepAlive
+            {
+                Time = keepAliveTime,
+                Interval = keepAliveInterval
+            };
         }
     }
 }

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net
+{
+    internal struct TcpKeepAlive
+    {
+        internal int Time { get; set; }
+        internal int Interval { get; set; }
+    }
+}

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
@@ -1,11 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Net
 {
     internal class TcpKeepAlive

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace System.Net
 {
-    internal struct TcpKeepAlive
+    internal class TcpKeepAlive
     {
         internal int Time { get; set; }
         internal int Interval { get; set; }

--- a/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/ServicePoint/TcpKeepAlive.cs
@@ -3,7 +3,7 @@
 
 namespace System.Net
 {
-    internal class TcpKeepAlive
+    internal sealed class TcpKeepAlive
     {
         internal int Time { get; set; }
         internal int Interval { get; set; }

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2076,6 +2076,56 @@ namespace System.Net.Tests
             });
         }
 
+        [Fact]
+        public async Task SendHttpGetRequest_WithContinueTimeout_And_BodyWillNotSentByClient()
+        {
+            await LoopbackServer.CreateServerAsync(
+            async (server, uri) =>
+            {
+                Task connection = server.AcceptConnectionAsync(async (client) => 
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2));
+                    await client.ReadRequestHeaderAsync();
+                    // This should time out, because we're expecting the body itself but we'll get it after 30 sec.
+                    await Assert.ThrowsAsync<TimeoutException>(() => client.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(3)));
+                });
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                request.Method = "POST";
+                request.ServicePoint.Expect100Continue = true;
+                request.ContinueTimeout = 30000;
+                Stream requestStream = await request.GetRequestStreamAsync();
+                requestStream.Write("aaaa\r\n\r\n"u8);
+                var _ = request.GetResponseAsync();
+                await connection;
+            }).WaitAsync(TimeSpan.FromSeconds(40));
+        }
+
+        [Theory]
+        [InlineData(true, 1000)]
+        [InlineData(false, 30000)]
+        public async Task SendHttpGetRequest_WithContinueTimeout_And_BodyWillSentByClient(bool expect100Continue, int continueTimeout)
+        {
+            await LoopbackServer.CreateServerAsync(
+            async (server, uri) =>
+            {
+                Task connection = server.AcceptConnectionAsync(async (client) => 
+                {
+                    await client.ReadRequestHeaderAsync();
+                    // This should not time out, because we're expecting the body itself and we should get it after 1 sec.
+                    string data = await client.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(3));
+                    Assert.StartsWith("aaaa", data);
+                });
+                HttpWebRequest request = WebRequest.CreateHttp(uri);
+                request.Method = "POST";
+                request.ServicePoint.Expect100Continue = expect100Continue;
+                request.ContinueTimeout = continueTimeout;
+                Stream requestStream = await request.GetRequestStreamAsync();
+                requestStream.Write("aaaa\r\n\r\n"u8);
+                var _ = request.GetResponseAsync();
+                await connection;
+            }).WaitAsync(TimeSpan.FromSeconds(40));
+        }
+
         private void RequestStreamCallback(IAsyncResult asynchronousResult)
         {
             RequestState state = (RequestState)asynchronousResult.AsyncState;

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2078,7 +2078,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public async Task SendHttpPostRequest_WithContinueTimeout_And_BodyWillNotSentByClient()
+        public async Task SendHttpPostRequest_WithContinueTimeoutAndBody_BodyIsDelayed()
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async (uri) =>
@@ -2106,7 +2106,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true, 1)]
         [InlineData(false, 30000)]
-        public async Task SendHttpPostRequest_WithContinueTimeout_And_BodyWillSentByClient(bool expect100Continue, int continueTimeout)
+        public async Task SendHttpPostRequest_WithContinueTimeoutAndBody_Success(bool expect100Continue, int continueTimeout)
         {
             await LoopbackServer.CreateClientAndServerAsync(
                 async (uri) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2077,7 +2077,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
-        public async Task SendHttpGetRequest_WithContinueTimeout_And_BodyWillNotSentByClient()
+        public async Task SendHttpPostRequest_WithContinueTimeout_And_BodyWillNotSentByClient()
         {
             await LoopbackServer.CreateServerAsync(
             async (server, uri) =>
@@ -2103,7 +2103,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true, 1000)]
         [InlineData(false, 30000)]
-        public async Task SendHttpGetRequest_WithContinueTimeout_And_BodyWillSentByClient(bool expect100Continue, int continueTimeout)
+        public async Task SendHttpPostRequest_WithContinueTimeout_And_BodyWillSentByClient(bool expect100Continue, int continueTimeout)
         {
             await LoopbackServer.CreateServerAsync(
             async (server, uri) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2128,8 +2128,7 @@ namespace System.Net.Tests
                         string data = await client.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
                         Assert.StartsWith("aaaa", data);
                     });
-                }
-            ).WaitAsync(TestHelper.PassingTestTimeout);
+                });
         }
 
         [Theory]


### PR DESCRIPTION
I'm going to create an issue with a list of properties that are not implemented. 
I'm still working on the `AllowWriteStreamBuffering` property, I'll create a follow-up PR for this.

Implemented properties from ServicePoint:
- TcpKeepAlive
- ReceiveBufferSize
- ContinueTimeout
- Expect100Continue
