### PR TITLE
Handle platform not supported during test discovery.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -122,9 +122,16 @@ namespace System.Security.Cryptography.Dsa.Tests
 
         private static bool GetHasSecondMinSize()
         {
-            using (DSA dsa = DSAFactory.Create())
+            try
             {
-                return GetSecondMin(dsa.LegalKeySizes) != int.MaxValue;
+                using (DSA dsa = DSAFactory.Create())
+                {
+                    return GetSecondMin(dsa.LegalKeySizes) != int.MaxValue;
+                }
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return false;
             }
         }
     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -454,9 +454,9 @@ namespace System.Security.Cryptography.Rsa.Tests
 
                 return true;
             }
-            catch (CryptographicException)
+            catch (Exception e) when (e is CryptographicException or PlatformNotSupportedException)
             {
-                // The key is too big for this platform.
+                // The key is too big for this platform or the platform is not supported.
                 return false;
             }
         }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Browser.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.EcDiffieHellman.Tests
+{
+    public partial class ECDiffieHellmanProvider : IECDiffieHellmanProvider
+    {
+        public bool IsCurveValid(Oid oid) => false;
+        public bool ExplicitCurvesSupported => false;
+        public bool CanDeriveNewPublicKey => false;
+        public bool SupportsRawDerivation => false;
+        public bool SupportsSha3 =>  false;
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Browser.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Browser.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography.EcDsa.Tests
+{
+    public partial class ECDsaProvider : IECDsaProvider
+    {
+        public bool IsCurveValid(Oid oid) => false;
+        public bool ExplicitCurvesSupported => false;
+        private static bool IsValueOrFriendlyNameValid(string friendlyNameOrValue) => false;
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -388,13 +388,17 @@
     <Compile Include="DefaultECDsaProvider.Windows.cs" />
     <Compile Include="DefaultECDiffieHellmanProvider.Windows.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows' and '$(UseAndroidCrypto)' != 'true'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'windows' and '$(UseAndroidCrypto)' != 'true' and '$(TargetPlatformIdentifier)' != 'browser'">
     <Compile Include="DefaultECDsaProvider.Unix.cs" />
     <Compile Include="DefaultECDiffieHellmanProvider.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser'">
+    <Compile Include="DefaultECDsaProvider.Browser.cs" />
+    <Compile Include="DefaultECDiffieHellmanProvider.Browser.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'">
     <Compile Include="X509Certificates\X509StoreMutableTests.cs" />

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestChainTests.cs
@@ -534,6 +534,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
                 return false;
             }
 
+            if (PlatformDetection.IsBrowser)
+            {
+                // Browser doesn't support PSS or RSA at all.
+                return false;
+            }
+
             using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             using (RSA rsa = cert.GetRSAPrivateKey())
             {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/SignatureSupport.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/SignatureSupport.cs
@@ -13,7 +13,23 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         //
         // If there's ever a platform that blocks RSASSA+SHA-1 but doesn't block ECDSA or DSA with SHA-1,
         // the logic here will need to get more complicated.
-        public static bool SupportsX509Sha1Signatures { get; } =
-            System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(RSA.Create());
+        public static bool SupportsX509Sha1Signatures { get; } = GetSupportsX509Sha1Signatures();
+
+
+        private static bool GetSupportsX509Sha1Signatures()
+        {
+            RSA rsa;
+
+            try
+            {
+                rsa = RSA.Create();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return false;
+            }
+
+            return System.Security.Cryptography.Tests.SignatureSupport.CanProduceSha1Signature(rsa);
+        }
     }
 }


### PR DESCRIPTION
When Browser is doing test discovery, it now more eagerly reads some static initialization that we were previously depending on conditionals preventing.

This changes the initialization to handle platform not supported in more scenarios.

Fixes #94820 