### PR TITLE
JIT: Enable jump-to-next removal optimization in MinOpts

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -298,9 +298,9 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 bool BasicBlock::CanRemoveJumpToNext(Compiler* compiler)
 {
     assert(KindIs(BBJ_ALWAYS));
-    const bool tryJumpOpt = compiler->opts.OptimizationEnabled() || ((bbFlags & BBF_NONE_QUIRK) != 0);
-    const bool skipJump   = tryJumpOpt && JumpsToNext() && !hasAlign() && ((bbFlags & BBF_KEEP_BBJ_ALWAYS) == 0) &&
-                          !compiler->fgInDifferentRegions(this, bbJumpDest);
+    const bool tryJumpOpt = !compiler->opts.compDbgCode || ((bbFlags & BBF_NONE_QUIRK) != 0);
+    const bool skipJump =
+        tryJumpOpt && JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest);
     return skipJump;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -297,7 +297,7 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 bool BasicBlock::CanRemoveJumpToNext(Compiler* compiler)
 {
     assert(KindIs(BBJ_ALWAYS));
-    return (JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest));
+    return JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -292,16 +292,12 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 //    compiler - current compiler instance
 //
 // Returns:
-//    true if the peephole optimization is enabled,
-//    and block is a BBJ_ALWAYS to the next block that we can fall through into
+//    true if block is a BBJ_ALWAYS to the next block that we can fall into
 //
 bool BasicBlock::CanRemoveJumpToNext(Compiler* compiler)
 {
     assert(KindIs(BBJ_ALWAYS));
-    const bool tryJumpOpt = !compiler->opts.compDbgCode || ((bbFlags & BBF_NONE_QUIRK) != 0);
-    const bool skipJump =
-        tryJumpOpt && JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest);
-    return skipJump;
+    return (JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -731,9 +731,7 @@ void CodeGen::genCodeForBBlist()
 
             case BBJ_ALWAYS:
             {
-                // Peephole optimization: If this block jumps to the next one, skip emitting the jump
-                // (unless we are jumping between hot/cold sections, or if we need the jump for EH reasons)
-                // (Skip this if optimizations are disabled, unless the block shouldn't have a jump in the first place)
+                // If this block jumps to the next one, we might be able to skip emitting the jump
                 if (block->CanRemoveJumpToNext(compiler))
                 {
 #ifdef TARGET_AMD64


### PR DESCRIPTION
Follow-up to #94239. In non-debug MinOpts scenarios, we should remove branches to the next block regardless of whether `BBF_NONE_QUIRK` is set; this should yield modest code size and TP improvements.

(Also, the emitter-level optimization tries to remove jumps to the next block regardless of `BBF_KEEP_BBJ_ALWAYS` being set. Removing this requirement from the block-level optimization doesn't seem to affect correctness.)