### PR TITLE
[wasi] Run the mono runtime component selection logic for wasi

### DIFF
--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -32,7 +32,7 @@
   <ItemGroup Condition="'$(Configuration)' == 'Debug' and '@(_MonoComponent->Count())' == 0">
     <_MonoComponent Include="hot_reload;debugger" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UsingWasiRuntimeWorkload)' != 'true'">
     <_MonoComponent Include="marshal-ilgen" />
   </ItemGroup>
 
@@ -263,7 +263,7 @@
     </ManagedToNativeGenerator>
   </Target>
 
-  <Target Name="_WasmSelectRuntimeComponentsForLinking" DependsOnTargets="_MonoSelectRuntimeComponents" />
+  <Target Name="_WasmSelectRuntimeComponentsForLinking" Condition="'$(UsingWasiRuntimeWorkload)' == 'true'" DependsOnTargets="_MonoSelectRuntimeComponents" />
 
   <Target Name="_GetNativeFilesForLinking" DependsOnTargets="_WasmSelectRuntimeComponentsForLinking" Returns="@(_WasmNativeFileForLinking)">
     <Message Text="MicrosoftNetCoreAppRuntimePackRidNativeDir: $(MicrosoftNetCoreAppRuntimePackRidNativeDir)" Importance="High" />

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -265,7 +265,7 @@
 
   <Target Name="_WasmSelectRuntimeComponentsForLinking" DependsOnTargets="_MonoSelectRuntimeComponents" />
 
-  <Target Name="_GetNativeFilesForLinking" Returns="@(_WasmNativeFileForLinking)">
+  <Target Name="_GetNativeFilesForLinking" DependsOnTargets="_WasmSelectRuntimeComponentsForLinking" Returns="@(_WasmNativeFileForLinking)">
     <Message Text="MicrosoftNetCoreAppRuntimePackRidNativeDir: $(MicrosoftNetCoreAppRuntimePackRidNativeDir)" Importance="High" />
     <PropertyGroup>
       <!-- FIXME: eh case -->


### PR DESCRIPTION
This filters the runtime components correctly such that we don't link both the stub and the full library.