### PR TITLE
Add eng/pipelines/common/variables.yml to coreclr pipelines

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -29,6 +29,9 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/clrinterpreter.yml
+++ b/eng/pipelines/coreclr/clrinterpreter.yml
@@ -9,6 +9,9 @@ trigger: none
 #    - main
 #  always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/crossgen2-outerloop.yml
+++ b/eng/pipelines/coreclr/crossgen2-outerloop.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/crossgen2.yml
+++ b/eng/pipelines/coreclr/crossgen2.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/exploratory.yml
+++ b/eng/pipelines/coreclr/exploratory.yml
@@ -10,6 +10,7 @@ schedules:
   always: true
 
 variables:
+  - template: /eng/pipelines/common/variables.yml
   # Set toolName variable from pipeline name so we can use it during template expansion
   - name: toolName
     value: ${{ variables['Build.DefinitionName'] }}

--- a/eng/pipelines/coreclr/gc-longrunning.yml
+++ b/eng/pipelines/coreclr/gc-longrunning.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/gc-simulator.yml
+++ b/eng/pipelines/coreclr/gc-simulator.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/gc-standalone.yml
+++ b/eng/pipelines/coreclr/gc-standalone.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/gcstress-extra.yml
+++ b/eng/pipelines/coreclr/gcstress-extra.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/gcstress0x3-gcstress0xc.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -17,6 +17,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jit-cfg.yml
+++ b/eng/pipelines/coreclr/jit-cfg.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jit-experimental.yml
+++ b/eng/pipelines/coreclr/jit-experimental.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress-isas-arm.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-arm.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress-isas-avx512.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-avx512.yml
@@ -23,6 +23,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress-isas-x86.yml
+++ b/eng/pipelines/coreclr/jitstress-isas-x86.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress-random.yml
+++ b/eng/pipelines/coreclr/jitstress-random.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstressregs-x86.yml
+++ b/eng/pipelines/coreclr/jitstressregs-x86.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-gcstress-extra.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress-extra.yml
@@ -9,6 +9,9 @@ trigger: none
 #     - main
 #   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
+++ b/eng/pipelines/coreclr/libraries-gcstress0x3-gcstress0xc.yml
@@ -9,6 +9,9 @@ trigger: none
 #     - main
 #   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-jitstress-random.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress-random.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-jitstress.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-jitstressregs.yml
+++ b/eng/pipelines/coreclr/libraries-jitstressregs.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/pgo.yml
+++ b/eng/pipelines/coreclr/pgo.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/pgostress.yml
+++ b/eng/pipelines/coreclr/pgostress.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/r2r-extra.yml
+++ b/eng/pipelines/coreclr/r2r-extra.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/r2r.yml
+++ b/eng/pipelines/coreclr/r2r.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/release-tests.yml
+++ b/eng/pipelines/coreclr/release-tests.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/runincontext.yml
+++ b/eng/pipelines/coreclr/runincontext.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
+++ b/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
@@ -35,6 +35,8 @@ schedules:
       - main
     always: false # run only if there were changes since the last successful scheduled run.
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
 
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml

--- a/eng/pipelines/coreclr/superpmi-asmdiffs-checked-release.yml
+++ b/eng/pipelines/coreclr/superpmi-asmdiffs-checked-release.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:

--- a/eng/pipelines/coreclr/tieringtest.yml
+++ b/eng/pipelines/coreclr/tieringtest.yml
@@ -8,6 +8,9 @@ schedules:
     - main
   always: true
 
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:


### PR DESCRIPTION
Most of the pipelines were missing the variables template. This caused e.g. CodeQL to run on them inadvertently.

/cc @BruceForstall 