### PR TITLE
bump-chrome-version.yml: Use `.dotnet/dotnet` if available, else use the system installed one

### DIFF
--- a/.github/workflows/bump-chrome-version.yml
+++ b/.github/workflows/bump-chrome-version.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run UpdateToLatestVersion
         run: >-
           make -C src/mono/wasm build-tasks &&
-          .dotnet/dotnet build eng/testing/bump-chrome-version.proj -p:Configuration=Release &&
+          PATH=$PWD/.dotnet:$PATH dotnet build eng/testing/bump-chrome-version.proj -p:Configuration=Release &&
           git add eng/testing/ChromeVersions.props &&
           cat eng/testing/bump-chrome-pr.env >> "$GITHUB_ENV"
 


### PR DESCRIPTION
…e system installed one.

Fixes:
`/home/runner/work/_temp/a5c062c7-589b-41d2-8f29-8769ac5e9ffd.sh: line 1: .dotnet/dotnet: No such file or directory`

`.dotnet/dotnet` is installed only if version in `global.json` is not already installed system-wide. 