### PR TITLE
[RISC-V] Fix JitDisasm in release build

### DIFF
--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -144,12 +144,13 @@ FILE* jitstdout()
 }
 
 // Like printf/logf, but only outputs to jitstdout -- skips call back into EE.
-void jitprintf(const char* fmt, ...)
+int jitprintf(const char* fmt, ...)
 {
     va_list vl;
     va_start(vl, fmt);
-    vfprintf(jitstdout(), fmt, vl);
+    int status = vfprintf(jitstdout(), fmt, vl);
     va_end(vl);
+    return status;
 }
 
 void jitShutdown(bool processIsTerminating)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1542,7 +1542,7 @@ void emitter::appendToCurIG(instrDesc* id)
  *  Display (optionally) an instruction offset.
  */
 
-void emitter::emitDispInsAddr(BYTE* code)
+void emitter::emitDispInsAddr(const BYTE* code)
 {
 #ifdef DEBUG
     if (emitComp->opts.disAddr)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -4211,8 +4211,6 @@ void emitter::emitDispIG(insGroup* ig, bool displayFunc, bool displayInstruction
 
         printf("\n");
 
-#if !defined(TARGET_RISCV64)
-        // TODO-RISCV64-Bug: When JitDump is on, it asserts in emitDispIns which is not implemented.
         if (displayInstructions)
         {
             instrDesc*     id  = emitFirstInstrDesc(ig->igData);
@@ -4245,7 +4243,6 @@ void emitter::emitDispIG(insGroup* ig, bool displayFunc, bool displayInstruction
                 printf("\n");
             }
         }
-#endif // !TARGET_RISCV64
     }
 }
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1491,6 +1491,12 @@ void emitter::dispIns(instrDesc* id)
     // For LoongArch64 using the emitDisInsName().
     NYI_LOONGARCH64("Not used on LOONGARCH64.");
 }
+#elif defined(TARGET_RISCV64)
+void emitter::dispIns(instrDesc* id)
+{
+    // For RISCV64 using the emitDisInsName().
+    NYI_RISCV64("Not used on RISCV64.");
+}
 #else
 void emitter::dispIns(instrDesc* id)
 {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1491,12 +1491,6 @@ void emitter::dispIns(instrDesc* id)
     // For LoongArch64 using the emitDisInsName().
     NYI_LOONGARCH64("Not used on LOONGARCH64.");
 }
-#elif defined(TARGET_RISCV64)
-void emitter::dispIns(instrDesc* id)
-{
-    // For RISCV64 using the emitDisInsName().
-    NYI_RISCV64("Not used on RISCV64.");
-}
 #else
 void emitter::dispIns(instrDesc* id)
 {

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2117,7 +2117,7 @@ protected:
     void emitDispJumpList();
     void emitDispClsVar(CORINFO_FIELD_HANDLE fldHnd, ssize_t offs, bool reloc = false);
     void emitDispFrameRef(int varx, int disp, int offs, bool asmfm);
-    void emitDispInsAddr(BYTE* code);
+    void emitDispInsAddr(const BYTE* code);
     void emitDispInsOffs(unsigned offs, bool doffs);
     void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
     void emitDispEmbBroadcastCount(instrDesc* id);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2103,14 +2103,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     instruction ins;
     size_t      sz; // = emitSizeOfInsDsc(id);
 
-#ifdef DEBUG
-#if DUMP_GC_TABLES
-    bool dspOffs = emitComp->opts.dspGCtbls;
-#else  // !DUMP_GC_TABLES
-    bool     dspOffs = !emitComp->opts.disDiffable;
-#endif // !DUMP_GC_TABLES
-#endif // DEBUG
-
     assert(REG_NA == (int)REG_NA);
 
     insOpts insOp = id->idInsOpt();

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3831,6 +3831,7 @@ void emitter::emitDispIns(
     size_t      instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize)
     {
+        // TODO-RISCV64: support different size instructions
         instrSize = sizeof(code_t);
         code_t instruction;
         memcpy(&instruction, instr, instrSize);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2892,12 +2892,17 @@ static const char* const RegNames[] =
 //    The length of the instruction's name include aligned space is 15.
 //
 
-void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
+void emitter::emitDisInsName(code_t code, BYTE* addr, bool doffs, unsigned offset, instrDesc* id)
 {
-    const BYTE* insAdr = addr - writeableOffset;
+    BYTE* insAdr = addr - writeableOffset;
 
     unsigned int opcode = code & 0x7f;
     assert((opcode & 0x3) == 0x3);
+
+    emitDispInsAddr(insAdr);
+    emitDispInsOffs(offset, doffs);
+
+    printf("      ");
 
     switch (opcode)
     {
@@ -3811,32 +3816,24 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
     }
 }
 
-#ifdef DEBUG
-
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
-    static constexpr code_t k32BitInstructionLowerMask = 0x1f; // 0b00000011
-    static constexpr code_t k32BitInstructionUpperMask = 0x1c; // 0b00011100
-
     if (pCode == nullptr)
         return;
 
-    printf("      ");
-
-    const BYTE* instr = pCode + writeableOffset;
+    BYTE* instr = pCode + writeableOffset;
     size_t instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize)
     {
         instrSize = sizeof(code_t);
         code_t instruction;
         memcpy(&instruction, instr, instrSize);
-        // checks whether the instruction is 4 bytes long
-        // assert(((instruction & k32BitInstructionUpperMask) != k32BitInstructionUpperMask) &&
-        //        ((instruction & k32BitInstructionLowerMask) == k32BitInstructionLowerMask));
-        emitDisInsName(instruction, instr, id);
+        emitDisInsName(instruction, instr, doffs, offset, id);
     }
 }
+
+#ifdef DEBUG
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3837,7 +3837,7 @@ void emitter::emitDispIns(
 
     const BYTE* address = emitCodeBlock + offset + writeableOffset;
     const BYTE* const addressSentinel = address + id->idCodeSize();
-    // TODO-RISCV64-C: add support for non-32 bit instructions
+    // TODO-RISCV64: add support for non-32 bit instructions
     for (; address < addressSentinel; address += sizeof(code_t))
     {
         code_t instruction;

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -941,9 +941,9 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNu
 }
 
 // This computes address from the immediate which is relocatable.
-void emitter::emitIns_R_AI(instruction  ins,
-                           emitAttr     attr,
-                           regNumber    reg,
+void emitter::emitIns_R_AI(instruction ins,
+                           emitAttr    attr,
+                           regNumber   reg,
                            ssize_t addr DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     assert(EA_IS_RELOC(attr)); // EA_PTR_DSP_RELOC
@@ -1243,8 +1243,8 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
 void emitter::emitIns_Call(EmitCallType          callType,
                            CORINFO_METHOD_HANDLE methHnd,
                            INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
-                           void*            addr,
-                           ssize_t          argSize,
+                           void*    addr,
+                           ssize_t  argSize,
                            emitAttr retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                            VARSET_VALARG_TP ptrVars,
                            regMaskTP        gcrefRegs,
@@ -1713,9 +1713,9 @@ void emitter::emitJumpDistBind()
         emitCounts_INS_OPTS_J * (6 << 2); // the max placeholder sizeof(INS_OPTS_JALR) - sizeof(INS_OPTS_J)
     NATIVE_OFFSET psd = B_DIST_SMALL_MAX_POS - maxPlaceholderSize;
 
-    /*****************************************************************************/
-    /* If the default small encoding is not enough, we start again here.     */
-    /*****************************************************************************/
+/*****************************************************************************/
+/* If the default small encoding is not enough, we start again here.     */
+/*****************************************************************************/
 
 AGAIN:
 
@@ -1746,7 +1746,7 @@ AGAIN:
         UNATIVE_OFFSET dstOffs;
         NATIVE_OFFSET  jmpDist; // the relative jump distance, as it will be encoded
 
-        /* Make sure the jumps are properly ordered */
+/* Make sure the jumps are properly ordered */
 
 #ifdef DEBUG
         assert(lastSJ == nullptr || lastIG != jmp->idjIG || lastSJ->idjOffs < (jmp->idjOffs + adjSJ));
@@ -2107,7 +2107,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #if DUMP_GC_TABLES
     bool dspOffs = emitComp->opts.dspGCtbls;
 #else
-    bool dspOffs = !emitComp->opts.disDiffable;
+    bool     dspOffs = !emitComp->opts.disDiffable;
 #endif
 #endif // DEBUG
 
@@ -2505,7 +2505,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                         regNumber reg2 = REG_R0;
                         if (INS_beqz != ins && INS_bnez != ins)
                             reg2 = id->idReg2();
-                        code = emitInsCode(ins) ^ 0x1000;
+                        code     = emitInsCode(ins) ^ 0x1000;
                         code |= (code_t)reg1 << 15; /* rj */
                         code |= (code_t)reg2 << 20; /* rd */
                         code |= 0x8 << 7;
@@ -2585,7 +2585,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                         regNumber reg2 = REG_R0;
                         if (INS_beqz != ins && INS_bnez != ins)
                             reg2 = id->idReg2();
-                        code = emitInsCode(ins) ^ 0x1000;
+                        code     = emitInsCode(ins) ^ 0x1000;
                         code |= (code_t)reg1 << 15; /* rj */
                         code |= (code_t)reg2 << 20; /* rd */
                         code |= 28 << 7;

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2840,9 +2840,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     {
 #if DUMP_GC_TABLES
         bool dspOffs = emitComp->opts.dspGCtbls;
-#else // DUMP_GC_TABLES
+#else // !DUMP_GC_TABLES
         bool dspOffs = !emitComp->opts.disDiffable;
-#endif // DUMP_GC_TABLES
+#endif // !DUMP_GC_TABLES
         emitDispIns(id, false, dspOffs, true, 0, *dp, (dstRW - odstRW), ig);
     }
 
@@ -2855,7 +2855,12 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             assert(!"JitBreakEmitOutputInstr reached");
         }
     }
-#endif
+#else // !DEBUG
+    if (emitComp->opts.disAsm)
+    {
+        emitDispIns(id, false, false, true, 0, *dp, (dstRW - odstRW), ig);
+    }
+#endif // !DEBUG
 
     /* All instructions are expected to generate code */
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2879,7 +2879,7 @@ static const char* const RegNames[] =
 
 //----------------------------------------------------------------------------------------
 // Disassemble the given instruction.
-// The `emitter::emitDisInsName` is focused on the most important for debugging.
+// The `emitter::emitDispInsName` is focused on the most important for debugging.
 // So it implemented as far as simply and independently which is very useful for
 // porting easily to the release mode.
 //
@@ -2892,9 +2892,9 @@ static const char* const RegNames[] =
 //    The length of the instruction's name include aligned space is 15.
 //
 
-void emitter::emitDisInsName(code_t code, BYTE* addr, bool doffs, unsigned offset, instrDesc* id)
+void emitter::emitDispInsName(code_t code, const BYTE* addr, bool doffs, unsigned offset, instrDesc* id)
 {
-    BYTE* insAdr = addr - writeableOffset;
+    const BYTE* insAdr = addr - writeableOffset;
 
     unsigned int opcode = code & 0x7f;
     assert((opcode & 0x3) == 0x3);
@@ -3822,14 +3822,14 @@ void emitter::emitDispIns(
     if (pCode == nullptr)
         return;
 
-    BYTE* instr = pCode + writeableOffset;
+    const BYTE* instr = pCode + writeableOffset;
     size_t instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize)
     {
         instrSize = sizeof(code_t);
         code_t instruction;
         memcpy(&instruction, instr, instrSize);
-        emitDisInsName(instruction, instr, doffs, offset, id);
+        emitDispInsName(instruction, instr, doffs, offset, id);
     }
 }
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3833,8 +3833,8 @@ void emitter::emitDispIns(
         return;
 
     const BYTE* address = emitCodeBlock + offset + writeableOffset;
-    const BYTE* const address_sentinel = address + id->idCodeSize();
-    for (; address < address_sentinel; address += sizeof(code_t))
+    const BYTE* const addressSentinel = address + id->idCodeSize();
+    for (; address < addressSentinel; address += sizeof(code_t))
     {
         code_t instruction;
         memcpy(&instruction, address, sizeof(code_t));

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1904,8 +1904,8 @@ AGAIN:
                 instruction ins = jmp->idIns();
                 assert((INS_jal <= ins) && (ins <= INS_bgeu));
 
-                if (ins > INS_jalr || (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr <
-                                                                       // beq/bne/blt/bltu/bge/bgeu
+                if (ins > INS_jalr ||
+                    (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr < beq/bne/blt/bltu/bge/bgeu
                 {
                     if (isValidSimm13(jmpDist + maxPlaceholderSize))
                     {
@@ -1981,8 +1981,8 @@ AGAIN:
                 instruction ins = jmp->idIns();
                 assert((INS_jal <= ins) && (ins <= INS_bgeu));
 
-                if (ins > INS_jalr || (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr <
-                                                                       // beq/bne/blt/bltu/bge/bgeu
+                if (ins > INS_jalr ||
+                    (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr < beq/bne/blt/bltu/bge/bgeu
                 {
                     if (isValidSimm13(jmpDist + maxPlaceholderSize))
                     {
@@ -2086,7 +2086,7 @@ AGAIN:
 }
 
 /*****************************************************************************
- *
+*
  *  Append the machine code corresponding to the given instruction descriptor
  *  to the code block at '*dp'; the base of the code block is 'bp', and 'ig'
  *  is the instruction group that contains the instruction. Updates '*dp' to
@@ -2106,9 +2106,9 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
 #ifdef DEBUG
 #if DUMP_GC_TABLES
     bool dspOffs = emitComp->opts.dspGCtbls;
-#else
+#else  // !DUMP_GC_TABLES
     bool     dspOffs = !emitComp->opts.disDiffable;
-#endif
+#endif // !DUMP_GC_TABLES
 #endif // DEBUG
 
     assert(REG_NA == (int)REG_NA);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3829,10 +3829,18 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
-    // RISCV64 implements this similar by `emitter::emitDisInsName`.
-    // For RISCV64 maybe the `emitDispIns` is over complicate.
-    // The `emitter::emitDisInsName` is focused on the most important for debugging.
-    NYI_RISCV64("RISCV64 not used the emitter::emitDispIns");
+    if (ig == nullptr)
+        return;
+
+    const BYTE* address = emitCodeBlock + offset + writeableOffset;
+    for (int size = id->idCodeSize(); size > 0;)
+    {
+        code_t instruction;
+        memcpy(&instruction, address, sizeof(code_t));
+        emitDisInsName(instruction, address, id);
+        address += sizeof(code_t);
+        size -= sizeof(code_t);
+    }
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3833,13 +3833,12 @@ void emitter::emitDispIns(
         return;
 
     const BYTE* address = emitCodeBlock + offset + writeableOffset;
-    for (int size = id->idCodeSize(); size > 0;)
+    const BYTE* const address_sentinel = address + id->idCodeSize();
+    for (; address < address_sentinel; address += sizeof(code_t))
     {
         code_t instruction;
         memcpy(&instruction, address, sizeof(code_t));
         emitDisInsName(instruction, address, id);
-        address += sizeof(code_t);
-        size -= sizeof(code_t);
     }
 }
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3822,7 +3822,7 @@ void emitter::emitDispIns(
     if (pCode == nullptr)
         return;
 
-    const BYTE* instr = pCode + writeableOffset;
+    const BYTE* instr = pCode + writeableOffset + offset;
     size_t instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize)
     {

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3829,15 +3829,22 @@ void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
+    static constexpr code_t k32BitInstructionLowerMask = 0x1f; // 0b00000011
+    static constexpr code_t k32BitInstructionUpperMask = 0x1c; // 0b00011100
+
     if (ig == nullptr)
         return;
 
     const BYTE* address = emitCodeBlock + offset + writeableOffset;
     const BYTE* const addressSentinel = address + id->idCodeSize();
+    // TODO-RISCV64-C: add support for non-32 bit instructions
     for (; address < addressSentinel; address += sizeof(code_t))
     {
         code_t instruction;
         memcpy(&instruction, address, sizeof(code_t));
+        // checks whether the instruction is 4 bytes long
+        assert((instruction & k32BitInstructionUpperMask != k32BitInstructionUpperMask) &&
+               (instruction & k32BitInstructionLowerMask == k32BitInstructionLowerMask));
         emitDisInsName(instruction, address, id);
     }
 }

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -941,9 +941,9 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNu
 }
 
 // This computes address from the immediate which is relocatable.
-void emitter::emitIns_R_AI(instruction ins,
-                           emitAttr    attr,
-                           regNumber   reg,
+void emitter::emitIns_R_AI(instruction  ins,
+                           emitAttr     attr,
+                           regNumber    reg,
                            ssize_t addr DEBUGARG(size_t targetHandle) DEBUGARG(GenTreeFlags gtFlags))
 {
     assert(EA_IS_RELOC(attr)); // EA_PTR_DSP_RELOC
@@ -1243,8 +1243,8 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
 void emitter::emitIns_Call(EmitCallType          callType,
                            CORINFO_METHOD_HANDLE methHnd,
                            INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
-                           void*    addr,
-                           ssize_t  argSize,
+                           void*            addr,
+                           ssize_t          argSize,
                            emitAttr retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                            VARSET_VALARG_TP ptrVars,
                            regMaskTP        gcrefRegs,
@@ -1713,9 +1713,9 @@ void emitter::emitJumpDistBind()
         emitCounts_INS_OPTS_J * (6 << 2); // the max placeholder sizeof(INS_OPTS_JALR) - sizeof(INS_OPTS_J)
     NATIVE_OFFSET psd = B_DIST_SMALL_MAX_POS - maxPlaceholderSize;
 
-/*****************************************************************************/
-/* If the default small encoding is not enough, we start again here.     */
-/*****************************************************************************/
+    /*****************************************************************************/
+    /* If the default small encoding is not enough, we start again here.     */
+    /*****************************************************************************/
 
 AGAIN:
 
@@ -1746,7 +1746,7 @@ AGAIN:
         UNATIVE_OFFSET dstOffs;
         NATIVE_OFFSET  jmpDist; // the relative jump distance, as it will be encoded
 
-/* Make sure the jumps are properly ordered */
+        /* Make sure the jumps are properly ordered */
 
 #ifdef DEBUG
         assert(lastSJ == nullptr || lastIG != jmp->idjIG || lastSJ->idjOffs < (jmp->idjOffs + adjSJ));
@@ -1904,8 +1904,8 @@ AGAIN:
                 instruction ins = jmp->idIns();
                 assert((INS_jal <= ins) && (ins <= INS_bgeu));
 
-                if (ins > INS_jalr ||
-                    (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr < beq/bne/blt/bltu/bge/bgeu
+                if (ins > INS_jalr || (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr <
+                                                                       // beq/bne/blt/bltu/bge/bgeu
                 {
                     if (isValidSimm13(jmpDist + maxPlaceholderSize))
                     {
@@ -1981,8 +1981,8 @@ AGAIN:
                 instruction ins = jmp->idIns();
                 assert((INS_jal <= ins) && (ins <= INS_bgeu));
 
-                if (ins > INS_jalr ||
-                    (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr < beq/bne/blt/bltu/bge/bgeu
+                if (ins > INS_jalr || (ins < INS_jalr && ins > INS_j)) // jal < beqz < bnez < jalr <
+                                                                       // beq/bne/blt/bltu/bge/bgeu
                 {
                     if (isValidSimm13(jmpDist + maxPlaceholderSize))
                     {
@@ -2086,7 +2086,7 @@ AGAIN:
 }
 
 /*****************************************************************************
-*
+ *
  *  Append the machine code corresponding to the given instruction descriptor
  *  to the code block at '*dp'; the base of the code block is 'bp', and 'ig'
  *  is the instruction group that contains the instruction. Updates '*dp' to
@@ -2505,7 +2505,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                         regNumber reg2 = REG_R0;
                         if (INS_beqz != ins && INS_bnez != ins)
                             reg2 = id->idReg2();
-                        code     = emitInsCode(ins) ^ 0x1000;
+                        code = emitInsCode(ins) ^ 0x1000;
                         code |= (code_t)reg1 << 15; /* rj */
                         code |= (code_t)reg2 << 20; /* rd */
                         code |= 0x8 << 7;
@@ -2585,7 +2585,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
                         regNumber reg2 = REG_R0;
                         if (INS_beqz != ins && INS_bnez != ins)
                             reg2 = id->idReg2();
-                        code     = emitInsCode(ins) ^ 0x1000;
+                        code = emitInsCode(ins) ^ 0x1000;
                         code |= (code_t)reg1 << 15; /* rj */
                         code |= (code_t)reg2 << 20; /* rd */
                         code |= 28 << 7;
@@ -2840,7 +2840,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     {
 #if DUMP_GC_TABLES
         bool dspOffs = emitComp->opts.dspGCtbls;
-#else // !DUMP_GC_TABLES
+#else  // !DUMP_GC_TABLES
         bool dspOffs = !emitComp->opts.disDiffable;
 #endif // !DUMP_GC_TABLES
         emitDispIns(id, false, dspOffs, true, 0, *dp, (dstRW - odstRW), ig);
@@ -2855,7 +2855,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             assert(!"JitBreakEmitOutputInstr reached");
         }
     }
-#else // !DEBUG
+#else  // !DEBUG
     if (emitComp->opts.disAsm)
     {
         emitDispIns(id, false, false, true, 0, *dp, (dstRW - odstRW), ig);
@@ -3828,7 +3828,7 @@ void emitter::emitDispIns(
         return;
 
     const BYTE* instr = pCode + writeableOffset + offset;
-    size_t instrSize;
+    size_t      instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize)
     {
         instrSize = sizeof(code_t);

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -73,9 +73,9 @@ unsigned emitOutput_Instr(BYTE* dst, code_t code);
 // Method to do check if mov is redundant with respect to the last instruction.
 // If yes, the caller of this method can choose to omit current mov instruction.
 static bool IsMovInstruction(instruction ins);
-bool        IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src, bool canSkip);
-bool        IsRedundantLdStr(
-           instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt); // New functions end.
+bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src, bool canSkip);
+bool IsRedundantLdStr(
+    instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt); // New functions end.
 
 /************************************************************************/
 /*           Public inline informational methods                        */
@@ -215,9 +215,9 @@ void emitIns_J_R(instruction ins, emitAttr attr, BasicBlock* dst, regNumber reg)
 
 void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 
-void emitIns_R_AI(instruction  ins,
-                  emitAttr     attr,
-                  regNumber    reg,
+void emitIns_R_AI(instruction ins,
+                  emitAttr    attr,
+                  regNumber   reg,
                   ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 enum EmitCallType
@@ -246,8 +246,8 @@ enum EmitCallType
 void emitIns_Call(EmitCallType          callType,
                   CORINFO_METHOD_HANDLE methHnd,
                   INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
-                  void*            addr,
-                  ssize_t          argSize,
+                  void*    addr,
+                  ssize_t  argSize,
                   emitAttr retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -60,7 +60,9 @@ bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
 
-void emitDispInsName(code_t code, const BYTE* addr, bool doffs, unsigned offset, instrDesc* id);
+void emitDispInsName(code_t code, const BYTE* addr, bool doffs, unsigned insOffset, instrDesc* id);
+
+void emitDispInsInstrNum(const instrDesc* id) const;
 
 emitter::code_t emitInsCode(instruction ins /*, insFormat fmt*/);
 

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -73,9 +73,9 @@ unsigned emitOutput_Instr(BYTE* dst, code_t code);
 // Method to do check if mov is redundant with respect to the last instruction.
 // If yes, the caller of this method can choose to omit current mov instruction.
 static bool IsMovInstruction(instruction ins);
-bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src, bool canSkip);
-bool IsRedundantLdStr(
-    instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt); // New functions end.
+bool        IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src, bool canSkip);
+bool        IsRedundantLdStr(
+           instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt); // New functions end.
 
 /************************************************************************/
 /*           Public inline informational methods                        */
@@ -215,9 +215,9 @@ void emitIns_J_R(instruction ins, emitAttr attr, BasicBlock* dst, regNumber reg)
 
 void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 
-void emitIns_R_AI(instruction ins,
-                  emitAttr    attr,
-                  regNumber   reg,
+void emitIns_R_AI(instruction  ins,
+                  emitAttr     attr,
+                  regNumber    reg,
                   ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(GenTreeFlags gtFlags = GTF_EMPTY));
 
 enum EmitCallType
@@ -232,7 +232,7 @@ enum EmitCallType
 
     EC_FUNC_TOKEN, //   Direct call to a helper/static/nonvirtual/global method
                    //  EC_FUNC_TOKEN_INDIR,    // Indirect call to a helper/static/nonvirtual/global method
-    // EC_FUNC_ADDR,  // Direct call to an absolute address
+                   // EC_FUNC_ADDR,  // Direct call to an absolute address
 
     //  EC_FUNC_VIRTUAL,        // Call to a virtual method (using the vtable)
     EC_INDIR_R, // Indirect call via register
@@ -246,8 +246,8 @@ enum EmitCallType
 void emitIns_Call(EmitCallType          callType,
                   CORINFO_METHOD_HANDLE methHnd,
                   INDEBUG_LDISASM_COMMA(CORINFO_SIG_INFO* sigInfo) // used to report call sites to the EE
-                  void*    addr,
-                  ssize_t  argSize,
+                  void*            addr,
+                  ssize_t          argSize,
                   emitAttr retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -27,8 +27,6 @@ struct CnsVal
 
 const char* emitFPregName(unsigned reg, bool varName = true);
 const char* emitVectorRegName(regNumber reg);
-
-void emitDisInsName(code_t code, const BYTE* addr, instrDesc* id);
 #endif // DEBUG
 
 void emitIns_J_cond_la(instruction ins, BasicBlock* dst, regNumber reg1 = REG_R0, regNumber reg2 = REG_R0);
@@ -61,6 +59,8 @@ private:
 bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
+
+void emitDisInsName(code_t code, const BYTE* addr, instrDesc* id);
 
 emitter::code_t emitInsCode(instruction ins /*, insFormat fmt*/);
 

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -60,7 +60,7 @@ bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
 
-void emitDisInsName(code_t code, const BYTE* addr, instrDesc* id);
+void emitDisInsName(code_t code, BYTE* addr, bool doffs, unsigned offset, instrDesc* id);
 
 emitter::code_t emitInsCode(instruction ins /*, insFormat fmt*/);
 

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -232,7 +232,7 @@ enum EmitCallType
 
     EC_FUNC_TOKEN, //   Direct call to a helper/static/nonvirtual/global method
                    //  EC_FUNC_TOKEN_INDIR,    // Indirect call to a helper/static/nonvirtual/global method
-                   // EC_FUNC_ADDR,  // Direct call to an absolute address
+    // EC_FUNC_ADDR,  // Direct call to an absolute address
 
     //  EC_FUNC_VIRTUAL,        // Call to a virtual method (using the vtable)
     EC_INDIR_R, // Indirect call via register

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -60,7 +60,7 @@ bool emitInsIsLoad(instruction ins);
 bool emitInsIsStore(instruction ins);
 bool emitInsIsLoadOrStore(instruction ins);
 
-void emitDisInsName(code_t code, BYTE* addr, bool doffs, unsigned offset, instrDesc* id);
+void emitDispInsName(code_t code, const BYTE* addr, bool doffs, unsigned offset, instrDesc* id);
 
 emitter::code_t emitInsCode(instruction ins /*, insFormat fmt*/);
 

--- a/src/coreclr/jit/host.h
+++ b/src/coreclr/jit/host.h
@@ -3,7 +3,7 @@
 
 /*****************************************************************************/
 
-void jitprintf(const char* fmt, ...);
+int jitprintf(const char* fmt, ...);
 
 #ifdef DEBUG
 


### PR DESCRIPTION
Fixes JitDisasm in release build which wasn't showing the assembly instructions

note: clang-format changed some indentations across the files

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @sirntar @yurai007 @tomeksowi @brucehoult