### PR TITLE
Build tests as self-contained for native AOT

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -33,6 +33,9 @@
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
+
+    <!-- Forced by ILLink targets -->
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <!-- Needed for the amd64 -> amd64 musl cross-build to pass the target flag. -->

--- a/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
@@ -20,6 +20,9 @@
     <_IsApplePlatform>true</_IsApplePlatform>
     <TargetsAppleMobile>true</TargetsAppleMobile>
     <_targetOS>$(TargetOS)</_targetOS>
+
+    <!-- Forced by ILLink targets -->
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -567,6 +567,11 @@
     <BuildNativeAotFrameworkObjects Condition="'$(IlcMultiModule)' == 'true'">true</BuildNativeAotFrameworkObjects>
     <DisableFrameworkLibGeneration Condition="'$(BuildNativeAotFrameworkObjects)' == 'true'">true</DisableFrameworkLibGeneration>
     <FrameworkLibPath Condition="'$(BuildNativeAotFrameworkObjects)' == 'true'">$(IlcSdkPath)</FrameworkLibPath>
+
+    <!-- Forced by ILLink targets -->
+    <SelfContained>true</SelfContained>
+    <HasRuntimeOutput>false</HasRuntimeOutput>
+    <_UsingDefaultForHasRuntimeOutput>false</_UsingDefaultForHasRuntimeOutput>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">


### PR DESCRIPTION
Restores what we had here long time ago:

https://github.com/dotnet/runtime/blob/8473eeb913cf688e7d3dbdf09a6a1f434498ada3/eng/testing/tests.singlefile.targets#L34-L35

https://github.com/dotnet/runtime/blob/8473eeb913cf688e7d3dbdf09a6a1f434498ada3/src/tests/Directory.Build.targets#L534-L537