### PR TITLE
Remove dependency on AppDomain from a hello world app

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -89,8 +89,6 @@ namespace System
         }
 #endif
 
-        internal static event EventHandler? ProcessExit;
-
         internal static void OnProcessExit()
         {
             AssemblyLoadContext.OnProcessExit();
@@ -98,8 +96,7 @@ namespace System
             {
                 EventListener.DisposeOnShutdown();
             }
-
-            ProcessExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
+            AppDomain.OnProcessExit();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -118,7 +118,7 @@ namespace System
                 EventListener.DisposeOnShutdown();
             }
 
-            s_invokeProcessExitCallback();
+            s_invokeProcessExitCallback?.Invoke();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -118,7 +118,7 @@ namespace System
                 EventListener.DisposeOnShutdown();
             }
 
-            s_invokeProcessExitCallback?.Invoke();
+            s_invokeProcessExitCallback();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -89,26 +89,7 @@ namespace System
         }
 #endif
 
-        private static event EventHandler? s_processExit;
-
-        // We invoke process exit callback through an indirection.
-        // Most apps will not install a callback in the first place.
-        // To invoke the callback, we need to pass the current AppDomain.
-        // AppDomain brings lots of unnecessary dependencies into trimmed apps.
-        // The indirection is set up when the callback is installed so that
-        // only apps that install a callback have AppDomain in the closure.
-        private static Action s_invokeProcessExitCallback;
-
-        internal static void AddProcessExitCallback(EventHandler eventHandler)
-        {
-            s_processExit += eventHandler;
-            s_invokeProcessExitCallback ??= () => s_processExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
-        }
-
-        internal static void RemoveProcessExitCallback(EventHandler eventHandler)
-        {
-            s_processExit -= eventHandler;
-        }
+        internal static event EventHandler? ProcessExit;
 
         internal static void OnProcessExit()
         {
@@ -118,7 +99,7 @@ namespace System
                 EventListener.DisposeOnShutdown();
             }
 
-            s_invokeProcessExitCallback();
+            ProcessExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -89,7 +89,26 @@ namespace System
         }
 #endif
 
-        internal static event EventHandler? ProcessExit;
+        private static event EventHandler? s_processExit;
+
+        // We invoke process exit callback through an indirection.
+        // Most apps will not install a callback in the first place.
+        // To invoke the callback, we need to pass the current AppDomain.
+        // AppDomain brings lots of unnecessary dependencies into trimmed apps.
+        // The indirection is set up when the callback is installed so that
+        // only apps that install a callback have AppDomain in the closure.
+        private static Action s_invokeProcessExitCallback;
+
+        internal static void AddProcessExitCallback(EventHandler eventHandler)
+        {
+            s_processExit += eventHandler;
+            s_invokeProcessExitCallback ??= () => s_processExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
+        }
+
+        internal static void RemoveProcessExitCallback(EventHandler eventHandler)
+        {
+            s_processExit -= eventHandler;
+        }
 
         internal static void OnProcessExit()
         {
@@ -99,7 +118,7 @@ namespace System
                 EventListener.DisposeOnShutdown();
             }
 
-            ProcessExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
+            s_invokeProcessExitCallback();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -97,15 +97,15 @@ namespace System
         // AppDomain brings lots of unnecessary dependencies into trimmed apps.
         // The indirection is set up when the callback is installed so that
         // only apps that install a callback have AppDomain in the closure.
-        private static Action? s_invokeProcessExitCallback;
+        private static Action s_invokeProcessExitCallback;
 
-        internal static void AddProcessExitCallback(EventHandler? eventHandler)
+        internal static void AddProcessExitCallback(EventHandler eventHandler)
         {
             s_processExit += eventHandler;
             s_invokeProcessExitCallback ??= () => s_processExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
         }
 
-        internal static void RemoveProcessExitCallback(EventHandler? eventHandler)
+        internal static void RemoveProcessExitCallback(EventHandler eventHandler)
         {
             s_processExit -= eventHandler;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -97,15 +97,15 @@ namespace System
         // AppDomain brings lots of unnecessary dependencies into trimmed apps.
         // The indirection is set up when the callback is installed so that
         // only apps that install a callback have AppDomain in the closure.
-        private static Action s_invokeProcessExitCallback;
+        private static Action? s_invokeProcessExitCallback;
 
-        internal static void AddProcessExitCallback(EventHandler eventHandler)
+        internal static void AddProcessExitCallback(EventHandler? eventHandler)
         {
             s_processExit += eventHandler;
             s_invokeProcessExitCallback ??= () => s_processExit?.Invoke(AppDomain.CurrentDomain, EventArgs.Empty);
         }
 
-        internal static void RemoveProcessExitCallback(EventHandler eventHandler)
+        internal static void RemoveProcessExitCallback(EventHandler? eventHandler)
         {
             s_processExit -= eventHandler;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -19,7 +19,8 @@ namespace System
 {
     public sealed partial class AppDomain : MarshalByRefObject
     {
-        private static readonly AppDomain s_domain = new AppDomain();
+        private static AppDomain? s_domain;
+
         private IPrincipal? _defaultPrincipal;
         private PrincipalPolicy _principalPolicy = PrincipalPolicy.NoPrincipal;
         private Func<IPrincipal>? s_getWindowsPrincipal;
@@ -27,7 +28,19 @@ namespace System
 
         private AppDomain() { }
 
-        public static AppDomain CurrentDomain => s_domain;
+        public static AppDomain CurrentDomain
+        {
+            get
+            {
+                // Create AppDomain instance only once external code asks for it. AppDomain brings lots of unnecessary
+                // dependencies into minimal trimmed app via ToString method.
+                if (s_domain == null)
+                {
+                    Interlocked.CompareExchange(ref s_domain, new AppDomain(), null);
+                }
+                return s_domain;
+            }
+        }
 
         public string BaseDirectory => AppContext.BaseDirectory;
 
@@ -72,10 +85,12 @@ namespace System
             remove { AppContext.FirstChanceException -= value; }
         }
 
-        public event EventHandler? ProcessExit
+        public event EventHandler? ProcessExit;
+
+        internal static void OnProcessExit()
         {
-            add { AppContext.ProcessExit += value; }
-            remove { AppContext.ProcessExit -= value; }
+            AppDomain? domain = s_domain;
+            domain?.ProcessExit?.Invoke(domain, EventArgs.Empty);
         }
 
         public string ApplyPolicy(string assemblyName)

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -74,8 +74,8 @@ namespace System
 
         public event EventHandler? ProcessExit
         {
-            add { AppContext.ProcessExit += value; }
-            remove { AppContext.ProcessExit -= value; }
+            add { AppContext.AddProcessExitCallback(value); }
+            remove { AppContext.RemoveProcessExitCallback(value); }
         }
 
         public string ApplyPolicy(string assemblyName)

--- a/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs
@@ -74,8 +74,8 @@ namespace System
 
         public event EventHandler? ProcessExit
         {
-            add { AppContext.AddProcessExitCallback(value); }
-            remove { AppContext.RemoveProcessExitCallback(value); }
+            add { AppContext.ProcessExit += value; }
+            remove { AppContext.ProcessExit -= value; }
         }
 
         public string ApplyPolicy(string assemblyName)


### PR DESCRIPTION
Saves 4% in size on a hello world.

A hello world app will bring the `AppDomain` type with it. `AppDomain`'s `ToString` is quite expensive for what it does.

Maybe this can be done cleaner, suggestions welcome.

Cc @dotnet/ilc-contrib 