### PR TITLE
Fix format.sh script and remove dotnet-format tool from dotnet-tools.json

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,12 +25,6 @@
       "commands": [
         "slngen"
       ]
-    },
-    "dotnet-format": {
-      "version": "6.0.240501",
-      "commands": [
-        "dotnet-format"
-      ]
     }
   }
 }

--- a/docs/coding-guidelines/code-formatting-tools.md
+++ b/docs/coding-guidelines/code-formatting-tools.md
@@ -8,7 +8,7 @@ To help enable an easy workflow and reduce the number of formatting changes requ
 
 ### C#/VB
 
-C# and VB code in the repository use the built-in Roslyn support for EditorConfig to enable auto-formatting in many IDEs. As a result, no additional tools are required to enable keeping your code formatted. If you want to use `dotnet format` to do formatting or are using the git pre-commit hook mentioned later in this document, you can run `./dotnet.cmd tool restore` or `./dotnet.sh tool restore` from the root of the repository to enable the `dotnet format` command.
+C# and VB code in the repository use the built-in Roslyn support for EditorConfig to enable auto-formatting in many IDEs. As a result, no additional tools are required to enable keeping your code formatted. You can also use the `dotnet format` command from the dotnet SDK to do formatting or use the git pre-commit hook mentioned later in this document.
 
 ### C/C++
 

--- a/eng/formatting/format.sh
+++ b/eng/formatting/format.sh
@@ -17,7 +17,7 @@ fi
 
 if [ -n "$MANAGED_FILES" ]; then
     # Format all selected files
-    echo "$MANAGED_FILES" | cat | xargs | sed -e 's/ /,/g' | dotnet format --no-restore --include -
+    echo "$MANAGED_FILES" | cat | xargs | sed -e 's/ /,/g' | dotnet format whitespace --include - --folder
 
     # Add back the modified files to staging
     echo "$MANAGED_FILES" | xargs git add


### PR DESCRIPTION
We're no longer using the separate dotnet-format tool since it is integrated into the dotnet SDK now.

With the move to the SDK the options changed a bit so we now need to use the `whitespace` format command so we can continue using the `--folder` option: https://github.com/dotnet/format/issues/1385

To run not just whitespace but code style formatters as well we'd need a workspace context (i.e. pass the .csproj to dotnet format), but inferring that from just the changed file list is hard.