### PR TITLE
Split out a `TestContext` class from `RepoDirectoriesProvider`

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/AdditionalProbingPath.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         [Fact]
         public void PlaceholderArchTfm()
         {
-            // Host should replace |arch| and |tfm| with actual architecture and TFM 
+            // Host should replace |arch| and |tfm| with actual architecture and TFM
             string probePath = Path.Combine(sharedState.AdditionalProbingPath, "|arch|", "|tfm|");
             TestApp app = sharedState.FrameworkReferenceApp;
             sharedState.DotNetWithNetCoreApp.Exec(Constants.AdditionalProbingPath.CommandLineArgument, probePath, app.AppDll)
@@ -111,24 +111,24 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestState()
             {
                 DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
-                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
                     .Build();
 
-                string nativeDependencyRelPath = $"{RepoDirectoriesProvider.Default.TargetRID}/{Binaries.GetSharedLibraryFileNameForCurrentPlatform("native")}";
-                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, b => b
+                string nativeDependencyRelPath = $"{TestContext.TargetRID}/{Binaries.GetSharedLibraryFileNameForCurrentPlatform("native")}";
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, b => b
                     .WithProject(DependencyName, DependencyVersion, p => p
                         .WithAssemblyGroup(null, g => g
                             .WithAsset($"{DependencyName}.dll", f => f.NotOnDisk()))
-                        .WithNativeLibraryGroup(RepoDirectoriesProvider.Default.TargetRID, g => g
+                        .WithNativeLibraryGroup(TestContext.TargetRID, g => g
                             .WithAsset(nativeDependencyRelPath, f => f.NotOnDisk()))));
                 RuntimeConfig.FromFile(FrameworkReferenceApp.RuntimeConfigJson)
-                    .WithTfm(RepoDirectoriesProvider.Default.Tfm)
+                    .WithTfm(TestContext.Tfm)
                     .Save();
 
                 AdditionalProbingPath = Path.Combine(Location, "probe");
                 (DependencyPath, NativeDependencyDirectory) = AddDependencies(AdditionalProbingPath);
 
-                AdditionalProbingPath_ArchTfm = Path.Combine(AdditionalProbingPath, RepoDirectoriesProvider.Default.BuildArchitecture, RepoDirectoriesProvider.Default.Tfm);
+                AdditionalProbingPath_ArchTfm = Path.Combine(AdditionalProbingPath, TestContext.BuildArchitecture, TestContext.Tfm);
                 (DependencyPath_ArchTfm, NativeDependencyDirectory_ArchTfm) = AddDependencies(AdditionalProbingPath_ArchTfm);
 
                 (string, string) AddDependencies(string probeDir)

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
             public DotNetBuilder DotNet(string name)
             {
-                return new DotNetBuilder(Location, RepoDirectoriesProvider.Default.BuiltDotnet, name);
+                return new DotNetBuilder(Location, TestContext.BuiltDotNet, name);
             }
 
             public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion, Action<NetCoreAppBuilder> customizer = null)

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DepsFile.cs
@@ -60,10 +60,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
             public SharedTestState()
             {
                 DotNetWithNetCoreApp = DotNet("WithNetCoreApp")
-                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                    .AddMicrosoftNETCoreAppFrameworkMockCoreClr(TestContext.MicrosoftNETCoreAppVersion)
                     .Build();
 
-                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, b => b
+                FrameworkReferenceApp = CreateFrameworkReferenceApp(MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion, b => b
                     .WithProject(DependencyName, "1.0.0", p => p
                         .WithAssemblyGroup(null, g => g.WithAsset($"{DependencyName}.dll"))));
 

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/PerAssemblyVersionResolutionMultipleFrameworks.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
                     HighWare,
                     "1.1.1",
                     runtimeConfig => runtimeConfig.WithFramework(MicrosoftNETCoreApp, "4.0.0"),
-                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, RepoDirectoriesProvider.Default.TargetRID)
+                    path => NetCoreAppBuilder.ForNETCoreApp(HighWare, TestContext.TargetRID)
                         .WithProject(HighWare, "1.1.1", p => p
                             .WithAssemblyGroup(null, g => g
                             .WithAsset(TestAssemblyWithNoVersions + ".dll")

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -92,8 +92,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         // The fallback RID is a compile-time define for the host. On Windows, it is always win10 and on
         // other platforms, it matches the build RID (non-portable for source-builds, portable otherwise)
         private static string FallbackRid = OperatingSystem.IsWindows()
-            ? $"win10-{RepoDirectoriesProvider.Default.BuildArchitecture}"
-            : RepoDirectoriesProvider.Default.BuildRID;
+            ? $"win10-{TestContext.BuildArchitecture}"
+            : TestContext.BuildRID;
 
         protected const string UnknownRid = "unknown-rid";
 
@@ -330,15 +330,15 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         }
 
         // The build RID from the test context should match the build RID of the host under test
-        private static string CurrentRid = RepoDirectoriesProvider.Default.BuildRID;
+        private static string CurrentRid = TestContext.BuildRID;
         private static string CurrentRidAsset = $"{CurrentRid}/{CurrentRid}Asset.dll";
 
         // Strip the -<arch> from the RID to get the OS
-        private static string CurrentOS = CurrentRid[..^(RepoDirectoriesProvider.Default.BuildArchitecture.Length + 1)];
+        private static string CurrentOS = CurrentRid[..^(TestContext.BuildArchitecture.Length + 1)];
         private static string CurrentOSAsset = $"{CurrentOS}/{CurrentOS}Asset.dll";
 
         // Append a different architecture - arm64 if current architecture is x64, otherwise x64
-        private static string DifferentArch = $"{CurrentOS}-{(RepoDirectoriesProvider.Default.BuildArchitecture == "x64" ? "arm64" : "x64")}";
+        private static string DifferentArch = $"{CurrentOS}-{(TestContext.BuildArchitecture == "x64" ? "arm64" : "x64")}";
         private static string DifferentArchAsset = $"{DifferentArch}/{DifferentArch}Asset.dll";
 
         [Theory]
@@ -601,7 +601,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         protected static void UseFallbacksFromBuiltDotNet(NetCoreAppBuilder builder)
         {
             IReadOnlyList<RuntimeFallbacks> fallbacks;
-            string depsJson = Path.Combine(new DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet).GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
+            string depsJson = Path.Combine(new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
             using (FileStream fileStream = File.Open(depsJson, FileMode.Open))
             using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
             {

--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void MuxerExec_BadExtension_Fails()
         {
             // Get a valid file name, but not exe or dll
-            string fxDir = Path.Combine(sharedTestState.RepoDirectories.DotnetSDK, "shared", "Microsoft.NETCore.App");
+            string fxDir = Path.Combine(TestContext.BuiltDotNet, "shared", "Microsoft.NETCore.App");
             fxDir = new DirectoryInfo(fxDir).GetDirectories()[0].FullName;
             string assemblyName = Path.Combine(fxDir, "Microsoft.NETCore.App.deps.json");
 
@@ -90,14 +90,14 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOutMatching($@"Architecture:\s*{RepoDirectoriesProvider.Default.BuildArchitecture}")
-                .And.HaveStdOutMatching($@"RID:\s*{RepoDirectoriesProvider.Default.BuildRID}");
+                .And.HaveStdOutMatching($@"Architecture:\s*{TestContext.BuildArchitecture}")
+                .And.HaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
         }
 
         [Fact]
         public void DotNetInfo_WithSDK()
         {
-            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, RepoDirectoriesProvider.Default.BuiltDotnet, "withSdk")
+            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, TestContext.BuiltDotNet, "withSdk")
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("1.0.0")
                 .AddMockSDK("1.0.0", "1.0.0")
                 .Build();
@@ -108,13 +108,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.NotHaveStdOutMatching($@"RID:\s*{RepoDirectoriesProvider.Default.BuildRID}");
+                .And.NotHaveStdOutMatching($@"RID:\s*{TestContext.BuildRID}");
         }
 
         // Return a non-existent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()
         {
-            return Path.Combine(sharedTestState.RepoDirectories.DotnetSDK, @"x\y/");
+            return Path.Combine(TestContext.BuiltDotNet, @"x\y/");
         }
 
         public class SharedTestState : IDisposable
@@ -126,8 +126,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                BuiltDotNet = new DotNetCli(RepoDirectories.BuiltDotnet);
+                BuiltDotNet = new DotNetCli(TestContext.BuiltDotNet);
 
                 BaseDirectory = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "argValidation")));
 

--- a/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/FrameworkResolution/FrameworkResolutionBase.cs
@@ -88,14 +88,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.FrameworkResolution
         public class SharedTestStateBase : IDisposable
         {
             private readonly string _builtDotnet;
-            private readonly RepoDirectoriesProvider _repoDirectories;
             private readonly string _baseDir;
             private readonly TestArtifact _baseDirArtifact;
 
             public SharedTestStateBase()
             {
                 _builtDotnet = Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish");
-                _repoDirectories = new RepoDirectoriesProvider();
 
                 string baseDir = Path.Combine(TestArtifact.TestArtifactsPath, "frameworkResolution");
                 _baseDir = SharedFramework.CalculateUniqueTestDirectory(baseDir);

--- a/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
+++ b/src/installer/tests/HostActivation.Tests/HostVersionCompatibility.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             string appExe = app.AppExe;
 
             RuntimeConfig appConfig = RuntimeConfig.FromFile(app.RuntimeConfigJson);
-            Assert.NotEqual(appConfig.Tfm, RepoDirectoriesProvider.Default.Tfm);
-            Assert.NotEqual(appConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+            Assert.NotEqual(appConfig.Tfm, TestContext.Tfm);
+            Assert.NotEqual(appConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version, TestContext.MicrosoftNETCoreAppVersion);
 
             // Use the newer apphost
             // This emulates the case when:
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdErrContaining($"--- Invoked apphost [version: {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdErrContaining($"--- Invoked apphost [version: {TestContext.MicrosoftNETCoreAppVersion}");
 
             // Use the newer apphost and hostFxr
             // This emulates the case when:
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdErrContaining($"--- Invoked apphost [version: {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdErrContaining($"--- Invoked apphost [version: {TestContext.MicrosoftNETCoreAppVersion}");
         }
 
         [Fact]
@@ -71,8 +71,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             RuntimeConfig previousAppConfig = RuntimeConfig.FromFile(previousVersionApp.RuntimeConfigJson);
             string previousVersion = previousAppConfig.GetIncludedFramework(Constants.MicrosoftNETCoreApp).Version;
-            Assert.NotEqual(RepoDirectoriesProvider.Default.Tfm, previousAppConfig.Tfm);
-            Assert.NotEqual(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, previousVersion);
+            Assert.NotEqual(TestContext.Tfm, previousAppConfig.Tfm);
+            Assert.NotEqual(TestContext.MicrosoftNETCoreAppVersion, previousVersion);
 
             // Use the older apphost
             // This emulates the case when:

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -28,7 +28,7 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(fixture.BuiltDotnet.BinPath, arch)
@@ -44,7 +44,7 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
                 .DotNetRoot(fixture.BuiltDotnet.BinPath)
@@ -60,7 +60,7 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             var dotnet = fixture.BuiltDotnet.BinPath;
             Command.Create(appExe)
                 .EnableTracingAndCaptureOutputs()
@@ -79,7 +79,7 @@ namespace HostActivation.Tests
                 .Copy();
 
             var appExe = fixture.TestProject.AppExe;
-            var arch = fixture.RepoDirProvider.BuildArchitecture.ToUpper();
+            var arch = TestContext.BuildArchitecture.ToUpper();
             var dotnet = fixture.BuiltDotnet.BinPath;
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
@@ -150,7 +150,7 @@ namespace HostActivation.Tests
         [Fact]
         public void EnvironmentVariable_DotNetInfo_ListEnvironment()
         {
-            var dotnet = new DotNetCli(sharedTestState.RepoDirectories.BuiltDotnet);
+            var dotnet = new DotNetCli(TestContext.BuiltDotNet);
 
             var command = dotnet.Exec("--info")
                 .CaptureStdOut();
@@ -194,7 +194,7 @@ namespace HostActivation.Tests
             var appExe = fixture.TestProject.AppExe;
             var arch1 = "someArch";
             var path1 = "x/y/z";
-            var arch2 = fixture.RepoDirProvider.BuildArchitecture;
+            var arch2 = TestContext.BuildArchitecture;
             var path2 = "a/b/c";
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
@@ -285,7 +285,7 @@ namespace HostActivation.Tests
         {
             using (var testArtifact = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "listOtherArchs"))))
             {
-                var dotnet = new DotNetBuilder(testArtifact.Location, sharedTestState.RepoDirectories.BuiltDotnet, "exe").Build();
+                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet, "exe").Build();
                 using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(dotnet.GreatestVersionHostFxrFilePath))
                 {
                     var installLocations = new (string, string)[] {
@@ -313,7 +313,7 @@ namespace HostActivation.Tests
                     pathOverride = System.Text.RegularExpressions.Regex.Escape(pathOverride);
                     foreach ((string arch, string path) in installLocations)
                     {
-                        if (arch == sharedTestState.RepoDirectories.BuildArchitecture)
+                        if (arch == TestContext.BuildArchitecture)
                             continue;
 
                         result.Should()
@@ -327,13 +327,11 @@ namespace HostActivation.Tests
         {
             public string BaseDirectory { get; }
             public TestProjectFixture PortableAppFixture { get; }
-            public RepoDirectoriesProvider RepoDirectories { get; }
             public string InstallLocation { get; }
 
             public SharedTestState()
             {
-                RepoDirectories = new RepoDirectoriesProvider();
-                var fixture = new TestProjectFixture("PortableApp", RepoDirectories);
+                var fixture = new TestProjectFixture("PortableApp", RepoDirectoriesProvider.Default);
                 fixture
                     .EnsureRestored()
                     // App Host generation is turned off by default on macOS

--- a/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/MultilevelSDKLookup.cs
@@ -328,7 +328,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(DotNet.GreatestVersionHostFxrFilePath))
             {
-                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (RepoDirectories.BuildArchitecture, _regDir) });
+                registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (TestContext.BuildArchitecture, _regDir) });
 
                 // Add SDK versions
                 AddAvailableSdkVersions(_regSdkBaseDir, "9999.0.4");

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             public SdkResolutionFixture(SharedTestState state)
             {
-                Dotnet = new DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet);
+                Dotnet = new DotNetCli(TestContext.BuiltDotNet);
 
                 _fixture = state.HostApiInvokerAppFixture.Copy();
 
@@ -502,7 +502,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining($"APP_CONTEXT_BASE_DIRECTORY = {Path.GetDirectoryName(fixture.TestProject.AppDll)}")
-                .And.HaveStdOutContaining($"RUNTIME_IDENTIFIER = {RepoDirectoriesProvider.Default.BuildRID}")
+                .And.HaveStdOutContaining($"RUNTIME_IDENTIFIER = {TestContext.BuildRID}")
                 .And.HaveStdOutContaining($"DOES_NOT_EXIST = <none>")
                 .And.HaveStdOutContaining($"ENTRY_ASSEMBLY_NAME = {fixture.TestProject.AssemblyName}");
         }

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
                 // Create a runtimeconfig.json for the C++/CLI test library
                 new RuntimeConfig(Path.Combine(folder, "ijw.runtimeconfig.json"))
-                    .WithFramework(new RuntimeConfig.Framework(Constants.MicrosoftNETCoreApp, RepoDirectories.MicrosoftNETCoreAppVersion))
+                    .WithFramework(new RuntimeConfig.Framework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion))
                     .Save();
 
                 ManagedHostFixture_FrameworkDependent = new TestProjectFixture("ManagedHost", RepoDirectories)

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
@@ -154,7 +154,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
 
                 Application = TestApp.CreateEmpty("App");
-                Application.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, RepoDirectories.MicrosoftNETCoreAppVersion);
+                Application.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
 
                 SelfContainedApplication = TestApp.CreateEmpty("SelfContainedApp");
                 SelfContainedApplication.PopulateSelfContained(TestApp.MockedComponent.None);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Nethost.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 if (useRegisteredLocation)
                 {
-                    registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, installLocation));
+                    registeredInstallLocationOverride.SetInstallLocation((TestContext.BuildArchitecture, installLocation));
                 }
 
                 result = Command.Create(sharedState.NativeHostPath, $"{GetHostFxrPath} {explicitLoad} {(useAssemblyPath ? sharedState.TestAssemblyPath : string.Empty)}")
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 if (shouldUseArchSpecificInstallLocation)
-                    registeredInstallLocationOverride.SetInstallLocation((sharedState.RepoDirectories.BuildArchitecture, string.Format(value, installLocation)));
+                    registeredInstallLocationOverride.SetInstallLocation((TestContext.BuildArchitecture, string.Format(value, installLocation)));
                 else
                     registeredInstallLocationOverride.SetInstallLocation((string.Empty, string.Format(value, installLocation)));
 
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 {
                     result.Should().HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        sharedState.RepoDirectories.BuildArchitecture);
+                        TestContext.BuildArchitecture);
                 }
                 else
                 {
@@ -257,7 +257,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(sharedState.NethostPath))
             {
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
-                    (sharedState.RepoDirectories.BuildArchitecture, installLocation),
+                    (TestContext.BuildArchitecture, installLocation),
                     ("someOtherArch", $"{installLocation}/invalid")
                 });
 
@@ -273,7 +273,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Pass()
                     .And.HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        sharedState.RepoDirectories.BuildArchitecture)
+                        TestContext.BuildArchitecture)
                     .And.HaveUsedRegisteredInstallLocation(installLocation)
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }
@@ -289,7 +289,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             {
                 registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] {
                     (string.Empty, $"{installLocation}/a/b/c"),
-                    (sharedState.RepoDirectories.BuildArchitecture, installLocation)
+                    (TestContext.BuildArchitecture, installLocation)
                 });
 
                 CommandResult result = Command.Create(sharedState.NativeHostPath, GetHostFxrPath)
@@ -304,7 +304,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 result.Should().Pass()
                     .And.HaveLookedForArchitectureSpecificInstallLocation(
                         registeredInstallLocationOverride.PathValueOverride,
-                        sharedState.RepoDirectories.BuildArchitecture)
+                        TestContext.BuildArchitecture)
                     .And.HaveUsedRegisteredInstallLocation(installLocation)
                     .And.HaveStdOutContaining($"hostfxr_path: {sharedState.HostFxrPath}".ToLower());
             }

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             Command.Create(appExe)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(builtDotnet, sharedTestState.RepoDirectories.BuildArchitecture)
+                .DotNetRoot(builtDotnet, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
                 .Execute()
                 .Should().Pass()
@@ -153,7 +153,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             // Verify running from within the working directory
             Command.Create(appExe)
                 .WorkingDirectory(fixture.TestProject.OutputDirectory)
-                .DotNetRoot(builtDotnet, sharedTestState.RepoDirectories.BuildArchitecture)
+                .DotNetRoot(builtDotnet, TestContext.BuildArchitecture)
                 .MultilevelLookup(false)
                 .CaptureStdErr()
                 .CaptureStdOut()
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(appExe))
             {
-                string architecture = fixture.RepoDirProvider.BuildArchitecture;
+                string architecture = TestContext.BuildArchitecture;
                 if (useRegisteredLocation)
                 {
                     registeredInstallLocationOverride.SetInstallLocation(new (string, string)[] { (architecture, builtDotnet) });
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(sharedTestState.MockApp.AppExe)
-                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture);
+                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, TestContext.BuildArchitecture);
             }
             else
             {
@@ -300,7 +300,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             if (useAppHost)
             {
                 command = Command.Create(app.AppExe)
-                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture);
+                    .DotNetRoot(sharedTestState.BuiltDotNet.BinPath, TestContext.BuildArchitecture);
             }
             else
             {
@@ -348,7 +348,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                     expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure;
                     expectedStdErr = $"Framework: '{Constants.MicrosoftNETCoreApp}', " +
-                        $"version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({fixture.RepoDirProvider.BuildArchitecture})";
+                        $"version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
                     expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
                 }
 
@@ -360,7 +360,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 result.Should().Fail()
                     .And.HaveStdErrContaining($"https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
-                    .And.HaveStdErrContaining($"&rid={RepoDirectoriesProvider.Default.BuildRID}")
+                    .And.HaveStdErrContaining($"&rid={TestContext.BuildRID}")
                     .And.HaveStdErrContaining(expectedStdErr);
 
                 // Some Unix systems will have 8 bit exit codes.
@@ -400,13 +400,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 WindowsUtils.WaitForPopupFromProcess(command.Process);
                 command.Process.Kill();
 
-                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({fixture.RepoDirProvider.BuildArchitecture})";
+                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
                 var result = command.WaitForExit(true)
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?{expectedUrlQuery}")
                     .And.HaveStdErrContaining("&gui=true")
-                    .And.HaveStdErrContaining($"&rid={RepoDirectoriesProvider.Default.BuildRID}")
+                    .And.HaveStdErrContaining($"&rid={TestContext.BuildRID}")
                     .And.HaveStdErrMatching($"details: (?>.|\\s)*{System.Text.RegularExpressions.Regex.Escape(expectedMissingFramework)}");
             }
         }
@@ -467,7 +467,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(dotnet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture)
+                    .DotNetRoot(dotnet.BinPath, TestContext.BuildArchitecture)
                     .MultilevelLookup(false)
                     .Start();
 

--- a/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/PortableAppActivation.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
 
 
             // Verify running from within the working directory
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Theory]
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
+                    .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
                     .And.NotHaveStdErr();
 
                 // Verify running from within the working directory
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion)
+                    .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion)
                     .And.NotHaveStdErr();
             }
         }
@@ -337,7 +337,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 if (missingHostfxr)
                 {
                     expectedErrorCode = Constants.ErrorCode.CoreHostLibMissingFailure;
-                    expectedStdErr = $"&apphost_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
+                    expectedStdErr = $"&apphost_version={TestContext.MicrosoftNETCoreAppVersion}";
                     expectedUrlQuery = "missing_runtime=true&";
                 }
                 else
@@ -348,8 +348,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
                     expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure;
                     expectedStdErr = $"Framework: '{Constants.MicrosoftNETCoreApp}', " +
-                        $"version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
-                    expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
+                        $"version '{TestContext.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
+                    expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={TestContext.MicrosoftNETCoreAppVersion}";
                 }
 
                 CommandResult result = Command.Create(appExe)
@@ -390,7 +390,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .BinPath;
 
                 expectedErrorCode = Constants.ErrorCode.FrameworkMissingFailure.ToString("x");
-                expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}";
+                expectedUrlQuery = $"framework={Constants.MicrosoftNETCoreApp}&framework_version={TestContext.MicrosoftNETCoreAppVersion}";
                 Command command = Command.Create(appExe)
                     .EnableTracingAndCaptureOutputs()
                     .DotNetRoot(invalidDotNet)
@@ -400,7 +400,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 WindowsUtils.WaitForPopupFromProcess(command.Process);
                 command.Process.Kill();
 
-                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
+                string expectedMissingFramework = $"'{Constants.MicrosoftNETCoreApp}', version '{TestContext.MicrosoftNETCoreAppVersion}' ({TestContext.BuildArchitecture})";
                 var result = command.WaitForExit(true)
                     .Should().Fail()
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
@@ -440,7 +440,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .And.HaveStdErrContaining($"Showing error dialog for application: '{Path.GetFileName(appExe)}' - error code: 0x{expectedErrorCode}")
                     .And.HaveStdErrContaining($"url: 'https://aka.ms/dotnet-core-applaunch?missing_runtime=true")
                     .And.HaveStdErrContaining("gui=true")
-                    .And.HaveStdErrContaining($"&apphost_version={sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                    .And.HaveStdErrContaining($"&apphost_version={TestContext.MicrosoftNETCoreAppVersion}");
             }
         }
 

--- a/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/StandaloneAppActivation.cs
@@ -31,14 +31,14 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
 
             if (OperatingSystem.IsWindows())
             {
                 // App sets FileVersion to NETCoreApp version. On Windows, this should be copied to app resources.
-                string expectedVersion = RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.Contains('-')
-                    ? RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion[..RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                    : RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion;
+                string expectedVersion = TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : TestContext.MicrosoftNETCoreAppVersion;
                 Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(appExe).FileVersion);
             }
         }
@@ -58,7 +58,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 // Note that this is an exact match - we don't expect any output from the host itself
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {TestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.NotHaveStdErr();
 
             // Make sure tracing indicates there is no runtime config and no deps json
@@ -66,7 +66,7 @@ namespace HostActivation.Tests
                 .EnableTracingAndCaptureOutputs()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
+                .And.HaveStdOut($"Hello World!{Environment.NewLine}{Environment.NewLine}.NET {TestContext.MicrosoftNETCoreAppVersion}{Environment.NewLine}")
                 .And.HaveStdErrContaining($"Runtime config does not exist at [{app.RuntimeConfigJson}]")
                 .And.HaveStdErrContaining($"Dependencies manifest does not exist at [{app.DepsJson}]");
         }
@@ -85,7 +85,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace HostActivation.Tests
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining(RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+                .And.HaveStdOutContaining(TestContext.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace HostActivation.Tests
                 .DotNetRoot(app.Location)
                 .Execute(expectedToFail: true)
                 .Should().Fail()
-                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), RepoDirectoriesProvider.Default.TargetRID)
+                .And.HaveUsedDotNetRootInstallLocation(Path.GetFullPath(app.Location), TestContext.TargetRID)
                 .And.HaveStdErrContaining($"The required library {Binaries.HostFxr.FileName} could not be found.");
         }
 

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NETCoreTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             using (var tester = NuGetArtifactTester.Open(
                 dirs,
                 "Microsoft.NETCore.App.Host",
-                $"Microsoft.NETCore.App.Host.{dirs.BuildRID}"))
+                $"Microsoft.NETCore.App.Host.{TestContext.BuildRID}"))
             {
                 tester.IsAppHostPack();
             }
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             using (var tester = NuGetArtifactTester.Open(
                 dirs,
                 "Microsoft.NETCore.App.Runtime",
-                $"Microsoft.NETCore.App.Runtime.{dirs.BuildRID}"))
+                $"Microsoft.NETCore.App.Runtime.{TestContext.BuildRID}"))
             {
                 tester.IsRuntimePack();
             }

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
             string nupkgPath = Path.Combine(
                 dirs.BaseArtifactsFolder,
                 "packages",
-                dirs.Configuration,
+                TestContext.Configuration,
                 "Shipping",
                 $"{id}.{dirs.MicrosoftNETCoreAppVersion}.nupkg");
 

--- a/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
+++ b/src/installer/tests/Microsoft.DotNet.CoreSetup.Packaging.Tests/NuGetArtifactTester.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.CoreSetup.Packaging.Tests
                 "packages",
                 TestContext.Configuration,
                 "Shipping",
-                $"{id}.{dirs.MicrosoftNETCoreAppVersion}.nupkg");
+                $"{id}.{TestContext.MicrosoftNETCoreAppVersion}.nupkg");
 
             // If the nuspec exists, the nupkg should exist.
             Assert.True(File.Exists(nupkgPath));

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -26,7 +26,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(selfContained ? null : RepoDirectoriesProvider.Default.BuiltDotnet)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");
@@ -74,9 +74,9 @@ namespace AppHost.Bundle.Tests
             if (OperatingSystem.IsWindows())
             {
                 // StandaloneApp sets FileVersion to NETCoreApp version. On Windows, this should be copied to singlefilehost resources.
-                string expectedVersion = RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.Contains('-')
-                    ? RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion[..RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion.IndexOf('-')]
-                    : RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion;
+                string expectedVersion = TestContext.MicrosoftNETCoreAppVersion.Contains('-')
+                    ? TestContext.MicrosoftNETCoreAppVersion[..TestContext.MicrosoftNETCoreAppVersion.IndexOf('-')]
+                    : TestContext.MicrosoftNETCoreAppVersion;
                 Assert.Equal(expectedVersion, System.Diagnostics.FileVersionInfo.GetVersionInfo(singleFile).FileVersion);
             }
         }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace AppHost.Bundle.Tests
 {
-    public class BundledAppWithSubDirs : BundleTestBase, IClassFixture<BundledAppWithSubDirs.SharedTestState>
+    public class BundledAppWithSubDirs : IClassFixture<BundledAppWithSubDirs.SharedTestState>
     {
         private SharedTestState sharedTestState;
 
@@ -23,7 +23,7 @@ namespace AppHost.Bundle.Tests
 
         private void RunTheApp(string path, bool selfContained)
         {
-            RunTheApp(path, selfContained ? null : RepoDirectoriesProvider.Default.BuiltDotnet)
+            RunTheApp(path, selfContained ? null : TestContext.BuiltDotNet)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Wow! We now say hello to the big world and you.");
         }
@@ -63,7 +63,7 @@ namespace AppHost.Bundle.Tests
             using (new TestArtifact(dotnetWithMockHostFxr))
             {
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "mockhostfxrFrameworkMissingFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet, "mockhostfxrFrameworkMissingFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(2, 2, 0));
                 var dotnet = dotnetBuilder.Build();
@@ -93,14 +93,14 @@ namespace AppHost.Bundle.Tests
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
                 string expectedErrorCode = Constants.ErrorCode.BundleExtractionFailure.ToString("x");
 
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, sharedTestState.RepoDirectories.BuiltDotnet, "mockhostfxrBundleVersionFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet, "mockhostfxrBundleVersionFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(5, 0, 0));
                 var dotnet = dotnetBuilder.Build();
 
                 Command command = Command.Create(singleFile)
                     .EnableTracingAndCaptureOutputs()
-                    .DotNetRoot(dotnet.BinPath, sharedTestState.RepoDirectories.BuildArchitecture)
+                    .DotNetRoot(dotnet.BinPath, TestContext.BuildArchitecture)
                     .MultilevelLookup(false)
                     .Start();
 
@@ -179,7 +179,7 @@ namespace AppHost.Bundle.Tests
             RunTheApp(singleFile, selfContained: true);
         }
 
-        public class SharedTestState : SharedTestStateBase, IDisposable
+        public class SharedTestState : IDisposable
         {
             public SingleFileTestApp FrameworkDependentApp { get; }
             public SingleFileTestApp SelfContainedApp { get; }

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NET.HostModel.Tests
                 Command.Create(symlink.SrcPath)
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(RepoDirectoriesProvider.Default.BuiltDotnet)
+                    .DotNetRoot(TestContext.BuiltDotNet)
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World");
@@ -105,7 +105,7 @@ namespace Microsoft.NET.HostModel.Tests
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, "dotnet");
 
-                using var symlink = new SymLink(dotnetSymlink, RepoDirectoriesProvider.Default.BuiltDotnet);
+                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet);
                 Command.Create(sharedTestState.FrameworkDependentApp.AppExe)
                     .EnvironmentVariable("DOTNET_ROOT", symlink.SrcPath)
                     .CaptureStdErr()
@@ -141,7 +141,7 @@ namespace Microsoft.NET.HostModel.Tests
         [SkipOnPlatform(TestPlatforms.Windows, "Creating symbolic links requires administrative privilege on Windows, so skip test.")]
         public void Put_dotnet_behind_symlink()
         {
-            var dotnet = new DotNet.Cli.Build.DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet);
+            var dotnet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
             using (var testDir = TestArtifact.Create("symlink"))
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, Binaries.DotNet.FileName);
@@ -161,7 +161,7 @@ namespace Microsoft.NET.HostModel.Tests
         public void Put_app_directory_behind_symlink_and_use_dotnet()
         {
             var app = sharedTestState.SelfContainedApp.Copy();
-            var dotnet = new DotNet.Cli.Build.DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet);
+            var dotnet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
 
             using (var newAppDir = TestArtifact.Create("PutTheBinDirSomewhereElse"))
             {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.NET.HostModel.Tests
             // work correctly in the presence of "."s in the hostName.
             using (var app = TestApp.CreateEmpty("App.With.Periods"))
             {
-                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+                app.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
 
                 string hostName = Path.GetFileName(app.AppExe);
                 string depsJsonName = Path.GetFileName(app.DepsJson);
@@ -354,7 +354,7 @@ namespace Microsoft.NET.HostModel.Tests
             {
                 App = TestApp.CreateFromBuiltAssets(AppName);
 
-                var builtDotNet = new DotNet.Cli.Build.DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet);
+                var builtDotNet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
                 SystemDll = Path.Combine(builtDotNet.GreatestVersionSharedFxPath, "System.dll");
             }
 

--- a/src/installer/tests/TestUtils/Binaries.cs
+++ b/src/installer/tests/TestUtils/Binaries.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static class CoreClr
         {
             public static string FileName = GetSharedLibraryFileNameForCurrentPlatform("coreclr");
-            public static string FilePath = Path.Combine(new DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet).GreatestVersionSharedFxPath, FileName);
+            public static string FilePath = Path.Combine(new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath, FileName);
 
             public static string MockName = GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr");
             public static string MockPath = Path.Combine(RepoDirectoriesProvider.Default.HostTestArtifacts, MockName);
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static (IEnumerable<string> Assemblies, IEnumerable<string> NativeLibraries) GetRuntimeFiles()
         {
-            var runtimePackDir = new DotNetCli(RepoDirectoriesProvider.Default.BuiltDotnet).GreatestVersionSharedFxPath;
+            var runtimePackDir = new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath;
             var assemblies = Directory.GetFiles(runtimePackDir, "*.dll").Where(f => IsAssembly(f));
 
             (string prefix, string suffix) = Binaries.GetSharedLibraryPrefixSuffix();

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -17,14 +17,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
     public class DotNetBuilder
     {
         private readonly string _path;
-        private readonly RepoDirectoriesProvider _repoDirectories;
 
         public DotNetBuilder(string basePath, string builtDotnet, string name)
         {
             _path = name == null ? basePath : Path.Combine(basePath, name);
             Directory.CreateDirectory(_path);
-
-            _repoDirectories = new RepoDirectoriesProvider(builtDotnet: _path);
 
             // Prepare the dotnet installation mock
 

--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             // ./shared/Microsoft.NETCore.App/<version> - create a mock of the root framework
             string netCoreAppPath = AddFramework(Constants.MicrosoftNETCoreApp, version);
 
-            string currentRid = _repoDirectories.TargetRID;
+            string currentRid = TestContext.TargetRID;
 
             NetCoreAppBuilder.ForNETCoreApp(Constants.MicrosoftNETCoreApp, currentRid)
                 .WithStandardRuntimeFallbacks()

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -12,7 +12,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static readonly RepoDirectoriesProvider Default = new RepoDirectoriesProvider();
 
         // Values from test context can be overridden in constructor
-        public string MicrosoftNETCoreAppVersion { get; }
         public string BuiltDotnet { get; }
 
         // Paths computed by looking for the repo root
@@ -21,14 +20,12 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public string HostTestArtifacts { get; }
 
         // Paths used for building/publishing projects
-        // TODO: Remove once test runs stop depending on SDK
         public string TestAssetsFolder { get; }
         public string NugetPackages { get; }
         public string DotnetSDK { get; }
 
         public RepoDirectoriesProvider(
-            string builtDotnet = null,
-            string microsoftNETCoreAppVersion = null)
+            string builtDotnet = null)
         {
             string repoRoot = GetRepoRootDirectory();
             BaseArtifactsFolder = Path.Combine(repoRoot, "artifacts");
@@ -37,8 +34,6 @@ namespace Microsoft.DotNet.CoreSetup.Test
             string artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
             HostArtifacts = Path.Combine(artifacts, "corehost");
             HostTestArtifacts = Path.Combine(artifacts, "corehost_test");
-
-            MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? TestContext.MicrosoftNETCoreAppVersion;
 
             TestAssetsFolder = TestContext.GetTestContextVariable("TEST_ASSETS");
             DotnetSDK = TestContext.GetTestContextVariable("DOTNET_SDK_PATH");

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -11,95 +11,45 @@ namespace Microsoft.DotNet.CoreSetup.Test
     {
         public static readonly RepoDirectoriesProvider Default = new RepoDirectoriesProvider();
 
-        public string BuildRID { get; }
-        public string BuildArchitecture { get; }
-        public string TargetRID { get; }
+        // Values from test context can be overridden in constructor
         public string MicrosoftNETCoreAppVersion { get; }
-        public string Tfm { get; }
-        public string TestAssetsFolder { get; }
-        public string Configuration { get; }
-        public string RepoRoot { get; }
+        public string BuiltDotnet { get; }
+
+        // Paths computed by looking for the repo root
         public string BaseArtifactsFolder { get; }
-        public string Artifacts { get; }
         public string HostArtifacts { get; }
         public string HostTestArtifacts { get; }
-        public string BuiltDotnet { get; }
+
+        // Paths used for building/publishing projects
+        // TODO: Remove once test runs stop depending on SDK
+        public string TestAssetsFolder { get; }
         public string NugetPackages { get; }
         public string DotnetSDK { get; }
-        public string TestAssetsOutput { get; }
-
-        private string _testContextVariableFilePath { get; }
-        private ImmutableDictionary<string, string> _testContextVariables { get; }
 
         public RepoDirectoriesProvider(
             string builtDotnet = null,
             string microsoftNETCoreAppVersion = null)
         {
-            RepoRoot = GetRepoRootDirectory();
-            BaseArtifactsFolder = Path.Combine(RepoRoot, "artifacts");
+            string repoRoot = GetRepoRootDirectory();
+            BaseArtifactsFolder = Path.Combine(repoRoot, "artifacts");
 
-            _testContextVariableFilePath = Path.Combine(
-                Directory.GetCurrentDirectory(),
-                "TestContextVariables.txt");
+            string osPlatformConfig = $"{TestContext.BuildRID}.{TestContext.Configuration}";
+            string artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
+            HostArtifacts = Path.Combine(artifacts, "corehost");
+            HostTestArtifacts = Path.Combine(artifacts, "corehost_test");
 
-            _testContextVariables = File.ReadAllLines(_testContextVariableFilePath)
-                .ToImmutableDictionary(
-                    line => line.Substring(0, line.IndexOf('=')),
-                    line => line.Substring(line.IndexOf('=') + 1),
-                    StringComparer.OrdinalIgnoreCase);
+            MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? TestContext.MicrosoftNETCoreAppVersion;
 
-            TargetRID = GetTestContextVariable("TEST_TARGETRID");
-            BuildRID = GetTestContextVariable("BUILDRID");
-            BuildArchitecture = GetTestContextVariable("BUILD_ARCHITECTURE");
-            MicrosoftNETCoreAppVersion = microsoftNETCoreAppVersion ?? GetTestContextVariable("MNA_VERSION");
-            Tfm = GetTestContextVariable("MNA_TFM");
-            TestAssetsFolder = GetTestContextVariable("TEST_ASSETS");
-            TestAssetsOutput = GetTestContextVariable("TEST_ASSETS_OUTPUT");
-
-            Configuration = GetTestContextVariable("BUILD_CONFIGURATION");
-
-            string osPlatformConfig = $"{BuildRID}.{Configuration}";
-            Artifacts = Path.Combine(BaseArtifactsFolder, "bin", osPlatformConfig);
-            HostArtifacts = Path.Combine(Artifacts, "corehost");
-            HostTestArtifacts = Path.Combine(Artifacts, "corehost_test");
-
-            DotnetSDK = GetTestContextVariable("DOTNET_SDK_PATH");
+            TestAssetsFolder = TestContext.GetTestContextVariable("TEST_ASSETS");
+            DotnetSDK = TestContext.GetTestContextVariable("DOTNET_SDK_PATH");
             if (!Directory.Exists(DotnetSDK))
             {
                 throw new InvalidOperationException("ERROR: Test SDK folder not found.");
             }
 
-            NugetPackages = GetTestContextVariable("NUGET_PACKAGES") ?? Path.Combine(RepoRoot, ".packages");
+            NugetPackages = TestContext.GetTestContextVariable("NUGET_PACKAGES");
 
-            BuiltDotnet = builtDotnet ?? Path.Combine(GetTestContextVariable("TEST_ARTIFACTS"), "sharedFrameworkPublish");
-        }
-
-        public string GetTestContextVariable(string name)
-        {
-            return GetTestContextVariableOrNull(name) ?? throw new ArgumentException(
-                $"Unable to find variable '{name}' in " +
-                $"test context variable file '{_testContextVariableFilePath}'");
-        }
-
-        public string GetTestContextVariableOrNull(string name)
-        {
-            // Allow env var override, although normally the test context variables file is used.
-            // Don't accept NUGET_PACKAGES env override specifically: Arcade sets this and it leaks
-            // in during build.cmd/sh runs, replacing the test-specific dir.
-            if (!name.Equals("NUGET_PACKAGES", StringComparison.OrdinalIgnoreCase))
-            {
-                if (Environment.GetEnvironmentVariable(name) is string envValue)
-                {
-                    return envValue;
-                }
-            }
-
-            if (_testContextVariables.TryGetValue(name, out string value))
-            {
-                return value;
-            }
-
-            return null;
+            BuiltDotnet = builtDotnet ?? TestContext.BuiltDotNet;
         }
 
         private static string GetRepoRootDirectory()

--- a/src/installer/tests/TestUtils/SingleFileTestApp.cs
+++ b/src/installer/tests/TestUtils/SingleFileTestApp.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// </summary>
         /// <param name="appName">Name of pre-built app</param>
         /// <returns>
-        /// The <paramref name="appName"/> is expected to be in <see cref="RepoDirectoriesProvider.TestAssetsFolder"/>
+        /// The <paramref name="appName"/> is expected to be in <see cref="TestContext.TestAssetsOutput"/>
         /// and have been built as framework-dependent
         /// </returns>
         public static SingleFileTestApp CreateFrameworkDependent(string appName)
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         /// </summary>
         /// <param name="appName">Name of pre-built app</param>
         /// <returns>
-        /// The <paramref name="appName"/> is expected to be in <see cref="RepoDirectoriesProvider.TestAssetsFolder"/>
+        /// The <paramref name="appName"/> is expected to be in <see cref="TestContext.TestAssetsOutput"/>
         /// and have been built as framework-dependent
         /// </returns>
         public static SingleFileTestApp CreateSelfContained(string appName)
@@ -136,23 +136,23 @@ namespace Microsoft.DotNet.CoreSetup.Test
         {
             // Copy the compiled app output - the app is expected to have been built as framework-dependent
             TestArtifact.CopyRecursive(
-                Path.Combine(RepoDirectoriesProvider.Default.TestAssetsOutput, AppName),
+                Path.Combine(TestContext.TestAssetsOutput, AppName),
                 builtApp.Location);
 
             // Remove any runtimeconfig.json or deps.json - we will be creating new ones
             File.Delete(builtApp.RuntimeConfigJson);
             File.Delete(builtApp.DepsJson);
 
-            var shortVersion = RepoDirectoriesProvider.Default.Tfm[3..]; // trim "net" from beginning
-            var builder = NetCoreAppBuilder.ForNETCoreApp(AppName, RepoDirectoriesProvider.Default.TargetRID, shortVersion);
+            var shortVersion = TestContext.Tfm[3..]; // trim "net" from beginning
+            var builder = NetCoreAppBuilder.ForNETCoreApp(AppName, TestContext.TargetRID, shortVersion);
 
             // Update the .runtimeconfig.json
             builder.WithRuntimeConfig(c =>
             {
-                c.WithTfm(RepoDirectoriesProvider.Default.Tfm);
+                c.WithTfm(TestContext.Tfm);
                 c = selfContained
-                    ? c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
-                    : c.WithFramework(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion);
+                    ? c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion)
+                    : c.WithFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);
             });
 
             // Add runtime libraries and assets for generating the .deps.json.
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                     .WithAsset(Path.GetFileName(builtApp.AppDll), f => f.NotOnDisk())));
             if (selfContained)
             {
-                builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{RepoDirectoriesProvider.Default.TargetRID}", RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, l => l
+                builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.TargetRID}", TestContext.MicrosoftNETCoreAppVersion, l => l
                     .WithAssemblyGroup(string.Empty, g =>
                     {
                         foreach (var file in Binaries.GetRuntimeFiles().Assemblies)

--- a/src/installer/tests/TestUtils/TestApp.cs
+++ b/src/installer/tests/TestUtils/TestApp.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             assetRelativePath = assetRelativePath ?? appName;
             TestApp app = CreateEmpty(appName);
             TestArtifact.CopyRecursive(
-                Path.Combine(RepoDirectoriesProvider.Default.TestAssetsOutput, assetRelativePath),
+                Path.Combine(TestContext.TestAssetsOutput, assetRelativePath),
                 app.Location);
             return app;
         }
@@ -110,18 +110,18 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public void PopulateSelfContained(MockedComponent mock, Action<NetCoreAppBuilder> customizer = null)
         {
-            var builder = NetCoreAppBuilder.ForNETCoreApp(Name, RepoDirectoriesProvider.Default.TargetRID);
+            var builder = NetCoreAppBuilder.ForNETCoreApp(Name, TestContext.TargetRID);
 
             // Update the .runtimeconfig.json - add included framework and remove any existing NETCoreApp framework
             builder.WithRuntimeConfig(c =>
-                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion)
+                c.WithIncludedFramework(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion)
                     .RemoveFramework(Constants.MicrosoftNETCoreApp));
 
             // Add main project assembly
             builder.WithProject(p => p.WithAssemblyGroup(null, g => g.WithMainAssembly()));
 
             // Add runtime libraries and assets
-            builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{RepoDirectoriesProvider.Default.TargetRID}", RepoDirectoriesProvider.Default.MicrosoftNETCoreAppVersion, l =>
+            builder.WithRuntimePack($"{Constants.MicrosoftNETCoreApp}.Runtime.{TestContext.TargetRID}", TestContext.MicrosoftNETCoreAppVersion, l =>
             {
                 if (mock == MockedComponent.None)
                 {

--- a/src/installer/tests/TestUtils/TestArtifact.cs
+++ b/src/installer/tests/TestUtils/TestArtifact.cs
@@ -12,21 +12,11 @@ namespace Microsoft.DotNet.CoreSetup.Test
 {
     public class TestArtifact : IDisposable
     {
-        private static readonly Lazy<RepoDirectoriesProvider> _repoDirectoriesProvider =
-            new Lazy<RepoDirectoriesProvider>(() => new RepoDirectoriesProvider());
-
         private static readonly Lazy<bool> _preserveTestRuns = new Lazy<bool>(() =>
-            _repoDirectoriesProvider.Value.GetTestContextVariableOrNull("PRESERVE_TEST_RUNS") == "1");
-
-        private static readonly string TestArtifactDirectoryEnvironmentVariable = "TEST_ARTIFACTS";
-        private static readonly Lazy<string> _testArtifactsPath = new Lazy<string>(() =>
-        {
-            return _repoDirectoriesProvider.Value.GetTestContextVariable(TestArtifactDirectoryEnvironmentVariable)
-                   ?? Path.Combine(AppContext.BaseDirectory, TestArtifactDirectoryEnvironmentVariable);
-        }, isThreadSafe: true);
+            TestContext.GetTestContextVariableOrNull("PRESERVE_TEST_RUNS") == "1");
 
         public static bool PreserveTestRuns() => _preserveTestRuns.Value;
-        public static string TestArtifactsPath => _testArtifactsPath.Value;
+        public static string TestArtifactsPath => TestContext.TestArtifactsPath;
 
         public string Location { get; }
         public string Name { get; }

--- a/src/installer/tests/TestUtils/TestContext.cs
+++ b/src/installer/tests/TestUtils/TestContext.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+
+namespace Microsoft.DotNet.CoreSetup.Test
+{
+    public sealed class TestContext
+    {
+        public static string BuildArchitecture { get; }
+        public static string BuildRID { get; }
+        public static string Configuration { get; }
+        public static string TargetRID { get; }
+
+        public static string MicrosoftNETCoreAppVersion { get; }
+        public static string Tfm { get; }
+
+        public static string TestAssetsOutput { get; }
+        public static string TestArtifactsPath { get; }
+
+        public static string BuiltDotNet { get; }
+
+        private static string _testContextVariableFilePath { get; }
+        private static ImmutableDictionary<string, string> _testContextVariables { get; }
+
+        static TestContext()
+        {
+            _testContextVariableFilePath = Path.Combine(
+                Directory.GetCurrentDirectory(),
+                "TestContextVariables.txt");
+
+            _testContextVariables = File.ReadAllLines(_testContextVariableFilePath)
+                .ToImmutableDictionary(
+                    line => line.Substring(0, line.IndexOf('=')),
+                    line => line.Substring(line.IndexOf('=') + 1),
+                    StringComparer.OrdinalIgnoreCase);
+
+            BuildArchitecture = GetTestContextVariable("BUILD_ARCHITECTURE");
+            BuildRID = GetTestContextVariable("BUILDRID");
+            Configuration = GetTestContextVariable("BUILD_CONFIGURATION");
+            TargetRID = GetTestContextVariable("TEST_TARGETRID");
+
+            MicrosoftNETCoreAppVersion = GetTestContextVariable("MNA_VERSION");
+            Tfm = GetTestContextVariable("MNA_TFM");
+
+            TestAssetsOutput = GetTestContextVariable("TEST_ASSETS_OUTPUT");
+            TestArtifactsPath = GetTestContextVariable("TEST_ARTIFACTS");
+
+            BuiltDotNet = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
+        }
+
+        public static string GetTestContextVariable(string name)
+        {
+            return GetTestContextVariableOrNull(name) ?? throw new ArgumentException(
+                $"Unable to find variable '{name}' in test context variable file '{_testContextVariableFilePath}'");
+        }
+
+        public static string GetTestContextVariableOrNull(string name)
+        {
+            // Allow env var override, although normally the test context variables file is used.
+            // Don't accept NUGET_PACKAGES env override specifically: Arcade sets this and it leaks
+            // in during build.cmd/sh runs, replacing the test-specific dir.
+            if (!name.Equals("NUGET_PACKAGES", StringComparison.OrdinalIgnoreCase))
+            {
+                if (Environment.GetEnvironmentVariable(name) is string envValue)
+                {
+                    return envValue;
+                }
+            }
+
+            if (_testContextVariables.TryGetValue(name, out string value))
+            {
+                return value;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -37,10 +37,10 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             RepoDirProvider = repoDirectoriesProvider;
 
-            Framework = framework ?? RepoDirProvider.Tfm;
+            Framework = framework ?? TestContext.Tfm;
 
             SdkDotnet = new DotNetCli(repoDirectoriesProvider.DotnetSDK);
-            CurrentRid = repoDirectoriesProvider.TargetRID;
+            CurrentRid = TestContext.TargetRID;
 
             BuiltDotnet = new DotNetCli(repoDirectoriesProvider.BuiltDotnet);
 
@@ -165,7 +165,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 buildArgs.Add(framework);
             }
 
-            buildArgs.Add($"/p:TestTargetRid={RepoDirProvider.TargetRID}");
+            buildArgs.Add($"/p:TestTargetRid={TestContext.TargetRID}");
             buildArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
 
             if (outputDirectory != null)
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 if (selfContained.Value && runtime == null)
                 {
                     publishArgs.Add("--runtime");
-                    publishArgs.Add(RepoDirProvider.TargetRID);
+                    publishArgs.Add(TestContext.TargetRID);
                 }
             }
 
@@ -329,7 +329,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 publishArgs.Add("/p:PublishSingleFile=true");
             }
 
-            publishArgs.Add($"/p:TestTargetRid={RepoDirProvider.TargetRID}");
+            publishArgs.Add($"/p:TestTargetRid={TestContext.TargetRID}");
             publishArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
 
             foreach (var arg in extraArgs)

--- a/src/installer/tests/TestUtils/TestProjectFixture.cs
+++ b/src/installer/tests/TestUtils/TestProjectFixture.cs
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
 
             buildArgs.Add($"/p:TestTargetRid={TestContext.TargetRID}");
-            buildArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
+            buildArgs.Add($"/p:MNAVersion={TestContext.MicrosoftNETCoreAppVersion}");
 
             if (outputDirectory != null)
             {
@@ -236,7 +236,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                 storeArgs.Add(outputDirectory);
             }
 
-            storeArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
+            storeArgs.Add($"/p:MNAVersion={TestContext.MicrosoftNETCoreAppVersion}");
             storeArgs.Add($"/p:NetCoreAppCurrent={Framework}");
 
             // Ensure the project's OutputType isn't 'Exe', since that causes issues with 'dotnet store'
@@ -330,7 +330,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
 
             publishArgs.Add($"/p:TestTargetRid={TestContext.TargetRID}");
-            publishArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
+            publishArgs.Add($"/p:MNAVersion={TestContext.MicrosoftNETCoreAppVersion}");
 
             foreach (var arg in extraArgs)
             {
@@ -360,7 +360,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             }
             restoreArgs.Add("--disable-parallel");
 
-            restoreArgs.Add($"/p:MNAVersion={RepoDirProvider.MicrosoftNETCoreAppVersion}");
+            restoreArgs.Add($"/p:MNAVersion={TestContext.MicrosoftNETCoreAppVersion}");
             restoreArgs.Add($"/p:NetCoreAppCurrent={Framework}");
 
             if (extraMSBuildProperties != null)


### PR DESCRIPTION
Trying to make the separation between how we get assorted configuration/paths in tests clearer:
- `TestContext`
  - values read from the test context file generated by build - should be able to stay the same when we try to run things in helix
- `RepoDirectoriesProvider`
  - values dependent on the repo layout - will need to be re-worked for moving to helix
  - values only needed for building with the SDK during test run - should go away once tests move to pre-built assets.