### PR TITLE
[wasm] Fix emission of runtime invoke wrappers.

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -9154,45 +9154,46 @@ can_encode_class (MonoAotCompile *acfg, MonoClass *klass)
 static gboolean
 can_encode_method (MonoAotCompile *acfg, MonoMethod *method)
 {
-		if (method->wrapper_type) {
-			switch (method->wrapper_type) {
-			case MONO_WRAPPER_NONE:
-			case MONO_WRAPPER_STELEMREF:
-			case MONO_WRAPPER_ALLOC:
-			case MONO_WRAPPER_OTHER:
-			case MONO_WRAPPER_WRITE_BARRIER:
-			case MONO_WRAPPER_DELEGATE_INVOKE:
-			case MONO_WRAPPER_DELEGATE_BEGIN_INVOKE:
-			case MONO_WRAPPER_DELEGATE_END_INVOKE:
-			case MONO_WRAPPER_SYNCHRONIZED:
-			case MONO_WRAPPER_MANAGED_TO_NATIVE:
-				break;
-			case MONO_WRAPPER_MANAGED_TO_MANAGED:
-			case MONO_WRAPPER_NATIVE_TO_MANAGED:
-			case MONO_WRAPPER_CASTCLASS: {
-				WrapperInfo *info = mono_marshal_get_wrapper_info (method);
+	if (method->wrapper_type) {
+		switch (method->wrapper_type) {
+		case MONO_WRAPPER_NONE:
+		case MONO_WRAPPER_STELEMREF:
+		case MONO_WRAPPER_ALLOC:
+		case MONO_WRAPPER_OTHER:
+		case MONO_WRAPPER_WRITE_BARRIER:
+		case MONO_WRAPPER_DELEGATE_INVOKE:
+		case MONO_WRAPPER_DELEGATE_BEGIN_INVOKE:
+		case MONO_WRAPPER_DELEGATE_END_INVOKE:
+		case MONO_WRAPPER_SYNCHRONIZED:
+		case MONO_WRAPPER_MANAGED_TO_NATIVE:
+			break;
+		case MONO_WRAPPER_MANAGED_TO_MANAGED:
+		case MONO_WRAPPER_NATIVE_TO_MANAGED:
+		case MONO_WRAPPER_CASTCLASS:
+		case MONO_WRAPPER_RUNTIME_INVOKE: {
+			WrapperInfo *info = mono_marshal_get_wrapper_info (method);
 
-				if (info)
+			if (info)
+				return TRUE;
+			else
+				return FALSE;
+			break;
+		}
+		default:
+			printf ("Skip: %s\n", mono_method_full_name (method, TRUE));
+			return FALSE;
+		}
+	} else {
+		if (!method->token) {
+			/* The method is part of a constructed type like Int[,].Set (). */
+			if (!g_hash_table_lookup (acfg->token_info_hash, method)) {
+				if (m_class_get_rank (method->klass))
 					return TRUE;
-				else
-					return FALSE;
-				break;
-			}
-			default:
-				//printf ("Skip (wrapper call): %d -> %s\n", patch_info->type, mono_method_full_name (patch_info->data.method, TRUE));
 				return FALSE;
 			}
-		} else {
-			if (!method->token) {
-				/* The method is part of a constructed type like Int[,].Set (). */
-				if (!g_hash_table_lookup (acfg->token_info_hash, method)) {
-					if (m_class_get_rank (method->klass))
-						return TRUE;
-					return FALSE;
-				}
-			}
 		}
-		return TRUE;
+	}
+	return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
runtime-invoke wrappers were not emitted on wasm because they contained a METHODCONST referencing themselves, and can_encode_method () returned FALSE for those.

Also fix formatting of can_encode_method ().