### PR TITLE
JIT: Keep fgBBcount up to date

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4491,7 +4491,7 @@ public:
                                     // created.
     BasicBlockList* fgReturnBlocks; // list of BBJ_RETURN blocks
     unsigned        fgEdgeCount;    // # of control flow edges between the BBs
-    unsigned        fgBBcount;      // # of BBs in the method
+    unsigned        fgBBcount;      // # of BBs in the method (in the linked list that starts with fgFirstBB)
 #ifdef DEBUG
     unsigned                     fgBBcountAtCodegen; // # of BBs in the method at the start of codegen
     jitstd::vector<BasicBlock*>* fgBBOrder;          // ordered vector of BBs
@@ -4630,6 +4630,7 @@ public:
     void fgInsertBBbefore(BasicBlock* insertBeforeBlk, BasicBlock* newBlk);
     void fgInsertBBafter(BasicBlock* insertAfterBlk, BasicBlock* newBlk);
     void fgUnlinkBlock(BasicBlock* block);
+    void fgUnlinkBlockForRemoval(BasicBlock* block);
 
 #ifdef FEATURE_JIT_METHOD_PERF
     unsigned fgMeasureIR();

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2892,8 +2892,12 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
 
     bool allNodesLinked = (fgNodeThreading == NodeThreading::AllTrees) || (fgNodeThreading == NodeThreading::LIR);
 
+    unsigned numBlocks = 0;
+
     for (BasicBlock* const block : Blocks())
     {
+        numBlocks++;
+
         if (checkBBNum)
         {
             // Check that bbNum is sequential
@@ -3101,6 +3105,8 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
             assert(block->bbWeight > BB_ZERO_WEIGHT);
         }
     }
+
+    assert(fgBBcount == numBlocks);
 
     // Make sure the one return BB is not changed.
     if (genReturnBB != nullptr)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1543,7 +1543,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                 // We rely on the fact that this does not clear out
                 // cur->bbNext or cur->bbPrev in the code that
                 // follows.
-                fgUnlinkBlock(cur);
+                fgUnlinkBlockForRemoval(cur);
             }
             else
             {
@@ -2361,6 +2361,8 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
     /* Unlink bNext and update all the marker pointers if necessary */
 
     fgUnlinkRange(bNext, bNext);
+
+    fgBBcount--;
 
     // If bNext was the last block of a try or handler, update the EH table.
 
@@ -6331,7 +6333,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                         */
 
                         fgRemoveRefPred(bNext, block);
-                        fgUnlinkBlock(bNext);
+                        fgUnlinkBlockForRemoval(bNext);
 
                         /* Mark the block as removed */
                         bNext->bbFlags |= BBF_REMOVED;

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -779,7 +779,7 @@ PhaseStatus Compiler::optIfConversion()
 
     bool madeChanges = false;
 
-    // This phase does not repect SSA: assignments are deleted/moved.
+    // This phase does not respect SSA: assignments are deleted/moved.
     assert(!fgDomsComputed);
     optReachableBitVecTraits = nullptr;
 
@@ -793,11 +793,6 @@ PhaseStatus Compiler::optIfConversion()
         block = block->Prev();
     }
 #endif
-
-    if (madeChanges)
-    {
-        fgRenumberBlocks();
-    }
 
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1323,7 +1323,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
 
     // Get rid of the second block
 
-    m_comp->fgUnlinkBlock(m_b2);
+    m_comp->fgUnlinkBlockForRemoval(m_b2);
     m_b2->bbFlags |= BBF_REMOVED;
     // If m_b2 was the last block of a try or handler, update the EH table.
     m_comp->ehUpdateForDeletedBlock(m_b2);
@@ -1331,7 +1331,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
     if (optReturnBlock)
     {
         // Get rid of the third block
-        m_comp->fgUnlinkBlock(m_b3);
+        m_comp->fgUnlinkBlockForRemoval(m_b3);
         m_b3->bbFlags |= BBF_REMOVED;
         // If m_b3 was the last block of a try or handler, update the EH table.
         m_comp->ehUpdateForDeletedBlock(m_b3);


### PR DESCRIPTION
Ensure fgBBcount is always the exact count of basic blocks in the linked list of blocks. Assert this in the post phase checks.

The goal is to avoid renumbering blocks simply as a means of getting an up-to-date block count. Remove one place that does this (if-conversion). We should be able to remove another in morph, but I want to do it separately. Also, it is a prerequisite to a more general purpose and more liberally used dead block elimination pass that I want to look at implementing.