### PR TITLE
JIT: Dump BB in/out memory SSAs inline when SSA is valid

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1965,7 +1965,7 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
     m_nodeToLoopMemoryBlockMap = nullptr;
     m_signatureToLookupInfoMap = nullptr;
     fgSsaPassesCompleted       = 0;
-    fgSsaChecksEnabled         = false;
+    fgSsaValid                 = false;
     fgVNPassesCompleted        = 0;
 
     // check that HelperCallProperties are initialized
@@ -4960,10 +4960,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             //
             // So, disable the ssa checks.
             //
-            if (fgSsaChecksEnabled)
+            if (fgSsaValid)
             {
-                JITDUMP("Disabling SSA checking before assertion prop\n");
-                fgSsaChecksEnabled = false;
+                JITDUMP("Marking SSA as invalid before assertion prop\n");
+                fgSsaValid = false;
             }
 
             if (doAssertionProp)
@@ -5742,7 +5742,7 @@ void Compiler::ResetOptAnnotations()
     m_dominancePreds     = nullptr;
     fgSsaPassesCompleted = 0;
     fgVNPassesCompleted  = 0;
-    fgSsaChecksEnabled   = false;
+    fgSsaValid           = false;
 
     for (BasicBlock* const block : Blocks())
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5051,7 +5051,7 @@ public:
     void fgResetForSsa();
 
     unsigned fgSsaPassesCompleted; // Number of times fgSsaBuild has been run.
-    bool     fgSsaChecksEnabled;   // True if SSA info can be cross-checked versus IR
+    bool     fgSsaValid;           // True if SSA info is valid and can be cross-checked versus IR
 
 #ifdef DEBUG
     void DumpSsaSummary();
@@ -5654,6 +5654,9 @@ public:
     void fgDumpStmtTree(Statement* stmt, unsigned bbNum);
     void fgDumpBlock(BasicBlock* block);
     void fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock);
+
+    void fgDumpBlockMemorySsaIn(BasicBlock* block);
+    void fgDumpBlockMemorySsaOut(BasicBlock* block);
 
     static fgWalkPreFn fgStress64RsltMulCB;
     void               fgStress64RsltMul();

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2521,11 +2521,11 @@ void Compiler::fgDumpBlockMemorySsaIn(BasicBlock* block)
     {
         if (byrefStatesMatchGcHeapStates)
         {
-            printf("%s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
+            printf("SSA MEM: %s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
         }
         else
         {
-            printf("%s", memoryKindNames[memoryKind]);
+            printf("SSA MEM: %s", memoryKindNames[memoryKind]);
         }
 
         if (block->bbMemorySsaPhiFunc[memoryKind] == nullptr)
@@ -2565,11 +2565,11 @@ void Compiler::fgDumpBlockMemorySsaOut(BasicBlock* block)
     {
         if (byrefStatesMatchGcHeapStates)
         {
-            printf("%s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
+            printf("SSA MEM: %s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
         }
         else
         {
-            printf("%s", memoryKindNames[memoryKind]);
+            printf("SSA MEM: %s", memoryKindNames[memoryKind]);
         }
 
         printf(" = m:%u\n", block->bbMemorySsaNumOut[memoryKind]);

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2461,6 +2461,11 @@ void Compiler::fgDumpBlock(BasicBlock* block)
     printf("\n------------ ");
     block->dspBlockHeader(this);
 
+    if (fgSsaValid)
+    {
+        fgDumpBlockMemorySsaIn(block);
+    }
+
     if (!block->IsLIR())
     {
         for (Statement* const stmt : block->Statements())
@@ -2471,6 +2476,12 @@ void Compiler::fgDumpBlock(BasicBlock* block)
     else
     {
         gtDispRange(LIR::AsRange(block));
+    }
+
+    if (fgSsaValid)
+    {
+        printf("\n");
+        fgDumpBlockMemorySsaOut(block);
     }
 }
 
@@ -2496,6 +2507,78 @@ void Compiler::fgDumpTrees(BasicBlock* firstBlock, BasicBlock* lastBlock)
     }
     printf("\n---------------------------------------------------------------------------------------------------------"
            "----------\n");
+}
+
+//------------------------------------------------------------------------
+// fgDumpBlockMemorySsaIn: Dump memory state SSAs incoming to a block.
+//
+// Arguments:
+//    block - The block
+//
+void Compiler::fgDumpBlockMemorySsaIn(BasicBlock* block)
+{
+    for (MemoryKind memoryKind : allMemoryKinds())
+    {
+        if (byrefStatesMatchGcHeapStates)
+        {
+            printf("%s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
+        }
+        else
+        {
+            printf("%s", memoryKindNames[memoryKind]);
+        }
+
+        if (block->bbMemorySsaPhiFunc[memoryKind] == nullptr)
+        {
+            printf(" = m:%u\n", block->bbMemorySsaNumIn[memoryKind]);
+        }
+        else
+        {
+            printf(" = phi(");
+            BasicBlock::MemoryPhiArg* phiArgs = block->bbMemorySsaPhiFunc[memoryKind];
+            const char*               sep     = "";
+            for (BasicBlock::MemoryPhiArg* arg = block->bbMemorySsaPhiFunc[memoryKind]; arg != nullptr;
+                 arg                           = arg->m_nextArg)
+            {
+                printf("%sm:%u", sep, arg->GetSsaNum());
+                sep = ", ";
+            }
+            printf(")\n");
+        }
+
+        if (byrefStatesMatchGcHeapStates)
+        {
+            break;
+        }
+    }
+}
+
+//------------------------------------------------------------------------
+// fgDumpBlockMemorySsaOut: Dump memory state SSAs outgoing from a block.
+//
+// Arguments:
+//    block - The block
+//
+void Compiler::fgDumpBlockMemorySsaOut(BasicBlock* block)
+{
+    for (MemoryKind memoryKind : allMemoryKinds())
+    {
+        if (byrefStatesMatchGcHeapStates)
+        {
+            printf("%s, %s", memoryKindNames[ByrefExposed], memoryKindNames[GcHeap]);
+        }
+        else
+        {
+            printf("%s", memoryKindNames[memoryKind]);
+        }
+
+        printf(" = m:%u\n", block->bbMemorySsaNumOut[memoryKind]);
+
+        if (byrefStatesMatchGcHeapStates)
+        {
+            break;
+        }
+    }
 }
 
 /*****************************************************************************
@@ -4525,7 +4608,7 @@ public:
 //
 void Compiler::fgDebugCheckSsa()
 {
-    if (!fgSsaChecksEnabled)
+    if (!fgSsaValid)
     {
         return;
     }

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -64,7 +64,7 @@ PhaseStatus Compiler::fgSsaBuild()
     SsaBuilder builder(this);
     builder.Build();
     fgSsaPassesCompleted++;
-    fgSsaChecksEnabled = true;
+    fgSsaValid = true;
 #ifdef DEBUG
     JitTestCheckSSA();
 #endif // DEBUG


### PR DESCRIPTION
When SSA is considered to be valid, write in and out SSA numbers for memory states when dumping the blocks.

For example:

```csharp
public static void Foo(C c)
{
    if (c.V % 2 == 0)
    {
        c.V = 123;
    }
    else
    {
        c.V = 456;
    }

    Console.WriteLine(c.V);
}

public class C
{
    public int V;
}
```
dumps

```
------------ BB01 [000..00A) -> BB03 (cond), preds={} succs={BB02,BB03}
ByrefExposed, GcHeap = m:1

***** BB01
STMT00000 ( 0x000[E-] ... 0x008 )
N009 ( 10, 10) [000007] ---XG------                         ▌  JTRUE     void
N008 (  8,  8) [000006] J--XG--N---                         └──▌  NE        int
N006 (  6,  6) [000004] ---XG------                            ├──▌  AND       int
N004 (  4,  4) [000002] ---XG------                            │  ├──▌  IND       int
N003 (  2,  2) [000024] -------N---                            │  │  └──▌  ADD       byref
N001 (  1,  1) [000000] -----------                            │  │     ├──▌  LCL_VAR   ref    V00 arg0         u:1
N002 (  1,  1) [000023] -----------                            │  │     └──▌  CNS_INT   long   8 Fseq[V]
N005 (  1,  1) [000003] -----------                            │  └──▌  CNS_INT   int    1
N007 (  1,  1) [000005] -----------                            └──▌  CNS_INT   int    0

ByrefExposed, GcHeap = m:1

------------ BB02 [00A..014) -> BB04 (always), preds={BB01} succs={BB04}
ByrefExposed, GcHeap = m:1

***** BB02
STMT00004 ( 0x00A[E-] ... 0x00D )
N005 (  6,  6) [000020] -A-XG------                         ▌  STOREIND  int
N003 (  2,  2) [000028] -------N---                         ├──▌  ADD       byref
N001 (  1,  1) [000017] -----------                         │  ├──▌  LCL_VAR   ref    V00 arg0         u:1
N002 (  1,  1) [000027] -----------                         │  └──▌  CNS_INT   long   8 Fseq[V]
N004 (  1,  1) [000018] -----------                         └──▌  CNS_INT   int    123

ByrefExposed, GcHeap = m:5

------------ BB03 [014..01F), preds={BB01} succs={BB04}
ByrefExposed, GcHeap = m:1

***** BB03
STMT00001 ( 0x014[E-] ... 0x01A )
N005 (  6,  9) [000011] -A-XG------                         ▌  STOREIND  int
N003 (  2,  2) [000026] -------N---                         ├──▌  ADD       byref
N001 (  1,  1) [000008] -----------                         │  ├──▌  LCL_VAR   ref    V00 arg0         u:1
N002 (  1,  1) [000025] -----------                         │  └──▌  CNS_INT   long   8 Fseq[V]
N004 (  1,  4) [000009] -----------                         └──▌  CNS_INT   int    456

ByrefExposed, GcHeap = m:4

------------ BB04 [01F..02B) (return), preds={BB02,BB03} succs={}
ByrefExposed, GcHeap = phi(m:5, m:4)

***** BB04
STMT00002 ( 0x01F[E-] ... 0x02A )
N005 ( 18, 10) [000015] --CXG------                         ▌  CALL      void   System.Console:WriteLine(int)
N004 (  4,  4) [000014] ---XG------ arg0 in rcx             └──▌  IND       int
N003 (  2,  2) [000030] -------N---                            └──▌  ADD       byref
N001 (  1,  1) [000012] -----------                               ├──▌  LCL_VAR   ref    V00 arg0         u:1 (last use)
N002 (  1,  1) [000029] -----------                               └──▌  CNS_INT   long   8 Fseq[V]

***** BB04
STMT00003 ( 0x02A[E-] ... ??? )
N001 (  0,  0) [000016] -----------                         ▌  RETURN    void

ByrefExposed, GcHeap = m:3

```

after SSA.