### PR TITLE
Disable CertificateValidationClientServer_EndToEnd_Ok in Windows NativeAoT

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -112,10 +112,13 @@ namespace System.Net.Security.Tests
             CertificateContext
         }
 
+        public static bool IsWindowsAOT => PlatformDetection.IsWindows && PlatformDetection.IsNativeAot;
+
         [Theory]
         [InlineData(ClientCertSource.ClientCertificate)]
         [InlineData(ClientCertSource.SelectionCallback)]
         [InlineData(ClientCertSource.CertificateContext)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88832", typeof(CertificateValidationClientServer), nameof(IsWindowsAOT))]
         public async Task CertificateValidationClientServer_EndToEnd_Ok(ClientCertSource clientCertSource)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);


### PR DESCRIPTION
Contributes to #88832.