### PR TITLE
Revert "Update to the latest dotnet/command-line-api version"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -80,13 +80,13 @@
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>4db411bed3b4f48dfb4ed59629a0dc1d23e724e6</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23407.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.440701">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759b</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.23509.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <optimizationPGOCoreCLRVersion>1.0.0-prerelease.23559.3</optimizationPGOCoreCLRVersion>
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderNativeVersion>16.11.29-beta1.23404.4</MicrosoftDiaSymReaderNativeVersion>
-    <SystemCommandLineVersion>2.0.0-beta4.23407.1</SystemCommandLineVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
     <TraceEventVersion>3.0.3</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -127,7 +127,7 @@ namespace System.CommandLine
             return command;
         }
 
-        public static CliRootCommand UseExtendedHelp(this CliRootCommand command, Func<HelpContext, IEnumerable<Func<HelpContext, bool>>> customizer)
+        public static CliRootCommand UseExtendedHelp(this CliRootCommand command, Func<HelpContext, IEnumerable<Action<HelpContext>>> customizer)
         {
             foreach (CliOption option in command.Options)
             {

--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -481,7 +481,8 @@ namespace ILVerify
         private static int Main(string[] args) =>
             new CliConfiguration(new ILVerifyRootCommand().UseVersion())
             {
-                ResponseFileTokenReplacer = Helpers.TryReadResponseFile
+                ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
+                EnableParseErrorReporting = true
             }.Invoke(args);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -298,9 +298,9 @@ namespace ILCompiler
             });
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext _)
+        public static IEnumerable<Action<HelpContext>> GetExtendedHelp(HelpContext _)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
+            foreach (Action<HelpContext> sectionDelegate in HelpBuilder.Default.GetLayout())
                 yield return sectionDelegate;
 
             yield return _ =>
@@ -354,7 +354,6 @@ namespace ILCompiler
                 Console.WriteLine();
                 Console.WriteLine("The following CPU names are predefined groups of instruction sets and can be used in --instruction-set too:");
                 Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
-                return true;
             };
         }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -738,7 +738,8 @@ namespace ILCompiler
                 .UseVersion()
                 .UseExtendedHelp(ILCompilerRootCommand.GetExtendedHelp))
             {
-                ResponseFileTokenReplacer = Helpers.TryReadResponseFile
+                ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
+                EnableParseErrorReporting = true
             }.Invoke(args);
     }
 }

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -282,9 +282,9 @@ namespace ILCompiler
             });
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext _)
+        public static IEnumerable<Action<HelpContext>> GetExtendedHelp(HelpContext _)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
+            foreach (Action<HelpContext> sectionDelegate in HelpBuilder.Default.GetLayout())
                 yield return sectionDelegate;
 
             yield return _ =>
@@ -343,7 +343,6 @@ namespace ILCompiler
                 Console.WriteLine();
                 Console.WriteLine(SR.CpuFamilies);
                 Console.WriteLine(string.Join(", ", Internal.JitInterface.InstructionSetFlags.AllCpuNames));
-                return true;
             };
         }
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -915,7 +915,8 @@ namespace ILCompiler
                 .UseVersion()
                 .UseExtendedHelp(Crossgen2RootCommand.GetExtendedHelp))
             {
-                ResponseFileTokenReplacer = Helpers.TryReadResponseFile
+                ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
+                EnableParseErrorReporting = true
             }.Invoke(args);
     }
 }

--- a/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
+++ b/src/coreclr/tools/dotnet-pgo/PgoRootCommand.cs
@@ -260,9 +260,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo
             }
         }
 
-        public static IEnumerable<Func<HelpContext, bool>> GetExtendedHelp(HelpContext context)
+        public static IEnumerable<Action<HelpContext>> GetExtendedHelp(HelpContext context)
         {
-            foreach (Func<HelpContext, bool> sectionDelegate in HelpBuilder.Default.GetLayout())
+            foreach (Action<HelpContext> sectionDelegate in HelpBuilder.Default.GetLayout())
                 yield return sectionDelegate;
 
             if (context.Command.Name == "create-mibc" || context.Command.Name == "create-jittrace")
@@ -280,7 +280,6 @@ namespace Microsoft.Diagnostics.Tools.Pgo
 ""perfview collect -LogFile:logOfCollection.txt -DataFile:jittrace.etl -Zip:false -merge:false -providers:Microsoft-Windows-DotNETRuntime:0x1E000080018:4""
 - Capture Jit and R2R events via perfview of all processes running using ETW tracing
 ");
-                    return true;
                 };
             }
         }

--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 .UseVersion()
                 .UseExtendedHelp(PgoRootCommand.GetExtendedHelp))
             {
-                ResponseFileTokenReplacer = Helpers.TryReadResponseFile
+                ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
+                EnableParseErrorReporting = true
             }.Invoke(args);
 
         public static void PrintWarning(string warning)

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -500,7 +500,8 @@ namespace R2RDump
         public static int Main(string[] args) =>
             new CliConfiguration(new R2RDumpRootCommand().UseVersion())
             {
-                ResponseFileTokenReplacer = Helpers.TryReadResponseFile
+                ResponseFileTokenReplacer = Helpers.TryReadResponseFile,
+                EnableParseErrorReporting = true
             }.Invoke(args);
     }
 }

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -299,7 +299,10 @@ namespace R2RTest
             new CliOption<DirectoryInfo>("--asp-net-path", "-asp") { Description = "Path to SERP's ASP.NET Core folder" }.AcceptExistingOnly();
 
         private static int Main(string[] args) =>
-            new CliConfiguration(new R2RTestRootCommand().UseVersion()).Invoke(args);
+            new CliConfiguration(new R2RTestRootCommand().UseVersion())
+            {
+                EnableParseErrorReporting = true
+            }.Invoke(args);
     }
 
     public partial class BuildOptions


### PR DESCRIPTION
Reverts dotnet/runtime#94746

These changes are part of a coordinated dependency update, so they need to be merged at the same time. This was merged ahead of time. The other PRs are:
- Roslyn: https://github.com/dotnet/roslyn/pull/70817
- Format: https://github.com/dotnet/format/pull/2026