### PR TITLE
[release/8.0] Downgrade ServicingVersion for Microsoft.Extensions.Options to 1

### DIFF
--- a/src/libraries/Microsoft.Extensions.Options/src/Microsoft.Extensions.Options.csproj
+++ b/src/libraries/Microsoft.Extensions.Options/src/Microsoft.Extensions.Options.csproj
@@ -5,7 +5,7 @@
     <EnableDefaultItems>true</EnableDefaultItems>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>2</ServicingVersion>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides a strongly typed way of specifying and accessing settings using dependency injection.</PackageDescription>
   </PropertyGroup>
 


### PR DESCRIPTION
We submitted two fixes in two months but we have yet to release the first servicing release, so both fixes need to get merged into the same servicing version.