### PR TITLE
Improve `.Distinct().ToList()` and `.Union(e).ToList()`

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
@@ -11,7 +11,7 @@ namespace System.Linq
         {
             public TSource[] ToArray() => Enumerable.HashSetToArray(new HashSet<TSource>(_source, _comparer));
 
-            public List<TSource> ToList() => Enumerable.HashSetToList(new HashSet<TSource>(_source, _comparer));
+            public List<TSource> ToList() => new List<TSource>(new HashSet<TSource>(_source, _comparer));
 
             public int GetCount(bool onlyIfCheap) => onlyIfCheap ? -1 : new HashSet<TSource>(_source, _comparer).Count;
         }

--- a/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
@@ -253,27 +253,5 @@ namespace System.Linq
             set.CopyTo(result);
             return result;
         }
-
-        private static List<TSource> HashSetToList<TSource>(HashSet<TSource> set)
-        {
-            int count = set.Count;
-
-            var result = new List<TSource>(count);
-            if (count > 0)
-            {
-                Span<TSource> span = SetCountAndGetSpan(result, count);
-
-                int index = 0;
-                foreach (TSource item in set)
-                {
-                    span[index] = item;
-                    ++index;
-                }
-
-                Debug.Assert(index == span.Length, "All list elements were not initialized.");
-            }
-
-            return result;
-        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
@@ -26,7 +26,7 @@ namespace System.Linq
 
             public TSource[] ToArray() => Enumerable.HashSetToArray(FillSet());
 
-            public List<TSource> ToList() => Enumerable.HashSetToList(FillSet());
+            public List<TSource> ToList() => new List<TSource>(FillSet());
 
             public int GetCount(bool onlyIfCheap) => onlyIfCheap ? -1 : FillSet().Count;
         }


### PR DESCRIPTION
`Enumerable.HashSetToList` fills the result list by copying from the set to the list itself, but this can be done faster (and more simply) by using the `List<T>(IEnumerable<T>)` constructor to call `HashSet<T>.CopyTo(T[])`.
```cs
public class Bench
{
    [Params(10, 1000, 1_000_000)]
    public int Count { get; set; }

    private int[] _arr;
    
    [GlobalSetup]
    public void Init()
    {
        _arr = new int[Count];
        new Random(3).NextBytes(MemoryMarshal.AsBytes(_arr.AsSpan()));
    }
    
    [Benchmark]
    public List<int> DistinctToList()
    {
        return _arr.Distinct().ToList();
    }
}
```

```

BenchmarkDotNet v0.13.10, Arch Linux
AMD Ryzen 9 5900X, 1 CPU, 24 logical and 12 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  Job-KQNFCO : .NET 8.0.1 (42.42.42.42424), X64 RyuJIT AVX2
  Job-BSODDZ : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

Runtime=.NET 8.0  

```
| Method         | Job        | Toolchain | Count   | Mean            | Error         | StdDev        | Ratio | RatioSD |
|--------------- |----------- |---------- |-------- |----------------:|--------------:|--------------:|------:|--------:|
| **DistinctToList** | **Job-KQNFCO** | **CoreRun**   | **10**      |        **119.9 ns** |       **2.42 ns** |       **2.49 ns** |  **0.86** |    **0.02** |
| DistinctToList | Job-BSODDZ | net8.0    | 10      |        138.2 ns |       1.33 ns |       1.11 ns |  1.00 |    0.00 |
|                |            |           |         |                 |               |               |       |         |
| **DistinctToList** | **Job-KQNFCO** | **CoreRun**   | **1000**    |      **6,280.2 ns** |      **60.54 ns** |      **56.63 ns** |  **0.80** |    **0.01** |
| DistinctToList | Job-BSODDZ | net8.0    | 1000    |      7,831.8 ns |      47.20 ns |      44.15 ns |  1.00 |    0.00 |
|                |            |           |         |                 |               |               |       |         |
| **DistinctToList** | **Job-KQNFCO** | **CoreRun**   | **1000000** | **17,175,312.7 ns** | **341,877.48 ns** | **406,980.82 ns** |  **0.94** |    **0.02** |
| DistinctToList | Job-BSODDZ | net8.0    | 1000000 | 18,496,042.9 ns | 123,385.89 ns |  96,331.59 ns |  1.00 |    0.00 |