### PR TITLE
Reenable OneLocBuild in runtime-official.yml

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -38,13 +38,12 @@ extends:
       # Localization build
       #
 
-      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0') }}:
-        - template: /eng/common/templates/job/onelocbuild.yml
-          parameters:
-            MirrorRepo: runtime
-            MirrorBranch: release/8.0
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: runtime
+          MirrorBranch: main
+          LclSource: lclFilesfromPackage
+          LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
       #
       # Source Index Build


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/90466

The OneLoc build passes again now in main: https://dev.azure.com/dnceng/internal/_build/results?buildId=2319609&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76&j=6aa31087-d1b8-5ee1-af29-f0fe63353381