### PR TITLE
Fix performance of System.Security. Cryptography.Tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -10,7 +10,8 @@ namespace System.Security.Cryptography.Rsa.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public partial class ImportExport
     {
-        public static bool Supports16384 { get; } = TestRsa16384();
+        private static readonly Lazy<bool> s_supports16384 = new Lazy<bool>(TestRsa16384);
+        public static bool Supports16384 => s_supports16384.Value;
 
         [Fact]
         public static void ExportAutoKey()

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
@@ -3,6 +3,7 @@
 
 using System.Security.Cryptography.Encryption.RC2.Tests;
 using System.Text;
+using Microsoft.DotNet.XUnitExtensions;
 using Test.Cryptography;
 using Xunit;
 
@@ -122,9 +123,17 @@ yZWUxoxAdjfrBGsx+U6BHM0Myqqe7fY7hjWzj4aBCw==",
                 TestData.DiminishedDPParameters);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalFact]
+        [OuterLoop("RSA 16384 takes considerable time.")]
         public static void ReadWritePublicPkcs1()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384.");
+            }
+
             ReadWriteBase64PublicPkcs1(
                 @"
 MIIICgKCCAEAmyxwX6kQNx+LSMao1StC1p5rKCEwcBjzI136An3B/BjthgezAOuu
@@ -198,9 +207,18 @@ m5NTLEHDwUd7idstLzPXuah0WEjgao5oO1BEUR4byjYlJ+F89Cs4BhUCAwEAAQ==",
                 TestData.DiminishedDPParameters);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+
+        [ConditionalFact]
+        [OuterLoop("RSA 16384 takes considerable time.")]
         public static void ReadWriteRsa16384SubjectPublicKeyInfo()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384.");
+            }
+
             ReadWriteBase64SubjectPublicKeyInfo(
                 @"
 MIIIIjANBgkqhkiG9w0BAQEFAAOCCA8AMIIICgKCCAEAmyxwX6kQNx+LSMao1StC
@@ -250,9 +268,17 @@ rAigcwt6noH/hX5ZO5X869SV1WvLOvhCt4Ru7LOzqUULk+Y3+gSNHX34/+Jw+VCq
                 TestData.RSA16384Params);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalFact]
+        [OuterLoop("RSA 16384 takes considerable time.")]
         public static void ReadWrite16384Pkcs8()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384");
+            }
+
             ReadWriteBase64Pkcs8(
                 @"
 MIIkQgIBADANBgkqhkiG9w0BAQEFAASCJCwwgiQoAgEAAoIIAQCbLHBfqRA3H4tI
@@ -525,9 +551,17 @@ rBZc";
                 TestData.RSA1032Parameters);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalFact]
+        [OuterLoop("RSA 16384 takes considerable time.")]
         public static void ReadEncryptedRsa16384()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384");
+            }
+
             // PBES2: PBKDF2 + des (single DES, not 3DES).
             const string base64 = @"
 MIIkizA9BgkqhkiG9w0BBQ0wMDAbBgkqhkiG9w0BBQwwDgQI63upT8JPNNcCAggA

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Xml.Linq;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Security.Cryptography.Rsa.Tests
@@ -76,9 +77,17 @@ namespace System.Security.Cryptography.Rsa.Tests
                 TestData.RSA1032Parameters);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalFact]
+        [OuterLoop("RSA 16384 takes considerable time.")]
         public static void TestRead16384Parameters_Public()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384");
+            }
+
             RSAParameters expectedParameters = ImportExport.MakePublic(TestData.RSA16384Params);
 
             // Bonus trait of this XML: the Modulus and Exponent parameters
@@ -157,9 +166,16 @@ zM=
                 expectedParameters);
         }
 
-        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalFact]
         public static void TestRead16384Parameters_Private()
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384");
+            }
+
             // Bonus trait of this XML: the D parameter is not in
             // canonical order.
             TestReadXml(
@@ -634,11 +650,19 @@ zM=
                 ));
         }
 
-        [ConditionalTheory(typeof(ImportExport), nameof(ImportExport.Supports16384))]
+        [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
+        [OuterLoop("RSA 16384 takes considerable time for primality tests.")]
         public static void TestWrite16384Parameters(bool includePrivateParameters)
         {
+            // Do not move this to the [ConditionalFact], otherwise the platform will check if RSA 16384 is supported
+            // during test discovery for innerloop, and the check itself is expensive.
+            if (!ImportExport.Supports16384)
+            {
+                throw new SkipTestException("Platform does not support RSA 16384");
+            }
+
             TestWriteXml(
                 TestData.RSA16384Params,
                 includePrivateParameters,


### PR DESCRIPTION
This moves the RSA 16384 tests to outerloop. These tests take a significant amount of time on Linux due to primality tests of RSA 16384. These six tests were accounting for over half the time of test suite on my machine.

This also significantly improves the inner-loop dev experience as test discovery is near-instant now instead of taking dozens of seconds.

This also impacted the `RSAOpenSsl` tests on macOS.

BEFORE ./dotnet.sh test src/libraries/System.Security.Cryptography/tests  696.78s user 9.53s system 342% cpu **3:25.93 total**
AFTER ./dotnet.sh test src/libraries/System.Security.Cryptography/tests  491.88s user 8.50s system 643% cpu **1:23.73 total**

Fixes #94436
Fixes #93840