### PR TITLE
[libs] Remove test data duplicates

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/StringComparer.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/StringComparer.cs
@@ -184,11 +184,9 @@ namespace System.Tests
             yield return new object[] { "abcd", "ab%cd", "en-US", CompareOptions.IgnoreSymbols, true };
             yield return new object[] { "abcd", "ab&cd", "en-US", CompareOptions.IgnoreSymbols, true };
             yield return new object[] { "abcd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
-            yield return new object[] { "abcd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
             yield return new object[] { "a-bcd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
             yield return new object[] { "abcd*", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
             yield return new object[] { "ab$dd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, false };
-            yield return new object[] { "abcd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
         }
 
         public static TheoryData<string, string, string, CompareOptions, bool> CreateFromCultureAndOptionsStringSortData => new TheoryData<string, string, string, CompareOptions, bool>


### PR DESCRIPTION
We were putting the same data into the tests 3 times. I don't think it was intentional and we do not gain anything by running 100% the same test case 3 times.

```
yield return new object[] { "abcd", "ab$cd", "en-US", CompareOptions.IgnoreSymbols, true };
```