### PR TITLE
Remove _monoAotBuildshCommand and _monoAotCrossCompileArg from pipelines

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -105,21 +105,6 @@ jobs:
         ${{ if notin(parameters.osGroup, 'ios', 'tvos', 'maccatalyst')}}:
           value: ''
 
-      - name: _monoAotBuildshCommand
-        value: ''
-
-      - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
-        - name: _monoAotBuildshCommand
-          value: 'mono_aot'
-
-      - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
-        - name: _monoAotBuildshCommand
-          value: 'mono_fullaot'
-
-      - ${{ if eq(parameters.archType, 'arm64') }}:
-        - name: _monoAotCrossCompileArg
-          value: 'cross'
-
       # Set no native sanitizers by default
       - name: _nativeSanitizersArg
         value: ''

--- a/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+++ b/eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
@@ -64,12 +64,12 @@ steps:
           target: ${{ coalesce(parameters.llvmAotStepContainer, parameters.container) }}
     - ${{ if eq(parameters.archType, 'arm64') }}:
       - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
-        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }}  $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2
+        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_aot ${{ parameters.buildConfig }} ${{ parameters.archType }} cross /p:RuntimeVariant=llvmfullaot -maxcpucount:2
           displayName: "LLVM AOT cross-compile CoreCLR tests"
           env:
             __MonoToolPrefix: aarch64-linux-gnu-
       - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
-        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }} $(_monoAotCrossCompileArg) /p:RuntimeVariant=llvmfullaot -maxcpucount:2
+        - script: $(Build.SourcesDirectory)/src/tests/build$(scriptExt) $(logRootNameArg)MonoAot mono_fullaot ${{ parameters.buildConfig }} ${{ parameters.archType }} cross /p:RuntimeVariant=llvmfullaot -maxcpucount:2
           displayName: "LLVM AOT cross-compile CoreCLR tests"
           env:
             __MonoToolPrefix: aarch64-linux-gnu-


### PR DESCRIPTION
The former is not used at all and the latter is only used for archType=arm64 so we can just use the "cross" value directly.