### PR TITLE
Arm64/SVE: Add insEncodeReg* methods

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3768,6 +3768,7 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     }
 
     assert(encoding_found);
+    ins = (instruction)((unsigned)ins - INS_sve_invalid);
 
     switch (index)
     {

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -10633,25 +10633,129 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
 /*****************************************************************************
  *
- *  Returns an encoding for the specified register used in the 'Pd' position
+ *  Return an encoding for the specified 'V' register used in '4' thru '0' position.
  */
 
-/*static*/ emitter::code_t emitter::insEncodeReg_Pd(regNumber reg)
+/*static*/ emitter::code_t emitter::insEncodeReg_V_4_to_0(regNumber reg)
 {
-    assert(emitter::isPredicateRegister(reg));
-    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
-    assert((ureg >= 0) && (ureg <= 15));
-    return ureg;
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 0;
 }
 
 /*****************************************************************************
  *
- *  Returns an encoding for the specified register used in the 'Pn' position
+ *  Return an encoding for the specified 'V' register used in '9' thru '5' position.
  */
 
-/*static*/ emitter::code_t emitter::insEncodeReg_Pn(regNumber reg)
+/*static*/ emitter::code_t emitter::insEncodeReg_V_9_to_5(regNumber reg)
 {
-    assert(emitter::isPredicateRegister(reg));
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 5;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '12' thru '10' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_12_to_10(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 10;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'V' register used in '21' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_V_21_to_17(regNumber reg)
+{
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'R' register used in '21' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_R_21_to_17(regNumber reg)
+{
+    assert(isIntegerRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'R' register used in '9' thru '5' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_R_9_to_5(regNumber reg)
+{
+    assert(isIntegerRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 5;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'R' register used in '4' thru '0' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_R_4_to_0(regNumber reg)
+{
+    assert(isIntegerRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 0;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '20' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_20_to_17(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '3' thru '0' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_3_to_0(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 0;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '8' thru '5' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_8_to_5(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
     emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
     assert((ureg >= 0) && (ureg <= 15));
     return ureg << 5;
@@ -10659,15 +10763,106 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
 /*****************************************************************************
  *
- *  Returns an encoding for the specified register used in the 'Pm' position
+ *  Return an encoding for the specified 'P' register used in '13' thru '10' position.
  */
 
-/*static*/ emitter::code_t emitter::insEncodeReg_Pm(regNumber reg)
+/*static*/ emitter::code_t emitter::insEncodeReg_P_13_to_10(regNumber reg)
 {
-    assert(emitter::isPredicateRegister(reg));
+    assert(isPredicateRegister(reg));
     emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
     assert((ureg >= 0) && (ureg <= 15));
-    return ureg << 16;
+    return ureg << 10;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'R' register used in '18' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_R_18_to_17(regNumber reg)
+{
+    assert(isIntegerRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '7' thru '5' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_7_to_5(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 5;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '3' thru '1' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_3_to_1(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 1;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'P' register used in '2' thru '0' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_P_2_to_0(regNumber reg)
+{
+    assert(isPredicateRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_P0;
+    assert((ureg >= 0) && (ureg <= 15));
+    return ureg << 0;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'V' register used in '19' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_V_19_to_17(regNumber reg)
+{
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'V' register used in '20' thru '17' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_V_20_to_17(regNumber reg)
+{
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 17;
+}
+
+/*****************************************************************************
+ *
+ *  Return an encoding for the specified 'V' register used in '9' thru '6' position.
+ */
+
+/*static*/ emitter::code_t emitter::insEncodeReg_V_9_to_6(regNumber reg)
+{
+    assert(isVectorRegister(reg));
+    emitter::code_t ureg = (emitter::code_t)reg - (emitter::code_t)REG_V0;
+    assert((ureg >= 0) && (ureg <= 32));
+    return ureg << 6;
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -3768,61 +3768,61 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     }
 
     assert(encoding_found);
-    ins = (instruction)((unsigned)ins - INS_sve_invalid);
+    const unsigned sve_ins_offset = ((unsigned)ins - INS_sve_invalid);
 
     switch (index)
     {
         case 0:
-            assert(ins < ArrLen(insCodes1));
-            code = insCodes1[ins];
+            assert(sve_ins_offset < ArrLen(insCodes1));
+            code = insCodes1[sve_ins_offset];
             break;
         case 1:
-            assert(ins < ArrLen(insCodes2));
-            code = insCodes2[ins];
+            assert(sve_ins_offset < ArrLen(insCodes2));
+            code = insCodes2[sve_ins_offset];
             break;
         case 2:
-            assert(ins < ArrLen(insCodes3));
-            code = insCodes3[ins];
+            assert(sve_ins_offset < ArrLen(insCodes3));
+            code = insCodes3[sve_ins_offset];
             break;
         case 3:
-            assert(ins < ArrLen(insCodes4));
-            code = insCodes4[ins];
+            assert(sve_ins_offset < ArrLen(insCodes4));
+            code = insCodes4[sve_ins_offset];
             break;
         case 4:
-            assert(ins < ArrLen(insCodes5));
-            code = insCodes5[ins];
+            assert(sve_ins_offset < ArrLen(insCodes5));
+            code = insCodes5[sve_ins_offset];
             break;
         case 5:
-            assert(ins < ArrLen(insCodes6));
-            code = insCodes6[ins];
+            assert(sve_ins_offset < ArrLen(insCodes6));
+            code = insCodes6[sve_ins_offset];
             break;
         case 6:
-            assert(ins < ArrLen(insCodes7));
-            code = insCodes7[ins];
+            assert(sve_ins_offset < ArrLen(insCodes7));
+            code = insCodes7[sve_ins_offset];
             break;
         case 7:
-            assert(ins < ArrLen(insCodes8));
-            code = insCodes8[ins];
+            assert(sve_ins_offset < ArrLen(insCodes8));
+            code = insCodes8[sve_ins_offset];
             break;
         case 8:
-            assert(ins < ArrLen(insCodes9));
-            code = insCodes9[ins];
+            assert(sve_ins_offset < ArrLen(insCodes9));
+            code = insCodes9[sve_ins_offset];
             break;
         case 9:
-            assert(ins < ArrLen(insCodes10));
-            code = insCodes10[ins];
+            assert(sve_ins_offset < ArrLen(insCodes10));
+            code = insCodes10[sve_ins_offset];
             break;
         case 10:
-            assert(ins < ArrLen(insCodes11));
-            code = insCodes11[ins];
+            assert(sve_ins_offset < ArrLen(insCodes11));
+            code = insCodes11[sve_ins_offset];
             break;
         case 11:
-            assert(ins < ArrLen(insCodes12));
-            code = insCodes12[ins];
+            assert(sve_ins_offset < ArrLen(insCodes12));
+            code = insCodes12[sve_ins_offset];
             break;
         case 12:
-            assert(ins < ArrLen(insCodes13));
-            code = insCodes13[ins];
+            assert(sve_ins_offset < ArrLen(insCodes13));
+            code = insCodes13[sve_ins_offset];
             break;
     }
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -316,58 +316,58 @@ static code_t insEncodeReg_Vm(regNumber reg);
 // Returns an encoding for the specified register used in the 'Va' position
 static code_t insEncodeReg_Va(regNumber reg);
 
-// Return an encoding for the specified register used in '4' thru '0' position.
+// Return an encoding for the specified 'V' register used in '4' thru '0' position.
 static code_t insEncodeReg_V_4_to_0(regNumber reg);
 
-// Return an encoding for the specified register used in '9' thru '5' position.
+// Return an encoding for the specified 'V' register used in '9' thru '5' position.
 static code_t insEncodeReg_V_9_to_5(regNumber reg);
 
-// Return an encoding for the specified register used in '12' thru '10' position.
+// Return an encoding for the specified 'P' register used in '12' thru '10' position.
 static code_t insEncodeReg_P_12_to_10(regNumber reg);
 
-// Return an encoding for the specified register used in '21' thru '17' position.
+// Return an encoding for the specified 'V' register used in '21' thru '17' position.
 static code_t insEncodeReg_V_21_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '21' thru '17' position.
+// Return an encoding for the specified 'R' register used in '21' thru '17' position.
 static code_t insEncodeReg_R_21_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '9' thru '5' position.
+// Return an encoding for the specified 'R' register used in '9' thru '5' position.
 static code_t insEncodeReg_R_9_to_5(regNumber reg);
 
-// Return an encoding for the specified register used in '4' thru '0' position.
+// Return an encoding for the specified 'R' register used in '4' thru '0' position.
 static code_t insEncodeReg_R_4_to_0(regNumber reg);
 
-// Return an encoding for the specified register used in '20' thru '17' position.
+// Return an encoding for the specified 'P' register used in '20' thru '17' position.
 static code_t insEncodeReg_P_20_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '3' thru '0' position.
+// Return an encoding for the specified 'P' register used in '3' thru '0' position.
 static code_t insEncodeReg_P_3_to_0(regNumber reg);
 
-// Return an encoding for the specified register used in '8' thru '5' position.
+// Return an encoding for the specified 'P' register used in '8' thru '5' position.
 static code_t insEncodeReg_P_8_to_5(regNumber reg);
 
-// Return an encoding for the specified register used in '13' thru '10' position.
+// Return an encoding for the specified 'P' register used in '13' thru '10' position.
 static code_t insEncodeReg_P_13_to_10(regNumber reg);
 
-// Return an encoding for the specified register used in '18' thru '17' position.
+// Return an encoding for the specified 'R' register used in '18' thru '17' position.
 static code_t insEncodeReg_R_18_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '7' thru '5' position.
+// Return an encoding for the specified 'P' register used in '7' thru '5' position.
 static code_t insEncodeReg_P_7_to_5(regNumber reg);
 
-// Return an encoding for the specified register used in '3' thru '1' position.
+// Return an encoding for the specified 'P' register used in '3' thru '1' position.
 static code_t insEncodeReg_P_3_to_1(regNumber reg);
 
-// Return an encoding for the specified register used in '2' thru '0' position.
+// Return an encoding for the specified 'P' register used in '2' thru '0' position.
 static code_t insEncodeReg_P_2_to_0(regNumber reg);
 
-// Return an encoding for the specified register used in '19' thru '17' position.
+// Return an encoding for the specified 'V' register used in '19' thru '17' position.
 static code_t insEncodeReg_V_19_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '20' thru '17' position.
+// Return an encoding for the specified 'V' register used in '20' thru '17' position.
 static code_t insEncodeReg_V_20_to_17(regNumber reg);
 
-// Return an encoding for the specified register used in '9' thru '6' position.
+// Return an encoding for the specified 'V' register used in '9' thru '6' position.
 static code_t insEncodeReg_V_9_to_6(regNumber reg);
 
 // Returns an encoding for the imm which represents the condition code.

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -316,14 +316,59 @@ static code_t insEncodeReg_Vm(regNumber reg);
 // Returns an encoding for the specified register used in the 'Va' position
 static code_t insEncodeReg_Va(regNumber reg);
 
-// Returns an encoding for the specified register used in the 'Pd' position
-static code_t insEncodeReg_Pd(regNumber reg);
+// Return an encoding for the specified register used in '4' thru '0' position.
+static code_t insEncodeReg_V_4_to_0(regNumber reg);
 
-// Returns an encoding for the specified register used in the 'Pn' position
-static code_t insEncodeReg_Pn(regNumber reg);
+// Return an encoding for the specified register used in '9' thru '5' position.
+static code_t insEncodeReg_V_9_to_5(regNumber reg);
 
-// Returns an encoding for the specified register used in the 'Pm' position
-static code_t insEncodeReg_Pm(regNumber reg);
+// Return an encoding for the specified register used in '12' thru '10' position.
+static code_t insEncodeReg_P_12_to_10(regNumber reg);
+
+// Return an encoding for the specified register used in '21' thru '17' position.
+static code_t insEncodeReg_V_21_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '21' thru '17' position.
+static code_t insEncodeReg_R_21_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '9' thru '5' position.
+static code_t insEncodeReg_R_9_to_5(regNumber reg);
+
+// Return an encoding for the specified register used in '4' thru '0' position.
+static code_t insEncodeReg_R_4_to_0(regNumber reg);
+
+// Return an encoding for the specified register used in '20' thru '17' position.
+static code_t insEncodeReg_P_20_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '3' thru '0' position.
+static code_t insEncodeReg_P_3_to_0(regNumber reg);
+
+// Return an encoding for the specified register used in '8' thru '5' position.
+static code_t insEncodeReg_P_8_to_5(regNumber reg);
+
+// Return an encoding for the specified register used in '13' thru '10' position.
+static code_t insEncodeReg_P_13_to_10(regNumber reg);
+
+// Return an encoding for the specified register used in '18' thru '17' position.
+static code_t insEncodeReg_R_18_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '7' thru '5' position.
+static code_t insEncodeReg_P_7_to_5(regNumber reg);
+
+// Return an encoding for the specified register used in '3' thru '1' position.
+static code_t insEncodeReg_P_3_to_1(regNumber reg);
+
+// Return an encoding for the specified register used in '2' thru '0' position.
+static code_t insEncodeReg_P_2_to_0(regNumber reg);
+
+// Return an encoding for the specified register used in '19' thru '17' position.
+static code_t insEncodeReg_V_19_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '20' thru '17' position.
+static code_t insEncodeReg_V_20_to_17(regNumber reg);
+
+// Return an encoding for the specified register used in '9' thru '6' position.
+static code_t insEncodeReg_V_9_to_6(regNumber reg);
 
 // Returns an encoding for the imm which represents the condition code.
 static code_t insEncodeCond(insCond cond);


### PR DESCRIPTION
Add bunch of `insEncodeReg*` methods because not all instructions have registers position at same position. See details at 
https://github.com/dotnet/runtime/issues/94549#issuecomment-1821981987. I have updated the [emitOutputInstr_sve.cpp.txt](https://github.com/dotnet/runtime/files/13434525/emitOutputInstr_sve.cpp.txt) in #94549 to call these methods.

Contributes to https://github.com/dotnet/runtime/issues/94549
