### PR TITLE
Add JSON null support for the built-in (ReadOnly)Memory converters.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/MemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/MemoryConverter.cs
@@ -2,12 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class MemoryConverter<T> : JsonCollectionConverter<Memory<T>, T>
     {
         internal override bool CanHaveMetadata => false;
+        public override bool HandleNull => true;
+
+        internal override bool OnTryRead(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options,
+            scoped ref ReadStack state,
+            [MaybeNullWhen(false)] out Memory<T> value)
+        {
+            if (reader.TokenType is JsonTokenType.Null)
+            {
+                value = default;
+                return true;
+            }
+
+            return base.OnTryRead(ref reader, typeToConvert, options, ref state, out value);
+        }
 
         protected override void Add(in T value, ref ReadStack state)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/MemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/MemoryConverter.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
             Type typeToConvert,
             JsonSerializerOptions options,
             scoped ref ReadStack state,
-            [MaybeNullWhen(false)] out Memory<T> value)
+            out Memory<T> value)
         {
             if (reader.TokenType is JsonTokenType.Null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
@@ -2,12 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ReadOnlyMemoryConverter<T> : JsonCollectionConverter<ReadOnlyMemory<T>, T>
     {
         internal override bool CanHaveMetadata => false;
+        public override bool HandleNull => true;
+
+        internal override bool OnTryRead(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options,
+            scoped ref ReadStack state,
+            [MaybeNullWhen(false)] out ReadOnlyMemory<T> value)
+        {
+            if (reader.TokenType is JsonTokenType.Null)
+            {
+                value = default;
+                return true;
+            }
+
+            return base.OnTryRead(ref reader, typeToConvert, options, ref state, out value);
+        }
 
         protected override void Add(in T value, ref ReadStack state)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
             Type typeToConvert,
             JsonSerializerOptions options,
             scoped ref ReadStack state,
-            [MaybeNullWhen(false)] out ReadOnlyMemory<T> value)
+            out ReadOnlyMemory<T> value)
         {
             if (reader.TokenType is JsonTokenType.Null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/JsonMetadataServicesConverter.cs
@@ -20,6 +20,7 @@ namespace System.Text.Json.Serialization.Converters
 
         internal override Type? KeyType => Converter.KeyType;
         internal override Type? ElementType => Converter.ElementType;
+        public override bool HandleNull { get; }
 
         internal override bool ConstructorIsParameterized => Converter.ConstructorIsParameterized;
         internal override bool SupportsCreateObjectDelegate => Converter.SupportsCreateObjectDelegate;
@@ -29,8 +30,16 @@ namespace System.Text.Json.Serialization.Converters
 
         public JsonMetadataServicesConverter(JsonConverter<T> converter)
         {
-            ConverterStrategy = converter.ConverterStrategy;
             Converter = converter;
+            ConverterStrategy = converter.ConverterStrategy;
+            IsInternalConverter = converter.IsInternalConverter;
+            IsInternalConverterForNumberType = converter.IsInternalConverterForNumberType;
+            CanBePolymorphic = converter.CanBePolymorphic;
+
+            // Ensure HandleNull values reflect the exact configuration of the source converter
+            HandleNullOnRead = converter.HandleNullOnRead;
+            HandleNullOnWrite = converter.HandleNullOnWrite;
+            HandleNull = converter.HandleNullOnWrite;
         }
 
         internal override bool OnTryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/MemoryByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/MemoryByteConverter.cs
@@ -5,9 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class MemoryByteConverter : JsonConverter<Memory<byte>>
     {
+        public override bool HandleNull => true;
+
         public override Memory<byte> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.GetBytesFromBase64();
+            return reader.TokenType is JsonTokenType.Null ? default : reader.GetBytesFromBase64();
         }
 
         public override void Write(Utf8JsonWriter writer, Memory<byte> value, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ReadOnlyMemoryByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ReadOnlyMemoryByteConverter.cs
@@ -5,9 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ReadOnlyMemoryByteConverter : JsonConverter<ReadOnlyMemory<byte>>
     {
+        public override bool HandleNull => true;
+
         public override ReadOnlyMemory<byte> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return reader.GetBytesFromBase64();
+            return reader.TokenType is JsonTokenType.Null ? default : reader.GetBytesFromBase64();
         }
 
         public override void Write(Utf8JsonWriter writer, ReadOnlyMemory<byte> value, JsonSerializerOptions options)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -12,6 +12,8 @@ namespace System.Text.Json.Serialization
     /// <typeparam name="T"></typeparam>
     internal abstract class JsonResumableConverter<T> : JsonConverter<T>
     {
+        public override bool HandleNull => false;
+
         public sealed override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (options is null)
@@ -51,7 +53,5 @@ namespace System.Text.Json.Serialization
                 throw;
             }
         }
-
-        public sealed override bool HandleNull => false;
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Memory.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Memory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Text.Json.Tests;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -102,6 +101,22 @@ namespace System.Text.Json.Serialization.Tests
 
             ReadOnlyMemory<byte> readOnlyMemory = await Serializer.DeserializeWrapper<ReadOnlyMemory<byte>>("\"VGhpcyBpcyBzb21lIHRlc3QgZGF0YSEhIQ==\"");
             AssertExtensions.SequenceEqual(s_testData, readOnlyMemory.Span);
+        }
+
+        [Fact]
+        public async Task DeserializeNullAsMemory()
+        {
+            ReadOnlyMemory<int> readOnlyMemOfInt = await Serializer.DeserializeWrapper<ReadOnlyMemory<int>>("null");
+            Assert.True(readOnlyMemOfInt.IsEmpty);
+
+            Memory<int> memOfInt = await Serializer.DeserializeWrapper<Memory<int>>("null");
+            Assert.True(memOfInt.IsEmpty);
+
+            ReadOnlyMemory<byte> readOnlyMemOfByte = await Serializer.DeserializeWrapper<ReadOnlyMemory<byte>>("null");
+            Assert.True(readOnlyMemOfByte.IsEmpty);
+
+            Memory<byte> memOfByte = await Serializer.DeserializeWrapper<Memory<byte>>("null");
+            Assert.True(memOfByte.IsEmpty);
         }
 
         [Fact]


### PR DESCRIPTION
Fix #95267.