### PR TITLE
Console.Unix: StdInReader: use stateful decoder.

### DIFF
--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -22,6 +22,7 @@ namespace System.IO
         private readonly StringBuilder _readLineSB; // SB that holds readLine output.  This is a field simply to enable reuse; it's only used in ReadLine.
         private readonly Stack<ConsoleKeyInfo> _tmpKeys = new Stack<ConsoleKeyInfo>(); // temporary working stack; should be empty outside of ReadLine
         private readonly Stack<ConsoleKeyInfo> _availableKeys = new Stack<ConsoleKeyInfo>(); // a queue of already processed key infos available for reading
+        private readonly Decoder _decoder;
         private readonly Encoding _encoding;
         private readonly Encoder _echoEncoder;
         private Encoder? _bufferReadEncoder;
@@ -41,6 +42,7 @@ namespace System.IO
             _endIndex = 0;
             _readLineSB = new StringBuilder();
             _echoEncoder = _encoding.GetEncoder();
+            _decoder = _encoding.GetDecoder();
         }
 
         /// <summary> Checks whether the unprocessed buffer is empty. </summary>
@@ -60,7 +62,7 @@ namespace System.IO
             Span<char> chars = (uint)maxCharsCount <= MaxStackAllocation ?
                 stackalloc char[MaxStackAllocation] :
                 new char[maxCharsCount];
-            int charLen = _encoding.GetChars(buffer, chars);
+            int charLen = _decoder.GetChars(buffer, chars, flush: false);
             chars = chars.Slice(0, charLen);
 
             // Ensure our buffer is large enough to hold all of the data


### PR DESCRIPTION
Characters may be split across buffers that are handled separately so we need to use a decoder to track state.

Though it affects ReadLine, no issue has been reported for it because the default buffer of 1000 bytes is sufficient to fit typical terminal input.

The problem was reported against the Console Cursor API. The cursor position handling uses single byte read buffers. Any character that needs multiple bytes therefore gets split accross several buffers.
For the issue to occur, such characters needed to be on stdin while parsing the cursor position.

Fixes https://github.com/dotnet/runtime/issues/88343.

@adamsitnik @stephentoub @dotnet/area-system-console ptal.

cc @waf 