### PR TITLE
Catch exception when subscribing to NetworkChange

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -174,9 +174,29 @@ namespace System.Net.Http
                 return;
             }
 
-            using (ExecutionContext.SuppressFlow())
+            // RFC: https://tools.ietf.org/html/rfc7838#section-2.2
+            //    When alternative services are used to send a client to the most
+            //    optimal server, a change in network configuration can result in
+            //    cached values becoming suboptimal.  Therefore, clients SHOULD remove
+            //    from cache all alternative services that lack the "persist" flag with
+            //    the value "1" when they detect such a change, when information about
+            //    network state is available.
+            try
             {
-                NetworkChange.NetworkAddressChanged += networkChangedDelegate;
+                using (ExecutionContext.SuppressFlow())
+                {
+                    NetworkChange.NetworkAddressChanged += networkChangedDelegate;
+                }
+            }
+            catch (Exception e)
+            {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Exception when subscribing to NetworkChange.NetworkAddressChanged: {e}");
+
+                // We can't monitor network changes, so technically "information
+                // about network state is not available" and we can just keep
+                // all Alt-Svc entries until their expiration time.
+                //
+                // keep the _networkChangeCleanup field null so we don't try again needlessly
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -188,7 +188,7 @@ namespace System.Net.Http
                     NetworkChange.NetworkAddressChanged += networkChangedDelegate;
                 }
             }
-            catch (Exception e)
+            catch (NetworkInformationException e)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Exception when subscribing to NetworkChange.NetworkAddressChanged: {e}");
 
@@ -196,7 +196,7 @@ namespace System.Net.Http
                 // about network state is not available" and we can just keep
                 // all Alt-Svc entries until their expiration time.
                 //
-                // keep the _networkChangeCleanup field null so we don't try again needlessly
+                // keep the _networkChangeCleanup field assigned so we don't try again needlessly
             }
         }
 


### PR DESCRIPTION
Fixes #94794.

We can simply swallow the exception and not monitor network changes. RFC allows us to.

RFC: https://tools.ietf.org/html/rfc7838#section-2.2

> When alternative services are used to send a client to the most
optimal server, a change in network configuration can result in
cached values becoming suboptimal.  Therefore, clients SHOULD remove
from cache all alternative services that lack the "persist" flag with
the value "1" **when they detect such a change, when information about
network state is available.**

