### PR TITLE
Do not ignore coreclr.dll load failure in hostpolicy.dll

### DIFF
--- a/src/native/corehost/hostpolicy/coreclr.cpp
+++ b/src/native/corehost/hostpolicy/coreclr.cpp
@@ -15,8 +15,7 @@ namespace
     bool coreclr_bind(const pal::string_t& libcoreclr_path)
     {
         assert(coreclr_contract.coreclr_initialize == nullptr);
-        coreclr_resolver_t::resolve_coreclr(libcoreclr_path, coreclr_contract);
-        return true;
+        return coreclr_resolver_t::resolve_coreclr(libcoreclr_path, coreclr_contract);
     }
 
     void log_error(const char* line)


### PR DESCRIPTION
The code ignored the error from loading coreclr.dll that lead to segfault caused by attempt to call a null function pointer.