### PR TITLE
[PERF] DaysInMonth optimization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -125,8 +125,9 @@ namespace System
         internal static ReadOnlySpan<uint> DaysToMonth365 => [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365];
         internal static ReadOnlySpan<uint> DaysToMonth366 => [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366];
 
-        private static ReadOnlySpan<byte> DaysInMonth365 => [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-        private static ReadOnlySpan<byte> DaysInMonth366 => [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        private const int DaysInMonth365 = 0b_11_10_11_10_11_11_10_11_10_11_00_11_00;
+        private const int DaysInMonth366 = DaysInMonth365 | 0x10;
+        private const byte ExtraDaysMask = 0x3;
 
         public static readonly DateTime MinValue;
         public static readonly DateTime MaxValue = new DateTime(MaxTicks, DateTimeKind.Unspecified);
@@ -1170,7 +1171,8 @@ namespace System
         {
             if (month < 1 || month > 12) ThrowHelper.ThrowArgumentOutOfRange_Month(month);
             // IsLeapYear checks the year argument
-            return (IsLeapYear(year) ? DaysInMonth366 : DaysInMonth365)[month - 1];
+            int days = IsLeapYear(year) ? DaysInMonth366 : DaysInMonth365;
+            return 28 + (days >> (2 * month) & ExtraDaysMask);
         }
 
         // Converts an OLE Date to a tick count.


### PR DESCRIPTION
The current code to calculate the days in a month uses a `ReadOnlySpan<byte>` which is accessed by it's index (month). This was optimized in net8 due to some new inlining feature and is blazing fast now. 

While looking at this [issue](https://github.com/dotnet/runtime/issues/91103), I came up with an alternative approach. Every month has at least 28 days with 0-3 "extra days", so to encode the total number of days in each month, we only need 2 bits per month times 12 months for a total of 24 bits which conveniently fits inside an `int`. Applying a right shift and a mask of the 2 least significant bits computes the extra days for a given month, and then we just add 28 to get the total. 

![image](https://github.com/dotnet/runtime/assets/8285062/332d2268-0154-4e4a-9413-6f4d981b215d)

Benchmarking this was a bit difficult, so I tried my best to create a realistic scenario. Micro-benchmarking this code had some mixed results (AOT was always faster, but non-AOT was usually equivalent). Also note, prior to net8, the codegen for this PR wasn't optimal unless I reorganized the variables/calculations, but this seems to be fixed now. This is my first PR to the runtime, so please let me know if I need to change anything. The `DaysInMonth` variable is expressed in binary and the `ExtraDaysMask` as hex, and I'm not sure which is preferred. Here are the benchmarks and results.

```c#
[SimpleJob(runtimeMoniker: RuntimeMoniker.Net80)]
[SimpleJob(runtimeMoniker: RuntimeMoniker.NativeAot80)]
public class GetDaysInMonth
{
	private static ReadOnlySpan<byte> DaysInMonth365 => [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
	private static ReadOnlySpan<byte> DaysInMonth366 => [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];

	const int DaysInMonth = 0b_11_10_11_10_11_11_10_11_10_11_00_11_00;
	const int DaysInMonthLeapYear = DaysInMonth | 0x10;
	const byte ExtraDaysMask = 0x3;
	static int[] years = { 2023, 2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032 };
	static int[] months = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };
	static (int Year, int Month)[] loop = (	from x in years
				                from m in months
				                select (x, m)).ToArray();

	[Benchmark(Baseline = true)]
	public void Base() { foreach (var x in loop) Base(x.Year, x.Month); }

	[Benchmark]
	public void PR() { foreach (var x in loop) PR(x.Year, x.Month); }

	[MethodImpl(MethodImplOptions.AggressiveInlining)]
	private static int Base(int year, int month)
	{
		if (month < 1 || month > 12) { throw new ArgumentOutOfRangeException(nameof(month)); }
		return (IsLeapYear(year) ? DaysInMonth366 : DaysInMonth365)[month - 1];
	}

	[MethodImpl(MethodImplOptions.AggressiveInlining)]
	private static int PR(int year, int month)
	{
		if (month < 1 || month > 12) { throw new ArgumentOutOfRangeException(nameof(month)); }
		int days = IsLeapYear(year) ? DaysInMonthLeapYear : DaysInMonth;

		return 28 + (days >> (2 * month) & ExtraDaysMask);
	}

	[MethodImpl(MethodImplOptions.AggressiveInlining)]
	public static bool IsLeapYear(int year)
	{
		// zero or negative bit set or 
		if (year < 1 || year > 9999)
		{
			throw new ArgumentOutOfRangeException();
		}
		if ((year & 3) != 0) return false;
		if ((year & 15) == 0) return true;
		return (uint)year % 25 != 0;
	}
}
```

```cmd
BenchmarkDotNet v0.13.10, Windows 11 (10.0.22621.2715/22H2/2022Update/SunValley2)
13th Gen Intel Core i5-13600K, 1 CPU, 20 logical and 14 physical cores
.NET SDK 8.0.100
  [Host]        : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  .NET 8.0      : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  NativeAOT 8.0 : .NET 8.0.0, X64 NativeAOT AVX2

| Method | Job           | Runtime       | Mean      | Error    | StdDev   | Ratio |
|------- |-------------- |-------------- |----------:|---------:|---------:|------:|
| Base   | .NET 8.0      | .NET 8.0      | 110.05 ns | 0.376 ns | 0.352 ns |  1.00 |
| PR     | .NET 8.0      | .NET 8.0      |  82.28 ns | 0.155 ns | 0.145 ns |  0.75 |
|        |               |               |           |          |          |       |
| Base   | NativeAOT 8.0 | NativeAOT 8.0 | 115.87 ns | 0.187 ns | 0.175 ns |  1.00 |
| PR     | NativeAOT 8.0 | NativeAOT 8.0 |  71.51 ns | 0.091 ns | 0.085 ns |  0.62 |
```



