### PR TITLE
JIT: Force inline small BasicBlock methods

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1631,59 +1631,6 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBjumpKinds jumpKind, unsigned j
 }
 
 //------------------------------------------------------------------------
-// isBBCallAlwaysPair: Determine if this is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//
-// Return Value:
-//    True iff "this" is the first block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//    -- a block corresponding to an exit from the try of a try/finally.
-//
-// Notes:
-//    In the flow graph, this becomes a block that calls the finally, and a second, immediately
-//    following empty block (in the bbNext chain) to which the finally will return, and which
-//    branches unconditionally to the next block to be executed outside the try/finally.
-//    Note that code is often generated differently than this description. For example, on ARM,
-//    the target of the BBJ_ALWAYS is loaded in LR (the return register), and a direct jump is
-//    made to the 'finally'. The effect is that the 'finally' returns directly to the target of
-//    the BBJ_ALWAYS. A "retless" BBJ_CALLFINALLY is one that has no corresponding BBJ_ALWAYS.
-//    This can happen if the finally is known to not return (e.g., it contains a 'throw'). In
-//    that case, the BBJ_CALLFINALLY flags has BBF_RETLESS_CALL set. Note that ARM never has
-//    "retless" BBJ_CALLFINALLY blocks due to a requirement to use the BBJ_ALWAYS for
-//    generating code.
-//
-bool BasicBlock::isBBCallAlwaysPair() const
-{
-    if (this->KindIs(BBJ_CALLFINALLY) && !(this->bbFlags & BBF_RETLESS_CALL))
-    {
-        // Some asserts that the next block is a BBJ_ALWAYS of the proper form.
-        assert(!this->IsLast());
-        assert(this->Next()->KindIs(BBJ_ALWAYS));
-        assert(this->Next()->bbFlags & BBF_KEEP_BBJ_ALWAYS);
-        assert(this->Next()->isEmpty());
-
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-//------------------------------------------------------------------------
-// isBBCallAlwaysPairTail: Determine if this is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//
-// Return Value:
-//    True iff "this" is the last block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair
-//    -- a block corresponding to an exit from the try of a try/finally.
-//
-// Notes:
-//    See notes on isBBCallAlwaysPair(), above.
-//
-bool BasicBlock::isBBCallAlwaysPairTail() const
-{
-    return (bbPrev != nullptr) && bbPrev->isBBCallAlwaysPair();
-}
-
-//------------------------------------------------------------------------
 // hasEHBoundaryIn: Determine if this block begins at an EH boundary.
 //
 // Return Value:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -538,7 +538,7 @@ public:
         return bbJumpKind;
     }
 
-    __forceinline void SetJumpKind(BBjumpKinds jumpKind)
+    FORCEINLINE void SetJumpKind(BBjumpKinds jumpKind)
     {
         // If this block's jump kind requires a target, ensure it is already set
         assert(!HasJumpDest() || HasInitializedJumpDest());
@@ -561,7 +561,7 @@ public:
         }
     }
 
-    __forceinline BasicBlock* Next() const
+    FORCEINLINE BasicBlock* Next() const
     {
         return bbNext;
     }
@@ -619,7 +619,7 @@ public:
         return KindIs(BBJ_ALWAYS, BBJ_CALLFINALLY, BBJ_COND, BBJ_EHCATCHRET, BBJ_EHFILTERRET, BBJ_LEAVE);
     }
 
-    __forceinline BasicBlock* GetJumpDest() const
+    FORCEINLINE BasicBlock* GetJumpDest() const
     {
         // If bbJumpKind indicates this block has a jump, bbJumpDest cannot be null
         assert(!HasJumpDest() || HasInitializedJumpDest());
@@ -634,7 +634,7 @@ public:
         assert(!HasJumpDest() || HasInitializedJumpDest());
     }
 
-    __forceinline void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)
+    FORCEINLINE void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)
     {
         bbJumpKind = jumpKind;
         bbJumpDest = jumpDest;
@@ -655,7 +655,7 @@ public:
         return (bbJumpDest == jumpDest);
     }
 
-    __forceinline bool JumpsToNext() const
+    FORCEINLINE bool JumpsToNext() const
     {
         assert(HasInitializedJumpDest());
         return (bbJumpDest == bbNext);
@@ -705,7 +705,7 @@ public:
     unsigned bbRefs; // number of blocks that can reach here, either by fall-through or a branch. If this falls to zero,
                      // the block is unreachable.
 
-    __forceinline bool isRunRarely() const
+    FORCEINLINE bool isRunRarely() const
     {
         return ((bbFlags & BBF_RUN_RARELY) != 0);
     }
@@ -831,7 +831,7 @@ public:
 
     // Set block weight to zero, and set run rarely flag.
     //
-    __forceinline void bbSetRunRarely()
+    FORCEINLINE void bbSetRunRarely()
     {
         this->scaleBBWeight(BB_ZERO_WEIGHT);
     }
@@ -889,7 +889,7 @@ public:
     //    "retless" BBJ_CALLFINALLY blocks due to a requirement to use the BBJ_ALWAYS for
     //    generating code.
     //
-    __forceinline bool isBBCallAlwaysPair() const
+    FORCEINLINE bool isBBCallAlwaysPair() const
     {
         if (this->KindIs(BBJ_CALLFINALLY) && !(this->bbFlags & BBF_RETLESS_CALL))
         {
@@ -917,12 +917,12 @@ public:
     // Notes:
     //    See notes on isBBCallAlwaysPair(), above.
     //
-    __forceinline bool isBBCallAlwaysPairTail() const
+    FORCEINLINE bool isBBCallAlwaysPairTail() const
     {
         return (bbPrev != nullptr) && bbPrev->isBBCallAlwaysPair();
     }
 
-    __forceinline bool KindIs(BBjumpKinds kind) const
+    FORCEINLINE bool KindIs(BBjumpKinds kind) const
     {
         return bbJumpKind == kind;
     }
@@ -1061,11 +1061,11 @@ public:
     // catch type: class token of handler, or one of BBCT_*. Only set on first block of catch handler.
     unsigned bbCatchTyp;
 
-    __forceinline bool hasTryIndex() const
+    FORCEINLINE bool hasTryIndex() const
     {
         return bbTryIndex != 0;
     }
-    __forceinline bool hasHndIndex() const
+    FORCEINLINE bool hasHndIndex() const
     {
         return bbHndIndex != 0;
     }


### PR DESCRIPTION
Several small methods aren't inlined in very large methods (such as `Compiler::impImportBlockCode`) by MSVC, probably due to its inlining budget. Force-inlining some of these methods, starting with a few `BasicBlock` methods, may slightly improve TP (at least this was the case locally).