### PR TITLE
Make sure LOHThreshold less than region_size

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -48147,6 +48147,9 @@ HRESULT GCHeap::Initialize()
 
     GCConfig::SetHeapCount(static_cast<int64_t>(nhp));
 
+    loh_size_threshold = (size_t)GCConfig::GetLOHThreshold();
+    loh_size_threshold = max (loh_size_threshold, LARGE_OBJECT_SIZE);
+
 #ifdef USE_REGIONS
     gc_heap::enable_special_regions_p = (bool)GCConfig::GetGCEnableSpecialRegions();
     size_t gc_region_size = (size_t)GCConfig::GetGCRegionSize();
@@ -48216,8 +48219,6 @@ HRESULT GCHeap::Initialize()
 #error "FEATURE_STRUCTALIGN is not supported for USE_REGIONS"
 #endif //FEATURE_STRUCTALIGN
 
-    loh_size_threshold = (size_t)GCConfig::GetLOHThreshold();
-    loh_size_threshold = max (loh_size_threshold, LARGE_OBJECT_SIZE);
     loh_size_threshold = min (loh_size_threshold, effective_max_small_object_size);
     GCConfig::SetLOHThreshold(loh_size_threshold);
 

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -51872,9 +51872,9 @@ void GCHeap::DiagScanDependentHandles (handle_scan_fn fn, int gen_number, ScanCo
     GCScan::GcScanDependentHandlesForProfilerAndETW (gen_number, context, fn);
 }
 
-uint64_t GCHeap::GetLOHThreshold()
+size_t GCHeap::GetLOHThreshold()
 {
-    return (uint64_t)loh_size_threshold;
+    return loh_size_threshold;
 }
 
 void GCHeap::DiagGetGCSettings(EtwGCSettingsInfo* etw_settings)

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -48219,7 +48219,6 @@ HRESULT GCHeap::Initialize()
 
     gc_heap::min_segment_size_shr = index_of_highest_set_bit (gc_region_size);
 #else
-    // TODO, andrewau, we cannot let user to set an arbitrarily high loh_size_threshold value for segments as well
     gc_heap::min_segment_size_shr = index_of_highest_set_bit (gc_heap::min_segment_size);
 #endif //USE_REGIONS
 

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -204,6 +204,7 @@ public:
     enable_no_gc_region_callback_status EnableNoGCRegionCallback(NoGCRegionCallbackFinalizerWorkItem* callback, uint64_t callback_threshold);
     FinalizerWorkItem* GetExtraWorkForFinalization();
     uint64_t GetGenerationBudget(int generation);
+    uint64_t GetLOHThreshold();
 
     unsigned GetGcCount();
 

--- a/src/coreclr/gc/gcimpl.h
+++ b/src/coreclr/gc/gcimpl.h
@@ -204,7 +204,7 @@ public:
     enable_no_gc_region_callback_status EnableNoGCRegionCallback(NoGCRegionCallbackFinalizerWorkItem* callback, uint64_t callback_threshold);
     FinalizerWorkItem* GetExtraWorkForFinalization();
     uint64_t GetGenerationBudget(int generation);
-    uint64_t GetLOHThreshold();
+    size_t GetLOHThreshold();
 
     unsigned GetGcCount();
 

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1013,6 +1013,8 @@ public:
     virtual FinalizerWorkItem* GetExtraWorkForFinalization() PURE_VIRTUAL
 
     virtual uint64_t GetGenerationBudget(int generation) PURE_VIRTUAL
+
+    virtual uint64_t GetLOHThreshold() PURE_VIRTUAL
 };
 
 #ifdef WRITE_BARRIER_CHECK

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -1014,7 +1014,7 @@ public:
 
     virtual uint64_t GetGenerationBudget(int generation) PURE_VIRTUAL
 
-    virtual uint64_t GetLOHThreshold() PURE_VIRTUAL
+    virtual size_t GetLOHThreshold() PURE_VIRTUAL
 };
 
 #ifdef WRITE_BARRIER_CHECK

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -278,7 +278,6 @@ CONFIG_STRING_INFO(INTERNAL_GcCoverage, W("GcCoverage"), "Specify a method or re
 CONFIG_STRING_INFO(INTERNAL_SkipGCCoverage, W("SkipGcCoverage"), "Specify a list of assembly names to skip with GC Coverage")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_StatsUpdatePeriod, W("StatsUpdatePeriod"), 60, "Specifies the interval, in seconds, at which to update the statistics")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), 0, "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCLOHThreshold, W("GCLOHThreshold"), 0, "Specifies the size that will make objects go on LOH")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 1, "Allow allocation of 2GB+ objects on GC heap")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_GCStress, W("GCStress"), 0, "Trigger GCs at regular intervals")
 CONFIG_DWORD_INFO(INTERNAL_GcStressOnDirectCalls, W("GcStressOnDirectCalls"), 0, "Whether to trigger a GC on direct calls")

--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -169,7 +169,7 @@ Object* GcAllocInternal(MethodTable *pEEType, uint32_t uFlags, uintptr_t numElem
         ASSERT(numElements == 0);
     }
 
-    if (cbSize >= RH_LARGE_OBJECT_SIZE)
+    if ((cbSize >= RH_LARGE_OBJECT_SIZE) && (cbSize >= GCHeapUtilities::GetGCHeap()->GetLOHThreshold()))
     {
         uFlags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -871,6 +871,9 @@ void EEStartupHelper()
         // requires write barriers to have been set up on x86, which happens as part
         // of InitJITHelpers1.
         hr = g_pGCHeap->Initialize();
+
+        g_pConfig->SetGCLOHThreshold((DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold());
+
         if (FAILED(hr))
         {
             LogErrorToHost("GC heap initialization failed with error 0x%08X", hr);

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -871,7 +871,6 @@ void EEStartupHelper()
         // requires write barriers to have been set up on x86, which happens as part
         // of InitJITHelpers1.
         hr = g_pGCHeap->Initialize();
-
         if (FAILED(hr))
         {
             LogErrorToHost("GC heap initialization failed with error 0x%08X", hr);

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -872,8 +872,6 @@ void EEStartupHelper()
         // of InitJITHelpers1.
         hr = g_pGCHeap->Initialize();
 
-        g_pConfig->SetGCLOHThreshold((DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold());
-
         if (FAILED(hr))
         {
             LogErrorToHost("GC heap initialization failed with error 0x%08X", hr);

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -96,7 +96,6 @@ HRESULT EEConfig::Init()
     fGCBreakOnOOM = false;
     iGCconcurrent = 0;
     iGCHoardVM = 0;
-    iGCLOHThreshold = 0;
 
     dwSpinInitialDuration = 0x32;
     dwSpinBackoffFactor = 0x3;

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -439,12 +439,6 @@ HRESULT EEConfig::sync()
     else
         iGCHoardVM = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_GCRetainVM);
 
-    if (!iGCLOHThreshold)
-    {
-        iGCLOHThreshold = Configuration::GetKnobDWORDValue(W("System.GC.LOHThreshold"), CLRConfig::EXTERNAL_GCLOHThreshold);
-        iGCLOHThreshold = max (iGCLOHThreshold, LARGE_OBJECT_SIZE);
-    }
-
 #ifdef FEATURE_CONSERVATIVE_GC
     iGCConservative =  (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_gcConservative) != 0);
 #endif // FEATURE_CONSERVATIVE_GC

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -394,6 +394,7 @@ public:
     void    SetGCconcurrent(int val)              {LIMITED_METHOD_CONTRACT; iGCconcurrent = val;  }
     int     GetGCRetainVM ()                const {LIMITED_METHOD_CONTRACT; return iGCHoardVM;}
     DWORD   GetGCLOHThreshold()             const {LIMITED_METHOD_CONTRACT; return iGCLOHThreshold;}
+    void    SetGCLOHThreshold(DWORD val)          {LIMITED_METHOD_CONTRACT; iGCLOHThreshold = val; }
 
 #ifdef FEATURE_CONSERVATIVE_GC
     bool    GetGCConservative()             const {LIMITED_METHOD_CONTRACT; return iGCConservative;}

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -393,8 +393,6 @@ public:
     int     GetGCconcurrent()               const {LIMITED_METHOD_CONTRACT; return iGCconcurrent; }
     void    SetGCconcurrent(int val)              {LIMITED_METHOD_CONTRACT; iGCconcurrent = val;  }
     int     GetGCRetainVM ()                const {LIMITED_METHOD_CONTRACT; return iGCHoardVM;}
-    DWORD   GetGCLOHThreshold()             const {LIMITED_METHOD_CONTRACT; return iGCLOHThreshold;}
-    void    SetGCLOHThreshold(DWORD val)          {LIMITED_METHOD_CONTRACT; iGCLOHThreshold = val; }
 
 #ifdef FEATURE_CONSERVATIVE_GC
     bool    GetGCConservative()             const {LIMITED_METHOD_CONTRACT; return iGCConservative;}
@@ -585,7 +583,6 @@ private: //----------------------------------------------------------------
 
     int  iGCconcurrent;
     int  iGCHoardVM;
-    DWORD iGCLOHThreshold;
 
 #ifdef FEATURE_CONSERVATIVE_GC
     bool iGCConservative;

--- a/src/coreclr/vm/gcenv.ee.cpp
+++ b/src/coreclr/vm/gcenv.ee.cpp
@@ -1221,12 +1221,6 @@ bool GCToEEInterface::GetIntConfigValue(const char* privateKey, const char* publ
       GC_NOTRIGGER;
     } CONTRACTL_END;
 
-    if (strcmp(privateKey, "GCLOHThreshold") == 0)
-    {
-        *value = g_pConfig->GetGCLOHThreshold();
-        return true;
-    }
-
     if (g_gcHeapHardLimitInfoSpecified)
     {
         if ((g_gcHeapHardLimitInfo.heapHardLimit != UINT64_MAX) && strcmp(privateKey, "GCHeapHardLimit") == 0) { *value = g_gcHeapHardLimitInfo.heapHardLimit; return true; }

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -410,7 +410,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     }
 #endif
 
-    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())
@@ -426,7 +426,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     {
 #ifndef FEATURE_64BIT_ALIGNMENT
         if ((DATA_ALIGNMENT < sizeof(double)) && (pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8) &&
-            (totalSize < (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold() - MIN_OBJECT_SIZE))
+            (totalSize < GCHeapUtilities::GetGCHeap()->GetLOHThreshold() - MIN_OBJECT_SIZE))
         {
             // Creation of an array of doubles, not in the large object heap.
             // We want to align the doubles to 8 byte boundaries, but the GC gives us pointers aligned
@@ -706,7 +706,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
     }
 #endif
 
-    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())
@@ -913,7 +913,7 @@ STRINGREF AllocateString( DWORD cchStringLength )
     SetTypeHandleOnThreadForAlloc(TypeHandle(g_pStringClass));
 
     GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS;
-    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     StringObject* orString = (StringObject*)Alloc(totalSize, flags);
@@ -1062,7 +1062,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
             flags |= GC_ALLOC_FINALIZE;
 
         DWORD totalSize = pMT->GetBaseSize();
-        if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+        if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
             flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
 #ifdef FEATURE_64BIT_ALIGNMENT

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -410,7 +410,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     }
 #endif
 
-    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -913,7 +913,7 @@ STRINGREF AllocateString( DWORD cchStringLength )
     SetTypeHandleOnThreadForAlloc(TypeHandle(g_pStringClass));
 
     GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS;
-    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     StringObject* orString = (StringObject*)Alloc(totalSize, flags);

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -1062,7 +1062,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
             flags |= GC_ALLOC_FINALIZE;
 
         DWORD totalSize = pMT->GetBaseSize();
-        if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+        if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
             flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
 #ifdef FEATURE_64BIT_ALIGNMENT

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -706,7 +706,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
     }
 #endif
 
-    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
+    if (totalSize >= LARGE_OBJECT_SIZE && totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())

--- a/src/coreclr/vm/gchelpers.cpp
+++ b/src/coreclr/vm/gchelpers.cpp
@@ -410,7 +410,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     }
 #endif
 
-    if (totalSize >= g_pConfig->GetGCLOHThreshold())
+    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())
@@ -426,7 +426,7 @@ OBJECTREF AllocateSzArray(MethodTable* pArrayMT, INT32 cElements, GC_ALLOC_FLAGS
     {
 #ifndef FEATURE_64BIT_ALIGNMENT
         if ((DATA_ALIGNMENT < sizeof(double)) && (pArrayMT->GetArrayElementType() == ELEMENT_TYPE_R8) &&
-            (totalSize < g_pConfig->GetGCLOHThreshold() - MIN_OBJECT_SIZE))
+            (totalSize < (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold() - MIN_OBJECT_SIZE))
         {
             // Creation of an array of doubles, not in the large object heap.
             // We want to align the doubles to 8 byte boundaries, but the GC gives us pointers aligned
@@ -706,7 +706,7 @@ OBJECTREF AllocateArrayEx(MethodTable *pArrayMT, INT32 *pArgs, DWORD dwNumArgs, 
     }
 #endif
 
-    if (totalSize >= g_pConfig->GetGCLOHThreshold())
+    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     if (pArrayMT->ContainsPointers())
@@ -913,7 +913,7 @@ STRINGREF AllocateString( DWORD cchStringLength )
     SetTypeHandleOnThreadForAlloc(TypeHandle(g_pStringClass));
 
     GC_ALLOC_FLAGS flags = GC_ALLOC_NO_FLAGS;
-    if (totalSize >= g_pConfig->GetGCLOHThreshold())
+    if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
         flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
     StringObject* orString = (StringObject*)Alloc(totalSize, flags);
@@ -1062,7 +1062,7 @@ OBJECTREF AllocateObject(MethodTable *pMT
             flags |= GC_ALLOC_FINALIZE;
 
         DWORD totalSize = pMT->GetBaseSize();
-        if (totalSize >= g_pConfig->GetGCLOHThreshold())
+        if (totalSize >= (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold())
             flags |= GC_ALLOC_LARGE_OBJECT_HEAP;
 
 #ifdef FEATURE_64BIT_ALIGNMENT

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -6929,7 +6929,7 @@ HRESULT ProfToEEInterfaceImpl::GetLOHObjectSizeThreshold(DWORD *pThreshold)
         return E_INVALIDARG;
     }
 
-    *pThreshold = g_pConfig->GetGCLOHThreshold();
+    *pThreshold = (DWORD)GCHeapUtilities::GetGCHeap()->GetLOHThreshold();
 
     return S_OK;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95219.

Here are the testing result on CoreCLR after all code review comments are incorporated, the table headers are the byte array sizes (which we need to add 24 to get the real object size), all tests are performed on Windows X64.

|     |         | Config   | GC.GetConfigurationVariable | 85000 - 25 | 85000 - 24 | 4194216 - 25 | 4194216 - 24 |
| --- | ------- | -------- | --------------------------- | ---------- | ---------- |------------- |------------- |
| wks | regions | N/A      | 85000                       | SOH        | LOH        | LOH          | LOH          |
| wks | regions | 1M       | 1048576                     | SOH        | SOH        | LOH          | LOH          |
| wks | regions | 4M       | 4194216                     | SOH        | SOH        | SOH          | LOH          |
| svr | regions | N/A      | 85000                       | SOH        | LOH        | LOH          | LOH          |
| svr | regions | 1M       | 1048576                     | SOH        | SOH        | LOH          | LOH          |
| svr | regions | 4M       | 4194216                     | SOH        | SOH        | SOH          | LOH          |
| wks | segment | N/A      | 85000                       | SOH        | LOH        | LOH          | LOH          |
| wks | segment | 1M       | 1048576                     | SOH        | SOH        | LOH          | LOH          |
| wks | segment | 4M       | 4194216                     | SOH        | SOH        | SOH          | LOH          |
| svr | segment | N/A      | 85000                       | SOH        | LOH        | LOH          | LOH          |
| svr | segment | 1M       | 1048576                     | SOH        | SOH        | LOH          | LOH          |
| svr | segment | 4M       | 4194304                     | SOH        | SOH        | SOH          | SOH          |

Additional tests on segments to see how far we can go there.

|     |         | Config   | GC.GetConfigurationVariable | 500M - 25  |
| --- | ------- | -------- | --------------------------- | ---------- |
| wks | segment | 1G       | 1073741824                  | OOM        |
| svr | segment | 1G       | 1073741824                  | SOH        |