### PR TITLE
[NativeAOT] Fix Lock's usage of NativeRuntimeEventSource.Log to account for recursive accesses during its own class construction

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -173,7 +173,7 @@ namespace System.Threading
                 s_minSpinCount = DetermineMinSpinCount();
 
                 // Also initialize some types that are used later to prevent potential class construction cycles
-                NativeRuntimeEventSource.Log.IsEnabled();
+                _ = NativeRuntimeEventSource.Log;
             }
             catch
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -444,9 +444,9 @@ namespace System.Threading
 
         Wait:
             bool areContentionEventsEnabled =
-                NativeRuntimeEventSource.Log.IsEnabled(
+                NativeRuntimeEventSource.Log?.IsEnabled(
                     EventLevel.Informational,
-                    NativeRuntimeEventSource.Keywords.ContentionKeyword);
+                    NativeRuntimeEventSource.Keywords.ContentionKeyword) ?? false;
             AutoResetEvent waitEvent = _waitEvent ?? CreateWaitEvent(areContentionEventsEnabled);
             if (State.TryLockBeforeWait(this))
             {
@@ -463,7 +463,7 @@ namespace System.Threading
                 long waitStartTimeTicks = 0;
                 if (areContentionEventsEnabled)
                 {
-                    NativeRuntimeEventSource.Log.ContentionStart(this);
+                    NativeRuntimeEventSource.Log!.ContentionStart(this);
                     waitStartTimeTicks = Stopwatch.GetTimestamp();
                 }
 
@@ -535,7 +535,7 @@ namespace System.Threading
                     {
                         double waitDurationNs =
                             (Stopwatch.GetTimestamp() - waitStartTimeTicks) * 1_000_000_000.0 / Stopwatch.Frequency;
-                        NativeRuntimeEventSource.Log.ContentionStop(waitDurationNs);
+                        NativeRuntimeEventSource.Log!.ContentionStop(waitDurationNs);
                     }
 
                     return currentThreadId;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -132,6 +132,12 @@ namespace System.Threading
 #if !CORECLR // CoreCLR sends the wait events from the native side
                     bool sendWaitEvents =
                         millisecondsTimeout != 0 &&
+#if NATIVEAOT
+                        // A null check is necessary in NativeAOT due to the possibility of reentrance during class
+                        // construction, as this path can be reached through Lock. See
+                        // https://github.com/dotnet/runtime/issues/94728 for a call stack.
+                        NativeRuntimeEventSource.Log != null &&
+#endif
                         NativeRuntimeEventSource.Log.IsEnabled(
                             EventLevel.Verbose,
                             NativeRuntimeEventSource.Keywords.WaitHandleKeyword);


### PR DESCRIPTION
`NativeRuntimeEventSource.Log` can be null if it's being constructed in the same thread earlier in the stack. Added null checks.

Fixes https://github.com/dotnet/runtime/issues/94728