### PR TITLE
Fix declaration of DiagAddNewRegion

### DIFF
--- a/src/coreclr/gc/env/gctoeeinterface.standalone.inl
+++ b/src/coreclr/gc/env/gctoeeinterface.standalone.inl
@@ -249,7 +249,7 @@ namespace standalone
             return ::GCToEEInterface::GetCurrentProcessCpuCount();
         }
 
-        void DiagAddNewRegion(int generation, BYTE * rangeStart, BYTE * rangeEnd, BYTE * rangeEndReserved)
+        void DiagAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
         {
             ::GCToEEInterface::DiagAddNewRegion(generation, rangeStart, rangeEnd, rangeEndReserved);
         }


### PR DESCRIPTION
`uint8_t` is the type that is used thorough the codebase here. `BYTE` happens to not be defined for some build configurations and produces a build break. I'm also removing the space because the prevailing code style in this file is no space between type and asterisk.