### PR TITLE
Fix ILLink/ILC hang when tracking too many hoisted local values

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ArrayValue.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ArrayValue.cs
@@ -19,7 +19,7 @@ namespace ILLink.Shared.TrimAnalysis
         public static MultiValue Create(MultiValue size, TypeDesc elementType)
         {
             MultiValue result = MultiValueLattice.Top;
-            foreach (var sizeValue in size)
+            foreach (var sizeValue in size.AsEnumerable ())
             {
                 result = MultiValueLattice.Meet(result, new MultiValue(new ArrayValue(sizeValue, elementType)));
             }
@@ -92,7 +92,7 @@ namespace ILLink.Shared.TrimAnalysis
                 // Since it's possible to store a reference to array as one of its own elements
                 // simple deep copy could lead to endless recursion.
                 // So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
-                foreach (SingleValue v in kvp.Value.Value)
+                foreach (SingleValue v in kvp.Value.Value.AsEnumerable ())
                 {
                     System.Diagnostics.Debug.Assert(v is not ArrayValue);
                 }
@@ -123,7 +123,7 @@ namespace ILLink.Shared.TrimAnalysis
                 result.Append(element.Key);
                 result.Append(",(");
                 bool firstValue = true;
-                foreach (var v in element.Value.Value)
+                foreach (var v in element.Value.Value.AsEnumerable ())
                 {
                     if (firstValue)
                     {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
@@ -67,7 +67,8 @@ namespace ILCompiler.Dataflow
             methodBody = GetInstantiatedMethodIL(methodBody);
 
             // Work around the fact that ValueSet is readonly
-            var methodsList = new List<MethodBodyValue>(MethodBodies);
+            Debug.Assert (!MethodBodies.IsUnknown ());
+            var methodsList = new List<MethodBodyValue>(MethodBodies.GetKnownValues ());
             methodsList.Add(new MethodBodyValue(methodBody));
 
             // For state machine methods, also scan the state machine members.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -210,7 +210,7 @@ namespace ILCompiler.Dataflow
                     continue;
 
                 MultiValue localValue = localVariable.Value.Value;
-                foreach (var val in localValue)
+                foreach (var val in localValue.AsEnumerable ())
                 {
                     if (val is LocalVariableReferenceValue localReference && localReference.ReferencedType.IsByRefOrPointer())
                     {
@@ -309,7 +309,8 @@ namespace ILCompiler.Dataflow
 
                 // Flow state through all methods encountered so far, as long as there
                 // are changes discovered in the hoisted local state on entry to any method.
-                foreach (var methodBodyValue in oldInterproceduralState.MethodBodies)
+                Debug.Assert (!oldInterproceduralState.MethodBodies.IsUnknown ());
+                foreach (var methodBodyValue in oldInterproceduralState.MethodBodies.GetKnownValues ())
                     Scan(methodBodyValue.MethodBody, ref interproceduralState);
             }
 
@@ -327,7 +328,8 @@ namespace ILCompiler.Dataflow
             }
             else
             {
-                Debug.Assert(interproceduralState.MethodBodies.Count() == 1);
+                Debug.Assert (!interproceduralState.MethodBodies.IsUnknown ());
+                Debug.Assert(interproceduralState.MethodBodies.GetKnownValues ().Count() == 1);
             }
 #endif
         }
@@ -1018,7 +1020,7 @@ namespace ILCompiler.Dataflow
         /// <exception cref="LinkerFatalErrorException">Throws if <paramref name="target"/> is not a valid target for an indirect store.</exception>
         protected void StoreInReference(MultiValue target, MultiValue source, MethodIL method, int offset, ValueBasicBlockPair?[] locals, int curBasicBlock, ref InterproceduralState ipState)
         {
-            foreach (var value in target)
+            foreach (var value in target.AsEnumerable ())
             {
                 switch (value)
                 {
@@ -1137,7 +1139,7 @@ namespace ILCompiler.Dataflow
                 return;
             }
 
-            foreach (var value in HandleGetField(methodBody, offset, field))
+            foreach (var value in HandleGetField(methodBody, offset, field).AsEnumerable ())
             {
                 // GetFieldValue may return different node types, in which case they can't be stored to.
                 // At least not yet.
@@ -1189,7 +1191,7 @@ namespace ILCompiler.Dataflow
             ref InterproceduralState interproceduralState)
         {
             MultiValue dereferencedValue = MultiValueLattice.Top;
-            foreach (var value in maybeReferenceValue)
+            foreach (var value in maybeReferenceValue.AsEnumerable ())
             {
                 switch (value)
                 {
@@ -1324,7 +1326,7 @@ namespace ILCompiler.Dataflow
 
             foreach (var param in methodArguments)
             {
-                foreach (var v in param)
+                foreach (var v in param.AsEnumerable ())
                 {
                     if (v is ArrayValue arr)
                     {
@@ -1366,7 +1368,7 @@ namespace ILCompiler.Dataflow
             StackSlot indexToStoreAt = PopUnknown(currentStack, 1, methodBody, offset);
             StackSlot arrayToStoreIn = PopUnknown(currentStack, 1, methodBody, offset);
             int? indexToStoreAtInt = indexToStoreAt.Value.AsConstInt();
-            foreach (var array in arrayToStoreIn.Value)
+            foreach (var array in arrayToStoreIn.Value.AsEnumerable ())
             {
                 if (array is ArrayValue arrValue)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -431,7 +431,7 @@ namespace ILCompiler.Dataflow
                         // type instead).
                         //
                         // At least until we have shared enum code, this needs extra handling to get it right.
-                        foreach (var value in argumentValues[0])
+                        foreach (var value in argumentValues[0].AsEnumerable ())
                         {
                             if (value is SystemTypeValue systemTypeValue
                                 && !systemTypeValue.RepresentedType.Type.IsGenericDefinition
@@ -466,7 +466,7 @@ namespace ILCompiler.Dataflow
                             ? 0 : 1;
 
                         // We need the data to do struct marshalling.
-                        foreach (var value in argumentValues[paramIndex])
+                        foreach (var value in argumentValues[paramIndex].AsEnumerable ())
                         {
                             if (value is SystemTypeValue systemTypeValue
                                 && !systemTypeValue.RepresentedType.Type.IsGenericDefinition
@@ -497,7 +497,7 @@ namespace ILCompiler.Dataflow
                 case IntrinsicId.Marshal_GetDelegateForFunctionPointer:
                     {
                         // We need the data to do delegate marshalling.
-                        foreach (var value in argumentValues[1])
+                        foreach (var value in argumentValues[1].AsEnumerable ())
                         {
                             if (value is SystemTypeValue systemTypeValue
                                 && !systemTypeValue.RepresentedType.Type.IsGenericDefinition
@@ -521,7 +521,7 @@ namespace ILCompiler.Dataflow
                 //
                 case IntrinsicId.Object_GetType:
                     {
-                        foreach (var valueNode in instanceValue)
+                        foreach (var valueNode in instanceValue.AsEnumerable ())
                         {
                             // Note that valueNode can be statically typed in IL as some generic argument type.
                             // For example:
@@ -619,7 +619,7 @@ namespace ILCompiler.Dataflow
             // Validate that the return value has the correct annotations as per the method return value annotations
             if (annotatedMethodReturnValue.DynamicallyAccessedMemberTypes != 0)
             {
-                foreach (var uniqueValue in methodReturnValue)
+                foreach (var uniqueValue in methodReturnValue.AsEnumerable ())
                 {
                     if (uniqueValue is ValueWithDynamicallyAccessedMembers methodReturnValueWithMemberTypes)
                     {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/TrimAnalysisAssignmentPattern.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/TrimAnalysisAssignmentPattern.cs
@@ -48,9 +48,9 @@ namespace ILCompiler.Dataflow
                 logger.ShouldSuppressAnalysisWarningsForRequires(Origin.MemberDefinition, DiagnosticUtilities.RequiresAssemblyFilesAttribute),
                 logger);
 
-            foreach (var sourceValue in Source)
+            foreach (var sourceValue in Source.AsEnumerable ())
             {
-                foreach (var targetValue in Target)
+                foreach (var targetValue in Target.AsEnumerable ())
                 {
                     if (targetValue is not ValueWithDynamicallyAccessedMembers targetWithDynamicallyAccessedMembers)
                         throw new NotImplementedException();

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/FeatureContextLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/FeatureContextLattice.cs
@@ -14,51 +14,43 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 	public struct FeatureContext : IEquatable<FeatureContext>, IDeepCopyValue<FeatureContext>
 	{
 		// The set of features known to be enabled in this context.
-		// Null represents "all possible features".
-		public ValueSet<string>? EnabledFeatures;
+		// Unknown represents "all possible features".
+		public ValueSet<string> EnabledFeatures;
 
-		public static readonly FeatureContext All = new FeatureContext (null);
+		public static readonly FeatureContext All = new FeatureContext (ValueSet<string>.Unknown);
 
 		public static readonly FeatureContext None = new FeatureContext (ValueSet<string>.Empty);
 
-		public FeatureContext (ValueSet<string>? enabled)
+		public FeatureContext (ValueSet<string> enabled)
 		{
 			EnabledFeatures = enabled;
 		}
 
 		public bool IsEnabled (string feature)
 		{
-			return EnabledFeatures == null || EnabledFeatures.Value.Contains (feature);
+			return EnabledFeatures.IsUnknown () || EnabledFeatures.Contains (feature);
 		}
 
 		public bool Equals (FeatureContext other) => EnabledFeatures == other.EnabledFeatures;
 		public override bool Equals (object? obj) => obj is FeatureContext other && Equals (other);
-		public override int GetHashCode () => EnabledFeatures?.GetHashCode () ?? typeof (FeatureContext).GetHashCode ();
+		public override int GetHashCode () => EnabledFeatures.GetHashCode ();
 
 		public static bool operator == (FeatureContext left, FeatureContext right) => left.Equals (right);
 		public static bool operator != (FeatureContext left, FeatureContext right) => !left.Equals (right);
 
 		public FeatureContext DeepCopy ()
 		{
-			return new FeatureContext (EnabledFeatures?.DeepCopy ());
+			return new FeatureContext (EnabledFeatures.DeepCopy ());
 		}
 
 		public FeatureContext Intersection (FeatureContext other)
 		{
-			if (EnabledFeatures == null)
-				return other.DeepCopy ();
-			if (other.EnabledFeatures == null)
-				return this.DeepCopy ();
-			return new FeatureContext (ValueSet<string>.Intersection (EnabledFeatures.Value, other.EnabledFeatures.Value));
+			return new FeatureContext (ValueSet<string>.Intersection (EnabledFeatures, other.EnabledFeatures));
 		}
 
 		public FeatureContext Union (FeatureContext other)
 		{
-			if (EnabledFeatures == null)
-				return this.DeepCopy ();
-			if (other.EnabledFeatures == null)
-				return other.DeepCopy ();
-			return new FeatureContext (ValueSet<string>.Union (EnabledFeatures.Value, other.EnabledFeatures.Value));
+			return new FeatureContext (ValueSet<string>.Union (EnabledFeatures, other.EnabledFeatures));
 		}
 	}
 

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/InterproceduralState.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
 
@@ -50,7 +51,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 
 		public void TrackMethod (MethodBodyValue method)
 		{
-			var methodsList = new List<MethodBodyValue> (Methods);
+			Debug.Assert (!Methods.IsUnknown ());
+			var methodsList = new List<MethodBodyValue> (Methods.GetKnownValues ());
 			methodsList.Add (method);
 			Methods = new ValueSet<MethodBodyValue> (methodsList);
 		}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
@@ -79,7 +79,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			while (!interproceduralState.Equals (oldInterproceduralState)) {
 				oldInterproceduralState = interproceduralState.Clone ();
 
-				foreach (var method in oldInterproceduralState.Methods) {
+				Debug.Assert (!oldInterproceduralState.Methods.IsUnknown ());
+				foreach (var method in oldInterproceduralState.Methods.GetKnownValues ()) {
 					AnalyzeMethod (method, ref interproceduralState);
 				}
 			}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowVisitor.cs
@@ -402,9 +402,10 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			Debug.Assert (IsLValueFlowCapture (flowCaptureReference.Id));
 			Debug.Assert (flowCaptureReference.GetValueUsageInfo (OwningSymbol).HasFlag (ValueUsageInfo.Write));
 			var capturedReferences = state.Current.LocalState.CapturedReferences.Get (flowCaptureReference.Id);
+			Debug.Assert (!capturedReferences.IsUnknown ());
 			if (!capturedReferences.HasMultipleValues) {
 				// Single captured reference. Treat this as an overwriting assignment.
-				var enumerator = capturedReferences.GetEnumerator ();
+				var enumerator = capturedReferences.GetKnownValues ().GetEnumerator ();
 				enumerator.MoveNext ();
 				targetOperation = enumerator.Current.Reference;
 				return ProcessSingleTargetAssignment (targetOperation, operation, state, merge: false);
@@ -421,7 +422,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 			// if the RHS has dataflow warnings.
 
 			TValue value = TopValue;
-			foreach (var capturedReference in capturedReferences) {
+			foreach (var capturedReference in capturedReferences.GetKnownValues ()) {
 				targetOperation = capturedReference.Reference;
 				var singleValue = ProcessSingleTargetAssignment (targetOperation, operation, state, merge: true);
 				value = LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Meet (value, singleValue);
@@ -529,7 +530,9 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 						// If an r-value captures an l-value, we must dereference the l-value
 						// and copy out the value to capture.
 						capturedValue = TopValue;
-						foreach (var capturedReference in state.Current.LocalState.CapturedReferences.Get (captureRef.Id)) {
+						var capturedReferences = state.Current.LocalState.CapturedReferences.Get (captureRef.Id);
+						Debug.Assert (!capturedReferences.IsUnknown ());
+						foreach (var capturedReference in capturedReferences.GetKnownValues ()) {
 							var value = Visit (capturedReference.Reference, state);
 							capturedValue = LocalStateAndContextLattice.LocalStateLattice.Lattice.ValueLattice.Meet (capturedValue, value);
 						}

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateAndContextLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalStateAndContextLattice.cs
@@ -41,6 +41,7 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		{
 			LocalStateLattice = localStateLattice;
 			ContextLattice = contextLattice;
+			Top = new (LocalStateLattice.Top, ContextLattice.Top);
 		}
 
 		public LocalStateAndContext<TValue, TContext> Top { get; }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/ArrayValue.cs
@@ -14,7 +14,7 @@ namespace ILLink.Shared.TrimAnalysis
 		public static MultiValue Create (MultiValue size)
 		{
 			MultiValue result = MultiValueLattice.Top;
-			foreach (var sizeValue in size) {
+			foreach (var sizeValue in size.AsEnumerable ()) {
 				result = MultiValueLattice.Meet (result, new MultiValue (new ArrayValue (sizeValue)));
 			}
 
@@ -73,7 +73,7 @@ namespace ILLink.Shared.TrimAnalysis
 				// Since it's possible to store a reference to array as one of its own elements
 				// simple deep copy could lead to endless recursion.
 				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
-				foreach (SingleValue v in kvp.Value) {
+				foreach (SingleValue v in kvp.Value.AsEnumerable ()) {
 					System.Diagnostics.Debug.Assert (v is not ArrayValue);
 				}
 #endif

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisAssignmentPattern.cs
@@ -59,8 +59,8 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			if (context.EnableTrimAnalyzer &&
 				!OwningSymbol.IsInRequiresUnreferencedCodeAttributeScope (out _) &&
 				!FeatureContext.IsEnabled (RequiresUnreferencedCodeAnalyzer.UnreferencedCode)) {
-				foreach (var sourceValue in Source) {
-					foreach (var targetValue in Target) {
+				foreach (var sourceValue in Source.AsEnumerable ()) {
+					foreach (var targetValue in Target.AsEnumerable ()) {
 						// The target should always be an annotated value, but the visitor design currently prevents
 						// declaring this in the type system.
 						if (targetValue is not ValueWithDynamicallyAccessedMembers targetWithDynamicallyAccessedMembers)

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -101,7 +101,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 			var arrayValue = ArrayValue.Create (Visit (operation.DimensionSizes[0], state));
 			var elements = operation.Initializer?.ElementValues.Select (val => Visit (val, state)).ToArray () ?? System.Array.Empty<MultiValue> ();
-			foreach (var array in arrayValue.Cast<ArrayValue> ()) {
+			foreach (var array in arrayValue.AsEnumerable ().Cast<ArrayValue> ()) {
 				for (int i = 0; i < elements.Length; i++) {
 					array.IndexValues.Add (i, ArrayValue.SanitizeArrayElementValue(elements[i]));
 				}
@@ -183,11 +183,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				MultiValue rightValue = Visit (operation.RightOperand, argument);
 
 				MultiValue result = TopValue;
-				foreach (var left in leftValue) {
+				foreach (var left in leftValue.AsEnumerable ()) {
 					if (left is UnknownValue)
 						result = _multiValueLattice.Meet (result, left);
 					else if (left is ConstIntValue leftConstInt) {
-						foreach (var right in rightValue) {
+						foreach (var right in rightValue.AsEnumerable ()) {
 							if (right is UnknownValue)
 								result = _multiValueLattice.Meet (result, right);
 							else if (right is ConstIntValue rightConstInt) {
@@ -240,7 +240,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				return UnknownValue.Instance;
 
 			MultiValue result = TopValue;
-			foreach (var value in arrayValue) {
+			foreach (var value in arrayValue.AsEnumerable ()) {
 				if (value is ArrayValue arr && arr.TryGetValueByIndex (index, out var elementValue))
 					result = _multiValueLattice.Meet (result, elementValue);
 				else
@@ -252,7 +252,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		public override void HandleArrayElementWrite (MultiValue arrayValue, MultiValue indexValue, MultiValue valueToWrite, IOperation operation, bool merge)
 		{
 			int? index = indexValue.AsConstInt ();
-			foreach (var arraySingleValue in arrayValue) {
+			foreach (var arraySingleValue in arrayValue.AsEnumerable ()) {
 				if (arraySingleValue is ArrayValue arr) {
 					if (index == null) {
 						// Reset the array to all unknowns - since we don't know which index is being assigned
@@ -297,7 +297,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				featureContext));
 
 			foreach (var argument in arguments) {
-				foreach (var argumentValue in argument) {
+				foreach (var argumentValue in argument.AsEnumerable ()) {
 					if (argumentValue is ArrayValue arrayValue)
 						arrayValue.IndexValues.Clear ();
 				}
@@ -338,7 +338,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 				break;
 
 			case IntrinsicId.Object_GetType: {
-					foreach (var valueNode in instance) {
+					foreach (var valueNode in instance.AsEnumerable ()) {
 						// Note that valueNode can be statically typed as some generic argument type.
 						// For example:
 						//   void Method<T>(T instance) { instance.GetType().... }

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -12,12 +13,14 @@ using System.Text;
 
 namespace ILLink.Shared.DataFlow
 {
-	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IEnumerable<TValue>, IDeepCopyValue<ValueSet<TValue>>
+	public readonly struct ValueSet<TValue> : IEquatable<ValueSet<TValue>>, IDeepCopyValue<ValueSet<TValue>>
 		where TValue : notnull
 	{
 		const int MaxValuesInSet = 256;
 
 		public static ValueSet<TValue> Empty;
+
+		public static ValueSet<TValue> Unknown = new ValueSet<TValue> (ValueSetSentinel.Unknown);
 
 		// Since we're going to do lot of type checks for this class a lot, it is much more efficient
 		// if the class is sealed (as then the runtime can do a simple method table pointer comparison)
@@ -119,11 +122,25 @@ namespace ILLink.Shared.DataFlow
 			}
 		}
 
+		private struct Enumerable : IEnumerable<TValue>
+		{
+			private readonly object? _values;
+
+			public Enumerable (object? values) => _values = values;
+
+			public Enumerator GetEnumerator () => new (_values);
+
+			IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator () => GetEnumerator ();
+
+			IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+		}
+
 		// This stores the values. By far the most common case will be either no values, or a single value.
 		// Cases where there are multiple values stored are relatively very rare.
 		//   null - no values (empty set)
 		//   TValue - single value itself
 		//   EnumerableValues typed object - multiple values, stored in the hashset
+		//   ValueSetSentinel.Unknown - unknown value, or "any possible value"
 		private readonly object? _values;
 
 		public ValueSet (TValue value) => _values = value;
@@ -132,8 +149,16 @@ namespace ILLink.Shared.DataFlow
 
 		private ValueSet (EnumerableValues values) => _values = values;
 
+		private enum ValueSetSentinel
+		{
+			Unknown
+		}
+
+		private ValueSet (ValueSetSentinel sentinel) => _values = sentinel;
+
 		public static implicit operator ValueSet<TValue> (TValue value) => new (value);
 
+		// Note: returns false for Unknown
 		public bool HasMultipleValues => _values is EnumerableValues;
 
 		public override bool Equals (object? obj) => obj is ValueSet<TValue> other && Equals (other);
@@ -148,14 +173,24 @@ namespace ILLink.Shared.DataFlow
 			if (_values is EnumerableValues enumerableValues) {
 				if (other._values is EnumerableValues otherValuesSet) {
 					return enumerableValues.Equals (otherValuesSet);
-				} else
-					return enumerableValues.Equals ((TValue) other._values);
-			} else {
-				if (other._values is EnumerableValues otherEnumerableValues) {
-					return otherEnumerableValues.Equals ((TValue) _values);
+				} else if (other._values is TValue otherValue) {
+					return enumerableValues.Equals (otherValue);
+				} else {
+					Debug.Assert (other._values is ValueSetSentinel.Unknown);
+					return false;
 				}
-
-				return EqualityComparer<TValue>.Default.Equals ((TValue) _values, (TValue) other._values);
+			} else if (_values is TValue value) {
+				if (other._values is EnumerableValues otherEnumerableValues) {
+					return otherEnumerableValues.Equals (value);
+				} else if (other._values is TValue otherValue) {
+					return EqualityComparer<TValue>.Default.Equals (value, otherValue);
+				} else {
+					Debug.Assert (other._values is ValueSetSentinel.Unknown);
+					return false;
+				}
+			} else {
+				Debug.Assert (_values is ValueSetSentinel.Unknown);
+				return other._values is ValueSetSentinel.Unknown;
 			}
 		}
 
@@ -173,17 +208,20 @@ namespace ILLink.Shared.DataFlow
 			return _values.GetHashCode ();
 		}
 
-		public Enumerator GetEnumerator () => new (_values);
+		public IEnumerable<TValue> GetKnownValues () => new Enumerable (_values is ValueSetSentinel.Unknown ? null : _values);
 
-		IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator () => GetEnumerator ();
-
-		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
-
-		public bool Contains (TValue value) => _values is null
-			? false
-			: _values is EnumerableValues valuesSet
-				? valuesSet.Contains (value)
-				: EqualityComparer<TValue>.Default.Equals (value, (TValue) _values);
+		// Note: returns false for Unknown
+		public bool Contains (TValue value)
+		{
+			if (_values is null)
+				return false;
+			if (_values is EnumerableValues valuesSet)
+				return valuesSet.Contains (value);
+			if (_values is TValue thisValue)
+				return EqualityComparer<TValue>.Default.Equals (value, thisValue);
+			Debug.Assert (_values is ValueSetSentinel.Unknown);
+			return false;
+		}
 
 		internal static ValueSet<TValue> Union (ValueSet<TValue> left, ValueSet<TValue> right)
 		{
@@ -192,27 +230,34 @@ namespace ILLink.Shared.DataFlow
 			if (right._values == null)
 				return left.DeepCopy ();
 
+			if (left._values is ValueSetSentinel.Unknown || right._values is ValueSetSentinel.Unknown)
+				return Unknown;
+
 			if (left._values is not EnumerableValues && right.Contains ((TValue) left._values))
 				return right.DeepCopy ();
 
 			if (right._values is not EnumerableValues && left.Contains ((TValue) right._values))
 				return left.DeepCopy ();
 
-			var values = new EnumerableValues (left.DeepCopy ());
-			values.UnionWith (right.DeepCopy ());
+			var values = new EnumerableValues (left.DeepCopy ().GetKnownValues ());
+			values.UnionWith (right.DeepCopy ().GetKnownValues ());
 			// Limit the number of values we track, to prevent hangs in case of patterns that
-			// create exponentially many possible values. This will result in analysis holes.
+			// create exponentially many possible values.
 			if (values.Count > MaxValuesInSet)
-				return default;
+				return Unknown;
 			return new ValueSet<TValue> (values);
 		}
 
 		internal static ValueSet<TValue> Intersection (ValueSet<TValue> left, ValueSet<TValue> right)
 		{
-			if (left._values == null)
+			if (left._values == null || right._values == null)
 				return Empty;
-			if (right._values == null)
-				return Empty;
+
+			if (left._values is ValueSetSentinel.Unknown)
+				return right.DeepCopy ();
+
+			if (right._values is ValueSetSentinel.Unknown)
+				return left.DeepCopy ();
 
 			if (left._values is not EnumerableValues)
 				return right.Contains ((TValue) left._values) ? left.DeepCopy () : Empty;
@@ -220,18 +265,22 @@ namespace ILLink.Shared.DataFlow
 			if (right._values is not EnumerableValues)
 				return left.Contains ((TValue) right._values) ? right.DeepCopy () : Empty;
 
-			var values = new EnumerableValues (left.DeepCopy ());
-			values.IntersectWith (right);
+			var values = new EnumerableValues (left.DeepCopy ().GetKnownValues ());
+			values.IntersectWith (right.GetKnownValues ());
 			return new ValueSet<TValue> (values);
 		}
 
 		public bool IsEmpty () => _values == null;
 
+		public bool IsUnknown () => _values is ValueSetSentinel.Unknown;
+
 		public override string ToString ()
 		{
+			if (IsUnknown ())
+				return "Unknown";
 			StringBuilder sb = new ();
 			sb.Append ('{');
-			sb.Append (string.Join (",", this.Select (v => v.ToString ())));
+			sb.Append (string.Join (",", GetKnownValues ().Select (v => v.ToString ())));
 			sb.Append ('}');
 			return sb.ToString ();
 		}
@@ -243,6 +292,9 @@ namespace ILLink.Shared.DataFlow
 			if (_values is null)
 				return this;
 
+			if (_values is ValueSetSentinel.Unknown)
+				return this;
+
 			// Optimize for the most common case with only a single value
 			if (_values is not EnumerableValues) {
 				if (_values is IDeepCopyValue<TValue> copyValue)
@@ -251,7 +303,7 @@ namespace ILLink.Shared.DataFlow
 					return this;
 			}
 
-			return new ValueSet<TValue> (this.Select (value => value is IDeepCopyValue<TValue> copyValue ? copyValue.DeepCopy () : value));
+			return new ValueSet<TValue> (GetKnownValues ().Select (value => value is IDeepCopyValue<TValue> copyValue ? copyValue.DeepCopy () : value));
 		}
 	}
 }

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ValueSet.cs
@@ -128,7 +128,7 @@ namespace ILLink.Shared.DataFlow
 			}
 		}
 
-		private readonly struct Enumerable : IEnumerable<TValue>
+		public readonly struct Enumerable : IEnumerable<TValue>
 		{
 			private readonly object? _values;
 
@@ -209,7 +209,7 @@ namespace ILLink.Shared.DataFlow
 			return _values.GetHashCode ();
 		}
 
-		public IEnumerable<TValue> GetKnownValues () => new Enumerable (_values == UnknownSentinel ? null : _values);
+		public Enumerable GetKnownValues () => new Enumerable (_values == UnknownSentinel ? null : _values);
 
 		// Note: returns false for Unknown
 		public bool Contains (TValue value)

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ArrayValue.cs
@@ -34,7 +34,7 @@ namespace ILLink.Shared.TrimAnalysis
 			// So we will simply treat array value as an element value as "too complex to analyze" and give up by storing Unknown instead
 
 			bool needSanitization = false;
-			foreach (var v in input) {
+			foreach (var v in input.AsEnumerable ()) {
 				if (v is ArrayValue)
 					needSanitization = true;
 			}
@@ -42,7 +42,7 @@ namespace ILLink.Shared.TrimAnalysis
 			if (!needSanitization)
 				return input;
 
-			return new(input.Select (v => v is ArrayValue ? UnknownValue.Instance : v));
+			return new(input.AsEnumerable ().Select (v => v is ArrayValue ? UnknownValue.Instance : v));
 		}
 	}
 }

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -68,7 +68,7 @@ namespace ILLink.Shared.TrimAnalysis
 					break;
 				}
 
-				foreach (var value in argumentValues[0]) {
+				foreach (var value in argumentValues[0].AsEnumerable ()) {
 					AddReturnValue (value switch {
 						RuntimeTypeHandleForNullableSystemTypeValue nullableSystemType
 							=> new NullableSystemTypeValue (nullableSystemType.NullableType, nullableSystemType.UnderlyingTypeValue),
@@ -94,7 +94,7 @@ namespace ILLink.Shared.TrimAnalysis
 					break;
 				}
 
-				foreach (var value in instanceValue) {
+				foreach (var value in instanceValue.AsEnumerable ()) {
 					if (value != NullValue.Instance)
 						AddReturnValue (value switch {
 							NullableSystemTypeValue nullableSystemType
@@ -123,7 +123,7 @@ namespace ILLink.Shared.TrimAnalysis
 					}
 
 					// Infrastructure piece to support "ldtoken method -> GetMethodFromHandle"
-					foreach (var value in argumentValues[0]) {
+					foreach (var value in argumentValues[0].AsEnumerable ()) {
 						if (value is RuntimeMethodHandleValue methodHandle)
 							AddReturnValue (new SystemReflectionMethodBaseValue (methodHandle.RepresentedMethod));
 						else
@@ -138,7 +138,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is SystemReflectionMethodBaseValue methodBaseValue)
 							AddReturnValue (new RuntimeMethodHandleValue (methodBaseValue.RepresentedMethod));
 						else
@@ -168,8 +168,8 @@ namespace ILLink.Shared.TrimAnalysis
 					}
 
 					var targetValue = _annotations.GetMethodThisParameterValue (calledMethod, DynamicallyAccessedMemberTypes.Interfaces);
-					foreach (var value in instanceValue) {
-						foreach (var interfaceName in argumentValues[0]) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
+						foreach (var interfaceName in argumentValues[0].AsEnumerable ()) {
 							if (interfaceName == NullValue.Instance) {
 								// Throws on null string, so no return value.
 								AddReturnValue (MultiValueLattice.Top);
@@ -206,7 +206,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers) {
 							// Currently we don't need to track the difference between Type and String annotated values
 							// that only matters when we use them, so Type.GetType is the difference really.
@@ -234,7 +234,7 @@ namespace ILLink.Shared.TrimAnalysis
 					break;
 				}
 
-				foreach (var typeHandleValue in argumentValues[0]) {
+				foreach (var typeHandleValue in argumentValues[0].AsEnumerable ()) {
 					if (typeHandleValue is RuntimeTypeHandleValue runtimeTypeHandleValue) {
 						MarkStaticConstructor (runtimeTypeHandleValue.RepresentedType);
 					} else {
@@ -332,9 +332,9 @@ namespace ILLink.Shared.TrimAnalysis
 					};
 
 					var targetValue = _annotations.GetMethodThisParameterValue (calledMethod, memberTypes);
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[0]) {
+							foreach (var stringParam in argumentValues[0].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue && !BindingFlagsAreUnsupported (bindingFlags)) {
 									switch (intrinsicId) {
 									case IntrinsicId.Type_GetEvent:
@@ -398,7 +398,7 @@ namespace ILLink.Shared.TrimAnalysis
 					var targetValue = _annotations.GetMethodThisParameterValue (calledMethod, requiredMemberTypes);
 
 					// Go over all types we've seen
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						// Mark based on bitfield requirements
 						_requireDynamicallyAccessedMembersAction.Invoke (value, targetValue);
 					}
@@ -434,9 +434,9 @@ namespace ILLink.Shared.TrimAnalysis
 						bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
 					var targetValue = _annotations.GetMethodThisParameterValue (calledMethod, GetDynamicallyAccessedMemberTypesFromBindingFlagsForMethods (bindingFlags));
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[0]) {
+							foreach (var stringParam in argumentValues[0].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue && !BindingFlagsAreUnsupported (bindingFlags)) {
 									AddReturnValue (MultiValueLattice.Top); ; // Initialize return value (so that it's not autofilled if there are no matching methods)
 									foreach (var methodValue in ProcessGetMethodByName (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags))
@@ -480,9 +480,9 @@ namespace ILLink.Shared.TrimAnalysis
 						bindingFlags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public;
 
 					var targetValue = _annotations.GetMethodThisParameterValue (calledMethod, GetDynamicallyAccessedMemberTypesFromBindingFlagsForNestedTypes (bindingFlags));
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[0]) {
+							foreach (var stringParam in argumentValues[0].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue && !BindingFlagsAreUnsupported (bindingFlags)) {
 									AddReturnValue (MultiValueLattice.Top);
 									foreach (var nestedTypeValue in GetNestedTypesOnType (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags)) {
@@ -548,9 +548,9 @@ namespace ILLink.Shared.TrimAnalysis
 
 					var targetValue = _annotations.GetMethodParameterValue (new (calledMethod, (ParameterIndex) 1), requiredMemberTypes);
 
-					foreach (var value in argumentValues[0]) {
+					foreach (var value in argumentValues[0].AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[1]) {
+							foreach (var stringParam in argumentValues[1].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue) {
 									switch (intrinsicId) {
 									case IntrinsicId.RuntimeReflectionExtensions_GetRuntimeEvent:
@@ -596,7 +596,7 @@ namespace ILLink.Shared.TrimAnalysis
 			//
 			case IntrinsicId.Expression_New: {
 					var targetValue = _annotations.GetMethodParameterValue (new (calledMethod, (ParameterIndex) 0), DynamicallyAccessedMemberTypes.PublicParameterlessConstructor);
-					foreach (var value in argumentValues[0]) {
+					foreach (var value in argumentValues[0].AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
 							MarkConstructorsOnType (systemTypeValue.RepresentedType, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, parameterCount: null);
 						} else {
@@ -617,7 +617,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var value in argumentValues[1]) {
+					foreach (var value in argumentValues[1].AsEnumerable ()) {
 						if (value is SystemReflectionMethodBaseValue methodBaseValue) {
 							// We have one of the accessors for the property. The Expression.Property will in this case search
 							// for the matching PropertyInfo and store that. So to be perfectly correct we need to mark the
@@ -654,9 +654,9 @@ namespace ILLink.Shared.TrimAnalysis
 					}
 
 					var targetValue = _annotations.GetMethodParameterValue (new (calledMethod, (ParameterIndex) 1), memberTypes);
-					foreach (var value in argumentValues[1]) {
+					foreach (var value in argumentValues[1].AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[2]) {
+							foreach (var stringParam in argumentValues[2].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue) {
 									BindingFlags bindingFlags = argumentValues[0].AsSingleValue () is NullValue ? BindingFlags.Static : BindingFlags.Default;
 									if (intrinsicId == IntrinsicId.Expression_Property) {
@@ -691,9 +691,9 @@ namespace ILLink.Shared.TrimAnalysis
 
 					// This is true even if we "don't know" - so it's only false if we're sure that there are no type arguments
 					bool hasTypeArguments = (argumentValues[2].AsSingleValue () as ArrayValue)?.Size.AsConstInt () != 0;
-					foreach (var value in argumentValues[0]) {
+					foreach (var value in argumentValues[0].AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
-							foreach (var stringParam in argumentValues[1]) {
+							foreach (var stringParam in argumentValues[1].AsEnumerable ()) {
 								if (stringParam is KnownStringValue stringValue) {
 									foreach (var method in GetMethodsOnTypeHierarchy (systemTypeValue.RepresentedType, stringValue.Contents, bindingFlags)) {
 										ValidateGenericMethodInstantiation (method.RepresentedMethod, argumentValues[2], calledMethod);
@@ -771,7 +771,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var typeNameValue in argumentValues[0]) {
+					foreach (var typeNameValue in argumentValues[0].AsEnumerable ()) {
 						if (typeNameValue is KnownStringValue knownStringValue) {
 							if (!_requireDynamicallyAccessedMembersAction.TryResolveTypeNameAndMark (knownStringValue.Contents, false, out TypeProxy foundType)) {
 								// Intentionally ignore - it's not wrong for code to call Type.GetType on non-existing name, the code might expect null/exception back.
@@ -806,7 +806,7 @@ namespace ILLink.Shared.TrimAnalysis
 					break;
 				}
 
-				foreach (var value in instanceValue) {
+				foreach (var value in instanceValue.AsEnumerable ()) {
 					if (value is SystemTypeValue typeValue) {
 						// Special case Nullable<T>
 						// Nullables without a type argument are considered SystemTypeValues
@@ -817,9 +817,9 @@ namespace ILLink.Shared.TrimAnalysis
 							//  There are several places even in the framework where typeof(Nullable<>).MakeGenericType would warn
 							//  without any good reason to do so.
 
-							foreach (var argumentValue in argumentValues[0]) {
+							foreach (var argumentValue in argumentValues[0].AsEnumerable ()) {
 								if ((argumentValue as ArrayValue)?.TryGetValueByIndex (0, out var underlyingMultiValue) == true) {
-									foreach (var underlyingValue in underlyingMultiValue) {
+									foreach (var underlyingValue in underlyingMultiValue.AsEnumerable ()) {
 										switch (underlyingValue) {
 										// Don't warn on these types - it will throw instead
 										case NullableValueWithDynamicallyAccessedMembers:
@@ -881,7 +881,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers) {
 							DynamicallyAccessedMemberTypes propagatedMemberTypes = DynamicallyAccessedMemberTypes.None;
 							if (valueWithDynamicallyAccessedMembers.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.All)
@@ -955,7 +955,7 @@ namespace ILLink.Shared.TrimAnalysis
 					};
 
 					// Go over all types we've seen
-					foreach (var value in instanceValue) {
+					foreach (var value in instanceValue.AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue && !BindingFlagsAreUnsupported (bindingFlags)) {
 							if (HasBindingFlag (bindingFlags, BindingFlags.Public) && !HasBindingFlag (bindingFlags, BindingFlags.NonPublic)
 								&& ctorParameterCount == 0) {
@@ -988,7 +988,7 @@ namespace ILLink.Shared.TrimAnalysis
 						break;
 					}
 
-					foreach (var methodValue in instanceValue) {
+					foreach (var methodValue in instanceValue.AsEnumerable ()) {
 						if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
 							ValidateGenericMethodInstantiation (methodBaseValue.RepresentedMethod, argumentValues[0], calledMethod);
 						} else if (methodValue == NullValue.Instance) {
@@ -1056,7 +1056,7 @@ namespace ILLink.Shared.TrimAnalysis
 					}
 
 					// Go over all types we've seen
-					foreach (var value in argumentValues[0]) {
+					foreach (var value in argumentValues[0].AsEnumerable ()) {
 						if (value is SystemTypeValue systemTypeValue) {
 							// Special case known type values as we can do better by applying exact binding flags and parameter count.
 							MarkConstructorsOnType (systemTypeValue.RepresentedType, bindingFlags, ctorParameterCount);
@@ -1174,7 +1174,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
 			if (annotatedMethodReturnValue.DynamicallyAccessedMemberTypes != DynamicallyAccessedMemberTypes.None) {
-				foreach (var uniqueValue in returnValue.Value) {
+				foreach (var uniqueValue in returnValue.Value.AsEnumerable ()) {
 					if (uniqueValue is ValueWithDynamicallyAccessedMembers methodReturnValueWithMemberTypes) {
 						if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (annotatedMethodReturnValue.DynamicallyAccessedMemberTypes))
 							throw new InvalidOperationException ($"Internal ILLink error: in {GetContainingSymbolDisplayName ()} processing call to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");
@@ -1230,7 +1230,7 @@ namespace ILLink.Shared.TrimAnalysis
 			if (!hasRequirements)
 				return true;
 
-			foreach (var typesValue in arrayParam) {
+			foreach (var typesValue in arrayParam.AsEnumerable ()) {
 				if (typesValue is not ArrayValue array) {
 					return false;
 				}
@@ -1320,13 +1320,13 @@ namespace ILLink.Shared.TrimAnalysis
 					bindingFlags |= BindingFlags.Public | BindingFlags.NonPublic;
 			}
 
-			foreach (var assemblyNameValue in argumentValues[0]) {
+			foreach (var assemblyNameValue in argumentValues[0].AsEnumerable ()) {
 				if (assemblyNameValue is KnownStringValue assemblyNameStringValue) {
 					if (assemblyNameStringValue.Contents is string assemblyName && assemblyName.Length == 0) {
 						// Throws exception for zero-length assembly name.
 						continue;
 					}
-					foreach (var typeNameValue in argumentValues[1]) {
+					foreach (var typeNameValue in argumentValues[1].AsEnumerable ()) {
 						if (typeNameValue is NullValue) {
 							// Throws exception for null type name.
 							continue;

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -23,7 +23,7 @@ namespace ILLink.Shared.TrimAnalysis
 			if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.None)
 				return;
 
-			foreach (var uniqueValue in value) {
+			foreach (var uniqueValue in value.AsEnumerable ()) {
 				if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
 					&& uniqueValue is GenericParameterValue genericParam
 					&& genericParam.GenericParameter.HasDefaultConstructorConstraint ()) {

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
@@ -59,12 +59,14 @@ namespace ILLink.Shared.TrimAnalysis
 			return values.Single ();
 		}
 
+		private static IEnumerable<SingleValue> Unknown = ImmutableArray.Create (UnknownValue.Instance);
+
 		// ValueSet<TValue> is not enumerable. This helper translates ValueSet<SingleValue>.Unknown
 		// into a ValueSet<SingleValue> whose sole element is UnknownValue.Instance.
 		internal static IEnumerable<SingleValue> AsEnumerable (this MultiValue multiValue)
 		{
 			return multiValue.IsUnknown ()
-				? ImmutableArray.Create (UnknownValue.Instance)
+				? Unknown
 				: multiValue.GetKnownValues ();
 		}
 	}

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using ILLink.Shared.DataFlow;
@@ -50,10 +52,20 @@ namespace ILLink.Shared.TrimAnalysis
 
 		internal static SingleValue? AsSingleValue (this in MultiValue node)
 		{
-			if (node.Count () != 1)
+			var values = node.AsEnumerable ();
+			if (values.Count () != 1)
 				return null;
 
-			return node.Single ();
+			return values.Single ();
+		}
+
+		// ValueSet<TValue> is not enumerable. This helper translates ValueSet<SingleValue>.Unknown
+		// into a ValueSet<SingleValue> whose sole element is UnknownValue.Instance.
+		internal static IEnumerable<SingleValue> AsEnumerable (this MultiValue multiValue)
+		{
+			return multiValue.IsUnknown ()
+				? ImmutableArray.Create (UnknownValue.Instance)
+				: multiValue.GetKnownValues ();
 		}
 	}
 }

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using ILLink.Shared.DataFlow;

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/ValueExtensions.cs
@@ -59,11 +59,11 @@ namespace ILLink.Shared.TrimAnalysis
 			return values.Single ();
 		}
 
-		private static IEnumerable<SingleValue> Unknown = ImmutableArray.Create (UnknownValue.Instance);
+		private static ValueSet<SingleValue>.Enumerable Unknown = new ValueSet<SingleValue>.Enumerable (UnknownValue.Instance);
 
 		// ValueSet<TValue> is not enumerable. This helper translates ValueSet<SingleValue>.Unknown
 		// into a ValueSet<SingleValue> whose sole element is UnknownValue.Instance.
-		internal static IEnumerable<SingleValue> AsEnumerable (this MultiValue multiValue)
+		internal static ValueSet<SingleValue>.Enumerable AsEnumerable (this MultiValue multiValue)
 		{
 			return multiValue.IsUnknown ()
 				? Unknown

--- a/src/tools/illink/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -17,7 +17,7 @@ namespace ILLink.Shared.TrimAnalysis
 		public static MultiValue Create (MultiValue size, TypeReference elementType)
 		{
 			MultiValue result = MultiValueLattice.Top;
-			foreach (var sizeValue in size) {
+			foreach (var sizeValue in size.AsEnumerable ()) {
 				result = MultiValueLattice.Meet (result, new MultiValue (new ArrayValue (sizeValue, elementType)));
 			}
 
@@ -87,7 +87,7 @@ namespace ILLink.Shared.TrimAnalysis
 				// Since it's possible to store a reference to array as one of its own elements
 				// simple deep copy could lead to endless recursion.
 				// So instead we simply disallow arrays as element values completely - and treat that case as "too complex to analyze".
-				foreach (SingleValue v in kvp.Value.Value) {
+				foreach (SingleValue v in kvp.Value.Value.AsEnumerable ()) {
 					System.Diagnostics.Debug.Assert (v is not ArrayValue);
 				}
 #endif
@@ -116,7 +116,7 @@ namespace ILLink.Shared.TrimAnalysis
 				result.Append (element.Key);
 				result.Append (",(");
 				bool firstValue = true;
-				foreach (var v in element.Value.Value) {
+				foreach (var v in element.Value.Value.AsEnumerable ()) {
 					if (firstValue) {
 						result.Append (',');
 						firstValue = false;

--- a/src/tools/illink/src/linker/Linker.Dataflow/InterproceduralState.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/InterproceduralState.cs
@@ -53,7 +53,8 @@ namespace Mono.Linker.Dataflow
 		public void TrackMethod (MethodIL methodIL)
 		{
 			// Work around the fact that ValueSet is readonly
-			var methodsList = new List<MethodIL> (MethodBodies);
+			Debug.Assert (!MethodBodies.IsUnknown ());
+			var methodsList = new List<MethodIL> (MethodBodies.GetKnownValues ());
 			methodsList.Add (methodIL);
 
 			// For state machine methods, also scan the state machine members.

--- a/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/MethodBodyScanner.cs
@@ -185,7 +185,7 @@ namespace Mono.Linker.Dataflow
 			foreach (var keyValuePair in locals) {
 				MultiValue localValue = keyValuePair.Value.Value;
 				VariableDefinition localVariable = keyValuePair.Key;
-				foreach (var val in localValue) {
+				foreach (var val in localValue.AsEnumerable ()) {
 					if (val is LocalVariableReferenceValue localReference && localReference.ReferencedType.IsByReference) {
 						string displayName = $"local variable V_{localReference.LocalDefinition.Index}";
 						throw new LinkerFatalErrorException (MessageContainer.CreateErrorMessage (
@@ -243,7 +243,8 @@ namespace Mono.Linker.Dataflow
 
 				// Flow state through all methods encountered so far, as long as there
 				// are changes discovered in the hoisted local state on entry to any method.
-				foreach (var methodIL in oldInterproceduralState.MethodBodies)
+				Debug.Assert (!oldInterproceduralState.MethodBodies.IsUnknown ());
+				foreach (var methodIL in oldInterproceduralState.MethodBodies.GetKnownValues ())
 					Scan (methodIL, ref interproceduralState);
 			}
 
@@ -258,7 +259,7 @@ namespace Mono.Linker.Dataflow
 				// foreach (var method in calleeMethods)
 				//  Debug.Assert (interproceduralState.Any (kvp => kvp.Key.Method == method));
 			} else {
-				Debug.Assert (interproceduralState.MethodBodies.Count () == 1);
+				Debug.Assert (interproceduralState.MethodBodies.GetKnownValues().Count () == 1);
 			}
 #endif
 		}
@@ -857,7 +858,7 @@ namespace Mono.Linker.Dataflow
 		/// <exception cref="LinkerFatalErrorException">Throws if <paramref name="target"/> is not a valid target for an indirect store.</exception>
 		protected void StoreInReference (MultiValue target, MultiValue source, MethodDefinition method, Instruction operation, LocalVariableStore locals, int curBasicBlock, ref InterproceduralState ipState)
 		{
-			foreach (var value in target) {
+			foreach (var value in target.AsEnumerable ()) {
 				switch (value) {
 				case LocalVariableReferenceValue localReference:
 					StoreMethodLocalValue (locals, source, localReference.LocalDefinition, curBasicBlock);
@@ -956,7 +957,7 @@ namespace Mono.Linker.Dataflow
 					return;
 				}
 
-				foreach (var value in GetFieldValue (field)) {
+				foreach (var value in GetFieldValue (field).AsEnumerable ()) {
 					// GetFieldValue may return different node types, in which case they can't be stored to.
 					// At least not yet.
 					if (value is not FieldValue fieldValue)
@@ -1012,7 +1013,7 @@ namespace Mono.Linker.Dataflow
 		internal MultiValue DereferenceValue (MultiValue maybeReferenceValue, LocalVariableStore locals, ref InterproceduralState interproceduralState)
 		{
 			MultiValue dereferencedValue = MultiValueLattice.Top;
-			foreach (var value in maybeReferenceValue) {
+			foreach (var value in maybeReferenceValue.AsEnumerable ()) {
 				switch (value) {
 				case FieldReferenceValue fieldReferenceValue:
 					dereferencedValue = MultiValue.Union (
@@ -1123,7 +1124,7 @@ namespace Mono.Linker.Dataflow
 			AssignRefAndOutParameters (callingMethodBody, calledMethod, methodArguments, operation, locals, curBasicBlock, ref interproceduralState);
 
 			foreach (var param in methodArguments) {
-				foreach (var v in param) {
+				foreach (var v in param.AsEnumerable ()) {
 					if (v is ArrayValue arr) {
 						MarkArrayValuesAsUnknown (arr, curBasicBlock);
 					}
@@ -1163,7 +1164,7 @@ namespace Mono.Linker.Dataflow
 			StackSlot indexToStoreAt = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			StackSlot arrayToStoreIn = PopUnknown (currentStack, 1, methodBody, operation.Offset);
 			int? indexToStoreAtInt = indexToStoreAt.Value.AsConstInt ();
-			foreach (var array in arrayToStoreIn.Value) {
+			foreach (var array in arrayToStoreIn.Value.AsEnumerable ()) {
 				if (array is ArrayValue arrValue) {
 					if (indexToStoreAtInt == null) {
 						MarkArrayValuesAsUnknown (arrValue, curBasicBlock);

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -283,7 +283,7 @@ namespace Mono.Linker.Dataflow
 			// GetType()
 			//
 			case IntrinsicId.Object_GetType: {
-					foreach (var valueNode in instanceValue) {
+					foreach (var valueNode in instanceValue.AsEnumerable ()) {
 						// Note that valueNode can be statically typed in IL as some generic argument type.
 						// For example:
 						//   void Method<T>(T instance) { instance.GetType().... }
@@ -359,7 +359,7 @@ namespace Mono.Linker.Dataflow
 
 			// Validate that the return value has the correct annotations as per the method return value annotations
 			if (annotatedMethodReturnValue.DynamicallyAccessedMemberTypes != 0) {
-				foreach (var uniqueValue in methodReturnValue) {
+				foreach (var uniqueValue in methodReturnValue.AsEnumerable ()) {
 					if (uniqueValue is ValueWithDynamicallyAccessedMembers methodReturnValueWithMemberTypes) {
 						if (!methodReturnValueWithMemberTypes.DynamicallyAccessedMemberTypes.HasFlag (annotatedMethodReturnValue.DynamicallyAccessedMemberTypes))
 							throw new InvalidOperationException ($"Internal trimming error: processing of call from {callingMethodDefinition.GetDisplayName ()} to {calledMethod.GetDisplayName ()} returned value which is not correctly annotated with the expected dynamic member access kinds.");

--- a/src/tools/illink/src/linker/Linker.Dataflow/TrimAnalysisAssignmentPattern.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/TrimAnalysisAssignmentPattern.cs
@@ -37,8 +37,8 @@ namespace Mono.Linker.Dataflow
 			bool diagnosticsEnabled = !context.Annotations.ShouldSuppressAnalysisWarningsForRequiresUnreferencedCode (Origin.Provider, out _);
 			var diagnosticContext = new DiagnosticContext (Origin, diagnosticsEnabled, context);
 
-			foreach (var sourceValue in Source) {
-				foreach (var targetValue in Target) {
+			foreach (var sourceValue in Source.AsEnumerable ()) {
+				foreach (var targetValue in Target.AsEnumerable ()) {
 					if (targetValue is not ValueWithDynamicallyAccessedMembers targetWithDynamicallyAccessedMembers)
 						throw new NotImplementedException ();
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -19,6 +19,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			ExponentialArrayStatesDataFlow.Test<int> ();
 			ArrayStatesDataFlow.Test<int> ();
 			ExponentialArrayInStateMachine.Test ();
+			ExponentialStateFieldInStateMachine.Test ();
 		}
 
 		class ExponentialArrayStates
@@ -96,8 +97,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			[ExpectedWarning ("IL3050", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
 			// The way we track arrays causes the analyzer to track exponentially many
 			// ArrayValues in the ValueSet for the pattern in this method, hitting the limit.
-			// When this happens, we replace the ValueSet wit a TopValue, which doesn't
-			// produce a warning in this case.
+			// When this happens, we replace the ValueSet with an unknown value, producing
+			// this warning.
+			[ExpectedWarning ("IL2055", ProducedBy = Tool.Analyzer)]
 			[ExpectedWarning ("IL2090", "'T'", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			[ExpectedWarning ("IL2090", "'T'", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 			[ExpectedWarning ("IL2090", "'T'", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
@@ -186,6 +188,60 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			}
 		}
 
+		class ExponentialStateFieldInStateMachine
+		{
+			[ExpectedWarning ("IL2072", nameof (GetWithPublicFields), nameof (DataFlowTypeExtensions.RequiresAll), CompilerGeneratedCode = true)]
+			public static async void Test ()
+			{
+				Type t = GetWithPublicFields ();
+
+				// 100
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+
+				// 200
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+
+				// 300
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+				await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync (); await MethodAsync ();
+
+				t.RequiresAll ();
+			}
+		}
+
 		class TestType { }
+
+		static async Task<int> MethodAsync ()
+		{
+			return await Task.FromResult (0);
+		}
+
+		static Type GetWithPublicFields () => null;
 	}
 }


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/87634 introduced a limit on the number of values tracked in dataflow analysis, but this approach was incorrect because resetting the set of tracked values was effectively moving up the dataflow lattice, breaking the invariant and causing potential hangs.

The hang was observed in https://github.com/dotnet/runtime/issues/94831, where (as found by @vitek-karas) the hoisted local `state` field of an async method with many await points was getting a large number of tracked values, hitting the limit, being reset to "empty", but then growing again, causing the analysis not to converge.

The fix is to instead introduce a special value `ValueSet<TValue>.Unknown` that is used for this case. It acts like "bottom" in the lattice, so that it destroys any other inputs on meet ("bottom" meet anything else is "bottom").

In this testcase the `state` field isn't involved in dataflow warnings, so this actually allows the method to be analyzed correctly, producing the expected warning for the `Type` local that flows across all of the await points.

Fixes https://github.com/dotnet/runtime/issues/94831.