### PR TITLE
Disable System.Net.Quic.Tests.MsQuicTests.ByteMixingOrNativeAVE_MinimalFailingTest on WinSrv2022

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -728,7 +728,7 @@ namespace System.Net.Quic.Tests
 
             // Open one stream, second call should block
             await using var stream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Unidirectional);
-            await stream.WriteAsync(new byte[64*1024], completeWrites: true);
+            await stream.WriteAsync(new byte[64 * 1024], completeWrites: true);
             await Assert.ThrowsAsync<TimeoutException>(() => clientConnection.OpenOutboundStreamAsync(QuicStreamType.Unidirectional).AsTask().WaitAsync(TimeSpan.FromSeconds(1)));
 
             await clientConnection.DisposeAsync();
@@ -1056,6 +1056,7 @@ namespace System.Net.Quic.Tests
 
         [Fact]
         [OuterLoop("May take several seconds")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/85331", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrLower)]
         public async Task ByteMixingOrNativeAVE_MinimalFailingTest()
         {
             const int writeSize = 64 * 1024;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -1056,7 +1056,7 @@ namespace System.Net.Quic.Tests
 
         [Fact]
         [OuterLoop("May take several seconds")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/85331", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrLower)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/85331", typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version20348OrLower))]
         public async Task ByteMixingOrNativeAVE_MinimalFailingTest()
         {
             const int writeSize = 64 * 1024;


### PR DESCRIPTION
Contributes to #85331.