### PR TITLE
Replaced string concatenation by StringBuilder usage

### DIFF
--- a/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
@@ -68,6 +68,8 @@
     <Compile Include="System\Net\Mail\SmtpFailedRecipientsException.cs" />
     <Compile Include="System\Net\Mail\SmtpStatusCode.cs" />
     <Compile Include="System\Net\DelegatedStream.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
+             Link="Common\System\Text\ValueStringBuilder.cs" />
     <Compile Include="$(CommonPath)DisableRuntimeMarshalling.cs"
              Link="Common\DisableRuntimeMarshalling.cs" />
     <Compile Include="$(CommonPath)System\Net\LazyAsyncResult.cs"

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
@@ -51,25 +51,26 @@ namespace System.Net.Mail
 
         internal string Encode(int charsConsumed, bool allowUnicode)
         {
-            StringBuilder? encodedAddresses = null;
+            var encodedAddresses = new ValueStringBuilder(stackalloc char[256]);
 
             //encode each address individually (except the first), fold and separate with a comma
             foreach (MailAddress address in this)
             {
-                if (encodedAddresses is null)
+                if (encodedAddresses.Length == 0)
                 {
                     //no need to append a comma to the first one because it may be the only one.
-                    encodedAddresses = new(address.Encode(charsConsumed, allowUnicode));
+                    encodedAddresses.Append(address.Encode(charsConsumed, allowUnicode));
                 }
                 else
                 {
                     //appending another one, append a comma to separate and then fold and add the encoded address
                     //the charsConsumed will be 1 because only the first line needs to account for the header itself for
                     //line length; subsequent lines have a single whitespace character because they are folded here
-                    encodedAddresses.Append(", ").Append(address.Encode(1, allowUnicode));
+                    encodedAddresses.Append(", ");
+                    encodedAddresses.Append(address.Encode(1, allowUnicode));
                 }
             }
-            return encodedAddresses?.ToString() ?? string.Empty;
+            return encodedAddresses.ToString();
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
@@ -59,8 +59,7 @@ namespace System.Net.Mail
                 if (encodedAddresses is null)
                 {
                     //no need to append a comma to the first one because it may be the only one.
-                    encodedAddresses = new();
-                    encodedAddresses.Append(address.Encode(charsConsumed, allowUnicode));
+                    encodedAddresses = new(address.Encode(charsConsumed, allowUnicode));
                 }
                 else
                 {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddressCollection.cs
@@ -51,25 +51,26 @@ namespace System.Net.Mail
 
         internal string Encode(int charsConsumed, bool allowUnicode)
         {
-            string encodedAddresses = string.Empty;
+            StringBuilder? encodedAddresses = null;
 
             //encode each address individually (except the first), fold and separate with a comma
             foreach (MailAddress address in this)
             {
-                if (string.IsNullOrEmpty(encodedAddresses))
+                if (encodedAddresses is null)
                 {
                     //no need to append a comma to the first one because it may be the only one.
-                    encodedAddresses = address.Encode(charsConsumed, allowUnicode);
+                    encodedAddresses = new();
+                    encodedAddresses.Append(address.Encode(charsConsumed, allowUnicode));
                 }
                 else
                 {
                     //appending another one, append a comma to separate and then fold and add the encoded address
                     //the charsConsumed will be 1 because only the first line needs to account for the header itself for
                     //line length; subsequent lines have a single whitespace character because they are folded here
-                    encodedAddresses += ", " + address.Encode(1, allowUnicode);
+                    encodedAddresses.Append(", ").Append(address.Encode(1, allowUnicode));
                 }
             }
-            return encodedAddresses;
+            return encodedAddresses?.ToString() ?? string.Empty;
         }
     }
 }

--- a/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -142,6 +142,8 @@
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs" 
+             Link="Common\System\Text\ValueStringBuilder.cs" /> 
   </ItemGroup>
   <!-- Unix specific files -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'unix'">


### PR DESCRIPTION
# Description

The proposed change is just a simple optimization of mail address collection encoding and touches only the collection type itself, not `MailAddress` which uses string concatenation internally in many places.

# Customer Impact

A bit smaller pressure on the GC.

# Regression

Nope.

# Testing

Existing tests are enough to cover the change.
