### PR TITLE
JIT: Disallow loop increments in the top block

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1120,23 +1120,9 @@ bool Compiler::optExtractInitTestIncr(
         incrStmt = incrStmt->GetPrevStmt();
     }
 
-    if (incrStmt == nullptr || optIsLoopIncrTree(incrStmt->GetRootNode()) == BAD_VAR_NUM)
+    if (incrStmt == nullptr || (optIsLoopIncrTree(incrStmt->GetRootNode()) == BAD_VAR_NUM))
     {
-        if (top == nullptr || top->bbStmtList == nullptr || top->bbStmtList->GetPrevStmt() == nullptr)
-        {
-            return false;
-        }
-
-        // If the prev stmt to loop test is not incr, then check if we have loop test evaluated into a tmp.
-        Statement* toplastStmt = top->lastStmt();
-        if (optIsLoopIncrTree(toplastStmt->GetRootNode()) != BAD_VAR_NUM)
-        {
-            incrStmt = toplastStmt;
-        }
-        else
-        {
-            return false;
-        }
+        return false;
     }
 
     assert(testStmt != incrStmt);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_95226/Runtime_95226.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_95226/Runtime_95226.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_95226
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<IndexOutOfRangeException>(() => Foo(new int[1]));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Foo(int[] arr)
+    {
+        int i = 0;
+        goto Bottom;
+Top:;
+        i++;
+        while (true)
+        {
+            if (AlwaysTrue())
+                break;
+        }
+Bottom:;
+        Use(arr[i]);
+        if (i < arr.Length)
+            goto Top;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AlwaysTrue() => true;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Use(int x)
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_95226/Runtime_95226.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_95226/Runtime_95226.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
If we have a loop increment in the top block then the body won't be dominated by the loop test, so we should not consider the induction structure to have been analyzed successfully.

I suspect this code exists from a time where flow graph optimizations did not do compaction as well as today. If we did not do compaction after loop inversion then I think many loops would have structure such as the following, taken from one of the very few diffs of this change:

```
------------ BB50 [297..2AC), preds={BB51} succs={BB51}

***** BB50
STMT00061 ( 0x2A6[E-] ... ??? )
               [000230] DA---+-----                         ▌  STORE_LCL_VAR int    V14 loc13
               [000229] -----+-----                         └──▌  ADD       int
               [000227] -----+-----                            ├──▌  LCL_VAR   int    V14 loc13
               [000228] -----+-----                            └──▌  CNS_INT   int    1

------------ BB51 [2AC..2B4) -> BB50 (cond), preds={BB49,BB50} succs={BB52,BB50}

***** BB51
STMT00059 ( 0x2AC[E-] ... 0x2B2 )
               [000217] ---X-+-----                         ▌  JTRUE     void
               [000216] J--X-+-N---                         └──▌  LT        int
               [000213] -----+-----                            ├──▌  LCL_VAR   int    V14 loc13
               [000215] ---X-+-----                            └──▌  ARR_LENGTH int
               [000214] -----+-----                               └──▌  LCL_VAR   ref    V05 loc4

```
Here the top block is a BBJ_NONE with the increment, and the bottom block test succeeds it immediately. I do not think it's worth it to add additional checks for this case since compaction handles it normally.

Fix #95226