### PR TITLE
[wasi] Wasi.Build.Tests - unblock single file bundle test on Windows

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
@@ -91,7 +91,6 @@ public class WasiTemplateTests : BuildTestBase
     }
 
     [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/82515", TestPlatforms.Windows)]
     [MemberData(nameof(TestDataForConsolePublishAndRun))]
     public void ConsolePublishAndRunForSingleFileBundle(string config, bool relinking, bool invariantTimezone)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/82515. The issue was closed before the blocking statement got removed. This PR is fixing it.