### PR TITLE
Permit MD5 regardless of FIPS configuration for Linux

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -347,6 +347,7 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t len);
     REQUIRED_FUNCTION(EVP_MD_CTX_copy_ex) \
     RENAMED_FUNCTION(EVP_MD_CTX_free, EVP_MD_CTX_destroy) \
     RENAMED_FUNCTION(EVP_MD_CTX_new, EVP_MD_CTX_create) \
+    REQUIRED_FUNCTION(EVP_MD_CTX_set_flags) \
     LIGHTUP_FUNCTION(EVP_MD_fetch) \
     RENAMED_FUNCTION(EVP_MD_get_size, EVP_MD_size) \
     REQUIRED_FUNCTION(EVP_PKCS82PKEY) \
@@ -843,6 +844,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_MD_CTX_copy_ex EVP_MD_CTX_copy_ex_ptr
 #define EVP_MD_CTX_free EVP_MD_CTX_free_ptr
 #define EVP_MD_CTX_new EVP_MD_CTX_new_ptr
+#define EVP_MD_CTX_set_flags EVP_MD_CTX_set_flags_ptr
 #define EVP_MD_fetch EVP_MD_fetch_ptr
 #define EVP_MD_get_size EVP_MD_get_size_ptr
 #define EVP_PKCS82PKEY EVP_PKCS82PKEY_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -347,6 +347,7 @@ int EVP_DigestFinalXOF(EVP_MD_CTX *ctx, unsigned char *md, size_t len);
     REQUIRED_FUNCTION(EVP_MD_CTX_copy_ex) \
     RENAMED_FUNCTION(EVP_MD_CTX_free, EVP_MD_CTX_destroy) \
     RENAMED_FUNCTION(EVP_MD_CTX_new, EVP_MD_CTX_create) \
+    LIGHTUP_FUNCTION(EVP_MD_fetch) \
     RENAMED_FUNCTION(EVP_MD_get_size, EVP_MD_size) \
     REQUIRED_FUNCTION(EVP_PKCS82PKEY) \
     REQUIRED_FUNCTION(EVP_PKEY2PKCS8) \
@@ -842,6 +843,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_MD_CTX_copy_ex EVP_MD_CTX_copy_ex_ptr
 #define EVP_MD_CTX_free EVP_MD_CTX_free_ptr
 #define EVP_MD_CTX_new EVP_MD_CTX_new_ptr
+#define EVP_MD_fetch EVP_MD_fetch_ptr
 #define EVP_MD_get_size EVP_MD_get_size_ptr
 #define EVP_PKCS82PKEY EVP_PKCS82PKEY_ptr
 #define EVP_PKEY2PKCS8 EVP_PKEY2PKCS8_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/osslcompat_30.h
+++ b/src/native/libs/System.Security.Cryptography.Native/osslcompat_30.h
@@ -19,6 +19,7 @@ void ERR_new(void);
 void ERR_set_debug(const char *file, int line, const char *func);
 void ERR_set_error(int lib, int reason, const char *fmt, ...);
 int EVP_CIPHER_get_nid(const EVP_CIPHER *e);
+EVP_MD* EVP_MD_fetch(OSSL_LIB_CTX *ctx, const char *algorithm, const char *properties);
 int EVP_MD_get_size(const EVP_MD* md);
 int EVP_PKEY_CTX_set_rsa_keygen_bits(EVP_PKEY_CTX* ctx, int bits);
 int EVP_PKEY_CTX_set_rsa_oaep_md(EVP_PKEY_CTX* ctx, const EVP_MD* md);

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp.c
@@ -6,6 +6,7 @@
 #include "pal_utilities.h"
 
 #include <assert.h>
+#include <pthread.h>
 
 #define SUCCESS 1
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp.c
@@ -8,6 +8,32 @@
 
 #define SUCCESS 1
 
+static const EVP_MD* g_evpFetchMd5 = NULL;
+static pthread_once_t g_evpFetch = PTHREAD_ONCE_INIT;
+
+static void EnsureFetchEvpMdAlgorithms(void)
+{
+    // This is called from a pthread_once - this method should not be called directly.
+
+#if NEED_OPENSSL_3_0
+    if (API_EXISTS(EVP_MD_fetch))
+    {
+        ERR_clear_error();
+
+        // Try to fetch an MD5 implementation that will work regardless if
+        // FIPS is enforced or not.
+        g_evpFetchMd5 = EVP_MD_fetch(NULL, "MD5", "-fips");
+    }
+#endif
+
+    // No error queue impact.
+    // If EVP_MD_fetch is unavailable, use the implicit loader. If it failed, use the implicit loader as a last resort.
+    if (g_evpFetchMd5 == NULL)
+    {
+        g_evpFetchMd5 = EVP_md5();
+    }
+}
+
 EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type)
 {
     ERR_clear_error();
@@ -230,8 +256,8 @@ int32_t CryptoNative_EvpMdSize(const EVP_MD* md)
 
 const EVP_MD* CryptoNative_EvpMd5(void)
 {
-    // No error queue impact.
-    return EVP_md5();
+    pthread_once(&g_evpFetch, EnsureFetchEvpMdAlgorithms);
+    return g_evpFetchMd5;
 }
 
 const EVP_MD* CryptoNative_EvpSha1(void)


### PR DESCRIPTION
This changes the native shim to always permit the use of MD5, regardless of whether or not the system is configured to block the use MD5 for FIPS purposes. This is only for the MD5 primitive. HMAC-MD5 remains blocked.

We currently do not have any CI that exercises Linux in this configuration. This was manually verified in RHEL 8 and RHEL 9 for OpenSSL 1.1.1 and OpenSSL 3, respectively.

OpenSSL 1.1.1:

<img width="1457" alt="image" src="https://github.com/dotnet/runtime/assets/361677/03d3c06e-51b7-4b89-a71b-cbba0293d530">

OpenSSL 3.0:

<img width="1454" alt="image" src="https://github.com/dotnet/runtime/assets/361677/2cee6362-8702-4dd1-b2ee-c46eebece826">


/cc @bartonjs @GrabYourPitchforks 