### PR TITLE
[release/6.0-staging] [PERF] Update Perf Android jobs to use the Windows 11 Pixel Queue.

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -48,7 +48,7 @@ if ($Internal) {
         "perftiger_crossgen" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
         "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf" }
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf" }
-        "perfpixel4a" { $Queue = "Windows.10.Amd64.Pixel.Perf" }
+        "perfpixel4a" { $Queue = "Windows.11.Amd64.Pixel.Perf" }
         Default { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
     }
     $PerfLabArguments = "--upload-to-perflab-container"


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/95614. Updates the Android runs to use the new Perf Android Queues.