### PR TITLE
[release/7.0] Fix SslStream.IsMutuallyAuthenticated

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/Interop.SSPI.cs
@@ -67,6 +67,7 @@ internal static partial class Interop
             SECPKG_ATTR_ISSUER_LIST_EX = 0x59,         // returns SecPkgContext_IssuerListInfoEx
             SECPKG_ATTR_CLIENT_CERT_POLICY = 0x60,     // sets    SecPkgCred_ClientCertCtlPolicy
             SECPKG_ATTR_CONNECTION_INFO = 0x5A,        // returns SecPkgContext_ConnectionInfo
+            SECPKG_ATTR_SESSION_INFO = 0x5D,           // sets SecPkgContext_SessionInfo
             SECPKG_ATTR_CIPHER_INFO = 0x64,            // returns SecPkgContext_CipherInfo
             SECPKG_ATTR_REMOTE_CERT_CHAIN = 0x67,      // returns PCCERT_CONTEXT
             SECPKG_ATTR_UI_INFO = 0x68,                // sets    SEcPkgContext_UiInfo
@@ -249,7 +250,7 @@ internal static partial class Interop
                 SCH_CRED_IGNORE_REVOCATION_OFFLINE = 0x1000,
                 SCH_CRED_CACHE_ONLY_URL_RETRIEVAL_ON_CREATE = 0x2000,
                 SCH_SEND_ROOT_CERT = 0x40000,
-                SCH_SEND_AUX_RECORD =   0x00200000,
+                SCH_SEND_AUX_RECORD = 0x00200000,
                 SCH_USE_STRONG_CRYPTO = 0x00400000,
                 SCH_USE_PRESHAREDKEY_ONLY = 0x800000,
                 SCH_ALLOW_NULL_ENCRYPTION = 0x02000000,
@@ -332,6 +333,21 @@ internal static partial class Interop
             public BOOL fOmitUsageCheck;
             public char* pwszSslCtlStoreName;
             public char* pwszSslCtlIdentifier;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal unsafe struct SecPkgContext_SessionInfo
+        {
+            public uint dwFlags;
+            public uint cbSessionId;
+            public fixed byte rgbSessionId[32];
+
+            [Flags]
+            public enum Flags
+            {
+                Zero = 0,
+                SSL_SESSION_RECONNECT = 0x01,
+            };
         }
 
         [LibraryImport(Interop.Libraries.SspiCli, SetLastError = true)]

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -298,6 +298,9 @@ namespace System.Net
         public static bool QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CONTEXT, out certContext);
 
+        public static bool QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
+            => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_LOCAL_CERT_CONTEXT, out certContext);
+
         public static bool QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CHAIN(ISSPIInterface secModule, SafeDeleteContext securityContext, out SafeFreeCertContext? certContext)
             => QueryCertContextAttribute(secModule, securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_REMOTE_CERT_CHAIN, out certContext);
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
 using System.Security.Authentication.ExtendedProtection;
 using Microsoft.Win32.SafeHandles;
 
@@ -310,10 +311,15 @@ namespace System.Net.Security
 
     internal sealed class SafeFreeCredential_SECURITY : SafeFreeCredentials
     {
+#pragma warning disable 0649
+        // This is used only by SslStream but it is included elsewhere
+        public X509Certificate? LocalCertificate;
+#pragma warning restore 0649
         public SafeFreeCredential_SECURITY() : base() { }
 
         protected override bool ReleaseHandle()
         {
+            LocalCertificate?.Dispose();
             return Interop.SspiCli.FreeCredentialsHandle(ref _handle) == 0;
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -18,7 +18,7 @@ namespace System.Net
             string? hostName)
         {
             if (remoteCertificate == null)
-                return  SslPolicyErrors.RemoteCertificateNotAvailable;
+                return SslPolicyErrors.RemoteCertificateNotAvailable;
 
             SslPolicyErrors errors = chain.Build(remoteCertificate)
                 ? SslPolicyErrors.None
@@ -93,7 +93,7 @@ namespace System.Net
 
         // This is only called when we selected local client certificate.
         // Currently this is only when Java crypto asked for it.
-        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+        internal static bool IsLocalCertificateUsed(SafeFreeCredentials? _1, SafeDeleteContext? _2) => true;
 
         //
         // Used only by client SSL code, never returns null.

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Android.cs
@@ -91,6 +91,10 @@ namespace System.Net
             return cert;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when Java crypto asked for it.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -104,7 +104,7 @@ namespace System.Net
 
         // This is only called when we selected local client certificate.
         // Currently this is only when Apple crypto asked for it.
-        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+        internal static bool IsLocalCertificateUsed(SafeFreeCredentials? _1, SafeDeleteContext? _2) => true;
 
         //
         // Used only by client SSL code, never returns null.

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -102,6 +102,10 @@ namespace System.Net
             return result;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when Apple crypto asked for it.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -103,7 +103,7 @@ namespace System.Net
 
         // This is only called when we selected local client certificate.
         // Currently this is only when OpenSSL needs it because peer asked.
-        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+        internal static bool IsLocalCertificateUsed(SafeFreeCredentials? _1, SafeDeleteContext? _2) => true;
 
         //
         // Used only by client SSL code, never returns null.

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -101,6 +101,10 @@ namespace System.Net
             return result;
         }
 
+        // This is only called when we selected local client certificate.
+        // Currently this is only when OpenSSL needs it because peer asked.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext? _) => true;
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -91,7 +91,7 @@ namespace System.Net
         }
 
         // Check that local certificate was used by schannel.
-        internal static bool IsLocalCertificateUsed(SafeFreeCredentials? _credentialsHandle, SafeDeleteContext securityContext)
+        internal static bool IsLocalCertificateUsed(SafeFreeCredentials? credentialsHandle, SafeDeleteContext securityContext)
         {
             SecPkgContext_SessionInfo info = default;
 
@@ -105,7 +105,7 @@ namespace System.Net
             {
                 // This is TLS Resumed session. Windows can fail to query the local cert bellow.
                 // Instead, we will determine the usage form used credentials.
-                SafeFreeCredential_SECURITY creds = (SafeFreeCredential_SECURITY)_credentialsHandle!;
+                SafeFreeCredential_SECURITY creds = (SafeFreeCredential_SECURITY)credentialsHandle!;
                 return creds.LocalCertificate != null;
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -94,6 +94,7 @@ namespace System.Net
         internal static bool IsLocalCertificateUsed(SafeFreeCredentials? _credentialsHandle, SafeDeleteContext securityContext)
         {
             SecPkgContext_SessionInfo info = default;
+
             // fails on Server 2008 and older. We will fall-back to probing LOCAL_CERT_CONTEXT in that case.
             if (SSPIWrapper.QueryBlittableContextAttributes(
                                     GlobalSSPI.SSPISecureChannel,

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -89,6 +89,28 @@ namespace System.Net
             return result;
         }
 
+        // Check that local certificate was used by schannel.
+        internal static bool IsLocalCertificateUsed(SafeDeleteContext securityContext)
+        {
+            SafeFreeCertContext? localContext = null;
+            try
+            {
+                if (SSPIWrapper.QueryContextAttributes_SECPKG_ATTR_LOCAL_CERT_CONTEXT(GlobalSSPI.SSPISecureChannel, securityContext, out localContext) &&
+                    localContext != null)
+                {
+                    return !localContext.IsInvalid;
+                }
+            }
+            finally
+            {
+                localContext?.Dispose();
+            }
+
+            // Some older Windows do not support that. This is only called when client certificate was provided
+            // so assume it was for a reason.
+            return true;
+        }
+
         //
         // Used only by client SSL code, never returns null.
         //

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -518,7 +518,6 @@ namespace System.Net.Security
             bool cachedCred = false;                   // this is a return result from this method.
 
             X509Certificate2? selectedCert = SelectClientCertificate(out sessionRestartAttempt);
-
             try
             {
                 // Try to locate cached creds first.
@@ -974,6 +973,12 @@ namespace System.Net.Security
                 }
 
                 _remoteCertificate = certificate;
+                if (_selectedClientCertificate != null && !CertificateValidationPal.IsLocalCertificateUsed(_securityContext!))
+                {
+                    // We may slect client cert but it may not be used.
+                    // This is primarily issue on Windows with credential caching
+                    _selectedClientCertificate = null;
+                }
 
                 if (_remoteCertificate == null)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -30,8 +30,6 @@ namespace System.Net.Security
         private int _trailerSize = 16;
         private int _maxDataSize = 16354;
 
-        private bool _refreshCredentialNeeded = true;
-
         private static readonly Oid s_serverAuthOid = new Oid("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.1");
         private static readonly Oid s_clientAuthOid = new Oid("1.3.6.1.5.5.7.3.2", "1.3.6.1.5.5.7.3.2");
 
@@ -107,11 +105,6 @@ namespace System.Net.Security
             {
                 return _sslAuthenticationOptions.RemoteCertRequired;
             }
-        }
-
-        internal void SetRefreshCredentialNeeded()
-        {
-            _refreshCredentialNeeded = true;
         }
 
         internal void CloseContext()
@@ -515,7 +508,7 @@ namespace System.Net.Security
 
         --*/
 
-        private bool AcquireClientCredentials(ref byte[]? thumbPrint)
+        private bool AcquireClientCredentials(ref byte[]? thumbPrint, bool newCredentialsRequested = false)
         {
             // Acquire possible Client Certificate information and set it on the handle.
 
@@ -580,7 +573,7 @@ namespace System.Net.Security
                         _sslAuthenticationOptions.CertificateContext = SslStreamCertificateContext.Create(selectedCert!);
                     }
 
-                    _credentialsHandle = AcquireCredentialsHandle(_sslAuthenticationOptions);
+                    _credentialsHandle = AcquireCredentialsHandle(_sslAuthenticationOptions, newCredentialsRequested);
                     thumbPrint = guessedThumbPrint; // Delay until here in case something above threw.
                 }
             }
@@ -691,9 +684,9 @@ namespace System.Net.Security
             return cachedCred;
         }
 
-        private static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions sslAuthenticationOptions)
+        private static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions sslAuthenticationOptions, bool newCredentialsRequested = false)
         {
-            SafeFreeCredentials? cred = SslStreamPal.AcquireCredentialsHandle(sslAuthenticationOptions);
+            SafeFreeCredentials? cred = SslStreamPal.AcquireCredentialsHandle(sslAuthenticationOptions, newCredentialsRequested);
 
             if (sslAuthenticationOptions.CertificateContext != null && cred != null)
             {
@@ -753,7 +746,6 @@ namespace System.Net.Security
                 if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, "NextMessage() returned SecurityStatusPal.CredentialsNeeded");
 
-                SetRefreshCredentialNeeded();
                 status = GenerateToken(incomingBuffer, ref nextmsg);
             }
 
@@ -792,6 +784,11 @@ namespace System.Net.Security
             bool sendTrustList = false;
             byte[]? thumbPrint = null;
 
+            // We need to try get credentials at the beginning.
+            // _credentialsHandle may be always null on some platforms but
+            // _securityContext will be allocated on first call.
+            bool refreshCredentialNeeded = _securityContext == null;
+
             //
             // Looping through ASC or ISC with potentially cached credential that could have been
             // already disposed from a different thread before ISC or ASC dir increment a cred ref count.
@@ -801,7 +798,7 @@ namespace System.Net.Security
                 do
                 {
                     thumbPrint = null;
-                    if (_refreshCredentialNeeded)
+                    if (refreshCredentialNeeded)
                     {
                         cachedCreds = _sslAuthenticationOptions.IsServer
                                         ? AcquireServerCredentials(ref thumbPrint)
@@ -830,15 +827,31 @@ namespace System.Net.Security
                                        _sslAuthenticationOptions,
                                        SelectClientCertificate
                                        );
+
+                        if (status.ErrorCode == SecurityStatusPalErrorCode.CredentialsNeeded)
+                        {
+                            refreshCredentialNeeded = true;
+                            cachedCreds = AcquireClientCredentials(ref thumbPrint, newCredentialsRequested: true);
+
+                            if (NetEventSource.Log.IsEnabled())
+                                NetEventSource.Info(this, "InitializeSecurityContext() returned 'CredentialsNeeded'.");
+
+                            status = SslStreamPal.InitializeSecurityContext(
+                                       ref _credentialsHandle!,
+                                       ref _securityContext,
+                                       _sslAuthenticationOptions.TargetHost,
+                                       inputBuffer,
+                                       ref result,
+                                       _sslAuthenticationOptions,
+                                       SelectClientCertificate);
+                        }
                     }
                 } while (cachedCreds && _credentialsHandle == null);
             }
             finally
             {
-                if (_refreshCredentialNeeded)
+                if (refreshCredentialNeeded)
                 {
-                    _refreshCredentialNeeded = false;
-
                     //
                     // Assuming the ISC or ASC has referenced the credential,
                     // we want to call dispose so to decrement the effective ref count.

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -56,7 +56,12 @@ namespace System.Net.Security
         {
             get
             {
-                return _selectedClientCertificate;
+                if (_selectedClientCertificate != null && CertificateValidationPal.IsLocalCertificateUsed(_credentialsHandle, _securityContext!))
+                {
+                    return _selectedClientCertificate;
+                }
+
+                return null;
             }
         }
 
@@ -973,13 +978,6 @@ namespace System.Net.Security
                 }
 
                 _remoteCertificate = certificate;
-                if (_selectedClientCertificate != null && !CertificateValidationPal.IsLocalCertificateUsed(_securityContext!))
-                {
-                    // We may slect client cert but it may not be used.
-                    // This is primarily issue on Windows with credential caching
-                    _selectedClientCertificate = null;
-                }
-
                 if (_remoteCertificate == null)
                 {
                     if (NetEventSource.Log.IsEnabled() && RemoteCertRequired) NetEventSource.Error(this, $"Remote certificate required, but no remote certificate received");

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Android.cs
@@ -55,7 +55,7 @@ namespace System.Net.Security
             throw new PlatformNotSupportedException();
         }
 
-        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions sslAuthenticationOptions)
+        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions _1, bool _2)
         {
             return null;
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -62,7 +62,7 @@ namespace System.Net.Security
             throw new PlatformNotSupportedException();
         }
 
-        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions sslAuthenticationOptions)
+        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions _1, bool _2)
         {
             return null;
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -46,7 +46,7 @@ namespace System.Net.Security
             return HandshakeInternal(ref context, inputBuffer, ref outputBuffer, sslAuthenticationOptions, clientCertificateSelectionCallback);
         }
 
-        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions sslAuthenticationOptions)
+        public static SafeFreeCredentials? AcquireCredentialsHandle(SslAuthenticationOptions _1, bool _2)
         {
             return null;
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamMutualAuthenticationTest.cs
@@ -37,7 +37,6 @@ namespace System.Net.Security.Tests
         {
             ClientCertificate,
             SelectionCallback,
-            CertificateContext
         }
 
         public static TheoryData<ClientCertSource> CertSourceData()
@@ -183,9 +182,6 @@ namespace System.Net.Security.Tests
                             break;
                         case ClientCertSource.SelectionCallback:
                             clientOptions.LocalCertificateSelectionCallback = ClientCertSelectionCallback;
-                            break;
-                        case ClientCertSource.CertificateContext:
-                            clientOptions.ClientCertificateContext = SslStreamCertificateContext.Create(_clientCertificate, new());
                             break;
                     }
 


### PR DESCRIPTION
This is essentially the same as 6.0 PR #92684, but for 7.0.

This is backport of PR #88488 and PR #79128 and parts of PR #63945.
It also brings spirit of test-only PR #68009 to get test coverage for TLS 1.3.

This only covers Windows to minimize the code delta i.e. it does not bring all the changes from PR #63945 to cover Linux & macOS.

## Customer Impact

The property `IsMutuallyAuthenticated` on `SslStream` indicates if mutual TLS authentication is performed with client certificate. Current 6.0 implementation can get confused in several cases, so the value is unreliable for security audits.

## Testing

This brings all the current tests from 8.0 branch.
Customer validated on private bits in production - neither functional, nor perf regression.

## Risk

Medium.
While the change is quite large, it should be specific just to that property i.e. it should not impact TLS handshake or any other I/O on `SslStream`. Since the `IsMutuallyAuthenticated` is already unreliable this should bring it up to 8.0 code base to fix all known cases when it is incorrect. To reduce complexity, this fixes only Windows as macOS & Linux changes from PR #68009 had more significant impact on functionality and flow.