### PR TITLE
[perf] Run localized Blazor scenario

### DIFF
--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -39,9 +39,9 @@ extends:
           runProfile: 'v8'
           collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
           onlySanityCheck: true
-          #perfForkToUse: - dummy change
-            #url: https://github.com/radical/performance
-            #branch: fix-build
+          perfForkToUse: - dummy change
+            url: https://github.com/ilonatommy/performance
+            branch: localized-benchmark
           #downloadSpecificBuild:
             #buildId: '1878694'
             #pipeline: 'perf-wasm'

--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -39,7 +39,7 @@ extends:
           runProfile: 'v8'
           collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
           onlySanityCheck: true
-          perfForkToUse: - dummy change
+          perfForkToUse:
             url: https://github.com/ilonatommy/performance
             branch: localized-benchmark
           #downloadSpecificBuild:

--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -39,9 +39,9 @@ extends:
           runProfile: 'v8'
           collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
           onlySanityCheck: true
-          perfForkToUse:
-            url: https://github.com/ilonatommy/performance
-            branch: localized-benchmark
+          #perfForkToUse: - dummy change
+            #url: https://github.com/radical/performance
+            #branch: fix-build
           #downloadSpecificBuild:
             #buildId: '1878694'
             #pipeline: 'perf-wasm'

--- a/eng/testing/performance/blazor_perf.proj
+++ b/eng/testing/performance/blazor_perf.proj
@@ -87,14 +87,14 @@
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Localized App - Publish$(RunConfigsString)">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation)</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
       <Timeout>1:00</Timeout>
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Localized App - Publish - AOT$(RunConfigsString)">
       <_PublishArgsWithAOT>--msbuild &quot;$(_MSBuildArgs);/p:RunAOTCompilation=true&quot;</_PublishArgsWithAOT>
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) $(_PublishArgsWithAOT) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) $(_PublishArgsWithAOT) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation)</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
       <Timeout>1:00</Timeout>
     </HelixWorkItem>

--- a/eng/testing/performance/blazor_perf.proj
+++ b/eng/testing/performance/blazor_perf.proj
@@ -8,7 +8,7 @@
 
     <Python>python3</Python>
     <HelixPreCommands Condition="'$(AGENT_OS)' != 'Windows_NT'">$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
-    
+
     <_MSBuildArgs>/p:_TrimmerDumpDependencies=true;/p:HybridGlobalization=$(hybridGlobalization);/warnaserror:NU1602,NU1604</_MSBuildArgs>
     <PublishArgs>--has-workload --readonly-dotnet --msbuild &quot;$(_MSBuildArgs)&quot; --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
     <PublishCommand>$(EnvVars) $(Python) pre.py publish $(PublishArgs)</PublishCommand>
@@ -38,6 +38,7 @@
     <BlazorPizzaDirectory>$(ScenarioDirectory)blazorpizza/</BlazorPizzaDirectory>
     <BlazorMinAOTDirectory>$(ScenarioDirectory)blazorminappaot/</BlazorMinAOTDirectory>
     <BlazorAOTDirectory>$(ScenarioDirectory)blazoraot/</BlazorAOTDirectory>
+    <BlazorPizzaAOTDirectory>$(ScenarioDirectory)blazorpizzaaot/</BlazorPizzaAOTDirectory>
     <BlazorLocalizedDirectory>$(ScenarioDirectory)blazorlocalized/</BlazorLocalizedDirectory>
     <PizzaAppPubLocation>pub/wwwroot</PizzaAppPubLocation>
     <PerflabTargetFrameworks>$PERFLAB_TARGET_FRAMEWORKS</PerflabTargetFrameworks>

--- a/eng/testing/performance/blazor_perf.proj
+++ b/eng/testing/performance/blazor_perf.proj
@@ -8,8 +8,9 @@
 
     <Python>python3</Python>
     <HelixPreCommands Condition="'$(AGENT_OS)' != 'Windows_NT'">$(HelixPreCommands);chmod +x $HELIX_WORKITEM_PAYLOAD/SOD/SizeOnDisk</HelixPreCommands>
-
-    <PublishArgs>--has-workload --readonly-dotnet --msbuild "/p:_TrimmerDumpDependencies=true;/p:HybridGlobalization=$(hybridGlobalization);/warnaserror:NU1602,NU1604" --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
+    
+    <_MSBuildArgs>/p:_TrimmerDumpDependencies=true;/p:HybridGlobalization=$(hybridGlobalization);/warnaserror:NU1602,NU1604</_MSBuildArgs>
+    <PublishArgs>--has-workload --readonly-dotnet --msbuild &quot;$(_MSBuildArgs)&quot; --msbuild-static AdditionalMonoLinkerOptions=%27&quot;%24(AdditionalMonoLinkerOptions) --dump-dependencies&quot;%27 --binlog $(LogDirectory)blazor_publish.binlog</PublishArgs>
     <PublishCommand>$(EnvVars) $(Python) pre.py publish $(PublishArgs)</PublishCommand>
     <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise didn't add anything.
     This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
@@ -26,6 +27,7 @@
     <BlazorMinAOTDirectory>$(ScenarioDirectory)blazorminappaot\</BlazorMinAOTDirectory>
     <BlazorAOTDirectory>$(ScenarioDirectory)blazoraot\</BlazorAOTDirectory>
     <BlazorPizzaAOTDirectory>$(ScenarioDirectory)blazorpizzaaot\</BlazorPizzaAOTDirectory>
+    <BlazorLocalizedDirectory>$(ScenarioDirectory)blazorlocalized\</BlazorLocalizedDirectory>
     <PerflabTargetFrameworks>%PERFLAB_TARGET_FRAMEWORKS%</PerflabTargetFrameworks>
     <PizzaAppPubLocation>pub\wwwroot</PizzaAppPubLocation>
   </PropertyGroup>
@@ -36,7 +38,7 @@
     <BlazorPizzaDirectory>$(ScenarioDirectory)blazorpizza/</BlazorPizzaDirectory>
     <BlazorMinAOTDirectory>$(ScenarioDirectory)blazorminappaot/</BlazorMinAOTDirectory>
     <BlazorAOTDirectory>$(ScenarioDirectory)blazoraot/</BlazorAOTDirectory>
-    <BlazorPizzaAOTDirectory>$(ScenarioDirectory)blazorpizzaaot/</BlazorPizzaAOTDirectory>
+    <BlazorLocalizedDirectory>$(ScenarioDirectory)blazorlocalized/</BlazorLocalizedDirectory>
     <PizzaAppPubLocation>pub/wwwroot</PizzaAppPubLocation>
     <PerflabTargetFrameworks>$PERFLAB_TARGET_FRAMEWORKS</PerflabTargetFrameworks>
   </PropertyGroup>
@@ -80,6 +82,19 @@
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <!-- Specifying both illink dump msbuild properties in case illink version is not updated -->
       <Command>cd $(BlazorPizzaAOTDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot; --dirs $(PizzaAppPubLocation)</Command>
+      <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
+      <Timeout>1:00</Timeout>
+    </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Localized App - Publish$(RunConfigsString)">
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+      <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
+      <Timeout>1:00</Timeout>
+    </HelixWorkItem>
+    <HelixWorkItem Include="SOD - Localized App - Publish - AOT$(RunConfigsString)">
+      <_PublishArgsWithAOT>--msbuild &quot;$(_MSBuildArgs);/p:RunAOTCompilation=true&quot;</_PublishArgsWithAOT>
+      <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
+      <Command>cd $(BlazorLocalizedDirectory) &amp;&amp; $(PublishCommand) $(_PublishArgsWithAOT) -f $(PerflabTargetFrameworks) &amp;&amp; $(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
       <PostCommands>$(Python) post.py --readonly-dotnet</PostCommands>
       <Timeout>1:00</Timeout>
     </HelixWorkItem>


### PR DESCRIPTION
Change for running the benchmark from https://github.com/dotnet/performance/pull/3470.
Runs the app in two variants: without and with AOT.

Because we cannot pass the same argument multiple times (e.g. `pre.py publish --msbuild /p:_TrimmerDumpDependencies=true --msbuild /warnaserror:NU1602,NU1604` ignores all the repeated args but the last one - `warnaserror:NU1602,NU1604`), we are saving the args to MSBuild property and append to it when AOT needs to be switched on.

Should be merged after the changes in the perf repo.