### PR TITLE
JIT: Check for reachable preds in RBO

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -818,7 +818,7 @@ bool Compiler::optJumpThreadCheck(BasicBlock* const block, BasicBlock* const dom
     {
         for (BasicBlock* const predBlock : block->PredBlocks())
         {
-            if (!fgSsaDomTree->Dominates(domBlock, predBlock))
+            if (m_dfs->Contains(predBlock) && !fgSsaDomTree->Dominates(domBlock, predBlock))
             {
                 JITDUMP("Dom " FMT_BB " is stale (does not dominate pred " FMT_BB "); no threading\n", domBlock->bbNum,
                         predBlock->bbNum);


### PR DESCRIPTION
Nothing guarantees that all preds are reachable, in which case the "dominates" query does not make sense.

Fixes the issue found in https://dev.azure.com/dnceng-public/public/_build/results?buildId=487403&view=ms.vss-build-web.run-extensions-tab.