### PR TITLE
Disable MetricEventSourceTest on Mono on Windows x86

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/MetricEventSourceTests.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace System.Diagnostics.Metrics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/95210", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsWindows), nameof(PlatformDetection.IsX86Process))]
     public class MetricEventSourceTests
     {
         ITestOutputHelper _output;


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/95210