### PR TITLE
[RISC-V] Add X0 field init at capture context.

### DIFF
--- a/src/coreclr/pal/src/arch/riscv64/context2.S
+++ b/src/coreclr/pal/src/arch/riscv64/context2.S
@@ -160,6 +160,7 @@ LOCAL_LABEL(Done_CONTEXT_CONTROL):
     ld  t1, 8(sp)
     ld  t3, 16(sp)
 
+    sd  x0, (CONTEXT_X0)(a0)
     sd  tp, (CONTEXT_Tp)(a0)
     sd  gp, (CONTEXT_Gp)(a0)
     sd  a0, (CONTEXT_A0)(a0)


### PR DESCRIPTION
Related to issue in managed stepping (related PR: https://github.com/dotnet/runtime/pull/94853), where during stepping we use stored X0 that not zero, that ruin NativeWalker and SW single stepper logic (for example, at conditional branch, where X0 could be used as one of register).

CC @clamp03 @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @brucehoult