### PR TITLE
Simplify condition for building cross-Jits

### DIFF
--- a/src/coreclr/crosscomponents.cmake
+++ b/src/coreclr/crosscomponents.cmake
@@ -7,13 +7,7 @@ if (CLR_CMAKE_HOST_OS STREQUAL CLR_CMAKE_TARGET_OS OR CLR_CMAKE_TARGET_IOS OR CL
     )
 
     if (NOT (CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS OR CLR_CMAKE_TARGET_MACCATALYST))
-        if (CLR_CMAKE_TARGET_OSX AND ARCH_TARGET_NAME STREQUAL arm64)
-            install_clr (TARGETS
-                clrjit_universal_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME}
-                DESTINATIONS .
-                COMPONENT crosscomponents
-            )
-        elseif (CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64)
+        if (CLR_CMAKE_TARGET_ARCH_ARM OR CLR_CMAKE_TARGET_ARCH_ARM64)
             install_clr (TARGETS
                 clrjit_universal_${ARCH_TARGET_NAME}_${ARCH_HOST_NAME}
                 DESTINATIONS .


### PR DESCRIPTION
It used to be the case that an OSX-ARM64-targeting Jit had to be built separately, but this is no longer true.