### PR TITLE
[mono][wasm] Fix broken VM suspend while emitting events in Debug configuration

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -1636,6 +1636,10 @@ mono_init_debugger_agent_for_wasm (int log_level_parm, MonoProfilerHandle *prof)
 
 	agent_config.enabled = TRUE;
 
+	start_debugger_thread_func = start_debugger_thread;
+	suspend_vm_func = suspend_vm;
+	suspend_current_func = suspend_current;
+
 	mono_init_debugger_agent_common (prof);
 }
 


### PR DESCRIPTION
Currently, when building Mono Wasm runtime from sources using
```bash
./build.sh mono+libs -c debug -os browser
```
And using debugger agent, any suspend-related event causes crash:
```
blazor.webassembly.js:1 RuntimeError: null function or function signature mismatch
    at process_event (0434295e:0x19b1e2)
    at process_profiler_event (0434295e:0x19475f)
    at emit_type_load (0434295e:0x1cdc6a)
    at send_type_load (0434295e:0x1cd9c2)
    at jit_end (0434295e:0x194cb8)
    at jit_done (0434295e:0x1957b9)
    at mono_profiler_raise_jit_done (0434295e:0x2ffaee)
    at mono_interp_transform_method (0434295e:0x4684f)
    at do_transform_method (0434295e:0x21def)
    at mono_interp_exec_method (0434295e:0x218dd)
```

After a little bit of investigation I found that the error is related to `suspend_vm_func` function pointer which is not properly initialized in regular Wasm (Blazor) apps.

![image_2023-11-19_15-27-11](https://github.com/dotnet/runtime/assets/20597871/efe2c1c5-de94-47d7-9c0b-f5e4d3f37b08)


Previously, `suspend_vm` has been used directly, so it worked correctly.

Please note that it's only reproducible in Debug builds. Seems like Release one just ignores it.

So I propose to use the same function pointers as before for Wasm apps.