### PR TITLE
Improve ConcurrentDictionary xml docs

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1545,7 +1545,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Gets a snapshot containing all the keys in the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <remarks>It's a standalone copy of all the keys. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
+        /// <remarks>The property returns a copy of all the keys. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
         public ICollection<TKey> Keys => GetKeys();
 
         /// <inheritdoc cref="Keys"/>
@@ -1554,7 +1554,7 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// Gets a snapshot containing all the values in the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <remarks>It's a standalone copy of all the values. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
+        /// <remarks>The property returns a copy of all the values. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
         public ICollection<TValue> Values => GetValues();
 
         /// <inheritdoc cref="Values"/>

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1569,14 +1569,14 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <param name="keyValuePair">The <see cref="KeyValuePair{TKey,TValue}"/>
         /// structure representing the key and value to add to the <see
-        /// cref="Dictionary{TKey,TValue}"/>.</param>
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="keyValuePair"/> of <paramref
         /// name="keyValuePair"/> is null.</exception>
         /// <exception cref="OverflowException">The <see
-        /// cref="Dictionary{TKey,TValue}"/>
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>
         /// contains too many elements.</exception>
         /// <exception cref="ArgumentException">An element with the same key already exists in the
-        /// <see cref="Dictionary{TKey,TValue}"/></exception>
+        /// <see cref="ConcurrentDictionary{TKey,TValue}"/></exception>
         void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair) => ((IDictionary<TKey, TValue>)this).Add(keyValuePair.Key, keyValuePair.Value);
 
         /// <summary>
@@ -1597,7 +1597,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         /// <value>true if the <see cref="ICollection{T}"/> is
         /// read-only; otherwise, false. For <see
-        /// cref="Dictionary{TKey,TValue}"/>, this property always returns
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>, this property always returns
         /// false.</value>
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
@@ -1607,7 +1607,7 @@ namespace System.Collections.Concurrent
         /// <param name="keyValuePair">The <see
         /// cref="KeyValuePair{TKey,TValue}"/>
         /// structure representing the key and value to remove from the <see
-        /// cref="Dictionary{TKey,TValue}"/>.</param>
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.</param>
         /// <returns>true if the key and value represented by <paramref name="keyValuePair"/> is successfully
         /// found and removed; otherwise, false.</returns>
         /// <exception cref="ArgumentNullException">The Key property of <paramref
@@ -1645,11 +1645,11 @@ namespace System.Collections.Concurrent
         /// elements.</exception>
         /// <exception cref="ArgumentException">
         /// <paramref name="key"/> is of a type that is not assignable to the key type <typeparamref
-        /// name="TKey"/> of the <see cref="Dictionary{TKey,TValue}"/>. -or-
+        /// name="TKey"/> of the <see cref="ConcurrentDictionary{TKey,TValue}"/>. -or-
         /// <paramref name="value"/> is of a type that is not assignable to <typeparamref name="TValue"/>,
-        /// the type of values in the <see cref="Dictionary{TKey,TValue}"/>.
+        /// the type of values in the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// -or- A value with the same key already exists in the <see
-        /// cref="Dictionary{TKey,TValue}"/>.
+        /// cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </exception>
         void IDictionary.Add(object key, object? value)
         {

--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1543,36 +1543,21 @@ namespace System.Collections.Concurrent
         bool IDictionary<TKey, TValue>.Remove(TKey key) => TryRemove(key, out _);
 
         /// <summary>
-        /// Gets a collection containing the keys in the <see
-        /// cref="Dictionary{TKey,TValue}"/>.
+        /// Gets a snapshot containing all the keys in the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="ICollection{TKey}"/> containing the keys in the
-        /// <see cref="Dictionary{TKey,TValue}"/>.</value>
+        /// <remarks>It's a standalone copy of all the keys. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
         public ICollection<TKey> Keys => GetKeys();
 
-        /// <summary>
-        /// Gets an <see cref="IEnumerable{TKey}"/> containing the keys of
-        /// the <see cref="IReadOnlyDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <value>An <see cref="IEnumerable{TKey}"/> containing the keys of
-        /// the <see cref="IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        /// <inheritdoc cref="Keys"/>
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => GetKeys();
 
         /// <summary>
-        /// Gets a collection containing the values in the <see
-        /// cref="Dictionary{TKey,TValue}"/>.
+        /// Gets a snapshot containing all the values in the <see cref="ConcurrentDictionary{TKey,TValue}"/>.
         /// </summary>
-        /// <value>An <see cref="ICollection{TValue}"/> containing the values in
-        /// the
-        /// <see cref="Dictionary{TKey,TValue}"/>.</value>
+        /// <remarks>It's a standalone copy of all the values. It's not kept in sync with <see cref="ConcurrentDictionary{TKey,TValue}"/>.</remarks>
         public ICollection<TValue> Values => GetValues();
 
-        /// <summary>
-        /// Gets an <see cref="IEnumerable{TValue}"/> containing the values
-        /// in the <see cref="IReadOnlyDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <value>An <see cref="IEnumerable{TValue}"/> containing the
-        /// values in the <see cref="IReadOnlyDictionary{TKey,TValue}"/>.</value>
+        /// <inheritdoc cref="Values"/>
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => GetValues();
         #endregion
 


### PR DESCRIPTION
After reading the discussion in https://github.com/dotnet/runtime/pull/93870#discussion_r1368745090 I've realized that `ConcurrentDictionary.Keys` and `Values` properties don't mention anything about them being snapshots. Moreover, some xml docs were referring to `this` as `Dictionary` rather than `ConcurrentDictionary`