### PR TITLE
Fix MacOS arm64 assert in createdump

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -195,7 +195,7 @@ CrashInfo::GatherCrashInfo(DumpType dumpType)
         return false;
     }
     // Add the special (fake) memory region for the special diagnostics info
-    MemoryRegion special(PF_R, SpecialDiagInfoAddress, SpecialDiagInfoAddress + SpecialDiagInfoSize);
+    MemoryRegion special(PF_R, SpecialDiagInfoAddress, SpecialDiagInfoAddress + PAGE_SIZE);
     m_memoryRegions.insert(special);
 #ifdef __APPLE__
     InitializeOtherMappings();


### PR DESCRIPTION
On MacOS arm64, the page size is 64K so the 1K SpecialDiagInfoSize caused the MemoryRegion assert to fire.