### PR TITLE
[wasi] Simplify, and clean up target for bundled resource generation

### DIFF
--- a/src/mono/wasi/Makefile
+++ b/src/mono/wasi/Makefile
@@ -54,6 +54,10 @@ app-builder:
 build-tasks:
 	$(DOTNET) build $(TOP)/src/tasks/tasks.proj /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)
 
+build-packages:
+	rm -f $(TOP)/artifacts/packages/$(CONFIG)/Shipping/*.nupkg
+	WASI_SDK_PATH=$(WASI_SDK_PATH) $(TOP)/build.sh mono.packages+mono.manifests+packs.product -os wasi -c $(CONFIG) --binaryLog /p:ContinueOnError=false /p:StopOnFirstFailure=true $(MSBUILD_ARGS)
+
 clean:
 	$(RM) -rf $(BUILDS_OBJ_DIR)
 

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -326,7 +326,6 @@
   <Target Name="_WasmSelectRuntimeComponentsForLinking" Condition="'$(UsingWasiRuntimeWorkload)' == 'true'" DependsOnTargets="_MonoSelectRuntimeComponents" />
 
   <Target Name="_GetNativeFilesForLinking" DependsOnTargets="_WasmSelectRuntimeComponentsForLinking" Returns="@(_WasmNativeFileForLinking)">
-    <Message Text="MicrosoftNetCoreAppRuntimePackRidNativeDir: $(MicrosoftNetCoreAppRuntimePackRidNativeDir)" Importance="High" />
     <PropertyGroup>
       <!-- FIXME: eh case -->
       <_WasmEHLib Condition="'$(WasmEnableExceptionHandling)' == 'true'">libmono-wasm-eh-wasm.a</_WasmEHLib>

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -15,7 +15,7 @@
         _GetNativeFilesForLinking;
         _GenerateManagedToNative;
         _WasmCompileNativeFiles;
-        _GenerateAssemblyObjectFiles;
+        _GenerateObjectFilesForSingleFileBundle;
         _WasiLinkDotNet;
     </_WasiBuildNativeCoreDependsOn>
 
@@ -359,74 +359,43 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="_GenerateAssemblyObjectFiles" Returns="@(_WasiObjectFilesForBundle)"
-    Condition="'$(WasmSingleFileBundle)' == 'true'"
-  >
-    <!-- Get the file hashes of everything in @(_WasmBundleFiles), then pass it all to EmitWasmBundleObjectFiles. This
-         will emit corresponding .o files for anything we don't already have on disk. -->
-    <PropertyGroup>
-      <_WasmAssembliesBundleObjectFile>wasi_bundled_assemblies.o</_WasmAssembliesBundleObjectFile>
-      <_WasmIcuBundleObjectFile>wasi_bundled_icu.o</_WasmIcuBundleObjectFile>
-      <_WasmRuntimeConfigBundleFile>wasi_runtime_config_bin.o</_WasmRuntimeConfigBundleFile>
-    </PropertyGroup>
-    <!-- TODO make this incremental compilation -->
+  <Target Name="_GenerateObjectFilesForSingleFileBundle" Returns="@(_WasiObjectFilesForBundle)" Condition="'$(WasmSingleFileBundle)' == 'true'">
+    <ItemGroup>
+      <_EmitBundleItemName
+                Include="_WasmAssembliesInternal"
+                BundleRegistrationFunctionName="mono_register_assemblies_bundle"
+                BundleFile="wasi_bundled_assemblies.o" />
+
+      <_IcuFilesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)icudt.dat" />
+      <_EmitBundleItemName
+                Include="_IcuFilesToBundle"
+                BundleRegistrationFunctionName="mono_register_icu_bundle"
+                BundleFile="wasi_bundled_icu.o" />
+
+      <_RuntimeConfigBinToBundle Include="$(_ParsedRuntimeConfigFilePath)" />
+      <_EmitBundleItemName
+                Include="_RuntimeConfigBinToBundle"
+                BundleRegistrationFunctionName="mono_register_runtimeconfig_bin"
+                BundleFile="wasi_bundled_runtimeconfig_bin.o" />
+    </ItemGroup>
+
+    <!-- If it's an item name -->
     <EmitBundleObjectFiles
-      FilesToBundle="@(_WasmAssembliesInternal)"
-      ClangExecutable="$(WasiClang)"
-      BundleRegistrationFunctionName="mono_register_assemblies_bundle"
-      BundleFile="$(_WasmAssembliesBundleObjectFile)"
-      OutputDirectory="$(_WasmIntermediateOutputPath)">
-      <Output TaskParameter="BundledResources" ItemName="_WasmBundledAssemblies" />
+                FilesToBundle="@(%(_EmitBundleItemName.Identity))"
+                ClangExecutable="$(WasiClang)"
+                BundleRegistrationFunctionName="@(_EmitBundleItemName->'%(BundleRegistrationFunctionName)')"
+                BundleFile="@(_EmitBundleItemName->'%(BundleFile)')"
+                OutputDirectory="$(_WasmIntermediateOutputPath)">
+                <Output TaskParameter="BundledResources" ItemName="_EmitBundleOutputItem" />
     </EmitBundleObjectFiles>
 
     <ItemGroup>
-      <_WasiObjectFilesForBundle Include="$(_WasmIntermediateOutputPath)$(_WasmAssembliesBundleObjectFile)" />
-      <_WasiObjectFilesForBundle Include="%(_WasmBundledAssemblies.DestinationFile)" />
+      <_EmitBundleOutputFile Remove="@(_EmitBundleOutputFile)" />
+      <_EmitBundleOutputFile Include="%(_EmitBundleOutputItem.DestinationFile)" />
+
+      <_WasiObjectFilesForBundle Include="@(_EmitBundleOutputFile)" />
+      <FileWrites Include="@(_EmitBundleOutputFile)" />
     </ItemGroup>
-
-    <!-- Clean up the bundle-objects dir - remove anything we no longer need -->
-    <ItemGroup>
-      <WasmBundleFileToDelete Include="$(_WasmIntermediateOutputPath)bundled_*.o" />
-      <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmAssembliesBundleObjectFile)" />
-      <WasmBundleFileToDelete Remove="%(_WasmBundledAssemblies.DestinationFile)" />
-    </ItemGroup>
-
-    <EmitBundleObjectFiles
-      Condition="'$(InvariantGlobalization)' != 'true'"
-      FilesToBundle="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)icudt.dat"
-      ClangExecutable="$(WasiClang)"
-      BundleRegistrationFunctionName="mono_register_icu_bundle"
-      BundleFile="$(_WasmIcuBundleObjectFile)"
-      OutputDirectory="$(_WasmIntermediateOutputPath)">
-      <Output TaskParameter="BundledResources" ItemName="BundledWasmIcu" />
-    </EmitBundleObjectFiles>
-
-    <ItemGroup Condition="'$(InvariantGlobalization)' != 'true'">
-      <_WasiObjectFilesForBundle Include="$(_WasmIntermediateOutputPath)$(_WasmIcuBundleObjectFile)" />
-      <_WasiObjectFilesForBundle Include="%(BundledWasmIcu.DestinationFile)" />
-
-      <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmIcuBundleObjectFile)" />
-      <WasmBundleFileToDelete Remove="%(BundledWasmIcu.DestinationFile)" />
-    </ItemGroup>
-
-    <!-- runtimeconfig.bin -->
-    <EmitBundleObjectFiles
-      FilesToBundle="$(_ParsedRuntimeConfigFilePath)"
-      ClangExecutable="$(WasiClang)"
-      BundleRegistrationFunctionName="mono_register_runtimeconfig_bin"
-      BundleFile="$(_WasmRuntimeConfigBundleFile)"
-      OutputDirectory="$(_WasmIntermediateOutputPath)">
-      <Output TaskParameter="BundledResources" ItemName="_BundledRuntimeConfigBin" />
-    </EmitBundleObjectFiles>
-
-    <ItemGroup>
-      <_WasiObjectFilesForBundle Include="$(_WasmIntermediateOutputPath)$(_WasmRuntimeConfigBundleFile)" />
-      <_WasiObjectFilesForBundle Include="%(_BundledRuntimeConfigBin.DestinationFile)" />
-
-      <WasmBundleFileToDelete Remove="$(_WasmIntermediateOutputPath)$(_WasmRuntimeConfigBundleFile)" />
-      <WasmBundleFileToDelete Remove="%(_BundledRuntimeConfigBin.DestinationFile)" />
-    </ItemGroup>
-    <Delete Files="@(WasmBundleFileToDelete)" />
   </Target>
 
   <Target Name="_WasmWriteRspFilesForLinking" DependsOnTargets="_CheckWasiClangIsExpectedVersion;_WasmCalculateInitialHeapSize">

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -387,11 +387,13 @@
                 BundleFile="@(_EmitBundleItemName->'%(BundleFile)')"
                 OutputDirectory="$(_WasmIntermediateOutputPath)">
                 <Output TaskParameter="BundledResources" ItemName="_EmitBundleOutputItem" />
+                <Output TaskParameter="BundleRegistrationFile" PropertyName="_EmitBundleRegistrationFile" />
     </EmitBundleObjectFiles>
 
     <ItemGroup>
       <_EmitBundleOutputFile Remove="@(_EmitBundleOutputFile)" />
       <_EmitBundleOutputFile Include="%(_EmitBundleOutputItem.DestinationFile)" />
+      <_EmitBundleOutputFile Include="$(_EmitBundleRegistrationFile)" />
 
       <_WasiObjectFilesForBundle Include="@(_EmitBundleOutputFile)" />
       <FileWrites Include="@(_EmitBundleOutputFile)" />

--- a/src/mono/wasi/build/WasiApp.Native.targets
+++ b/src/mono/wasi/build/WasiApp.Native.targets
@@ -362,38 +362,36 @@
   <Target Name="_GenerateObjectFilesForSingleFileBundle" Returns="@(_WasiObjectFilesForBundle)" Condition="'$(WasmSingleFileBundle)' == 'true'">
     <ItemGroup>
       <_EmitBundleItemName
-                Include="_WasmAssembliesInternal"
+                Include="@(_WasmAssembliesInternal)"
                 BundleRegistrationFunctionName="mono_register_assemblies_bundle"
                 BundleFile="wasi_bundled_assemblies.o" />
 
-      <_IcuFilesToBundle Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)icudt.dat" />
       <_EmitBundleItemName
-                Include="_IcuFilesToBundle"
+                Include="$(MicrosoftNetCoreAppRuntimePackRidNativeDir)icudt.dat"
                 BundleRegistrationFunctionName="mono_register_icu_bundle"
                 BundleFile="wasi_bundled_icu.o" />
 
-      <_RuntimeConfigBinToBundle Include="$(_ParsedRuntimeConfigFilePath)" />
       <_EmitBundleItemName
-                Include="_RuntimeConfigBinToBundle"
+                Include="$(_ParsedRuntimeConfigFilePath)"
                 BundleRegistrationFunctionName="mono_register_runtimeconfig_bin"
                 BundleFile="wasi_bundled_runtimeconfig_bin.o" />
     </ItemGroup>
 
-    <!-- If it's an item name -->
+    <!-- batched on .BundleRegistrationFunctionName+.BundleFile -->
     <EmitBundleObjectFiles
-                FilesToBundle="@(%(_EmitBundleItemName.Identity))"
+                FilesToBundle="@(_EmitBundleItemName)"
                 ClangExecutable="$(WasiClang)"
-                BundleRegistrationFunctionName="@(_EmitBundleItemName->'%(BundleRegistrationFunctionName)')"
-                BundleFile="@(_EmitBundleItemName->'%(BundleFile)')"
+                BundleRegistrationFunctionName="%(_EmitBundleItemName.BundleRegistrationFunctionName)"
+                BundleFile="%(_EmitBundleItemName.BundleFile)"
                 OutputDirectory="$(_WasmIntermediateOutputPath)">
                 <Output TaskParameter="BundledResources" ItemName="_EmitBundleOutputItem" />
-                <Output TaskParameter="BundleRegistrationFile" PropertyName="_EmitBundleRegistrationFile" />
+                <Output TaskParameter="BundleRegistrationFile" ItemName="_EmitBundleRegistrationFile" />
     </EmitBundleObjectFiles>
 
     <ItemGroup>
       <_EmitBundleOutputFile Remove="@(_EmitBundleOutputFile)" />
       <_EmitBundleOutputFile Include="%(_EmitBundleOutputItem.DestinationFile)" />
-      <_EmitBundleOutputFile Include="$(_EmitBundleRegistrationFile)" />
+      <_EmitBundleOutputFile Include="@(_EmitBundleRegistrationFile)" />
 
       <_WasiObjectFilesForBundle Include="@(_EmitBundleOutputFile)" />
       <FileWrites Include="@(_EmitBundleOutputFile)" />

--- a/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
+++ b/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
@@ -63,6 +63,10 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
     [Output]
     public ITaskItem[] BundledResources { get; set; } = default!;
 
+    // Set only if @BundleFile was set
+    [Output]
+    public string? BundleRegistrationFile { get; set; }
+
     public override bool Execute()
     {
         if (!Directory.Exists(OutputDirectory))
@@ -184,7 +188,6 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
         }
         finally
         {
-            // msbuild does not release cores between invocations if the task is batched
             be9?.ReleaseCores(allowedParallelism);
         }
 
@@ -227,9 +230,7 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
                 GenerateBundledResourcePreallocationAndRegistration(resourceSymbols, BundleRegistrationFunctionName, files, outputUtf8Writer);
             });
 
-            TaskItem itemForBundleFile = new TaskItem(Path.Combine(OutputDirectory, BundleFile));
-            itemForBundleFile.SetMetadata("DestinationFile", bundleFilePath);
-            bundledResources.Add(itemForBundleFile);
+            BundleRegistrationFile = bundleFilePath;
         }
 
         BundledResources = bundledResources.ToArray();


### PR DESCRIPTION
- [wasi] EmitBuildBase: Output an item for the bundle file also. This is correct as it represents all the outputs
- [wasi] WasiApp.Native.targets: Simplify target for bundling resources in single file bundle, and remove special cased way of handling bundlefiles
- [wasi] EmitBundleBase: ReleaseCores once the execution is done, as msbuild does not seem to release them between batched task invocations
- [wasi] Makefile: add build-packages target
