### PR TITLE
Optimize a castclass over nullables

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18580,7 +18580,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
                     // CORINFO_HELP_BOX_NULLABLE may return null
                     // CORINFO_HELP_BOX always returns non-null
                     *pIsNonNull = !isNullableHelper;
-                    *pIsExact = true;
+                    *pIsExact   = true;
                 }
             }
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18560,6 +18560,34 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
             break;
         }
 
+        case CORINFO_HELP_BOX:
+        {
+            GenTree* typeArg = call->gtArgs.GetUserArgByIndex(0)->GetNode();
+            if (typeArg->IsIconHandle(GTF_ICON_CLASS_HDL))
+            {
+                objClass    = gtGetHelperArgClassHandle(typeArg);
+                *pIsNonNull = false;
+                *pIsExact   = false;
+            }
+        }
+        break;
+
+        case CORINFO_HELP_BOX_NULLABLE:
+        {
+            GenTree* typeArg = call->gtArgs.GetUserArgByIndex(0)->GetNode();
+            if (typeArg->IsIconHandle(GTF_ICON_CLASS_HDL))
+            {
+                CORINFO_CLASS_HANDLE nullableCls = gtGetHelperArgClassHandle(typeArg);
+                if (nullableCls != NO_CLASS_HANDLE)
+                {
+                    objClass    = info.compCompHnd->getTypeForBox(nullableCls);
+                    *pIsNonNull = false;
+                    *pIsExact   = false;
+                }
+            }
+        }
+        break;
+
         case CORINFO_HELP_CHKCASTCLASS:
         case CORINFO_HELP_CHKCASTANY:
         case CORINFO_HELP_CHKCASTARRAY:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18580,8 +18580,6 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
                     // CORINFO_HELP_BOX_NULLABLE may return null
                     // CORINFO_HELP_BOX always returns non-null
                     *pIsNonNull = !isNullableHelper;
-
-                    // Since only box value types, we know the type exactly
                     *pIsExact = true;
                 }
             }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18582,7 +18582,7 @@ CORINFO_CLASS_HANDLE Compiler::gtGetHelperCallClassHandle(GenTreeCall* call, boo
                 {
                     objClass    = info.compCompHnd->getTypeForBox(nullableCls);
                     *pIsNonNull = false;
-                    *pIsExact   = false;
+                    *pIsExact   = true;
                 }
             }
         }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/50915

```cs
int Test<T>(T t) => ((IMyInterface)t).M();

interface IMyInterface
{
    int M();
}

struct S : IMyInterface
{
    public int M() => 42;
}
```
(for `T` being `Nullable<S>`)

```diff
; Assembly listing for method Program:Test[System.Nullable`1[S]](System.Nullable`1[S]):int
       sub      rsp, 40
       mov      qword ptr [rsp+0x30], rcx
       lea      rdx, [rsp+0x30]
       mov      rcx, 0xD1FFAB1E      ; System.Nullable`1[S]
       call     CORINFO_HELP_BOX_NULLABLE
-      mov      rdx, rax
-      mov      rcx, 0xD1FFAB1E      ; IMyInterface
-      call     CORINFO_HELP_CHKCASTINTERFACE
-      mov      rcx, rax
-      mov      r11, 0xD1FFAB1E      ; code for IMyInterface:M():int:this
-      call     [r11]IMyInterface:M():int:this
-      nop      
+      movsx    rax, byte  ptr [rax+0x08]
+      mov      eax, 42
       add      rsp, 40
       ret      
-; Total bytes of code 69
+; Total bytes of code 44
```