### PR TITLE
[browser] Fix debug URL in lauchSettings.json in wasmbrowser template

### DIFF
--- a/src/mono/wasm/templates/templates/browser/Properties/launchSettings.json
+++ b/src/mono/wasm/templates/templates/browser/Properties/launchSettings.json
@@ -7,7 +7,7 @@
           "ASPNETCORE_ENVIRONMENT": "Development"
         },
         "applicationUrl": "https://localhost:5001;http://localhost:5000",
-        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/debug?browser={browserInspectUri}"
+        "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
       }
     }
 }


### PR DESCRIPTION
Regression from wasmbrowser template migration to WebAssembly SDK
Tested manually be creating a project from updated template and launched from Visual studio using F5
Fixes https://github.com/dotnet/runtime/issues/95391