### PR TITLE
[main] Fixed DateTimeOffset.Now calls on Android with specific conditions

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.Android.cs
@@ -1,8 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Threading;
 using System.Globalization;
+using System.Threading;
 
 namespace System
 {

--- a/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.Android.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTimeOffset.Android.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading;
+using System.Globalization;
 
 namespace System
 {
@@ -60,7 +61,7 @@ namespace System
                 }
 
                 // Fast path obtained offset incorporated into ToLocalTime(DateTime.UtcNow, true) logic
-                int localDateTimeOffsetSeconds = Convert.ToInt32(localDateTimeOffset);
+                int localDateTimeOffsetSeconds = Convert.ToInt32(localDateTimeOffset, CultureInfo.InvariantCulture);
                 TimeSpan offset = TimeSpan.FromSeconds(localDateTimeOffsetSeconds);
                 long localTicks = utcDateTime.Ticks + offset.Ticks;
                 if (localTicks < DateTime.MinTicks || localTicks > DateTime.MaxTicks)


### PR DESCRIPTION
Fixed issue when DateTimeOffset.Now throws exception on Android with Arabic language & western hemisphere timezone
Fixes #94709 