### PR TITLE
JIT: alt jit range

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -15,6 +15,7 @@
 /// JIT
 ///
 CONFIG_INTEGER(AltJitLimit, W("AltJitLimit"), 0)               // Max number of functions to use altjit for (decimal)
+CONFIG_STRING(AltJitRange, W("AltJitRange"))                   // Range of methods to compile with altjit
 CONFIG_INTEGER(AltJitSkipOnAssert, W("AltJitSkipOnAssert"), 0) // If AltJit hits an assert, fall back to the fallback
                                                                // JIT. Useful in conjunction with
                                                                // DOTNET_ContinueOnAssert=1


### PR DESCRIPTION
Allow specifying which methods the alt jit should handle via a hash range. This makes it easier bisect / binary search a suspect alt jit running in front of a known-good base jit (or vice-versa).

Also make it clearer in the disasm summary that the method was handled by the alt jit.