### PR TITLE
Update coreclr test run scripts

### DIFF
--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -230,7 +230,7 @@ echo printlastresultsonly      - Print the last test results without running tes
 echo runincontext              - Run each tests in an unloadable AssemblyLoadContext
 echo timeout ^<n^>               - Sets the per-test timeout in milliseconds ^(default is 10 minutes = 10 * 60 * 1000 = 600000^).
 echo                             Note: some options override this ^(gcstresslevel, longgc, gcsimulator^).
-echo logsdir ^<dir^>             - Specify the logs directory ^(default: a new unique directory in the series: log, log.1, log.2, etc.^)
+echo logsdir ^<dir^>             - Specify the logs directory ^(default: artifacts/log^)
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
 echo.

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -18,8 +18,6 @@ for %%i in ("%__RepoRootDir%") do set "__RepoRootDir=%%~fi"
 if %__ProjectDir:~-1%==\ set "__ProjectDir=%__ProjectDir:~0,-1%"
 set "__ProjectFilesDir=%__ProjectDir%"
 set "__RootBinDir=%__RepoRootDir%\artifacts"
-set "__LogsDir=%__RootBinDir%\log"
-set "__MsbuildDebugLogsDir=%__LogsDir%\MsbuildDebugLogs"
 set __ToolsDir=%__ProjectDir%\..\Tools
 set "DotNetCli=%__RepoRootDir%\dotnet.cmd"
 
@@ -30,6 +28,7 @@ set __LongGCTests=
 set __GCSimulatorTests=
 set __IlasmRoundTrip=
 set __PrintLastResultsOnly=
+set LogsDirArg=
 set RunInUnloadableContext=
 set TieringTest=
 
@@ -60,6 +59,7 @@ if /i "%1" == "jitminopts"                              (set DOTNET_JITMinOpts=1
 if /i "%1" == "jitforcerelocs"                          (set DOTNET_ForceRelocs=1&shift&goto Arg_Loop)
 
 if /i "%1" == "printlastresultsonly"                    (set __PrintLastResultsOnly=1&shift&goto Arg_Loop)
+if /i "%1" == "logsdir"                                 (set LogsDirArg=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=1&shift&goto Arg_Loop)
 REM This test feature is currently intentionally undocumented
 if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=1&set CrossgenLargeVersionBubble=1&shift&goto Arg_Loop)
@@ -108,6 +108,10 @@ if not defined XunitTestReportDirBase set  XunitTestReportDirBase=%XunitTestBinB
 REM Set up arguments to call run.py
 
 set __RuntestPyArgs=-arch %__BuildArch% -build_type %__BuildType%
+
+if defined LogsDirArg (
+    set __RuntestPyArgs=%__RuntestPyArgs% -logs_dir %LogsDirArg%
+)
 
 if defined DoLink (
     set __RuntestPyArgs=%__RuntestPyArgs% --il_link
@@ -226,6 +230,7 @@ echo printlastresultsonly      - Print the last test results without running tes
 echo runincontext              - Run each tests in an unloadable AssemblyLoadContext
 echo timeout ^<n^>               - Sets the per-test timeout in milliseconds ^(default is 10 minutes = 10 * 60 * 1000 = 600000^).
 echo                             Note: some options override this ^(gcstresslevel, longgc, gcsimulator^).
+echo logsdir ^<dir^>             - Specify the logs directory ^(default: a new unique directory in the series: log, log.1, log.2, etc.^)
 echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild invocations.
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
 echo.

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -36,7 +36,7 @@ function print_usage {
     echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '  --link=<ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --printLastResultsOnly           : Print the results of the last run'
-    echo '  --logsDir=<path>                 : Specify the logs directory (default: a new unique directory in the series: log, log.1, log.2, etc.)'
+    echo '  --logsDir=<path>                 : Specify the logs directory (default: artifacts/log)'
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
     echo '  --tieringtest                    : Run each test to encourage tier1 rejitting'
     echo '  --runnativeaottests              : Run NativeAOT compiled tests'

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -36,6 +36,7 @@ function print_usage {
     echo '  --ilasmroundtrip                 : Runs ilasm round trip on the tests'
     echo '  --link=<ILlink>                  : Runs the tests after linking via ILlink'
     echo '  --printLastResultsOnly           : Print the results of the last run'
+    echo '  --logsDir=<path>                 : Specify the logs directory (default: a new unique directory in the series: log, log.1, log.2, etc.)'
     echo '  --runincontext                   : Run each tests in an unloadable AssemblyLoadContext'
     echo '  --tieringtest                    : Run each test to encourage tier1 rejitting'
     echo '  --runnativeaottests              : Run NativeAOT compiled tests'
@@ -57,6 +58,7 @@ buildOS=
 buildConfiguration="Debug"
 testRootDir=
 coreRootDir=
+logsDir=
 testEnv=
 gcsimulator=
 longgc=
@@ -140,6 +142,9 @@ do
         --coreRootDir=*)
             coreRootDir=${i#*=}
             ;;
+        --logsDir=*)
+            logsDir=${i#*=}
+            ;;
         --enableEventLogging)
             export DOTNET_EnableEventLog=1
             ;;
@@ -215,6 +220,11 @@ fi
 if [[ -n "$coreRootDir" ]]; then
     runtestPyArguments+=("-core_root" "$coreRootDir")
     echo "CORE_ROOT                     : ${coreRootDir}"
+fi
+
+if [[ -n "$logsDir" ]]; then
+    runtestPyArguments+=("-logs_dir" "$logsDir")
+    echo "Logs directory                : ${logsDir}"
 fi
 
 if [[ -n "${testEnv}" ]]; then


### PR DESCRIPTION
1. Add a run.py `-logs_dir` argument (run.cmd: `logsdir`; run.sh: `-logsDir`) to allow specifying a particular logs directory name. By default, use "logs", as before. This can be used to help preserve per-test-run output (note, however, that currently many per-test-run assets litter the tests artifacts directories). This can be useful if you have multiple test run results logs directory and you want to use `--analyze_results_only` (run.cmd: `printlastresultsonly`) to analyze a run that is not the default logs directory.
2. Remove the unnecessary run.py `--skip_test_run` argument. It was added to use the logic to precompile the libraries, but that logic is now gone.
3. Move generated repro files for failed tests to the "log\repro" directory, and name them with a `repro_` filename prefix.
4. Fix repro file generation. Currently, it gives up on creating repro files for merged tests (it doesn't know how to generate a repro file). Repro files now work for `BuildAsStandalone=true` test builds.
5. Print out the path of all repro files that are created.
6. Add a `setlocal` to the generated Windows repro files.
7. Misc. minor improvements.

Contributes to #95032
