### PR TITLE
Add Arm64 encodings for IF_SVE_EQ_3A to IF_SVE_HR_3A

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -10513,6 +10513,30 @@ void CodeGen::genArm64EmitterUnitTests()
                               INS_OPTS_SCALABLE_D); /* REVH    <Zd>.<T>, <Pg>/M, <Zn>.<T> */
     theEmitter->emitIns_R_R_R(INS_sve_revw, EA_SCALABLE, REG_V25, REG_P4, REG_V16,
                               INS_OPTS_SCALABLE_D); /* REVW    <Zd>.D, <Pg>/M, <Zn>.D */
+
+    // IF_SVE_EQ_3A
+    // Note: Scalable size is the size of the destination <T>, not the source <Tb>.
+    theEmitter->emitIns_R_R_R(INS_sve_sadalp, EA_SCALABLE, REG_V26, REG_P3, REG_V8,
+                              INS_OPTS_SCALABLE_H); /* SADALP  <Zda>.<T>, <Pg>/M, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_uadalp, EA_SCALABLE, REG_V27, REG_P2, REG_V9,
+                              INS_OPTS_SCALABLE_S); /* UADALP  <Zda>.<T>, <Pg>/M, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_uadalp, EA_SCALABLE, REG_V28, REG_P0, REG_V31,
+                              INS_OPTS_SCALABLE_D); /* UADALP  <Zda>.<T>, <Pg>/M, <Zn>.<Tb> */
+
+    // IF_SVE_ES_3A
+    theEmitter->emitIns_R_R_R(INS_sve_sqabs, EA_SCALABLE, REG_V29, REG_P7, REG_V0,
+                              INS_OPTS_SCALABLE_B); /* SQABS   <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_sqneg, EA_SCALABLE, REG_V31, REG_P6, REG_V1,
+                              INS_OPTS_SCALABLE_H); /* SQNEG   <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_sqneg, EA_SCALABLE, REG_V0, REG_P5, REG_V2,
+                              INS_OPTS_SCALABLE_S); /* SQNEG   <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_sqneg, EA_SCALABLE, REG_V1, REG_P4, REG_V3,
+                              INS_OPTS_SCALABLE_D); /* SQNEG   <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_urecpe, EA_SCALABLE, REG_V2, REG_P3, REG_V4,
+                              INS_OPTS_SCALABLE_S); /* URECPE  <Zd>.S, <Pg>/M, <Zn>.S */
+    theEmitter->emitIns_R_R_R(INS_sve_ursqrte, EA_SCALABLE, REG_V3, REG_P0, REG_V5,
+                              INS_OPTS_SCALABLE_S); /* URSQRTE <Zd>.S, <Pg>/M, <Zn>.S */
+
     // IF_SVE_GA_2A
     theEmitter->emitIns_R_R_I(INS_sve_sqrshrn, EA_SCALABLE, REG_V0, REG_V0, 5,
                               INS_OPTS_SCALABLE_H); // SQRSHRN <Zd>.H, {<Zn1>.S-<Zn2>.S }, #<const>
@@ -10532,6 +10556,54 @@ void CodeGen::genArm64EmitterUnitTests()
                               INS_OPTS_SCALABLE_H); // SQRSHRUN <Zd>.H, {<Zn1>.S-<Zn2>.S }, #<const>
     theEmitter->emitIns_R_R_I(INS_sve_uqrshrn, EA_SCALABLE, REG_V15, REG_V12, 1,
                               INS_OPTS_SCALABLE_H); // UQRSHRN <Zd>.H, {<Zn1>.S-<Zn2>.S }, #<const>
+
+// IF_SVE_GS_3A
+#ifdef ALL_ARM64_EMITTER_UNIT_TESTS_SVE_UNSUPPORTED
+    theEmitter->emitIns_R_R_R(INS_sve_faddqv, EA_8BYTE, REG_V16, REG_P0, REG_V12,
+                              INS_OPTS_SCALABLE_H_WITH_SIMD_VECTOR); /* FADDQV  <Vd>.<T>, <Pg>, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_fmaxnmqv, EA_8BYTE, REG_V17, REG_P1, REG_V11,
+                              INS_OPTS_SCALABLE_S_WITH_SIMD_VECTOR); /* FMAXNMQV <Vd>.<T>, <Pg>, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_fmaxqv, EA_8BYTE, REG_V18, REG_P3, REG_V10,
+                              INS_OPTS_SCALABLE_D_WITH_SIMD_VECTOR); /* FMAXQV  <Vd>.<T>, <Pg>, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_fminnmqv, EA_8BYTE, REG_V19, REG_P4, REG_V9,
+                              INS_OPTS_SCALABLE_H_WITH_SIMD_VECTOR); /* FMINNMQV <Vd>.<T>, <Pg>, <Zn>.<Tb> */
+    theEmitter->emitIns_R_R_R(INS_sve_fminqv, EA_8BYTE, REG_V20, REG_P5, REG_V8,
+                              INS_OPTS_SCALABLE_D_WITH_SIMD_VECTOR); /* FMINQV  <Vd>.<T>, <Pg>, <Zn>.<Tb> */
+#endif                                                               // ALL_ARM64_EMITTER_UNIT_TESTS_SVE_UNSUPPORTED
+
+    // IF_SVE_HE_3A
+    theEmitter->emitIns_R_R_R(INS_sve_faddv, EA_2BYTE, REG_V21, REG_P7, REG_V7,
+                              INS_OPTS_SCALABLE_H_WITH_SIMD_SCALAR); /* FADDV   <V><d>, <Pg>, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_fmaxnmv, EA_2BYTE, REG_V22, REG_P6, REG_V6,
+                              INS_OPTS_SCALABLE_H_WITH_SIMD_SCALAR); /* FMAXNMV <V><d>, <Pg>, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_fmaxv, EA_4BYTE, REG_V23, REG_P5, REG_V5,
+                              INS_OPTS_SCALABLE_S_WITH_SIMD_SCALAR); /* FMAXV   <V><d>, <Pg>, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_fminnmv, EA_8BYTE, REG_V24, REG_P4, REG_V4,
+                              INS_OPTS_SCALABLE_D_WITH_SIMD_SCALAR); /* FMINNMV <V><d>, <Pg>, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_fminv, EA_4BYTE, REG_V25, REG_P3, REG_V3,
+                              INS_OPTS_SCALABLE_S_WITH_SIMD_SCALAR); /* FMINV   <V><d>, <Pg>, <Zn>.<T> */
+
+    // IF_SVE_HQ_3A
+    theEmitter->emitIns_R_R_R(INS_sve_frinta, EA_SCALABLE, REG_V26, REG_P7, REG_V2,
+                              INS_OPTS_SCALABLE_H); /* FRINTA  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frinti, EA_SCALABLE, REG_V27, REG_P6, REG_V1,
+                              INS_OPTS_SCALABLE_S); /* FRINTI  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frintm, EA_SCALABLE, REG_V28, REG_P5, REG_V0,
+                              INS_OPTS_SCALABLE_D); /* FRINTM  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frintn, EA_SCALABLE, REG_V29, REG_P4, REG_V10,
+                              INS_OPTS_SCALABLE_H); /* FRINTN  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frintp, EA_SCALABLE, REG_V30, REG_P3, REG_V11,
+                              INS_OPTS_SCALABLE_S); /* FRINTP  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frintx, EA_SCALABLE, REG_V31, REG_P2, REG_V12,
+                              INS_OPTS_SCALABLE_D); /* FRINTX  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_frintz, EA_SCALABLE, REG_V0, REG_P0, REG_V13,
+                              INS_OPTS_SCALABLE_H); /* FRINTZ  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+
+    // IF_SVE_HR_3A
+    theEmitter->emitIns_R_R_R(INS_sve_frecpx, EA_SCALABLE, REG_V5, REG_P5, REG_V5,
+                              INS_OPTS_SCALABLE_H); /* FRECPX  <Zd>.<T>, <Pg>/M, <Zn>.<T> */
+    theEmitter->emitIns_R_R_R(INS_sve_fsqrt, EA_SCALABLE, REG_V6, REG_P6, REG_V6,
+                              INS_OPTS_SCALABLE_S); /* FSQRT   <Zd>.<T>, <Pg>/M, <Zn>.<T> */
 
 #endif // ALL_ARM64_EMITTER_UNIT_TESTS_SVE
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1705,7 +1705,8 @@ protected:
 #define PERFSCORE_THROUGHPUT_10C 10.0f   // slower - 10 cycles
 #define PERFSCORE_THROUGHPUT_11C 10.0f   // slower - 10 cycles
 #define PERFSCORE_THROUGHPUT_13C 13.0f   // slower - 13 cycles
-#define PERFSCORE_THROUGHPUT_14C 13.0f   // slower - 13 cycles
+#define PERFSCORE_THROUGHPUT_14C 14.0f   // slower - 13 cycles
+#define PERFSCORE_THROUGHPUT_16C 16.0f   // slower - 13 cycles
 #define PERFSCORE_THROUGHPUT_19C 19.0f   // slower - 19 cycles
 #define PERFSCORE_THROUGHPUT_25C 25.0f   // slower - 25 cycles
 #define PERFSCORE_THROUGHPUT_33C 33.0f   // slower - 33 cycles
@@ -1730,6 +1731,7 @@ protected:
 #define PERFSCORE_LATENCY_11C 11.0f
 #define PERFSCORE_LATENCY_12C 12.0f
 #define PERFSCORE_LATENCY_13C 13.0f
+#define PERFSCORE_LATENCY_14C 14.0f
 #define PERFSCORE_LATENCY_15C 15.0f
 #define PERFSCORE_LATENCY_16C 16.0f
 #define PERFSCORE_LATENCY_18C 18.0f

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -985,12 +985,12 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             break;
 
         // Scalable to/from SIMD scalar.
+        case IF_SVE_AF_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise logical reduction (predicated)
+        case IF_SVE_AK_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (predicated)
         case IF_SVE_CN_3A: // ........xx...... ...gggmmmmmddddd -- SVE conditionally extract element to SIMD&FP scalar
         case IF_SVE_CP_3A: // ........xx...... ...gggnnnnnddddd -- SVE copy SIMD&FP scalar register to vector
                            // (predicated)
         case IF_SVE_CR_3A: // ........xx...... ...gggnnnnnddddd -- SVE extract element to SIMD&FP scalar register
-        case IF_SVE_AF_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise logical reduction (predicated)
-        case IF_SVE_AK_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (predicated)
             elemsize = id->idOpSize();
             assert(insOptsScalableWithSimdScalar(id->idInsOpt())); // xx
             assert(isVectorRegister(id->idReg1()));                // ddddd
@@ -1000,6 +1000,7 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             break;
 
         // Scalable to FP SIMD scalar.
+        case IF_SVE_HE_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction
         case IF_SVE_HJ_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point serial reduction (predicated)
             elemsize = id->idOpSize();
             assert(insOptsScalableWithSimdFPScalar(id->idInsOpt())); // xx
@@ -1023,6 +1024,7 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         // Scalable FP.
         case IF_SVE_GR_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 floating-point pairwise operations
         case IF_SVE_HL_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point arithmetic (predicated)
+        case IF_SVE_HR_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point unary operations
             elemsize = id->idOpSize();
             assert(insOptsScalableFloat(id->idInsOpt())); // xx
             assert(isVectorRegister(id->idReg1()));       // ddddd
@@ -1035,6 +1037,7 @@ void emitter::emitInsSanityCheck(instrDesc* id)
         case IF_SVE_AG_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise logical reduction (quadwords)
         case IF_SVE_AJ_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer add reduction (quadwords)
         case IF_SVE_AL_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (quadwords)
+        case IF_SVE_GS_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction (quadwords)
             datasize = id->idOpSize();
             assert(insOptsScalableWithSimdVector(id->idInsOpt())); // xx
             assert(isVectorRegister(id->idReg1()));                // ddddd
@@ -1115,6 +1118,37 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             assert(isLowPredicateRegister(id->idReg2()));      // ggg
             assert(isGeneralRegisterOrZR(id->idReg3()));       // mmmmm
             assert(isValidScalarDatasize(elemsize));
+            break;
+
+        // Scalable, .H, .S or .D
+        case IF_SVE_EQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer pairwise add and accumulate long
+        case IF_SVE_HQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point round to integral value
+            elemsize = id->idOpSize();
+            assert(insOptsScalableAtLeastHalf(id->idInsOpt())); // xx
+            assert(isVectorRegister(id->idReg1()));             // ddddd
+            assert(isLowPredicateRegister(id->idReg2()));       // ggg
+            assert(isVectorRegister(id->idReg3()));             // mmmmm
+            assert(isScalableVectorSize(elemsize));
+            break;
+
+        // Scalable, possibly fixed to .S
+        case IF_SVE_ES_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer unary operations (predicated)
+            elemsize = id->idOpSize();
+            switch (id->idIns())
+            {
+                case INS_sve_sqabs:
+                case INS_sve_sqneg:
+                    assert(insOptsScalableSimple(id->idInsOpt()));
+                    break;
+
+                default:
+                    assert(id->idInsOpt() == INS_OPTS_SCALABLE_S);
+                    break;
+            }
+            assert(isVectorRegister(id->idReg1()));       // ddddd
+            assert(isLowPredicateRegister(id->idReg2())); // ggg
+            assert(isVectorRegister(id->idReg3()));       // mmmmm
+            assert(isScalableVectorSize(elemsize));
             break;
 
         case IF_SVE_GA_2A: // ............iiii ......nnnn.ddddd -- SME2 multi-vec shift narrow
@@ -8570,6 +8604,15 @@ void emitter::emitIns_R_R_R(
             fmt = IF_SVE_EP_3A;
             break;
 
+        case INS_sve_sadalp:
+        case INS_sve_uadalp:
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableAtLeastHalf(opt));
+            fmt = IF_SVE_EQ_3A;
+            break;
+
         case INS_sve_addp:
         case INS_sve_smaxp:
         case INS_sve_sminp:
@@ -8580,6 +8623,24 @@ void emitter::emitIns_R_R_R(
             assert(isVectorRegister(reg3));
             assert(insOptsScalableSimple(opt));
             fmt = IF_SVE_ER_3A;
+            break;
+
+        case INS_sve_sqabs:
+        case INS_sve_sqneg:
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableSimple(opt));
+            fmt = IF_SVE_ES_3A;
+            break;
+
+        case INS_sve_urecpe:
+        case INS_sve_ursqrte:
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(opt == INS_OPTS_SCALABLE_S);
+            fmt = IF_SVE_ES_3A;
             break;
 
         case INS_sve_sqadd:
@@ -8628,6 +8689,32 @@ void emitter::emitIns_R_R_R(
             fmt = IF_SVE_GR_3A;
             break;
 
+        case INS_sve_faddqv:
+        case INS_sve_fmaxnmqv:
+        case INS_sve_fminnmqv:
+        case INS_sve_fmaxqv:
+        case INS_sve_fminqv:
+            unreached(); // TODO-SVE: Not yet supported.
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableWithSimdVector(opt));
+            fmt = IF_SVE_GS_3A;
+            break;
+
+        case INS_sve_fmaxnmv:
+        case INS_sve_fmaxv:
+        case INS_sve_fminnmv:
+        case INS_sve_fminv:
+        case INS_sve_faddv:
+            assert(isFloatReg(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableWithSimdFPScalar(opt));
+            assert(isValidVectorElemsizeSveFloat(size));
+            fmt = IF_SVE_HE_3A;
+            break;
+
         case INS_sve_fadda:
             assert(isFloatReg(reg1));
             assert(isLowPredicateRegister(reg2));
@@ -8665,6 +8752,29 @@ void emitter::emitIns_R_R_R(
             assert(isVectorRegister(reg3));
             assert(insOptsScalableFloat(opt));
             fmt = IF_SVE_HL_3A;
+            break;
+
+        case INS_sve_frintn:
+        case INS_sve_frintm:
+        case INS_sve_frintp:
+        case INS_sve_frintz:
+        case INS_sve_frinta:
+        case INS_sve_frintx:
+        case INS_sve_frinti:
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableFloat(opt));
+            fmt = IF_SVE_HQ_3A;
+            break;
+
+        case INS_sve_frecpx:
+        case INS_sve_fsqrt:
+            assert(isVectorRegister(reg1));
+            assert(isLowPredicateRegister(reg2));
+            assert(isVectorRegister(reg3));
+            assert(insOptsScalableFloat(opt));
+            fmt = IF_SVE_HR_3A;
             break;
 
         default:
@@ -14307,13 +14417,19 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case IF_SVE_CR_3A: // ........xx...... ...gggnnnnnddddd -- SVE extract element to SIMD&FP scalar register
         case IF_SVE_CU_3A: // ........xx...... ...gggnnnnnddddd -- SVE reverse within elements
         case IF_SVE_EP_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 integer halving add/subtract (predicated)
+        case IF_SVE_EQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer pairwise add and accumulate long
         case IF_SVE_ER_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 integer pairwise arithmetic
+        case IF_SVE_ES_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer unary operations (predicated)
         case IF_SVE_ET_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 saturating add/subtract
         case IF_SVE_EU_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 saturating/rounding bitwise shift left
                            // (predicated)
         case IF_SVE_GR_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 floating-point pairwise operations
+        case IF_SVE_GS_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction (quadwords)
+        case IF_SVE_HE_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction
         case IF_SVE_HJ_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point serial reduction (predicated)
         case IF_SVE_HL_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point arithmetic (predicated)
+        case IF_SVE_HQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point round to integral value
+        case IF_SVE_HR_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point unary operations
             code = emitInsCodeSve(ins, fmt);
             code |= insEncodeReg_V_4_to_0(id->idReg1());   // ddddd
             code |= insEncodeReg_P_12_to_10(id->idReg2()); // ggg
@@ -16637,6 +16753,7 @@ void emitter::emitDispInsHelp(
         case IF_SVE_AK_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (predicated)
         case IF_SVE_CR_3A: // ........xx...... ...gggnnnnnddddd -- SVE extract element to SIMD&FP scalar register
         case IF_SVE_CS_3A: // ........xx...... ...gggnnnnnddddd -- SVE extract element to general register
+        case IF_SVE_HE_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction
             emitDispReg(id->idReg1(), size, true);                    // ddddd
             emitDispPredicateReg(id->idReg2(), PREDICATE_NONE, true); // ggg
             emitDispSveReg(id->idReg3(), id->idInsOpt(), false);      // mmmmm
@@ -16646,6 +16763,7 @@ void emitter::emitDispInsHelp(
         case IF_SVE_AG_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise logical reduction (quadwords)
         case IF_SVE_AJ_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer add reduction (quadwords)
         case IF_SVE_AL_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (quadwords)
+        case IF_SVE_GS_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction (quadwords)
             emitDispVectorReg(id->idReg1(), id->idInsOpt(), true);    // ddddd
             emitDispPredicateReg(id->idReg2(), PREDICATE_NONE, true); // ggg
             emitDispSveReg(id->idReg3(), id->idInsOpt(), false);      // mmmmm
@@ -16662,6 +16780,9 @@ void emitter::emitDispInsHelp(
         case IF_SVE_AP_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise unary operations (predicated)
         case IF_SVE_AQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer unary operations (predicated)
         case IF_SVE_CU_3A: // ........xx...... ...gggnnnnnddddd -- SVE reverse within elements
+        case IF_SVE_ES_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer unary operations (predicated)
+        case IF_SVE_HQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point round to integral value
+        case IF_SVE_HR_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point unary operations
             emitDispSveReg(id->idReg1(), id->idInsOpt(), true);        // ddddd
             emitDispPredicateReg(id->idReg2(), PREDICATE_MERGE, true); // ggg
             emitDispSveReg(id->idReg3(), id->idInsOpt(), false);       // mmmmm
@@ -16687,6 +16808,13 @@ void emitter::emitDispInsHelp(
             emitDispSveReg(id->idReg1(), id->idInsOpt(), true);        // ddddd
             emitDispPredicateReg(id->idReg2(), PREDICATE_MERGE, true); // ggg
             emitDispReg(encodingZRtoSP(id->idReg3()), size, false);    // mmmmm
+            break;
+
+        // <Zda>.<T>, <Pg>/M, <Zn>.<Tb>
+        case IF_SVE_EQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer pairwise add and accumulate long
+            emitDispSveReg(id->idReg1(), id->idInsOpt(), true);                           // ddddd
+            emitDispLowPredicateReg(id->idReg2(), PREDICATE_MERGE, true);                 // ggg
+            emitDispSveReg(id->idReg3(), (insOpts)((unsigned)id->idInsOpt() - 1), false); // mmmmm
             break;
 
         case IF_SVE_GA_2A: // ............iiii ......nnnn.ddddd -- SME2 multi-vec shift narrow
@@ -19015,6 +19143,31 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             result.insThroughput = PERFSCORE_THROUGHPUT_2X;
             break;
 
+        case IF_SVE_ES_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer unary operations (predicated)
+            switch (ins)
+            {
+                // Arithmetic, complex
+                case INS_sve_sqabs:
+                case INS_sve_sqneg:
+                    // Reciprocal estimate
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    break;
+
+                // Reciprocal estimate
+                case INS_sve_urecpe:
+                case INS_sve_ursqrte:
+                    result.insLatency    = PERFSCORE_LATENCY_4C;
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    break;
+
+                default:
+                    // all other instructions
+                    perfScoreUnhandledInstruction(id, &result);
+                    break;
+            }
+            break;
+
         // Arithmetic, complex
         case IF_SVE_ET_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 saturating add/subtract
             result.insLatency    = PERFSCORE_LATENCY_2C;
@@ -19028,11 +19181,23 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             result.insThroughput = PERFSCORE_THROUGHPUT_1C;
             break;
 
+        // Arithmetic, pairwise add and accum long
+        case IF_SVE_EQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE2 integer pairwise add and accumulate long
+            result.insLatency    = PERFSCORE_LATENCY_4C;
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
         // Floating point arithmetic
         // Floating point min/max pairwise
         case IF_SVE_GR_3A: // ........xx...... ...gggmmmmmddddd -- SVE2 floating-point pairwise operations
             result.insLatency    = PERFSCORE_LATENCY_2C;
             result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+            break;
+
+        // Floating point reduction, F64. (Note: Worse for F32 and F16)
+        case IF_SVE_HE_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction
+            result.insLatency    = PERFSCORE_LATENCY_2C;
+            result.insThroughput = PERFSCORE_THROUGHPUT_2C;
             break;
 
         // Floating point associative add, F64. (Note: Worse for F32 and F16)
@@ -19087,10 +19252,39 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             }
             break;
 
+        // Floating point round to integral, F64. (Note: Worse for F32 and F16)
+        case IF_SVE_HQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point round to integral value
+            result.insLatency    = PERFSCORE_LATENCY_3C;
+            result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case IF_SVE_HR_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point unary operations
+            switch (ins)
+            {
+                // Floating point reciprocal estimate, F64. (Note: Worse for F32 and F16)
+                case INS_sve_frecpx:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_3C;
+                    result.insLatency    = PERFSCORE_LATENCY_1C;
+                    break;
+
+                // Floating point square root F64. (Note: Worse for F32 and F16)
+                case INS_sve_fsqrt:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_16C;
+                    result.insLatency    = PERFSCORE_LATENCY_14C;
+                    break;
+
+                default:
+                    // all other instructions
+                    perfScoreUnhandledInstruction(id, &result);
+                    break;
+            }
+            break;
+
         // Not available in Arm Neoverse N2 Software Optimization Guide.
         case IF_SVE_AG_3A: // ........xx...... ...gggnnnnnddddd -- SVE bitwise logical reduction (quadwords)
         case IF_SVE_AJ_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer add reduction (quadwords)
         case IF_SVE_AL_3A: // ........xx...... ...gggnnnnnddddd -- SVE integer min/max reduction (quadwords)
+        case IF_SVE_GS_3A: // ........xx...... ...gggnnnnnddddd -- SVE floating-point recursive reduction (quadwords)
             result.insLatency    = PERFSCORE_LATENCY_20C;    // TODO-SVE: Placeholder
             result.insThroughput = PERFSCORE_THROUGHPUT_25C; // TODO-SVE: Placeholder
             break;


### PR DESCRIPTION
Next batch.

Full coreclr test output (identical to capstone output):
```
and z0.b, p1/m, z0.b, z2.b
bic z3.h, p4/m, z3.h, z5.h
eor z14.s, p5/m, z14.s, z16.s
orr z29.d, p7/m, z29.d, z31.d
add z5.b, p6/m, z5.b, z7.b
sub z15.h, p7/m, z15.h, z29.h
subr z2.s, p0/m, z2.s, z13.s
sdiv z3.s, p2/m, z3.s, z9.s
sdivr z31.d, p3/m, z31.d, z29.d
udiv z1.s, p0/m, z1.s, z0.s
udivr z13.d, p7/m, z13.d, z15.d
smax z24.b, p0/m, z24.b, z2.b
smin z9.h, p1/m, z9.h, z27.h
sabd z5.b, p2/m, z5.b, z6.b
uabd z23.s, p3/m, z23.s, z9.s
umax z15.s, p4/m, z15.s, z2.s
umin z12.d, p7/m, z12.d, z0.d
mul z5.d, p1/m, z5.d, z3.d
smulh z17.s, p5/m, z17.s, z5.s
umulh z12.b, p2/m, z12.b, z24.b
asr z5.s, p0/m, z5.s, z21.s
asrr z1.b, p7/m, z1.b, z20.b
lsl z0.h, p2/m, z0.h, z0.h
lslr z27.d, p6/m, z27.d, z31.d
lsr z5.b, p5/m, z5.b, z6.b
lsrr z15.s, p4/m, z15.s, z17.s
asr z4.b, p3/m, z4.b, z24.d
lsl z19.h, p7/m, z19.h, z3.d
lsr z0.s, p0/m, z0.s, z0.d
clasta z31.b, p7, z31.b, z31.b
clastb z30.d, p6, z30.d, z30.d
clasta h12, p1, h12, z15.h
clastb s13, p2, s13, z16.s
clastb d14, p0, d14, z17.d
clasta w0, p0, w0, z0.b
clasta w1, p2, w1, z3.h
clastb w23, p5, w23, z12.s
clastb x3, p6, x3, z9.d
shadd z15.b, p0/m, z15.b, z10.b
shsub z16.h, p1/m, z16.h, z11.h
shsubr z17.s, p2/m, z17.s, z12.s
srhadd z18.d, p3/m, z18.d, z13.d
uhadd z19.b, p4/m, z19.b, z14.b
uhsub z20.h, p5/m, z20.h, z15.h
uhsubr z21.s, p6/m, z21.s, z16.s
urhadd z22.d, p7/m, z22.d, z17.d
addp z23.b, p6/m, z23.b, z18.b
smaxp z24.h, p5/m, z24.h, z19.h
sminp z25.s, p4/m, z25.s, z20.s
umaxp z26.d, p3/m, z26.d, z21.d
uminp z27.b, p2/m, z27.b, z22.b
sqadd z28.b, p1/m, z28.b, z23.b
sqsub z29.h, p0/m, z29.h, z24.h
sqsubr z30.h, p1/m, z30.h, z25.h
suqadd z31.b, p2/m, z31.b, z26.b
uqadd z0.s, p3/m, z0.s, z27.s
uqsub z1.d, p4/m, z1.d, z28.d
uqsubr z2.b, p5/m, z2.b, z29.b
usqadd z3.b, p6/m, z3.b, z30.b
sqrshl z4.b, p7/m, z4.b, z31.b
sqrshlr z5.h, p0/m, z5.h, z30.h
sqshl z6.s, p1/m, z6.s, z29.s
sqshlr z7.d, p2/m, z7.d, z28.d
srshl z8.b, p3/m, z8.b, z27.b
srshlr z9.h, p4/m, z9.h, z26.h
uqrshl z10.s, p5/m, z10.s, z25.s
uqrshlr z11.d, p6/m, z11.d, z24.d
uqshl z12.b, p7/m, z12.b, z23.b
uqshlr z13.h, p0/m, z13.h, z22.h
urshl z14.s, p1/m, z14.s, z21.s
urshlr z15.d, p2/m, z15.d, z20.d
faddp z16.h, p3/m, z16.h, z19.h
fmaxnmp z17.s, p4/m, z17.s, z18.s
fmaxp z18.d, p5/m, z18.d, z17.d
fminnmp z19.s, p6/m, z19.s, z16.s
fminp z20.h, p7/m, z20.h, z15.h
fadda h21, p6, h21, z14.h
fadda s22, p5, s22, z13.s
fadda d23, p4, d23, z12.d
fabd z24.h, p3/m, z24.h, z11.h
fadd z25.s, p2/m, z25.s, z10.s
fdiv z28.s, p0/m, z28.s, z7.s
fdivr z29.d, p1/m, z29.d, z6.d
fmax z30.h, p2/m, z30.h, z5.h
fmaxnm z31.s, p3/m, z31.s, z4.s
fmin z0.d, p4/m, z0.d, z3.d
fminnm z1.h, p5/m, z1.h, z2.h
fmul z2.s, p6/m, z2.s, z1.s
fmulx z3.d, p7/m, z3.d, z0.d
fscale z4.h, p6/m, z4.h, z31.h
fsub z5.s, p5/m, z5.s, z30.s
fsubr z6.d, p4/m, z6.d, z29.d
andv b0, p0, z0.b
eorv h1, p1, z1.h
orv s2, p2, z2.s
orv d3, p3, z3.d
saddv d1, p4, z2.b
saddv d2, p5, z3.h
uaddv d3, p6, z4.s
smaxv d15, p7, z4.d
sminv s16, p6, z14.s
umaxv h17, p5, z24.h
uminv b18, p4, z31.b
cls z31.b, p0/m, z0.b
clz z30.h, p1/m, z1.h
cnot z29.s, p2/m, z2.s
cnt z28.d, p3/m, z3.d
fabs z27.h, p4/m, z4.h
fneg z26.s, p5/m, z5.s
not z25.b, p6/m, z6.b
abs z24.b, p7/m, z7.b
neg z23.s, p0/m, z8.s
sxtb z22.h, p1/m, z9.h
sxtb z22.s, p1/m, z9.s
sxtb z22.d, p1/m, z9.d
sxth z21.s, p2/m, z10.s
sxth z21.d, p2/m, z10.d
sxtw z20.d, p3/m, z11.d
uxtb z19.h, p4/m, z12.h
uxtb z19.s, p4/m, z12.s
uxtb z19.d, p4/m, z12.d
uxth z18.s, p5/m, z13.s
uxth z18.d, p5/m, z13.d
uxtw z17.d, p6/m, z14.d
compact z16.s, p7, z13.s
compact z15.d, p0, z12.d
mov z14.b, p1/m, b11
mov z13.s, p2/m, s10
mov z12.h, p3/m, h9
mov z11.d, p4/m, d8
mov z10.d, p5/m, sp
mov z9.h, p6/m, w30
mov z8.s, p7/m, w29
mov z7.b, p0/m, w28
lasta b6, p1, z27.b
lasta h5, p2, z26.h
lastb s4, p3, z25.s
lastb d3, p4, z24.d
lasta w1, p5, z23.b
lasta w0, p6, z22.s
lastb w30, p7, z21.h
lastb fp, p0, z20.d
rbit z28.h, p1/m, z19.h
rbit z28.b, p1/m, z19.b
rbit z28.s, p1/m, z19.s
rbit z28.d, p1/m, z19.d
revb z27.h, p2/m, z18.h
revb z27.s, p2/m, z18.s
revb z27.d, p2/m, z18.d
revh z26.s, p3/m, z17.s
revh z26.d, p3/m, z17.d
revw z25.d, p4/m, z16.d
sadalp z26.h, p3/m, z8.b
uadalp z27.s, p2/m, z9.h
uadalp z28.d, p0/m, z31.s
sqabs z29.b, p7/m, z0.b
sqneg z31.h, p6/m, z1.h
sqneg z0.s, p5/m, z2.s
sqneg z1.d, p4/m, z3.d
urecpe z2.s, p3/m, z4.s
ursqrte z3.s, p0/m, z5.s
sqrshrn z0.h, { z0.s, z1.s }, #5
sqrshrun z0.h, { z0.s, z1.s }, #5
uqrshrn z0.h, { z0.s, z1.s }, #5
sqrshrn z0.h, { z2.s, z3.s }, #16
sqrshrun z0.h, { z4.s, z5.s }, #7
uqrshrn z0.h, { z6.s, z7.s }, #1
sqrshrn z30.h, { z16.s, z17.s }, #16
sqrshrun z16.h, { z8.s, z9.s }, #7
uqrshrn z15.h, { z12.s, z13.s }, #1
faddv h21, p7, z7.h
fmaxnmv h22, p6, z6.h
fmaxv s23, p5, z5.s
fminnmv d24, p4, z4.d
fminv s25, p3, z3.s
frinta z26.h, p7/m, z2.h
frinti z27.s, p6/m, z1.s
frintm z28.d, p5/m, z0.d
frintn z29.h, p4/m, z10.h
frintp z30.s, p3/m, z11.s
frintx z31.d, p2/m, z12.d
frintz z0.h, p0/m, z13.h
frecpx z5.h, p5/m, z5.h
fsqrt z6.s, p6/m, z6.s
```