### PR TITLE
[7.0] Remove jit-format job in .NET 7.0 branch

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -153,13 +153,3 @@ jobs:
       crossgen2: true
       displayNameArgs: R2R_CG2
       liveLibrariesBuildConfig: Release
-
-#
-# Formatting
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-    platforms:
-    - Linux_x64
-    - windows_x64


### PR DESCRIPTION
Remove jit-format from outerloop pipeline in .NET 7 branch.

jit-format currently only works well in `main`. It is also not useful in servicing branches.
