### PR TITLE
Store entry assembly path for easy access for diagnostics

### DIFF
--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -224,6 +224,34 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
 
         ReportMem(g_gcDacGlobals.GetAddr(), sizeof(GcDacVars));
 
+        PTR_WSTR entryAssemblyPath = (PTR_WSTR)g_EntryAssemblyPath;
+        entryAssemblyPath.EnumMem();
+
+        // Triage dumps must not include full paths (PII data). Replace entry assembly path with file name only.
+        if (flags == CLRDATA_ENUM_MEM_TRIAGE)
+        {
+            WCHAR* path = entryAssemblyPath;
+            if (path != NULL)
+            {
+                size_t pathLen = u16_strlen(path) + 1;
+
+                // Get the file name based on the last directory separator
+                const WCHAR* name = u16_strrchr(path, DIRECTORY_SEPARATOR_CHAR_W);
+                if (name != NULL)
+                {
+                    name += 1;
+                    size_t len = u16_strlen(name) + 1;
+                    wcscpy_s(path, len, name);
+
+                    // Null out the rest of the buffer
+                    for (size_t i = len; i < pathLen; ++i)
+                        path[i] = '\0';
+
+                    DacUpdateMemoryRegion(entryAssemblyPath.GetAddr(), pathLen, (BYTE*)path);
+                }
+            }
+        }
+
         // We need all of the dac variables referenced by the GC DAC global struct.
         // This struct contains pointers to pointers, so we first dereference the pointers
         // to obtain the location of the variable that's reported.

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -245,7 +245,7 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
 
                     // Null out the rest of the buffer
                     for (size_t i = len; i < pathLen; ++i)
-                        path[i] = '\0';
+                        path[i] = W('\0');
 
                     DacUpdateMemoryRegion(entryAssemblyPath.GetAddr(), pathLen, (BYTE*)path);
                 }

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -574,6 +574,8 @@
 #include "crosscomp.h"
 #endif
 
+#include <dn-u16.h>
+
 // Information stored in the DAC table of interest to the DAC implementation
 // Note that this information is shared between all instantiations of ClrDataAccess, so initialize
 // it just once in code:ClrDataAccess.GetDacGlobals (rather than use fields in ClrDataAccess);

--- a/src/coreclr/inc/daccess.h
+++ b/src/coreclr/inc/daccess.h
@@ -1493,10 +1493,10 @@ public:
     }
     void EnumMem(void) const
     {
-        char* str = DacInstantiateStringW(m_addr, maxChars, false);
+        WCHAR* str = DacInstantiateStringW(m_addr, maxChars, false);
         if (str)
         {
-            DacEnumMemoryRegion(m_addr, strlen(str) + 1);
+            DacEnumMemoryRegion(m_addr, u16_strlen(str) + 1);
         }
     }
 };

--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -236,5 +236,7 @@ DEFINE_DACVAR(SIZE_T, dac__g_clrNotificationArguments, ::g_clrNotificationArgume
 DEFINE_DACVAR(bool, dac__g_metadataUpdatesApplied, ::g_metadataUpdatesApplied)
 #endif
 
+DEFINE_DACVAR(PTR_WSTR, dac__g_EntryAssemblyPath, ::g_EntryAssemblyPath)
+
 #undef DEFINE_DACVAR
 #undef DEFINE_DACVAR_NO_DUMP

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -310,6 +310,15 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
 
     _ASSERTE (!pThread->PreemptiveGCDisabled());
 
+    if (g_EntryAssemblyPath == NULL)
+    {
+        // Store the entry assembly path for diagnostic purposes (for example, dumps)
+        size_t len = u16_strlen(pwzAssemblyPath) + 1;
+        NewArrayHolder<WCHAR> path { new WCHAR[len] };
+        wcscpy_s(path, len, pwzAssemblyPath);
+        g_EntryAssemblyPath = path.Extract();
+    }
+
     Assembly *pAssembly = AssemblySpec::LoadAssembly(pwzAssemblyPath);
 
 #if defined(FEATURE_MULTICOREJIT)

--- a/src/coreclr/vm/vars.cpp
+++ b/src/coreclr/vm/vars.cpp
@@ -112,6 +112,8 @@ GPTR_IMPL(MethodTable,      g_pEHClass);
 GVAL_IMPL(bool,             g_isNewExceptionHandlingEnabled);
 #endif
 
+GVAL_IMPL_INIT(PTR_WSTR, g_EntryAssemblyPath, NULL);
+
 #ifndef DACCESS_COMPILE
 
 // <TODO> @TODO - PROMOTE. </TODO>

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -394,6 +394,9 @@ GPTR_DECL(MethodTable,      g_pEHClass);
 GVAL_DECL(bool,             g_isNewExceptionHandlingEnabled);
 #endif
 
+// Full path to the managed entry assembly - stored for ease of identifying the entry asssembly for diagnostics
+GVAL_DECL(PTR_WSTR, g_EntryAssemblyPath);
+
 // Global System Information
 extern SYSTEM_INFO g_SystemInfo;
 


### PR DESCRIPTION
- Add `g_EntryAssemblyPath` global variable holding the full path to the entry assembly
  - Set right before loading the entry assembly (so also before startup hooks are run) - NULL if there is no entry assembly
- Ensure value is included dumps
  - For triage dumps, the dumped value is updated to only be the assembly file name instead of the full path

Example:
```
0:000> ||
.  0 User mini triage dump: C:\repos\helloworld\triage.dmp
0:000> x coreclr!g_EntryAssemblyPath
00007ffb`14f7dd58 coreclr!g_EntryAssemblyPath = 0x00000211`88016eb0 "helloworld.dll"

0:000> ||
.  0 User mini dump: C:\repos\helloworld\mini.dmp
0:000> x coreclr!g_EntryAssemblyPath
00007ffb`14f7dd58 coreclr!g_EntryAssemblyPath = 0x00000211`88016eb0 "C:\repos\helloworld\bin\Debug\net8.0\helloworld.dll"
```

Fixes https://github.com/dotnet/runtime/issues/94474

@leculver 
@dotnet/dotnet-diag 