### PR TITLE
Switch PortableAppActivation tests to pre-built test asset

### DIFF
--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/DependencyResolutionBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
 
             public DotNetBuilder DotNet(string name)
             {
-                return new DotNetBuilder(Location, TestContext.BuiltDotNet, name);
+                return new DotNetBuilder(Location, TestContext.BuiltDotNet.BinPath, name);
             }
 
             public TestApp CreateFrameworkReferenceApp(string fxName, string fxVersion, Action<NetCoreAppBuilder> customizer = null)

--- a/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
+++ b/src/installer/tests/HostActivation.Tests/DependencyResolution/RidAssetResolution.cs
@@ -601,7 +601,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.DependencyResolution
         protected static void UseFallbacksFromBuiltDotNet(NetCoreAppBuilder builder)
         {
             IReadOnlyList<RuntimeFallbacks> fallbacks;
-            string depsJson = Path.Combine(new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
+            string depsJson = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, $"{Constants.MicrosoftNETCoreApp}.deps.json");
             using (FileStream fileStream = File.Open(depsJson, FileMode.Open))
             using (DependencyContextJsonReader reader = new DependencyContextJsonReader())
             {

--- a/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
+++ b/src/installer/tests/HostActivation.Tests/DotnetArgValidation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void MuxerExec_MissingAppAssembly_Fails()
         {
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.dll");
-            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(expectedToFail: true)
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void MuxerExec_MissingAppAssembly_BadExtension_Fails()
         {
             string assemblyName = Path.Combine(GetNonexistentAndUnnormalizedPath(), "foo.xzy");
-            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(expectedToFail: true)
@@ -45,11 +45,10 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void MuxerExec_BadExtension_Fails()
         {
             // Get a valid file name, but not exe or dll
-            string fxDir = Path.Combine(TestContext.BuiltDotNet, "shared", "Microsoft.NETCore.App");
-            fxDir = new DirectoryInfo(fxDir).GetDirectories()[0].FullName;
+            string fxDir = TestContext.BuiltDotNet.GreatestVersionSharedFxPath;
             string assemblyName = Path.Combine(fxDir, "Microsoft.NETCore.App.deps.json");
 
-            sharedTestState.BuiltDotNet.Exec("exec", assemblyName)
+            TestContext.BuiltDotNet.Exec("exec", assemblyName)
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(expectedToFail: true)
@@ -60,7 +59,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void MissingArgumentValue_Fails()
         {
-            sharedTestState.BuiltDotNet.Exec("--fx-version")
+            TestContext.BuiltDotNet.Exec("--fx-version")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute(expectedToFail: true)
@@ -72,7 +71,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         public void InvalidFileOrCommand_NoSDK_ListsPossibleIssues()
         {
             string fileName = "NonExistent";
-            sharedTestState.BuiltDotNet.Exec(fileName)
+            TestContext.BuiltDotNet.Exec(fileName)
                 .WorkingDirectory(sharedTestState.BaseDirectory.Location)
                 .CaptureStdOut()
                 .CaptureStdErr()
@@ -85,7 +84,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void DotNetInfo_NoSDK()
         {
-            sharedTestState.BuiltDotNet.Exec("--info")
+            TestContext.BuiltDotNet.Exec("--info")
                 .CaptureStdOut()
                 .CaptureStdErr()
                 .Execute()
@@ -97,7 +96,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         [Fact]
         public void DotNetInfo_WithSDK()
         {
-            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, TestContext.BuiltDotNet, "withSdk")
+            DotNetCli dotnet = new DotNetBuilder(sharedTestState.BaseDirectory.Location, TestContext.BuiltDotNet.BinPath, "withSdk")
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("1.0.0")
                 .AddMockSDK("1.0.0", "1.0.0")
                 .Build();
@@ -114,20 +113,17 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         // Return a non-existent path that contains a mix of / and \
         private string GetNonexistentAndUnnormalizedPath()
         {
-            return Path.Combine(TestContext.BuiltDotNet, @"x\y/");
+            return Path.Combine(TestContext.BuiltDotNet.BinPath, @"x\y/");
         }
 
         public class SharedTestState : IDisposable
         {
             public RepoDirectoriesProvider RepoDirectories { get; }
 
-            public DotNetCli BuiltDotNet { get; }
             public TestArtifact BaseDirectory { get; }
 
             public SharedTestState()
             {
-                BuiltDotNet = new DotNetCli(TestContext.BuiltDotNet);
-
                 BaseDirectory = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "argValidation")));
 
                 // Create an empty global.json file

--- a/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
+++ b/src/installer/tests/HostActivation.Tests/MultiArchInstallLocation.cs
@@ -150,9 +150,7 @@ namespace HostActivation.Tests
         [Fact]
         public void EnvironmentVariable_DotNetInfo_ListEnvironment()
         {
-            var dotnet = new DotNetCli(TestContext.BuiltDotNet);
-
-            var command = dotnet.Exec("--info")
+            var command = TestContext.BuiltDotNet.Exec("--info")
                 .CaptureStdOut();
 
             var envVars = new (string Architecture, string Path)[] {
@@ -285,7 +283,7 @@ namespace HostActivation.Tests
         {
             using (var testArtifact = new TestArtifact(SharedFramework.CalculateUniqueTestDirectory(Path.Combine(TestArtifact.TestArtifactsPath, "listOtherArchs"))))
             {
-                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet, "exe").Build();
+                var dotnet = new DotNetBuilder(testArtifact.Location, TestContext.BuiltDotNet.BinPath, "exe").Build();
                 using (var registeredInstallLocationOverride = new RegisteredInstallLocationOverride(dotnet.GreatestVersionHostFxrFilePath))
                 {
                     var installLocations = new (string, string)[] {

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
 
             public SdkResolutionFixture(SharedTestState state)
             {
-                Dotnet = new DotNetCli(TestContext.BuiltDotNet);
+                Dotnet = TestContext.BuiltDotNet;
 
                 _fixture = state.HostApiInvokerAppFixture.Copy();
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ApplicationExecution.cs
@@ -68,9 +68,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new Microsoft.DotNet.Cli.Build.DotNetCli(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"));
-                DotNetRoot = dotNet.BinPath;
-                HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 PortableAppFixture = new TestProjectFixture("PortableApp", RepoDirectories)
                     .EnsureRestored()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/GetFunctionPointer.cs
@@ -230,9 +230,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new Microsoft.DotNet.Cli.Build.DotNetCli(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"));
-                DotNetRoot = dotNet.BinPath;
-                HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 ApplicationFixture = new TestProjectFixture("AppWithCustomEntryPoints", RepoDirectories)
                     .EnsureRestored()

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/Ijwhost.cs
@@ -116,8 +116,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new Microsoft.DotNet.Cli.Build.DotNetCli(RepoDirectories.BuiltDotnet);
-                HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
                 string folder = Path.Combine(BaseDirectory, "ijw");
                 IjwApp = new TestApp(folder, "ijw");
                 // Copy over ijwhost

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssembly.cs
@@ -149,9 +149,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new Microsoft.DotNet.Cli.Build.DotNetCli(RepoDirectories.BuiltDotnet);
-                DotNetRoot = dotNet.BinPath;
-                HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 Application = TestApp.CreateEmpty("App");
                 Application.PopulateFrameworkDependent(Constants.MicrosoftNETCoreApp, TestContext.MicrosoftNETCoreAppVersion);

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/LoadAssemblyAndGetFunctionPointer.cs
@@ -250,9 +250,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 
             public SharedTestState()
             {
-                var dotNet = new Microsoft.DotNet.Cli.Build.DotNetCli(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"));
-                DotNetRoot = dotNet.BinPath;
-                HostFxrPath = dotNet.GreatestVersionHostFxrFilePath;
+                DotNetRoot = TestContext.BuiltDotNet.BinPath;
+                HostFxrPath = TestContext.BuiltDotNet.GreatestVersionHostFxrFilePath;
 
                 ComponentWithNoDependenciesFixture = new TestProjectFixture("ComponentWithNoDependencies", RepoDirectories)
                     .EnsureRestored()

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             SharedState = sharedState;
 
             string exeDotNetPath = SharedFramework.CalculateUniqueTestDirectory(Path.Combine(sharedState.BaseDir, "exe"));
-            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, sharedState.BuiltDotNet.BinPath, null);
+            ExecutableDotNetBuilder = new DotNetBuilder(exeDotNetPath, TestContext.BuiltDotNet.BinPath, null);
             ExecutableDotNet = ExecutableDotNetBuilder
                 .AddMicrosoftNETCoreAppFrameworkMockHostPolicy("9999.0.0")
                 .Build();
@@ -1051,8 +1051,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         {
             private readonly RepoDirectoriesProvider RepoDirectories;
 
-            public DotNetCli BuiltDotNet { get; }
-
             public string BaseDir { get; }
 
             public string CurrentWorkingDir { get; }
@@ -1072,13 +1070,11 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 // The three tested locations will be the cwd and the exe dir. cwd is no longer supported.
                 //     All dirs will be placed inside the base folder
 
-                BuiltDotNet = new DotNetCli(Path.Combine(TestArtifact.TestArtifactsPath, "sharedFrameworkPublish"));
-
                 RepoDirectories = new RepoDirectoriesProvider();
 
                 // Executable location is created per test as each test adds a different set of SDK versions
 
-                var currentWorkingSdk = new DotNetBuilder(BaseDir, BuiltDotNet.BinPath, "current")
+                var currentWorkingSdk = new DotNetBuilder(BaseDir, TestContext.BuiltDotNet.BinPath, "current")
                     .AddMockSDK("10000.0.0", "9999.0.0")
                     .Build();
                 CurrentWorkingDir = currentWorkingSdk.BinPath;

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -26,7 +26,7 @@ namespace AppHost.Bundle.Tests
             Command.Create(path)
                 .CaptureStdErr()
                 .CaptureStdOut()
-                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet)
+                .DotNetRoot(selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World!");

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -23,7 +23,7 @@ namespace AppHost.Bundle.Tests
 
         private void RunTheApp(string path, bool selfContained)
         {
-            RunTheApp(path, selfContained ? null : TestContext.BuiltDotNet)
+            RunTheApp(path, selfContained ? null : TestContext.BuiltDotNet.BinPath)
                 .Should().Pass()
                 .And.HaveStdOutContaining("Wow! We now say hello to the big world and you.");
         }
@@ -63,7 +63,7 @@ namespace AppHost.Bundle.Tests
             using (new TestArtifact(dotnetWithMockHostFxr))
             {
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet, "mockhostfxrFrameworkMissingFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet.BinPath, "mockhostfxrFrameworkMissingFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(2, 2, 0));
                 var dotnet = dotnetBuilder.Build();
@@ -93,7 +93,7 @@ namespace AppHost.Bundle.Tests
                 Directory.CreateDirectory(dotnetWithMockHostFxr);
                 string expectedErrorCode = Constants.ErrorCode.BundleExtractionFailure.ToString("x");
 
-                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet, "mockhostfxrBundleVersionFailure")
+                var dotnetBuilder = new DotNetBuilder(dotnetWithMockHostFxr, TestContext.BuiltDotNet.BinPath, "mockhostfxrBundleVersionFailure")
                     .RemoveHostFxr()
                     .AddMockHostFxr(new Version(5, 0, 0));
                 var dotnet = dotnetBuilder.Build();

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.AppHost.Tests/AppHostUsedWithSymbolicLinks.cs
@@ -89,7 +89,7 @@ namespace Microsoft.NET.HostModel.Tests
                 Command.Create(symlink.SrcPath)
                     .CaptureStdErr()
                     .CaptureStdOut()
-                    .DotNetRoot(TestContext.BuiltDotNet)
+                    .DotNetRoot(TestContext.BuiltDotNet.BinPath)
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World");
@@ -105,7 +105,7 @@ namespace Microsoft.NET.HostModel.Tests
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, "dotnet");
 
-                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet);
+                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet.BinPath);
                 Command.Create(sharedTestState.FrameworkDependentApp.AppExe)
                     .EnvironmentVariable("DOTNET_ROOT", symlink.SrcPath)
                     .CaptureStdErr()
@@ -141,12 +141,11 @@ namespace Microsoft.NET.HostModel.Tests
         [SkipOnPlatform(TestPlatforms.Windows, "Creating symbolic links requires administrative privilege on Windows, so skip test.")]
         public void Put_dotnet_behind_symlink()
         {
-            var dotnet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
             using (var testDir = TestArtifact.Create("symlink"))
             {
                 var dotnetSymlink = Path.Combine(testDir.Location, Binaries.DotNet.FileName);
 
-                using var symlink = new SymLink(dotnetSymlink, dotnet.DotnetExecutablePath);
+                using var symlink = new SymLink(dotnetSymlink, TestContext.BuiltDotNet.DotnetExecutablePath);
                 Command.Create(symlink.SrcPath, sharedTestState.SelfContainedApp.AppDll)
                     .CaptureStdErr()
                     .CaptureStdOut()
@@ -161,7 +160,6 @@ namespace Microsoft.NET.HostModel.Tests
         public void Put_app_directory_behind_symlink_and_use_dotnet()
         {
             var app = sharedTestState.SelfContainedApp.Copy();
-            var dotnet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
 
             using (var newAppDir = TestArtifact.Create("PutTheBinDirSomewhereElse"))
             {
@@ -169,7 +167,7 @@ namespace Microsoft.NET.HostModel.Tests
                 Directory.Move(app.Location, newAppDir.Location);
 
                 using var symlink = new SymLink(app.Location, newAppDir.Location);
-                dotnet.Exec(app.AppDll)
+                TestContext.BuiltDotNet.Exec(app.AppDll)
                     .CaptureStdErr()
                     .CaptureStdOut()
                     .Execute()

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundlerConsistencyTests.cs
@@ -354,8 +354,7 @@ namespace Microsoft.NET.HostModel.Tests
             {
                 App = TestApp.CreateFromBuiltAssets(AppName);
 
-                var builtDotNet = new DotNet.Cli.Build.DotNetCli(TestContext.BuiltDotNet);
-                SystemDll = Path.Combine(builtDotNet.GreatestVersionSharedFxPath, "System.dll");
+                SystemDll = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, "System.dll");
             }
 
             public void Dispose()

--- a/src/installer/tests/TestUtils/Binaries.cs
+++ b/src/installer/tests/TestUtils/Binaries.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static class CoreClr
         {
             public static string FileName = GetSharedLibraryFileNameForCurrentPlatform("coreclr");
-            public static string FilePath = Path.Combine(new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath, FileName);
+            public static string FilePath = Path.Combine(TestContext.BuiltDotNet.GreatestVersionSharedFxPath, FileName);
 
             public static string MockName = GetSharedLibraryFileNameForCurrentPlatform("mockcoreclr");
             public static string MockPath = Path.Combine(RepoDirectoriesProvider.Default.HostTestArtifacts, MockName);
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static (IEnumerable<string> Assemblies, IEnumerable<string> NativeLibraries) GetRuntimeFiles()
         {
-            var runtimePackDir = new DotNetCli(TestContext.BuiltDotNet).GreatestVersionSharedFxPath;
+            var runtimePackDir = TestContext.BuiltDotNet.GreatestVersionSharedFxPath;
             var assemblies = Directory.GetFiles(runtimePackDir, "*.dll").Where(f => IsAssembly(f));
 
             (string prefix, string suffix) = Binaries.GetSharedLibraryPrefixSuffix();

--- a/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
+++ b/src/installer/tests/TestUtils/RepoDirectoriesProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
             NugetPackages = TestContext.GetTestContextVariable("NUGET_PACKAGES");
 
-            BuiltDotnet = builtDotnet ?? TestContext.BuiltDotNet;
+            BuiltDotnet = builtDotnet ?? TestContext.BuiltDotNet.BinPath;
         }
 
         private static string GetRepoRootDirectory()

--- a/src/installer/tests/TestUtils/TestContext.cs
+++ b/src/installer/tests/TestUtils/TestContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.IO;
+using Microsoft.DotNet.Cli.Build;
 
 namespace Microsoft.DotNet.CoreSetup.Test
 {
@@ -17,7 +18,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public static string TestAssetsOutput { get; }
         public static string TestArtifactsPath { get; }
 
-        public static string BuiltDotNet { get; }
+        public static DotNetCli BuiltDotNet { get; }
 
         private static string _testContextVariableFilePath { get; }
         private static ImmutableDictionary<string, string> _testContextVariables { get; }
@@ -45,7 +46,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
             TestAssetsOutput = GetTestContextVariable("TEST_ASSETS_OUTPUT");
             TestArtifactsPath = GetTestContextVariable("TEST_ARTIFACTS");
 
-            BuiltDotNet = Path.Combine(TestArtifactsPath, "sharedFrameworkPublish");
+            BuiltDotNet = new DotNetCli(Path.Combine(TestArtifactsPath, "sharedFrameworkPublish"));
         }
 
         public static string GetTestContextVariable(string name)


### PR DESCRIPTION
- Use pre-built `HelloWorld` test asset in `PortableAppActivation` tests
  - Remove `Muxer_activation_of_Publish_Output_Portable_DLL_with_DepsJson_and_RuntimeConfig_Local_Succeeds`, since build vs publish output is not interesting here
- Make `TestContext.BuiltDotNet` into a `DotNetCli` instance instead of just the path, so that various tests don't have to create their own 