### PR TITLE
JIT: Model that handler flow can bypass filters

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1410,7 +1410,7 @@ public:
     };
 
     template <typename TFunc>
-    BasicBlockVisit VisitEHSecondPassSuccs(Compiler* comp, TFunc func);
+    BasicBlockVisit VisitEHEnclosedHandlerSecondPassSuccs(Compiler* comp, TFunc func);
 
     template <typename TFunc>
     BasicBlockVisit VisitAllSuccs(Compiler* comp, TFunc func);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2254,12 +2254,6 @@ public:
     // Returns true if "block" is the start of a handler or filter region.
     bool bbIsHandlerBeg(BasicBlock* block);
 
-    // Returns true iff "block" is where control flows if an exception is raised in the
-    // try region, and sets "*regionIndex" to the index of the try for the handler.
-    // Differs from "IsHandlerBeg" in the case of filters, where this is true for the first
-    // block of the filter, but not for the filter's handler.
-    bool bbIsExFlowBlock(BasicBlock* block, unsigned* regionIndex);
-
     bool ehHasCallableHandlers();
 
     // Return the EH descriptor for the given region index.

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -611,19 +611,6 @@ bool Compiler::bbIsHandlerBeg(BasicBlock* block)
     return (ehDsc != nullptr) && ((block == ehDsc->ebdHndBeg) || (ehDsc->HasFilter() && (block == ehDsc->ebdFilter)));
 }
 
-bool Compiler::bbIsExFlowBlock(BasicBlock* block, unsigned* regionIndex)
-{
-    if (block->hasHndIndex())
-    {
-        *regionIndex = block->getHndIndex();
-        return block == ehGetDsc(*regionIndex)->ExFlowBlock();
-    }
-    else
-    {
-        return false;
-    }
-}
-
 bool Compiler::ehHasCallableHandlers()
 {
 #if defined(FEATURE_EH_FUNCLETS)

--- a/src/coreclr/jit/ssabuilder.h
+++ b/src/coreclr/jit/ssabuilder.h
@@ -98,7 +98,10 @@ private:
     // Add GT_PHI_ARG nodes to the GT_PHI nodes within block's successors.
     void AddPhiArgsToSuccessors(BasicBlock* block);
 
-private:
+    // Similar to Add[Memory]DefToEHSuccessorPhis, but adds initial values to
+    // the handlers of a newly entered block based on one entering block.
+    void AddPhiArgsToNewlyEnteredHandler(BasicBlock* predEnterBlock, BasicBlock* enterBlock, BasicBlock* handlerStart);
+
     Compiler*     m_pCompiler;
     CompAllocator m_allocator;
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_94974/Runtime_94974.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_94974/Runtime_94974.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public static class Runtime_94974
+{
+    [Fact]
+    public static int Problem()
+    {
+        int result = 100;
+        try
+        {
+            try
+            {
+                throw new Exception();
+            }
+            finally
+            {
+                result = 100;
+            }
+        }
+        catch when (Bar(result = 101))
+        {
+            return result;
+        }
+        
+        return result;
+    }
+    
+    public static bool Bar(int x) => true;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_94974/Runtime_94974.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_94974/Runtime_94974.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
During second pass EH, handler flow can skip over filters. This happens in the attached test case. The JIT did not model this possibility, meaning that we would always think the filter was executed right before the filter-handler.

If we wanted to be fully precise we probably would only need to model that control can flow from enclosed handlers to filter-handler. This change models instead that all enclosed blocks can flow directly to the filter-handler.

Liveness already had this extra handling, so as a side effect we can unify liveness to use `VisitEHSuccs` now. Some extra handling is necessary in SSA; when entering a try region we need to add initial values to both the filter and filter-handler now, so factor out some code to a new `AddPhiArgsToNewlyEnteredHandler` that can be used on both handlers.

Fix #94974