### PR TITLE
Ensure metadata for the type hierarchy is preserved

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -45,6 +45,14 @@ namespace ILCompiler.DependencyAnalysis
             else
                 dependencies.Add(factory.ModuleMetadata(_type.Module), "Containing module of a reflectable type");
 
+            MetadataType baseType = _type.MetadataBaseType;
+            if (baseType != null)
+                GetMetadataDependencies(ref dependencies, factory, baseType, "Base type of a reflectable type");
+
+            // TODO-SIZE: if we start trimming interface lists, we can probably trim here
+            foreach (DefType interfaceType in _type.ExplicitlyImplementedInterfaces)
+                GetMetadataDependencies(ref dependencies, factory, interfaceType, "Interface of a reflectable type");
+
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
 
             if (_type.IsEnum)


### PR DESCRIPTION
Fixes #95444.

I'm not very sympathetic to the original scenario in the bug (if there's trimming warnings, anything can happen), but this can be hit in trim-safe code as well (see the test).

We could sometimes end up generating metadata for a type whose base type doesn't resolve. This is limited to the scenarios where the type is metadata-only (i.e. we don't have a `MethodTable`). If there's a `MethodTable`, the complete hierarchy of metadata was already being generated even without this fix because `EETypeNode` depends on the `TypeMetadataNode` and `EETypeNode` depends on the base type `EETypeNode`.

Cc @dotnet/ilc-contrib 