### PR TITLE
[mono] Fix function prototype warning in debugger-engine.c

### DIFF
--- a/src/mono/mono/component/debugger-engine.c
+++ b/src/mono/mono/component/debugger-engine.c
@@ -1549,7 +1549,7 @@ mono_de_set_log_level (int level, FILE *file)
 }
 
 void
-mono_de_set_using_icordbg ()
+mono_de_set_using_icordbg (void)
 {
 	using_icordbg = TRUE;
 }


### PR DESCRIPTION
> debugger-engine.c:1552:27: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]