### PR TITLE
[DataTable] Cache boolean result from BinaryNode.EvalBinary

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Filter/BinaryNode.cs
@@ -12,6 +12,8 @@ namespace System.Data
 {
     internal class BinaryNode : ExpressionNode
     {
+        private static readonly object s_true = true;
+        private static readonly object s_false = false;
         internal int _op;
 
         internal ExpressionNode _left;
@@ -862,37 +864,37 @@ namespace System.Data
                         if ((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft)) ||
                              (vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight)))
                             return DBNull.Value;
-                        return (0 == BinaryCompare(vLeft, vRight, resultType, Operators.EqualTo));
+                        return (0 == BinaryCompare(vLeft, vRight, resultType, Operators.EqualTo)) ? s_true : s_false;
 
                     case Operators.GreaterThen:
                         if ((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft)) ||
                              (vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight)))
                             return DBNull.Value;
-                        return (0 < BinaryCompare(vLeft, vRight, resultType, op));
+                        return (0 < BinaryCompare(vLeft, vRight, resultType, op)) ? s_true : s_false;
 
                     case Operators.LessThen:
                         if ((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft)) ||
                              (vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight)))
                             return DBNull.Value;
-                        return (0 > BinaryCompare(vLeft, vRight, resultType, op));
+                        return (0 > BinaryCompare(vLeft, vRight, resultType, op)) ? s_true : s_false;
 
                     case Operators.GreaterOrEqual:
                         if ((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft)) ||
                              (vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight)))
                             return DBNull.Value;
-                        return (0 <= BinaryCompare(vLeft, vRight, resultType, op));
+                        return (0 <= BinaryCompare(vLeft, vRight, resultType, op)) ? s_true : s_false;
 
                     case Operators.LessOrEqual:
                         if (((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft))) ||
                              ((vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight))))
                             return DBNull.Value;
-                        return (0 >= BinaryCompare(vLeft, vRight, resultType, op));
+                        return (0 >= BinaryCompare(vLeft, vRight, resultType, op)) ? s_true : s_false;
 
                     case Operators.NotEqual:
                         if (((vLeft == DBNull.Value) || (left.IsSqlColumn && DataStorage.IsObjectSqlNull(vLeft))) ||
                              ((vRight == DBNull.Value) || (right.IsSqlColumn && DataStorage.IsObjectSqlNull(vRight))))
                             return DBNull.Value;
-                        return (0 != BinaryCompare(vLeft, vRight, resultType, op));
+                        return (0 != BinaryCompare(vLeft, vRight, resultType, op)) ? s_true : s_false;
 
                     case Operators.Is:
                         vLeft = BinaryNode.Eval(left, row, version, recordNos);
@@ -932,7 +934,7 @@ namespace System.Data
                         {
                             if ((bool)vLeft == false)
                             {
-                                value = false;
+                                value = s_false;
                                 break;
                             }
                         }
@@ -940,7 +942,7 @@ namespace System.Data
                         {
                             if (((SqlBoolean)vLeft).IsFalse)
                             {
-                                value = false;
+                                value = s_false;
                                 break;
                             }
                         }
@@ -956,12 +958,12 @@ namespace System.Data
 
                         if (vRight is bool)
                         {
-                            value = (bool)vRight;
+                            value = (bool)vRight ? s_true : s_false;
                             break;
                         }
                         else
                         {
-                            value = ((SqlBoolean)vRight).IsTrue;
+                            value = ((SqlBoolean)vRight).IsTrue ? s_true : s_false;
                         }
                         break;
                     case Operators.Or:
@@ -985,7 +987,7 @@ namespace System.Data
 
                             if ((bool)vLeft)
                             {
-                                value = true;
+                                value = s_true;
                                 break;
                             }
                         }
@@ -1003,7 +1005,7 @@ namespace System.Data
                             break;
                         }
 
-                        value = (vRight is bool) ? ((bool)vRight) : (((SqlBoolean)vRight).IsTrue);
+                        value = ((vRight is bool) ? ((bool)vRight) : (((SqlBoolean)vRight).IsTrue)) ? s_true : s_false;
                         break;
 
                     /*  for M3, use original code , in below,  and make sure to have two different code path; increases perf
@@ -1097,7 +1099,7 @@ namespace System.Data
 
                         /* validate IN parameters : must all be constant expressions */
 
-                        value = false;
+                        value = s_false;
 
                         FunctionNode into = (FunctionNode)right;
 
@@ -1113,7 +1115,7 @@ namespace System.Data
 
                             if (0 == BinaryCompare(vLeft, vRight, resultType, Operators.EqualTo))
                             {
-                                value = true;
+                                value = s_true;
                                 break;
                             }
                         }


### PR DESCRIPTION
This PR will minimize boxing of bools in [BinaryNode.EvalBinary](https://github.com/dotnet/runtime/blob/08bef8ee129b9f6d4e7bdc3229b41856b96fd722/src/libraries/System.Data.Common/src/System/Data/Filter/BinaryNode.cs#L283) method by caching static object instances for true/false.

I was really amazed that this is not done by compiler and will suggest to built in if possible.
Meanwhile this removed tons of allocations when using [DataTable.Select(string? filterExpression)](https://github.com/dotnet/runtime/blob/08bef8ee129b9f6d4e7bdc3229b41856b96fd722/src/libraries/System.Data.Common/src/System/Data/DataTable.cs#L4224).

Benchmark is the same as in [[DataTable] Optimize [NameNode/ConstNode] [=|!=|>|<|>=|<=] [NameNode/ConstNode] filtering](https://github.com/dotnet/runtime/pull/95247)

Results:
Before
BenchmarkDotNet v0.13.10-nightly.20231019.90, Windows 11 (10.0.22621.2715/22H2/2022Update/SunValley2)
11th Gen Intel Core i9-11900K 3.50GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  Job-RYTSRU : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:EnableUnsafeBinaryFormatterSerialization=true  IterationTime=250.0000 ms
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1

| Method      | ConditionsCount | Mean       | Error    | StdDev   | Median     | Min        | Max        | Gen0     | Gen1    | Allocated  |
|------------ |---------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|---------:|--------:|-----------:|
| SelectByAge | 1               |   250.1 us |  7.51 us |  8.65 us |   246.9 us |   240.4 us |   269.3 us |  10.5769 |  0.9615 |   86.97 KB |
| SelectByAge | 5               |   560.4 us | 10.32 us |  9.65 us |   561.5 us |   546.5 us |   578.2 us |  45.2586 |  4.3103 |  369.74 KB |
| SelectByAge | 10              |   965.6 us | 19.05 us | 20.38 us |   961.3 us |   943.1 us |   999.6 us |  85.9375 |  7.8125 |  722.18 KB |
| SelectByAge | 15              | 1,361.4 us | 26.62 us | 27.34 us | 1,356.9 us | 1,323.4 us | 1,411.5 us | 130.2083 | 15.6250 | 1073.35 KB |


After:
| Method      | ConditionsCount | Mean       | Error    | StdDev   | Median     | Min        | Max        | Gen0    | Gen1   | Allocated |
|------------ |---------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|--------:|-------:|----------:|
| SelectByAge | 1               |   226.8 us |  5.60 us |  6.23 us |   222.8 us |   221.1 us |   239.3 us |  7.4280 |      - |  63.53 KB |
| SelectByAge | 5               |   512.4 us | 13.87 us | 15.97 us |   507.8 us |   492.4 us |   545.6 us | 18.7891 | 2.0877 | 159.03 KB |
| SelectByAge | 10              |   831.0 us | 16.23 us | 17.37 us |   826.3 us |   810.5 us |   870.9 us | 31.0345 | 3.4483 | 277.92 KB |
| SelectByAge | 15              | 1,213.6 us | 26.43 us | 29.38 us | 1,201.5 us | 1,165.1 us | 1,261.4 us | 47.6190 | 4.7619 | 396.13 KB |

I really hope if this kind of caching can be integrated in compiler.