### PR TITLE
Disable Determinism test on NativeAOT iOS/tvOS runs

### DIFF
--- a/src/tests/nativeaot/SmokeTests/Determinism/Determinism.csproj
+++ b/src/tests/nativeaot/SmokeTests/Determinism/Determinism.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- test tries to read files from disk, bundling them into the app isn't easily possible right now -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Determinism.cs" />


### PR DESCRIPTION
It tries to read files from disk but we currently don't have a good way to bundle these into the mobile app.