### PR TITLE
JIT: Fix optRedirectBlock for "fallthrough" BBJ_ALWAYS

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2704,13 +2704,6 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
             break;
 
         case BBJ_ALWAYS:
-            // Fall-through successors are assumed correct and are not modified
-            if (blk->JumpsToNext() && blk->HasFlag(BBF_NONE_QUIRK))
-            {
-                break;
-            }
-
-            FALLTHROUGH;
         case BBJ_LEAVE:
         case BBJ_CALLFINALLY:
         case BBJ_COND:
@@ -3259,7 +3252,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
                     weightAdjust = topPredBlock->bbWeight;
                 }
             }
-            else
+            else if (topPredBlock != newT)
             {
                 JITDUMP("in optCanonicalizeLoop (current): redirect bottom->top backedge " FMT_BB " -> " FMT_BB
                         " to " FMT_BB " -> " FMT_BB "\n",
@@ -3290,7 +3283,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
                     weightAdjust = topPredBlock->bbWeight;
                 }
             }
-            else
+            else if (topPredBlock != newT)
             {
                 JITDUMP("in optCanonicalizeLoop (outer): redirect %s->top %sedge " FMT_BB " -> " FMT_BB " to " FMT_BB
                         " -> " FMT_BB "\n",


### PR DESCRIPTION
Loop canonicalization creates a new top block in some cases that jumps to the old top block. We should not redirect this block to jump to itself.

Removes one instance of `BBF_NONE_QUIRK` and makes `optRedirectBlock` behave as expected (I ran into this quirk while porting loop unrolling to the new loop representation).

No diffs are expected.