### PR TITLE
Upgrade superpmi benchmarks to 9.0

### DIFF
--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -76,45 +76,45 @@ extends:
           jobParameters:
             testGroup: outerloop
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: ci
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: outerloop
-            liveLibrariesBuildConfig: Release
-            collectionType: pmi
-            collectionName: libraries
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_arm64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: ci
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: outerloop
+      #       liveLibrariesBuildConfig: Release
+      #       collectionType: pmi
+      #       collectionName: libraries
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: ci
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: outerloop
-            liveLibrariesBuildConfig: Release
-            collectionType: crossgen2
-            collectionName: libraries
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_arm64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: ci
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: outerloop
+      #       liveLibrariesBuildConfig: Release
+      #       collectionType: crossgen2
+      #       collectionName: libraries
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -196,95 +196,95 @@ extends:
             collectionType: run_pgo
             collectionName: benchmarks
 
-      #
-      # Collection of coreclr test run
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-          buildConfig: checked
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: superpmi
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: outerloop
-            liveLibrariesBuildConfig: Release
-            SuperPmiCollect: true
+      # #
+      # # Collection of coreclr test run
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - osx_arm64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: superpmi
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: outerloop
+      #       liveLibrariesBuildConfig: Release
+      #       SuperPmiCollect: true
 
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-          buildConfig: checked
-          platforms:
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_arm64
-          helixQueueGroup: ci
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testGroup: outerloop
-            liveLibrariesBuildConfig: Release
-            collectionType: nativeaot
-            collectionName: smoke_tests
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+      #     buildConfig: checked
+      #     platforms:
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_arm64
+      #     helixQueueGroup: ci
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testGroup: outerloop
+      #       liveLibrariesBuildConfig: Release
+      #       collectionType: nativeaot
+      #       collectionName: smoke_tests
 
-      #
-      # Collection of libraries test run: normal
-      # Libraries Test Run using Release libraries, and Checked CoreCLR
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: superpmi
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            dependsOnTestBuildConfiguration: Release
-            dependsOnTestArchitecture: x64
-            coreclrTestGroup: superpmi_collection
-            SuperPmiCollect: true
-            SuperPmiCollectionName: libraries_tests
+      # #
+      # # Collection of libraries test run: normal
+      # # Libraries Test Run using Release libraries, and Checked CoreCLR
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - osx_arm64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: superpmi
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: checked
+      #       dependsOnTestBuildConfiguration: Release
+      #       dependsOnTestArchitecture: x64
+      #       coreclrTestGroup: superpmi_collection
+      #       SuperPmiCollect: true
+      #       SuperPmiCollectionName: libraries_tests
 
-      #
-      # Collection of libraries test run: no_tiered_compilation
-      # Libraries Test Run using Release libraries, and Checked CoreCLR
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-          buildConfig: Release
-          platforms:
-          - osx_arm64
-          - linux_arm
-          - linux_arm64
-          - linux_x64
-          - windows_x64
-          - windows_x86
-          - windows_arm64
-          helixQueueGroup: superpmi
-          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-          jobParameters:
-            testScope: innerloop
-            liveRuntimeBuildConfig: checked
-            dependsOnTestBuildConfiguration: Release
-            dependsOnTestArchitecture: x64
-            coreclrTestGroup: superpmi_collection_no_tiered_compilation
-            SuperPmiCollect: true
-            SuperPmiCollectionName: libraries_tests_no_tiered_compilation
+      # #
+      # # Collection of libraries test run: no_tiered_compilation
+      # # Libraries Test Run using Release libraries, and Checked CoreCLR
+      # #
+      # - template: /eng/pipelines/common/platform-matrix.yml
+      #   parameters:
+      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+      #     buildConfig: Release
+      #     platforms:
+      #     - osx_arm64
+      #     - linux_arm
+      #     - linux_arm64
+      #     - linux_x64
+      #     - windows_x64
+      #     - windows_x86
+      #     - windows_arm64
+      #     helixQueueGroup: superpmi
+      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+      #     jobParameters:
+      #       testScope: innerloop
+      #       liveRuntimeBuildConfig: checked
+      #       dependsOnTestBuildConfiguration: Release
+      #       dependsOnTestArchitecture: x64
+      #       coreclrTestGroup: superpmi_collection_no_tiered_compilation
+      #       SuperPmiCollect: true
+      #       SuperPmiCollectionName: libraries_tests_no_tiered_compilation

--- a/eng/pipelines/coreclr/superpmi-collect.yml
+++ b/eng/pipelines/coreclr/superpmi-collect.yml
@@ -76,45 +76,45 @@ extends:
           jobParameters:
             testGroup: outerloop
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_arm64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: ci
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: outerloop
-      #       liveLibrariesBuildConfig: Release
-      #       collectionType: pmi
-      #       collectionName: libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_arm64
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: ci
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: outerloop
+            liveLibrariesBuildConfig: Release
+            collectionType: pmi
+            collectionName: libraries
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_arm64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: ci
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: outerloop
-      #       liveLibrariesBuildConfig: Release
-      #       collectionType: crossgen2
-      #       collectionName: libraries
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_arm64
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: ci
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: outerloop
+            liveLibrariesBuildConfig: Release
+            collectionType: crossgen2
+            collectionName: libraries
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -196,95 +196,95 @@ extends:
             collectionType: run_pgo
             collectionName: benchmarks
 
-      # #
-      # # Collection of coreclr test run
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - osx_arm64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: superpmi
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: outerloop
-      #       liveLibrariesBuildConfig: Release
-      #       SuperPmiCollect: true
+      #
+      # Collection of coreclr test run
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          buildConfig: checked
+          platforms:
+          - osx_arm64
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: superpmi
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: outerloop
+            liveLibrariesBuildConfig: Release
+            SuperPmiCollect: true
 
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
-      #     buildConfig: checked
-      #     platforms:
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_arm64
-      #     helixQueueGroup: ci
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testGroup: outerloop
-      #       liveLibrariesBuildConfig: Release
-      #       collectionType: nativeaot
-      #       collectionName: smoke_tests
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/superpmi-collect-job.yml
+          buildConfig: checked
+          platforms:
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_arm64
+          helixQueueGroup: ci
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testGroup: outerloop
+            liveLibrariesBuildConfig: Release
+            collectionType: nativeaot
+            collectionName: smoke_tests
 
-      # #
-      # # Collection of libraries test run: normal
-      # # Libraries Test Run using Release libraries, and Checked CoreCLR
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-      #     buildConfig: Release
-      #     platforms:
-      #     - osx_arm64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: superpmi
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testScope: innerloop
-      #       liveRuntimeBuildConfig: checked
-      #       dependsOnTestBuildConfiguration: Release
-      #       dependsOnTestArchitecture: x64
-      #       coreclrTestGroup: superpmi_collection
-      #       SuperPmiCollect: true
-      #       SuperPmiCollectionName: libraries_tests
+      #
+      # Collection of libraries test run: normal
+      # Libraries Test Run using Release libraries, and Checked CoreCLR
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+          buildConfig: Release
+          platforms:
+          - osx_arm64
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: superpmi
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testScope: innerloop
+            liveRuntimeBuildConfig: checked
+            dependsOnTestBuildConfiguration: Release
+            dependsOnTestArchitecture: x64
+            coreclrTestGroup: superpmi_collection
+            SuperPmiCollect: true
+            SuperPmiCollectionName: libraries_tests
 
-      # #
-      # # Collection of libraries test run: no_tiered_compilation
-      # # Libraries Test Run using Release libraries, and Checked CoreCLR
-      # #
-      # - template: /eng/pipelines/common/platform-matrix.yml
-      #   parameters:
-      #     jobTemplate: /eng/pipelines/libraries/run-test-job.yml
-      #     buildConfig: Release
-      #     platforms:
-      #     - osx_arm64
-      #     - linux_arm
-      #     - linux_arm64
-      #     - linux_x64
-      #     - windows_x64
-      #     - windows_x86
-      #     - windows_arm64
-      #     helixQueueGroup: superpmi
-      #     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-      #     jobParameters:
-      #       testScope: innerloop
-      #       liveRuntimeBuildConfig: checked
-      #       dependsOnTestBuildConfiguration: Release
-      #       dependsOnTestArchitecture: x64
-      #       coreclrTestGroup: superpmi_collection_no_tiered_compilation
-      #       SuperPmiCollect: true
-      #       SuperPmiCollectionName: libraries_tests_no_tiered_compilation
+      #
+      # Collection of libraries test run: no_tiered_compilation
+      # Libraries Test Run using Release libraries, and Checked CoreCLR
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+          buildConfig: Release
+          platforms:
+          - osx_arm64
+          - linux_arm
+          - linux_arm64
+          - linux_x64
+          - windows_x64
+          - windows_x86
+          - windows_arm64
+          helixQueueGroup: superpmi
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobParameters:
+            testScope: innerloop
+            liveRuntimeBuildConfig: checked
+            dependsOnTestBuildConfiguration: Release
+            dependsOnTestArchitecture: x64
+            coreclrTestGroup: superpmi_collection_no_tiered_compilation
+            SuperPmiCollect: true
+            SuperPmiCollectionName: libraries_tests_no_tiered_compilation

--- a/src/coreclr/scripts/superpmi_aspnet.py
+++ b/src/coreclr/scripts/superpmi_aspnet.py
@@ -230,7 +230,7 @@ def build_and_run(coreclr_args):
             crank_arguments = ["--config", configFile,
                                "--profile", benchmark_machine,
                                "--scenario", scenario,
-                               "--application.framework", "net8.0",
+                               "--application.framework", "net9.0",
                                "--application.channel", "edge",
                                "--application.sdkVersion", "latest",
                                "--application.environmentVariables", "DOTNET_JitName=" + spminame,

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -203,7 +203,7 @@ def build_and_run(coreclr_args, output_mch_name):
 
     run_command(
         [dotnet_exe, "build", project_file, "--configuration", "Release",
-         "--framework", "net8.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
+         "--framework", "net9.0", "--no-restore", "/p:NuGetPackageRoot=" + artifacts_packages_directory,
          "-o", artifacts_directory], _exit_on_fail=True)
 
     # This is specifically for PowerShell.Benchmarks.

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -405,7 +405,7 @@ def setup_benchmark(workitem_directory, arch):
         # have not published yet. As a result, we hit errors of "dotnet restore". As a workaround, hard code the
         # working version until we move to ".NET 8" in the script.
         run_command(
-            get_python_name() + [dotnet_install_script, "install", "--channels", "8.0-preview", "--architecture", arch, "--install-dir",
+            get_python_name() + [dotnet_install_script, "install", "--channels", "9.0", "--architecture", arch, "--install-dir",
                                  dotnet_directory, "--verbose"])
 
 


### PR DESCRIPTION
Benchmarks got updated to net9.0 in https://github.com/dotnet/performance/pull/3504 and https://github.com/dotnet/performance/pull/3511, so updated superpmi scripts to build against net9.0

Successful run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2324955&view=results