### PR TITLE
JIT: Process all EH successors for "in-block" defs in SSA

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1416,6 +1416,9 @@ public:
     BasicBlockVisit VisitAllSuccs(Compiler* comp, TFunc func);
 
     template <typename TFunc>
+    BasicBlockVisit VisitEHSuccs(Compiler* comp, TFunc func);
+
+    template <typename TFunc>
     BasicBlockVisit VisitRegularSuccs(Compiler* comp, TFunc func);
 
     bool HasPotentialEHSuccs(Compiler* comp);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -509,7 +509,7 @@ BasicBlockVisit BasicBlock::VisitEHSecondPassSuccs(Compiler* comp, TFunc func)
 //   1. On thrown exceptions, control may flow to handlers
 //   2. As part of two pass EH, control may flow from filters to enclosed handlers
 //
-template <bool skipJumpDest, typename TFunc>
+template <bool         skipJumpDest, typename TFunc>
 static BasicBlockVisit VisitEHSuccs(Compiler* comp, BasicBlock* block, TFunc func)
 {
     if (!block->HasPotentialEHSuccs(comp))

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -816,7 +816,7 @@ void SsaBuilder::RenameDef(GenTree* defNode, BasicBlock* block)
 #endif // DEBUG
 
                 // Now add this SSA # to all phis of the reachable catch blocks.
-                AddMemoryDefToHandlerPhis(ByrefExposed, block, ssaNum);
+                AddMemoryDefToEHSuccessorPhis(ByrefExposed, block, ssaNum);
             }
 
             if (!isLocal)
@@ -839,7 +839,7 @@ void SsaBuilder::RenameDef(GenTree* defNode, BasicBlock* block)
 
                     m_renameStack.PushMemory(GcHeap, block, ssaNum);
                     m_pCompiler->GetMemorySsaMap(GcHeap)->Set(defNode, ssaNum);
-                    AddMemoryDefToHandlerPhis(GcHeap, block, ssaNum);
+                    AddMemoryDefToEHSuccessorPhis(GcHeap, block, ssaNum);
                 }
             }
         }
@@ -884,9 +884,9 @@ unsigned SsaBuilder::RenamePushDef(GenTree* defNode, BasicBlock* block, unsigned
 
     // If necessary, add SSA name to the arg list of a phi def in any handlers for try
     // blocks that "block" is within. (But only do this for "real" definitions, not phis.)
-    if (!defNode->IsPhiDefn())
+    if (!defNode->IsPhiDefn() && block->HasPotentialEHSuccs(m_pCompiler))
     {
-        AddDefToHandlerPhis(block, lclNum, ssaNum);
+        AddDefToEHSuccessorPhis(block, lclNum, ssaNum);
     }
 
     return ssaNum;
@@ -923,135 +923,123 @@ void SsaBuilder::RenameLclUse(GenTreeLclVarCommon* lclNode, BasicBlock* block)
     lclNode->SetSsaNum(ssaNum);
 }
 
-void SsaBuilder::AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigned ssaNum)
+void SsaBuilder::AddDefToEHSuccessorPhis(BasicBlock* block, unsigned lclNum, unsigned ssaNum)
 {
-    assert(m_pCompiler->lvaTable[lclNum].lvTracked); // Precondition.
+    assert(block->HasPotentialEHSuccs(m_pCompiler));
+    assert(m_pCompiler->lvaTable[lclNum].lvTracked);
+
+    DBG_SSA_JITDUMP("Definition of local V%02u/d:%d in block " FMT_BB
+                    " has potential EH successors; adding as phi arg to EH successors\n",
+                    lclNum, ssaNum, block->bbNum);
+
     unsigned lclIndex = m_pCompiler->lvaTable[lclNum].lvVarIndex;
 
-    EHblkDsc* tryBlk = m_pCompiler->ehGetBlockExnFlowDsc(block);
-    if (tryBlk != nullptr)
-    {
-        DBG_SSA_JITDUMP("Definition of local V%02u/d:%d in block " FMT_BB
-                        " has exn handler; adding as phi arg to handlers.\n",
-                        lclNum, ssaNum, block->bbNum);
-        while (true)
+    block->VisitEHSuccs(m_pCompiler, [=](BasicBlock* succ) {
+        // Is "lclNum" live on entry to the handler?
+        if (!VarSetOps::IsMember(m_pCompiler, succ->bbLiveIn, lclIndex))
         {
-            BasicBlock* handler = tryBlk->ExFlowBlock();
+            return BasicBlockVisit::Continue;
+        }
 
-            // Is "lclNum" live on entry to the handler?
-            if (VarSetOps::IsMember(m_pCompiler, handler->bbLiveIn, lclIndex))
-            {
 #ifdef DEBUG
-                bool phiFound = false;
+        bool phiFound = false;
 #endif
-                // A prefix of blocks statements will be SSA definitions.  Search those for "lclNum".
-                for (Statement* const stmt : handler->Statements())
-                {
-                    // If the tree is not an SSA def, break out of the loop: we're done.
-                    if (!stmt->IsPhiDefnStmt())
-                    {
-                        break;
-                    }
-
-                    GenTreeLclVar* phiDef = stmt->GetRootNode()->AsLclVar();
-                    assert(phiDef->IsPhiDefn());
-
-                    if (phiDef->GetLclNum() == lclNum)
-                    {
-                        // It's the definition for the right local.  Add "ssaNum" to the RHS.
-                        AddPhiArg(handler, stmt, phiDef->Data()->AsPhi(), lclNum, ssaNum, block);
-#ifdef DEBUG
-                        phiFound = true;
-#endif
-                        break;
-                    }
-                }
-                assert(phiFound);
-            }
-
-            unsigned nextTryIndex = tryBlk->ebdEnclosingTryIndex;
-            if (nextTryIndex == EHblkDsc::NO_ENCLOSING_INDEX)
+        // A prefix of blocks statements will be SSA definitions.  Search those for "lclNum".
+        for (Statement* const stmt : succ->Statements())
+        {
+            // If the tree is not an SSA def, break out of the loop: we're done.
+            if (!stmt->IsPhiDefnStmt())
             {
                 break;
             }
 
-            tryBlk = m_pCompiler->ehGetDsc(nextTryIndex);
+            GenTreeLclVar* phiDef = stmt->GetRootNode()->AsLclVar();
+            assert(phiDef->IsPhiDefn());
+
+            if (phiDef->GetLclNum() == lclNum)
+            {
+                // It's the definition for the right local.  Add "ssaNum" to the RHS.
+                AddPhiArg(succ, stmt, phiDef->Data()->AsPhi(), lclNum, ssaNum, block);
+#ifdef DEBUG
+                phiFound = true;
+#endif
+                break;
+            }
         }
-    }
+        assert(phiFound);
+
+        return BasicBlockVisit::Continue;
+
+    });
 }
 
-void SsaBuilder::AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum)
+void SsaBuilder::AddMemoryDefToEHSuccessorPhis(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum)
 {
-    if (m_pCompiler->ehBlockHasExnFlowDsc(block))
+    assert(block->HasPotentialEHSuccs(m_pCompiler));
+
+    // Don't do anything for a compiler-inserted BBJ_ALWAYS that is a "leave helper".
+    if ((block->bbFlags & BBF_INTERNAL) && block->isBBCallAlwaysPairTail())
     {
-        // Don't do anything for a compiler-inserted BBJ_ALWAYS that is a "leave helper".
-        if ((block->bbFlags & BBF_INTERNAL) && block->isBBCallAlwaysPairTail())
+        return;
+    }
+
+    // Otherwise...
+    DBG_SSA_JITDUMP("Definition of %s/d:%d in block " FMT_BB
+                    " has potential EH successors; adding as phi arg to EH successors.\n",
+                    memoryKindNames[memoryKind], ssaNum, block->bbNum);
+
+    block->VisitEHSuccs(m_pCompiler, [=](BasicBlock* succ) {
+        // Is memoryKind live on entry to the handler?
+        if ((succ->bbMemoryLiveIn & memoryKindSet(memoryKind)) == 0)
         {
-            return;
+            return BasicBlockVisit::Continue;
         }
 
-        // Otherwise...
-        DBG_SSA_JITDUMP("Definition of %s/d:%d in block " FMT_BB " has exn handler; adding as phi arg to handlers.\n",
-                        memoryKindNames[memoryKind], ssaNum, block->bbNum);
-        EHblkDsc* tryBlk = m_pCompiler->ehGetBlockExnFlowDsc(block);
-        while (true)
-        {
-            BasicBlock* handler = tryBlk->ExFlowBlock();
-
-            // Is memoryKind live on entry to the handler?
-            if ((handler->bbMemoryLiveIn & memoryKindSet(memoryKind)) != 0)
-            {
-                // Add "ssaNum" to the phi args of memoryKind.
-                BasicBlock::MemoryPhiArg*& handlerMemoryPhi = handler->bbMemorySsaPhiFunc[memoryKind];
+        // Add "ssaNum" to the phi args of memoryKind.
+        BasicBlock::MemoryPhiArg*& handlerMemoryPhi = succ->bbMemorySsaPhiFunc[memoryKind];
 
 #if DEBUG
-                if (m_pCompiler->byrefStatesMatchGcHeapStates)
-                {
-                    // When sharing phis for GcHeap and ByrefExposed, callers should ask to add phis
-                    // for ByrefExposed only.
-                    assert(memoryKind != GcHeap);
-                    if (memoryKind == ByrefExposed)
-                    {
-                        // The GcHeap and ByrefExposed phi funcs should always be in sync.
-                        assert(handlerMemoryPhi == handler->bbMemorySsaPhiFunc[GcHeap]);
-                    }
-                }
+        if (m_pCompiler->byrefStatesMatchGcHeapStates)
+        {
+            // When sharing phis for GcHeap and ByrefExposed, callers should ask to add phis
+            // for ByrefExposed only.
+            assert(memoryKind != GcHeap);
+            if (memoryKind == ByrefExposed)
+            {
+                // The GcHeap and ByrefExposed phi funcs should always be in sync.
+                assert(handlerMemoryPhi == succ->bbMemorySsaPhiFunc[GcHeap]);
+            }
+        }
 #endif
 
-                if (handlerMemoryPhi == BasicBlock::EmptyMemoryPhiDef)
-                {
-                    handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum);
-                }
-                else
-                {
-#ifdef DEBUG
-                    BasicBlock::MemoryPhiArg* curArg = handler->bbMemorySsaPhiFunc[memoryKind];
-                    while (curArg != nullptr)
-                    {
-                        assert(curArg->GetSsaNum() != ssaNum);
-                        curArg = curArg->m_nextArg;
-                    }
-#endif // DEBUG
-                    handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum, handlerMemoryPhi);
-                }
-
-                DBG_SSA_JITDUMP("   Added phi arg u:%d for %s to phi defn in handler block " FMT_BB ".\n", ssaNum,
-                                memoryKindNames[memoryKind], memoryKind, handler->bbNum);
-
-                if ((memoryKind == ByrefExposed) && m_pCompiler->byrefStatesMatchGcHeapStates)
-                {
-                    // Share the phi between GcHeap and ByrefExposed.
-                    handler->bbMemorySsaPhiFunc[GcHeap] = handlerMemoryPhi;
-                }
-            }
-            unsigned tryInd = tryBlk->ebdEnclosingTryIndex;
-            if (tryInd == EHblkDsc::NO_ENCLOSING_INDEX)
-            {
-                break;
-            }
-            tryBlk = m_pCompiler->ehGetDsc(tryInd);
+        if (handlerMemoryPhi == BasicBlock::EmptyMemoryPhiDef)
+        {
+            handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum);
         }
-    }
+        else
+        {
+#ifdef DEBUG
+            BasicBlock::MemoryPhiArg* curArg = succ->bbMemorySsaPhiFunc[memoryKind];
+            while (curArg != nullptr)
+            {
+                assert(curArg->GetSsaNum() != ssaNum);
+                curArg = curArg->m_nextArg;
+            }
+#endif // DEBUG
+            handlerMemoryPhi = new (m_pCompiler) BasicBlock::MemoryPhiArg(ssaNum, handlerMemoryPhi);
+        }
+
+        DBG_SSA_JITDUMP("   Added phi arg u:%d for %s to phi defn in handler block " FMT_BB ".\n", ssaNum,
+                        memoryKindNames[memoryKind], memoryKind, succ->bbNum);
+
+        if ((memoryKind == ByrefExposed) && m_pCompiler->byrefStatesMatchGcHeapStates)
+        {
+            // Share the phi between GcHeap and ByrefExposed.
+            succ->bbMemorySsaPhiFunc[GcHeap] = handlerMemoryPhi;
+        }
+
+        return BasicBlockVisit::Continue;
+    });
 }
 
 //------------------------------------------------------------------------
@@ -1134,7 +1122,10 @@ void SsaBuilder::BlockRenameVariables(BasicBlock* block)
             {
                 unsigned ssaNum = m_pCompiler->lvMemoryPerSsaData.AllocSsaNum(m_allocator);
                 m_renameStack.PushMemory(memoryKind, block, ssaNum);
-                AddMemoryDefToHandlerPhis(memoryKind, block, ssaNum);
+                if (block->HasPotentialEHSuccs(m_pCompiler))
+                {
+                    AddMemoryDefToEHSuccessorPhis(memoryKind, block, ssaNum);
+                }
 
                 block->bbMemorySsaNumOut[memoryKind] = ssaNum;
             }

--- a/src/coreclr/jit/ssabuilder.h
+++ b/src/coreclr/jit/ssabuilder.h
@@ -86,14 +86,14 @@ private:
     void RenameLclUse(GenTreeLclVarCommon* lclNode, BasicBlock* block);
 
     // Assumes that "block" contains a definition for local var "lclNum", with SSA number "ssaNum".
-    // IF "block" is within one or more try blocks,
-    // and the local variable is live at the start of the corresponding handlers,
+    // IF "block" is within one or more blocks with EH successors,
+    // and the local variable is live at the start of the corresponding successors,
     // add this SSA number "ssaNum" to the argument list of the phi for the variable in the start
     // block of those handlers.
-    void AddDefToHandlerPhis(BasicBlock* block, unsigned lclNum, unsigned ssaNum);
+    void AddDefToEHSuccessorPhis(BasicBlock* block, unsigned lclNum, unsigned ssaNum);
 
     // Same as above, for memory.
-    void AddMemoryDefToHandlerPhis(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum);
+    void AddMemoryDefToEHSuccessorPhis(MemoryKind memoryKind, BasicBlock* block, unsigned ssaNum);
 
     // Add GT_PHI_ARG nodes to the GT_PHI nodes within block's successors.
     void AddPhiArgsToSuccessors(BasicBlock* block);


### PR DESCRIPTION
When we saw a def we were only adding phi args to enclosing handlers, but this misses the special case of throws inside filters, where control can flow to enclosed handlers.

Fix #94954