### PR TITLE
JIT: removed unneeded throw helper blocks

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5105,14 +5105,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     m_pLowering = new (this, CMK_LSRA) Lowering(this, m_pLinearScan); // PHASE_LOWERING
     m_pLowering->Run();
 
-    if (!compMacOsArm64Abi())
-    {
-        // Set stack levels; this information is necessary for x86
-        // but on other platforms it is used only in asserts.
-        // TODO: do not run it in release on other platforms, see https://github.com/dotnet/runtime/issues/42673.
-        StackLevelSetter stackLevelSetter(this);
-        stackLevelSetter.Run();
-    }
+    // Set stack levels and analyze throw helper usage.
+    StackLevelSetter stackLevelSetter(this);
+    stackLevelSetter.Run();
 
     // We can not add any new tracked variables after this point.
     lvaTrackedFixed = true;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6295,6 +6295,7 @@ public:
         BasicBlock*     acdDstBlk; // block  to  which we jump
         unsigned        acdData;
         SpecialCodeKind acdKind; // what kind of a special block is this?
+        bool            acdUsed; // do we need to keep this helper block?
 #if !FEATURE_FIXED_OUT_ARGS
         bool     acdStkLvlInit; // has acdStkLvl value been already set?
         unsigned acdStkLvl;     // stack level in stack slots.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6325,13 +6325,14 @@ public:
 
     typedef JitHashTable<AddCodeDscKey, AddCodeDscKey, AddCodeDsc*> AddCodeDscMap;
 
-    AddCodeDscMap* fgAddCodeDscMap;
+    AddCodeDscMap* fgGetAddCodeDscMap();
 
 private:
     static unsigned acdHelper(SpecialCodeKind codeKind);
 
     AddCodeDsc* fgAddCodeList;
     bool        fgRngChkThrowAdded;
+    AddCodeDscMap* fgAddCodeDscMap;
 
     void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
     PhaseStatus fgCreateThrowHelperBlocks();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6302,12 +6302,36 @@ public:
 #endif                          // !FEATURE_FIXED_OUT_ARGS
     };
 
+    struct AddCodeDscKey
+    {
+    public:
+        AddCodeDscKey(): acdKind(SCK_NONE), acdData(0) {}
+        AddCodeDscKey(SpecialCodeKind kind, unsigned data): acdKind(kind), acdData(data) {}
+
+        static bool Equals(const AddCodeDscKey& x, const AddCodeDscKey& y)
+        {
+            return (x.acdData == y.acdData) && (x.acdKind == y.acdKind);
+        }
+
+        static unsigned GetHashCode(const AddCodeDscKey& x)
+        {
+            return (x.acdData << 3) | (unsigned) x.acdKind;
+        }
+
+    private:
+        SpecialCodeKind acdKind;
+        unsigned acdData;
+    };
+
+    typedef JitHashTable<AddCodeDscKey, AddCodeDscKey, AddCodeDsc*> AddCodeDscMap;
+
+    AddCodeDscMap* fgAddCodeDscMap;
+
 private:
     static unsigned acdHelper(SpecialCodeKind codeKind);
 
     AddCodeDsc* fgAddCodeList;
     bool        fgRngChkThrowAdded;
-    AddCodeDsc* fgExcptnTargetCache[SCK_COUNT];
 
     void fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind);
     PhaseStatus fgCreateThrowHelperBlocks();

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -99,13 +99,8 @@ void Compiler::fgInit()
 
     // Initialize the logic for adding code. This is used to insert code such
     // as the code that raises an exception when an array range check fails.
-
-    fgAddCodeList = nullptr;
-
-    for (int i = 0; i < SCK_COUNT; i++)
-    {
-        fgExcptnTargetCache[i] = nullptr;
-    }
+    fgAddCodeList   = nullptr;
+    fgAddCodeDscMap = nullptr;
 
     /* Keep track of the max count of pointer arguments */
     fgPtrArgCntMax = 0;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3568,6 +3568,10 @@ void Compiler::fgAddCodeRef(BasicBlock* srcBlk, SpecialCodeKind kind)
     add->acdStkLvlInit = false;
 #endif // !FEATURE_FIXED_OUT_ARGS
 
+    // This gets set true in the stack level setter
+    // if there's still a need for this helper
+    add->acdUsed = false;
+
     fgAddCodeList = add;
 
     // Defer creating of the blocks until later.

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3770,7 +3770,7 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
 //
 // Arguments:
 //    kind - kind of exception to throw
-//    block - block where we need to throw an exception
+//    refData -- bbThrowIndex of the block that will jump to the throw helper
 //
 // Return Value:
 //    Code descriptor for the appropriate throw helper block, or nullptr if no such

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -76,7 +76,6 @@ PhaseStatus StackLevelSetter::DoPhase()
         madeChanges = true;
     }
 
-    // Might want an "other" category for things like this...
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
 }
 
@@ -156,6 +155,23 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
         case GT_CKFINITE:
             SetThrowHelperBlock(SCK_ARITH_EXCPN, block);
             break;
+
+        case GT_DIV:
+        case GT_UDIV:
+        {
+            ExceptionSetFlags exSetFlags = node->OperExceptions(comp);
+
+            if ((exSetFlags & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None)
+            {
+                SetThrowHelperBlock(SCK_DIV_BY_ZERO, block);
+            }
+
+            if ((exSetFlags & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
+            {
+                SetThrowHelperBlock(SCK_ARITH_EXCPN, block);
+            }
+        }
+        break;
 
         default: // Other opers can target throw only due to overflow.
             break;

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -59,21 +59,26 @@ PhaseStatus StackLevelSetter::DoPhase()
     comp->fgSetPtrArgCntMax(maxStackLevel);
     CheckArgCnt();
 
-    // Check if there are any unused throw helper blocks, and if so, remove them.
+    // When optimizing, check if there are any unused throw helper blocks,
+    // and if so, remove them.
+    //
     bool madeChanges = false;
 
-    for (Compiler::AddCodeDsc* add = comp->fgGetAdditionalCodeDescriptors(); add != nullptr; add = add->acdNext)
+    if (comp->opts.OptimizationEnabled())
     {
-        if (add->acdUsed)
+        for (Compiler::AddCodeDsc* add = comp->fgGetAdditionalCodeDescriptors(); add != nullptr; add = add->acdNext)
         {
-            continue;
-        }
+            if (add->acdUsed)
+            {
+                continue;
+            }
 
-        BasicBlock* const block = add->acdDstBlk;
-        JITDUMP("Throw help block " FMT_BB " is unused\n", block->bbNum);
-        block->bbFlags &= ~BBF_DONT_REMOVE;
-        comp->fgRemoveBlock(block, /* unreachable */ true);
-        madeChanges = true;
+            BasicBlock* const block = add->acdDstBlk;
+            JITDUMP("Throw help block " FMT_BB " is unused\n", block->bbNum);
+            block->bbFlags &= ~BBF_DONT_REMOVE;
+            comp->fgRemoveBlock(block, /* unreachable */ true);
+            madeChanges = true;
+        }
     }
 
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;
@@ -86,6 +91,9 @@ PhaseStatus StackLevelSetter::DoPhase()
 //   Block starts and ends with an empty outgoing stack.
 //   Nodes in blocks are iterated in the reverse order to memorize GT_PUTARG_STK
 //   and GT_PUTARG_SPLIT stack sizes.
+//
+//   Also note which (if any) throw helper blocks might end up being used by
+//   codegen.
 //
 // Arguments:
 //   block - the block to process.
@@ -105,11 +113,6 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
             SubStackLevel(numSlots);
         }
 
-        if (throwHelperBlocksUsed && node->OperMayThrow(comp))
-        {
-            SetThrowHelperBlocks(node, block);
-        }
-
         if (node->IsCall())
         {
             GenTreeCall* call                = node->AsCall();
@@ -117,6 +120,41 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
 #if defined(UNIX_X86_ABI)
             call->gtArgs.SetStkSizeBytes(usedStackSlotsCount * TARGET_POINTER_SIZE);
 #endif // UNIX_X86_ABI
+        }
+
+        if (!throwHelperBlocksUsed)
+        {
+            continue;
+        }
+
+        // When optimizing we want to know what throw helpers might be used
+        // so we can remove the ones that aren't needed.
+        //
+        // If we're not optimizing then the helper requests made in
+        // morph are likely still accurate, so we don't bother checking
+        // if helpers are indeed used.
+        //
+        bool checkForHelpers = comp->opts.OptimizationEnabled();
+
+#if !FEATURE_FIXED_OUT_ARGS
+        // Even if not optimizing, if we have a moving SP frame, a shared helper may
+        // be reached with mixed stack depths and so force this method to use
+        // a frame pointer. Once we see that the method will need a frame
+        // pointer we no longer need to check for this case.
+        //
+        checkForHelpers |= !framePointerRequired;
+#endif
+
+        if (checkForHelpers)
+        {
+            if (((node->gtFlags & GTF_EXCEPT) != 0) && node->OperMayThrow(comp))
+            {
+                SetThrowHelperBlocks(node, block);
+            }
+            else
+            {
+                // assert(((node->gtFlags & GTF_CALL) != 0) || !node->OperMayThrow(comp));
+            }
         }
     }
     assert(currentStackLevel == 0);

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -151,10 +151,6 @@ void StackLevelSetter::ProcessBlock(BasicBlock* block)
             {
                 SetThrowHelperBlocks(node, block);
             }
-            else
-            {
-                // assert(((node->gtFlags & GTF_CALL) != 0) || !node->OperMayThrow(comp));
-            }
         }
     }
     assert(currentStackLevel == 0);

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -156,6 +156,7 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
             SetThrowHelperBlock(SCK_ARITH_EXCPN, block);
             break;
 
+#if defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
         case GT_DIV:
         case GT_UDIV:
         {
@@ -172,6 +173,7 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
             }
         }
         break;
+#endif
 
         default: // Other opers can target throw only due to overflow.
             break;

--- a/src/coreclr/jit/stacklevelsetter.h
+++ b/src/coreclr/jit/stacklevelsetter.h
@@ -16,10 +16,8 @@ public:
 private:
     void ProcessBlock(BasicBlock* block);
 
-#if !FEATURE_FIXED_OUT_ARGS
     void SetThrowHelperBlocks(GenTree* node, BasicBlock* block);
     void SetThrowHelperBlock(SpecialCodeKind kind, BasicBlock* block);
-#endif // !FEATURE_FIXED_OUT_ARGS
 
     unsigned PopArgumentsFromCall(GenTreeCall* call);
     void AddStackLevel(unsigned value);
@@ -35,10 +33,10 @@ private:
     CompAllocator memAllocator;
 
     typedef JitHashTable<GenTreePutArgStk*, JitPtrKeyFuncs<GenTreePutArgStk>, unsigned> PutArgNumSlotsMap;
-    PutArgNumSlotsMap putArgNumSlots; // The hash table keeps stack slot sizes for active GT_PUTARG_STK nodes.
+    PutArgNumSlotsMap putArgNumSlots;        // The hash table keeps stack slot sizes for active GT_PUTARG_STK nodes.
+    bool              throwHelperBlocksUsed; // Were any throw helper blocks requested for this method.
 
 #if !FEATURE_FIXED_OUT_ARGS
-    bool framePointerRequired;  // Is frame pointer required based on the analysis made by this phase.
-    bool throwHelperBlocksUsed; // Were any throw helper blocks created for this method.
-#endif                          // !FEATURE_FIXED_OUT_ARGS
+    bool framePointerRequired; // Is frame pointer required based on the analysis made by this phase.
+#endif                         // !FEATURE_FIXED_OUT_ARGS
 };


### PR DESCRIPTION
Various optimizations can happen between the time the throw helper blocks are first requested (morph) and finally used (codegen). Prune away ones that aren't needed during the stack level setter.

Fixes #93948.