### PR TITLE
Initial gcdump support

### DIFF
--- a/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/gen-eventing-event-inc.lst
@@ -15,6 +15,7 @@ BGCOverflow_V1
 BGCPlanEnd
 BGCRevisit
 BGCSweepEnd
+BulkType
 Contention
 ContentionLockCreated
 ContentionStart_V2

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -282,7 +282,7 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
     // Determine this MethodTable's module.
     RuntimeInstance * pRuntimeInstance = GetRuntimeInstance();
 
-    // There can be invalid pEETypes where EETypeElementType is ElementType_Unknown and accessing the TypeManager can cause problems
+    // EEType for GC statics are not fully populated and they do not have a valid TypeManager. We will identify them by checking for `ElementType_Unknown`.
     // Specifically, the TypeManagerHandle _value). We will not be able to get the osModuleHandle for these
     ULONGLONG osModuleHandle = 0;
     if (pEEType->GetElementType() != ElementType_Unknown)

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -91,15 +91,14 @@ void BulkTypeEventLogger::FireBulkTypeEvent()
 
         // Do var-sized data individually per field
         // No name in event, so just the null terminator
-        LPCWSTR wszName = NULL;
         m_pBulkTypeEventBuffer[iSize++] = 0;
         m_pBulkTypeEventBuffer[iSize++] = 0;
 
         // Type parameter count
-        DWORD cTypeParams = target.cTypeParameters;
+        ULONG cTypeParams = target.cTypeParameters;
         ULONG *ptrInt = (ULONG*)(m_pBulkTypeEventBuffer + iSize);
         *ptrInt = cTypeParams;
-        iSize += 4;
+        iSize += sizeof(ULONG);
 
         // Type parameter array
         if (cTypeParams == 1)
@@ -283,7 +282,7 @@ int BulkTypeEventLogger::LogSingleType(MethodTable * pEEType)
     RuntimeInstance * pRuntimeInstance = GetRuntimeInstance();
 
     // EEType for GC statics are not fully populated and they do not have a valid TypeManager. We will identify them by checking for `ElementType_Unknown`.
-    // Specifically, the TypeManagerHandle _value). We will not be able to get the osModuleHandle for these
+    // We will not be able to get the osModuleHandle for these
     ULONGLONG osModuleHandle = 0;
     if (pEEType->GetElementType() != ElementType_Unknown)
     {

--- a/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_bulktype.cpp
@@ -22,7 +22,6 @@
 
 BulkTypeValue::BulkTypeValue()
     : cTypeParameters(0)
-    , rgTypeParameters()
     , ullSingleTypeParameter(0)
 {
     LIMITED_METHOD_CONTRACT;
@@ -47,7 +46,6 @@ void BulkTypeValue::Clear()
     ZeroMemory(&fixedSizedData, sizeof(fixedSizedData));
     cTypeParameters = 0;
     ullSingleTypeParameter = 0;
-    rgTypeParameters.Release();
 }
 
 //---------------------------------------------------------------------------------------
@@ -106,10 +104,9 @@ void BulkTypeEventLogger::FireBulkTypeEvent()
             memcpy(m_pBulkTypeEventBuffer + iSize, &target.ullSingleTypeParameter, sizeof(ULONGLONG) * cTypeParams);
             iSize += sizeof(ULONGLONG) * cTypeParams;
         }
-        else
+        else if (cTypeParams > 1)
         {
-            memcpy(m_pBulkTypeEventBuffer + iSize, target.rgTypeParameters.GetValue(), sizeof(ULONGLONG) * cTypeParams);
-            iSize += sizeof(ULONGLONG) * cTypeParams;
+            ASSERT_UNCONDITIONALLY("unexpected value of cTypeParams greater than 1");
         }
     }
 
@@ -380,7 +377,6 @@ void BulkTypeEventLogger::LogTypeAndParameters(uint64_t thAsAddr)
     // We're about to recursively call ourselves for the type parameters, so make a
     // local copy of their type handles first (else, as we log them we could flush
     // and clear out m_rgBulkTypeValues, thus trashing pVal)
-    NewArrayHolder<ULONGLONG> rgTypeParameters;
     DWORD cTypeParams = pVal->cTypeParameters;
     if (cTypeParams == 1)
     {
@@ -388,17 +384,8 @@ void BulkTypeEventLogger::LogTypeAndParameters(uint64_t thAsAddr)
     }
     else if (cTypeParams > 1)
     {
-        rgTypeParameters = new (nothrow) ULONGLONG[cTypeParams];
-        for (DWORD i=0; i < cTypeParams; i++)
-        {
-            rgTypeParameters[i] = pVal->rgTypeParameters[i];
-        }
-
-        // Recursively log any referenced parameter types
-        for (DWORD i=0; i < cTypeParams; i++)
-        {
-            LogTypeAndParameters(rgTypeParameters[i]);
-        }
+        
+        ASSERT_UNCONDITIONALLY("unexpected value of cTypeParams greater than 1");
     }
 }
 

--- a/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
@@ -35,21 +35,20 @@
 
 BOOL ETW::GCLog::ShouldWalkHeapObjectsForEtw()
 {
-    // @TODO: until the below issue is fixed correctly
-    // https://github.com/dotnet/runtime/issues/88491
-    return FALSE;
+    return RUNTIME_PROVIDER_CATEGORY_ENABLED(
+            TRACE_LEVEL_INFORMATION,
+            CLR_GCHEAPDUMP_KEYWORD);    
 }
 
 BOOL ETW::GCLog::ShouldWalkHeapRootsForEtw()
 {
-    // @TODO: until the below issue is fixed correctly
-    // https://github.com/dotnet/runtime/issues/88491
-    return FALSE;
+    return RUNTIME_PROVIDER_CATEGORY_ENABLED(
+            TRACE_LEVEL_INFORMATION,
+            CLR_GCHEAPDUMP_KEYWORD);    
 }
 
 BOOL ETW::GCLog::ShouldTrackMovementForEtw()
 {
-    LIMITED_METHOD_CONTRACT;
     return RUNTIME_PROVIDER_CATEGORY_ENABLED(
         TRACE_LEVEL_INFORMATION,
         CLR_GCHEAPSURVIVALANDMOVEMENT_KEYWORD);
@@ -57,13 +56,8 @@ BOOL ETW::GCLog::ShouldTrackMovementForEtw()
 
 BOOL ETW::GCLog::ShouldWalkStaticsAndCOMForEtw()
 {
-    // @TODO:
-    return FALSE;
-}
-
-void ETW::GCLog::WalkStaticsAndCOMForETW()
-{
-    // @TODO:
+    // @TODO
+    return false;
 }
 
 // Batches the list of moved/surviving references for the GCBulkMovedObjectRanges /
@@ -480,6 +474,14 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
     pThread->EnablePreemptiveMode();
 
     return hr;
+}
+
+//---------------------------------------------------------------------------------------
+// WalkStaticsAndCOMForETW walks both CCW/RCW objects and static variables.
+//---------------------------------------------------------------------------------------
+
+void ETW::GCLog::WalkStaticsAndCOMForETW()
+{
 }
 
 // Holds state that batches of roots, nodes, edges, and types as the GC walks the heap

--- a/src/coreclr/nativeaot/Runtime/eventtracepriv.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracepriv.h
@@ -114,18 +114,9 @@ public:
     // Below are the remainder of each struct in the bulk type event (i.e., the
     // variable-sized data). The var-sized fields are copied into the event individually
     // (not directly), so they don't need to have the same layout as in the ETW manifest
-
-    // This is really a denorm of the size already stored in rgTypeParameters, but we
-    // need a persistent place to stash this away so EventDataDescCreate & EventWrite
-    // have a reliable place to copy it from.  This is filled in at the last minute,
-    // when sending the event.
     ULONG cTypeParameters;
 
-    // If > 1 type parameter, this is an array of their MethodTable*'s
-    NewArrayHolder<ULONGLONG> rgTypeParameters;
-
-    // If exactly one type parameter, this is its MethodTable*.  (If != 1 type parameter,
-    // this is 0.)
+    // We only expect one type parameter
     ULONGLONG ullSingleTypeParameter;
 };
 

--- a/src/coreclr/nativeaot/Runtime/eventtracepriv.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracepriv.h
@@ -138,6 +138,9 @@ class BulkTypeEventLogger
 {
 private:
 
+    // The maximum event size, and the size of the buffer that we allocate to hold the event contents.
+    static const size_t kSizeOfEventBuffer = 65536;
+
     // Estimate of how many bytes we can squeeze in the event data for the value struct
     // array.  (Intentionally overestimate the size of the non-array parts to keep it safe.)
     static const int kMaxBytesTypeValues = (cbMaxEtwEvent - 0x30);
@@ -178,14 +181,25 @@ private:
     // List of types we've batched.
     BulkTypeValue m_rgBulkTypeValues[kMaxCountTypeValues];
 
+    BYTE *m_pBulkTypeEventBuffer;
+
     int LogSingleType(MethodTable * pEEType);
 
 public:
     BulkTypeEventLogger() :
         m_nBulkTypeValueCount(0),
         m_nBulkTypeValueByteCount(0)
+        , m_pBulkTypeEventBuffer(NULL)
     {
         LIMITED_METHOD_CONTRACT;
+
+        m_pBulkTypeEventBuffer = new (nothrow) BYTE[kSizeOfEventBuffer];
+    }
+
+    ~BulkTypeEventLogger()
+    {
+        delete[] m_pBulkTypeEventBuffer;
+        m_pBulkTypeEventBuffer = NULL;
     }
 
     void LogTypeAndParameters(ULONGLONG thAsAddr);

--- a/src/coreclr/nativeaot/Runtime/eventtracepriv.h
+++ b/src/coreclr/nativeaot/Runtime/eventtracepriv.h
@@ -116,7 +116,7 @@ public:
     // (not directly), so they don't need to have the same layout as in the ETW manifest
     ULONG cTypeParameters;
 
-    // We only expect one type parameter
+    // We expect only one type parameter. See the explanation at BulkTypeEventLogger::LogSingleType on generic parameters for additional details.
     ULONGLONG ullSingleTypeParameter;
 };
 

--- a/src/coreclr/vm/eventtrace_bulktype.cpp
+++ b/src/coreclr/vm/eventtrace_bulktype.cpp
@@ -20,7 +20,7 @@
 #include "eventtracepriv.h"
 
 //---------------------------------------------------------------------------------------
-// BulkStaticsLogger: Batches up and logs static variable roots
+// BulkComLogger: Batches up and logs RCW and CCW
 //---------------------------------------------------------------------------------------
 
 BulkComLogger::BulkComLogger(BulkTypeEventLogger *typeLogger)

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -13,5 +13,6 @@
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/eventpipe_common.csproj" />
     <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+     <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Support for `gcdump `with `GCBulkNode`, `GCBulkEdge`, `GCBulkRootEdge`, `TypeBulkType `events
 - GCBulkRootStaticVar is not supported yet
 - Requires client time symbol lookup for Types since native AOT doesn't carry metadata.
 - Fixes #88491