### PR TITLE
Reverse parsed mail adresses in a single action

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressParser.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressParser.cs
@@ -40,13 +40,14 @@ namespace System.Net.Mail
             int index = data.Length - 1;
             while (index >= 0)
             {
-                // Because we're parsing in reverse, we must make an effort to preserve the order of the addresses.
                 TryParseAddress(data, true, ref index, out ParseAddressInfo parsedAddress, throwExceptionIfFail: true);
-                results.Insert(0, new MailAddress(parsedAddress.DisplayName, parsedAddress.User, parsedAddress.Host, null));
+                results.Add(new MailAddress(parsedAddress.DisplayName, parsedAddress.User, parsedAddress.Host, null));
                 Debug.Assert(index == -1 || data[index] == MailBnfHelper.Comma,
                     "separator not found while parsing multiple addresses");
                 index--;
             }
+            // Because we're parsing in reverse, we must make an effort to preserve the order of the addresses.
+            results.Reverse();
             return results;
         }
 


### PR DESCRIPTION
# Description

Te correct order in the resulting collection can be achieved in a single action instead of insertions of items at the start. The difference is that more addresses are parsed, more `Array.Copy` is invoked with its checks and memory barier protected memory copies.

# Customer Impact

Bonus performance points.

# Regression

Nope.

# Testing

The existing tests are sufficient.
