### PR TITLE
[release/8.0] Revert performance optimization resulting in incorrect lookups in certain case insensitive frozen collections

### DIFF
--- a/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenFromKnownValuesTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenFromKnownValuesTests.cs
@@ -142,6 +142,15 @@ namespace System.Collections.Frozen.Tests
                 Enumerable.Range(0, 100).Select(i => $"{i:D2}ABCDEFGH\U0001F600").ToArray(), // left justified substring non-ascii
                 Enumerable.Range(0, 100).Select(i => $"ABCDEFGH\U0001F600{i:D2}").ToArray(), // right justified substring non-ascii
                 Enumerable.Range(0, 20).Select(i => i.ToString("D2")).Select(s => (char)(s[0] + 128) + "" + (char)(s[1] + 128)).ToArray(), // left-justified non-ascii
+                
+                Enumerable.Range(0, 10).Select(i => $"{i}ABCDefgh").ToArray(), // left justified single char ascii, mixed casing
+                Enumerable.Range(0, 10).Select(i => $"ABCDefgh{i}").ToArray(), // right justified single char ascii, mixed casing
+                Enumerable.Range(0, 100).Select(i => $"{i:D2}ABCDefgh").ToArray(), // left justified substring ascii, mixed casing
+                Enumerable.Range(0, 100).Select(i => $"ABCDefgh{i:D2}").ToArray(), // right justified substring ascii, mixed casing
+                Enumerable.Range(0, 10).Select(i => $"{i}ABCDefgh\U0001F600").ToArray(), // left justified single char non-ascii, mixed casing
+                Enumerable.Range(0, 10).Select(i => $"ABCDefgh\U0001F600{i}").ToArray(), // right justified single char non-ascii, mixed casing
+                Enumerable.Range(0, 100).Select(i => $"{i:D2}ABCDefgh\U0001F600").ToArray(), // left justified substring non-ascii, mixed casing
+                Enumerable.Range(0, 100).Select(i => $"ABCDefgh\U0001F600{i:D2}").ToArray(), // right justified substring non-ascii, mixed casing
             }
             select new object[] { keys.ToDictionary(i => i, i => i, comparer) };
 
@@ -191,6 +200,23 @@ namespace System.Collections.Frozen.Tests
                     Assert.True(frozen.TryGetValue(pair.Key, out TValue value));
                     Assert.Equal(pair.Value, value);
                 }
+
+                if (typeof(TKey) == typeof(string) && ReferenceEquals(frozen.Comparer, StringComparer.OrdinalIgnoreCase))
+                {
+                    foreach (KeyValuePair<TKey, TValue> pair in source)
+                    {
+                        TKey keyUpper = (TKey)(object)((string)(object)pair.Key).ToUpper();
+                        bool isValidTest = frozen.Comparer.Equals(pair.Key, keyUpper);
+                        if (isValidTest)
+                        {
+                            Assert.Equal(pair.Value, frozen.GetValueRefOrNullRef(keyUpper));
+                            Assert.Equal(pair.Value, frozen[keyUpper]);
+                            Assert.True(frozen.TryGetValue(keyUpper, out TValue value));
+                            Assert.Equal(pair.Value, value);
+                        }
+                    }
+                }
+
                 foreach (KeyValuePair<TKey, TValue> pair in frozen)
                 {
                     Assert.True(source.TryGetValue(pair.Key, out TValue value));
@@ -269,6 +295,22 @@ namespace System.Collections.Frozen.Tests
                     Assert.True(frozen.TryGetValue(pair.Key, out TKey actualKey));
                     Assert.Equal(pair.Key, actualKey);
                 }
+
+                if (typeof(TKey) == typeof(string) && ReferenceEquals(frozen.Comparer, StringComparer.OrdinalIgnoreCase))
+                {
+                    foreach (KeyValuePair<TKey, TValue> pair in source)
+                    {
+                        TKey keyUpper = (TKey)(object)((string)(object)pair.Key).ToUpper();
+                        bool isValidTest = frozen.Comparer.Equals(pair.Key, keyUpper);
+                        if (isValidTest)
+                        {
+                            Assert.True(frozen.Contains(keyUpper));
+                            Assert.True(frozen.TryGetValue(keyUpper, out TKey actualKey));
+                            Assert.Equal(pair.Key, actualKey);
+                        }
+                    }
+                }
+
                 foreach (TKey key in frozen)
                 {
                     Assert.True(source.TryGetValue(key, out _));

--- a/src/libraries/System.Collections.Immutable/tests/Frozen/KeyAnalyzerTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/KeyAnalyzerTests.cs
@@ -97,6 +97,14 @@ namespace System.Collections.Frozen.Tests
             Assert.False(r.AllAsciiIfIgnoreCase);
             Assert.Equal(7, r.HashIndex);
             Assert.Equal(1, r.HashCount);
+
+            r = RunAnalysis(new[] { "1abc", "2abc", "3abc", "4abc", "5abc", "6abc" }, true);
+            Assert.False(r.RightJustifiedSubstring);
+            Assert.True(r.IgnoreCase);
+            Assert.True(r.AllAsciiIfIgnoreCase);
+            Assert.Equal(0, r.HashIndex);
+            Assert.Equal(1, r.HashCount);
+
         }
 
         [Fact]


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/94667 to release/8.0

## Customer impact

Addresses a customer reported issue where under certain circumstances, frozen collections produce erroneous lookup results when keyed on case-insensitive strings. After a lot deliberation, we have decided to revert the particular performance optimization that was causing the bug. While this change will result in perf regression, we are fine with this since

1. It only impacts the use case which is currently misbehaving and
2. It is the smallest possible change that fixes the bug.

## Testing

Added unit testing covering the impacted scenario.

## Risk

Low. Makes targeted changes in the `KeyAnalyzer` component disabling the optimization for the cases where it isn't valid.