### PR TITLE
[mono][wasm] Fix uninitialized `suspended_objs` hash table

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -1629,6 +1629,11 @@ mono_init_debugger_agent_for_wasm (int log_level_parm, MonoProfilerHandle *prof)
 	objrefs = g_hash_table_new_full (NULL, NULL, NULL, mono_debugger_free_objref);
 	obj_to_objref = g_hash_table_new (NULL, NULL);
 
+	/* Needed for the mono_g_hash_table_new_type_internal () call below */
+	mono_gc_base_init ();
+
+	suspended_objs = mono_g_hash_table_new_type_internal ((GHashFunc)mono_object_hash_internal, NULL, MONO_HASH_KEY_GC, MONO_ROOT_SOURCE_DEBUGGER, NULL, "Debugger Suspended Object Table");
+
 	log_level = log_level_parm;
 
 	vm_start_event_sent = TRUE;


### PR DESCRIPTION
Currently, there are asserts in the JS console like the following:

```
logging.ts:119 Error: [MONO] /Users/seclerp/repos/runtime/src/mono/mono/metadata/mono-hash.c:439: assertion 'hash != NULL' failed

    at mono_wasm_stringify_as_error_with_stack (logging.ts:95:18)
    at mono_wasm_trace_logger (logging.ts:119:27)
    at wasm_trace_logger (dotnet.native.wasm:0x8ba8)
    at eglib_log_adapter (dotnet.native.wasm:0x52e01)
    at monoeg_g_logstr (dotnet.native.wasm:0x4ab0c)
    at monoeg_g_logv_nofree (dotnet.native.wasm:0x4aa59)
    at monoeg_g_logv (dotnet.native.wasm:0x4a9cc)
    at monoeg_g_log (dotnet.native.wasm:0x4ab54)
    at mono_g_hash_table_insert_replace (dotnet.native.wasm:0x14fc16)
    at mono_g_hash_table_insert_internal (dotnet.native.wasm:0x14fba6)
```

The reason for this is that `suspended_objs` is left uninitialized (`null`) for the Mono Wasm debugger agent.