### PR TITLE
Fix option source generator with self-validator classes

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Emitter.cs
@@ -646,10 +646,12 @@ namespace Microsoft.Extensions.Options.Generators
             OutCloseBrace();
         }
 
-        private void GenModelSelfValidationIfNecessary(ValidatedModel modelToValidate)
+        private void GenModelSelfValidationIfNecessary(ValidatedModel modelToValidate, string modelName)
         {
             if (modelToValidate.SelfValidates)
             {
+                OutLn($"context.MemberName = \"Validate\";");
+                OutLn($"context.DisplayName = string.IsNullOrEmpty(name) ? \"{modelName}.Validate\" : $\"{{name}}.Validate\";");
                 OutLn($"(builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));");
                 OutLn();
             }
@@ -682,7 +684,7 @@ namespace Microsoft.Extensions.Options.Generators
             OutLn($"global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;");
             OutLn($"var context = new {StaticValidationContextType}(options);");
 
-            int capacity = modelToValidate.MembersToValidate.Max(static vm => vm.ValidationAttributes.Count);
+            int capacity = modelToValidate.MembersToValidate.Count == 0 ? 0 : modelToValidate.MembersToValidate.Max(static vm => vm.ValidationAttributes.Count);
             if (capacity > 0)
             {
                 OutLn($"var validationResults = new {StaticListType}<{StaticValidationResultType}>();");
@@ -713,7 +715,7 @@ namespace Microsoft.Extensions.Options.Generators
                 }
             }
 
-            GenModelSelfValidationIfNecessary(modelToValidate);
+            GenModelSelfValidationIfNecessary(modelToValidate, modelToValidate.SimpleName);
             OutLn($"return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();");
             OutCloseBrace();
         }

--- a/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Parser.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Extensions.Options.Generators
                                 : syntax.GetLocation();
 
                             var membersToValidate = GetMembersToValidate(modelType, true, lowerLocationInCompilation, validatorType);
-                            if (membersToValidate.Count == 0)
+                            bool selfValidate = ModelSelfValidates(modelType);
+                            if (membersToValidate.Count == 0 && !selfValidate)
                             {
                                 // this type lacks any eligible members
                                 Diag(DiagDescriptors.NoEligibleMembersFromValidator, syntax.GetLocation(), modelType.ToString(), validatorType.ToString());
@@ -113,7 +114,7 @@ namespace Microsoft.Extensions.Options.Generators
                             modelsValidatorTypeValidates.Add(new ValidatedModel(
                                 GetFQN(modelType),
                                 modelType.Name,
-                                ModelSelfValidates(modelType),
+                                selfValidate,
                                 membersToValidate));
                         }
 
@@ -689,8 +690,9 @@ namespace Microsoft.Extensions.Options.Generators
                 return "global::" + validator.Namespace + "." + validator.Name;
             }
 
+            bool selfValidate = ModelSelfValidates(mt);
             var membersToValidate = GetMembersToValidate(mt, true, location, validatorType);
-            if (membersToValidate.Count == 0)
+            if (membersToValidate.Count == 0 && !selfValidate)
             {
                 // this type lacks any eligible members
                 Diag(DiagDescriptors.NoEligibleMember, location, mt.ToString(), member.ToString());
@@ -700,7 +702,7 @@ namespace Microsoft.Extensions.Options.Generators
             var model = new ValidatedModel(
                 GetFQN(mt),
                 mt.Name,
-                ModelSelfValidates(mt),
+                selfValidate,
                 membersToValidate);
 
             var validatorTypeName = "__" + mt.Name + "Validator__";

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetCoreApp/Validators.g.cs
@@ -1182,6 +1182,8 @@ namespace SelfValidation
                 (builder ??= new()).AddResults(validationResults);
             }
 
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.Validate" : $"{name}.Validate";
             (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1231,6 +1233,34 @@ namespace SelfValidation
                 (builder ??= new()).AddResult(global::SelfValidation.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.Validate" : $"{name}.Validate";
+            (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
+
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
+        }
+    }
+}
+namespace SelfValidation
+{
+    partial class SelfValidateOptions
+    {
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null" />).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>Validation result.</returns>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2026:RequiresUnreferencedCode",
+             Justification = "The created ValidationContext object is used in a way that never call reflection")]
+        public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SelfValidation.SelfValidateOptions options)
+        {
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
+            var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
+
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SelfValidateOptions.Validate" : $"{name}.Validate";
             (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Baselines/NetFX/Validators.g.cs
@@ -1124,6 +1124,8 @@ namespace SelfValidation
                 (builder ??= new()).AddResults(validationResults);
             }
 
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SecondModel.Validate" : $"{name}.Validate";
             (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
@@ -1171,6 +1173,32 @@ namespace SelfValidation
                 (builder ??= new()).AddResult(global::SelfValidation.__SecondModelValidator__.Validate(string.IsNullOrEmpty(name) ? "FirstModel.P2" : $"{name}.P2", options.P2));
             }
 
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "FirstModel.Validate" : $"{name}.Validate";
+            (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
+
+            return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();
+        }
+    }
+}
+namespace SelfValidation
+{
+    partial class SelfValidateOptions
+    {
+        /// <summary>
+        /// Validates a specific named options instance (or all when <paramref name="name"/> is <see langword="null" />).
+        /// </summary>
+        /// <param name="name">The name of the options instance being validated.</param>
+        /// <param name="options">The options instance.</param>
+        /// <returns>Validation result.</returns>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Options.SourceGeneration", "42.42.42.42")]
+        public global::Microsoft.Extensions.Options.ValidateOptionsResult Validate(string? name, global::SelfValidation.SelfValidateOptions options)
+        {
+            global::Microsoft.Extensions.Options.ValidateOptionsResultBuilder? builder = null;
+            var context = new global::System.ComponentModel.DataAnnotations.ValidationContext(options);
+
+            context.MemberName = "Validate";
+            context.DisplayName = string.IsNullOrEmpty(name) ? "SelfValidateOptions.Validate" : $"{name}.Validate";
             (builder ??= new()).AddResults(((global::System.ComponentModel.DataAnnotations.IValidatableObject)options).Validate(context));
 
             return builder is null ? global::Microsoft.Extensions.Options.ValidateOptionsResult.Success : builder.Build();

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/SelfValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/SelfValidationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.Extensions.Options;
 using SelfValidation;
 using Xunit;
@@ -41,5 +42,14 @@ public class SelfValidationTests
 
         var validator = default(FirstValidator);
         Assert.Equal(ValidateOptionsResult.Success, validator.Validate("SelfValidation", firstModel));
+    }
+
+    [Fact]
+    public void SelfValidateOptionsTest()
+    {
+        SelfValidateOptions validator = new();
+        ValidateOptionsResult vr = validator.Validate("SelfValidation", validator);
+        Assert.Equal(1, vr.Failures.Count());
+        Assert.Equal($"Display: SelfValidation.Validate, Member: Validate", vr.Failures.First());
     }
 }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/TestClasses/SelfValidation.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/TestClasses/SelfValidation.cs
@@ -50,4 +50,15 @@ namespace SelfValidation
     public partial struct FirstValidator : IValidateOptions<FirstModel>
     {
     }
+
+    // SelfValidateOptions is self validate class as it implements IValidatableObject and contains no properties have ValidationAttribute
+    // Source generator should generate valid code for this class
+    [OptionsValidator]
+    public partial class SelfValidateOptions : IValidateOptions<SelfValidateOptions>, IValidatableObject
+    {
+        public IEnumerable<ValidationResult> Validate(ValidationContext context)
+        {
+            return new[] { new ValidationResult($"Display: {context.DisplayName}, Member: {context.MemberName}") };
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94910
Fixes https://github.com/dotnet/runtime/issues/94912

This modification addresses the handling of options validation source generation for options that implement `IValidatableObject` but lack any properties tagged with the `ValidationAttribute`. The update corrects both the display of validation context and the member's name properties passed to `IValidatableObject.Validate`.