### PR TITLE
Fix build issues with clang18

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -564,6 +564,11 @@ if (CLR_CMAKE_HOST_UNIX)
     add_compile_options(-Wimplicit-fallthrough)
   endif()
 
+  # VLAs are non standard in C++, aren't available on Windows and
+  # are a warning by default since clang 18.
+  # For consistency, enable warnings for all compiler versions.
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wvla>)
+
   #These seem to indicate real issues
   add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
 

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -606,6 +606,10 @@ if (CLR_CMAKE_HOST_UNIX)
     # other clang 16.0 suppressions
     add_compile_options(-Wno-single-bit-bitfield-constant-conversion)
     add_compile_options(-Wno-cast-function-type-strict)
+    
+    # clang 18.0 warns about VLAs being a C++ extension by default.
+    # https://github.com/llvm/llvm-project/issues/62836
+    add_compile_options(-Wno-vla-cxx-extension)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -606,10 +606,6 @@ if (CLR_CMAKE_HOST_UNIX)
     # other clang 16.0 suppressions
     add_compile_options(-Wno-single-bit-bitfield-constant-conversion)
     add_compile_options(-Wno-cast-function-type-strict)
-    
-    # clang 18.0 warns about VLAs being a C++ extension by default.
-    # https://github.com/llvm/llvm-project/issues/62836
-    add_compile_options(-Wno-vla-cxx-extension)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -631,9 +631,9 @@ bool GCToOSInterface::VirtualCommit(void* address, size_t size, uint16_t node)
         if ((int)node <= g_highestNumaNode)
         {
             int usedNodeMaskBits = g_highestNumaNode + 1;
-            int nodeMaskLength = (usedNodeMaskBits + sizeof(unsigned long) - 1) / sizeof(unsigned long);
-            unsigned long nodeMask[nodeMaskLength];
-            memset(nodeMask, 0, sizeof(nodeMask));
+            int nodeMaskLength = usedNodeMaskBits + sizeof(unsigned long) - 1;
+            unsigned long* nodeMask = (unsigned long*)alloca(nodeMaskLength);
+            memset(nodeMask, 0, nodeMaskLength);
 
             int index = node / sizeof(unsigned long);
             nodeMask[index] = ((unsigned long)1) << (node & (sizeof(unsigned long) - 1));
@@ -1189,10 +1189,10 @@ uint64_t GetAvailablePhysicalMemory()
 #elif defined(__FreeBSD__)
     size_t inactive_count = 0, laundry_count = 0, free_count = 0;
     size_t sz = sizeof(inactive_count);
-    sysctlbyname("vm.stats.vm.v_inactive_count", &inactive_count, &sz, NULL, 0); 
+    sysctlbyname("vm.stats.vm.v_inactive_count", &inactive_count, &sz, NULL, 0);
 
     sz = sizeof(laundry_count);
-    sysctlbyname("vm.stats.vm.v_laundry_count", &laundry_count, &sz, NULL, 0); 
+    sysctlbyname("vm.stats.vm.v_laundry_count", &laundry_count, &sz, NULL, 0);
 
     sz = sizeof(free_count);
     sysctlbyname("vm.stats.vm.v_free_count", &free_count, &sz, NULL, 0);

--- a/src/coreclr/pal/src/file/path.cpp
+++ b/src/coreclr/pal/src/file/path.cpp
@@ -399,8 +399,8 @@ GetTempPathW(
         return 0;
     }
 
-    char TempBuffer[nBufferLength > 0 ? nBufferLength : 1];
-    DWORD dwRetVal = GetTempPathA( nBufferLength, TempBuffer );
+    char* tempBuffer = (char*)alloca(nBufferLength > 0 ? nBufferLength : 1);
+    DWORD dwRetVal = GetTempPathA( nBufferLength, tempBuffer );
 
     if ( dwRetVal >= nBufferLength )
     {
@@ -411,7 +411,7 @@ GetTempPathW(
     else if ( dwRetVal != 0 )
     {
         /* Convert to wide. */
-        if ( 0 == MultiByteToWideChar( CP_ACP, 0, TempBuffer, -1,
+        if ( 0 == MultiByteToWideChar( CP_ACP, 0, tempBuffer, -1,
                                        lpBuffer, dwRetVal + 1 ) )
         {
             ASSERT( "An error occurred while converting the string to wide.\n" );

--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -426,6 +426,7 @@ function_name() to call the system's implementation
 #undef va_start
 #undef va_end
 #undef va_copy
+#undef va_arg
 #undef stdin
 #undef stdout
 #undef stderr

--- a/src/native/minipal/getexepath.h
+++ b/src/native/minipal/getexepath.h
@@ -37,7 +37,7 @@ static inline char* minipal_getexepath(void)
         return NULL;
     }
 
-    char path_buf[path_length];
+    char* path_buf = (char*)alloca(path_length);
     if (_NSGetExecutablePath(path_buf, &path_length) != 0)
     {
         errno = EINVAL;


### PR DESCRIPTION
Clang 18 introduced some changes that prevent building CoreCLR:
* The warning for VLAs being a C++ extension is now on by default which causes errors with ``-Werror``. https://github.com/llvm/llvm-project/issues/62836
* ``stdarg.h`` now has a guard that depends on ``va_arg`` not being defined, currently the PAL internal doesn't undefined that macro (despite PAL defining it) which prevent ``stdarg.h`` from being included again and causes missing symbols (``va_start``, ``va_end``, ``va_arg``).

This PR fixes the warning by disabling it to match the behaviour of previous clang versions and undefines ``va_arg`` in ``palinternal.h``.