### PR TITLE
[LoongArch64] Fix the overwritten of reg21 when `pLookup->sizeOffset >2047`

### DIFF
--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1851,10 +1851,10 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
 
                 if (pLookup->sizeOffset > 2047)
                 {
-                    // pcaddi  $r21,0
-                    *(DWORD*)p = 0x18000015; p += 4;
-                    // ld.d  $t4,$r21, #dataOffset
-                    *(DWORD*)p = 0x28c002b0 | (dataOffset << 10); p += 4;
+                    // pcaddi  $t4,0
+                    *(DWORD*)p = 0x18000010; p += 4;
+                    // ld.d  $t4,$t4, #dataOffset
+                    *(DWORD*)p = 0x28c00210 | (dataOffset << 10); p += 4;
                     // ldx.d  $t5,$a0,$t4
                     *(DWORD*)p = 0x380c4091; p += 4;
 

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1793,11 +1793,13 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
             _ASSERTE(pLookup->offsets[i] >= 0);
             if (i == pLookup->indirections - 1 && pLookup->sizeOffset != CORINFO_NO_SIZE_CHECK)
             {
-                codeSize += (pLookup->sizeOffset > 2047 ? 24 : 16);
+                // if( > 2047) (4*5 bytes) else 4*4 bytes for instructions.
+                codeSize += (pLookup->sizeOffset > 2047 ? 20 : 16);
                 indirectionsDataSize += (pLookup->sizeOffset > 2047 ? 4 : 0);
             }
 
-            codeSize += (pLookup->offsets[i] > 2047 ? 8 : 4); // if( > 2047) (8 bytes) else 4 bytes for instructions.
+            // if( > 2047) (8 bytes) else 4 bytes for instructions.
+            codeSize += (pLookup->offsets[i] > 2047 ? 8 : 4);
             indirectionsDataSize += (pLookup->offsets[i] > 2047 ? 4 : 0); // 4 bytes for storing indirection offset values
         }
 

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1829,9 +1829,14 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
 
         if (indirectionsDataSize)
         {
+            _ASSERTE(indirectionsDataSize < 2047);
+            _ASSERTE(dataOffset < 0x80000);
+
+            // get the first dataOffset's addr.
             // pcaddi  $r21,0
-            *(DWORD*)p = 0x18000015;
+            *(DWORD*)p = 0x18000015 | (dataOffset << 3); // dataOffset is 4byte aligned.
             p += 4;
+            dataOffset = 0;
         }
 
         if (pLookup->testForNull || pLookup->sizeOffset != CORINFO_NO_SIZE_CHECK)
@@ -1851,47 +1856,41 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
 
                 if (pLookup->sizeOffset > 2047)
                 {
-                    // pcaddi  $t4,0
-                    *(DWORD*)p = 0x18000010; p += 4;
-                    // ld.d  $t4,$t4, #dataOffset
-                    *(DWORD*)p = 0x28c00210 | (dataOffset << 10); p += 4;
+                    // ld.wu  $t4,$r21,0
+                    *(DWORD*)p = 0x2a8002b0 | (dataOffset << 10); p += 4;
                     // ldx.d  $t5,$a0,$t4
                     *(DWORD*)p = 0x380c4091; p += 4;
 
                     // move to next indirection offset data
-                    dataOffset = dataOffset - 12 + 4; // subtract 12 as we have moved PC by 12 and add 4 as next data is at 4 bytes from previous data
+                    dataOffset += 4;
                 }
                 else
                 {
                     // ld.d $t5, $a0, #(pLookup->sizeOffset)
                     *(DWORD*)p = 0x28c00091 | ((UINT32)pLookup->sizeOffset << 10); p += 4;
-                    dataOffset -= 4; // subtract 4 as we have moved PC by 4
                 }
 
                 // lu12i.w $t4, (slotOffset&0xfffff000)>>12
                 *(DWORD*)p = 0x14000010 | ((((UINT32)slotOffset & 0xfffff000) >> 12) << 5); p += 4;
                 // ori $t4, $t4, slotOffset&0xfff
                 *(DWORD*)p = 0x03800210 | (((UINT32)slotOffset & 0xfff) << 10); p += 4;
-                dataOffset -= 8;
 
                 // bge $t4,$t5, // CALL HELPER:
                 pBLECall = p;       // Offset filled later
                 *(DWORD*)p = 0x64000211; p += 4;
-                dataOffset -= 4;
             }
 
             if(pLookup->offsets[i] > 2047)
             {
-                _ASSERTE(dataOffset < 2047);
                 // ld.wu  $t4,$r21,0
-                *(DWORD*)p = 0x2a8002b0 | (dataOffset<<10);
+                *(DWORD*)p = 0x2a8002b0 | (dataOffset << 10);
                 p += 4;
                 // ldx.d  $a0,$a0,$t4
                 *(DWORD*)p = 0x380c4084;
                 p += 4;
 
                 // move to next indirection offset data
-                dataOffset = dataOffset - 8 + 4; // subtract 8 as we have moved PC by 8 and add 4 as next data is at 4 bytes from previous data
+                dataOffset += 4;
             }
             else
             {
@@ -1901,9 +1900,10 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
                 // ld.d  $a0,$a0,pLookup->offsets[i]
                 *(DWORD*)p = 0x28c00084 | ((pLookup->offsets[i] & 0xfff)<<10);
                 p += 4;
-                dataOffset -= 4; // subtract 4 as we have moved PC by 4
             }
         }
+
+        _ASSERTE(indirectionsDataSize == dataOffset);
 
         // No null test required
         if (!pLookup->testForNull)


### PR DESCRIPTION
Fix the overwritten of reg21 when `pLookup->sizeOffset >2047` within the loongarch64/stubs.cpp.

@gbalykov 
Thanks very much for your advice!
https://github.com/dotnet/runtime/pull/94735#discussion_r1393771885