### PR TITLE
Fix DateTimeFormat comments for year pattern (#95629)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -69,9 +69,9 @@ namespace System
 
         "y"     "0"         two digit year (year % 100) w/o leading zero           0
         "yy"    "00"        two digit year (year % 100) with leading zero          00
-        "yyy"   "D3"        year                                  2000
-        "yyyy"  "D4"        year                                  2000
-        "yyyyy" "D5"        year                                  2000
+        "yyy"   "D3"        year with leading zeroes              2000
+        "yyyy"  "D4"        year with leading zeroes              2000
+        "yyyyy" "D5"        year with leading zeroes              02000
         ...
 
         "z"     "+0;-0"     timezone offset w/o leading zero      -8
@@ -618,7 +618,7 @@ namespace System
                         // Notes about OS behavior:
                         // y: Always print (year % 100). No leading zero.
                         // yy: Always print (year % 100) with leading zero.
-                        // yyy/yyyy/yyyyy/... : Print year value.  No leading zero.
+                        // yyy/yyyy/yyyyy/... : Print year value.  With leading zeros.
 
                         int year = cal.GetYear(dateTime);
                         tokenLen = ParseRepeatPattern(format, i, ch);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95629

Comments describing the format for the year pattern with more than 2 'y'-s ('yyy', 'yyyy', ...) did not correctly reflect the implementation.