### PR TITLE
Fix PALTests build

### DIFF
--- a/src/coreclr/pal/tests/palsuite/file_io/GetTempPathW/test1/GetTempPathW.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/GetTempPathW/test1/GetTempPathW.cpp
@@ -24,7 +24,7 @@ static void SetTmpDir(const WCHAR path[])
 
 static void SetAndCompare(const WCHAR tmpDirPath[], const WCHAR expected[])
 {
-    DWORD dwBufferLength = _MAX_DIR;
+    const DWORD dwBufferLength = _MAX_DIR;
     WCHAR path[dwBufferLength];
 
     SetTmpDir(tmpDirPath);
@@ -50,7 +50,7 @@ static void SetAndCompare(const WCHAR tmpDirPath[], const WCHAR expected[])
 
 static void SetAndCheckLength(const WCHAR tmpDirPath [], int bufferLength, int expectedResultLength)
 {
-    WCHAR path[bufferLength];
+    WCHAR* path = (WCHAR*)alloca(bufferLength);
 
     SetTmpDir(tmpDirPath);
     DWORD dwResultLen = GetTempPathW(bufferLength, path);

--- a/src/coreclr/pal/tests/palsuite/file_io/gettemppatha/test1/gettemppatha.cpp
+++ b/src/coreclr/pal/tests/palsuite/file_io/gettemppatha/test1/gettemppatha.cpp
@@ -24,7 +24,7 @@ static void SetTmpDir(CHAR path[])
 
 static void SetAndCompare(CHAR tmpDirPath[], CHAR expected[])
 {
-    DWORD dwBufferLength = _MAX_DIR;
+    const DWORD dwBufferLength = _MAX_DIR;
     CHAR  path[dwBufferLength];
     
     SetTmpDir(tmpDirPath);
@@ -50,7 +50,7 @@ static void SetAndCompare(CHAR tmpDirPath[], CHAR expected[])
 
 static void SetAndCheckLength(CHAR tmpDirPath[], int bufferLength, int expectedResultLength)
 {
-    CHAR  path[bufferLength];
+    CHAR* path = (CHAR*)alloca(bufferLength);
 
     SetTmpDir(tmpDirPath);
     DWORD dwResultLen = GetTempPathA(bufferLength, path);


### PR DESCRIPTION
Something changed in the build or tools that led to build errors like:
```
/__w/1/s/src/coreclr/pal/tests/palsuite/file_io/gettemppatha/test1/gettemppatha.cpp:28:16: error: variable length arrays are a C99 feature [-Werror,-Wvla-extension]
      CHAR  path[dwBufferLength];
                 ^~~~~~~~~~~~~~
```