### PR TITLE
JIT: Skip EH table for inlinees in fgDfsReversePostorder

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -810,7 +810,7 @@ unsigned Compiler::fgDfsReversePostorder()
 
     // If we didn't end up visiting everything, try the EH roots.
     //
-    if (preorderIndex != fgBBcount + 1)
+    if ((preorderIndex != fgBBcount + 1) && !compIsForInlining())
     {
         for (EHblkDsc* const HBtab : EHClauses(this))
         {


### PR DESCRIPTION
The EH table for the inlinee points at the inliner's EH table and we shouldn't try to DFS from its blocks.

Fix #95199