### PR TITLE
Limit optSwitchConvert to TYP_INT/TYP_LONG

### DIFF
--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -79,9 +79,9 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
             GenTree* op1 = rootNode->gtGetOp1()->gtGetOp1();
             GenTree* op2 = rootNode->gtGetOp1()->gtGetOp2();
 
-            if (!varTypeIsIntegral(op1) || !varTypeIsIntegral(op2))
+            if (!varTypeIsIntOrI(op1) || !varTypeIsIntOrI(op2))
             {
-                // Only integral types are supported
+                // Only TYP_INT and TYP_LONG are supported
                 return false;
             }
 
@@ -253,6 +253,7 @@ bool Compiler::optSwitchDetectAndConvert(BasicBlock* firstBlock)
 bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t* testValues, GenTree* nodeToTest)
 {
     assert(firstBlock->KindIs(BBJ_COND));
+    assert(!varTypeIsSmall(nodeToTest));
 
     if (testsCount < SWITCH_MIN_TESTS)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95600

The optSwitchConvert operates on locals and it only sees small-typed locals with jit stress - I could also just fix it for small types (will require some GT_CAST inserted + tests) but since there are no asm diffs I just conservatively disable it for small ints.