### PR TITLE
Fix propagating cmake exit code from gen-buildsys.sh

### DIFF
--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -116,4 +116,6 @@ $cmake_command \
   $__UnprocessedCMakeArgs \
   "$1"
 
+cmake_exit_code=$?
 popd
+exit $cmake_exit_code

--- a/eng/native/gen-buildsys.sh
+++ b/eng/native/gen-buildsys.sh
@@ -104,9 +104,6 @@ if [[ "$host_arch" == "wasm" ]]; then
     fi
 fi
 
-# We have to be able to build with CMake 3.6.2, so we can't use the -S or -B options
-pushd "$2"
-
 $cmake_command \
   --no-warn-unused-cli \
   -G "$generator" \
@@ -114,8 +111,7 @@ $cmake_command \
   "-DCMAKE_INSTALL_PREFIX=$__CMakeBinDir" \
   $cmake_extra_defines \
   $__UnprocessedCMakeArgs \
-  "$1"
+  -S "$1" \
+  -B "$3"
 
-cmake_exit_code=$?
-popd
-exit $cmake_exit_code
+exit $?


### PR DESCRIPTION
While looking at https://github.com/dotnet/runtime/pull/95405 I noticed that we didn't fail the build when the cmake configure step failed but tried to run the build regardless.

The reason is because in ece10adbddc8d7b18711f1ad753f75a6e2234caa another command `popd` was added after the cmake invocation which overwrote the exit code so build-commons.sh didn't know cmake failed.

We can use the `-S` and `-B` flags to set the directories instead again now that we use a new enough minimum CMake version.