### PR TITLE
Fix printing Helix workitems count for Android

### DIFF
--- a/src/libraries/sendtohelix-mobile.targets
+++ b/src/libraries/sendtohelix-mobile.targets
@@ -141,7 +141,6 @@
   </Target>
 
   <Target Name="AfterBuildHelixWorkItems_Mobile" AfterTargets="BuildHelixWorkItems">
-    <Message Condition="'$(Scenario)' == ''" Importance="High" Text="Done building Helix work items. Work item count: @(XHarnessAppBundleToTest->Count())" />
 
     <PropertyGroup>
       <_TestPath Condition="'%(XHarnessAppBundleToTest.CustomCommands)' != ''">$([System.IO.Path]::GetDirectoryName('%(XHarnessAppBundleToTest.Identity)'))</_TestPath>

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -299,13 +299,19 @@
       </HelixWorkItem>
     </ItemGroup>
 
-    <Message Condition="'$(Scenario)' != ''" Importance="High" Text="Done building Helix work items for scenario $(Scenario). Work item count: @(HelixWorkItem->Count())" />
-    <Message Condition="'$(Scenario)' == '' and '$(TargetOS)' != 'android' and '$(TargetOS)' != 'ios' and '$(TargetOS)' != 'iossimulator' and '$(TargetOS)' != 'tvos' and '$(TargetOS)' != 'tvossimulator' and '$(TargetOS)' != 'maccatalyst'" Importance="High" Text="Done building Helix work items. Work item count: @(HelixWorkItem->Count())" />
+    <ItemGroup>
+      <HelixWorkItemOrXHarnessTest Include="@(HelixWorkItem)" />
+      <HelixWorkItemOrXHarnessTest Include="@(XHarnessAppBundleToTest)" />
+      <HelixWorkItemOrXHarnessTest Include="@(XHarnessApkToTest)" />
+    </ItemGroup>
+
+    <Message Condition="'$(Scenario)' != ''" Importance="High" Text="Done building Helix work items for scenario $(Scenario). Work item count: @(HelixWorkItemOrXHarnessTest->Count())" />
+    <Message Condition="'$(Scenario)' == ''" Importance="High" Text="Done building Helix work items. Work item count: @(HelixWorkItemOrXHarnessTest->Count())" />
 
     <Message Text="HelixCorrelationPayload: %(HelixCorrelationPayload.Identity)" Condition="'$(HelixDryRun)' == 'true'" Importance="High" />
     <Message Text="HelixWorkItem: %(HelixWorkItem.Identity), Command: %(HelixWorkItem.Command), PreCommands: %(HelixWorkItem.PreCommands) with PayloadArchive: %(HelixWorkItem.PayloadArchive)" Condition="'$(HelixDryRun)' == 'true'" Importance="High" />
 
-    <Error Condition="@(XHarnessApkToTest->Count()) == 0 and @(XHarnessAppBundleToTest->Count()) == 0 and @(HelixWorkItem->Count()) == 0"
+    <Error Condition="@(HelixWorkItemOrXHarnessTest->Count()) == 0"
            Text="No helix work items, or APKs, or AppBundles found to test" />
 
     <Error Condition="'%(HelixWorkItem.Identity)' != '' and ('%(HelixWorkItem.PayloadArchive)' == '' or !Exists(%(HelixWorkItem.PayloadArchive)))"


### PR DESCRIPTION
I noticed that we printed "Done building Helix work items. Work item count: 0" in the Send to Helix step for Android jobs. This is because we only looked at Apple-specific XHarnessAppBundleToTest items in sendtohelix-mobile.proj.

Simplified this logic a bit so we can print in sendtohelixhelp.proj instead together with the non-mobile message.