### PR TITLE
Fixed setting ReadMode to Message for NamedPipeClientStream on Windows

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs
@@ -43,6 +43,10 @@ namespace System.IO.Pipes
             {
                 access |= Interop.Kernel32.GenericOperations.GENERIC_WRITE;
             }
+            else
+            {
+                access |= Interop.Kernel32.FileOperations.FILE_WRITE_ATTRIBUTES;
+            }
 
             SafePipeHandle handle = CreateNamedPipeClient(_normalizedPipePath, ref secAttrs, _pipeFlags, access);
 


### PR DESCRIPTION
Fixes a longstanding issue inherited from the .NET framework which prevents ReadMode being set to Message on the client end of read only named pipes on Windows platforms.

Also added in new tests for Message mode on Windows to verify correct functionality.

Fix #83072