### PR TITLE
Shortcut `List<T>` for `Enumerable.Any()`

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -32,6 +32,11 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
+            if (source is List<TSource> list)
+            {
+                return list.Exists(element => predicate(element));
+            }
+
             foreach (TSource element in source)
             {
                 if (predicate(element))

--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -32,9 +32,17 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            if (source is List<TSource> list)
+            if (TryGetSpan(source, out var span))
             {
-                return list.Exists(element => predicate(element));
+                foreach (TSource element in span)
+                {
+                    if (predicate(element))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             foreach (TSource element in source)

--- a/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Enumerable.cs
@@ -29,7 +29,7 @@ namespace System.Linq
             // is a reference type and generic implementations are shared.  So for now we're protecting ourselves
             // and forcing a conscious choice to remove this in the future, at which point it should be paired with
             // sufficient performance testing.
-            where TSource : struct
+            //where TSource : struct
         {
             if (source is null)
             {


### PR DESCRIPTION
`List<T>.Any()` is a common use case in our code bases. This shortcuts this use case to use the more specific `List<T>.Exists()` method instead. The results make it clear that we're introducing a trade-off for the non-List scenarios that need to do a bit of extra work here.

I think it's entirely up for discussion whether this is a beneficial change overall so I'm interested in hearing how you all think about these situations. There's some precedent here already with similar special casings for e.g. `Enumerable.Count()`.

# Benchmark

```cs
namespace System.Linq.Tests
{
    [BenchmarkCategory(Categories.Libraries, Categories.LINQ)]
    [MemoryDiagnoser]
    public class Perf_Any
    {
        private IEnumerable<int> _itemsAsList;
        private IEnumerable<int> _itemsAsArray;
        private IEnumerable<int> _itemsAsEnumerable;

        [Params(10, 100, 100_000)]
        public int NumberOfItems;

        [GlobalSetup]
        public void GlobalSetup()
        {
            _itemsAsList = Enumerable.Range(0, NumberOfItems).ToList();
            _itemsAsArray = Enumerable.Range(0, NumberOfItems).ToArray();
            _itemsAsEnumerable = Enumerable.Range(0, NumberOfItems);
        }

        [Benchmark]
        public bool EnumerableAsListAny() => _itemsAsList.Any(x => x == NumberOfItems / 2);

        [Benchmark]
        public bool EnumerableAsArrayAny() => _itemsAsArray.Any(x => x == NumberOfItems / 2);

        [Benchmark]
        public bool EnumerableAsEnumerableAny() => _itemsAsEnumerable.Any(x => x == NumberOfItems / 2);
    }
}
```

# Results

## Before

| Method                    | NumberOfItems | Mean          | Error      | StdDev     | Median        | Min           | Max           | Gen0   | Allocated |
|-------------------------- |-------------- |--------------:|-----------:|-----------:|--------------:|--------------:|--------------:|-------:|----------:|
| EnumerableAsListAny       | 10            |      23.91 ns |   0.248 ns |   0.232 ns |      23.84 ns |      23.63 ns |      24.44 ns | 0.0124 |     104 B |
| EnumerableAsArrayAny      | 10            |      22.35 ns |   0.186 ns |   0.145 ns |      22.33 ns |      22.15 ns |      22.65 ns | 0.0114 |      96 B |
| EnumerableAsEnumerableAny | 10            |      20.69 ns |   0.422 ns |   0.452 ns |      20.47 ns |      20.28 ns |      21.85 ns | 0.0124 |     104 B |
| EnumerableAsListAny       | 100           |     130.22 ns |   1.061 ns |   0.993 ns |     130.21 ns |     129.12 ns |     132.31 ns | 0.0122 |     104 B |
| EnumerableAsArrayAny      | 100           |     126.21 ns |   0.745 ns |   0.660 ns |     125.94 ns |     125.46 ns |     127.89 ns | 0.0113 |      96 B |
| EnumerableAsEnumerableAny | 100           |     120.03 ns |   0.488 ns |   0.457 ns |     120.04 ns |     119.40 ns |     120.73 ns | 0.0122 |     104 B |
| EnumerableAsListAny       | 100000        | 110,985.33 ns | 377.216 ns | 334.392 ns | 111,036.76 ns | 110,365.40 ns | 111,511.07 ns |      - |     104 B |
| EnumerableAsArrayAny      | 100000        |  99,391.45 ns | 301.758 ns | 251.982 ns |  99,299.96 ns |  99,033.52 ns |  99,873.81 ns |      - |      96 B |
| EnumerableAsEnumerableAny | 100000        |  93,668.73 ns | 268.387 ns | 237.918 ns |  93,746.97 ns |  93,234.81 ns |  93,998.76 ns |      - |     104 B |

## After

| Method                    | NumberOfItems | Mean         | Error      | StdDev     | Median       | Min          | Max          | Gen0   | Allocated |
|-------------------------- |-------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|-------:|----------:|
| EnumerableAsListAny       | 10            |     22.51 ns |   0.356 ns |   0.316 ns |     22.44 ns |     22.08 ns |     23.15 ns | 0.0181 |     152 B |
| EnumerableAsArrayAny      | 10            |     27.86 ns |   0.279 ns |   0.247 ns |     27.84 ns |     27.52 ns |     28.36 ns | 0.0143 |     120 B |
| EnumerableAsEnumerableAny | 10            |     24.93 ns |   0.222 ns |   0.173 ns |     24.96 ns |     24.60 ns |     25.18 ns | 0.0153 |     128 B |
| EnumerableAsListAny       | 100           |     80.59 ns |   0.493 ns |   0.461 ns |     80.56 ns |     79.77 ns |     81.26 ns | 0.0181 |     152 B |
| EnumerableAsArrayAny      | 100           |    131.39 ns |   0.849 ns |   0.794 ns |    131.29 ns |    130.49 ns |    132.86 ns | 0.0143 |     120 B |
| EnumerableAsEnumerableAny | 100           |    123.58 ns |   0.771 ns |   0.644 ns |    123.33 ns |    122.80 ns |    124.97 ns | 0.0150 |     128 B |
| EnumerableAsListAny       | 100000        | 59,542.60 ns | 371.268 ns | 329.120 ns | 59,458.50 ns | 59,179.61 ns | 60,388.83 ns |      - |     152 B |
| EnumerableAsArrayAny      | 100000        | 99,191.96 ns | 288.957 ns | 256.153 ns | 99,148.06 ns | 98,827.81 ns | 99,742.60 ns |      - |     120 B |
| EnumerableAsEnumerableAny | 100000        | 95,835.06 ns | 386.615 ns | 322.841 ns | 95,887.31 ns | 95,202.76 ns | 96,316.87 ns |      - |     128 B |

## Summary
Plugging this into the ResultsComparer, you get this summary:

better: 3, geomean: 1.475
worse: 5, geomean: 1.107
total diff: 8

| Slower                                                                      | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_Any.EnumerableAsArrayAny(NumberOfItems: 10)          |      1.25 |            22.33 |            27.84 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsEnumerableAny(NumberOfItems: 10)     |      1.22 |            20.47 |            24.96 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsArrayAny(NumberOfItems: 100)         |      1.04 |           125.94 |           131.29 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsEnumerableAny(NumberOfItems: 100)    |      1.03 |           120.04 |           123.33 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsEnumerableAny(NumberOfItems: 100000) |      1.02 |         93746.97 |         95887.31 |         |

| Faster                                                                | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| --------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Linq.Tests.Perf_Any.EnumerableAsListAny(NumberOfItems: 100000) |      1.87 |        111036.76 |         59458.50 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsListAny(NumberOfItems: 100)    |      1.62 |           130.21 |            80.56 |         |
| System.Linq.Tests.Perf_Any.EnumerableAsListAny(NumberOfItems: 10)     |      1.06 |            23.84 |            22.44 |         |