### PR TITLE
Fix casing for "memoryRandomization" experiment so it matches the condition.

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -100,7 +100,7 @@ if ($NoR2R) {
 
 if ($ExperimentName) {
     $Configurations += " ExperimentName=$ExperimentName"
-    if ($ExperimentName -eq "memoryrandomization") {
+    if ($ExperimentName -eq "memoryRandomization") {
         $ExtraBenchmarkDotNetArguments += " --memoryRandomization true"
     }
 }

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -387,7 +387,7 @@ fi
 
 if [[ ! -z "$experimentname" ]]; then
     configurations="$configurations ExperimentName=$experimentname"
-    if [[ "$experimentname" == "memoryrandomization" ]]; then
+    if [[ "$experimentname" == "memoryRandomization" ]]; then
         extra_benchmark_dotnet_arguments="$extra_benchmark_dotnet_arguments --memoryRandomization true"
     fi
 fi


### PR DESCRIPTION
Mistake from https://github.com/dotnet/runtime/pull/95291. cc @DrewScoggins 