### PR TITLE
Don't put any modifiers after ref

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
@@ -98,12 +98,22 @@ namespace Microsoft.Interop
         public static SyntaxTokenList AddToModifiers(this SyntaxTokenList modifiers, SyntaxKind modifierToAdd)
         {
             if (modifiers.IndexOf(modifierToAdd) >= 0)
+            {
                 return modifiers;
+            }
 
-            int idx = modifiers.IndexOf(SyntaxKind.PartialKeyword);
-            return idx >= 0
-                ? modifiers.Insert(idx, SyntaxFactory.Token(modifierToAdd))
-                : modifiers.Add(SyntaxFactory.Token(modifierToAdd));
+            int idxPartial = modifiers.IndexOf(SyntaxKind.PartialKeyword);
+            int idxRef = modifiers.IndexOf(SyntaxKind.RefKeyword);
+
+            int idxInsert = (idxPartial, idxRef) switch
+            {
+                (-1, -1) => modifiers.Count,
+                (-1, _) => idxRef,
+                (_, -1) => idxPartial,
+                (_, _) => Math.Min(idxPartial, idxRef)
+            };
+
+            return modifiers.Insert(idxInsert, SyntaxFactory.Token(modifierToAdd));
         }
 
         public static bool IsInPartialContext(this TypeDeclarationSyntax syntax, [NotNullWhen(false)] out SyntaxToken? nonPartialIdentifier)

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SyntaxExtensions.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Interop
                 return modifiers;
             }
 
+            // https://github.com/dotnet/csharplang/blob/main/meetings/2018/LDM-2018-04-04.md#ordering-of-ref-and-partial-keywords
             int idxPartial = modifiers.IndexOf(SyntaxKind.PartialKeyword);
             int idxRef = modifiers.IndexOf(SyntaxKind.RefKeyword);
 

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -374,6 +374,54 @@ namespace LibraryImportGenerator.UnitTests
             }
             """;
 
+        public static string LibraryImportInRefStruct = """
+            using System;
+            using System.Runtime.InteropServices;
+
+            public static partial class MyClass
+            {
+                public ref partial struct RSPublic
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+
+                internal ref partial struct RSInternal
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+
+                private ref partial struct RSPrivate
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+            }
+
+            public ref partial struct RSContainer
+            {
+                public ref partial struct RSPublic
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+
+                internal ref partial struct RSInternal
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+
+                private ref partial struct RSPrivate
+                {
+                    [LibraryImport("DNE")]
+                    public static partial int Method();
+                }
+            }
+
+        """;
+
         public static readonly string DisableRuntimeMarshalling = "[assembly:System.Runtime.CompilerServices.DisableRuntimeMarshalling]";
 
         public static readonly string UsingSystemRuntimeInteropServicesMarshalling = "using System.Runtime.InteropServices.Marshalling;";

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -382,19 +382,19 @@ namespace LibraryImportGenerator.UnitTests
             {
                 public ref partial struct RSPublic
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
 
                 internal ref partial struct RSInternal
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
 
                 private ref partial struct RSPrivate
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
             }
@@ -403,19 +403,19 @@ namespace LibraryImportGenerator.UnitTests
             {
                 public ref partial struct RSPublic
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
 
                 internal ref partial struct RSInternal
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
 
                 private ref partial struct RSPrivate
                 {
-                    [LibraryImport("DNE")]
+                    [LibraryImport("DoesNotExist")]
                     public static partial int Method();
                 }
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -28,7 +28,10 @@ namespace LibraryImportGenerator.UnitTests
             [CallerLineNumber] int lineNumber = 0,
             [CallerFilePath] string? filePath = null)
             => TestUtils.GetFileLineName(lineNumber, filePath);
-
+        public static IEnumerable<object[]> MyTests()
+        {
+            yield return new[] { ID(), CodeSnippets.LibraryImportInRefStruct };
+        }
         public static IEnumerable<object[]> CodeSnippetsToCompile()
         {
             yield return new[] { ID(), CodeSnippets.TrivialClassDeclarations };
@@ -41,6 +44,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { ID(), CodeSnippets.AllLibraryImportNamedArguments };
             yield return new[] { ID(), CodeSnippets.DefaultParameters };
             yield return new[] { ID(), CodeSnippets.UseCSharpFeaturesForConstants };
+            yield return new[] { ID(), CodeSnippets.LibraryImportInRefStruct };
 
             // Parameter / return types
             yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<byte>() };
@@ -439,8 +443,10 @@ namespace LibraryImportGenerator.UnitTests
         }
 
         [Theory]
-        [MemberData(nameof(CodeSnippetsToCompile))]
-        [MemberData(nameof(CustomCollections))]
+        //[MemberData(nameof(CodeSnippetsToCompile))]
+        //[MemberData(nameof(CustomCollections))]
+        [MemberData(nameof(MyTests))]
+
         public async Task ValidateSnippets(string id, string source)
         {
             TestUtils.Use(id);

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -28,10 +28,7 @@ namespace LibraryImportGenerator.UnitTests
             [CallerLineNumber] int lineNumber = 0,
             [CallerFilePath] string? filePath = null)
             => TestUtils.GetFileLineName(lineNumber, filePath);
-        public static IEnumerable<object[]> MyTests()
-        {
-            yield return new[] { ID(), CodeSnippets.LibraryImportInRefStruct };
-        }
+
         public static IEnumerable<object[]> CodeSnippetsToCompile()
         {
             yield return new[] { ID(), CodeSnippets.TrivialClassDeclarations };
@@ -443,10 +440,8 @@ namespace LibraryImportGenerator.UnitTests
         }
 
         [Theory]
-        //[MemberData(nameof(CodeSnippetsToCompile))]
-        //[MemberData(nameof(CustomCollections))]
-        [MemberData(nameof(MyTests))]
-
+        [MemberData(nameof(CodeSnippetsToCompile))]
+        [MemberData(nameof(CustomCollections))]
         public async Task ValidateSnippets(string id, string source)
         {
             TestUtils.Use(id);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94840.

We need to make sure we don't add the unsafe modifier after the `ref` keyword. We'll insert at the min index of `partial` and `ref` keyword.