### PR TITLE
Remove exclusion for a test that seems to work

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -755,9 +755,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ArrayMarshalling/SafeArray/SafeArrayTest/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: SAFEARRAY</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest/*">
-            <Issue>https://github.com/dotnet/runtime/issues/74620</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/MultipleALCs/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: AssemblyLoadContext.LoadFromAssemblyPath</Issue>
         </ExcludeList>


### PR DESCRIPTION
Resolves #74620.

I looked at where we are with ComWrappers on Native AOT because apparently [CsWinRT is making good progress](https://twitter.com/driver1998/status/1724274192886206611). Looks like this was the last disabled test and it was disabled for no reason.

Cc @dotnet/ilc-contrib 