### PR TITLE
[release/6.0-staging] Disabling mock test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1013,6 +1013,13 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(1000)]
         public async Task EchoServerStreaming_DifferentMessageSize_Success(int messageSize)
         {
+            // Disable failing test in 6.0 branch, see https://github.com/dotnet/runtime/issues/95158
+            // The mock tests don't exist in newer releases -> no need to keep an active issue.
+            if (this.UseQuicImplementationProvider == QuicImplementationProviders.Mock)
+            {
+                return;
+            }
+
             int iters = 5;
             var message = new byte[messageSize];
             var readBuffer = new byte[5 * messageSize]; // bigger than message


### PR DESCRIPTION
Fixes #95158

## Customer Impact

Test-only change, cleaning up CI noise.

## Testing

Locally made sure the test is skipped, also CI.

## Risk

Low - only test change and only for mock transport (used only in tests).

cc @carlossanlop @karelz 