### PR TITLE
Fix managed ContentionStart data

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -126,7 +126,7 @@ namespace System.Diagnostics.Tracing
             data[4].DataPointer = (nint)(&LockOwnerThreadID);
             data[4].Size = sizeof(ulong);
             data[4].Reserved = 0;
-            WriteEventCore(81, 3, data);
+            WriteEventCore(81, 5, data);
         }
 
         [NonEvent]


### PR DESCRIPTION
The managed ContentionStart event was recently added and I think it's only used for AOT so the impact was probably low.