### PR TITLE
JIT: Switch morph DFS to use general DFS

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4737,6 +4737,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     fgStress64RsltMul();
 #endif // DEBUG
 
+    if (opts.OptimizationEnabled())
+    {
+        // Build post-order that morph will use, and remove dead blocks
+        //
+        DoPhase(this, PHASE_DFS_BLOCKS, &Compiler::fgDfsBlocksAndRemove);
+    }
+
     // Morph the trees in all the blocks of the method
     //
     unsigned const preMorphBBCount = fgBBcount;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5143,7 +5143,7 @@ public:
     FoldResult fgFoldConditional(BasicBlock* block);
 
     PhaseStatus fgMorphBlocks();
-    void fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorder = 0);
+    void fgMorphBlock(BasicBlock* block);
     void fgMorphStmts(BasicBlock* block);
 
     void fgMergeBlockReturn(BasicBlock* block);
@@ -5939,6 +5939,8 @@ public:
 
     bool fgUpdateFlowGraph(bool doTailDup = false, bool isPhase = false);
     PhaseStatus fgUpdateFlowGraphPhase();
+
+    PhaseStatus fgDfsBlocksAndRemove();
 
     PhaseStatus fgFindOperOrder();
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -41,6 +41,7 @@ CompPhaseNameMacro(PHASE_MERGE_FINALLY_CHAINS,       "Merge callfinally chains",
 CompPhaseNameMacro(PHASE_CLONE_FINALLY,              "Clone finally",                  false, -1, false)
 CompPhaseNameMacro(PHASE_UPDATE_FINALLY_FLAGS,       "Update finally target flags",    false, -1, false)
 CompPhaseNameMacro(PHASE_EARLY_UPDATE_FLOW_GRAPH,    "Update flow graph early pass",   false, -1, false)
+CompPhaseNameMacro(PHASE_DFS_BLOCKS,                 "DFS blocks and remove dead code",false, -1, false)
 CompPhaseNameMacro(PHASE_STR_ADRLCL,                 "Morph - Structs/AddrExp",        false, -1, false)
 CompPhaseNameMacro(PHASE_EARLY_LIVENESS,             "Early liveness",                 false, -1, false)
 CompPhaseNameMacro(PHASE_PHYSICAL_PROMOTION,         "Physical promotion",             false, -1, false)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -6418,19 +6418,19 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
 //
 PhaseStatus Compiler::fgDfsBlocksAndRemove()
 {
-    m_dfs = fgComputeDfs();
+    m_dfsTree = fgComputeDfs();
 
     PhaseStatus status = PhaseStatus::MODIFIED_NOTHING;
-    if (m_dfs->GetPostOrderCount() != fgBBcount)
+    if (m_dfsTree->GetPostOrderCount() != fgBBcount)
     {
 #ifdef DEBUG
         if (verbose)
         {
-            printf("%u/%u blocks are unreachable and will be removed\n", fgBBcount - m_dfs->GetPostOrderCount(),
+            printf("%u/%u blocks are unreachable and will be removed\n", fgBBcount - m_dfsTree->GetPostOrderCount(),
                    fgBBcount);
             for (BasicBlock* block : Blocks())
             {
-                if (!m_dfs->Contains(block))
+                if (!m_dfsTree->Contains(block))
                 {
                     printf("  " FMT_BB "\n", block->bbNum);
                 }
@@ -6438,7 +6438,7 @@ PhaseStatus Compiler::fgDfsBlocksAndRemove()
         }
 #endif
 
-        fgRemoveUnreachableBlocks([=](BasicBlock* block) { return !m_dfs->Contains(block); });
+        fgRemoveUnreachableBlocks([=](BasicBlock* block) { return !m_dfsTree->Contains(block); });
         status = PhaseStatus::MODIFIED_EVERYTHING;
     }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13864,7 +13864,7 @@ void Compiler::fgMorphBlock(BasicBlock* block)
 
                 for (BasicBlock* const pred : block->PredBlocks())
                 {
-                    assert(m_dfs->Contains(pred)); // We should have removed dead blocks before this.
+                    assert(m_dfsTree->Contains(pred)); // We should have removed dead blocks before this.
 
                     // A smaller pred postorder number means the pred appears later in the reverse postorder.
                     // An equal number means pred == block (block is a self-loop).
@@ -14063,9 +14063,9 @@ PhaseStatus Compiler::fgMorphBlocks()
 
         // Morph the blocks in RPO.
         //
-        for (unsigned i = m_dfs->GetPostOrderCount(); i != 0; i--)
+        for (unsigned i = m_dfsTree->GetPostOrderCount(); i != 0; i--)
         {
-            BasicBlock* const block = m_dfs->GetPostOrder()[i - 1];
+            BasicBlock* const block = m_dfsTree->GetPostOrder()[i - 1];
             fgMorphBlock(block);
         }
         assert(bbNumMax == fgBBNumMax);
@@ -14105,8 +14105,7 @@ PhaseStatus Compiler::fgMorphBlocks()
     fgGlobalMorph     = false;
     fgGlobalMorphDone = true;
     compCurBB         = nullptr;
-
-    m_dfs = nullptr;
+    m_dfsTree         = nullptr;
 
 #ifdef DEBUG
     if (optLocalAssertionProp)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13831,7 +13831,7 @@ void Compiler::fgMorphStmts(BasicBlock* block)
 //    highestReachablePostorder - maximum postorder number for a
 //     reachable block.
 //
-void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorder)
+void Compiler::fgMorphBlock(BasicBlock* block)
 {
     JITDUMP("\nMorphing " FMT_BB "\n", block->bbNum);
 
@@ -13846,8 +13846,6 @@ void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorde
         }
         else
         {
-            assert(highestReachablePostorder > 0);
-
             // Determine if this block can leverage assertions from its pred blocks.
             //
             // Some blocks are ineligible.
@@ -13866,7 +13864,9 @@ void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorde
 
                 for (BasicBlock* const pred : block->PredBlocks())
                 {
-                    // A smaller pred postorder number means the pred appears later in the postorder.
+                    assert(m_dfs->Contains(pred)); // We should have removed dead blocks before this.
+
+                    // A smaller pred postorder number means the pred appears later in the reverse postorder.
                     // An equal number means pred == block (block is a self-loop).
                     // Either way the assertion info is not available, and we must assume the worst.
                     //
@@ -13876,17 +13876,6 @@ void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorde
                                 pred->bbNum);
                         hasPredAssertions = false;
                         break;
-                    }
-
-                    if (pred->bbPostorderNum > highestReachablePostorder)
-                    {
-                        // This pred was not reachable from the original DFS root set, so
-                        // we can ignore its assertion information.
-                        //
-                        JITDUMP(FMT_BB " ignoring assertions from unreachable pred " FMT_BB
-                                       " [pred postorder num %u, highest reachable %u]\n",
-                                block->bbNum, pred->bbNum, pred->bbPostorderNum, highestReachablePostorder);
-                        continue;
                     }
 
                     // Yes, pred assertions are available.
@@ -14047,11 +14036,6 @@ PhaseStatus Compiler::fgMorphBlocks()
     }
     else
     {
-        // We are optimizing. Process in RPO.
-        //
-        fgRenumberBlocks();
-        const unsigned highestReachablePostorder = fgDfsReversePostorder();
-
         // Disallow general creation of new blocks or edges as it
         // would invalidate RPO.
         //
@@ -14079,10 +14063,10 @@ PhaseStatus Compiler::fgMorphBlocks()
 
         // Morph the blocks in RPO.
         //
-        for (unsigned i = 1; i <= bbNumMax; i++)
+        for (unsigned i = m_dfs->GetPostOrderCount(); i != 0; i--)
         {
-            BasicBlock* const block = fgBBReversePostorder[i];
-            fgMorphBlock(block, highestReachablePostorder);
+            BasicBlock* const block = m_dfs->GetPostOrder()[i - 1];
+            fgMorphBlock(block);
         }
         assert(bbNumMax == fgBBNumMax);
 
@@ -14121,6 +14105,8 @@ PhaseStatus Compiler::fgMorphBlocks()
     fgGlobalMorph     = false;
     fgGlobalMorphDone = true;
     compCurBB         = nullptr;
+
+    m_dfs = nullptr;
 
 #ifdef DEBUG
     if (optLocalAssertionProp)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13870,7 +13870,7 @@ void Compiler::fgMorphBlock(BasicBlock* block)
                     // An equal number means pred == block (block is a self-loop).
                     // Either way the assertion info is not available, and we must assume the worst.
                     //
-                    if (pred->bbPostorderNum <= block->bbPostorderNum)
+                    if (pred->bbNewPostorderNum <= block->bbNewPostorderNum)
                     {
                         JITDUMP(FMT_BB " pred " FMT_BB " not processed; clearing assertions in\n", block->bbNum,
                                 pred->bbNum);


### PR DESCRIPTION
* Introduce a phase to run the general DFS and delete dead blocks. Run this before morph.
* Switch morph to use the results produced by the DFS and remove its own renumbering and DFS.

Diffs expected from no longer morphing dead code, from increased precision around EH constructs, and from no longer renumbering.