### PR TITLE
Fix DescriptionNameTests.DumpRuntimeInformationToConsole failing on Mono on Windows

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/DescriptionNameTests.cs
@@ -53,12 +53,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             if (OperatingSystem.IsLinux())
             {
-                Console.WriteLine($"### CGROUPS VERSION: {Interop.cgroups.s_cgroupVersion}");
-                string cgroupsLocation = Interop.cgroups.s_cgroupMemoryPath;
-                if (cgroupsLocation != null)
-                {
-                    Console.WriteLine($"### CGROUPS MEMORY: {cgroupsLocation}");
-                }
+                // needs to be in a separate method due to Mono issue: https://github.com/dotnet/runtime/issues/77513
+                DumpCGroupInformationToConsole();
             }
 
             Console.WriteLine($"### ENVIRONMENT VARIABLES");
@@ -160,6 +156,16 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                         Console.WriteLine($"###\t(Exception: {e.Message})");
                     }
                 }
+            }
+        }
+
+        private static void DumpCGroupInformationToConsole()
+        {
+            Console.WriteLine($"### CGROUPS VERSION: {Interop.cgroups.s_cgroupVersion}");
+            string cgroupsLocation = Interop.cgroups.s_cgroupMemoryPath;
+            if (cgroupsLocation != null)
+            {
+                Console.WriteLine($"### CGROUPS MEMORY: {cgroupsLocation}");
             }
         }
 


### PR DESCRIPTION
Mono runs static field initializers quite eagerly (https://github.com/dotnet/runtime/issues/77513) which means we're getting this DllNotFoundException on Windows, even though this code should only run on Linux:

```
System.Runtime.InteropServices.RuntimeInformationTests.DescriptionNameTests.DumpRuntimeInformationToConsole [FAIL]
   System.TypeInitializationException : The type initializer for 'cgroups' threw an exception.
   ---- System.DllNotFoundException : libSystem.Native
   Stack Trace:
      /_/src/mono/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.Mono.cs(22,0): at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
      /_/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.cs(57,0): at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
      ----- Inner Stack Trace -----
      /_/src/libraries/System.Runtime/tests/System.Runtime.InteropServices.RuntimeInformation.Tests/Microsoft.Interop.LibraryImportGenerator/Microsoft.Interop.LibraryImportGenerator/LibraryImports.g.cs(65,0): at Interop.Sys.GetFormatInfoForMountPoint(String name, Byte* formatNameBuffer, Int32 bufferLength, Int64* formatType)
      /_/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs(215,0): at Interop.cgroups.FindCGroupVersion()
      /_/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs(35,0): at Interop.cgroups..cctor()
```

The workaround is to extract the code into a helper method.