### PR TITLE
Do not consider InUse registers for assigning to consecutive candidates

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -3241,13 +3241,15 @@ regNumber LinearScan::assignCopyReg(RefPosition* refPosition)
 
     assert(allocatedReg != REG_NA);
 
+    // restore the related interval
+    currentInterval->relatedInterval = savedRelatedInterval;
+
     INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_COPY_REG, currentInterval, allocatedReg, nullptr, registerScore));
 
     // Now restore the old info
-    currentInterval->relatedInterval = savedRelatedInterval;
-    currentInterval->physReg         = oldPhysReg;
-    currentInterval->assignedReg     = oldRegRecord;
-    currentInterval->isActive        = true;
+    currentInterval->physReg     = oldPhysReg;
+    currentInterval->assignedReg = oldRegRecord;
+    currentInterval->isActive    = true;
 
     return allocatedReg;
 }
@@ -11966,11 +11968,13 @@ void LinearScan::RegisterSelection::try_SPILL_COST()
 #ifdef TARGET_ARM64
                 else if (assignedInterval->getNextRefPosition()->needsConsecutive)
                 {
-                    // if next refposition is part of consecutive registers and there is already a register
-                    // assigned to it then do not reassign for currentRefPosition, because with that, other
-                    // registers for the next consecutive register assignment would have to be copied to
-                    // different consecutive registers since this register is busy from this point onwards.
-                    continue;
+                    // If next refposition is part of consecutive registers and there is already a register
+                    // assigned to it then try not to reassign for currentRefPosition, because with that,
+                    // other registers for the next consecutive register assignment would have to be copied
+                    // to different consecutive registers since this register is busy from this point onwards.
+                    //
+                    // Have it as a candidate, but make its spill cost higher than others.
+                    currentSpillWeight = linearScan->getWeight(reloadRefPosition) * 10;
                 }
 #endif
             }

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -144,11 +144,14 @@ bool LinearScan::canAssignNextConsecutiveRegisters(RefPosition* firstRefPosition
                 nextRefPosition = getNextConsecutiveRefPosition(nextRefPosition);
             }
 
-            // If regToAssign is not free, check if it is already assigned to the interval corresponding
-            // to the subsequent nextRefPosition. If yes, it would just use regToAssign for that nextRefPosition.
-            if ((nextRefPosition->getInterval() != nullptr) &&
-                (nextRefPosition->getInterval()->assignedReg != nullptr) &&
-                ((nextRefPosition->getInterval()->assignedReg->regNum == regToAssign)))
+            Interval* interval = nextRefPosition->getInterval();
+
+            // If regToAssign is not free, make sure it is not in use at current location.
+            // If not, then check if it is already assigned to the interval corresponding
+            // to the subsequent nextRefPosition.
+            // If yes, it would just use regToAssign for that nextRefPosition.
+            if ((interval != nullptr) && !isRegInUse(regToAssign, interval->registerType) &&
+                (interval->assignedReg != nullptr) && ((interval->assignedReg->regNum == regToAssign)))
             {
                 continue;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -85,15 +85,6 @@ namespace System.Buffers.Text
                             goto DoneExit;
                     }
 
-                    end = srcMax - 48;
-                    if (AdvSimd.Arm64.IsSupported && (end >= src))
-                    {
-                        NeonEncode(ref src, ref dest, end, maxSrcLength, destLength, srcBytes, destBytes);
-
-                        if (src == srcEnd)
-                            goto DoneExit;
-                    }
-
                     end = srcMax - 16;
                     if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
                     {
@@ -487,60 +478,6 @@ namespace System.Buffers.Text
 
             srcBytes = src + 4;
             destBytes = dest;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-        private static unsafe void NeonEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
-        {
-            // C# implementatino of https://github.com/aklomp/base64/blob/e516d769a2a432c08404f1981e73b431566057be/lib/arch/neon64/enc_loop.c
-            // If we have Neon support, pick off 48 bytes at a time for as long as we can.
-            byte* src = srcBytes;
-            byte* dest = destBytes;
-
-            Vector128<byte> str1;
-            Vector128<byte> str2;
-            Vector128<byte> str3;
-
-            Vector128<byte> res1;
-            Vector128<byte> res2;
-            Vector128<byte> res3;
-            Vector128<byte> res4;
-
-            Vector128<byte> tbl_enc = Vector128.Create("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"u8).AsByte();
-            do
-            {
-                // Load 48 bytes and deinterleave:
-                AssertRead<Vector128<byte>>(src, srcStart, sourceLength);
-                (str1, str2, str3) = AdvSimd.Arm64.LoadVector128x3(src);
-
-                // Divide bits of three input bytes over four output bytes:
-                res1 = AdvSimd.ShiftRightLogical(str1, 2);
-                res2 = AdvSimd.ShiftRightLogical(str2, 4) | AdvSimd.ShiftLeftLogical(str1, 4);
-                res3 = AdvSimd.ShiftRightLogical(str3, 6) | AdvSimd.ShiftLeftLogical(str2, 2);
-                res4 = str3;
-
-                // Clear top two bits:
-                res1 &= AdvSimd.DuplicateToVector128(0x3F).AsByte();
-                res2 &= AdvSimd.DuplicateToVector128(0x3F).AsByte();
-                res3 &= AdvSimd.DuplicateToVector128(0x3F).AsByte();
-                res4 &= AdvSimd.DuplicateToVector128(0x3F).AsByte();
-
-                // The bits have now been shifted to the right locations;
-                // translate their values 0..63 to the Base64 alphabet.
-                // Use a 64-byte table lookup:
-                res1 = AdvSimd.Arm64.VectorTableLookup(tbl_enc, res1);
-                res2 = AdvSimd.Arm64.VectorTableLookup(tbl_enc, res2);
-                res3 = AdvSimd.Arm64.VectorTableLookup(tbl_enc, res3);
-                res4 = AdvSimd.Arm64.VectorTableLookup(tbl_enc, res4);
-
-                // Interleave and store result:
-                AssertWrite<Vector128<byte>>(dest, destStart, destLength);
-                AdvSimd.Arm64.StoreVector128x4AndZip(dest, (res1, res2, res3, res4));
-
-                src += 48;
-                dest += 64;
-            } while (src <= srcEnd);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
When checking if consecutive registers are available, also take into account the information if registers are in use at the same location. If that is the case, do not consider it as candidate for consecutive register allocation.

I also experimented with 6e8b09624165bca37b33336d0c0181e268aa7170 to not spill a register that is already assigned to the consecutive registers because that could involve lot of moving around, since the next consecutive registers might have to be in different registers than the ones they were originally obtained. It doesn't make much difference in the codegen of the example of the code that was introduced in #95513 . I might revert depending on how CI and TP impact is.

<img width="1419" alt="image" src="https://github.com/dotnet/runtime/assets/12488060/578b45a7-05d5-4549-a1f7-c6e9092b88e5">

 
Details: https://github.com/dotnet/runtime/pull/95513#discussion_r1414572949