### PR TITLE
[tests] Disables tests on Apple mobile platforms

### DIFF
--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -268,7 +268,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetExactRootDirMatchCases))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws(TarEntryFormat format, TarEntryType entryType, string fileName)
         {
             ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Internal(format, entryType, fileName, inverted: false);
@@ -276,14 +275,18 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void ExtractToDirectory_ExactRootDirMatch_Directory_Relative_Throws()
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -303,7 +306,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public void ExtractToDirectory_ExactRootDirMatch_HardLinks_Throws(TarEntryFormat format)
         {
             ExtractToDirectory_ExactRootDirMatch_Links_Throws(format, TarEntryType.HardLink, inverted: false);
@@ -359,8 +361,13 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -390,8 +397,13 @@ namespace System.Formats.Tar.Tests
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -280,13 +280,10 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -361,13 +358,10 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -397,13 +391,10 @@ namespace System.Formats.Tar.Tests
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -283,7 +283,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -364,7 +364,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -400,7 +400,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -268,6 +268,7 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetExactRootDirMatchCases))]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public void ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws(TarEntryFormat format, TarEntryType entryType, string fileName)
         {
             ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Internal(format, entryType, fileName, inverted: false);
@@ -275,14 +276,12 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public void ExtractToDirectory_ExactRootDirMatch_Directory_Relative_Throws()
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
@@ -303,6 +302,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public void ExtractToDirectory_ExactRootDirMatch_HardLinks_Throws(TarEntryFormat format)
         {
             ExtractToDirectory_ExactRootDirMatch_Links_Throws(format, TarEntryType.HardLink, inverted: false);
@@ -357,10 +357,7 @@ namespace System.Formats.Tar.Tests
 
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
@@ -390,10 +387,7 @@ namespace System.Formats.Tar.Tests
 
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -283,7 +283,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -364,7 +364,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -400,7 +400,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectory.Stream.Tests.cs
@@ -281,6 +281,7 @@ namespace System.Formats.Tar.Tests
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
@@ -357,6 +358,7 @@ namespace System.Formats.Tar.Tests
 
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
@@ -387,6 +389,7 @@ namespace System.Formats.Tar.Tests
 
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -348,7 +348,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -429,7 +429,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -465,7 +465,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -345,13 +345,10 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -426,13 +423,10 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -462,13 +456,10 @@ namespace System.Formats.Tar.Tests
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
 
-#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
             using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
-#else
-            using TempDirectory root = new TempDirectory();
-#endif
+
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -333,6 +333,7 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetExactRootDirMatchCases))]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public async Task ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Async(TarEntryFormat format, TarEntryType entryType, string fileName)
         {
             await ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Internal_Async(format, entryType, fileName, inverted: false);
@@ -340,14 +341,12 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public async Task ExtractToDirectory_ExactRootDirMatch_Directory_Relative_Throws_Async()
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
@@ -368,6 +367,7 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "The temporary directory on Apple mobile platforms exceeds the path length limit.")]
         public async Task ExtractToDirectory_ExactRootDirMatch_HardLinks_Throws_Async(TarEntryFormat format)
         {
             await ExtractToDirectory_ExactRootDirMatch_Links_Throws_Async(format, TarEntryType.HardLink, inverted: false);
@@ -422,10 +422,7 @@ namespace System.Formats.Tar.Tests
 
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
@@ -455,10 +452,7 @@ namespace System.Formats.Tar.Tests
 
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
-
-            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
-            // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
+            using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -333,7 +333,6 @@ namespace System.Formats.Tar.Tests
 
         [Theory]
         [MemberData(nameof(GetExactRootDirMatchCases))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public async Task ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Async(TarEntryFormat format, TarEntryType entryType, string fileName)
         {
             await ExtractToDirectory_ExactRootDirMatch_RegularFile_And_Directory_Throws_Internal_Async(format, entryType, fileName, inverted: false);
@@ -341,14 +340,18 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public async Task ExtractToDirectory_ExactRootDirMatch_Directory_Relative_Throws_Async()
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -368,7 +371,6 @@ namespace System.Formats.Tar.Tests
         [InlineData(TarEntryFormat.Ustar)]
         [InlineData(TarEntryFormat.Pax)]
         [InlineData(TarEntryFormat.Gnu)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88049", TestPlatforms.iOS | TestPlatforms.tvOS)]
         public async Task ExtractToDirectory_ExactRootDirMatch_HardLinks_Throws_Async(TarEntryFormat format)
         {
             await ExtractToDirectory_ExactRootDirMatch_Links_Throws_Async(format, TarEntryType.HardLink, inverted: false);
@@ -424,8 +426,13 @@ namespace System.Formats.Tar.Tests
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 
@@ -455,8 +462,13 @@ namespace System.Formats.Tar.Tests
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
 
+#if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
+            // the folder used to store files needs to have a shorter path on Apple mobile platforms,
+            // because the TempDirectory gets created in folder with a path longer than 100 bytes
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/CoreSimulator/Devices/tempDir");
+#else
             using TempDirectory root = new TempDirectory();
-
+#endif
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
             string destinationFolderPath = Path.Join(root.Path, destinationFolderName);
 

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -346,6 +346,7 @@ namespace System.Formats.Tar.Tests
         {
             string entryFolderName = "folder";
             string destinationFolderName = "folderSibling";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
@@ -422,6 +423,7 @@ namespace System.Formats.Tar.Tests
 
             string entryFolderName = inverted ? "folderSibling" : "folder";
             string destinationFolderName = inverted ? "folder" : "folderSibling";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);
@@ -452,6 +454,7 @@ namespace System.Formats.Tar.Tests
 
             string linkTargetFileName = "file.txt";
             string linkFileName = "link";
+
             using TempDirectory root = new TempDirectory();
 
             string entryFolderPath = Path.Join(root.Path, entryFolderName);

--- a/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarFile/TarFile.ExtractToDirectoryAsync.Stream.Tests.cs
@@ -348,7 +348,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -429,7 +429,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif
@@ -465,7 +465,7 @@ namespace System.Formats.Tar.Tests
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             // the folder used to store files needs to have a shorter path on Apple mobile platforms,
             // because the TempDirectory gets created in folder with a path longer than 100 bytes
-            using TempDirectory root = new TempDirectory("/Users/helix-runner/Library/Developer/tmp");
+            using TempDirectory root = new TempDirectory("/Users/helix-runner/tmp");
 #else
             using TempDirectory root = new TempDirectory();
 #endif


### PR DESCRIPTION
## Description

This PR disables tests on Apple mobile platforms due to temporary directory that exceeds the path length limit.