### PR TITLE
Bump WasmBuildTests timeout to 180min

### DIFF
--- a/eng/pipelines/common/templates/browser-wasm-build-tests.yml
+++ b/eng/pipelines/common/templates/browser-wasm-build-tests.yml
@@ -110,7 +110,7 @@ jobs:
           /p:InstallWorkloadForTesting=true
           /p:WasmSkipMissingRuntimePackBuild=true
           /p:PreparePackagesForWorkloadInstall=false
-        timeoutInMinutes: 120
+        timeoutInMinutes: 180
         condition: >-
           or(
             eq(variables['alwaysRunVar'], true),


### PR DESCRIPTION
Looking at the data for the last 30 days a successful or failed WasmBuildTests job took between 70-90 minutes. When Helix queues are overloaded the 120min timeout can result in canceled builds which is especially true on servicing queues which first need to spin up VMs so bump the timeout to 180mins.