### PR TITLE
Alternative fix for RuntimeHelpers.GetSubArray AOT compatibility warning 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -29,10 +29,9 @@ namespace System.Runtime.CompilerServices
 
             T[] dest;
 
-            if (typeof(T).IsValueType || typeof(T[]) == array.GetType())
+            if (typeof(T[]) == array.GetType())
             {
-                // We know the type of the array to be exactly T[] or an array variance
-                // compatible value type substitution like int[] <-> uint[].
+                // We know the type of the array to be exactly T[].
 
                 if (length == 0)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -47,7 +47,7 @@ namespace System.Runtime.CompilerServices
                 // an array of the exact same backing type. The cast to T[] will
                 // never fail.
 
-                dest = Unsafe.As<T[]>(Array.CreateInstance(array.GetType().GetElementType()!, length));
+                dest = Unsafe.As<T[]>(Array.CreateInstanceFromArrayType(array.GetType(), length));
             }
 
             // In either case, the newly-allocated array is the exact same type as the

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -27,18 +27,33 @@ namespace System.Runtime.CompilerServices
 
             (int offset, int length) = range.GetOffsetAndLength(array.Length);
 
-            if (length == 0)
+            T[] dest;
+
+            if (typeof(T).IsValueType || typeof(T[]) == array.GetType())
             {
-                return Array.Empty<T>();
+                // We know the type of the array to be exactly T[] or an array variance
+                // compatible value type substitution like int[] <-> uint[].
+
+                if (length == 0)
+                {
+                    return Array.Empty<T>();
+                }
+
+                dest = new T[length];
+            }
+            else
+            {
+                // The array is actually a U[] where U:T. We'll make sure to create
+                // an array of the exact same backing type. The cast to T[] will
+                // never fail.
+
+                dest = Unsafe.As<T[]>(Array.CreateInstance(array.GetType().GetElementType()!, length));
             }
 
-            T[] dest = new T[length];
-
-            // Due to array variance, it's possible that the incoming array is
-            // actually of type U[], where U:T; or that an int[] <-> uint[] or
-            // similar cast has occurred. In any case, since it's always legal
-            // to reinterpret U as T in this scenario (but not necessarily the
-            // other way around), we can use Buffer.Memmove here.
+            // In either case, the newly-allocated array is the exact same type as the
+            // original incoming array. It's safe for us to Buffer.Memmove the contents
+            // from the source array to the destination array, otherwise the contents
+            // wouldn't have been valid for the source array in the first place.
 
             Buffer.Memmove(
                 ref MemoryMarshal.GetArrayDataReference(dest),

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -367,6 +367,10 @@ namespace System.Runtime.CompilerServices.Tests
             object[] arr = new string[10];
             object[] slice = RuntimeHelpers.GetSubArray<object>(arr, new Range(Index.FromStart(1), Index.FromEnd(2)));
             Assert.IsType<string[]>(slice);
+
+            uint[] arr2 = (uint[])(object)new int[10];
+            uint[] slice2 = RuntimeHelpers.GetSubArray<uint>(arr2, new Range(Index.FromStart(1), Index.FromEnd(2)));
+            Assert.IsType<int[]>(slice2);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -348,7 +348,7 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         [Fact]
-        public static void ArrayRangeHelperTest()
+        public static void ArrayGetSubArrayTest()
         {
             int[] a = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             Range range = Range.All;
@@ -359,6 +359,14 @@ namespace System.Runtime.CompilerServices.Tests
 
             range = new Range(Index.FromStart(0), Index.FromStart(a.Length + 1));
             Assert.Throws<ArgumentOutOfRangeException>(() => { int [] array = RuntimeHelpers.GetSubArray(a, range); });
+        }
+
+        [Fact]
+        public static void ArrayGetSubArrayCoVarianceTest()
+        {
+            object[] arr = new string[10];
+            object[] slice = RuntimeHelpers.GetSubArray<object>(arr, new Range(Index.FromStart(1), Index.FromEnd(2)));
+            Assert.IsType<string[]>(slice);
         }
 
         [Fact]


### PR DESCRIPTION
C# LDM would like to keep the original "virtual" RuntimeHelpers.GetSubArray behavior.

Fixes https://github.com/dotnet/roslyn/issues/69053