### PR TITLE
[PERF] Update Perf Android jobs to use the Windows 11 Pixel Queue.

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -54,7 +54,7 @@ if ($Internal) {
         "perftiger_crossgen" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
         "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf" }
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf" }
-        "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
+        "perfpixel4a" { $Queue = "Windows.11.Amd64.Pixel.Perf" }
         "perfampere" { $Queue = "Windows.Server.Arm64.Perf" }
         "cloudvm" { $Queue = "Windows.10.Amd64" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }


### PR DESCRIPTION
Update Perf Android jobs to use the Windows 11 Pixel Queue.
Successful test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2328997&view=results
This should not have any impact on the test results as this only updates the machine the devices are tethered to.