### PR TITLE
Make GetKeyedServices(KeyedService.AnyKey) return all services

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -101,6 +101,30 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void ResolveKeyedServicesAnyKey()
+        {
+            var service1 = new Service();
+            var service2 = new Service();
+            var service3 = new Service();
+            var service4 = new Service();
+            var service5 = new Service();
+            var service6 = new Service();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedSingleton<IService>("first-service", service1);
+            serviceCollection.AddKeyedSingleton<IService>("service", service2);
+            serviceCollection.AddKeyedSingleton<IService>("service", service3);
+            serviceCollection.AddKeyedSingleton<IService>("service", service4);
+            serviceCollection.AddKeyedSingleton<IService>(null, service5);
+            serviceCollection.AddSingleton<IService>(service6);
+
+            var provider = CreateServiceProvider(serviceCollection);
+
+            var allServices = provider.GetKeyedServices<IService>(KeyedService.AnyKey).ToList();
+            Assert.Equal(6, allServices.Count);
+            Assert.Equal(new[] { service1, service2, service3, service4, service5, service6 }, allServices);
+        }
+
+        [Fact]
         public void ResolveKeyedGenericServices()
         {
             var service1 = new FakeService();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -686,17 +686,27 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         /// <summary>
-        /// Returns true if both keys are null or equals, or if key1 is KeyedService.AnyKey and key2 is not null
+        /// Returns true if both keys are null or equals, or if either key is KeyedService.AnyKey.
         /// </summary>
         private static bool KeysMatch(object? key1, object? key2)
         {
-            if (key1 == null && key2 == null)
-                return true;
+            // Use reference equality when comparing to AnyKey or null.
+            // Use key1's definition of equality when comparing key1 and key2.
 
-            if (key1 != null && key2 != null)
-                return key1.Equals(KeyedService.AnyKey) || key1.Equals(key2);
+            if (key1 is null)
+            {
+                return key2 is null || key2 == KeyedService.AnyKey;
+            }
 
-            return false;
+            if (key2 is null)
+            {
+                return key1 == KeyedService.AnyKey;
+            }
+
+            return
+                key1 == KeyedService.AnyKey ||
+                key2 == KeyedService.AnyKey ||
+                key1.Equals(key2);
         }
 
         private struct ServiceDescriptorCacheItem


### PR DESCRIPTION
I expected GetKeyedServices(KeyedService.AnyKey) to return all services, since AnyKey is documented as "Gets a key that matches any key." This changes the behavior of KeysMatch accordingly.

Feel free to say "this isn't the right answer" if there's a better answer.