### PR TITLE
Revert "Pin the Alpine Arm32 image to previous tag (#94683)"

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -86,9 +86,9 @@ jobs:
     # Linux musl arm32
     - ${{ if eq(parameters.platform, 'linux_musl_arm') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Alpine.315.Arm32.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-arm32v7-20230807201723-7ea784e
+        - (Alpine.315.Arm32.Open)Ubuntu.1804.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-arm32v7
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Alpine.315.Arm32)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-arm32v7-20230807201723-7ea784e
+        - (Alpine.315.Arm32)Ubuntu.1804.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.15-helix-arm32v7
 
     # Linux musl arm64
     - ${{ if eq(parameters.platform, 'linux_musl_arm64') }}:


### PR DESCRIPTION
This reverts commit 46c8a668eb4bbc66d9eb988d2988ecc84074be10.

Enabling the rolling Alpine Arm32 image back, as the problem was mitigated in a different way in https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/933

Contributes to https://github.com/dotnet/runtime/issues/91757, https://github.com/dotnet/dnceng/issues/1423

I will backport this to release/8.0-staging as soon as it will be merged.

cc @wfurt @carlossanlop @dougbu FYI