### PR TITLE
Changing compression level validation to allow any valid value

### DIFF
--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
@@ -20,7 +20,7 @@ namespace System.IO.Compression
                 CompressionLevel.Fastest => 1,
                 CompressionLevel.Optimal => Quality_Default,
                 CompressionLevel.SmallestSize => Quality_Max,
-                _ when (int)compressionLevel is > Quality_Min and <= Quality_Max => (int)compressionLevel,
+                _ when (int)compressionLevel is >= Quality_Min and <= Quality_Max => (int)compressionLevel,
                 _ => throw new ArgumentException(SR.ArgumentOutOfRange_Enum, nameof(compressionLevel))
             };
     }

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/BrotliUtils.cs
@@ -20,6 +20,7 @@ namespace System.IO.Compression
                 CompressionLevel.Fastest => 1,
                 CompressionLevel.Optimal => Quality_Default,
                 CompressionLevel.SmallestSize => Quality_Max,
+                _ when (int)compressionLevel is > Quality_Min and <= Quality_Max => (int)compressionLevel,
                 _ => throw new ArgumentException(SR.ArgumentOutOfRange_Enum, nameof(compressionLevel))
             };
     }

--- a/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
@@ -43,7 +43,7 @@ namespace System.IO.Compression
         [InlineData((CompressionLevel)5)]
         public void Ctor_ArgumentValidation_ValidCompressionLevel(CompressionLevel compressionLevel)
         {
-            Assert.DoesNotThrow(() => new BrotliStream(new MemoryStream(), compressionLevel));
+            _ = new BrotliStream(new MemoryStream(), compressionLevel);
         }
 
         [Fact]

--- a/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
@@ -38,7 +38,7 @@ namespace System.IO.Compression
         }
 
         [Theory]
-        [InlineData((CompressionLevel)(0))]
+        [InlineData((CompressionLevel)0)]
         [InlineData((CompressionLevel)11)]
         [InlineData((CompressionLevel)5)]
         public void Ctor_ArgumentValidation_ValidCompressionLevel(CompressionLevel compressionLevel)

--- a/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/CompressionStreamUnitTests.Brotli.cs
@@ -31,10 +31,19 @@ namespace System.IO.Compression
 
         [Theory]
         [InlineData((CompressionLevel)(-1))]
-        [InlineData((CompressionLevel)4)]
+        [InlineData((CompressionLevel)12)]
         public void Ctor_ArgumentValidation_InvalidCompressionLevel(CompressionLevel compressionLevel)
         {
             Assert.Throws<ArgumentException>(() => new BrotliStream(new MemoryStream(), compressionLevel));
+        }
+
+        [Theory]
+        [InlineData((CompressionLevel)(0))]
+        [InlineData((CompressionLevel)11)]
+        [InlineData((CompressionLevel)5)]
+        public void Ctor_ArgumentValidation_ValidCompressionLevel(CompressionLevel compressionLevel)
+        {
+            Assert.DoesNotThrow(() => new BrotliStream(new MemoryStream(), compressionLevel));
         }
 
         [Fact]


### PR DESCRIPTION
Compression level was validating to restrict to values represented in the compression level enum

However there are other values which are appropriate and users may want to use

This PR enables the usage of any compression level lieing between the defined minimum and maximum and throws the existing exception if the value set sits outside the valid range