### PR TITLE
Fix FormatException message argument

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -1547,7 +1547,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             result.flags |= ParseFlags.YearDefault;
         }
 
-        // Processing teriminal case: DS.DX_NN
+        // Processing terminal case: DS.DX_NN
         private static bool GetDayOfNN(ref DateTimeResult result, scoped ref DateTimeStyles styles, scoped ref DateTimeRawInfo raw, DateTimeFormatInfo dtfi)
         {
             if ((result.flags & ParseFlags.HaveDate) != 0)
@@ -1589,7 +1589,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
             return false;
         }
 
-        // Processing teriminal case: DS.DX_NNN
+        // Processing terminal case: DS.DX_NNN
         private static bool GetDayOfNNN(ref DateTimeResult result, scoped ref DateTimeRawInfo raw, DateTimeFormatInfo dtfi)
         {
             if ((result.flags & ParseFlags.HaveDate) != 0)
@@ -5183,7 +5183,7 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
                 case ParseFailureKind.Format_BadDatePattern:
                     return new FormatException(SR.Format(SR.Format_BadDatePattern, result.failureMessageFormatArgument));
                 case ParseFailureKind.Format_BadDateTime:
-                    return new FormatException(SR.Format(SR.Format_BadDateTime, result.failureMessageFormatArgument));
+                    return new FormatException(SR.Format(SR.Format_BadDateTime, new string(result.originalDateTimeString)));
                 case ParseFailureKind.Format_BadDateTimeCalendar:
                     return new FormatException(SR.Format(SR.Format_BadDateTimeCalendar, new string(result.originalDateTimeString), result.calendar));
                 case ParseFailureKind.Format_BadDayOfWeek:
@@ -6124,7 +6124,6 @@ new DS[] { DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR, 
         internal void SetBadDateTimeFailure()
         {
             this.failure = ParseFailureKind.Format_BadDateTime;
-            this.failureMessageFormatArgument = null;
         }
 
         internal void SetFailure(ParseFailureKind failure)

--- a/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
@@ -114,7 +114,7 @@ namespace System.Tests
             var date = new DateOnly(year, month, day);
             var time = new TimeOnly(hour, minute, second, millisecond);
             var dateTime = new DateTime(date, time);
-            
+
             Assert.Equal(new DateTime(year, month, day, hour, minute, second, millisecond), dateTime);
         }
 
@@ -125,7 +125,7 @@ namespace System.Tests
             var date = new DateOnly(year, month, day);
             var time = new TimeOnly(hour, minute, second, millisecond);
             var dateTime = new DateTime(date, time, DateTimeKind.Local);
-            
+
             Assert.Equal(new DateTime(year, month, day, hour, minute, second, millisecond, DateTimeKind.Local), dateTime);
         }
 
@@ -2983,6 +2983,13 @@ namespace System.Tests
                     }
                 break;
             }
+        }
+
+        [Fact]
+        public void TestBadFormatException()
+        {
+            FormatException ex = Assert.Throws<FormatException>(() => DateTime.ParseExact("11.2023", "dd.mm.yyyy", System.Globalization.CultureInfo.InvariantCulture));
+            Assert.Contains("11.2023", ex.Message, StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95331

https://github.com/dotnet/runtime/pull/82947

## Customer Impact

When encountering a failure in parsing a date string, the exception message will lack a crucial section containing the original date string being parsed. This omission complicates the diagnosis of the failure, making it challenging to discern the underlying reason. This issue has surfaced as a recent regression in .NET 8.0 and has been reported three times within a short period.

## Testing
Passed the regression tests and added more tests to cover the failing cases.

## Risk
Low, the modification solely impacts the parameter of the exception message and does not alter any other aspects of the logic
