### PR TITLE
[wasi] Initial wasi/aot build support

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -244,6 +244,8 @@
         IsNative="true" />
 
       <LibrariesRuntimeFiles Include="
+        $(LibrariesNativeArtifactsPath)src\wasi-default.rsp;
+        $(LibrariesNativeArtifactsPath)src\wasi-link.rsp;
         $(LibrariesNativeArtifactsPath)src\*.c"
         NativeSubDirectory="src"
         IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -229,6 +229,8 @@
     <PlatformManifestFileEntry Include="emcc-default.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-link.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-props.json" IsNative="true" />
+    <PlatformManifestFileEntry Include="wasi-default.rsp" IsNative="true" />
+    <PlatformManifestFileEntry Include="wasi-link.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.WasmIntrinsics.xml" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.NoWasmIntrinsics.xml" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.LegacyJsInterop.xml" IsNative="true" />

--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.targets.in
@@ -95,7 +95,7 @@
 
   <!-- TFM specific -->
 
-  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
+  <Import Condition="'$(TargetsCurrent)' == 'true' and '$(RunAOTCompilation)' == 'true' and ('$(UsingBrowserRuntimeWorkload)' == 'true' or '$(UsingMobileWorkload)' == 'true' or '$(UsingWasiRuntimeWorkload)' == 'true')" Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoAOTCompiler.Task" />
 
   <ImportGroup Condition="'$(TargetsCurrent)' == 'true' and ('$(TargetPlatformIdentifier)' == 'android' or '$(_IsAndroidLibraryMode)' == 'true')">
     <Import Project="Sdk.props" Sdk="Microsoft.NET.Runtime.MonoTargets.Sdk" />

--- a/src/mono/wasi/Makefile
+++ b/src/mono/wasi/Makefile
@@ -52,7 +52,7 @@ app-builder:
 	$(DOTNET) build $(TOP)/src/tasks/WasmAppBuilder
 
 build-tasks:
-	$(DOTNET) build $(TOP)/src/tasks/WasmBuildTasks $(MSBUILD_ARGS)
+	$(DOTNET) build $(TOP)/src/tasks/tasks.proj /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)
 
 clean:
 	$(RM) -rf $(BUILDS_OBJ_DIR)

--- a/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
@@ -21,17 +21,22 @@ public class WasiTemplateTests : BuildTestBase
     }
 
     [Theory]
-    [InlineData("Debug")]
-    [InlineData("Release")]
-    public void ConsoleBuildThenPublish(string config)
+    [InlineData("Debug", /*aot*/ false)]
+    [InlineData("Debug", /*aot*/ true)]
+    [InlineData("Release", /*aot*/ false)]
+    [InlineData("Release", /*aot*/ true)]
+    public void ConsoleBuildThenPublish(string config, bool aot)
     {
         string id = $"{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "wasiconsole");
         string projectName = Path.GetFileNameWithoutExtension(projectFile);
         File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simpleMainWithArgs);
 
-        var buildArgs = new BuildArgs(projectName, config, false, id, null);
+        var buildArgs = new BuildArgs(projectName, config, true, id, null);
         buildArgs = ExpandBuildArgs(buildArgs);
+
+        if (aot)
+            AddItemsPropertiesToProject(projectFile, "<RunAOTCompilation>true</RunAOTCompilation>");
 
         BuildProject(buildArgs,
                     id: id,

--- a/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
@@ -36,7 +36,9 @@ public class WasiTemplateTests : BuildTestBase
         buildArgs = ExpandBuildArgs(buildArgs);
 
         if (aot)
-            AddItemsPropertiesToProject(projectFile, "<RunAOTCompilation>true</RunAOTCompilation>");
+        {
+            AddItemsPropertiesToProject(projectFile, "<RunAOTCompilation>true</RunAOTCompilation><_WasmDevel>false</_WasmDevel>");
+        }
 
         BuildProject(buildArgs,
                     id: id,

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -1,25 +1,29 @@
 <Project>
   <!-- not really meant to be used w/o WasmApp.targets -->
 
+  <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.EmccCompile" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
   <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.WasmResolveAssemblyDependencies" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
   <UsingTask TaskName="ManagedToNativeGenerator" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
+  <UsingTask TaskName="EmitBundleObjectFiles" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
+  <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.EmitWasmBundleObjectFiles" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
 
   <PropertyGroup>
     <_WasiBuildNativeCoreDependsOn>
-        _SetupWasiSdk;
-        _SetWasmBuildNativeDefaults;
+        _WasmAotCompileApp;
+        _WasmStripAOTAssemblies;
         _PrepareForWasiBuildNative;
         _GetNativeFilesForLinking;
         _GenerateManagedToNative;
+        _WasmCompileNativeFiles;
         _GenerateAssemblyObjectFiles;
-        _WasiLink;
+        _WasiLinkDotNet;
     </_WasiBuildNativeCoreDependsOn>
 
-    <!--<_BeforeWasmBuildAppDependsOn>-->
-      <!--$(_BeforeWasmBuildAppDependsOn);-->
-      <!--_SetupEmscripten;-->
-      <!--_SetWasmBuildNativeDefaults-->
-    <!--</_BeforeWasmBuildAppDependsOn>-->
+    <_BeforeWasmBuildAppDependsOn>
+      $(_BeforeWasmBuildAppDependsOn);
+      _SetupWasiSdk;
+      _SetWasmBuildNativeDefaults;
+    </_BeforeWasmBuildAppDependsOn>
 
     <_ExeExt Condition="$([MSBuild]::IsOSPlatform('WINDOWS'))">.exe</_ExeExt>
     <!--<WasmUseEMSDK_PATH Condition="'$(WasmUseEMSDK_PATH)' == '' and '$(EMSDK_PATH)' != '' and Exists('$(MSBuildThisFileDirectory)WasmApp.InTree.targets')">true</WasmUseEMSDK_PATH>-->
@@ -48,6 +52,17 @@
       <_ToolchainMissingErrorMessage Condition="'$(_ToolchainMissingErrorMessage)' == '' and '$(_ToolchainMissingPaths)' != ''">Using WASI_SDK_PATH=$(WASI_SDK_PATH), cannot find $(_ToolchainMissingPaths) .</_ToolchainMissingErrorMessage>
       <_IsToolchainMissing Condition="'$(_ToolchainMissingErrorMessage)' != ''">true</_IsToolchainMissing>
     </PropertyGroup>
+
+    <PropertyGroup>
+      <WasiSdkBinPath Condition="'$(WasiSdkBinPath)' != ''">$([MSBuild]::NormalizeDirectory($(WasiSdkBinPath)))</WasiSdkBinPath>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_PrepareForWasiBuildNative">
+    <Error Condition="'$(_IsToolchainMissing)' == 'true'"
+           Text="$(_ToolchainMissingErrorMessage) SDK is required for building native files." />
+
+
   </Target>
 
   <Target Name="_SetWasmBuildNativeDefaults">
@@ -107,8 +122,8 @@
 
     <PropertyGroup>
       <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','wasi-wasm'))</_MonoAotCrossCompilerPath>
-      <_WasiClangDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-default.rsp'))</_WasiClangDefaultFlagsRsp>
-      <_WasiClangDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-link.rsp'))</_WasiClangDefaultLinkFlagsRsp>
+      <_WasiClangDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'wasi-default.rsp'))</_WasiClangDefaultFlagsRsp>
+      <_WasiClangDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'wasi-link.rsp'))</_WasiClangDefaultLinkFlagsRsp>
       <WasmNativeStrip Condition="'$(WasmNativeStrip)' == '' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">false</WasmNativeStrip>
       <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
       <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">true</WasmNativeDebugSymbols>
@@ -128,40 +143,60 @@
       <_WasmDevel Condition="'$(_WasmDevel)' == '' and '$(WasmBuildNative)' == 'true' and '$(Configuration)' == 'Debug'">true</_WasmDevel>
 
       <!--<_EmccAssertionLevelDefault Condition="'$(_EmccAssertionLevelDefault)' == ''">0</_EmccAssertionLevelDefault>-->
-      <!--<_EmccOptimizationFlagDefault Condition="'$(_WasmDevel)' == 'true'">-O0</_EmccOptimizationFlagDefault>-->
-      <!--<_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == '' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">-O1</_EmccOptimizationFlagDefault>-->
-      <!--<_EmccOptimizationFlagDefault Condition="'$(_EmccOptimizationFlagDefault)' == ''">-Oz</_EmccOptimizationFlagDefault>-->
+      <_WasiClangOptimizationFlagDefault Condition="'$(_WasmDevel)' == 'true'">-O0</_WasiClangOptimizationFlagDefault>
+      <_WasiClangOptimizationFlagDefault Condition="'$(_WasiClangOptimizationFlagDefault)' == '' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">-O1</_WasiClangOptimizationFlagDefault>
+      <_WasiClangOptimizationFlagDefault Condition="'$(_WasiClangOptimizationFlagDefault)' == ''">-Oz</_WasiClangOptimizationFlagDefault>
 
-      <!--<EmccCompileOptimizationFlag Condition="'$(EmccCompileOptimizationFlag)' == ''">$(_EmccOptimizationFlagDefault)</EmccCompileOptimizationFlag>-->
-      <!--<EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == '' and '$(Configuration)' == 'Release'">-O2</EmccLinkOptimizationFlag>-->
-      <!--<EmccLinkOptimizationFlag    Condition="'$(EmccLinkOptimizationFlag)' == ''"   >$(EmccCompileOptimizationFlag)</EmccLinkOptimizationFlag>-->
+      <WasiClangCompileOptimizationFlag Condition="'$(WasiClangCompileOptimizationFlag)' == ''">$(_WasiClangOptimizationFlagDefault)</WasiClangCompileOptimizationFlag>
+      <WasiClangLinkOptimizationFlag    Condition="'$(WasiClangLinkOptimizationFlag)' == '' and '$(Configuration)' == 'Release'">-O2</WasiClangLinkOptimizationFlag>
+      <WasiClangLinkOptimizationFlag    Condition="'$(WasiClangLinkOptimizationFlag)' == ''"   >$(WasiClangCompileOptimizationFlag)</WasiClangLinkOptimizationFlag>
 
-      <!--<_EmccCompileRsp>$(_WasmIntermediateOutputPath)emcc-compile.rsp</_EmccCompileRsp>-->
-      <!--<_EmccCompileOutputMessageImportance Condition="'$(EmccVerbose)' == 'true'">Normal</_EmccCompileOutputMessageImportance>-->
-      <!--<_EmccCompileOutputMessageImportance Condition="'$(EmccVerbose)' != 'true'">Low</_EmccCompileOutputMessageImportance>-->
+      <_WasiClangCompileRsp>$(_WasmIntermediateOutputPath)wasi-compile.rsp</_WasiClangCompileRsp>
+      <_WasiClangCompileOutputMessageImportance Condition="'$(WasiClangVerbose)' == 'true'">Normal</_WasiClangCompileOutputMessageImportance>
+      <_WasiClangCompileOutputMessageImportance Condition="'$(WasiClangVerbose)' != 'true'">Low</_WasiClangCompileOutputMessageImportance>
 
-      <!--<_EmccCompileBitcodeRsp>$(_WasmIntermediateOutputPath)emcc-compile-bc.rsp</_EmccCompileBitcodeRsp>-->
-      <!--<_EmccLinkRsp>$(_WasmIntermediateOutputPath)emcc-link.rsp</_EmccLinkRsp>-->
+      <_WasiClangCompileBitcodeRsp>$(_WasmIntermediateOutputPath)wasi-compile-bc.rsp</_WasiClangCompileBitcodeRsp>
+      <_WasiClangLinkRsp>$(_WasmIntermediateOutputPath)clang-link.rsp</_WasiClangLinkRsp>
 
-      <!-- TODOWASI this needs similar AOT logic as EMCC in https://github.com/dotnet/runtime/pull/80507 -->
+       <!--TODOWASI this needs similar AOT logic as EMCC in https://github.com/dotnet/runtime/pull/80507-->
       <WasmInitialHeapSize Condition="'$(WasmInitialHeapSize)' == ''">52428800</WasmInitialHeapSize>
     </PropertyGroup>
 
     <ItemGroup>
-      <_WasmLinkDependencies Remove="@(_WasmLinkDependencies)" />
-
-      <!--<_EmccCommonFlags Include="$(_DefaultEmccFlags)" />-->
-      <!--<_EmccCommonFlags Include="$(EmccFlags)" />-->
-      <!--<_EmccCommonFlags Include="-s EXPORT_ES6=1" />-->
-      <!--<_EmccCommonFlags Include="-g"                                Condition="'$(WasmNativeStrip)' == 'false'" />-->
-      <!--<_EmccCommonFlags Include="-v"                                Condition="'$(EmccVerbose)' != 'false'" />-->
-      <!--<_EmccCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmEnableExceptionHandling)' == 'false'" />-->
-      <!--<_EmccCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmEnableExceptionHandling)' == 'true'" />-->
-      <!--<_EmccCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />-->
-
       <_WasmCommonIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
       <_WasmCommonIncludePaths Include="$(_WasmRuntimePackIncludeDir)mono-2.0" />
       <_WasmCommonIncludePaths Include="$(_WasmRuntimePackIncludeDir)wasm" />
+
+      <_WasmLinkDependencies Remove="@(_WasmLinkDependencies)" />
+
+      <_WasiClangCommonFlags Include="$(_DefaultWasiClangFlags)" />
+      <_WasiClangCommonFlags Include="$(WasiClangFlags)" />
+      <_WasiClangCommonFlags Include="--sysroot=&quot;$(WasiSdkRoot.Replace('\', '/'))/share/wasi-sysroot&quot;" />
+      <_WasiClangCommonFlags Include="-g"                                Condition="'$(WasmNativeStrip)' == 'false'" />
+      <_WasiClangCommonFlags Include="-v"                                Condition="'$(WasiClangVerbose)' != 'false'" />
+      <!--<_WasiClangCommonFlags Include="-s DISABLE_EXCEPTION_CATCHING=0"   Condition="'$(WasmEnableExceptionHandling)' == 'false'" />-->
+      <!--<_WasiClangCommonFlags Include="-fwasm-exceptions"                 Condition="'$(WasmEnableExceptionHandling)' == 'true'" />-->
+      <!--<_WasiClangCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />-->
+
+      <_WasmCommonCFlags Include="-DGEN_PINVOKE=1" />
+      <_WasmCommonCFlags Condition="'$(RunAOTCompilation)' == 'true'"      Include="-DENABLE_AOT=1" />
+      <_WasmCommonCFlags Condition="'$(_DriverGenCNeeded)' == 'true'"      Include="-DDRIVER_GEN=1" />
+      <_WasmCommonCFlags Condition="'$(WasmSingleFileBundle)' == 'true'"   Include="-DWASM_SINGLE_FILE=1" />
+      <_WasmCommonCFlags Condition="'$(InvariantGlobalization)' == 'true'" Include="-DINVARIANT_GLOBALIZATION=1" />
+      <_WasmCommonCFlags Condition="'$(InvariantTimezone)' == 'true'"      Include="-DINVARIANT_TIMEZONE=1" />
+      <_WasmCommonCFlags Condition="'$(WasmLinkIcalls)' == 'true'"         Include="-DLINK_ICALLS=1" />
+      <_WasiClangCFlags Include="@(_WasmCommonCFlags)" />
+
+      <_WasiClangCFlags Include="&quot;-I%(_WasmCommonIncludePaths.Identity)&quot;" />
+      <_WasiClangCFlags Include="-I&quot;$(MicrosoftNetCoreAppRuntimePackRidNativeDir.Replace('\', '/'))include&quot;" />
+
+      <_WasiClangCFlags Condition="'@(WasiAfterRuntimeLoadedDeclarations)' != ''"
+                         Include="-D WASI_AFTER_RUNTIME_LOADED_DECLARATIONS=&quot;@(WasiAfterRuntimeLoadedDeclarations, ' ')&quot;" />
+      <_WasiClangCFlags Condition="'@(WasiAfterRuntimeLoadedCalls)' != ''"
+                         Include="-D WASI_AFTER_RUNTIME_LOADED_CALLS=&quot;@(WasiAfterRuntimeLoadedCalls, ' ')&quot;" />
+
+      <_WasiClangLDFlags Include="$(WasiClangLinkOptimizationFlag)" />
+      <_WasiClangLDFlags Include="@(_WasiClangCommonFlags)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -172,56 +207,18 @@
     </ItemGroup>
 
     <ItemGroup>
-      <_WasmCommonCFlags Include="-DGEN_PINVOKE=1" />
-      <_WasmCommonCFlags Condition="'$(WasmSingleFileBundle)' == 'true'"   Include="-DWASM_SINGLE_FILE=1" />
-      <_WasmCommonCFlags Condition="'$(InvariantGlobalization)' == 'true'" Include="-DINVARIANT_GLOBALIZATION=1" />
-      <_WasmCommonCFlags Condition="'$(InvariantTimezone)' == 'true'"      Include="-DINVARIANT_TIMEZONE=1" />
-      <_WasmCommonCFlags Condition="'$(WasmLinkIcalls)' == 'true'"         Include="-DLINK_ICALLS=1" />
+      <_DriverCDependencies Include="$(_WasmPInvokeHPath);$(_WasmICallTablePath)" />
+      <_DriverCDependencies Include="$(_DriverGenCPath)" Condition="'$(_DriverGenCNeeded)' == 'true'" />
 
-      <!-- Adding optimization flag at the top, so it gets precedence -->
-      <!--<_EmccCFlags Include="$(EmccCompileOptimizationFlag)" />-->
-      <!--<_EmccCFlags Include="-s ASSERTIONS=$(_EmccAssertionLevelDefault)" Condition="'$(_WasmDevel)' == 'true'" />-->
-      <!--<_EmccCFlags Include="@(_EmccCommonFlags)" />-->
+      <_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)pinvoke.c"
+                               Dependencies="$(_WasmPInvokeHPath);$(_WasmPInvokeTablePath)" />
+      <_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)driver.c"
+                               Dependencies="@(_DriverCDependencies)" />
+      <_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)main.c" />
+      <_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)stubs.c" />
+      <_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)synthetic-pthread.c" />
 
-      <!--<_EmccCFlags Include="-DDISABLE_PERFTRACING_LISTEN_PORTS=1" />-->
-      <!--<_EmccCFlags Include="-DENABLE_AOT=1"                    Condition="'$(_WasmShouldAOT)' == 'true'" />-->
-      <!--<_EmccCFlags Include="-DDRIVER_GEN=1"                    Condition="'$(_WasmShouldAOT)' == 'true'" />-->
-      <!--<_EmccCFlags Include="-DLINK_ICALLS=1"                   Condition="'$(WasmLinkIcalls)' == 'true'" />-->
-      <!--<_EmccCFlags Include="-DENABLE_AOT_PROFILER=1"           Condition="$(WasmProfilers.Contains('aot'))" />-->
-      <!--<_EmccCFlags Include="-DENABLE_BROWSER_PROFILER=1"       Condition="$(WasmProfilers.Contains('browser'))" />-->
-      <!--<_EmccCFlags Include="-DGEN_PINVOKE=1" />-->
-      <!--<_EmccCFlags Include="-emit-llvm" />-->
-
-      <!--<_EmccCFlags Include="-g" Condition="'$(WasmNativeDebugSymbols)' == 'true'" />-->
-
-      <!-- Adding optimization flag at the top, so it gets precedence -->
-      <!--<_EmccLDFlags Include="$(EmccLinkOptimizationFlag)" />-->
-      <!--<_EmccLDFlags Include="@(_EmccCommonFlags)" />-->
-
-      <!-- ILLinker should have removed unused imports, so error for Publish -->
-      <!--<_EmccLDSFlags Include="-s ERROR_ON_UNDEFINED_SYMBOLS=0" Condition="'$(WasmBuildingForNestedPublish)' != 'true'" />-->
-
-      <!--<_DriverCDependencies Include="$(_WasmPInvokeHPath);$(_WasmICallTablePath)" />-->
-      <!--<_DriverCDependencies Include="$(_DriverGenCPath)" Condition="'$(_DriverGenCNeeded)' == 'true'" />-->
-
-      <!--<_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)pinvoke.c"-->
-                               <!--Dependencies="$(_WasmPInvokeHPath);$(_WasmPInvokeTablePath)" />-->
-      <!--<_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)driver.c"-->
-                               <!--Dependencies="@(_DriverCDependencies)" />-->
-      <!--<_WasmRuntimePackSrcFile Include="$(_WasmRuntimePackSrcDir)corebindings.c" />-->
-
-      <!--<_WasmRuntimePackSrcFile ObjectFile="$(_WasmIntermediateOutputPath)%(FileName).o" />-->
-
-      <!-- See src\mono\wasm\runtime\modularize-dotnet.md -->
-      <!--<_WasmExtraJSFile Include="$(_WasmRuntimePackSrcDir)\*.%(JSFileType.Identity)"     Kind="%(JSFileType.Kind)" />-->
-      <!--<_WasmExtraJSFile Include="$(_WasmRuntimePackSrcDir)\es6\*.%(JSFileType.Identity)" Kind="%(JSFileType.Kind)" />-->
-
-      <_WasmNativeFileForLinking Include="@(NativeFileReference)" />
-
-      <!--<EmscriptenEnvVars Include="EMSDK_PYTHON=$(EmscriptenPythonToolsPath)python.exe" Condition="'$(OS)' == 'Windows_NT'" />-->
-      <!--<EmscriptenEnvVars Include="PYTHONPATH=$(EmscriptenPythonToolsPath)" Condition="'$(OS)' == 'Windows_NT'" />-->
-      <!--<EmscriptenEnvVars Include="PYTHONHOME=" Condition="'$(OS)' == 'Windows_NT'" />-->
-      <!--<EmscriptenEnvVars Include="EM_CACHE=$(WasmCachePath)" Condition="'$(WasmCachePath)' != ''" />-->
+      <_WasmRuntimePackSrcFile ObjectFile="$(_WasmIntermediateOutputPath)%(FileName).o" />
     </ItemGroup>
 
     <Error Text="Could not find NativeFileReference %(NativeFileReference.Identity)" Condition="'%(NativeFileReference.Identity)' != '' and !Exists(%(NativeFileReference.Identity))" />
@@ -264,6 +261,70 @@
     </ManagedToNativeGenerator>
   </Target>
 
+  <Target Name="_WasmCompileNativeFiles" DependsOnTargets="_CheckWasiClangIsExpectedVersion">
+    <ItemGroup>
+      <_WasiClangCFlags Include="$(WasiClangExtraCFlags)" />
+    </ItemGroup>
+
+    <WriteLinesToFile Lines="@(_WasiClangCFlags)" File="$(_WasiClangCompileRsp)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_WasiClangCompileRsp)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <_WasmSourceFileToCompile Remove="@(_WasmSourceFileToCompile)" />
+      <_WasmSourceFileToCompile Include="@(_WasmRuntimePackSrcFile)" Dependencies="%(_WasmRuntimePackSrcFile.Dependencies);$(_WasiClangDefaultFlagsRsp);$(_WasiClangCompileRsp)" />
+    </ItemGroup>
+    <EmccCompile
+          SourceFiles="@(_WasmSourceFileToCompile)"
+          Arguments='"@$(_WasiClangDefaultFlagsRsp)" $(_WasiClangDefaultFlags) "@$(_WasiClangCompileRsp)"'
+          CompilerBinaryPath="$(WasiClang)"
+          EnvironmentVariables="@(EmscriptenEnvVars)"
+          DisableParallelCompile="$(DisableParallelEmccCompile)"
+          MessageToIndicateCompiling="Compiling native assets using $(WasiClang) with $(WasiClangCompileOptimizationFlag). This may take a while ..."
+          OutputMessageImportance="$(_WasiClangCompileOutputMessageImportance)">
+      <Output TaskParameter="OutputFiles" ItemName="FileWrites" />
+    </EmccCompile>
+
+    <ItemGroup>
+      <_WasmNativeFileForLinking Include="%(_WasmSourceFileToCompile.ObjectFile)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_WasmCompileAssemblyBitCodeFilesForAOT"
+            Inputs="@(_BitcodeFile);$(_WasiClangCompileBitcodeRsp)"
+            Outputs="@(_BitcodeFile->'%(ObjectFile)')"
+            Condition="'$(_WasmShouldAOT)' == 'true' and @(_BitcodeFile->Count()) > 0"
+            DependsOnTargets="_CheckWasiClangIsExpectedVersion;_WasmWriteRspForCompilingBitcode"
+            Returns="@(FileWrites)">
+
+    <ItemGroup>
+      <_BitCodeFile Dependencies="%(_BitCodeFile.Dependencies);$(_WasiClangDefaultFlagsRsp);$(_WasiClangCompileBitcodeRsp)" />
+    </ItemGroup>
+
+    <EmccCompile
+          SourceFiles="@(_BitCodeFile)"
+          Arguments="&quot;@$(_WasiClangDefaultFlagsRsp)&quot; $(_WasiClangDefaultFlags) &quot;@$(_WasiClangCompileBitcodeRsp)&quot;"
+          CompilerBinaryPath="$(WasiClang)"
+          EnvironmentVariables="@(EmscriptenEnvVars)"
+          DisableParallelCompile="$(DisableParallelEmccCompile)"
+          MessageToIndicateCompiling="Compiling assembly bitcode files with $(WasiClangLinkOptimizationFlag) ..."
+          OutputMessageImportance="$(_WasiClangCompileOutputMessageImportance)">
+      <Output TaskParameter="OutputFiles" ItemName="FileWrites" />
+    </EmccCompile>
+  </Target>
+
+  <Target Name="_WasmWriteRspForCompilingBitcode">
+    <ItemGroup>
+      <_BitcodeLDFlags Include="@(_WasiClangLDFlags)" />
+      <_BitcodeLDFlags Include="$(WasiClangExtraBitcodeLDFlags)" />
+    </ItemGroup>
+    <WriteLinesToFile Lines="@(_BitcodeLDFlags)" File="$(_WasiClangCompileBitcodeRsp)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_WasiClangCompileBitcodeRsp)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_WasmSelectRuntimeComponentsForLinking" Condition="'$(UsingWasiRuntimeWorkload)' == 'true'" DependsOnTargets="_MonoSelectRuntimeComponents" />
 
   <Target Name="_GetNativeFilesForLinking" DependsOnTargets="_WasmSelectRuntimeComponentsForLinking" Returns="@(_WasmNativeFileForLinking)">
@@ -282,7 +343,7 @@
 
     <ItemGroup>
       <!-- order matters -->
-      <!--<_WasmNativeFileForLinking Include="%(_BitcodeFile.ObjectFile)" />-->
+      <_WasmNativeFileForLinking Include="%(_BitcodeFile.ObjectFile)" />
       <!--<_WasmNativeFileForLinking Include="%(_WasmSourceFileToCompile.ObjectFile)" />-->
       <_MonoRuntimeComponentDontLink Include="libmono-component-diagnostics_tracing-static.a" />
       <_MonoRuntimeComponentDontLink Include="wasm-bundled-timezones.a" Condition="'$(InvariantTimezone)' == 'true'"/>
@@ -300,64 +361,6 @@
     </ItemGroup>
   </Target>
 
-  <!--<Target Name="_WasmWriteRspFilesForLinking" DependsOnTargets="_CheckEmccIsExpectedVersion">-->
-    <!--<PropertyGroup>-->
-      <!--<_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>-->
-      <!--<_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-js.a</_WasmEHLib>-->
-      <!--<_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-js.a</_WasmEHLibToExclude>-->
-      <!--<_WasmEHLibToExclude Condition="'$(WasmEnableExceptionHandling)' != 'true'">libmono-wasm-eh-wasm.a</_WasmEHLibToExclude>-->
-    <!--</PropertyGroup>-->
-    <!--<ItemGroup>-->
-      <!--[> order matters <]-->
-      <!--<_WasmNativeFileForLinking Include="%(_BitcodeFile.ObjectFile)" />-->
-      <!--<_WasmNativeFileForLinking Include="%(_WasmSourceFileToCompile.ObjectFile)" />-->
-
-      <!--<_WasmNativeFileForLinking-->
-          <!--Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)*.a"-->
-          <!--Exclude="@(_MonoRuntimeComponentDontLink->'$(MicrosoftNetCoreAppRuntimePackRidNativeDir)%(Identity)')" />-->
-      <!--<_WasmNativeFileForLinking Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)$(_WasmEHLib)" />-->
-      <!--<_WasmNativeFileForLinking Remove="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)$(_WasmEHLibToExclude)" />-->
-
-      <!--<_WasmExtraJSFile Include="@(Content)" Condition="'%(Content.Extension)' == '.js'" />-->
-
-    <!--</ItemGroup>-->
-
-    <!--<WriteLinesToFile Lines="@(_EmccLinkStepArgs)" File="$(_EmccLinkRsp)" Overwrite="true" WriteOnlyWhenDifferent="true" />-->
-    <!--<ItemGroup>-->
-      <!--<FileWrites Include="$(_EmccLinkRsp)" />-->
-    <!--</ItemGroup>-->
-  <!--</Target>-->
-
-  <!--<Target Name="_WasmLinkDotNet"-->
-          <!--Inputs="@(_WasmLinkDependencies);$(_WasiClangDefaultFlagsRsp);$(_WasiClangDefaultLinkFlagsRsp);$(_EmccLinkRsp)"-->
-          <!--Outputs="$(_WasmIntermediateOutputPath)dotnet.js;$(_WasmIntermediateOutputPath)dotnet.wasm"-->
-          <!--DependsOnTargets="_CheckEmccIsExpectedVersion;_WasmSelectRuntimeComponentsForLinking;_WasmCompileAssemblyBitCodeFilesForAOT;_WasmWriteRspFilesForLinking"-->
-          <!--Returns="@(FileWrites)" >-->
-
-    <!--<Message Text="Linking for initial memory %24(EmccInitialHeapSize)=$(EmccInitialHeapSize) bytes. Set this msbuild property to change the value." Importance="High" />-->
-    <!--<Message Text="Linking with emcc with $(EmccLinkOptimizationFlag). This may take a while ..." Importance="High" />-->
-    <!--<Message Text="Running emcc with @(_EmccLinkStepArgs->'%(Identity)', ' ')" Importance="Low" />-->
-    <!--<Exec Command='emcc "@$(_WasiClangDefaultFlagsRsp)" "@$(_WasiClangDefaultLinkFlagsRsp)" "@$(_EmccLinkRsp)"' EnvironmentVariables="@(EmscriptenEnvVars)" />-->
-    <!--<ItemGroup>-->
-      <!--<FileWrites Include="$(_WasmIntermediateOutputPath)dotnet.wasm" />-->
-      <!--<FileWrites Include="$(_WasmIntermediateOutputPath)dotnet.js" />-->
-      <!--<FileWrites Include="$(_WasmIntermediateOutputPath)dotnet.js.symbols" Condition="'$(WasmEmitSymbolMap)' == 'true'" />-->
-    <!--</ItemGroup>-->
-
-    <!--<ItemGroup>-->
-      <!--[> WasmOptConfigurationFlags property is set by reading from emcc-props.json <]-->
-      <!--<WasmOptConfigurationFlags Condition="'$(WasmOptConfigurationFlags)' != ''" Include="$(WasmOptConfigurationFlags)" />-->
-    <!--</ItemGroup>-->
-
-    <!--<Message Text="Stripping symbols from dotnet.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />-->
-    <!--<Exec Command="wasm-opt$(_ExeExt) -enable-simd -enable-exception-handling @(WasmOptConfigurationFlags, ' ') -strip-dwarf &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot; -o &quot;$(_WasmIntermediateOutputPath)dotnet.wasm&quot;"-->
-          <!--Condition="'$(WasmNativeStrip)' == 'true'"-->
-          <!--IgnoreStandardErrorWarningFormat="true"-->
-          <!--EnvironmentVariables="@(EmscriptenEnvVars)" />-->
-  <!--</Target>-->
-
-  <UsingTask TaskName="EmitBundleObjectFiles" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" />
-  <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.EmitWasmBundleObjectFiles" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
   <Target Name="_GenerateAssemblyObjectFiles" Returns="@(_WasiObjectFilesForBundle)"
     Condition="'$(WasmSingleFileBundle)' == 'true'"
   >
@@ -384,7 +387,7 @@
 
     <!-- Clean up the bundle-objects dir - remove anything we no longer need -->
     <ItemGroup>
-      <WasmBundleFileToDelete Include="$(_WasmIntermediateOutputPath)*.o" />
+      <WasmBundleFileToDelete Include="$(_WasmIntermediateOutputPath)bundled_*.o" />
       <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmAssembliesBundleObjectFile)" />
       <WasmBundleFileToDelete Remove="%(_WasmBundledAssemblies.DestinationFile)" />
     </ItemGroup>
@@ -408,13 +411,16 @@
       <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmIcuBundleObjectFile)" />
       <WasmBundleFileToDelete Remove="%(BundledWasmIcu.DestinationFile)" />
     </ItemGroup>
-    
+
     <Delete Files="@(WasmBundleFileToDelete)" />
   </Target>
 
-  <Target Name="_WasiLink">
-          <!--Inputs="@(_WasmNativeFileForLinking);@(_WasmAssembliesInternal);@(IntermediateAssembly)"-->
-          <!--Outputs="$(_WasmOutputFileName)">-->
+  <!-- replace with wasmlinkdotnet -->
+  <Target Name="_WasiLinkDotNet"
+          DependsOnTargets="_CheckWasiClangIsExpectedVersion;_WasmSelectRuntimeComponentsForLinking;_WasmCompileAssemblyBitCodeFilesForAOT;_WasmWriteRspFilesForLinking"
+          Inputs="@(_WasmLinkDependencies);$(_WasiClangDefaultFlagsRsp);$(_WasiClangDefaultLinkFlagsRsp);$(_WasiClangLinkRsp)"
+          Outputs="$(_WasmOutputFileName)"
+          Returns="@(FileWrites)">
 
     <!-- Generate a file entrypoint_YourAssemblyName.c containing the dotnet_wasi_getentrypointassemblyname symbol.
        This means we don't have to hardcode the assembly name in main.c -->
@@ -432,51 +438,39 @@
               Lines="const char* dotnet_wasi_getentrypointassemblyname() { return &quot;managed/$(WasmMainAssemblyFileName)&quot;%3B }"
               WriteOnlyWhenDifferent="true" />
     <ItemGroup>
-      <!--<_WasmNativeFileForLinking Include="$(_WasiObjectFilesForBundle)" />-->
-      <!--<_WasmNativeFileForLinking Include="$(_WasiGetEntrypointCFile)" />-->
       <FileWrites Include="$(_WasiGetEntrypointCFile)" />
       <WasiAfterRuntimeLoadedDeclarations Include="@(WasiAfterRuntimeLoaded->'void %(Identity)();')" />
       <WasiAfterRuntimeLoadedCalls Include="@(WasiAfterRuntimeLoaded->'%(Identity)();')" />
 
-      <_WasmRuntimePackSrcFile Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)src/*.c" />
-    </ItemGroup>
+      <_WasiClangXLinkerFlags Include="--initial-memory=$(WasmInitialHeapSize)" />
 
-    <!-- Invoke the WASI SDK clang binary to build the .wasm file -->
-    <ItemGroup>
-      <_WasiSdkLinkerFlags Include="--initial-memory=$(WasmInitialHeapSize)" />
+      <_WasmNativeFileForLinking Include="@(NativeFileReference)" />
 
       <_WasiFilePathForFixup Include="$(_WasiGetEntrypointCFile)" />
       <_WasiFilePathForFixup Include="@(_WasiObjectFilesForBundle)" />
       <_WasiFilePathForFixup Include="@(_WasmNativeFileForLinking)" />
-      <_WasiFilePathForFixup Include="@(_WasmRuntimePackSrcFile)" />
 
       <_WasiSdkClangArgs Condition="'$(OS)' == 'Windows_NT'" Include="&quot;$([System.String]::new(%(_WasiFilePathForFixup.Identity)).Replace('\', '/'))&quot;" />
       <_WasiSdkClangArgs Condition="'$(OS)' != 'Windows_NT'" Include="@(_WasiFilePathForFixup -> '&quot;%(Identity)&quot;')" />
 
-      <_WasiSdkClangArgs Include="@(_WasmCommonCFlags)" />
-
-      <_WasiSdkClangArgs Include="&quot;-I%(_WasmCommonIncludePaths.Identity)&quot;" />
-      <_WasiSdkClangArgs Include="--sysroot=&quot;$(WasiSdkRoot.Replace('\', '/'))/share/wasi-sysroot&quot;" />
-      <_WasiSdkClangArgs Include="-I&quot;$(MicrosoftNetCoreAppRuntimePackRidNativeDir.Replace('\', '/'))include&quot;" />
       <_WasiSdkClangArgs Include="-Wl,--export=malloc,--export=free,--export=__heap_base,--export=__data_end" />
       <!-- keep in sync with src\mono\wasi\wasi.proj -->
       <_WasiSdkClangArgs Include="-Wl,-z,stack-size=8388608,-lwasi-emulated-process-clocks,-lwasi-emulated-signal,-lwasi-emulated-mman"/>
       <_WasiSdkClangArgs Include="-Wl,-s" Condition="'$(WasmNativeStrip)' == 'true'"/>
 
-      <_WasiSdkClangArgs Include="@(_WasiSdkLinkerFlags -> '-Xlinker %(Identity)', ' ')" />
+      <_WasiSdkClangArgs Include="&quot;@$(_WasiClangDefaultLinkFlagsRsp)&quot;" />
+      <_WasiSdkClangArgs Include="@(_WasiClangXLinkerFlags -> '-Xlinker %(Identity)', ' ')" />
+      <_WasiSdkClangArgs Include="@(_WasiClangLDFlags)" />
 
-      <_WasiSdkClangArgs Condition="'@(WasiAfterRuntimeLoadedDeclarations)' != ''"
-                         Include="-D WASI_AFTER_RUNTIME_LOADED_DECLARATIONS=&quot;@(WasiAfterRuntimeLoadedDeclarations, ' ')&quot;" />
-      <_WasiSdkClangArgs Condition="'@(WasiAfterRuntimeLoadedCalls)' != ''"
-                         Include="-D WASI_AFTER_RUNTIME_LOADED_CALLS=&quot;@(WasiAfterRuntimeLoadedCalls, ' ')&quot;" />
       <_WasiSdkClangArgs Include="-o &quot;$(_WasmOutputFileName.Replace('\', '/'))&quot;" />
     </ItemGroup>
 
-    <WriteLinesToFile Lines="@(_WasiSdkClangArgs)" File="$(_WasmIntermediateOutputPath)clang-compile.rsp" Overwrite="true" />
+    <WriteLinesToFile Lines="@(_WasiSdkClangArgs)" File="$(_WasiClangLinkRsp)" Overwrite="true" />
+
     <!--<Message Importance="High" Text="Performing WASI SDK build: &quot;$(WasiClang)&quot; @(_WasiSdkClangArgs, ' ')" />-->
-    <Message Importance="High" Text="Performing WASI SDK build: &quot;$(WasiClang)&quot; &quot;@$(_WasmIntermediateOutputPath)clang-compile.rsp&quot;" />
+    <Message Importance="High" Text="Performing WASI SDK build: &quot;$(WasiClang)&quot; &quot;$(_WasiClangLinkRsp)&quot;" />
     <!--<Exec Command="&quot;$(WasiClang)&quot; @(_WasiSdkClangArgs, ' ')" />-->
-    <Exec Command="&quot;$(WasiClang)&quot; &quot;@$(_WasmIntermediateOutputPath)clang-compile.rsp&quot;" />
+    <Exec Command="&quot;$(WasiClang)&quot; &quot;@$(_WasiClangLinkRsp)&quot;" />
 
     <!-- FIXME: this will be done by the bundler -->
     <Copy SourceFiles="$(_WasmOutputFileName)" DestinationFolder="$(WasmAppDir)" />
@@ -488,13 +482,7 @@
   <Target Name="_CompleteWasmBuildNative">
     <ItemGroup>
       <WasmNativeAsset Include="$(_WasmIntermediateOutputPath)dotnet.wasm" />
-      <WasmNativeAsset Include="$(_WasmIntermediateOutputPath)dotnet.js" />
-      <WasmNativeAsset Include="$(_WasmIntermediateOutputPath)dotnet.worker.js" Condition="Exists('$(_WasmIntermediateOutputPath)dotnet.worker.js')" />
-      <WasmNativeAsset Include="$(_WasmIntermediateOutputPath)dotnet.js.symbols" Condition="'$(WasmEmitSymbolMap)' == 'true' and Exists('$(_WasmIntermediateOutputPath)dotnet.js.symbols')" />
     </ItemGroup>
-  </Target>
-
-  <Target Name="_GenerateDriverGenC" Condition="'$(_WasmShouldAOT)' != 'true'">
   </Target>
 
   <!--
@@ -506,7 +494,7 @@
   <Target Name="_WasmAotCompileApp" Condition="'$(_WasmShouldAOT)' == 'true'">
     <PropertyGroup>
       <!-- FIXME: do it once -->
-      <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','browser-wasm'))</_MonoAotCrossCompilerPath>
+      <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier', 'wasi-wasm'))</_MonoAotCrossCompilerPath>
     </PropertyGroup>
 
     <Error Condition="'@(_WasmAssembliesInternal)' == ''" Text="Item _WasmAssembliesInternal is empty" />
@@ -589,7 +577,7 @@
       DedupAssembly="$(_WasmDedupAssembly)"
       CacheFilePath="$(_AOTCompilerCacheFile)"
       LLVMDebug="dwarfdebug"
-      LLVMPath="$(EmscriptenUpstreamBinPath)"
+      LLVMPath="$(WasiSdkBinPath)"
       IntermediateOutputPath="$(_WasmIntermediateOutputPath)"
       AotProfilePath="@(AotProfilePath)">
 
@@ -629,4 +617,7 @@
       <_WasmAssembliesInternal Include="@(_WasmStrippedAssemblies)" />
     </ItemGroup>
   </Target>
+
+  <Target Name="_CheckWasiClangIsExpectedVersion" />
+  <Target Name="_WasmWriteRspFilesForLinking" />
 </Project>

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -58,13 +58,6 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="_PrepareForWasiBuildNative">
-    <Error Condition="'$(_IsToolchainMissing)' == 'true'"
-           Text="$(_ToolchainMissingErrorMessage) SDK is required for building native files." />
-
-
-  </Target>
-
   <Target Name="_SetWasmBuildNativeDefaults">
     <!-- if already set, maybe by a user projects, then a missing emsdk is an error -->
     <Error Condition="'$(WasmBuildNative)' == 'true' and '$(_IsToolchainMissing)' == 'true'"

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -159,7 +159,16 @@
       <_WasmCommonIncludePaths Include="$(_WasmIntermediateOutputPath.TrimEnd('\/'))" />
       <_WasmCommonIncludePaths Include="$(_WasmRuntimePackIncludeDir)mono-2.0" />
       <_WasmCommonIncludePaths Include="$(_WasmRuntimePackIncludeDir)wasm" />
+    </ItemGroup>
 
+    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+      <!-- Fixup on windows -->
+      <_WasmCommonIncludePathsFixedUp Include="$([System.String]::new(%(_WasmCommonIncludePaths.Identity)).Replace('\', '/'))" />
+      <_WasmCommonIncludePaths Remove="@(_WasmCommonIncludePaths)" />
+      <_WasmCommonIncludePaths Include="@(_WasmCommonIncludePathsFixedUp)" />
+    </ItemGroup>
+
+    <ItemGroup>
       <_WasmLinkDependencies Remove="@(_WasmLinkDependencies)" />
 
       <_WasiClangCommonFlags Include="$(_DefaultWasiClangFlags)" />
@@ -190,13 +199,6 @@
 
       <_WasiClangLDFlags Include="$(WasiClangLinkOptimizationFlag)" />
       <_WasiClangLDFlags Include="@(_WasiClangCommonFlags)" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-      <!-- Fixup on windows -->
-      <_WasmCommonIncludePathsFixedUp Include="$([System.String]::new(%(_WasmCommonIncludePaths.Identity)).Replace('\', '/'))" />
-      <_WasmCommonIncludePaths Remove="@(_WasmCommonIncludePaths)" />
-      <_WasmCommonIncludePaths Include="@(_WasmCommonIncludePathsFixedUp)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -453,7 +453,7 @@
       <_WasiSdkClangArgs Include="-Wl,-z,stack-size=8388608,-lwasi-emulated-process-clocks,-lwasi-emulated-signal,-lwasi-emulated-mman"/>
       <_WasiSdkClangArgs Include="-Wl,-s" Condition="'$(WasmNativeStrip)' == 'true'"/>
 
-      <_WasiSdkClangArgs Include="&quot;@$(_WasiClangDefaultLinkFlagsRsp)&quot;" />
+      <_WasiSdkClangArgs Include="&quot;@$(_WasiClangDefaultLinkFlagsRsp.Replace('\', '/'))&quot;" />
       <_WasiSdkClangArgs Include="@(_WasiClangXLinkerFlags -> '-Xlinker %(Identity)', ' ')" />
       <_WasiSdkClangArgs Include="@(_WasiClangLDFlags)" />
 

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -77,7 +77,7 @@
   -->
 
   <PropertyGroup>
-    <WasmDedup Condition="'$(WasmDedup)' == ''">false</WasmDedup>
+    <WasmDedup Condition="'$(WasmDedup)' == ''">true</WasmDedup>
     <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">false</WasmEnableExceptionHandling>
     <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
 

--- a/src/mono/wasi/build/WasiSdk.Defaults.props
+++ b/src/mono/wasi/build/WasiSdk.Defaults.props
@@ -4,5 +4,7 @@
     <WasiSysRoot>$([MSBuild]::NormalizeDirectory($(WasiSdkRoot), 'share', 'wasi-sysroot'))</WasiSysRoot>
     <WasiClang>$(WasiSdkRoot)\bin\clang</WasiClang>
     <WasiClang Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WasiClang).exe</WasiClang>
+
+    <WasiSdkBinPath>$([MSBuild]::NormalizeDirectory($(WasiSdkRoot), 'bin'))</WasiSdkBinPath>
   </PropertyGroup>
 </Project>

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -264,6 +264,7 @@
     <ItemGroup>
       <IcuDataFiles Include="$(NativeBinDir)*.dat" />
       <WasmSrcFiles Include="$(NativeBinDir)src\*.c;" />
+      <WasmSrcFiles Include="$(_WasiDefaultsRspPath);$(_WasiCompileRspPath);$(_WasiLinkRspPath)" />
       <WasmHeaderFiles Include="$(NativeBinDir)include\wasm\*.h" />
     </ItemGroup>
 

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -11,7 +11,6 @@
       _WasmAotCompileApp;
       _WasmStripAOTAssemblies;
       _PrepareForWasmBuildNative;
-      _GenerateDriverGenC;
       _GenerateManagedToNative;
       _WasmCompileNativeFiles;
       _WasmLinkDotNet;
@@ -547,9 +546,6 @@
       <WasmNativeAsset Include="$(_WasmIntermediateOutputPath)dotnet.native.js.symbols" Condition="'$(WasmEmitSymbolMap)' == 'true' and Exists('$(_WasmIntermediateOutputPath)dotnet.native.js.symbols')" />
       <_WasmAssembliesInternal Remove="$(_WasmDedupAssembly)"/>
     </ItemGroup>
-  </Target>
-
-  <Target Name="_GenerateDriverGenC" Condition="'$(_WasmShouldAOT)' != 'true'">
   </Target>
 
   <Target Name="_ReadEmccProps" Condition="'$(_IsEMSDKMissing)' != 'true'">

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -34,6 +34,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
         public string?      WorkingDirectory       { get; set; }
         public string       OutputMessageImportance{ get; set; } = "Low";
         public string?      MessageToIndicateCompiling { get; set; }
+        public string       CompilerBinaryPath     { get; set; } = "emcc";
 
         [Output]
         public ITaskItem[]? OutputFiles            { get; private set; }
@@ -192,7 +193,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
                 string tmpObjFile = Path.GetTempFileName();
                 try
                 {
-                    string command = $"emcc {Arguments} -c -o \"{tmpObjFile}\" \"{srcFile}\"";
+                    string command = $"{CompilerBinaryPath} {Arguments} -c -o \"{tmpObjFile}\" \"{srcFile}\"";
                     var startTime = DateTime.Now;
 
                     // Log the command in a compact format which can be copy pasted


### PR DESCRIPTION
With  this `RunAOTCompilation=true`+publish runs the AOT build, same as for `browser-wasm`. The build structure closely follows what we have for `wasm`. And this will get consolidated in future PRs.

The output does not run right now, and fails with:
```
$ wasmtime run  --env MONO_LOG_LEVEL=debug --env MONO_LOG_MASK=aot --dir . dotnet.wasm Wasi.Console.Sample
[MONO] debug: Found statically linked AOT module 'System.Private.CoreLib'.
[MONO] debug: AOT: module System.Private.CoreLib wants to load image 0: System.Private.CoreLib
[MONO] debug: AOT: image 'System.Private.CoreLib' found.
[MONO] debug: AOT: FOUND method (wrapper managed-to-native) object:__icall_wrapper_(null) () [0x29fe - 0x29ff 0xc84d0]
[MONO] debug: AOT: FOUND method (wrapper managed-to-native) object:__icall_wrapper_(null) (intptr,int) [0x2981 - 0x2982 0xc84d0]
[MONO] debug: AOT: FOUND method (wrapper managed-to-native) object:__icall_wrapper_(null) (int) [0x29bd - 0x29be 0xc84d0]
[MONO] debug: AOT: FOUND method (wrapper managed-to-native) object:__icall_wrapper_(null) (intptr,int) [0x29a9 - 0x29aa 0xc84d0]
[MONO] debug: AOT: FOUND method (wrapper managed-to-native) object:__icall_wrapper_(null) (intptr,int) [0x29a8 - 0x29a9 0xc84d0]
[MONO] debug: AOT: FOUND method System.OutOfMemoryException:.ctor (string) [0xfb4 - 0xfb5 0xc84d0]
[MONO] debug: AOT: FOUND method System.NullReferenceException:.ctor (string) [0xf31 - 0xf32 0xc84d0]
[MONO] debug: AOT: FOUND method System.StackOverflowException:.ctor (string) [0x1069 - 0x106a 0xc84d0]
[MONO] debug: AOT: FOUND method System.AppContext:Setup (char**,char**,int) [0xb64 - 0xb65 0xc84d0]
[MONO] debug: AOT: FOUND method (wrapper other) object:gsharedvt_out_sig (object&,object&,int&,intptr) [0x2c8e - 0x2c8f 0xc84d0]
[MONO] error: * Assertion: should not be reached at /Users/ankj/dev/r2/src/mono/mono/mini/mini.c:4435
```
`/Users/ankj/dev/r2/src/mono/mono/mini/mini.c:4435` - this is in `mono_llvm_cpp_catch_exception`

- EmccCompile: Add CompilerBinaryPath input property
- [wasi] Add default rsp files to the runtime pack
- [wasi] Add build support for AOT
- [wasi] Add simple aot build tests
- [wasi] update build-tasks target