### PR TITLE
[wasi] Bundle `runtimeconfig` in the single file bundle

### DIFF
--- a/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/WasiTemplateTests.cs
@@ -81,40 +81,89 @@ public class WasiTemplateTests : BuildTestBase
                         UseCache: false));
     }
 
-    public static TheoryData<string, bool, bool> TestDataForConsolePublishAndRun()
+    public static TheoryData<string, bool> TestDataForConsolePublishAndRunForSingleFileBundle(bool propertyValue)
     {
-        var data = new TheoryData<string, bool, bool>();
-        data.Add("Debug", false, false);
-        data.Add("Debug", true, true);
-        data.Add("Release", false, false); // Release relinks by default
+        var data = new TheoryData<string, bool>();
+        data.Add("Debug", propertyValue);
+        data.Add("Release", propertyValue);
         return data;
     }
 
     [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
-    [MemberData(nameof(TestDataForConsolePublishAndRun))]
-    public void ConsolePublishAndRunForSingleFileBundle(string config, bool relinking, bool invariantTimezone)
+    [MemberData(nameof(TestDataForConsolePublishAndRunForSingleFileBundle), parameters: false)]
+    [MemberData(nameof(TestDataForConsolePublishAndRunForSingleFileBundle), parameters: true)]
+    public void ConsolePublishAndRunForSingleFileBundle_InvariantTimeZone(string config, bool invariantTimezone)
     {
+        string mainWithTzTest = """
+            using System;
+
+            Console.WriteLine("Hello, Wasi Console!");
+            for (int i = 0; i < args.Length; i ++)
+                Console.WriteLine($"args[{i}] = {args[i]}");
+
+            try
+            {
+                TimeZoneInfo tst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
+                Console.WriteLine($"{tst.DisplayName} BaseUtcOffset is {tst.BaseUtcOffset}");
+            }
+            catch (TimeZoneNotFoundException tznfe)
+            {
+                Console.WriteLine($"Could not find Asia/Tokyo: {tznfe.Message}");
+            }
+
+            return 42;
+            """;
+
+        string extraProperties = invariantTimezone ? "<InvariantTimezone>true</InvariantTimezone>" : "";
+        CommandResult res = ConsolePublishAndRunForSingleFileBundleInternal(config, mainWithTzTest, extraProperties: extraProperties);
+        if(invariantTimezone)
+            Assert.Contains("Could not find Asia/Tokyo", res.Output);
+        else
+            Assert.Contains("Asia/Tokyo BaseUtcOffset is 09:00:00", res.Output);
+    }
+
+    [ConditionalTheory(typeof(BuildTestBase), nameof(IsUsingWorkloads))]
+    [MemberData(nameof(TestDataForConsolePublishAndRunForSingleFileBundle), parameters: false)]
+    [MemberData(nameof(TestDataForConsolePublishAndRunForSingleFileBundle), parameters: true)]
+    public void ConsolePublishAndRunForSingleFileBundle_InvariantGlobalization(string config, bool invariantGlobalization)
+    {
+        string mainWithGlobalizationTest = """
+            using System;
+            using System.Globalization;
+
+            Console.WriteLine("Hello, Wasi Console!");
+            for (int i = 0; i < args.Length; i ++)
+                Console.WriteLine($"args[{i}] = {args[i]}");
+
+            Console.WriteLine($"Number: {int.Parse("1", CultureInfo.InvariantCulture)}");
+            return 42;
+            """;
+
+        string extraProperties = invariantGlobalization ? "<InvariantGlobalization>true</InvariantGlobalization>" : "";
+        CommandResult res = ConsolePublishAndRunForSingleFileBundleInternal(config, mainWithGlobalizationTest, extraProperties: extraProperties);
+        Assert.Contains("Number: 1", res.Output);
+    }
+
+    private CommandResult ConsolePublishAndRunForSingleFileBundleInternal(string config, string programContents, string extraProperties = "", bool aot = false)
+    {
+        if (programContents.Length == 0)
+            throw new ArgumentException("Cannot be empty", nameof(programContents));
+
         string id = $"{config}_{GetRandomId()}";
         string projectFile = CreateWasmTemplateProject(id, "wasiconsole");
         string projectName = Path.GetFileNameWithoutExtension(projectFile);
-        File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), s_simpleMainWithArgs);
+        File.WriteAllText(Path.Combine(_projectDir!, "Program.cs"), programContents);
 
-        string extraProperties = "<WasmSingleFileBundle>true</WasmSingleFileBundle>";
-        if (relinking)
-            extraProperties += "<WasmBuildNative>true</WasmBuildNative>";
-        if (invariantTimezone)
-            extraProperties += "<InvariantTimezone>true</InvariantTimezone>";
-
+        extraProperties += "<WasmSingleFileBundle>true</WasmSingleFileBundle>";
         AddItemsPropertiesToProject(projectFile, extraProperties);
 
-        var buildArgs = new BuildArgs(projectName, config, /*aot*/false, id, null);
+        var buildArgs = new BuildArgs(projectName, config, aot, id, null);
         buildArgs = ExpandBuildArgs(buildArgs);
 
-        bool expectRelinking = config == "Release" || relinking;
         BuildProject(buildArgs,
                     id: id,
                     new BuildProjectOptions(
-                        DotnetWasmFromRuntimePack: !expectRelinking,
+                        DotnetWasmFromRuntimePack: false, // singlefilebundle will always relink
                         CreateProject: false,
                         Publish: true,
                         TargetFramework: BuildTestBase.DefaultTargetFramework,
@@ -133,15 +182,8 @@ public class WasiTemplateTests : BuildTestBase
         Assert.Contains("args[0] = x", res.Output);
         Assert.Contains("args[1] = y", res.Output);
         Assert.Contains("args[2] = z", res.Output);
-        if(invariantTimezone)
-        {
-            Assert.Contains("Could not find Asia/Tokyo", res.Output);
-        }
-        else
-        {
-            Assert.Contains("Asia/Tokyo BaseUtcOffset is 09:00:00", res.Output);
-        }
 
+        return res;
     }
 
     [Theory]
@@ -187,20 +229,11 @@ public class WasiTemplateTests : BuildTestBase
 
     private static readonly string s_simpleMainWithArgs = """
         using System;
+        using System.Globalization;
 
         Console.WriteLine("Hello, Wasi Console!");
         for (int i = 0; i < args.Length; i ++)
             Console.WriteLine($"args[{i}] = {args[i]}");
-
-        try
-        {
-            TimeZoneInfo tst = TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");
-            Console.WriteLine($"{tst.DisplayName} BaseUtcOffset is {tst.BaseUtcOffset}");
-        }
-        catch (TimeZoneNotFoundException tznfe)
-        {
-            Console.WriteLine($"Could not find Asia/Tokyo: {tznfe.Message}");
-        }
 
         return 42;
         """;

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -367,6 +367,7 @@
     <PropertyGroup>
       <_WasmAssembliesBundleObjectFile>wasi_bundled_assemblies.o</_WasmAssembliesBundleObjectFile>
       <_WasmIcuBundleObjectFile>wasi_bundled_icu.o</_WasmIcuBundleObjectFile>
+      <_WasmRuntimeConfigBundleFile>wasi_runtime_config_bin.o</_WasmRuntimeConfigBundleFile>
     </PropertyGroup>
     <!-- TODO make this incremental compilation -->
     <EmitBundleObjectFiles
@@ -403,13 +404,28 @@
     <ItemGroup Condition="'$(InvariantGlobalization)' != 'true'">
       <_WasiObjectFilesForBundle Include="$(_WasmIntermediateOutputPath)$(_WasmIcuBundleObjectFile)" />
       <_WasiObjectFilesForBundle Include="%(BundledWasmIcu.DestinationFile)" />
-    </ItemGroup>
 
-    <ItemGroup Condition="'$(InvariantGlobalization)' != 'true'">
       <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmIcuBundleObjectFile)" />
       <WasmBundleFileToDelete Remove="%(BundledWasmIcu.DestinationFile)" />
     </ItemGroup>
 
+    <!-- runtimeconfig.bin -->
+    <EmitBundleObjectFiles
+      FilesToBundle="$(_ParsedRuntimeConfigFilePath)"
+      ClangExecutable="$(WasiClang)"
+      BundleRegistrationFunctionName="mono_register_runtimeconfig_bin"
+      BundleFile="$(_WasmRuntimeConfigBundleFile)"
+      OutputDirectory="$(_WasmIntermediateOutputPath)">
+      <Output TaskParameter="BundledResources" ItemName="_BundledRuntimeConfigBin" />
+    </EmitBundleObjectFiles>
+
+    <ItemGroup>
+      <_WasiObjectFilesForBundle Include="$(_WasmIntermediateOutputPath)$(_WasmRuntimeConfigBundleFile)" />
+      <_WasiObjectFilesForBundle Include="%(_BundledRuntimeConfigBin.DestinationFile)" />
+
+      <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmRuntimeConfigBundleFile)" />
+      <WasmBundleFileToDelete Remove="%(_BundledRuntimeConfigBin.DestinationFile)" />
+    </ItemGroup>
     <Delete Files="@(WasmBundleFileToDelete)" />
   </Target>
 

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -184,7 +184,7 @@
       <!--<_WasiClangCommonFlags Include="-msimd128"                         Condition="'$(WasmEnableSIMD)' == 'true'" />-->
 
       <_WasmCommonCFlags Include="-DGEN_PINVOKE=1" />
-      <_WasmCommonCFlags Condition="'$(RunAOTCompilation)' == 'true'"      Include="-DENABLE_AOT=1" />
+      <_WasmCommonCFlags Condition="'$(_WasmShouldAOT)' == 'true'"         Include="-DENABLE_AOT=1" />
       <_WasmCommonCFlags Condition="'$(_DriverGenCNeeded)' == 'true'"      Include="-DDRIVER_GEN=1" />
       <_WasmCommonCFlags Condition="'$(WasmSingleFileBundle)' == 'true'"   Include="-DWASM_SINGLE_FILE=1" />
       <_WasmCommonCFlags Condition="'$(InvariantGlobalization)' == 'true'" Include="-DINVARIANT_GLOBALIZATION=1" />

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -334,7 +334,7 @@
     </RuntimeConfigParserTask>
 
     <ItemGroup>
-      <WasmFilesToIncludeInFileSystem Include="$(_ParsedRuntimeConfigFilePath)" />
+      <WasmFilesToIncludeInFileSystem Condition="'$(WasmSingleFileBundle)' != 'true'" Include="$(_ParsedRuntimeConfigFilePath)" />
     </ItemGroup>
   </Target>
 
@@ -352,7 +352,6 @@
     <ItemGroup Condition="'$(WasmBuildNative)' != 'true'">
       <!-- Add the default ones when we don't compile one -->
       <WasmNativeAsset Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)dotnet.wasm"/>
-      <WasmFilesToIncludeInFileSystem Include="@(WasmNativeAsset)" Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.js.symbols'" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(InvariantGlobalization)' != 'true' and '$(WasmSingleFileBundle)' != 'true'">

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -162,7 +162,8 @@
     <RunCommand Condition="'$(RunCommand)' == ''">dotnet</RunCommand>
 
     <_RuntimeConfigJsonPath>$([MSBuild]::NormalizePath($(_AppBundleDirForRunCommand), '$(AssemblyName).runtimeconfig.json'))</_RuntimeConfigJsonPath>
-    <RunArguments Condition="'$(RunArguments)' == ''">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(WasmHostArguments)</RunArguments>
+    <RunArguments Condition="'$(RunArguments)' == '' and '$(WasmSingleFileBundle)' != 'true'">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; --runtime-config &quot;$(_RuntimeConfigJsonPath)&quot; $(WasmHostArguments)</RunArguments>
+    <RunArguments Condition="'$(RunArguments)' == '' and '$(WasmSingleFileBundle)' == 'true'">exec &quot;$([MSBuild]::NormalizePath($(WasmAppHostDir), 'WasmAppHost.dll'))&quot; $(WasmHostArguments)</RunArguments>
     <RunWorkingDirectory Condition="'$(RunWorkingDirectory)' == ''">$(_AppBundleDirForRunCommand)</RunWorkingDirectory>
   </PropertyGroup>
 

--- a/src/mono/wasm/host/wasi/WasiEngineHost.cs
+++ b/src/mono/wasm/host/wasi/WasiEngineHost.cs
@@ -53,11 +53,11 @@ internal sealed class WasiEngineHost
         //                                        runtimeArguments: _args.CommonConfig.RuntimeArguments);
         // runArgsJson.Save(Path.Combine(_args.CommonConfig.AppPath, "runArgs.json"));
 
-        var args = new List<string>()
+        List<string> args = new() { "run" };
+
+        if (!_args.IsSingleFileBundle)
         {
-            "run",
-            "--dir",
-            "."
+            args.AddRange(["--dir", "."]);
         };
 
         args.AddRange(engineArgs);

--- a/src/tasks/WasmAppBuilder/wasi/WasiAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/wasi/WasiAppBuilder.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json.Nodes;
 using Microsoft.Build.Framework;
 
@@ -21,9 +22,21 @@ public class WasiAppBuilder : WasmAppBuilderBaseTask
             throw new LogAsErrorException($"{nameof(IcuDataFileNames)} property shouldn't be empty when {nameof(InvariantGlobalization)}=false");
 
         if (Assemblies.Length == 0 && !IsSingleFileBundle)
+            throw new LogAsErrorException("Cannot build Wasm app without any assemblies");
+
+        if (IsSingleFileBundle)
         {
-            Log.LogError("Cannot build Wasm app without any assemblies");
-            return false;
+            if (ExtraFilesToDeploy.Length > 0)
+            {
+                throw new LogAsErrorException($"$({nameof(ExtraFilesToDeploy)}) is not supported for single file bundles. " +
+                                              $"Value: {string.Join(",", ExtraFilesToDeploy.Select(e => e.GetMetadata("FullPath")))}");
+            }
+
+            if (FilesToIncludeInFileSystem.Length > 0)
+            {
+                throw new LogAsErrorException($"$({nameof(FilesToIncludeInFileSystem)}) is not supported for single file bundles. " +
+                                              $"Value: {string.Join(",", FilesToIncludeInFileSystem.Select(e => e.ItemSpec))}");
+            }
         }
 
         return true;


### PR DESCRIPTION
This removes the need for having access to a local filesystem for reading the runtimeconfig . Thus the app can be run with `wasmtime run foo.wasm`.

- [wasi] WasiAppBuilder: error out for single file bundles, if there ..
- [wasi] driver.c: bundle runtimeconfig.bin, and use that for the single file bundle case
- [wasi] Don't add '--dir' for single file bundles

Fixes https://github.com/dotnet/runtime/issues/94407 .