### PR TITLE
Added guard to throw InvalidOperrationException.

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -151,6 +151,11 @@ namespace System.Text.Json.Serialization
 
         internal bool TryRead(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options, scoped ref ReadStack state, out T? value, out bool isPopulatedValue)
         {
+            if (typeToConvert != typeof(T))
+            {
+                ThrowHelper.ThrowInvalidOperationException($"Type '{typeToConvert}' is not compatible with converter '{GetType()}'.");
+            }
+
             // For perf and converter simplicity, handle null here instead of forwarding to the converter.
             if (reader.TokenType == JsonTokenType.Null && !HandleNullOnRead && !state.IsContinuation)
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -1416,10 +1416,10 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36605")]
         public static void ConverterRead_VerifyInvalidTypeToConvertFails()
         {
-            var options = new JsonSerializerOptions();
+            var options = new JsonSerializerOptions(JsonSerializerOptions.Default);
+            options.MakeReadOnly();
             Type typeToConvert = typeof(KeyValuePair<int, int>);
             byte[] bytes = Encoding.UTF8.GetBytes(@"{""Key"":1,""Value"":2}");
 


### PR DESCRIPTION
Added guard to throw InvalidOperrationException if the argument typeToConvert and Converter are incompatible. The exception message is "Type 'NameOfType' is not compatible with converter 'ConverterName'." and "Type 'NameOfType' is not compatible with converter 'ConverterName'.

NOTES:
The test threw a NotSupportedException on the following line and could not reproduce this issue, so the JsonSerializerOptions instantiation was changed. OptionsTests.ConverterRead_VerifyInvalidTypeToConvertFails() lineno 1432 KeyValuePair<int, int> kvp = converter.Read(ref reader, typeToConvert, options);

Fix #36605