### PR TITLE
Fixes for Bionic on x64

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -34,6 +34,7 @@ The .NET Foundation licenses this file to you under the MIT license.
 
       <CrossCompileRid />
       <CrossCompileRid Condition="!$(RuntimeIdentifier.EndsWith('-$(_hostArchitecture)'))">$(RuntimeIdentifier)</CrossCompileRid>
+      <CrossCompileRid Condition="'$(CrossCompileRid)' == '' and '$(_linuxLibcFlavor)' == 'bionic'">$(RuntimeIdentifier)</CrossCompileRid>
 
       <CrossCompileArch />
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-x64'))">x86_64</CrossCompileArch>

--- a/src/coreclr/nativeaot/Runtime/amd64/InteropThunksHelpers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/InteropThunksHelpers.S
@@ -14,7 +14,11 @@ LEAF_ENTRY RhCommonStub, _TEXT
     alloc_stack    SIZEOF_FP_REGS
     SAVE_FLOAT_ARGUMENT_REGISTERS 0
 
+#ifdef FEATURE_EMULATED_TLS
+    call    C_FUNC(RhpGetThunkData)
+#else
     INLINE_GET_TLS_VAR  tls_thunkData
+#endif
 
     RESTORE_FLOAT_ARGUMENT_REGISTERS 0
     free_stack    SIZEOF_FP_REGS
@@ -36,6 +40,7 @@ LEAF_ENTRY RhGetCommonStubAddress, _TEXT
 LEAF_END RhGetCommonStubAddress, _TEXT
 
 
+#ifndef FEATURE_EMULATED_TLS
 LEAF_ENTRY RhGetCurrentThunkContext, _TEXT
 
     INLINE_GET_TLS_VAR  tls_thunkData
@@ -43,3 +48,4 @@ LEAF_ENTRY RhGetCurrentThunkContext, _TEXT
     mov    rax, qword ptr [rax]
     ret
 LEAF_END RhGetCurrentThunkContext, _TEXT
+#endif //FEATURE_EMULATED_TLS

--- a/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
+++ b/src/coreclr/nativeaot/Runtime/unix/unixasmmacrosamd64.inc
@@ -300,8 +300,12 @@ C_FUNC(\Name):
 
 
 .macro INLINE_GETTHREAD
+#ifdef FEATURE_EMULATED_TLS
+        call        C_FUNC(RhpGetThread)
+#else
         // Inlined version of call C_FUNC(RhpGetThread)
         INLINE_GET_TLS_VAR tls_CurrentThread
+#endif
 .endm
 
 .macro INLINE_THREAD_UNHIJACK threadReg, trashReg1, trashReg2


### PR DESCRIPTION
Fixes #93942. Works around #95223 (a better but more risky fix is in #95312, so I'm not going to resolve that with this PR).

The first issue is that we don't consider x64 Windows (or x64 Linux) to x64 Bionic build a crossbuild. The crossbuild detection only looks at architecture, not at the OS. The fix is very conservative so that we can backport to 8.0. Bionic is always a crossbuild.

The second part is a port of https://github.com/dotnet/corert/pull/8323 to x64. It is a lot less work than on arm64 because x64 Linux already has to assume `INLINE_GETTHREAD` could be a call so everything is setup for it.

I tested this all on a x64 Bionic hello world. I also ran all of smoke tests on x64 Linux with `FEATURE_EMULATED_TLS` enabled. All of this looks very non-risky so I'm going to ask for a backport.

Cc @dotnet/ilc-contrib 