### PR TITLE
Fix generating debug info for static fields

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ObjectWriter.cs
@@ -1213,11 +1213,16 @@ namespace ILCompiler.DependencyAnalysis
                         objectWriter.EmitDebugFunctionInfo(node, nodeContents.Data.Length);
                     }
 
+                    // Ensure any allocated MethodTables have debug info
                     if (node is ConstructedEETypeNode MethodTable)
                     {
                         objectWriter._userDefinedTypeDescriptor.GetTypeIndex(MethodTable.Type, needsCompleteType: true);
                     }
                 }
+
+                // Ensure all fields associated with generated static bases have debug info
+                foreach (MetadataType typeWithStaticBase in objectWriter._nodeFactory.MetadataManager.GetTypesWithStaticBases())
+                    objectWriter._userDefinedTypeDescriptor.GetTypeIndex(typeWithStaticBase, needsCompleteType: true);
 
                 // Native side of the object writer is going to do more native memory allocations.
                 // Free up as much memory as possible so that we don't get OOM killed.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -51,6 +51,9 @@ namespace ILCompiler
 
         private readonly List<InterfaceDispatchCellNode> _interfaceDispatchCells = new List<InterfaceDispatchCellNode>();
         private readonly SortedSet<NonGCStaticsNode> _cctorContextsGenerated = new SortedSet<NonGCStaticsNode>(CompilerComparer.Instance);
+        private readonly SortedSet<MetadataType> _typesWithGCStaticsGenerated = new SortedSet<MetadataType>(CompilerComparer.Instance);
+        private readonly SortedSet<MetadataType> _typesWithNonGCStaticsGenerated = new SortedSet<MetadataType>(CompilerComparer.Instance);
+        private readonly SortedSet<MetadataType> _typesWithThreadStaticsGenerated = new SortedSet<MetadataType>(CompilerComparer.Instance);
         private readonly SortedSet<TypeDesc> _typesWithEETypesGenerated = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<TypeDesc> _typesWithConstructedEETypesGenerated = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<MethodDesc> _methodsGenerated = new SortedSet<MethodDesc>(TypeSystemComparer.Instance);
@@ -245,10 +248,22 @@ namespace ILCompiler
                 _reflectableMethods.Add(reflectedMethodNode.Method);
             }
 
-            var nonGcStaticSectionNode = obj as NonGCStaticsNode;
-            if (nonGcStaticSectionNode != null && nonGcStaticSectionNode.HasLazyStaticConstructor)
+            if (obj is NonGCStaticsNode nonGcStaticSectionNode)
             {
-                _cctorContextsGenerated.Add(nonGcStaticSectionNode);
+                if (nonGcStaticSectionNode.HasLazyStaticConstructor)
+                    _cctorContextsGenerated.Add(nonGcStaticSectionNode);
+
+                _typesWithNonGCStaticsGenerated.Add(nonGcStaticSectionNode.Type);
+            }
+
+            if (obj is GCStaticsNode gcStaticsNode)
+            {
+                _typesWithGCStaticsGenerated.Add(gcStaticsNode.Type);
+            }
+
+            if (obj is TypeThreadStaticIndexNode threadStaticsNode)
+            {
+                _typesWithThreadStaticsGenerated.Add(threadStaticsNode.Type);
             }
 
             var gvmEntryNode = obj as TypeGVMEntriesNode;
@@ -716,6 +731,20 @@ namespace ILCompiler
         {
             return _cctorContextsGenerated;
         }
+
+        internal IEnumerable<MetadataType> GetTypesWithStaticBases()
+        {
+            var allTypes = new SortedSet<MetadataType>(CompilerComparer.Instance);
+            allTypes.UnionWith(_typesWithNonGCStaticsGenerated);
+            allTypes.UnionWith(_typesWithGCStaticsGenerated);
+            allTypes.UnionWith(_typesWithThreadStaticsGenerated);
+            return allTypes;
+        }
+
+        internal bool HasNonGcStaticBase(MetadataType type) => _typesWithNonGCStaticsGenerated.Contains(type);
+        internal bool HasGcStaticBase(MetadataType type) => _typesWithGCStaticsGenerated.Contains(type);
+        internal bool HasThreadStaticBase(MetadataType type) => _typesWithThreadStaticsGenerated.Contains(type);
+        internal bool HasConstructedEEType(TypeDesc type) => _typesWithConstructedEETypesGenerated.Contains(type);
 
         internal IEnumerable<TypeGVMEntriesNode> GetTypeGVMEntries()
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -551,7 +551,7 @@ namespace ILCompiler
         private uint GetClassTypeIndex(TypeDesc type, bool needsCompleteType)
         {
             TypeDesc debugType = GetDebugType(type);
-            DefType defType = debugType as DefType;
+            MetadataType defType = debugType as MetadataType;
             Debug.Assert(defType != null, "GetClassTypeIndex was called with non def type");
             ClassTypeDescriptor classTypeDescriptor = new ClassTypeDescriptor
             {
@@ -590,6 +590,11 @@ namespace ILCompiler
             string threadStaticDataName = NodeFactory.NameMangler.NodeMangler.ThreadStatics(type);
             bool isNativeAOT = Abi == TargetAbi.NativeAot;
 
+            bool hasNonGcStatics = NodeFactory.MetadataManager.HasNonGcStaticBase(defType);
+            bool hasGcStatics = NodeFactory.MetadataManager.HasGcStaticBase(defType);
+            bool hasThreadStatics = NodeFactory.MetadataManager.HasThreadStaticBase(defType);
+            bool hasInstanceFields = defType.IsValueType || NodeFactory.MetadataManager.HasConstructedEEType(defType);
+
             bool isCanonical = defType.IsCanonicalSubtype(CanonicalFormKind.Any);
 
             foreach (var fieldDesc in defType.GetFields())
@@ -597,8 +602,22 @@ namespace ILCompiler
                 if (fieldDesc.HasRva || fieldDesc.IsLiteral)
                     continue;
 
-                if (isCanonical && fieldDesc.IsStatic)
-                    continue;
+                if (fieldDesc.IsStatic)
+                {
+                    if (isCanonical)
+                        continue;
+                    if (fieldDesc.IsThreadStatic && !hasThreadStatics)
+                        continue;
+                    if (fieldDesc.HasGCStaticBase && !hasGcStatics)
+                        continue;
+                    if (!fieldDesc.HasGCStaticBase && !hasNonGcStatics)
+                        continue;
+                }
+                else
+                {
+                    if (!hasInstanceFields)
+                        continue;
+                }
 
                 LayoutInt fieldOffset = fieldDesc.Offset;
                 int fieldOffsetEmit = fieldOffset.IsIndeterminate ? 0xBAAD : fieldOffset.AsInt;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -608,10 +608,16 @@ namespace ILCompiler
                         continue;
                     if (fieldDesc.IsThreadStatic && !hasThreadStatics)
                         continue;
-                    if (fieldDesc.HasGCStaticBase && !hasGcStatics)
-                        continue;
-                    if (!fieldDesc.HasGCStaticBase && !hasNonGcStatics)
-                        continue;
+                    if (fieldDesc.HasGCStaticBase)
+                    {
+                        if (!hasGcStatics)
+                            continue;
+                    }
+                    else
+                    {
+                        if (!hasNonGcStatics)
+                            continue;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #93868.

The existing algorithm for generating debug info about static fields was:

* If we're generating debug information about a type, generate debug information about all non-literal and non-RVA fields on it.

This is both too little, and too much.

It's too little: if the only thing we're touching on a type is reading/writing the static fields, we'd not be generating debug information for that type because the current logic only looks at methods and `MethodTable`s.

It's too much: if we didn't touch any statics on the type, the static base wasn't generated either. Debug information would refer to something that doesn't exist.

I'm updating this logic to look at actual bases instead - if a static/gcstatic/threadstatic/instance base was generated, generate debug info for the fields. Skip them otherwise because they got optimized away ("trimmed").

For the following program

```csharp
// Licensed to the .NET Foundation under one or more agreements.
// The .NET Foundation licenses this file to you under the MIT license.

using System;

class Program
{
    static void Main()
    {
        Console.WriteLine(OnlyUsingStatics.Value);
        Console.WriteLine(AnotherStatics.UsedGCStatic);

        OnlyUsingStatics.Value = 123;
        AnotherStatics.UsedGCStatic = new object();
        AnotherStatics.ThreadStatic = 123;
    }
}

class OnlyUsingStatics
{
    public static int Value = 123;
    public static object UnusedGCStatic;
}

class AnotherStatics
{
    public static int UnusedNonGCStatic;
    public static object UsedGCStatic;
    [ThreadStatic]
    public static int ThreadStatic;
}
```

Before (only `OnlyUsingStatics` visible because of the cctor method we generated; but even that shows an error in optimized builds because the cctor gets optimized away):

![image](https://github.com/dotnet/runtime/assets/13110571/ce64b6ad-9787-4697-9bd6-4fdd91db8e64)

After:

![image](https://github.com/dotnet/runtime/assets/13110571/0eea4716-6de0-4ec6-a967-ac7edb843bca)

Cc @dotnet/ilc-contrib 