### PR TITLE
Fix null reference exception in ilverify

### DIFF
--- a/src/coreclr/tools/ILVerify/Program.cs
+++ b/src/coreclr/tools/ILVerify/Program.cs
@@ -34,7 +34,7 @@ namespace ILVerify
             _command = command;
 
             _inputFilePaths = Get(command.InputFilePath);
-            _referenceFilePaths = Get(command.Reference);
+            _referenceFilePaths = Get(command.Reference) ?? new Dictionary<string, string>();
             _verbose = Get(_command.Verbose);
 
             string[] includePatterns = Get(command.Include);


### PR DESCRIPTION
Invoking ilverify with empty list of references lead to null reference exception.

Contributes to https://github.com/dotnet/runtime/issues/54110#issuecomment-1817961976