### PR TITLE
Console.Unix: fix ANSI colors over redirected standard output.

### DIFF
--- a/src/libraries/System.Console/src/System/Console.cs
+++ b/src/libraries/System.Console/src/System/Console.cs
@@ -406,7 +406,7 @@ namespace System
                     throw new IOException(SR.InvalidOperation_SetWindowSize);
                 }
 
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, "width");
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, nameof(WindowWidth));
 
                 ConsolePal.WindowWidth = value;
             }
@@ -426,7 +426,7 @@ namespace System
                     throw new IOException(SR.InvalidOperation_SetWindowSize);
                 }
 
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, "height");
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, nameof(WindowHeight));
 
                 ConsolePal.WindowHeight = value;
             }

--- a/src/libraries/System.Console/src/System/Console.cs
+++ b/src/libraries/System.Console/src/System/Console.cs
@@ -406,7 +406,7 @@ namespace System
                     throw new IOException(SR.InvalidOperation_SetWindowSize);
                 }
 
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, "width");
 
                 ConsolePal.WindowWidth = value;
             }
@@ -426,7 +426,7 @@ namespace System
                     throw new IOException(SR.InvalidOperation_SetWindowSize);
                 }
 
-                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+                ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, "height");
 
                 ConsolePal.WindowHeight = value;
             }
@@ -449,8 +449,8 @@ namespace System
                 throw new IOException(SR.InvalidOperation_SetWindowSize);
             }
 
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
-            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width, nameof(width));
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height, nameof(height));
 
             ConsolePal.SetWindowSize(width, height);
         }

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -952,9 +952,9 @@ namespace System
             }
         }
 
-        internal static void WriteToTerminal(ReadOnlySpan<byte> buffer, SafeFileHandle? overrideHandle = null, bool mayChangeCursorPosition = true)
+        internal static void WriteToTerminal(ReadOnlySpan<byte> buffer, SafeFileHandle? handle = null, bool mayChangeCursorPosition = true)
         {
-            SafeFileHandle? handle = overrideHandle ?? s_terminalHandle;
+            handle ??= s_terminalHandle;
             Debug.Assert(handle is not null);
 
             lock (Console.Out) // synchronize with other writers
@@ -1119,9 +1119,9 @@ namespace System
 
         /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
         /// <param name="value">The string to write.</param>
-        /// <param name="overrideHandle">Handle to use instead of s_terminalHandle.</param>
+        /// <param name="handle">Handle to use instead of s_terminalHandle.</param>
         /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
-        internal static void WriteTerminalAnsiString(string? value, SafeFileHandle? overrideHandle = null, bool mayChangeCursorPosition = true)
+        internal static void WriteTerminalAnsiString(string? value, SafeFileHandle? handle = null, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;
@@ -1139,7 +1139,7 @@ namespace System
             }
 
             EnsureConsoleInitialized();
-            WriteToTerminal(data, overrideHandle, mayChangeCursorPosition);
+            WriteToTerminal(data, handle, mayChangeCursorPosition);
         }
     }
 }

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -801,7 +801,7 @@ namespace System
             string evaluatedString = s_fgbgAndColorStrings[fgbgIndex, ccValue]; // benign race
             if (evaluatedString != null)
             {
-                WriteTerminalAnsiString(evaluatedString);
+                WriteTerminalAnsiColorString(evaluatedString);
                 return;
             }
 
@@ -841,7 +841,7 @@ namespace System
                     int ansiCode = consoleColorToAnsiCode[ccValue] % maxColors;
                     evaluatedString = TermInfo.ParameterizedStrings.Evaluate(formatString, ansiCode);
 
-                    WriteTerminalAnsiString(evaluatedString);
+                    WriteTerminalAnsiColorString(evaluatedString);
 
                     s_fgbgAndColorStrings[fgbgIndex, ccValue] = evaluatedString; // benign race
                 }
@@ -853,7 +853,7 @@ namespace System
         {
             if (ConsoleUtils.EmitAnsiColorCodes)
             {
-                WriteTerminalAnsiString(TerminalFormatStringsInstance.Reset);
+                WriteTerminalAnsiColorString(TerminalFormatStringsInstance.Reset);
             }
         }
 
@@ -952,13 +952,14 @@ namespace System
             }
         }
 
-        internal static void WriteToTerminal(ReadOnlySpan<byte> buffer, bool mayChangeCursorPosition = true)
+        internal static void WriteToTerminal(ReadOnlySpan<byte> buffer, SafeFileHandle? overrideHandle = null, bool mayChangeCursorPosition = true)
         {
-            Debug.Assert(s_terminalHandle is not null);
+            SafeFileHandle? handle = overrideHandle ?? s_terminalHandle;
+            Debug.Assert(handle is not null);
 
             lock (Console.Out) // synchronize with other writers
             {
-                Write(s_terminalHandle, buffer, mayChangeCursorPosition);
+                Write(handle, buffer, mayChangeCursorPosition);
             }
         }
 
@@ -1110,10 +1111,17 @@ namespace System
             Volatile.Write(ref s_invalidateCachedSettings, 1);
         }
 
+        // Ansi colors are enabled when stdout is a terminal or when
+        // DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION is set.
+        // In both cases, they are written to stdout.
+        internal static void WriteTerminalAnsiColorString(string? value)
+            => WriteTerminalAnsiString(value, Interop.Sys.FileDescriptors.STDOUT_FILENO, mayChangeCursorPosition: false);
+
         /// <summary>Writes a terminfo-based ANSI escape string to stdout.</summary>
         /// <param name="value">The string to write.</param>
+        /// <param name="overrideHandle">Handle to use instead of s_terminalHandle.</param>
         /// <param name="mayChangeCursorPosition">Writing this value may change the cursor position.</param>
-        internal static void WriteTerminalAnsiString(string? value, bool mayChangeCursorPosition = true)
+        internal static void WriteTerminalAnsiString(string? value, SafeFileHandle? overrideHandle = null, bool mayChangeCursorPosition = true)
         {
             if (string.IsNullOrEmpty(value))
                 return;
@@ -1131,7 +1139,7 @@ namespace System
             }
 
             EnsureConsoleInitialized();
-            WriteToTerminal(data, mayChangeCursorPosition);
+            WriteToTerminal(data, overrideHandle, mayChangeCursorPosition);
         }
     }
 }

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -57,7 +57,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("WindowWidth", () => Console.WindowWidth = value);
         }
     }
 
@@ -89,7 +89,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("WindowHeight", () => Console.WindowHeight = value);
         }
     }
 

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -559,7 +559,7 @@ public class WindowAndCursorProps
         Assert.Throws<PlatformNotSupportedException>(() => Console.SetWindowPosition(50, 50));
     }
 
-    [PlatformSpecific((TestPlatforms.Windows) | (TestPlatforms.AnyUnix & ~TestPlatforms.Browser & ~TestPlatforms.iOS & ~TestPlatforms.MacCatalyst & ~TestPlatforms.tvOS))]
+    [PlatformSpecific(TestPlatforms.Windows)]
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoNorServerCore))]
     public void SetWindowSize_GetWindowSize_ReturnsExpected()
     {

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -57,7 +57,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowWidth = value);
         }
     }
 
@@ -89,7 +89,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowHeight = value);
         }
     }
 

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -57,7 +57,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowWidth = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("width", () => Console.WindowWidth = value);
         }
     }
 
@@ -89,7 +89,7 @@ public class WindowAndCursorProps
         }
         else
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("value", () => Console.WindowHeight = value);
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("height", () => Console.WindowHeight = value);
         }
     }
 


### PR DESCRIPTION
This fixes a regression that was introduced in https://github.com/dotnet/runtime/pull/94414.

ANSI colors always need to be sent to standard output.

The `Color.RedirectedOutput_EnvVarSet_EmitsAnsiCodes` test caught the regression.

@adamsitnik @dotnet/area-system-console ptal.