### PR TITLE
Add support for enumerating keyed services with KeyedService.AnyKey

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -119,11 +119,14 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
 
             var provider = CreateServiceProvider(serviceCollection);
 
-
             // Return all services registered with a non null key
             var allServices = provider.GetKeyedServices<IService>(KeyedService.AnyKey).ToList();
             Assert.Equal(4, allServices.Count);
             Assert.Equal(new[] { service1, service2, service3, service4 }, allServices);
+
+            // Check again (caching)
+            var allServices2 = provider.GetKeyedServices<IService>(KeyedService.AnyKey).ToList();
+            Assert.Equal(allServices, allServices2);
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -101,6 +101,61 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void ResolveKeyedServicesAnyKey()
+        {
+            var service1 = new Service();
+            var service2 = new Service();
+            var service3 = new Service();
+            var service4 = new Service();
+            var service5 = new Service();
+            var service6 = new Service();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedSingleton<IService>("first-service", service1);
+            serviceCollection.AddKeyedSingleton<IService>("service", service2);
+            serviceCollection.AddKeyedSingleton<IService>("service", service3);
+            serviceCollection.AddKeyedSingleton<IService>("service", service4);
+            serviceCollection.AddKeyedSingleton<IService>(null, service5);
+            serviceCollection.AddSingleton<IService>(service6);
+
+            var provider = CreateServiceProvider(serviceCollection);
+
+
+            // Return all services registered with a non null key
+            var allServices = provider.GetKeyedServices<IService>(KeyedService.AnyKey).ToList();
+            Assert.Equal(4, allServices.Count);
+            Assert.Equal(new[] { service1, service2, service3, service4 }, allServices);
+        }
+
+        [Fact]
+        public void ResolveKeyedServicesAnyKeyWithAnyKeyRegistration()
+        {
+            var service1 = new Service();
+            var service2 = new Service();
+            var service3 = new Service();
+            var service4 = new Service();
+            var service5 = new Service();
+            var service6 = new Service();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddKeyedTransient<IService>(KeyedService.AnyKey, (sp, key) => new Service());
+            serviceCollection.AddKeyedSingleton<IService>("first-service", service1);
+            serviceCollection.AddKeyedSingleton<IService>("service", service2);
+            serviceCollection.AddKeyedSingleton<IService>("service", service3);
+            serviceCollection.AddKeyedSingleton<IService>("service", service4);
+            serviceCollection.AddKeyedSingleton<IService>(null, service5);
+            serviceCollection.AddSingleton<IService>(service6);
+
+            var provider = CreateServiceProvider(serviceCollection);
+
+            _ = provider.GetKeyedService<IService>("something-else");
+            _ = provider.GetKeyedService<IService>("something-else-again");
+
+            // Return all services registered with a non null key, but not the one "created" with KeyedService.AnyKey
+            var allServices = provider.GetKeyedServices<IService>(KeyedService.AnyKey).ToList();
+            Assert.Equal(5, allServices.Count);
+            Assert.Equal(new[] { service1, service2, service3, service4 }, allServices.Skip(1));
+        }
+
+        [Fact]
         public void ResolveKeyedGenericServices()
         {
             var service1 = new FakeService();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -283,7 +283,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 ServiceCallSite[] callSites;
 
                 // If item type is not generic we can safely use descriptor cache
+                // Special case for KeyedService.AnyKey, we don't want to check the cache because a KeyedService.AnyKey registration
+                // will "hide" all the other service registration
                 if (!itemType.IsConstructedGenericType &&
+                    !KeyedService.AnyKey.Equals(cacheKey.ServiceKey) &&
                     _descriptorLookup.TryGetValue(cacheKey, out ServiceDescriptorCacheItem descriptors))
                 {
                     callSites = new ServiceCallSite[descriptors.Count];
@@ -694,7 +697,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 return true;
 
             if (key1 != null && key2 != null)
-                return key1.Equals(KeyedService.AnyKey) || key1.Equals(key2);
+            {
+                return key1.Equals(key2)
+                    || key1.Equals(KeyedService.AnyKey)
+                    || key2.Equals(KeyedService.AnyKey);
+            }
 
             return false;
         }


### PR DESCRIPTION
My take on how we should fix #95308

Registering "keyed" service with a `null` key was supposed to be possible for convenience, however it will be considered as a non-keyed service. That's why I think we should not return them when enumerating services.