### PR TITLE
Consuming the return type instead of an interface

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
@@ -39,7 +39,7 @@ namespace System.Net.Mail
 
         internal void ParseValue(string addresses)
         {
-            IList<MailAddress> result = MailAddressParser.ParseMultipleAddresses(addresses);
+            List<MailAddress> result = MailAddressParser.ParseMultipleAddresses(addresses);
 
             for (int i = 0; i < result.Count; i++)
             {


### PR DESCRIPTION
# Description

Since `MailAddressParser.ParseMultipleAddresses` returns an instance of `List<MailAddress>` it makes much more sense to comsume it as is rather than do virtual calls and hope that the JIT compiler would eliminate them.

Perhaps it makes more sense even to use a `foreach` loop, but I decided to go with a simple change and move forward if it's okay.

# Regression

Negative regression, i.e. perf improvement.

# Testing

No new tests are needed.
