### PR TITLE
[DataTable] Optimize [NameNode/ConstNode] [=|!=|>|<|>=|<=] [NameNode/ConstNode] filtering

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
@@ -319,7 +319,7 @@ namespace System.Data
                             Operators.LessThen => compareResult.Value < 0,
                             Operators.GreaterOrEqual => compareResult.Value >= 0,
                             Operators.LessOrEqual => compareResult.Value <= 0,
-                            Operators.NotEqual => (object)(compareResult.Value != 0),
+                            Operators.NotEqual => compareResult.Value != 0,
                             _ => throw ExprException.UnsupportedOperator(op),
                         };
                     }

--- a/src/libraries/System.Data.Common/src/System/Data/Filter/NameNode.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Filter/NameNode.cs
@@ -160,6 +160,24 @@ namespace System.Data
             return this;
         }
 
+        internal int? CompareValueTo(DataRow? row, DataRowVersion version, object? value)
+        {
+            if (!_found)
+            {
+                throw ExprException.UnboundName(_name);
+            }
+
+            if (row == null)
+            {
+                if (IsTableConstant())
+                    return null; // this column is TableConstant Aggregate Function and we cannot compare directly
+
+                throw ExprException.UnboundName(_name);
+            }
+
+            return _column!.CompareValueTo(row.GetRecordFromVersion(version), value);
+        }
+
         /// <summary>
         ///     Parses given name and checks it validity
         /// </summary>


### PR DESCRIPTION
This PR optimizes several of most common scenarios when filtering database table(according my knowledge).
Affected method [DataTable.Select(string? filterExpression)](https://github.com/dotnet/runtime/blob/08bef8ee129b9f6d4e7bdc3229b41856b96fd722/src/libraries/System.Data.Common/src/System/Data/DataTable.cs#L4224).
I've added shortcut based on [DataColumn.CompareValueTo](https://github.com/dotnet/runtime/blob/08bef8ee129b9f6d4e7bdc3229b41856b96fd722/src/libraries/System.Data.Common/src/System/Data/DataColumn.cs#L1475) in NameNode and use it in BinaryNode.
Cases:

- [Column] [Operation] [Constant]
- [Constant] [Operation] [Column] 

Operation:

- EqualTo 
- GreaterThen 
- LessThen 
- GreaterOrEqual
- LessOrEqual 
- NotEqual 

This change minimize boxing of stored values in the column.

Benchmark:
I am using table with 1000 rows.
```
[BenchmarkCategory(Categories.Libraries, Categories.Data)]
public class DataTableSelectTests
{
	private DataTable _table;
	private string _ageColumnCondition;

	[GlobalSetup]
	public void Setup()
	{
		_table = new DataTable("test");
		var c = new DataColumn("name");
		_table.Columns.Add(c);
		c = new DataColumn("age");
		c.DataType = typeof(int);
		_table.Columns.Add(c);
		c = new DataColumn("id");
		_table.Columns.Add(c);

		for (var i = 0; i < 1000; i++)
		{
			var row = _table.NewRow();
			row[0] = "human" + i;
			row[1] = i;
			row[2] = i;
			_table.Rows.Add(row);
		}

		_ageColumnCondition = string.Join("OR",
			Enumerable.Range(0, ConditionsCount)
				.Select(cnt => $"(age = {cnt})"));
	}

	[Params(1, 5, 10, 15)]
	public int ConditionsCount = 5;

	[Benchmark]
	public int SelectByAge() => _table.Select(_ageColumnCondition).Length;
}
```

Results:
Before
BenchmarkDotNet v0.13.10-nightly.20231019.90, Windows 11 (10.0.22621.2715/22H2/2022Update/SunValley2)
11th Gen Intel Core i9-11900K 3.50GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  Job-RYTSRU : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1

| Method      | ConditionsCount | Mean       | Error    | StdDev   | Median     | Min        | Max        | Gen0     | Gen1    | Allocated  |
|------------ |---------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|---------:|--------:|-----------:|
| SelectByAge | 1               |   250.1 us |  7.51 us |  8.65 us |   246.9 us |   240.4 us |   269.3 us |  10.5769 |  0.9615 |   86.97 KB |
| SelectByAge | 5               |   560.4 us | 10.32 us |  9.65 us |   561.5 us |   546.5 us |   578.2 us |  45.2586 |  4.3103 |  369.74 KB |
| SelectByAge | 10              |   965.6 us | 19.05 us | 20.38 us |   961.3 us |   943.1 us |   999.6 us |  85.9375 |  7.8125 |  722.18 KB |
| SelectByAge | 15              | 1,361.4 us | 26.62 us | 27.34 us | 1,356.9 us | 1,323.4 us | 1,411.5 us | 130.2083 | 15.6250 | 1073.35 KB |



After
| Method      | ConditionsCount | Mean     | Error    | StdDev   | Median   | Min      | Max      | Gen0    | Gen1   | Allocated |
|------------ |---------------- |---------:|---------:|---------:|---------:|---------:|---------:|--------:|-------:|----------:|
| SelectByAge | 1               | 207.8 us |  5.77 us |  6.64 us | 205.1 us | 200.1 us | 221.4 us |  7.5630 | 0.8403 |  63.55 KB |
| SelectByAge | 5               | 361.4 us |  8.90 us | 10.25 us | 357.9 us | 350.3 us | 383.4 us | 30.9423 | 2.8129 | 252.81 KB |
| SelectByAge | 10              | 579.9 us | 11.49 us | 12.30 us | 582.3 us | 557.5 us | 607.2 us | 58.2960 | 6.7265 | 488.88 KB |
| SelectByAge | 15              | 806.8 us | 11.90 us |  9.94 us | 805.4 us | 791.9 us | 830.8 us | 87.2093 | 8.7209 | 724.27 KB |