### PR TITLE
[mono][debugger] If debugger is disconnected but vm is not exited restart the debugger thread

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -11090,7 +11090,7 @@ bool mono_debugger_agent_receive_and_process_command (void)
 		if (command_set == CMD_SET_VM && (command == CMD_VM_DISPOSE || command == CMD_VM_EXIT))
 			break;
 	}
-	return !(command_set == CMD_SET_VM && command == CMD_VM_DISPOSE);
+	return (command_set == CMD_SET_VM && command == CMD_VM_DISPOSE);
 }
 
 static gboolean


### PR DESCRIPTION
Fixing wrong check.

Fixes #95256