### PR TITLE
Fix NativeFormatGen.csproj build and code style issues

### DIFF
--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/CsWriter.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/CsWriter.cs
@@ -4,12 +4,14 @@
 using System;
 using System.IO;
 
-class CsWriter : IDisposable
-{
-    TextWriter _writer;
+namespace NativeFormatGen;
 
-    int _indent;
-    bool _emptyLineAssumed;
+internal class CsWriter : IDisposable
+{
+    private StreamWriter _writer;
+
+    private int _indent;
+    private bool _emptyLineAssumed;
 
     public CsWriter(string filename)
     {

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryReaderGen.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+namespace NativeFormatGen;
+
 //
 // Generates the C# MdBinaryReader class. This classes is responsible for correctly decoding
-// data members in the .metadata file. See NativeFormatReaderGen.cs for how the MetadataReader 
+// data members in the .metadata file. See NativeFormatReaderGen.cs for how the MetadataReader
 // use this class.
 //
 
-class MdBinaryReaderGen : CsWriter
+internal sealed class MdBinaryReaderGen : CsWriter
 {
     public MdBinaryReaderGen(string fileName)
         : base(fileName)
@@ -20,8 +22,8 @@ class MdBinaryReaderGen : CsWriter
         WriteLine();
 
         WriteLine("using System;");
-        WriteLine("using System.IO;");
         WriteLine("using System.Collections.Generic;");
+        WriteLine("using System.IO;");
         WriteLine("using System.Reflection;");
         WriteLine("using Internal.NativeFormat;");
         WriteLine("using Debug = System.Diagnostics.Debug;");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/MdBinaryWriterGen.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+namespace NativeFormatGen;
+
 //
 // Generates the C# MdBinaryWriter class. This classes is responsible for correctly decoding
-// data members in the .metadata file. See NativeFormatWriterGen.cs for how the MetadataWriter 
+// data members in the .metadata file. See NativeFormatWriterGen.cs for how the MetadataWriter
 // use this class.
 //
 
-class MdBinaryWriterGen : CsWriter
+internal sealed class MdBinaryWriterGen : CsWriter
 {
     public MdBinaryWriterGen(string fileName)
         : base(fileName)
@@ -20,8 +22,8 @@ class MdBinaryWriterGen : CsWriter
         WriteLine();
 
         WriteLine("using System;");
-        WriteLine("using System.IO;");
         WriteLine("using System.Collections.Generic;");
+        WriteLine("using System.IO;");
         WriteLine("using System.Reflection;");
         WriteLine("using Internal.LowLevelLinq;");
         WriteLine("using Internal.NativeFormat;");

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/Program.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/Program.cs
@@ -1,9 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-class Program
+using System.IO;
+
+namespace NativeFormatGen;
+
+public class Program
 {
-    static void Main(string[] args)
+    public static void Main(string[] args)
     {
         using (var writer = new PublicGen(@"NativeFormatReaderCommonGen.cs"))
         {
@@ -15,7 +19,7 @@ class Program
             writer.EmitSource();
         }
 
-        using (var writer = new WriterGen(@"..\..\..\..\aot\ILCompiler.MetadataTransform\Internal\Metadata\NativeFormat\Writer\NativeFormatWriterGen.cs"))
+        using (var writer = new WriterGen(Path.Combine("..", "..", "..", "..", "aot", "ILCompiler.MetadataTransform", "Internal", "Metadata", "NativeFormat", "Writer", "NativeFormatWriterGen.cs")))
         {
             writer.EmitSource();
         }
@@ -25,7 +29,7 @@ class Program
             writer.EmitSource();
         }
 
-        using (var writer = new MdBinaryWriterGen(@"..\..\..\..\aot\ILCompiler.MetadataTransform\Internal\Metadata\NativeFormat\Writer\MdBinaryWriterGen.cs"))
+        using (var writer = new MdBinaryWriterGen(Path.Combine("..", "..", "..", "..", "aot", "ILCompiler.MetadataTransform", "Internal", "Metadata", "NativeFormat", "Writer", "MdBinaryWriterGen.cs")))
         {
             writer.EmitSource();
         }

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/PublicGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/PublicGen.cs
@@ -3,6 +3,8 @@
 
 using System.Linq;
 
+namespace NativeFormatGen;
+
 //
 // This class generates the common API declarations that any metadata reader must implement.
 // In general, this script consumes the metadata record schema defined in SchemaDef.cs and
@@ -24,7 +26,7 @@ using System.Linq;
 // the implementation be supplied by the reader.
 //
 
-class PublicGen : CsWriter
+internal sealed class PublicGen : CsWriter
 {
     public PublicGen(string fileName)
         : base(fileName)
@@ -34,8 +36,8 @@ class PublicGen : CsWriter
     public void EmitSource()
     {
         WriteLine("using System;");
-        WriteLine("using System.Reflection;");
         WriteLine("using System.Collections.Generic;");
+        WriteLine("using System.Reflection;");
         WriteLine("using System.Runtime.CompilerServices;");
         WriteLine();
 

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/ReaderGen.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+namespace NativeFormatGen;
+
 //
 // This class generates most of the implementation of the MetadataReader for the NativeAOT format,
 // ensuring that the contract defined by CsPublicGen2 is implemented.The generated file is
@@ -8,7 +10,7 @@
 // source counterpart 'NativeFormatReader.cs'.
 //
 
-class ReaderGen : CsWriter
+internal sealed class ReaderGen : CsWriter
 {
     public ReaderGen(string fileName)
         : base(fileName)
@@ -28,9 +30,9 @@ class ReaderGen : CsWriter
         WriteLine();
 
         WriteLine("using System;");
+        WriteLine("using System.Collections.Generic;");
         WriteLine("using System.Diagnostics;");
         WriteLine("using System.Reflection;");
-        WriteLine("using System.Collections.Generic;");
         WriteLine("using System.Runtime.CompilerServices;");
         WriteLine("using Internal.NativeFormat;");
         WriteLine();
@@ -42,7 +44,7 @@ class ReaderGen : CsWriter
             EmitRecord(record);
             EmitHandle(record);
         }
-        
+
         foreach (var typeName in SchemaDef.TypeNamesWithCollectionTypes)
         {
             EmitCollection(typeName + "HandleCollection", typeName + "Handle");
@@ -144,7 +146,7 @@ class ReaderGen : CsWriter
         WriteLine("_Validate();");
         CloseScope();
 
-        OpenScope($"public static implicit operator  Handle({handleName} handle)");
+        OpenScope($"public static implicit operator Handle({handleName} handle)");
         WriteLine("return new Handle(handle._value);");
         CloseScope("Handle");
 

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/SchemaDef.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+namespace NativeFormatGen;
+
 /// <summary>
 /// Defines the set of flags that may be applied to a schema record definition.
 /// </summary>
@@ -65,18 +67,18 @@ public class MemberDef
         Comment = comment;
     }
 
-    readonly public string Name;
-    readonly public object TypeName;
-    readonly public MemberDefFlags Flags;
-    readonly public string Value;
-    readonly public string Comment;
+    public readonly string Name;
+    public readonly object TypeName;
+    public readonly MemberDefFlags Flags;
+    public readonly string Value;
+    public readonly string Comment;
 
     public string GetMemberType(MemberTypeKind kind = MemberTypeKind.Accessor)
     {
         string typeName;
         if ((Flags & MemberDefFlags.RecordRef) != 0)
         {
-            if (TypeName is String[])
+            if (TypeName is string[])
             {
                 typeName = (kind == MemberTypeKind.WriterField) ? "MetadataRecord" : "Handle";
             }
@@ -107,16 +109,16 @@ public class MemberDef
 
     public string GetMemberFieldName()
     {
-        return "_" + Char.ToLower(Name[0], System.Globalization.CultureInfo.InvariantCulture) + Name.Substring(1);
+        return "_" + char.ToLower(Name[0], System.Globalization.CultureInfo.InvariantCulture) + Name.Substring(1);
     }
 
     public string GetMemberDescription()
     {
-        var typeSet = TypeName as String[];
+        var typeSet = TypeName as string[];
         if (typeSet == null)
             return null;
 
-        return "One of: " + String.Join(", ", typeSet);
+        return "One of: " + string.Join(", ", typeSet);
     }
 }
 
@@ -134,11 +136,11 @@ public class RecordDef
         Members = members;
     }
 
-    readonly public string Name;
-    readonly public string BaseTypeName;
-    readonly public RecordDefFlags Flags;
-    readonly public string Comment;
-    readonly public MemberDef[] Members;
+    public readonly string Name;
+    public readonly string BaseTypeName;
+    public readonly RecordDefFlags Flags;
+    public readonly string Comment;
+    public readonly MemberDef[] Members;
 }
 
 public class EnumType
@@ -149,8 +151,8 @@ public class EnumType
         UnderlyingType = underlyingType;
     }
 
-    readonly public string Name;
-    readonly public string UnderlyingType;
+    public readonly string Name;
+    public readonly string UnderlyingType;
 }
 
 public class PrimitiveType
@@ -162,15 +164,15 @@ public class PrimitiveType
         CustomCompare = customCompare;
     }
 
-    readonly public string Name;
-    readonly public string TypeName;
-    readonly public bool CustomCompare;
+    public readonly string Name;
+    public readonly string TypeName;
+    public readonly bool CustomCompare;
 }
 
 /// <summary>
 /// This class defines the metadata schema that is consumed by all generators.
 /// </summary>
-class SchemaDef
+internal sealed class SchemaDef
 {
     public static readonly EnumType[] EnumTypes = new EnumType[]
     {
@@ -290,8 +292,8 @@ class SchemaDef
 
     private static readonly RecordDef[] ConstantValueRecordSchema =
         (
-            from primitiveType in PrimitiveTypes select
-                new RecordDef(
+            from primitiveType in PrimitiveTypes
+            select new RecordDef(
                     name: "Constant" + primitiveType.TypeName + "Value",
                     members: new MemberDef[] {
                         new MemberDef(name: "Value", typeName: primitiveType.Name,
@@ -325,8 +327,8 @@ class SchemaDef
 
     private static readonly RecordDef[] ConstantArrayRecordSchema =
         (
-            from primitiveType in PrimitiveTypes select
-                new RecordDef(
+            from primitiveType in PrimitiveTypes
+            select new RecordDef(
                     name: "Constant" + primitiveType.TypeName + "Array",
                     members: new MemberDef[] {
                         new MemberDef(name: "Value", typeName: primitiveType.TypeName,

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/WriterGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/Generator/WriterGen.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-class WriterGen : CsWriter
+namespace NativeFormatGen;
+
+internal sealed class WriterGen : CsWriter
 {
     public WriterGen(string fileName)
         : base(fileName)
@@ -128,7 +130,7 @@ class WriterGen : CsWriter
 
         // Compute hash seed using stable hashcode
         byte[] nameBytes = System.Text.Encoding.UTF8.GetBytes(record.Name);
-        byte[] hashBytes = System.Security.Cryptography.SHA256.Create().ComputeHash(nameBytes);
+        byte[] hashBytes = System.Security.Cryptography.SHA256.HashData(nameBytes);
         int hashSeed = System.BitConverter.ToInt32(hashBytes, 0);
         WriteLine($"int hash = {hashSeed};");
 

--- a/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
+++ b/src/coreclr/tools/Common/Internal/Metadata/NativeFormat/NativeFormatReaderGen.cs
@@ -123,7 +123,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ArraySignatureHandle handle)
+        public static implicit operator Handle(ArraySignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -236,7 +236,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ByReferenceSignatureHandle handle)
+        public static implicit operator Handle(ByReferenceSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -348,7 +348,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantBooleanArrayHandle handle)
+        public static implicit operator Handle(ConstantBooleanArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -460,7 +460,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantBooleanValueHandle handle)
+        public static implicit operator Handle(ConstantBooleanValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -584,7 +584,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantBoxedEnumValueHandle handle)
+        public static implicit operator Handle(ConstantBoxedEnumValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -696,7 +696,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantByteArrayHandle handle)
+        public static implicit operator Handle(ConstantByteArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -808,7 +808,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantByteValueHandle handle)
+        public static implicit operator Handle(ConstantByteValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -920,7 +920,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantCharArrayHandle handle)
+        public static implicit operator Handle(ConstantCharArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1032,7 +1032,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantCharValueHandle handle)
+        public static implicit operator Handle(ConstantCharValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1144,7 +1144,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantDoubleArrayHandle handle)
+        public static implicit operator Handle(ConstantDoubleArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1256,7 +1256,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantDoubleValueHandle handle)
+        public static implicit operator Handle(ConstantDoubleValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1378,7 +1378,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantEnumArrayHandle handle)
+        public static implicit operator Handle(ConstantEnumArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1490,7 +1490,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantHandleArrayHandle handle)
+        public static implicit operator Handle(ConstantHandleArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1602,7 +1602,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt16ArrayHandle handle)
+        public static implicit operator Handle(ConstantInt16ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1714,7 +1714,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt16ValueHandle handle)
+        public static implicit operator Handle(ConstantInt16ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1826,7 +1826,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt32ArrayHandle handle)
+        public static implicit operator Handle(ConstantInt32ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -1938,7 +1938,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt32ValueHandle handle)
+        public static implicit operator Handle(ConstantInt32ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2050,7 +2050,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt64ArrayHandle handle)
+        public static implicit operator Handle(ConstantInt64ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2162,7 +2162,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantInt64ValueHandle handle)
+        public static implicit operator Handle(ConstantInt64ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2264,7 +2264,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantReferenceValueHandle handle)
+        public static implicit operator Handle(ConstantReferenceValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2376,7 +2376,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantSByteArrayHandle handle)
+        public static implicit operator Handle(ConstantSByteArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2488,7 +2488,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantSByteValueHandle handle)
+        public static implicit operator Handle(ConstantSByteValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2600,7 +2600,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantSingleArrayHandle handle)
+        public static implicit operator Handle(ConstantSingleArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2712,7 +2712,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantSingleValueHandle handle)
+        public static implicit operator Handle(ConstantSingleValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2825,7 +2825,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantStringArrayHandle handle)
+        public static implicit operator Handle(ConstantStringArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -2937,7 +2937,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantStringValueHandle handle)
+        public static implicit operator Handle(ConstantStringValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3049,7 +3049,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt16ArrayHandle handle)
+        public static implicit operator Handle(ConstantUInt16ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3161,7 +3161,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt16ValueHandle handle)
+        public static implicit operator Handle(ConstantUInt16ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3273,7 +3273,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt32ArrayHandle handle)
+        public static implicit operator Handle(ConstantUInt32ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3385,7 +3385,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt32ValueHandle handle)
+        public static implicit operator Handle(ConstantUInt32ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3497,7 +3497,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt64ArrayHandle handle)
+        public static implicit operator Handle(ConstantUInt64ArrayHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3609,7 +3609,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ConstantUInt64ValueHandle handle)
+        public static implicit operator Handle(ConstantUInt64ValueHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3743,7 +3743,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(CustomAttributeHandle handle)
+        public static implicit operator Handle(CustomAttributeHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -3896,7 +3896,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(EventHandle handle)
+        public static implicit operator Handle(EventHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4059,7 +4059,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(FieldHandle handle)
+        public static implicit operator Handle(FieldHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4172,7 +4172,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(FieldSignatureHandle handle)
+        public static implicit operator Handle(FieldSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4284,7 +4284,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(FunctionPointerSignatureHandle handle)
+        public static implicit operator Handle(FunctionPointerSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4447,7 +4447,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(GenericParameterHandle handle)
+        public static implicit operator Handle(GenericParameterHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4581,7 +4581,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MemberReferenceHandle handle)
+        public static implicit operator Handle(MemberReferenceHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4753,7 +4753,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MethodHandle handle)
+        public static implicit operator Handle(MethodHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4877,7 +4877,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MethodInstantiationHandle handle)
+        public static implicit operator Handle(MethodInstantiationHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -4999,7 +4999,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MethodSemanticsHandle handle)
+        public static implicit operator Handle(MethodSemanticsHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5154,7 +5154,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MethodSignatureHandle handle)
+        public static implicit operator Handle(MethodSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5266,7 +5266,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(MethodTypeVariableSignatureHandle handle)
+        public static implicit operator Handle(MethodTypeVariableSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5400,7 +5400,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ModifiedTypeHandle handle)
+        public static implicit operator Handle(ModifiedTypeHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5544,7 +5544,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(NamedArgumentHandle handle)
+        public static implicit operator Handle(NamedArgumentHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5697,7 +5697,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(NamespaceDefinitionHandle handle)
+        public static implicit operator Handle(NamespaceDefinitionHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5820,7 +5820,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(NamespaceReferenceHandle handle)
+        public static implicit operator Handle(NamespaceReferenceHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -5973,7 +5973,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ParameterHandle handle)
+        public static implicit operator Handle(ParameterHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6086,7 +6086,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(PointerSignatureHandle handle)
+        public static implicit operator Handle(PointerSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6249,7 +6249,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(PropertyHandle handle)
+        public static implicit operator Handle(PropertyHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6383,7 +6383,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(PropertySignatureHandle handle)
+        public static implicit operator Handle(PropertySignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6505,7 +6505,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(QualifiedFieldHandle handle)
+        public static implicit operator Handle(QualifiedFieldHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6627,7 +6627,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(QualifiedMethodHandle handle)
+        public static implicit operator Handle(QualifiedMethodHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -6740,7 +6740,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(SZArraySignatureHandle handle)
+        public static implicit operator Handle(SZArraySignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7002,7 +7002,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ScopeDefinitionHandle handle)
+        public static implicit operator Handle(ScopeDefinitionHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7184,7 +7184,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(ScopeReferenceHandle handle)
+        public static implicit operator Handle(ScopeReferenceHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7438,7 +7438,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeDefinitionHandle handle)
+        public static implicit operator Handle(TypeDefinitionHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7570,7 +7570,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeForwarderHandle handle)
+        public static implicit operator Handle(TypeForwarderHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7694,7 +7694,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeInstantiationSignatureHandle handle)
+        public static implicit operator Handle(TypeInstantiationSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7817,7 +7817,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeReferenceHandle handle)
+        public static implicit operator Handle(TypeReferenceHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -7930,7 +7930,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeSpecificationHandle handle)
+        public static implicit operator Handle(TypeSpecificationHandle handle)
         {
             return new Handle(handle._value);
         } // Handle
@@ -8042,7 +8042,7 @@ namespace Internal.Metadata.NativeFormat
             _Validate();
         }
 
-        public static implicit operator  Handle(TypeVariableSignatureHandle handle)
+        public static implicit operator Handle(TypeVariableSignatureHandle handle)
         {
             return new Handle(handle._value);
         } // Handle

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/Internal/Metadata/NativeFormat/Writer/MdBinaryWriterGen.cs
@@ -6,8 +6,8 @@
 #pragma warning disable 649, SA1121, IDE0036, SA1129
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Internal.LowLevelLinq;
 using Internal.NativeFormat;


### PR DESCRIPTION
Building the NativeFormatGen project failed because of various code style checks.

Fixed the issues and also remove an additional whitespace in the Handle method and wrong order of usings.
Also fixed running the project on non-Windows platforms due to hardcoded directory separators.