### PR TITLE
[mono][System.Reflection.Emit] Fix explicitly setting the return type on a dynamic method

### DIFF
--- a/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetReturnType.cs
+++ b/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetReturnType.cs
@@ -132,7 +132,6 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/2389", TestRuntimes.Mono)]
         public void SetReturnType_NullReturnType_ReturnsVoid()
         {
             TypeBuilder type = Helpers.DynamicType(TypeAttributes.Abstract);

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeMethodBuilder.Mono.cs
@@ -603,7 +603,9 @@ namespace System.Reflection.Emit
                 Array.Copy(parameterTypes, this.parameters, parameterTypes.Length);
             }
 
-            rtype = returnType;
+            if (returnType != null)
+                rtype = returnType;
+
             returnModReq = returnTypeRequiredCustomModifiers;
             returnModOpt = returnTypeOptionalCustomModifiers;
             paramModReq = parameterTypeRequiredCustomModifiers;


### PR DESCRIPTION
## Description

This PR fixes the support of `SetReturnType` and `SetParameters` in the `MethodBuilder` API with Mono, by properly setting the return type of the dynamic method only if it is non null value.
 
This was manifested in two scenarios:
1. If the dynamic method return and parameter types are manually set in the following sequence: 
    ```cs
     methodBuilder.SetReturnType(interfaceMethodInfo.ReturnType);
     methodBuilder.SetParameters(paramTypes);
    ```
     The subsequent call to `SetParameters` (which internally calls `SetSignatureCore`) would overwrite the set return type to `null` causing the method not to be considered as an implementation of a interface method. This scenario is used in https://github.com/dotnet/aspnetcore/blob/4dc81f80abd45cb5c2e04d3b742bc6755c1153ee/src/SignalR/server/Core/src/Internal/TypedClientBuilder.cs#L136-L137 causing ASP.NET test failures when using Mono.

2. Setting explicit `null` as a return type via `SetReturnType` overwrites the default return type value which should be `typeof(void)`  

    This scenario was covered with `System.Reflection.Emit` libraries tests https://github.com/dotnet/runtime/blob/4fa760f59503b9bb24983ef4275e77ee2fd375c1/src/libraries/System.Reflection.Emit/tests/MethodBuilder/MethodBuilderSetReturnType.cs#L141-L143 but was disabled for Mono as reported in: https://github.com/dotnet/runtime/issues/2389

## Verification

This fix was verified by enabling the disabled unit test (and verifying locally that it passes) and manually verifying that the [repro-iclientproxy-vtable-fail](https://github.com/lambdageek/repro-iclientproxy-vtable-fail) as described in https://github.com/dotnet/runtime/issues/94490#issue-1982229368 does not crash.

---
Fixes https://github.com/dotnet/runtime/issues/94490