### PR TITLE
Disable EventSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -21,7 +21,8 @@ namespace BasicEventSourceTests
         /// Tests the EventSource.Write[T] method (can only use the self-describing mechanism).
         ///
         /// </summary>
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // ActiveIssue: https://github.com/dotnet/runtime/issues/26197
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_Write_Fuzzy()
         {
             using (var logger = new EventSource("EventSourceName"))

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -30,7 +30,7 @@ namespace BasicEventSourceTests
 
         /// ETW only works with elevated process
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798", typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798")]
         public void Test_EventSource_EtwManifestGeneration()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions { TimeOut = 300_000 /* ms */ };
@@ -77,7 +77,7 @@ namespace BasicEventSourceTests
         }
 
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798", typeof(PlatformDetection), nameof(PlatformDetection.IsX86Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798")]
         public void Test_EventSource_EtwManifestGenerationRollover()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.Etw.cs
@@ -19,6 +19,7 @@ namespace BasicEventSourceTests
         /// Tests the ETW code path
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_Write_T_ETW()
         {
             using (var listener = new EtwListener())
@@ -27,9 +28,8 @@ namespace BasicEventSourceTests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/21295", TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/25035")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPrivilegedProcess))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_Write_T_In_Manifest_Serialization_WithEtwListener()
         {
             using (var eventListener = new EventListenerListener())

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.Etw.cs
@@ -19,6 +19,7 @@ namespace BasicEventSourceTests
         /// Tests the ETW path.
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_WriteEvent_Manifest_ETW()
         {
             using (var listener = new EtwListener())
@@ -32,6 +33,7 @@ namespace BasicEventSourceTests
         /// Tests both the ETW and TraceListener paths.
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_WriteEvent_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())
@@ -45,6 +47,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener case
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_WriteEvent_ComplexData_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())
@@ -59,6 +62,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener case
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_WriteEvent_ByteArray_Manifest_ETW()
         {
             using (var listener = new EtwListener())
@@ -73,6 +77,7 @@ namespace BasicEventSourceTests
         /// Tests the EventListener case
         /// </summary>
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServer))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/88305")]
         public void Test_WriteEvent_ByteArray_SelfDescribing_ETW()
         {
             using (var listener = new EtwListener())


### PR DESCRIPTION
The manifest generation tests use lots of sleeps and are problematic with longer running targets, i.e. jitstress and gcstress. 

The ETW tests keep failing because the process is not elevated even though we should be guarding against that, further research is necessary to determine what the issue is. For now we should disable these tests to get them off the blocking CI list