### PR TITLE
Reporting of type loads via console output and a new event perfcounter

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/JitInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/JitInfo.CoreCLR.cs
@@ -26,6 +26,15 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern long GetCompiledMethodCount(bool currentThread = false);
 
+        /// <summary>
+        /// Get the number of types that have been loaded. If <paramref name="currentThread"/> is true,
+        /// then this value is scoped to the current thread, otherwise, this is a global value.
+        /// </summary>
+        /// <param name="currentThread">Whether the returned value should be specific to the current thread. Default: false</param>
+        /// <returns>The number of types the runtime typeloader has loaded.</returns>
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public static extern long GetLoadedTypeCount(bool currentThread = false);
+
         // Normalized to 100ns ticks on vm side
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern long GetCompilationTimeInTicks(bool currentThread = false);

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -247,6 +247,7 @@ CONFIG_DWORD_INFO(INTERNAL_ContinueOnAssert, W("ContinueOnAssert"), 0, "If set, 
 CONFIG_DWORD_INFO(INTERNAL_InjectFatalError, W("InjectFatalError"), 0, "")
 CONFIG_DWORD_INFO(INTERNAL_InjectFault, W("InjectFault"), 0, "")
 CONFIG_DWORD_INFO(INTERNAL_SuppressChecks, W("SuppressChecks"),0,  "")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_TypeLoadSummary, W("TypeLoadSummary"), 0, "If set to nonzero value, log type loads to standard output (somewhat akin to JitDisasmSummary)")
 #ifdef FEATURE_EH_FUNCLETS
 CONFIG_DWORD_INFO(INTERNAL_SuppressLockViolationsOnReentryFromOS, W("SuppressLockViolationsOnReentryFromOS"), 0, "64 bit OOM tests re-enter the CLR via RtlVirtualUnwind.  This indicates whether to suppress resulting locking violations.")
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/JitInfo.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/JitInfo.NativeAot.cs
@@ -9,6 +9,8 @@ namespace System.Runtime
 
         public static long GetCompiledMethodCount(bool currentThread = false) => 0;
 
+        public static long GetLoadedTypeCount(bool currentThread = false) => 0;
+
         private static long GetCompilationTimeInTicks(bool _ /*currentThread*/ = false) => 0;
     }
 }

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3371,7 +3371,7 @@ public:
     }
 };
 
-static uint32_t TypeLoadIndex = 0;
+static volatile LONG TypeLoadIndex = 0;
 
 //---------------------------------------------------------------------------------------
 //
@@ -3568,10 +3568,10 @@ retry:
 
         if (logTypeLoad)
         {
-            uint32_t index = InterlockedIncrement(&TypeLoadIndex);
+            LONG index = InterlockedIncrement(&TypeLoadIndex);
             SString typeName;
             typeHnd.GetName(typeName);
-            printf("%u: %s\n", index, typeName.GetUTF8());
+            printf("%d: %s\n", index, typeName.GetUTF8());
         }
 
         pLoadingEntry->SetResult(typeHnd);

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -3371,6 +3371,8 @@ public:
     }
 };
 
+static uint32_t TypeLoadIndex = 0;
+
 //---------------------------------------------------------------------------------------
 //
 TypeHandle
@@ -3547,6 +3549,8 @@ retry:
     {
         PendingTypeLoadHolder ptlh(pLoadingEntry);
 
+        bool logTypeLoad = (typeHnd.IsNull() && g_pConfig->TypeLoadSummary());
+
         TRIGGERS_TYPELOAD();
 
         while (currentLevel < targetLevel)
@@ -3561,6 +3565,15 @@ retry:
         }
 
         _ASSERTE(!typeHnd.IsNull());
+
+        if (logTypeLoad)
+        {
+            uint32_t index = InterlockedIncrement(&TypeLoadIndex);
+            SString typeName;
+            typeHnd.GetName(typeName);
+            printf("%u: %s\n", index, typeName.GetUTF8());
+        }
+
         pLoadingEntry->SetResult(typeHnd);
     }
     EX_HOOK

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -498,6 +498,7 @@ FCFuncStart(gJitInfoFuncs)
     FCFuncElement("GetCompiledILBytes", GetCompiledILBytes)
     FCFuncElement("GetCompiledMethodCount", GetCompiledMethodCount)
     FCFuncElement("GetCompilationTimeInTicks", GetCompilationTimeInTicks)
+    FCFuncElement("GetLoadedTypeCount", GetLoadedTypeCount)
 FCFuncEnd()
 
 FCFuncStart(gVarArgFuncs)

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -175,6 +175,8 @@ HRESULT EEConfig::Init()
     fEnableFullDebug = false;
 #endif
 
+    fTypeLoadSummary = false;
+
 #ifdef FEATURE_DOUBLE_ALIGNMENT_HINT
     DoubleArrayToLargeObjectHeapThreshold = 1000;
 #endif
@@ -608,6 +610,8 @@ HRESULT EEConfig::sync()
 
     fJitVerificationDisable = (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_JitVerificationDisable) != 0);
 #endif
+
+    fTypeLoadSummary = (CLRConfig::GetConfigValue(CLRConfig::INTERNAL_TypeLoadSummary) != 0);
 
 #ifdef FEATURE_COMINTEROP
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_LogCCWRefCountChange, (LPWSTR*)&pszLogCCWRefCountChange));

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -343,8 +343,11 @@ public:
 
     inline bool EnableFullDebug() const
     {LIMITED_METHOD_CONTRACT;  return fEnableFullDebug; }
-
 #endif
+
+    inline bool TypeLoadSummary() const
+    {LIMITED_METHOD_CONTRACT;  return fTypeLoadSummary; }
+
 #ifdef ENABLE_STARTUP_DELAY
     inline int StartupDelayMS()
     { LIMITED_METHOD_CONTRACT; return iStartupDelayMS; }
@@ -531,6 +534,8 @@ private: //----------------------------------------------------------------
 
     bool fEnableFullDebug;
 #endif // _DEBUG
+
+    bool   fTypeLoadSummary;            // Dump type loads to standard output
 
 #ifdef FEATURE_COMINTEROP
     bool bLogCCWRefCountChange;           // Is CCW logging on

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -98,9 +98,11 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 Volatile<int64_t> g_cbILJitted = 0;
 Volatile<int64_t> g_cMethodsJitted = 0;
 Volatile<int64_t> g_c100nsTicksInJit = 0;
+Volatile<int64_t> g_loadedTypeCount = 0;
 thread_local int64_t t_cbILJittedForThread = 0;
 thread_local int64_t t_cMethodsJittedForThread = 0;
 thread_local int64_t t_c100nsTicksInJitForThread = 0;
+thread_local int64_t t_loadedTypeCount = 0;
 
 // This prevents tearing of 64 bit values on 32 bit systems
 static inline
@@ -135,6 +137,14 @@ FCIMPL1(INT64, GetCompilationTimeInTicks, CLR_BOOL currentThread)
     FCALL_CONTRACT;
 
     return currentThread ? t_c100nsTicksInJitForThread : AtomicLoad64WithoutTearing(&g_c100nsTicksInJit);
+}
+FCIMPLEND
+
+FCIMPL1(INT64, GetLoadedTypeCount, CLR_BOOL currentThread)
+{
+    FCALL_CONTRACT;
+
+    return currentThread ? t_loadedTypeCount : AtomicLoad64WithoutTearing(&g_loadedTypeCount);
 }
 FCIMPLEND
 

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -1152,12 +1152,15 @@ bool __stdcall TrackAllocationsEnabled();
 extern Volatile<int64_t> g_cbILJitted;
 extern Volatile<int64_t> g_cMethodsJitted;
 extern Volatile<int64_t> g_c100nsTicksInJit;
+extern Volatile<int64_t> g_loadedTypeCount;
 extern thread_local int64_t t_cbILJittedForThread;
 extern thread_local int64_t t_cMethodsJittedForThread;
 extern thread_local int64_t t_c100nsTicksInJitForThread;
+extern thread_local int64_t t_loadedTypeCount;
 
 FCDECL1(INT64, GetCompiledILBytes, CLR_BOOL currentThread);
 FCDECL1(INT64, GetCompiledMethodCount, CLR_BOOL currentThread);
+FCDECL1(INT64, GetLoadedTypeCount, CLR_BOOL currentThread);
 FCDECL1(INT64, GetCompilationTimeInTicks, CLR_BOOL currentThread);
 
 #endif // JITINTERFACE_H

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -49,6 +49,7 @@ namespace System.Diagnostics.Tracing
         private PollingCounter? _assemblyCounter;
         private PollingCounter? _ilBytesJittedCounter;
         private PollingCounter? _methodsJittedCounter;
+        private IncrementingPollingCounter? _typesLoadedCounter;
         private IncrementingPollingCounter? _jitTimeCounter;
 
 #if NATIVEAOT
@@ -128,6 +129,7 @@ namespace System.Diagnostics.Tracing
 
                 _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted", this, () => Runtime.JitInfo.GetCompiledILBytes()) { DisplayName = "IL Bytes Jitted", DisplayUnits = "B" };
                 _methodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => Runtime.JitInfo.GetCompiledMethodCount()) { DisplayName = "Number of Methods Jitted" };
+                _typesLoadedCounter ??= new IncrementingPollingCounter("types-loaded-count", this, () => Runtime.JitInfo.GetLoadedTypeCount()) { DisplayName = "Number of Types Loaded" };
                 _jitTimeCounter ??= new IncrementingPollingCounter("time-in-jit", this, () => Runtime.JitInfo.GetCompilationTime().TotalMilliseconds) { DisplayName = "Time spent in JIT", DisplayUnits = "ms", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
 
                 AppContext.LogSwitchValues(this);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12482,6 +12482,7 @@ namespace System.Runtime
         public static System.TimeSpan GetCompilationTime(bool currentThread = false) { throw null; }
         public static long GetCompiledILBytes(bool currentThread = false) { throw null; }
         public static long GetCompiledMethodCount(bool currentThread = false) { throw null; }
+        public static long GetLoadedTypeCount(bool currentThread = false) { throw null; }
     }
     public sealed partial class MemoryFailPoint : System.Runtime.ConstrainedExecution.CriticalFinalizerObject, System.IDisposable
     {


### PR DESCRIPTION
Based on our startup perf investigations we have come to the conclusion that it would be useful to have an easy way to monitor CoreCLR type loads. This change introduces two ways of such monitoring:

1) Via console logging similar to logging jitted methods when DOTNET_JitDisasmSummary is set (for type loads the name of the corresponding environment variable is DOTNET_TypeLoadSummary);

2) As a new perfcounter "types-loaded-count".

I have added a simple unit test case to System.Runtime tests exercising the new counter.

Thanks

Tomas