### PR TITLE
JIT: Added DOTNET_JitRawHexCode/JitRawHexCodeFile

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2120,7 +2120,6 @@ void CodeGen::genEmitUnwindDebugGCandEH()
             FILE* dmpf = jitstdout();
 
             fprintf(dmpf, "Generated native code for %s:\n", compiler->info.compFullName);
-            fprintf(dmpf, "\n");
             hexDump(dmpf, addr, codeSize);
             fprintf(dmpf, "\n\n");
         }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2098,21 +2098,31 @@ void CodeGen::genEmitUnwindDebugGCandEH()
 #endif // LATE_DISASM
 
 #ifdef DEBUG
-    if ((compiler->opts.disAsm || compiler->verbose) && compiler->opts.disAsmHexDumpFile)
+    if (JitConfig.JitRawHexCode().contains(compiler->info.compMethodHnd, compiler->info.compClassHnd,
+                                           &compiler->info.compMethodInfo->args))
     {
-        FILE*   hexDmpf;
-        errno_t ec = _wfopen_s(&hexDmpf, compiler->opts.disAsmHexDumpFile, W("at")); // NOTE: file append mode
-        if (ec == 0)
+        BYTE* addr = (BYTE*)*codePtr + compiler->GetEmitter()->writeableOffset;
+
+        const WCHAR* rawHexCodeFilePath = JitConfig.JitRawHexCodeFile();
+        if (rawHexCodeFilePath)
         {
-            assert(hexDmpf);
-
-            BYTE* addr = (BYTE*)*codePtr + compiler->GetEmitter()->writeableOffset;
-            for (unsigned int i = 0; i < codeSize; i++)
+            FILE*   hexDmpf;
+            errno_t ec = _wfopen_s(&hexDmpf, rawHexCodeFilePath, W("at")); // NOTE: file append mode
+            if (ec == 0)
             {
-                fprintf(hexDmpf, "%02X", *addr++);
+                assert(hexDmpf);
+                hexDump(hexDmpf, addr, codeSize);
+                fclose(hexDmpf);
             }
+        }
+        else
+        {
+            FILE* dmpf = jitstdout();
 
-            fclose(hexDmpf);
+            fprintf(dmpf, "Generated native code for %s:\n", compiler->info.compFullName);
+            fprintf(dmpf, "\n");
+            hexDump(dmpf, addr, codeSize);
+            fprintf(dmpf, "\n\n");
         }
     }
 #endif // DEBUG
@@ -2121,74 +2131,8 @@ void CodeGen::genEmitUnwindDebugGCandEH()
 
     genReportEH();
 
-#ifdef JIT32_GCENCODER
-#ifdef DEBUG
-    void* infoPtr =
-#endif // DEBUG
-#endif
-        // Create and store the GC info for this method.
-        genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
-
-#ifdef DEBUG
-    FILE* dmpf = jitstdout();
-
-    compiler->opts.dmpHex = false;
-    if (!strcmp(compiler->info.compMethodName, "<name of method you want the hex dump for"))
-    {
-        FILE*   codf;
-        errno_t ec = fopen_s(&codf, "C:\\JIT.COD", "at"); // NOTE: file append mode
-        if (ec != 0)
-        {
-            assert(codf);
-            dmpf                  = codf;
-            compiler->opts.dmpHex = true;
-        }
-    }
-    if (compiler->opts.dmpHex)
-    {
-        size_t consSize = GetEmitter()->emitDataSize();
-
-        fprintf(dmpf, "Generated code for %s:\n", compiler->info.compFullName);
-        fprintf(dmpf, "\n");
-
-        if (codeSize)
-        {
-            fprintf(dmpf, "    Code  at %p [%04X bytes]\n", dspPtr(*codePtr), codeSize);
-        }
-        if (consSize)
-        {
-            fprintf(dmpf, "    Const at %p [%04X bytes]\n", dspPtr(consPtr), consSize);
-        }
-#ifdef JIT32_GCENCODER
-        size_t infoSize = compiler->compInfoBlkSize;
-        if (infoSize)
-            fprintf(dmpf, "    Info  at %p [%04X bytes]\n", dspPtr(infoPtr), infoSize);
-#endif // JIT32_GCENCODER
-
-        fprintf(dmpf, "\n");
-
-        if (codeSize)
-        {
-            hexDump(dmpf, "Code", (BYTE*)*codePtr, codeSize);
-        }
-        if (consSize)
-        {
-            hexDump(dmpf, "Const", (BYTE*)consPtr, consSize);
-        }
-#ifdef JIT32_GCENCODER
-        if (infoSize)
-            hexDump(dmpf, "Info", (BYTE*)infoPtr, infoSize);
-#endif // JIT32_GCENCODER
-
-        fflush(dmpf);
-    }
-
-    if (dmpf != jitstdout())
-    {
-        fclose(dmpf);
-    }
-
-#endif // DEBUG
+    // Create and store the GC info for this method.
+    genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 
     /* Tell the emitter that we're done with this function */
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2097,6 +2097,26 @@ void CodeGen::genEmitUnwindDebugGCandEH()
     getDisAssembler().disAsmCode((BYTE*)*codePtr, finalHotCodeSize, (BYTE*)coldCodePtr, finalColdCodeSize);
 #endif // LATE_DISASM
 
+#ifdef DEBUG
+    if ((compiler->opts.disAsm || compiler->verbose) && compiler->opts.disAsmHexDumpFile)
+    {
+        FILE*   hexDmpf;
+        errno_t ec = _wfopen_s(&hexDmpf, compiler->opts.disAsmHexDumpFile, W("at")); // NOTE: file append mode
+        if (ec == 0)
+        {
+            assert(hexDmpf);
+
+            BYTE* addr = (BYTE*)*codePtr + compiler->GetEmitter()->writeableOffset;
+            for (unsigned int i = 0; i < codeSize; i++)
+            {
+                fprintf(hexDmpf, "%02X", *addr++);
+            }
+
+            fclose(hexDmpf);
+        }
+    }
+#endif // DEBUG
+
     /* Report any exception handlers to the VM */
 
     genReportEH();

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2835,7 +2835,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.dspInstrs       = false;
     opts.dspLines        = false;
     opts.varNames        = false;
-    opts.dmpHex          = false;
     opts.disAsmSpilled   = false;
     opts.disAddr         = false;
     opts.dspCode         = false;
@@ -2846,8 +2845,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.dspUnwind       = false;
     opts.compLongAddress = false;
     opts.optRepeat       = false;
-
-    opts.disAsmHexDumpFile = nullptr;
 
 #ifdef LATE_DISASM
     opts.doLateDisasm = false;
@@ -2932,12 +2929,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         if (JitConfig.JitLateDisasm().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args))
             opts.doLateDisasm = true;
 #endif // LATE_DISASM
-
-        const WCHAR* disAsmHexDumpFile = JitConfig.JitDisasmHexDumpFile();
-        if (disAsmHexDumpFile != nullptr)
-        {
-            opts.disAsmHexDumpFile = disAsmHexDumpFile;
-        }
 
         // This one applies to both Ngen/Jit Disasm output: DOTNET_JitDasmWithAddress=1
         if (JitConfig.JitDasmWithAddress() != 0)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2847,6 +2847,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.compLongAddress = false;
     opts.optRepeat       = false;
 
+    opts.disAsmHexDumpFile = nullptr;
+
 #ifdef LATE_DISASM
     opts.doLateDisasm = false;
 #endif // LATE_DISASM
@@ -2930,6 +2932,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         if (JitConfig.JitLateDisasm().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args))
             opts.doLateDisasm = true;
 #endif // LATE_DISASM
+
+        const WCHAR* disAsmHexDumpFile = JitConfig.JitDisasmHexDumpFile();
+        if (disAsmHexDumpFile != nullptr)
+        {
+            opts.disAsmHexDumpFile = disAsmHexDumpFile;
+        }
 
         // This one applies to both Ngen/Jit Disasm output: DOTNET_JitDasmWithAddress=1
         if (JitConfig.JitDasmWithAddress() != 0)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9705,23 +9705,24 @@ public:
         bool disAlignment; // Display alignment boundaries in disassembly code
         bool disCodeBytes; // Display instruction code bytes in disassembly code
 #ifdef DEBUG
-        bool compProcedureSplittingEH; // Separate cold code from hot code for functions with EH
-        bool dspCode;                  // Display native code generated
-        bool dspEHTable;               // Display the EH table reported to the VM
-        bool dspDebugInfo;             // Display the Debug info reported to the VM
-        bool dspInstrs;                // Display the IL instructions intermixed with the native code output
-        bool dspLines;                 // Display source-code lines intermixed with native code output
-        bool dmpHex;                   // Display raw bytes in hex of native code output
-        bool varNames;                 // Display variables names in native code output
-        bool disAsmSpilled;            // Display native code when any register spilling occurs
-        bool disasmWithGC;             // Display GC info interleaved with disassembly.
-        bool disAddr;                  // Display process address next to each instruction in disassembly code
-        bool disAsm2;                  // Display native code after it is generated using external disassembler
-        bool dspOrder;                 // Display names of each of the methods that we ngen/jit
-        bool dspUnwind;                // Display the unwind info output
-        bool compLongAddress;          // Force using large pseudo instructions for long address
-                                       // (IF_LARGEJMP/IF_LARGEADR/IF_LARGLDC)
-        bool dspGCtbls;                // Display the GC tables
+        bool compProcedureSplittingEH;  // Separate cold code from hot code for functions with EH
+        bool dspCode;                   // Display native code generated
+        bool dspEHTable;                // Display the EH table reported to the VM
+        bool dspDebugInfo;              // Display the Debug info reported to the VM
+        bool dspInstrs;                 // Display the IL instructions intermixed with the native code output
+        bool dspLines;                  // Display source-code lines intermixed with native code output
+        bool dmpHex;                    // Display raw bytes in hex of native code output
+        bool varNames;                  // Display variables names in native code output
+        bool disAsmSpilled;             // Display native code when any register spilling occurs
+        bool disasmWithGC;              // Display GC info interleaved with disassembly.
+        bool disAddr;                   // Display process address next to each instruction in disassembly code
+        bool disAsm2;                   // Display native code after it is generated using external disassembler
+        bool dspOrder;                  // Display names of each of the methods that we ngen/jit
+        bool dspUnwind;                 // Display the unwind info output
+        bool compLongAddress;           // Force using large pseudo instructions for long address
+                                        // (IF_LARGEJMP/IF_LARGEADR/IF_LARGLDC)
+        bool dspGCtbls;                 // Display the GC tables
+        const WCHAR* disAsmHexDumpFile; // Writes the raw bytes in hex of native code to the specified file
 #endif
 
 // Default numbers used to perform loop alignment. All the numbers are chosen

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9705,24 +9705,22 @@ public:
         bool disAlignment; // Display alignment boundaries in disassembly code
         bool disCodeBytes; // Display instruction code bytes in disassembly code
 #ifdef DEBUG
-        bool compProcedureSplittingEH;  // Separate cold code from hot code for functions with EH
-        bool dspCode;                   // Display native code generated
-        bool dspEHTable;                // Display the EH table reported to the VM
-        bool dspDebugInfo;              // Display the Debug info reported to the VM
-        bool dspInstrs;                 // Display the IL instructions intermixed with the native code output
-        bool dspLines;                  // Display source-code lines intermixed with native code output
-        bool dmpHex;                    // Display raw bytes in hex of native code output
-        bool varNames;                  // Display variables names in native code output
-        bool disAsmSpilled;             // Display native code when any register spilling occurs
-        bool disasmWithGC;              // Display GC info interleaved with disassembly.
-        bool disAddr;                   // Display process address next to each instruction in disassembly code
-        bool disAsm2;                   // Display native code after it is generated using external disassembler
-        bool dspOrder;                  // Display names of each of the methods that we ngen/jit
-        bool dspUnwind;                 // Display the unwind info output
-        bool compLongAddress;           // Force using large pseudo instructions for long address
-                                        // (IF_LARGEJMP/IF_LARGEADR/IF_LARGLDC)
-        bool dspGCtbls;                 // Display the GC tables
-        const WCHAR* disAsmHexDumpFile; // Writes the raw bytes in hex of native code to the specified file
+        bool compProcedureSplittingEH; // Separate cold code from hot code for functions with EH
+        bool dspCode;                  // Display native code generated
+        bool dspEHTable;               // Display the EH table reported to the VM
+        bool dspDebugInfo;             // Display the Debug info reported to the VM
+        bool dspInstrs;                // Display the IL instructions intermixed with the native code output
+        bool dspLines;                 // Display source-code lines intermixed with native code output
+        bool varNames;                 // Display variables names in native code output
+        bool disAsmSpilled;            // Display native code when any register spilling occurs
+        bool disasmWithGC;             // Display GC info interleaved with disassembly.
+        bool disAddr;                  // Display process address next to each instruction in disassembly code
+        bool disAsm2;                  // Display native code after it is generated using external disassembler
+        bool dspOrder;                 // Display names of each of the methods that we ngen/jit
+        bool dspUnwind;                // Display the unwind info output
+        bool compLongAddress;          // Force using large pseudo instructions for long address
+                                       // (IF_LARGEJMP/IF_LARGEADR/IF_LARGLDC)
+        bool dspGCtbls;                // Display the GC tables
 #endif
 
 // Default numbers used to perform loop alignment. All the numbers are chosen

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -677,6 +677,10 @@ CONFIG_STRING(JitFunctionFile, W("JitFunctionFile"))
 #endif // DEBUG
 
 #if defined(DEBUG)
+CONFIG_STRING(JitDisasmHexDumpFile, W("JitDisasmHexDumpFile"))
+#endif // DEBUG
+
+#if defined(DEBUG)
 #if defined(TARGET_ARM64)
 // JitSaveFpLrWithCalleeSavedRegisters:
 //    0: use default frame type decision

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -677,7 +677,8 @@ CONFIG_STRING(JitFunctionFile, W("JitFunctionFile"))
 #endif // DEBUG
 
 #if defined(DEBUG)
-CONFIG_STRING(JitDisasmHexDumpFile, W("JitDisasmHexDumpFile"))
+CONFIG_METHODSET(JitRawHexCode, W("JitRawHexCode"))
+CONFIG_STRING(JitRawHexCodeFile, W("JitRawHexCodeFile"))
 #endif // DEBUG
 
 #if defined(DEBUG)

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1319,7 +1319,7 @@ int SimpleSprintf_s(_In_reads_(cbBufSize - (pWriteStart - pBufStart)) char* pWri
 
 #ifdef DEBUG
 
-void hexDump(FILE* dmpf, const char* name, BYTE* addr, size_t size)
+void hexDump(FILE* dmpf, BYTE* addr, size_t size)
 {
     if (!size)
     {
@@ -1328,19 +1328,10 @@ void hexDump(FILE* dmpf, const char* name, BYTE* addr, size_t size)
 
     assert(addr);
 
-    fprintf(dmpf, "Hex dump of %s:\n", name);
-
     for (unsigned i = 0; i < size; i++)
     {
-        if ((i % 16) == 0)
-        {
-            fprintf(dmpf, "\n    %04X: ", i);
-        }
-
-        fprintf(dmpf, "%02X ", *addr++);
+        fprintf(dmpf, "%02X", *addr++);
     }
-
-    fprintf(dmpf, "\n\n");
 }
 
 #endif // DEBUG

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -321,7 +321,7 @@ int SimpleSprintf_s(_In_reads_(cbBufSize - (pWriteStart - pBufStart)) char* pWri
                     ...);
 
 #ifdef DEBUG
-void hexDump(FILE* dmpf, const char* name, BYTE* addr, size_t size);
+void hexDump(FILE* dmpf, BYTE* addr, size_t size);
 #endif // DEBUG
 
 /******************************************************************************

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -86,7 +86,8 @@ bool RecordVariable(const WCHAR* key)
         W("JitInlinePolicyDumpXml"),
         W("JitInlineReplayFile"),
         W("JitFunctionFile")
-        W("JitDisasmHexDumpFile")
+        W("JitRawHexCode"),
+        W("JitRawHexCodeFile")
     };
 
     for (const WCHAR* ignoredVar : s_ignoredVars)

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -86,6 +86,7 @@ bool RecordVariable(const WCHAR* key)
         W("JitInlinePolicyDumpXml"),
         W("JitInlineReplayFile"),
         W("JitFunctionFile")
+        W("JitDisasmHexDumpFile")
     };
 
     for (const WCHAR* ignoredVar : s_ignoredVars)


### PR DESCRIPTION
This adds a new environment variable, `DOTNET_JitRawHexCode/JitRawHexCodeFile`, in Debug/Checked builds that will enable writing the native code in hex to given file or stdout.