### PR TITLE
Use full TLS record size for application data on Windows

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -248,7 +248,7 @@ internal static partial class Interop
                 SCH_CRED_IGNORE_REVOCATION_OFFLINE = 0x1000,
                 SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE = 0x2000,
                 SCH_SEND_ROOT_CERT = 0x40000,
-                SCH_SEND_AUX_RECORD =   0x00200000,
+                SCH_SEND_AUX_RECORD = 0x00200000,
                 SCH_USE_STRONG_CRYPTO = 0x00400000,
                 SCH_USE_PRESHAREDKEY_ONLY = 0x800000,
                 SCH_ALLOW_NULL_ENCRYPTION = 0x02000000,
@@ -374,7 +374,7 @@ internal static partial class Interop
             ref CredHandle contextHandle,
             in SecBufferDesc input,
             uint sequenceNumber,
-            uint *qualityOfProtection);
+            uint* qualityOfProtection);
 
         [LibraryImport(Interop.Libraries.SspiCli, SetLastError = true)]
         internal static partial int QuerySecurityContextToken(
@@ -513,5 +513,29 @@ internal static partial class Interop
             long ulAttribute,
             in SecPkgCred_ClientCertPolicy pBuffer,
             long cbBuffer);
+
+        internal enum SecTrafficSecretType
+        {
+            None,
+            Client,
+            Server
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct SecTrafficSecrets
+        {
+            public fixed char SymmetricAlgId[64];
+            public fixed char ChainingMode[64];
+            public fixed char HashAlgId[64];
+
+            public ushort KeySize;
+            public ushort IvSize;
+            public ushort MsgSequenceStart;
+            public ushort MsgSequenceEnd;
+            public SecTrafficSecretType TrafficSecretType;
+            public ushort TrafficSecretSize;
+            public fixed byte TrafficSecret[100];
+        }
+
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -248,7 +248,7 @@ internal static partial class Interop
                 SCH_CRED_IGNORE_REVOCATION_OFFLINE = 0x1000,
                 SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE = 0x2000,
                 SCH_SEND_ROOT_CERT = 0x40000,
-                SCH_SEND_AUX_RECORD = 0x00200000,
+                SCH_SEND_AUX_RECORD =   0x00200000,
                 SCH_USE_STRONG_CRYPTO = 0x00400000,
                 SCH_USE_PRESHAREDKEY_ONLY = 0x800000,
                 SCH_ALLOW_NULL_ENCRYPTION = 0x02000000,
@@ -374,7 +374,7 @@ internal static partial class Interop
             ref CredHandle contextHandle,
             in SecBufferDesc input,
             uint sequenceNumber,
-            uint* qualityOfProtection);
+            uint *qualityOfProtection);
 
         [LibraryImport(Interop.Libraries.SspiCli, SetLastError = true)]
         internal static partial int QuerySecurityContextToken(
@@ -513,29 +513,5 @@ internal static partial class Interop
             long ulAttribute,
             in SecPkgCred_ClientCertPolicy pBuffer,
             long cbBuffer);
-
-        internal enum SecTrafficSecretType
-        {
-            None,
-            Client,
-            Server
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct SecTrafficSecrets
-        {
-            public fixed char SymmetricAlgId[64];
-            public fixed char ChainingMode[64];
-            public fixed char HashAlgId[64];
-
-            public ushort KeySize;
-            public ushort IvSize;
-            public ushort MsgSequenceStart;
-            public ushort MsgSequenceEnd;
-            public SecTrafficSecretType TrafficSecretType;
-            public ushort TrafficSecretSize;
-            public fixed byte TrafficSecret[100];
-        }
-
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -928,7 +928,7 @@ namespace System.Net.Security
 
             _headerSize = streamSizes.Header;
             _trailerSize = streamSizes.Trailer;
-            _maxDataSize = checked(streamSizes.MaximumMessage - (_headerSize + _trailerSize));
+            _maxDataSize = streamSizes.MaximumMessage;
             Debug.Assert(_maxDataSize > 0, "_maxDataSize > 0");
 
             SslStreamPal.QueryContextConnectionInfo(_securityContext!, ref _connectionInfo);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -945,14 +945,10 @@ namespace System.Net.Security
         /*++
             Encrypt - Encrypts our bytes before we send them over the wire
 
-            PERF: make more efficient, this does an extra copy when the offset
-            is non-zero.
-
             Input:
                 buffer - bytes for sending
-                offset -
-                size   -
                 output - Encrypted bytes
+                resultSize - number of bytes in the output buffer
         --*/
         internal ProtocolToken Encrypt(ReadOnlyMemory<byte> buffer)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -942,14 +942,6 @@ namespace System.Net.Security
 #endif
         }
 
-        /*++
-            Encrypt - Encrypts our bytes before we send them over the wire
-
-            Input:
-                buffer - bytes for sending
-                output - Encrypted bytes
-                resultSize - number of bytes in the output buffer
-        --*/
         internal ProtocolToken Encrypt(ReadOnlyMemory<byte> buffer)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.DumpBuffer(this, buffer.Span);
@@ -1333,7 +1325,7 @@ namespace System.Net.Security
 
             var oldPayload = Payload;
 
-            Payload = RentBuffer? ArrayPool<byte>.Shared.Rent(Size + size) : new byte[Size + size];
+            Payload = RentBuffer ? ArrayPool<byte>.Shared.Rent(Size + size) : new byte[Size + size];
             if (oldPayload != null)
             {
                 oldPayload.AsSpan<byte>().CopyTo(Payload);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -486,7 +486,7 @@ namespace System.Net.Security
                 }
 
                 Debug.Assert(headerSecBuffer.cbBuffer >= 0 && dataSecBuffer.cbBuffer >= 0 && trailerSecBuffer.cbBuffer >= 0);
-                Debug.Assert(checked(headerSecBuffer.cbBuffer + dataSecBuffer.cbBuffer + trailerSecBuffer.cbBuffer) <= output.Length);
+                Debug.Assert(checked(headerSecBuffer.cbBuffer + dataSecBuffer.cbBuffer + trailerSecBuffer.cbBuffer) <= token.Payload!.Length);
 
                 token.Size = checked(headerSecBuffer.cbBuffer + dataSecBuffer.cbBuffer + trailerSecBuffer.cbBuffer);
                 token.Status = new SecurityStatusPal(SecurityStatusPalErrorCode.OK);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -63,7 +63,7 @@ namespace System.Net.Security
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);
         }
 
-        private static unsafe void SetAlpn(ref InputSecurityBuffers inputBuffers, List<SslApplicationProtocol> alpn, Span<byte> localBuffer)
+        private static void SetAlpn(ref InputSecurityBuffers inputBuffers, List<SslApplicationProtocol> alpn, Span<byte> localBuffer)
         {
             if (alpn.Count == 1 && alpn[0] == SslApplicationProtocol.Http11)
             {
@@ -84,7 +84,7 @@ namespace System.Net.Security
             else
             {
                 int protocolLength = Interop.Sec_Application_Protocols.GetProtocolLength(alpn);
-                int bufferLength = sizeof(Interop.Sec_Application_Protocols) + protocolLength;
+                int bufferLength = Unsafe.SizeOf<Interop.Sec_Application_Protocols>() + protocolLength;
 
                 Span<byte> alpnBuffer = bufferLength <= localBuffer.Length ? localBuffer : new byte[bufferLength];
                 Interop.Sec_Application_Protocols.SetProtocols(alpnBuffer, alpn, protocolLength);
@@ -101,7 +101,7 @@ namespace System.Net.Security
             throw new PlatformNotSupportedException(nameof(SelectApplicationProtocol));
         }
 
-        public static unsafe ProtocolToken AcceptSecurityContext(
+        public static ProtocolToken AcceptSecurityContext(
             ref SafeFreeCredentials? credentialsHandle,
             ref SafeDeleteSslContext? context,
             ReadOnlySpan<byte> inputBuffer,
@@ -143,7 +143,7 @@ namespace System.Net.Security
             return false;
         }
 
-        public static unsafe ProtocolToken InitializeSecurityContext(
+        public static ProtocolToken InitializeSecurityContext(
             ref SafeFreeCredentials? credentialsHandle,
             ref SafeDeleteSslContext? context,
             string? targetName,

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;
 using System.Security.Authentication.ExtendedProtection;
@@ -49,7 +50,8 @@ namespace System.Net.Security
 
         private static byte[] InitSessionTokenBuffer()
         {
-            var schannelSessionToken = new Interop.SChannel.SCHANNEL_SESSION_TOKEN() {
+            var schannelSessionToken = new Interop.SChannel.SCHANNEL_SESSION_TOKEN()
+            {
                 dwTokenType = Interop.SChannel.SCHANNEL_SESSION,
                 dwFlags = Interop.SChannel.SSL_SESSION_DISABLE_RECONNECTS,
             };
@@ -445,32 +447,32 @@ namespace System.Net.Security
             input.Span.CopyTo(token.AvailableSpan.Slice(headerSize, input.Length));
 
             const int NumSecBuffers = 4; // header + data + trailer + empty
-            Interop.SspiCli.SecBuffer* unmanagedBuffer = stackalloc Interop.SspiCli.SecBuffer[NumSecBuffers];
+            Span<Interop.SspiCli.SecBuffer> unmanagedBuffers = stackalloc Interop.SspiCli.SecBuffer[NumSecBuffers];
             Interop.SspiCli.SecBufferDesc sdcInOut = new Interop.SspiCli.SecBufferDesc(NumSecBuffers)
             {
-                pBuffers = unmanagedBuffer
+                pBuffers = Unsafe.AsPointer(ref MemoryMarshal.GetReference(unmanagedBuffers))
             };
             fixed (byte* outputPtr = token.Payload)
             {
-                Interop.SspiCli.SecBuffer* headerSecBuffer = &unmanagedBuffer[0];
-                headerSecBuffer->BufferType = SecurityBufferType.SECBUFFER_STREAM_HEADER;
-                headerSecBuffer->pvBuffer = (IntPtr)outputPtr;
-                headerSecBuffer->cbBuffer = headerSize;
+                ref Interop.SspiCli.SecBuffer headerSecBuffer = ref unmanagedBuffers[0];
+                headerSecBuffer.BufferType = SecurityBufferType.SECBUFFER_STREAM_HEADER;
+                headerSecBuffer.pvBuffer = (IntPtr)outputPtr;
+                headerSecBuffer.cbBuffer = headerSize;
 
-                Interop.SspiCli.SecBuffer* dataSecBuffer = &unmanagedBuffer[1];
-                dataSecBuffer->BufferType = SecurityBufferType.SECBUFFER_DATA;
-                dataSecBuffer->pvBuffer = (IntPtr)(outputPtr + headerSize);
-                dataSecBuffer->cbBuffer = input.Length;
+                ref Interop.SspiCli.SecBuffer dataSecBuffer = ref unmanagedBuffers[1];
+                dataSecBuffer.BufferType = SecurityBufferType.SECBUFFER_DATA;
+                dataSecBuffer.pvBuffer = (IntPtr)(outputPtr + headerSize);
+                dataSecBuffer.cbBuffer = input.Length;
 
-                Interop.SspiCli.SecBuffer* trailerSecBuffer = &unmanagedBuffer[2];
-                trailerSecBuffer->BufferType = SecurityBufferType.SECBUFFER_STREAM_TRAILER;
-                trailerSecBuffer->pvBuffer = (IntPtr)(outputPtr + headerSize + input.Length);
-                trailerSecBuffer->cbBuffer = trailerSize;
+                ref Interop.SspiCli.SecBuffer trailerSecBuffer = ref unmanagedBuffers[2];
+                trailerSecBuffer.BufferType = SecurityBufferType.SECBUFFER_STREAM_TRAILER;
+                trailerSecBuffer.pvBuffer = (IntPtr)(outputPtr + headerSize + input.Length);
+                trailerSecBuffer.cbBuffer = trailerSize;
 
-                Interop.SspiCli.SecBuffer* emptySecBuffer = &unmanagedBuffer[3];
-                emptySecBuffer->BufferType = SecurityBufferType.SECBUFFER_EMPTY;
-                emptySecBuffer->cbBuffer = 0;
-                emptySecBuffer->pvBuffer = IntPtr.Zero;
+                ref Interop.SspiCli.SecBuffer emptySecBuffer = ref unmanagedBuffers[3];
+                emptySecBuffer.BufferType = SecurityBufferType.SECBUFFER_EMPTY;
+                emptySecBuffer.cbBuffer = 0;
+                emptySecBuffer.pvBuffer = IntPtr.Zero;
 
                 int errorCode = GlobalSSPI.SSPISecureChannel.EncryptMessage(securityContext, ref sdcInOut, 0);
 
@@ -483,10 +485,10 @@ namespace System.Net.Security
                     return token;
                 }
 
-                Debug.Assert(headerSecBuffer->cbBuffer >= 0 && dataSecBuffer->cbBuffer >= 0 && trailerSecBuffer->cbBuffer >= 0);
-                Debug.Assert(checked(headerSecBuffer->cbBuffer + dataSecBuffer->cbBuffer + trailerSecBuffer->cbBuffer) <= token.Payload!.Length);
+                Debug.Assert(headerSecBuffer.cbBuffer >= 0 && dataSecBuffer.cbBuffer >= 0 && trailerSecBuffer.cbBuffer >= 0);
+                Debug.Assert(checked(headerSecBuffer.cbBuffer + dataSecBuffer.cbBuffer + trailerSecBuffer.cbBuffer) <= output.Length);
 
-                token.Size = checked(headerSecBuffer->cbBuffer + dataSecBuffer->cbBuffer + trailerSecBuffer->cbBuffer);
+                token.Size = checked(headerSecBuffer.cbBuffer + dataSecBuffer.cbBuffer + trailerSecBuffer.cbBuffer);
                 token.Status = new SecurityStatusPal(SecurityStatusPalErrorCode.OK);
             }
 
@@ -496,25 +498,26 @@ namespace System.Net.Security
         public static unsafe SecurityStatusPal DecryptMessage(SafeDeleteSslContext? securityContext, Span<byte> buffer, out int offset, out int count)
         {
             const int NumSecBuffers = 4; // data + empty + empty + empty
+
+            Span<Interop.SspiCli.SecBuffer> unmanagedBuffers = stackalloc Interop.SspiCli.SecBuffer[NumSecBuffers];
+            for (int i = 1; i < NumSecBuffers; i++)
+            {
+                ref Interop.SspiCli.SecBuffer emptyBuffer = ref unmanagedBuffers[i];
+                emptyBuffer.BufferType = SecurityBufferType.SECBUFFER_EMPTY;
+                emptyBuffer.pvBuffer = IntPtr.Zero;
+                emptyBuffer.cbBuffer = 0;
+            }
+
             fixed (byte* bufferPtr = buffer)
             {
-                Interop.SspiCli.SecBuffer* unmanagedBuffer = stackalloc Interop.SspiCli.SecBuffer[NumSecBuffers];
-                Interop.SspiCli.SecBuffer* dataBuffer = &unmanagedBuffer[0];
-                dataBuffer->BufferType = SecurityBufferType.SECBUFFER_DATA;
-                dataBuffer->pvBuffer = (IntPtr)bufferPtr;
-                dataBuffer->cbBuffer = buffer.Length;
-
-                for (int i = 1; i < NumSecBuffers; i++)
-                {
-                    Interop.SspiCli.SecBuffer* emptyBuffer = &unmanagedBuffer[i];
-                    emptyBuffer->BufferType = SecurityBufferType.SECBUFFER_EMPTY;
-                    emptyBuffer->pvBuffer = IntPtr.Zero;
-                    emptyBuffer->cbBuffer = 0;
-                }
+                ref Interop.SspiCli.SecBuffer dataBuffer = ref unmanagedBuffers[0];
+                dataBuffer.BufferType = SecurityBufferType.SECBUFFER_DATA;
+                dataBuffer.pvBuffer = (IntPtr)bufferPtr;
+                dataBuffer.cbBuffer = buffer.Length;
 
                 Interop.SspiCli.SecBufferDesc sdcInOut = new Interop.SspiCli.SecBufferDesc(NumSecBuffers)
                 {
-                    pBuffers = unmanagedBuffer
+                    pBuffers = Unsafe.AsPointer(ref MemoryMarshal.GetReference(unmanagedBuffers))
                 };
                 Interop.SECURITY_STATUS errorCode = (Interop.SECURITY_STATUS)GlobalSSPI.SSPISecureChannel.DecryptMessage(securityContext!, ref sdcInOut, out _);
 
@@ -525,12 +528,12 @@ namespace System.Net.Security
                 for (int i = 0; i < NumSecBuffers; i++)
                 {
                     // Successfully decoded data and placed it at the following position in the buffer,
-                    if ((errorCode == Interop.SECURITY_STATUS.OK && unmanagedBuffer[i].BufferType == SecurityBufferType.SECBUFFER_DATA)
+                    if ((errorCode == Interop.SECURITY_STATUS.OK && unmanagedBuffers[i].BufferType == SecurityBufferType.SECBUFFER_DATA)
                         // or we failed to decode the data, here is the encoded data.
-                        || (errorCode != Interop.SECURITY_STATUS.OK && unmanagedBuffer[i].BufferType == SecurityBufferType.SECBUFFER_EXTRA))
+                        || (errorCode != Interop.SECURITY_STATUS.OK && unmanagedBuffers[i].BufferType == SecurityBufferType.SECBUFFER_EXTRA))
                     {
-                        offset = (int)((byte*)unmanagedBuffer[i].pvBuffer - bufferPtr);
-                        count = unmanagedBuffer[i].cbBuffer;
+                        offset = (int)((byte*)unmanagedBuffers[i].pvBuffer - bufferPtr);
+                        count = unmanagedBuffers[i].cbBuffer;
 
                         // output is ignored on Windows. We always decrypt in place and we set outputOffset to indicate where the data start.
                         Debug.Assert(offset >= 0 && count >= 0, $"Expected offset and count greater than 0, got {offset} and {count}");


### PR DESCRIPTION
Don't reduce MaximumMessage by Header and Trailer sizes (they are not included in the size limit).

Previous behavior led to us not consuming input in multiples of power of 2 which led to unnecessary fragmenting of data into TLS packets. The behavior was most noticeable when using 16kB buffer in calls to Write(Async) functions. Where we would split it into two TLS packets with the latter containing only about 40 B of useful data (see wireshark captures below).

This PR also removes some unsafe annotations on the code path.

<details>

<Summary>WireShark captures (Windows)</Summary>

before (notice the 135B TLS packets)
<img width="1120" alt="image" src="https://github.com/dotnet/runtime/assets/32671551/64c82024-5875-4125-9c6f-e7b6d52f6826">


after
![image](https://github.com/dotnet/runtime/assets/32671551/c496a8ee-92f7-4a5a-8734-52f90a2b3680)


</details>

<details>
<Summary>Benchmarks (Windows)</Summary>

The LargeReadWriteAsync benchmarks use 64kB buffers, so this PR should reduce the number of encryption calls by 1/5

| Method                         | Job        | Toolchain                                                                               | Mean        | Error     | StdDev    | Median      | Min         | Max         | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------------- |----------- |---------------------------------------------------------------------------------------- |------------:|----------:|----------:|------------:|------------:|------------:|------:|--------:|----------:|------------:|
| ReadWriteAsync                 | Job-VRYUDS | \pr\corerun.exe |    34.00 us |  0.366 us |  0.343 us |    33.91 us |    33.44 us |    34.71 us |  0.99 |    0.02 |         - |          NA |
| ReadWriteAsync                 | Job-GONFII | \main\corerun.exe                                                                       |    34.33 us |  0.395 us |  0.350 us |    34.26 us |    33.74 us |    35.01 us |  1.00 |    0.00 |         - |          NA |
|                                |            |                                                                                         |             |           |           |             |             |             |       |         |           |             |
| LargeReadWriteAsync            | Job-VRYUDS | \pr\corerun.exe |    57.22 us |  1.710 us |  1.969 us |    57.91 us |    53.08 us |    59.97 us |  0.88 |    0.04 |     491 B |        1.01 |
| LargeReadWriteAsync            | Job-GONFII | \main\corerun.exe                                                                       |    65.05 us |  1.296 us |  1.492 us |    65.03 us |    62.89 us |    68.19 us |  1.00 |    0.00 |     484 B |        1.00 |
|                                |            |                                                                                         |             |           |           |             |             |             |       |         |           |             |
| ConcurrentReadWrite            | Job-VRYUDS | \pr\corerun.exe | 1,381.65 us | 51.610 us | 59.434 us | 1,389.42 us | 1,266.48 us | 1,471.83 us |  1.02 |    0.07 |         - |        0.00 |
| ConcurrentReadWrite            | Job-GONFII | \main\corerun.exe                                                                       | 1,367.73 us | 75.121 us | 83.496 us | 1,379.64 us | 1,165.86 us | 1,469.80 us |  1.00 |    0.00 |       1 B |        1.00 |
|                                |            |                                                                                         |             |           |           |             |             |             |       |         |           |             |
| ConcurrentReadWriteLargeBuffer | Job-VRYUDS | \pr\corerun.exe | 1,021.83 us | 46.291 us | 53.309 us | 1,032.54 us |   895.20 us | 1,094.38 us |  0.99 |    0.11 |         - |        0.00 |
| ConcurrentReadWriteLargeBuffer | Job-GONFII | \main\corerun.exe                                                                       | 1,043.22 us | 70.858 us | 81.600 us | 1,038.13 us |   838.79 us | 1,156.26 us |  1.00 |    0.00 |       4 B |        1.00 |


</details>
