### PR TITLE
[wasm] Enable WasmStripILAfterAOT by default

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BuildPublishTests.cs
@@ -175,8 +175,8 @@ public class BuildPublishTests : BlazorWasmTestBase
     }
 
     [Theory]
-    [InlineData("", false)] // Default case
-    [InlineData("true", true)] // the other case
+    [InlineData("", true)] // Default case
+    [InlineData("false", false)] // the other case
     public async Task Test_WasmStripILAfterAOT(string stripILAfterAOT, bool expectILStripping)
     {
         string config = "Release";

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTests.cs
@@ -493,8 +493,8 @@ namespace Wasm.Build.Tests
         }
 
         [Theory]
-        [InlineData("", false)] // Default case
-        [InlineData("true", true)] // the other case
+        [InlineData("", true)] // Default case
+        [InlineData("false", false)] // the other case
         public void Test_WasmStripILAfterAOT(string stripILAfterAOT, bool expectILStripping)
         {
             string config = "Release";

--- a/src/mono/wasm/build/WasmApp.targets
+++ b/src/mono/wasm/build/WasmApp.targets
@@ -88,7 +88,7 @@
                                               - AppBundle/_framework contains generated files (dlls, runtime scripts, icu)
                                               - AppBundle/_content contains web files from nuget packages (css, js, etc)
       - $(WasmStripILAfterAOT)              - Set to true to enable trimming away AOT compiled methods body (IL code)
-                                              Defaults to false.
+                                              Defaults to true.
 
       Public items:
       - @(WasmExtraFilesToDeploy) - Files to copy to $(WasmAppDir).
@@ -150,7 +150,7 @@
     <WasmAssemblyExtension Condition="'$(WasmEnableWebcil)' == 'true'">.wasm</WasmAssemblyExtension>
     <WasmAssemblyExtension Condition="'$(WasmEnableWebcil)' != 'true'">.dll</WasmAssemblyExtension>
 
-    <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">false</WasmStripILAfterAOT>
+    <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">true</WasmStripILAfterAOT>
 
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
   </PropertyGroup>


### PR DESCRIPTION
As a follow up of https://github.com/dotnet/runtime/pull/90436, this PR change the default value of `WasmStripILAfterAOT` to `true`.