### PR TITLE
Correct time zone name creation when generated lazily.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -108,7 +108,7 @@ namespace System
                 // We check reference equality to see if 'this' is the same as
                 // TimeZoneInfo.Local or TimeZoneInfo.Utc.  This check is needed to
                 // support setting the DateTime Kind property to 'Local' or
-                // 'Utc' on the ConverTime(...) return value.
+                // 'Utc' on the ConvertTime(...) return value.
                 //
                 // Using reference equality instead of value equality was a
                 // performance based design compromise.  The reference equality
@@ -1011,9 +1011,9 @@ namespace System
 
             _id = id;
             _baseUtcOffset = baseUtcOffset;
-            _displayName = displayName ?? string.Empty;
-            _standardDisplayName = standardDisplayName ?? string.Empty;
-            _daylightDisplayName = disableDaylightSavingTime ? string.Empty : daylightDisplayName ?? string.Empty;
+            _displayName = displayName;
+            _standardDisplayName = standardDisplayName;
+            _daylightDisplayName = disableDaylightSavingTime ? null : daylightDisplayName;
             _supportsDaylightSavingTime = adjustmentRulesSupportDst && !disableDaylightSavingTime;
             _adjustmentRules = adjustmentRules;
 
@@ -1031,10 +1031,12 @@ namespace System
         {
             bool hasIanaId = TryConvertIanaIdToWindowsId(id, allocate: false, out _);
 
+            standardDisplayName ??= string.Empty;
+
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName,
+                displayName ?? string.Empty,
                 standardDisplayName,
                 standardDisplayName,
                 adjustmentRules: null,
@@ -1085,9 +1087,9 @@ namespace System
             return new TimeZoneInfo(
                 id,
                 baseUtcOffset,
-                displayName,
-                standardDisplayName,
-                daylightDisplayName,
+                displayName ?? string.Empty,
+                standardDisplayName ?? string.Empty,
+                daylightDisplayName ?? string.Empty,
                 adjustmentRules,
                 disableDaylightSavingTime,
                 hasIanaId);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -3196,6 +3196,30 @@ namespace System.Tests
             Assert.NotEqual(TimeZoneInfo.Utc.StandardName, TimeZoneInfo.Local.StandardName);
         }
 
+        [InlineData("Pacific Standard Time")]
+        [InlineData("America/Los_Angeles")]
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static void TestZoneNamesUsingAlternativeId(string zoneId)
+        {
+            RemoteExecutor.Invoke(id =>
+            {
+                TimeZoneInfo tzi = TimeZoneInfo.FindSystemTimeZoneById(id);
+                Assert.False(string.IsNullOrEmpty(tzi.StandardName), $"StandardName for '{id}' is null or empty.");
+                Assert.False(string.IsNullOrEmpty(tzi.DaylightName), $"DaylightName for '{id}' is null or empty.");
+                Assert.False(string.IsNullOrEmpty(tzi.DisplayName), $"DisplayName for '{id}' is null or empty.");
+            }, zoneId).Dispose();
+        }
+
+        [Fact]
+        public static void TestCustomTimeZonesWithNullNames()
+        {
+            TimeZoneInfo custom = TimeZoneInfo.CreateCustomTimeZone("Custom Time Zone With Null Names", TimeSpan.FromHours(-8), null, null);
+            Assert.Equal("Custom Time Zone With Null Names", custom.Id);
+            Assert.Equal(string.Empty, custom.StandardName);
+            Assert.Equal(string.Empty, custom.DaylightName);
+            Assert.Equal(string.Empty, custom.DisplayName);
+        }
+
         private static bool IsEnglishUILanguage => CultureInfo.CurrentUICulture.Name.Length == 0 || CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "en";
 
         private static bool IsEnglishUILanguageAndRemoteExecutorSupported => IsEnglishUILanguage && RemoteExecutor.IsSupported;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -3196,9 +3196,11 @@ namespace System.Tests
             Assert.NotEqual(TimeZoneInfo.Utc.StandardName, TimeZoneInfo.Local.StandardName);
         }
 
+        private static bool SupportICUAndRemoteExecution => PlatformDetection.IsIcuGlobalization && RemoteExecutor.IsSupported;
+
         [InlineData("Pacific Standard Time")]
         [InlineData("America/Los_Angeles")]
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ConditionalTheory(nameof(SupportICUAndRemoteExecution))]
         public static void TestZoneNamesUsingAlternativeId(string zoneId)
         {
             RemoteExecutor.Invoke(id =>


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/95213

This addresses the regression introduced in .NET 8.0 https://github.com/dotnet/runtime/pull/88368, where creating a `TimeZoneInfo` object using a Windows Id on Linux/Mac resulted in empty strings for Standard, Daylight, and display names.