### PR TITLE
Set version in ZIP local header to ZIP64, when the file offset is >4GB

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -964,7 +964,7 @@ namespace System.IO.Compression
             long finalPosition = _archive.ArchiveStream.Position;
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
-            bool zip64Needed = SizesTooLarge()
+            bool zip64Needed = SizesTooLarge() || (_offsetOfLocalHeader > uint.MaxValue)
 #if DEBUG_FORCE_ZIP64
                 || _archive._forceZip64
 #endif

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -490,7 +490,7 @@ namespace System.IO.Compression
             }
 
 
-            if (_offsetOfLocalHeader > uint.MaxValue
+            if (OffsetTooLarge()
 #if DEBUG_FORCE_ZIP64
                 || _archive._forceZip64
 #endif
@@ -799,6 +799,10 @@ namespace System.IO.Compression
 
         private bool SizesTooLarge() => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
 
+        private bool OffsetTooLarge() => _offsetOfLocalHeader > uint.MaxValue;
+
+        private bool ShouldUseZIP64() => SizesTooLarge() || OffsetTooLarge();
+
         // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
         private bool WriteLocalFileHeader(bool isEmptyFile)
         {
@@ -812,6 +816,9 @@ namespace System.IO.Compression
             Zip64ExtraField zip64ExtraField = default;
             bool zip64Used = false;
             uint compressedSizeTruncated, uncompressedSizeTruncated;
+
+            // save offset
+            _offsetOfLocalHeader = writer.BaseStream.Position;
 
             // if we already know that we have an empty file don't worry about anything, just do a straight shot of the header
             if (isEmptyFile)
@@ -840,7 +847,7 @@ namespace System.IO.Compression
                 {
                     // We are in seekable mode so we will not need to write a data descriptor
                     _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
-                    if (SizesTooLarge()
+                    if (ShouldUseZIP64()
 #if DEBUG_FORCE_ZIP64
                         || (_archive._forceZip64 && _archive.Mode == ZipArchiveMode.Update)
 #endif
@@ -864,9 +871,6 @@ namespace System.IO.Compression
                     }
                 }
             }
-
-            // save offset
-            _offsetOfLocalHeader = writer.BaseStream.Position;
 
             // calculate extra field. if zip64 stuff + original extraField aren't going to fit, dump the original extraField, because this is more important
             int bigExtraFieldLength = (zip64Used ? zip64ExtraField.TotalSize : 0)
@@ -964,7 +968,7 @@ namespace System.IO.Compression
             long finalPosition = _archive.ArchiveStream.Position;
             BinaryWriter writer = new BinaryWriter(_archive.ArchiveStream);
 
-            bool zip64Needed = SizesTooLarge() || (_offsetOfLocalHeader > uint.MaxValue)
+            bool zip64Needed = ShouldUseZIP64()
 #if DEBUG_FORCE_ZIP64
                 || _archive._forceZip64
 #endif

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -47,7 +47,7 @@ namespace System.IO.Compression.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
-        [OuterLoop]
+        [OuterLoop("It requires 5 GB of free disk space")]
         public static void CheckZIP64VersionIsSet_ForSmallFilesAfterBigFiles()
         {
             // issue #94899

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_LargeFiles.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace System.IO.Compression.Tests
@@ -35,6 +36,82 @@ namespace System.IO.Compression.Tests
 
                     Assert.True(entryStream.CanRead);
                     Assert.Equal(buffer.Length, entryStream.Length);
+                }
+            }
+            finally
+            {
+                File.Delete(zipArchivePath);
+
+                tempDir.Delete(recursive: true);
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsSpeedOptimized), nameof(PlatformDetection.Is64BitProcess))] // don't run it on slower runtimes
+        [OuterLoop]
+        public static void CheckZIP64VersionIsSet_ForSmallFilesAfterBigFiles()
+        {
+            // issue #94899
+
+            byte[] largeBuffer = GC.AllocateUninitializedArray<byte>(1_000_000_000); // 1 GB
+            byte[] smallBuffer = GC.AllocateUninitializedArray<byte>(1000);
+
+            string zipArchivePath = Path.Combine(Path.GetTempPath(), "over4GB.zip");
+            DirectoryInfo tempDir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "over4GB"));
+
+            try
+            {
+                using FileStream fs = File.Open(zipArchivePath, FileMode.Create, FileAccess.ReadWrite);
+                const string LargeFileName = "largefile";
+                const string SmallFileName = "smallfile";
+                const uint ZipLocalFileHeader_OffsetToVersionFromHeaderStart = 4;
+                const ushort Zip64Version = 45;
+
+                {
+                    // Create
+
+                    using var archive = new ZipArchive(fs, ZipArchiveMode.Create, true);
+                    ZipArchiveEntry file = archive.CreateEntry(LargeFileName, CompressionLevel.NoCompression);
+
+                    using (Stream stream = file.Open())
+                    {
+                        // Write 5GB of data
+
+                        stream.Write(largeBuffer);
+                        stream.Write(largeBuffer);
+                        stream.Write(largeBuffer);
+                        stream.Write(largeBuffer);
+                        stream.Write(largeBuffer);
+                    }
+
+                    file = archive.CreateEntry(SmallFileName, CompressionLevel.NoCompression);
+
+                    using (Stream stream = file.Open())
+                    {
+                        stream.Write(smallBuffer);
+                    }
+                }
+
+                fs.Position = 0;
+
+                {
+                    // Validate
+
+                    using var reader = new BinaryReader(fs);
+                    using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+                    FieldInfo offsetOfLHField = typeof(ZipArchiveEntry).GetField("_offsetOfLocalHeader", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                    if (offsetOfLHField is null || offsetOfLHField.FieldType != typeof(long))
+                    {
+                        Assert.Fail("Cannot find the private field of _offsetOfLocalHeader in ZipArchiveEntry or the type is not long. Code may be changed after the test is written.");
+                    }
+
+                    foreach (ZipArchiveEntry entry in archive.Entries)
+                    {
+                        fs.Position = (long)offsetOfLHField.GetValue(entry) + ZipLocalFileHeader_OffsetToVersionFromHeaderStart;
+                        ushort versionNeeded = reader.ReadUInt16();
+
+                        Assert.True(versionNeeded >= Zip64Version, "ZIP64 version is not set for files with LH at >4GB offset.");
+                    }
                 }
             }
             finally


### PR DESCRIPTION
Fix #94899. Analysis in the comments. This PR fixes some compatibility issues of ZIP64 archives with certain decompressors (such as .NET Framework).

The spec is unclear whether the versionNeeded should be same in the CD and LH, and decompressors like 7-Zip & Windows don't complain about the discrepancy. Nevertheless I found 7-Zip set the LH to version ZIP64 under such circumstance.

The test is put in the outer loop because it will create a large 5GB file.