### PR TITLE
[8.0] Remove jit-format job in .NET 8.0 branch

### DIFF
--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -155,13 +155,3 @@ extends:
             readyToRun: true
             displayNameArgs: R2R_CG2
             liveLibrariesBuildConfig: Release
-
-      #
-      # Formatting
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/format-job.yml
-          platforms:
-          - linux_x64
-          - windows_x64


### PR DESCRIPTION
Remove jit-format from outerloop pipeline in .NET 8 branch.

jit-format currently only works well in main. It is also not useful in servicing branches.