### PR TITLE
[release/7.0-staging] [Android] Bump target SDK version for Android sample

### DIFF
--- a/docs/workflow/testing/libraries/testing-android.md
+++ b/docs/workflow/testing/libraries/testing-android.md
@@ -23,9 +23,9 @@ Android SDK and NDK can be automatically installed via the following script:
 set -e
 
 NDK_VER=r23c
-SDK_VER=6200805_latest
-SDK_API_LEVEL=29
-SDK_BUILD_TOOLS=29.0.3
+SDK_VER=9123335_latest
+SDK_API_LEVEL=33
+SDK_BUILD_TOOLS=33.0.1
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     HOST_OS=darwin
@@ -63,7 +63,7 @@ Android Studio offers a convenient UI:
 Before running a build you might want to set the Android SDK and NDK environment variables:
 ```
 export ANDROID_SDK_ROOT=<PATH-TO-ANDROID-SDK>
-export ANDROID_NDK_ROOT=<PATH-TO-ANDROID-NDK>  
+export ANDROID_NDK_ROOT=<PATH-TO-ANDROID-NDK>
 ```
 
 Now we're ready to build everything for Android:

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -301,6 +301,7 @@ namespace System.Diagnostics.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [InlineData(true), InlineData(false)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.Android, "Android doesn't allow executing custom shell scripts")]
         public void ProcessStart_UseShellExecute_Executes(bool filenameAsUrl)
         {
             string filename = WriteScriptFile(TestDirectory, GetTestFileName(), returnValue: 42);
@@ -373,6 +374,7 @@ namespace System.Diagnostics.Tests
             nameof(PlatformDetection.IsNotAppSandbox))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34685", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.Android, "Android doesn't allow executing custom shell scripts")]
         public void ProcessStart_UseShellExecute_WorkingDirectory()
         {
             // Create a directory that will ProcessStartInfo.WorkingDirectory
@@ -2621,7 +2623,7 @@ namespace System.Diagnostics.Tests
             {
                 // returns the username of the owner of the process or null if the username can't be queried.
                 // for services.exe, this will be null.
-                string? servicesUser = Helpers.GetProcessUserName(p); 
+                string? servicesUser = Helpers.GetProcessUserName(p);
 
                 // this isn't really verifying that services.exe is owned by SYSTEM, but we are sure it is not owned by the current user.
                 if (servicesUser != currentProcessUser)

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -97,6 +97,7 @@ namespace System.Net.Security.Tests
         [InlineData(false)]
         [SkipOnPlatform(TestPlatforms.Android, "The invalid certificate is rejected by Android and the .NET validation code isn't reached")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/70981", TestPlatforms.OSX)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/68206", TestPlatforms.Android)]
         public Task ConnectWithRevocation_WithCallback(bool checkRevocation)
         {
             X509RevocationMode mode = checkRevocation ? X509RevocationMode.Online : X509RevocationMode.NoCheck;

--- a/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/tasks/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -73,6 +73,8 @@ public class AndroidAppBuilderTask : Task
 
     public string? MinApiLevel { get; set; }
 
+    public string? TargetApiLevel { get; set; }
+
     public string? BuildApiLevel { get; set; }
 
     public string? BuildToolsVersion { get; set; }
@@ -108,6 +110,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.AndroidSdk = AndroidSdk;
         apkBuilder.AndroidNdk = AndroidNdk;
         apkBuilder.MinApiLevel = MinApiLevel;
+        apkBuilder.TargetApiLevel = TargetApiLevel;
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
         apkBuilder.StripDebugSymbols = StripDebugSymbols;

--- a/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
+++ b/src/tasks/AndroidAppBuilder/Templates/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="%PackageName%"
           a:versionCode="1"
           a:versionName="1.0">
-  <uses-sdk a:minSdkVersion="%MinSdkLevel%" />
+  <uses-sdk a:minSdkVersion="%MinSdkLevel%" a:targetSdkVersion="%TargetSdkVersion%" />
   <uses-permission a:name="android.permission.INTERNET"/>
   <uses-permission a:name="android.permission.READ_EXTERNAL_STORAGE"/>
   <uses-permission a:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Backport of #80923 to release/7.0-staging

/cc @simonrozsival 

This is a **test-only** change.

Prior to this change, the Android sample app located at `src/mono/sample/Android` have been failing to install on phones with Android SDK 31+. The error message looks like this
```
This app was built for an older version of Android and doesn't include the latest privacy protections. 

Installing this app may put your device at risk. Learn more (https://support.google.com/android/answer/2812853?hl=en) about Play Protect.
```
We use this app to benchmark android app size and startup time. Because of this issue, we weren't able to get data for .NET7 since early November.

This PR added the `targetSdkVersion` switch and setting it to `Android SDK 31`. This ensured that the Android app is built for the SDK version aligned with the devices used for testing in the perf lab.

## Customer Impact
There is no customer impact. This change is for testing only.

## Testing

Validated manually that the Android sample app located at `src/mono/sample/Android` is able to install on phones with Android SDK 31+ without error.

## Risk
None