### PR TITLE
Ensure ExceptionStringIds are handled

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ExceptionStringID.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ExceptionStringID.cs
@@ -34,8 +34,6 @@ namespace Internal.TypeSystem
         InvalidProgramSpecific,
         InvalidProgramVararg,
         InvalidProgramCallVirtFinalize,
-        InvalidProgramCallAbstractMethod,
-        InvalidProgramCallVirtStatic,
         InvalidProgramNonStaticMethod,
         InvalidProgramGenericMethod,
         InvalidProgramNonBlittableTypes,
@@ -43,7 +41,6 @@ namespace Internal.TypeSystem
 
         // BadImageFormatException
         BadImageFormatGeneric,
-        BadImageFormatSpecific,
 
         // MarshalDirectiveException
         MarshalDirectiveGeneric,

--- a/src/coreclr/tools/Common/TypeSystem/Common/Properties/Resources.resx
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Properties/Resources.resx
@@ -165,12 +165,6 @@
   <data name="InvalidProgramCallVirtFinalize" xml:space="preserve">
     <value>Callvirt of '{0}' not supported</value>
   </data>
-  <data name="InvalidProgramCallAbstractMethod" xml:space="preserve">
-    <value>Direct call to abstract method '{0}' not allowed</value>
-  </data>
-  <data name="InvalidProgramCallVirtStatic" xml:space="preserve">
-    <value>Callvirt of static method '{0}' not allowed</value>
-  </data>
   <data name="InvalidProgramNonStaticMethod" xml:space="preserve">
     <value>UnmanagedCallersOnly attribute specified on non-static method '{0}'</value>
   </data>
@@ -185,9 +179,6 @@
   </data>
   <data name="BadImageFormatGeneric" xml:space="preserve">
     <value>The format of a DLL or executable being loaded is invalid</value>
-  </data>
-  <data name="BadImageFormatSpecific" xml:space="preserve">
-    <value>The format of a DLL or executable being loaded is invalid with {0}</value>
   </data>
   <data name="MarshalDirectiveGeneric" xml:space="preserve">
     <value>Marshaling directives are invalid</value>

--- a/src/coreclr/tools/Common/TypeSystem/Common/ThrowHelper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ThrowHelper.cs
@@ -24,6 +24,12 @@ namespace Internal.TypeSystem
         }
 
         [System.Diagnostics.DebuggerHidden]
+        public static void ThrowMissingMethodException(string methodName)
+        {
+            throw new TypeSystemException.MissingMethodException(ExceptionStringID.MissingMethod, methodName);
+        }
+
+        [System.Diagnostics.DebuggerHidden]
         public static void ThrowMissingFieldException(TypeDesc owningType, string fieldName)
         {
             throw new TypeSystemException.MissingFieldException(ExceptionStringID.MissingField, Format.Field(owningType, fieldName));
@@ -57,12 +63,6 @@ namespace Internal.TypeSystem
         public static void ThrowBadImageFormatException()
         {
             throw new TypeSystemException.BadImageFormatException();
-        }
-
-        [System.Diagnostics.DebuggerHidden]
-        public static void ThrowBadImageFormatException(string message)
-        {
-            throw new TypeSystemException.BadImageFormatException(message);
         }
 
         [System.Diagnostics.DebuggerHidden]

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemException.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemException.cs
@@ -155,12 +155,6 @@ namespace Internal.TypeSystem
                 : base(ExceptionStringID.BadImageFormatGeneric)
             {
             }
-
-            internal BadImageFormatException(string reason)
-                : base(ExceptionStringID.BadImageFormatSpecific, reason)
-            {
-
-            }
         }
 
         public class MarshalDirectiveException : TypeSystemException

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -151,7 +151,7 @@ namespace Internal.TypeSystem.Ecma
                         break;
 
                     default:
-                        ThrowHelper.ThrowBadImageFormatException("unknown metadata token type: " + handle.Kind);
+                        ThrowHelper.ThrowBadImageFormatException();
                         item = null;
                         break;
                 }
@@ -378,7 +378,7 @@ namespace Internal.TypeSystem.Ecma
         {
             TypeDesc type = GetObject(handle, NotFoundBehavior.Throw) as TypeDesc;
             if (type == null)
-                ThrowHelper.ThrowBadImageFormatException($"type expected for handle {handle}");
+                ThrowHelper.ThrowBadImageFormatException();
             return type;
         }
 
@@ -386,7 +386,7 @@ namespace Internal.TypeSystem.Ecma
         {
             MethodDesc method = GetObject(handle, NotFoundBehavior.Throw) as MethodDesc;
             if (method == null)
-                ThrowHelper.ThrowBadImageFormatException($"method expected for handle {handle}");
+                ThrowHelper.ThrowBadImageFormatException();
             return method;
         }
 
@@ -394,7 +394,7 @@ namespace Internal.TypeSystem.Ecma
         {
             FieldDesc field = GetObject(handle, NotFoundBehavior.Throw) as FieldDesc;
             if (field == null)
-                ThrowHelper.ThrowBadImageFormatException($"field expected for handle {handle}");
+                ThrowHelper.ThrowBadImageFormatException();
             return field;
         }
 
@@ -449,7 +449,7 @@ namespace Internal.TypeSystem.Ecma
 
             MethodDesc methodDef = resolvedMethod as MethodDesc;
             if (methodDef == null)
-                ThrowHelper.ThrowBadImageFormatException($"method expected for handle {handle}");
+                ThrowHelper.ThrowBadImageFormatException();
 
             BlobReader signatureReader = _metadataReader.GetBlobReader(methodSpecification.Signature);
             EcmaSignatureParser parser = new EcmaSignatureParser(this, signatureReader, NotFoundBehavior.ReturnResolutionFailure);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1889,7 +1889,7 @@ namespace Internal.JitInterface
             // a static method would have never found an instance method.
             if (originalMethod.Signature.IsStatic && isCallVirt)
             {
-                ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallVirtStatic, originalMethod);
+                ThrowHelper.ThrowMissingMethodException("?");
             }
 
             exactType = type;
@@ -2095,7 +2095,7 @@ namespace Internal.JitInterface
                     // Compensate for always treating delegates as direct calls above
                     !(isLdftn && isVirtualBehaviorUnresolved))
                 {
-                    ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramCallAbstractMethod, targetMethod);
+                    ThrowHelper.ThrowInvalidProgramException(ExceptionStringID.InvalidProgramSpecific, targetMethod);
                 }
 
                 bool allowInstParam = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ALLOWINSTPARAM) != 0;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -407,7 +407,7 @@ namespace Internal.TypeSystem.Ecma
         {
             TypeDesc type = GetObject(handle, NotFoundBehavior.Throw) as TypeDesc;
             if (type == null)
-                ThrowHelper.ThrowBadImageFormatException($"type expected for handle {MetadataTokens.GetToken(handle):X}");
+                ThrowHelper.ThrowBadImageFormatException();
             return type;
         }
     }


### PR DESCRIPTION
I went over all the ExceptionStringID in the compiler and fixed them up to ensure we have code that translates them to messages.

Fixes #94107.

Cc @dotnet/ilc-contrib 