### PR TITLE
[XUnitLogChecker] Fix condition that sets env variables for libraries runner scripts

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -133,8 +133,8 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
-                              '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                              $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
+                          '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                           $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
       <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture)" />
       <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
       

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -132,21 +132,14 @@
       <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(RunScriptOutputDirectory)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
+    <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
                               '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
                               $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
-      <SetScriptCommand Condition="'$(TargetOS)' == 'windows'">$(SetScriptCommand)
-set __TestArchitecture=$(TargetArchitecture);
-set __IsXUnitLogCheckerSupported=1
-      </SetScriptCommand>
-      <SetScriptCommand Condition="'$(TargetOS)' != 'windows'">$(SetScriptCommand)
-export __TestArchitecture=$(TargetArchitecture);
-export __IsXUnitLogCheckerSupported=1
-      </SetScriptCommand>        
-    </PropertyGroup>
-
-    <ItemGroup>
-      <SetScriptCommands Include="$(SetScriptCommand)" />
+      <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture)" />
+      <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
+      
+      <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __TestArchitecture=$(TargetArchitecture)" />
+      <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
     </ItemGroup>
 
     <GenerateRunScript RunCommands="@(RunScriptCommands)"

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -69,6 +69,16 @@
     <ArchiveTestsAfterTargets Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(TestSingleFile)' == 'true'" />
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
+                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                         $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
+    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture)" />
+    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
+
+    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __TestArchitecture=$(TargetArchitecture)" />
+    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
+  </ItemGroup>
+
   <!-- Archive test binaries. -->
   <Target Name="ArchiveTests"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true' and ('$(TargetsMobile)' != 'true' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(BuildTestsOnHelix)' == 'true')"
@@ -130,16 +140,6 @@
     <PropertyGroup Condition="'$(RunScriptOutputDirectory)' != ''">
       <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(RunScriptOutputDirectory)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     </PropertyGroup>
-
-    <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
-                          '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                           $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
-      <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture)" />
-      <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
-      
-      <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __TestArchitecture=$(TargetArchitecture)" />
-      <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
-    </ItemGroup>
 
     <GenerateRunScript RunCommands="@(RunScriptCommands)"
                        SetCommands="@(SetScriptCommands)"

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -102,7 +102,6 @@
 
       <!-- Escape potential user input. -->
       <RunScriptCommand>$([MSBuild]::Escape('$(RunScriptCommand)'))</RunScriptCommand>
-
     </PropertyGroup>
 
     <!-- Set $(TestDebugger) to eg c:\debuggers\windbg.exe to run tests under a debugger. -->

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -69,11 +69,6 @@
     <ArchiveTestsAfterTargets Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(TestSingleFile)' == 'true'" />
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">
-    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture);set __IsXUnitLogCheckerSupported=1" />
-    <SetScriptCommands  Condition="'$(TargetOS)' != 'windows'" Include="export __TestArchitecture=$(TargetArchitecture);export __IsXUnitLogCheckerSupported=1"/>
-  </ItemGroup>
-
   <!-- Archive test binaries. -->
   <Target Name="ArchiveTests"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true' and ('$(TargetsMobile)' != 'true' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(BuildTestsOnHelix)' == 'true')"
@@ -107,6 +102,7 @@
 
       <!-- Escape potential user input. -->
       <RunScriptCommand>$([MSBuild]::Escape('$(RunScriptCommand)'))</RunScriptCommand>
+
     </PropertyGroup>
 
     <!-- Set $(TestDebugger) to eg c:\debuggers\windbg.exe to run tests under a debugger. -->
@@ -135,6 +131,23 @@
     <PropertyGroup Condition="'$(RunScriptOutputDirectory)' != ''">
       <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(RunScriptOutputDirectory)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
+                              '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                              $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
+      <SetScriptCommand Condition="'$(TargetOS)' == 'windows'">$(SetScriptCommand)
+set __TestArchitecture=$(TargetArchitecture);
+set __IsXUnitLogCheckerSupported=1
+      </SetScriptCommand>
+      <SetScriptCommand Condition="'$(TargetOS)' != 'windows'">$(SetScriptCommand)
+export __TestArchitecture=$(TargetArchitecture);
+export __IsXUnitLogCheckerSupported=1
+      </SetScriptCommand>        
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SetScriptCommands Include="$(SetScriptCommand)" />
+    </ItemGroup>
 
     <GenerateRunScript RunCommands="@(RunScriptCommands)"
                        SetCommands="@(SetScriptCommands)"

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,7 +2035,6 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
-  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,6 +2035,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
+  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;


### PR DESCRIPTION
`$(BuildTargetFramework)`  was showing up empty at the point where it was needed.
I changed it to an existing condition I found in the same file to ensure we have the right target framework.
I also moved the `SetScriptCommands` itemgroup inside the target that consumes it, to keep it consistent with the other similar itemgroup for `RunScriptCommands`.