### PR TITLE
Remove boxing from "value is S" for nullables

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2976,7 +2976,7 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 
                         // For br_true/false, we'll only replace "box + isinst" to a boolean
                         int returnToken = 1 + sizeof(mdToken);
-                        if ((nextOpcode == CEE_LDNULL))
+                        if (nextOpcode == CEE_LDNULL)
                         {
                             // for ldnull case, we'll replace the whole "box + isinst + ldnull + cgt_un" sequence
                             returnToken = 4 + sizeof(mdToken);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3096,6 +3096,9 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                         }
                     }
                     break;
+
+                    default:
+                        break;
                 }
             }
             break;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2980,7 +2980,8 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                         {
                             // for ldnull case, we'll replace the whole "box + isinst + ldnull + cgt_un" sequence
                             returnToken = 4 + sizeof(mdToken);
-                            if (impGetNonPrefixOpcode(nextCodeAddr + 1, codeEndp) != CEE_CGT_UN)
+                            if ((opts == BoxPatterns::IsByRefLike) ||
+                                (impGetNonPrefixOpcode(nextCodeAddr + 1, codeEndp) != CEE_CGT_UN))
                             {
                                 break;
                             }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2954,163 +2954,148 @@ int Compiler::impBoxPatternMatch(CORINFO_RESOLVED_TOKEN* pResolvedToken,
                     }
                 }
 
-                const BYTE* nextCodeAddr = codeAddr + 1 + sizeof(mdToken);
-
-                switch (nextCodeAddr[0])
+                const BYTE*  nextCodeAddr = codeAddr + 1 + sizeof(mdToken);
+                const OPCODE nextOpcode   = impGetNonPrefixOpcode(nextCodeAddr, codeEndp);
+                switch (nextOpcode)
                 {
                     // box + isinst + br_true/false
                     case CEE_BRTRUE:
                     case CEE_BRTRUE_S:
                     case CEE_BRFALSE:
                     case CEE_BRFALSE_S:
-                        if ((nextCodeAddr + ((nextCodeAddr[0] >= CEE_BRFALSE) ? 5 : 2)) <= codeEndp)
-                        {
-                            if (opts == BoxPatterns::MakeInlineObservation)
-                            {
-                                compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_BOX);
-                                return 1 + sizeof(mdToken);
-                            }
-
-                            CorInfoHelpFunc foldAsHelper;
-                            if (opts == BoxPatterns::IsByRefLike)
-                            {
-                                // Treat ByRefLike types as if they were regular boxing operations
-                                // so they can be elided.
-                                foldAsHelper = CORINFO_HELP_BOX;
-                            }
-                            else
-                            {
-                                foldAsHelper = info.compCompHnd->getBoxHelper(pResolvedToken->hClass);
-                            }
-
-                            if (foldAsHelper == CORINFO_HELP_BOX)
-                            {
-                                CORINFO_RESOLVED_TOKEN isInstResolvedToken;
-
-                                impResolveToken(codeAddr + 1, &isInstResolvedToken, CORINFO_TOKENKIND_Casting);
-
-                                TypeCompareState castResult =
-                                    info.compCompHnd->compareTypesForCast(pResolvedToken->hClass,
-                                                                          isInstResolvedToken.hClass);
-
-                                if (castResult != TypeCompareState::May)
-                                {
-                                    JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as constant\n");
-
-                                    impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG("spilling side-effects"));
-                                    impPopStack();
-                                    impPushOnStack(gtNewIconNode((castResult == TypeCompareState::Must) ? 1 : 0),
-                                                   typeInfo(TYP_INT));
-                                    return 1 + sizeof(mdToken);
-                                }
-                            }
-                            else if ((foldAsHelper == CORINFO_HELP_BOX_NULLABLE) &&
-                                     ((impStackTop().val->gtFlags & GTF_SIDE_EFFECT) == 0))
-                            {
-                                // For nullable we're going to fold it to "ldfld hasValue + brtrue/brfalse" or
-                                // "ldc.i4.0 + brtrue/brfalse" in case if the underlying type is not castable to
-                                // the target type.
-                                CORINFO_RESOLVED_TOKEN isInstResolvedToken;
-                                impResolveToken(codeAddr + 1, &isInstResolvedToken, CORINFO_TOKENKIND_Casting);
-
-                                CORINFO_CLASS_HANDLE nullableCls   = pResolvedToken->hClass;
-                                CORINFO_CLASS_HANDLE underlyingCls = info.compCompHnd->getTypeForBox(nullableCls);
-
-                                TypeCompareState castResult =
-                                    info.compCompHnd->compareTypesForCast(underlyingCls, isInstResolvedToken.hClass);
-
-                                if (castResult == TypeCompareState::Must)
-                                {
-                                    GenTree* objToBox = impPopStack().val;
-
-                                    // Spill struct to get its address (to access hasValue field)
-                                    // TODO-Bug?: verify if flags matter here
-                                    GenTreeFlags indirFlags = GTF_EMPTY;
-                                    objToBox                = impGetNodeAddr(objToBox, CHECK_SPILL_ALL, &indirFlags);
-
-                                    static_assert_no_msg(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
-                                    impPushOnStack(gtNewIndir(TYP_UBYTE, objToBox), typeInfo(TYP_INT));
-
-                                    JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as nullableVT.hasValue\n");
-                                    return 1 + sizeof(mdToken);
-                                }
-                                else if (castResult == TypeCompareState::MustNot)
-                                {
-                                    impPopStack();
-                                    impPushOnStack(gtNewIconNode(0), typeInfo(TYP_INT));
-                                    JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as constant (false)\n");
-                                    return 1 + sizeof(mdToken);
-                                }
-                            }
-                        }
-                        break;
-
-                    // box + isinst + unbox.any
-                    case CEE_UNBOX_ANY:
-                        if ((nextCodeAddr + 1 + sizeof(mdToken)) <= codeEndp)
-                        {
-                            if (opts == BoxPatterns::MakeInlineObservation)
-                            {
-                                compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_BOX);
-                                return 2 + sizeof(mdToken) * 2;
-                            }
-
-                            // See if the resolved tokens in box, isinst and unbox.any describe types that are equal.
-                            CORINFO_RESOLVED_TOKEN isinstResolvedToken = {};
-                            impResolveToken(codeAddr + 1, &isinstResolvedToken, CORINFO_TOKENKIND_Class);
-
-                            if (info.compCompHnd->compareTypesForEquality(isinstResolvedToken.hClass,
-                                                                          pResolvedToken->hClass) ==
-                                TypeCompareState::Must)
-                            {
-                                CORINFO_RESOLVED_TOKEN unboxResolvedToken = {};
-                                impResolveToken(nextCodeAddr + 1, &unboxResolvedToken, CORINFO_TOKENKIND_Class);
-
-                                // If so, box + isinst + unbox.any is a nop.
-                                if (info.compCompHnd->compareTypesForEquality(unboxResolvedToken.hClass,
-                                                                              pResolvedToken->hClass) ==
-                                    TypeCompareState::Must)
-                                {
-                                    JITDUMP("\n Importing BOX; ISINST, UNBOX.ANY as NOP\n");
-                                    return 2 + sizeof(mdToken) * 2;
-                                }
-                            }
-                        }
-                        break;
-
-                    // box + isinst + ldnull + cgt.un
                     case CEE_LDNULL:
-                        if ((impGetNonPrefixOpcode(nextCodeAddr + 1, codeEndp) == CEE_CGT_UN) &&
-                            (opts == BoxPatterns::None) &&
-                            (info.compCompHnd->getBoxHelper(pResolvedToken->hClass) == CORINFO_HELP_BOX_NULLABLE) &&
-                            ((impStackTop().val->gtFlags & GTF_SIDE_EFFECT) == 0))
+                    {
+                        // "ldnull + cgt_un" is used when BOX+ISINST is not fed into a branch, e.g.:
+                        //
+                        //   if (obj is string) {        <--- box + isinst + br_true
+                        //
+                        //   bool b = obj is string;     <--- box + isinst + ldnull + cgt_un
+                        //
+                        //   bool b = obj is not string; <--- box + isinst + ldnull + cgt_un + ldc.i4.0 + ceq
+                        //
+
+                        // For br_true/false, we'll only replace "box + isinst" to a boolean
+                        int returnToken = 1 + sizeof(mdToken);
+                        if ((nextOpcode == CEE_LDNULL))
                         {
-                            // The code is copied from "BOX + ISINST + BR_TRUE/FALSE" case above.
+                            // for ldnull case, we'll replace the whole "box + isinst + ldnull + cgt_un" sequence
+                            returnToken = 4 + sizeof(mdToken);
+                            if (impGetNonPrefixOpcode(nextCodeAddr + 1, codeEndp) != CEE_CGT_UN)
+                            {
+                                break;
+                            }
+                        }
 
-                            CORINFO_RESOLVED_TOKEN isInstTok;
-                            impResolveToken(codeAddr + 1, &isInstTok, CORINFO_TOKENKIND_Casting);
+                        if (opts == BoxPatterns::MakeInlineObservation)
+                        {
+                            compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_BOX);
+                            return returnToken;
+                        }
 
-                            CORINFO_CLASS_HANDLE underlyingCls =
-                                info.compCompHnd->getTypeForBox(pResolvedToken->hClass);
+                        CorInfoHelpFunc foldAsHelper;
+                        if (opts == BoxPatterns::IsByRefLike)
+                        {
+                            // Treat ByRefLike types as if they were regular boxing operations
+                            // so they can be elided.
+                            foldAsHelper = CORINFO_HELP_BOX;
+                        }
+                        else
+                        {
+                            foldAsHelper = info.compCompHnd->getBoxHelper(pResolvedToken->hClass);
+                        }
+
+                        if (foldAsHelper == CORINFO_HELP_BOX)
+                        {
+                            CORINFO_RESOLVED_TOKEN isInstResolvedToken;
+
+                            impResolveToken(codeAddr + 1, &isInstResolvedToken, CORINFO_TOKENKIND_Casting);
+
                             TypeCompareState castResult =
-                                info.compCompHnd->compareTypesForCast(underlyingCls, isInstTok.hClass);
+                                info.compCompHnd->compareTypesForCast(pResolvedToken->hClass,
+                                                                      isInstResolvedToken.hClass);
+
+                            if (castResult != TypeCompareState::May)
+                            {
+                                JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as constant\n");
+
+                                impSpillSideEffects(false, CHECK_SPILL_ALL DEBUGARG("spilling side-effects"));
+                                impPopStack();
+                                impPushOnStack(gtNewIconNode((castResult == TypeCompareState::Must) ? 1 : 0),
+                                               typeInfo(TYP_INT));
+                                return returnToken;
+                            }
+                        }
+                        else if ((foldAsHelper == CORINFO_HELP_BOX_NULLABLE) &&
+                                 ((impStackTop().val->gtFlags & GTF_SIDE_EFFECT) == 0))
+                        {
+                            // For nullable we're going to fold it to "ldfld hasValue + brtrue/brfalse" or
+                            // "ldc.i4.0 + brtrue/brfalse" in case if the underlying type is not castable to
+                            // the target type.
+                            CORINFO_RESOLVED_TOKEN isInstResolvedToken;
+                            impResolveToken(codeAddr + 1, &isInstResolvedToken, CORINFO_TOKENKIND_Casting);
+
+                            CORINFO_CLASS_HANDLE nullableCls   = pResolvedToken->hClass;
+                            CORINFO_CLASS_HANDLE underlyingCls = info.compCompHnd->getTypeForBox(nullableCls);
+
+                            TypeCompareState castResult =
+                                info.compCompHnd->compareTypesForCast(underlyingCls, isInstResolvedToken.hClass);
 
                             if (castResult == TypeCompareState::Must)
                             {
-                                GenTree* objToBox = impGetNodeAddr(impPopStack().val, CHECK_SPILL_ALL, nullptr);
+                                GenTree* objToBox = impPopStack().val;
+
+                                // Spill struct to get its address (to access hasValue field)
+                                // TODO-Bug?: verify if flags matter here
+                                GenTreeFlags indirFlags = GTF_EMPTY;
+                                objToBox                = impGetNodeAddr(objToBox, CHECK_SPILL_ALL, &indirFlags);
+
+                                static_assert_no_msg(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
                                 impPushOnStack(gtNewIndir(TYP_UBYTE, objToBox), typeInfo(TYP_INT));
-                                JITDUMP("\n Importing BOX; ISINST; LDNULL; CGT_UN as nullableVT.hasValue\n")
-                                return 4 + sizeof(mdToken);
+
+                                JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as nullableVT.hasValue\n");
+                                return returnToken;
                             }
-                            if (castResult == TypeCompareState::MustNot)
+                            else if (castResult == TypeCompareState::MustNot)
                             {
                                 impPopStack();
-                                impPushOnStack(gtNewFalse(), typeInfo(TYP_INT));
-                                JITDUMP("\n Importing BOX; ISINST; LDNULL; CGT_UN as constant (false)\n")
-                                return 4 + sizeof(mdToken);
+                                impPushOnStack(gtNewIconNode(0), typeInfo(TYP_INT));
+                                JITDUMP("\n Importing BOX; ISINST; BR_TRUE/FALSE as constant (false)\n");
+                                return returnToken;
                             }
                         }
-                        break;
+                    }
+                    break;
+
+                    // box + isinst + unbox.any
+                    case CEE_UNBOX_ANY:
+                    {
+                        if (opts == BoxPatterns::MakeInlineObservation)
+                        {
+                            compInlineResult->Note(InlineObservation::CALLEE_FOLDABLE_BOX);
+                            return 2 + sizeof(mdToken) * 2;
+                        }
+
+                        // See if the resolved tokens in box, isinst and unbox.any describe types that are equal.
+                        CORINFO_RESOLVED_TOKEN isinstResolvedToken = {};
+                        impResolveToken(codeAddr + 1, &isinstResolvedToken, CORINFO_TOKENKIND_Class);
+
+                        if (info.compCompHnd->compareTypesForEquality(isinstResolvedToken.hClass,
+                                                                      pResolvedToken->hClass) == TypeCompareState::Must)
+                        {
+                            CORINFO_RESOLVED_TOKEN unboxResolvedToken = {};
+                            impResolveToken(nextCodeAddr + 1, &unboxResolvedToken, CORINFO_TOKENKIND_Class);
+
+                            // If so, box + isinst + unbox.any is a nop.
+                            if (info.compCompHnd->compareTypesForEquality(unboxResolvedToken.hClass,
+                                                                          pResolvedToken->hClass) ==
+                                TypeCompareState::Must)
+                            {
+                                JITDUMP("\n Importing BOX; ISINST, UNBOX.ANY as NOP\n");
+                                return 2 + sizeof(mdToken) * 2;
+                            }
+                        }
+                    }
+                    break;
                 }
             }
             break;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/95685 
```cs
bool Test<T>(T value) => value is int; // T is Nullable<int>
```
```diff
; Assembly listing for method Prog:Test[System.Nullable`1[int]]
-      sub      rsp, 40
-      mov      qword ptr [rsp+0x38], rdx
-      lea      rdx, [rsp+0x38]
-      mov      rcx, 0xD1FFAB1E      ; System.Nullable`1[int]
-      call     CORINFO_HELP_BOX_NULLABLE
-      test     rax, rax
-      je       SHORT G_M33107_IG04
-      mov      rcx, 0xD1FFAB1E      ; System.Int32
-      xor      rdx, rdx
-      cmp      qword ptr [rax], rcx
-      cmovne   rax, rdx
-G_M33107_IG04:
-      test     rax, rax
-      setne    al
-      movzx    rax, al
-      add      rsp, 40
+      mov      qword ptr [rsp+0x10], rdx
+      movzx    rax, byte  ptr [rsp+0x10]
       ret      
-; Total bytes of code 67
+; Total bytes of code 11
```

I recommend reviewing with "hide whitespaces" mode on the review tab. I removed some codeAddr validations and replaced those with `impGetNonPrefixOpcode` that does the same.