### PR TITLE
JIT: Add explicit successor for BBJ_COND false branch

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5728,7 +5728,7 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
 
                 if (jumpDestAssertionIndex != NO_ASSERTION_INDEX)
                 {
-                    // Update jumpDestValueGen if we have an assertion for the bbJumpDest edge
+                    // Update jumpDestValueGen if we have an assertion for the bbTarget edge
                     optImpliedAssertions(jumpDestAssertionIndex, jumpDestValueGen);
                     BitVecOps::AddElemD(apTraits, jumpDestValueGen, jumpDestAssertionIndex - 1);
                 }
@@ -5755,7 +5755,7 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
             optPrintAssertionIndices(block->bbAssertionGen);
             if (block->KindIs(BBJ_COND))
             {
-                printf(" => " FMT_BB " valueGen = ", block->GetJumpDest()->bbNum);
+                printf(" => " FMT_BB " valueGen = ", block->GetTarget()->bbNum);
                 optPrintAssertionIndices(jumpDestGen[block->bbNum]);
             }
             printf("\n");
@@ -6315,7 +6315,7 @@ PhaseStatus Compiler::optAssertionPropMain()
             optDumpAssertionIndices(" out  = ", block->bbAssertionOut, "\n");
             if (block->KindIs(BBJ_COND))
             {
-                printf(" " FMT_BB " = ", block->GetJumpDest()->bbNum);
+                printf(" " FMT_BB " = ", block->GetTarget()->bbNum);
                 optDumpAssertionIndices(bbJtrueAssertionOut[block->bbNum], "\n");
             }
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5550,7 +5550,7 @@ public:
     {
         ASSERT_TP pAssertionOut;
 
-        if (predBlock->KindIs(BBJ_COND) && predBlock->TargetIs(block))
+        if (predBlock->KindIs(BBJ_COND) && predBlock->TrueTargetIs(block))
         {
             pAssertionOut = mJumpDestOut[predBlock->bbNum];
 

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5558,7 +5558,7 @@ public:
             {
                 // Scenario where next block and conditional block, both point to the same block.
                 // In such case, intersect the assertions present on both the out edges of predBlock.
-                assert(predBlock->HasNormalJumpTo(block));
+                assert(predBlock->FalseTargetIs(block));
                 BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
 
                 if (VerboseDataflow())

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5558,7 +5558,7 @@ public:
             {
                 // Scenario where next block and conditional block, both point to the same block.
                 // In such case, intersect the assertions present on both the out edges of predBlock.
-                assert(predBlock->NextIs(block));
+                assert(predBlock->HasNormalJumpTo(block));
                 BitVecOps::IntersectionD(apTraits, pAssertionOut, predBlock->bbAssertionOut);
 
                 if (VerboseDataflow())

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5755,7 +5755,7 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
             optPrintAssertionIndices(block->bbAssertionGen);
             if (block->KindIs(BBJ_COND))
             {
-                printf(" => " FMT_BB " valueGen = ", block->GetTarget()->bbNum);
+                printf(" => " FMT_BB " valueGen = ", block->GetTrueTarget()->bbNum);
                 optPrintAssertionIndices(jumpDestGen[block->bbNum]);
             }
             printf("\n");
@@ -6315,7 +6315,7 @@ PhaseStatus Compiler::optAssertionPropMain()
             optDumpAssertionIndices(" out  = ", block->bbAssertionOut, "\n");
             if (block->KindIs(BBJ_COND))
             {
-                printf(" " FMT_BB " = ", block->GetTarget()->bbNum);
+                printf(" " FMT_BB " = ", block->GetTrueTarget()->bbNum);
                 optDumpAssertionIndices(bbJtrueAssertionOut[block->bbNum], "\n");
             }
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5550,7 +5550,7 @@ public:
     {
         ASSERT_TP pAssertionOut;
 
-        if (predBlock->KindIs(BBJ_COND) && predBlock->HasJumpTo(block))
+        if (predBlock->KindIs(BBJ_COND) && predBlock->TargetIs(block))
         {
             pAssertionOut = mJumpDestOut[predBlock->bbNum];
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -660,7 +660,7 @@ void BasicBlock::dspSuccs(Compiler* compiler)
         while (iter.NextElem(&bbNum))
         {
             // Note that we will output switch successors in increasing numerical bbNum order, which is
-            // not related to their order in the bbSwtTarget->bbsDstTab table.
+            // not related to their order in the bbSwtTargets->bbsDstTab table.
             printf("%s" FMT_BB, first ? "" : ",", bbNum);
             first = false;
         }
@@ -753,23 +753,23 @@ void BasicBlock::dspKind()
         {
             printf(" ->");
 
-            const unsigned     jumpCnt = bbSwtTarget->bbsCount;
-            BasicBlock** const jumpTab = bbSwtTarget->bbsDstTab;
+            const unsigned     jumpCnt = bbSwtTargets->bbsCount;
+            BasicBlock** const jumpTab = bbSwtTargets->bbsDstTab;
 
             for (unsigned i = 0; i < jumpCnt; i++)
             {
                 printf("%c" FMT_BB, (i == 0) ? ' ' : ',', jumpTab[i]->bbNum);
 
-                const bool isDefault = bbSwtTarget->bbsHasDefault && (i == jumpCnt - 1);
+                const bool isDefault = bbSwtTargets->bbsHasDefault && (i == jumpCnt - 1);
                 if (isDefault)
                 {
                     printf("[def]");
                 }
 
-                const bool isDominant = bbSwtTarget->bbsHasDominantCase && (i == bbSwtTarget->bbsDominantCase);
+                const bool isDominant = bbSwtTargets->bbsHasDominantCase && (i == bbSwtTargets->bbsDominantCase);
                 if (isDominant)
                 {
-                    printf("[dom(" FMT_WT ")]", bbSwtTarget->bbsDominantFraction);
+                    printf("[dom(" FMT_WT ")]", bbSwtTargets->bbsDominantFraction);
                 }
             }
 
@@ -1176,7 +1176,7 @@ unsigned BasicBlock::NumSucc() const
             return bbEhfTarget->bbeCount;
 
         case BBJ_SWITCH:
-            return bbSwtTarget->bbsCount;
+            return bbSwtTargets->bbsCount;
 
         default:
             unreached();
@@ -1220,7 +1220,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
             return bbEhfTarget->bbeSuccs[i];
 
         case BBJ_SWITCH:
-            return bbSwtTarget->bbsDstTab[i];
+            return bbSwtTargets->bbsDstTab[i];
 
         default:
             unreached();
@@ -1614,7 +1614,7 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* swtTarget)
 {
     BasicBlock* block  = BasicBlock::New(compiler);
     block->bbKind      = BBJ_SWITCH;
-    block->bbSwtTarget = swtTarget;
+    block->bbSwtTargets = swtTarget;
     return block;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1207,13 +1207,13 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
         case BBJ_COND:
             if (i == 0)
             {
-                return bbNext;
+                return bbFalseTarget;
             }
             else
             {
                 assert(i == 1);
-                assert(bbNext != bbTarget);
-                return bbTarget;
+                assert(bbFalseTarget != bbTrueTarget);
+                return bbTrueTarget;
             }
 
         case BBJ_EHFINALLYRET:
@@ -1328,13 +1328,13 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
         case BBJ_COND:
             if (i == 0)
             {
-                return bbNext;
+                return bbFalseTarget;
             }
             else
             {
                 assert(i == 1);
-                assert(bbNext != bbTarget);
-                return bbTarget;
+                assert(bbFalseTarget != bbTrueTarget);
+                return bbTrueTarget;
             }
 
         case BBJ_SWITCH:
@@ -1599,7 +1599,7 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, BasicBlock* target
     // In some cases, we don't know a block's jump target during initialization, so don't check the jump kind/target
     // yet.
     // The checks will be done any time the jump kind/target is read or written to after initialization.
-    block->bbKind = kind;
+    block->bbKind   = kind;
     block->bbTarget = target;
 
     if (block->KindIs(BBJ_THROW))
@@ -1612,16 +1612,16 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, BasicBlock* target
 
 BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* swtTarget)
 {
-    BasicBlock* block = BasicBlock::New(compiler);
-    block->bbKind = BBJ_SWITCH;
-    block->bbSwtTarget  = swtTarget;
+    BasicBlock* block  = BasicBlock::New(compiler);
+    block->bbKind      = BBJ_SWITCH;
+    block->bbSwtTarget = swtTarget;
     return block;
 }
 
 BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, unsigned targetOffs)
 {
-    BasicBlock* block = BasicBlock::New(compiler);
-    block->bbKind = kind;
+    BasicBlock* block   = BasicBlock::New(compiler);
+    block->bbKind       = kind;
     block->bbTargetOffs = targetOffs;
     return block;
 }

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1610,11 +1610,19 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, BasicBlock* target
     return block;
 }
 
-BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* swtTarget)
+BasicBlock* BasicBlock::New(Compiler* compiler, BBehfDesc* ehfTargets)
 {
-    BasicBlock* block  = BasicBlock::New(compiler);
-    block->bbKind      = BBJ_SWITCH;
-    block->bbSwtTargets = swtTarget;
+    BasicBlock* block   = BasicBlock::New(compiler);
+    block->bbKind       = BBJ_EHFINALLYRET;
+    block->bbEhfTargets = ehfTargets;
+    return block;
+}
+
+BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* swtTargets)
+{
+    BasicBlock* block   = BasicBlock::New(compiler);
+    block->bbKind       = BBJ_SWITCH;
+    block->bbSwtTargets = swtTargets;
     return block;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -678,7 +678,7 @@ void BasicBlock::dspSuccs(Compiler* compiler)
 // Display a compact representation of the bbKind, that is, where this block branches.
 // This is similar to code in Compiler::fgTableDispBasicBlock(), but doesn't have that code's requirements to align
 // things strictly.
-void BasicBlock::dspJumpKind()
+void BasicBlock::dspKind()
 {
     switch (bbKind)
     {
@@ -792,7 +792,7 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
     dspBlockILRange();
     if (showKind)
     {
-        dspJumpKind();
+        dspKind();
     }
     if (showPreds)
     {
@@ -1592,15 +1592,15 @@ BasicBlock* BasicBlock::New(Compiler* compiler)
     return block;
 }
 
-BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds jumpKind, BasicBlock* jumpDest /* = nullptr */)
+BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, BasicBlock* target /* = nullptr */)
 {
     BasicBlock* block = BasicBlock::New(compiler);
 
     // In some cases, we don't know a block's jump target during initialization, so don't check the jump kind/target
     // yet.
     // The checks will be done any time the jump kind/target is read or written to after initialization.
-    block->bbKind = jumpKind;
-    block->bbTarget = jumpDest;
+    block->bbKind = kind;
+    block->bbTarget = target;
 
     if (block->KindIs(BBJ_THROW))
     {
@@ -1610,19 +1610,19 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds jumpKind, BasicBlock* ju
     return block;
 }
 
-BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* jumpSwt)
+BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* swtTarget)
 {
     BasicBlock* block = BasicBlock::New(compiler);
     block->bbKind = BBJ_SWITCH;
-    block->bbSwtTarget  = jumpSwt;
+    block->bbSwtTarget  = swtTarget;
     return block;
 }
 
-BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds jumpKind, unsigned jumpOffs)
+BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds kind, unsigned targetOffs)
 {
     BasicBlock* block = BasicBlock::New(compiler);
-    block->bbKind = jumpKind;
-    block->bbTargetOffs = jumpOffs;
+    block->bbKind = kind;
+    block->bbTargetOffs = targetOffs;
     return block;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1112,7 +1112,7 @@ bool BasicBlock::bbFallsThrough() const
             return false;
 
         case BBJ_COND:
-            return NextIs(GetNormalJumpDest());
+            return NextIs(GetFalseTarget());
 
         case BBJ_CALLFINALLY:
             return !HasFlag(BBF_RETLESS_CALL);

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -297,7 +297,7 @@ bool BasicBlock::IsFirstColdBlock(Compiler* compiler) const
 bool BasicBlock::CanRemoveJumpToNext(Compiler* compiler)
 {
     assert(KindIs(BBJ_ALWAYS));
-    return JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbJumpDest);
+    return JumpsToNext() && !hasAlign() && !compiler->fgInDifferentRegions(this, bbTarget);
 }
 
 //------------------------------------------------------------------------
@@ -711,11 +711,11 @@ void BasicBlock::dspJumpKind()
             break;
 
         case BBJ_EHFILTERRET:
-            printf(" -> " FMT_BB " (fltret)", bbJumpDest->bbNum);
+            printf(" -> " FMT_BB " (fltret)", bbTarget->bbNum);
             break;
 
         case BBJ_EHCATCHRET:
-            printf(" -> " FMT_BB " (cret)", bbJumpDest->bbNum);
+            printf(" -> " FMT_BB " (cret)", bbTarget->bbNum);
             break;
 
         case BBJ_THROW:
@@ -729,24 +729,24 @@ void BasicBlock::dspJumpKind()
         case BBJ_ALWAYS:
             if (HasFlag(BBF_KEEP_BBJ_ALWAYS))
             {
-                printf(" -> " FMT_BB " (ALWAYS)", bbJumpDest->bbNum);
+                printf(" -> " FMT_BB " (ALWAYS)", bbTarget->bbNum);
             }
             else
             {
-                printf(" -> " FMT_BB " (always)", bbJumpDest->bbNum);
+                printf(" -> " FMT_BB " (always)", bbTarget->bbNum);
             }
             break;
 
         case BBJ_LEAVE:
-            printf(" -> " FMT_BB " (leave)", bbJumpDest->bbNum);
+            printf(" -> " FMT_BB " (leave)", bbTarget->bbNum);
             break;
 
         case BBJ_CALLFINALLY:
-            printf(" -> " FMT_BB " (callf)", bbJumpDest->bbNum);
+            printf(" -> " FMT_BB " (callf)", bbTarget->bbNum);
             break;
 
         case BBJ_COND:
-            printf(" -> " FMT_BB " (cond)", bbJumpDest->bbNum);
+            printf(" -> " FMT_BB " (cond)", bbTarget->bbNum);
             break;
 
         case BBJ_SWITCH:
@@ -993,7 +993,7 @@ BasicBlock* BasicBlock::GetUniquePred(Compiler* compiler) const
 //
 BasicBlock* BasicBlock::GetUniqueSucc() const
 {
-    return KindIs(BBJ_ALWAYS) ? bbJumpDest : nullptr;
+    return KindIs(BBJ_ALWAYS) ? bbTarget : nullptr;
 }
 
 // Static vars.
@@ -1149,7 +1149,7 @@ unsigned BasicBlock::NumSucc() const
             return 1;
 
         case BBJ_COND:
-            if (bbJumpDest == bbNext)
+            if (bbTarget == bbNext)
             {
                 return 1;
             }
@@ -1202,7 +1202,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
-            return bbJumpDest;
+            return bbTarget;
 
         case BBJ_COND:
             if (i == 0)
@@ -1212,8 +1212,8 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
             else
             {
                 assert(i == 1);
-                assert(bbNext != bbJumpDest);
-                return bbJumpDest;
+                assert(bbNext != bbTarget);
+                return bbTarget;
             }
 
         case BBJ_EHFINALLYRET:
@@ -1272,7 +1272,7 @@ unsigned BasicBlock::NumSucc(Compiler* comp)
             return 1;
 
         case BBJ_COND:
-            if (bbJumpDest == bbNext)
+            if (bbTarget == bbNext)
             {
                 return 1;
             }
@@ -1311,8 +1311,8 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
     {
         case BBJ_EHFILTERRET:
             // Handler is the (sole) normal successor of the filter.
-            assert(comp->fgFirstBlockOfHandler(this) == bbJumpDest);
-            return bbJumpDest;
+            assert(comp->fgFirstBlockOfHandler(this) == bbTarget);
+            return bbTarget;
 
         case BBJ_EHFINALLYRET:
             assert(bbJumpEhf != nullptr);
@@ -1323,7 +1323,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
         case BBJ_LEAVE:
-            return bbJumpDest;
+            return bbTarget;
 
         case BBJ_COND:
             if (i == 0)
@@ -1333,8 +1333,8 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
             else
             {
                 assert(i == 1);
-                assert(bbNext != bbJumpDest);
-                return bbJumpDest;
+                assert(bbNext != bbTarget);
+                return bbTarget;
             }
 
         case BBJ_SWITCH:
@@ -1600,7 +1600,7 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBjumpKinds jumpKind, BasicBlock
     // yet.
     // The checks will be done any time the jump kind/target is read or written to after initialization.
     block->bbJumpKind = jumpKind;
-    block->bbJumpDest = jumpDest;
+    block->bbTarget = jumpDest;
 
     if (block->KindIs(BBJ_THROW))
     {

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1112,7 +1112,7 @@ bool BasicBlock::bbFallsThrough() const
             return false;
 
         case BBJ_COND:
-            return true;
+            return NextIs(GetNormalJumpDest());
 
         case BBJ_CALLFINALLY:
             return !HasFlag(BBF_RETLESS_CALL);

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -660,7 +660,7 @@ void BasicBlock::dspSuccs(Compiler* compiler)
         while (iter.NextElem(&bbNum))
         {
             // Note that we will output switch successors in increasing numerical bbNum order, which is
-            // not related to their order in the bbJumpSwt->bbsDstTab table.
+            // not related to their order in the bbSwtTarget->bbsDstTab table.
             printf("%s" FMT_BB, first ? "" : ",", bbNum);
             first = false;
         }
@@ -753,23 +753,23 @@ void BasicBlock::dspJumpKind()
         {
             printf(" ->");
 
-            const unsigned     jumpCnt = bbJumpSwt->bbsCount;
-            BasicBlock** const jumpTab = bbJumpSwt->bbsDstTab;
+            const unsigned     jumpCnt = bbSwtTarget->bbsCount;
+            BasicBlock** const jumpTab = bbSwtTarget->bbsDstTab;
 
             for (unsigned i = 0; i < jumpCnt; i++)
             {
                 printf("%c" FMT_BB, (i == 0) ? ' ' : ',', jumpTab[i]->bbNum);
 
-                const bool isDefault = bbJumpSwt->bbsHasDefault && (i == jumpCnt - 1);
+                const bool isDefault = bbSwtTarget->bbsHasDefault && (i == jumpCnt - 1);
                 if (isDefault)
                 {
                     printf("[def]");
                 }
 
-                const bool isDominant = bbJumpSwt->bbsHasDominantCase && (i == bbJumpSwt->bbsDominantCase);
+                const bool isDominant = bbSwtTarget->bbsHasDominantCase && (i == bbSwtTarget->bbsDominantCase);
                 if (isDominant)
                 {
-                    printf("[dom(" FMT_WT ")]", bbJumpSwt->bbsDominantFraction);
+                    printf("[dom(" FMT_WT ")]", bbSwtTarget->bbsDominantFraction);
                 }
             }
 
@@ -1176,7 +1176,7 @@ unsigned BasicBlock::NumSucc() const
             return bbJumpEhf->bbeCount;
 
         case BBJ_SWITCH:
-            return bbJumpSwt->bbsCount;
+            return bbSwtTarget->bbsCount;
 
         default:
             unreached();
@@ -1220,7 +1220,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
             return bbJumpEhf->bbeSuccs[i];
 
         case BBJ_SWITCH:
-            return bbJumpSwt->bbsDstTab[i];
+            return bbSwtTarget->bbsDstTab[i];
 
         default:
             unreached();
@@ -1614,7 +1614,7 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBswtDesc* jumpSwt)
 {
     BasicBlock* block = BasicBlock::New(compiler);
     block->bbKind = BBJ_SWITCH;
-    block->bbJumpSwt  = jumpSwt;
+    block->bbSwtTarget  = jumpSwt;
     return block;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -687,14 +687,14 @@ void BasicBlock::dspKind()
             printf(" ->");
 
             // Early in compilation, we display the jump kind before the BBJ_EHFINALLYRET successors have been set.
-            if (bbEhfTarget == nullptr)
+            if (bbEhfTargets == nullptr)
             {
                 printf(" ????");
             }
             else
             {
-                const unsigned     jumpCnt = bbEhfTarget->bbeCount;
-                BasicBlock** const jumpTab = bbEhfTarget->bbeSuccs;
+                const unsigned     jumpCnt = bbEhfTargets->bbeCount;
+                BasicBlock** const jumpTab = bbEhfTargets->bbeSuccs;
 
                 for (unsigned i = 0; i < jumpCnt; i++)
                 {
@@ -1168,12 +1168,12 @@ unsigned BasicBlock::NumSucc() const
 
             // We may call this before we've computed the BBJ_EHFINALLYRET successors in the importer. Tolerate.
             //
-            if (bbEhfTarget == nullptr)
+            if (bbEhfTargets == nullptr)
             {
                 return 0;
             }
 
-            return bbEhfTarget->bbeCount;
+            return bbEhfTargets->bbeCount;
 
         case BBJ_SWITCH:
             return bbSwtTargets->bbsCount;
@@ -1217,7 +1217,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
             }
 
         case BBJ_EHFINALLYRET:
-            return bbEhfTarget->bbeSuccs[i];
+            return bbEhfTargets->bbeSuccs[i];
 
         case BBJ_SWITCH:
             return bbSwtTargets->bbsDstTab[i];
@@ -1257,12 +1257,12 @@ unsigned BasicBlock::NumSucc(Compiler* comp)
 
             // We may call this before we've computed the BBJ_EHFINALLYRET successors in the importer. Tolerate.
             //
-            if (bbEhfTarget == nullptr)
+            if (bbEhfTargets == nullptr)
             {
                 return 0;
             }
 
-            return bbEhfTarget->bbeCount;
+            return bbEhfTargets->bbeCount;
 
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:
@@ -1315,9 +1315,9 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
             return bbTarget;
 
         case BBJ_EHFINALLYRET:
-            assert(bbEhfTarget != nullptr);
-            assert(i < bbEhfTarget->bbeCount);
-            return bbEhfTarget->bbeSuccs[i];
+            assert(bbEhfTargets != nullptr);
+            assert(i < bbEhfTargets->bbeCount);
+            return bbEhfTargets->bbeSuccs[i];
 
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -1622,7 +1622,7 @@ BasicBlock* BasicBlock::New(Compiler* compiler, BBKinds jumpKind, unsigned jumpO
 {
     BasicBlock* block = BasicBlock::New(compiler);
     block->bbKind = jumpKind;
-    block->bbJumpOffs = jumpOffs;
+    block->bbTargetOffs = jumpOffs;
     return block;
 }
 

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -687,14 +687,14 @@ void BasicBlock::dspJumpKind()
             printf(" ->");
 
             // Early in compilation, we display the jump kind before the BBJ_EHFINALLYRET successors have been set.
-            if (bbJumpEhf == nullptr)
+            if (bbEhfTarget == nullptr)
             {
                 printf(" ????");
             }
             else
             {
-                const unsigned     jumpCnt = bbJumpEhf->bbeCount;
-                BasicBlock** const jumpTab = bbJumpEhf->bbeSuccs;
+                const unsigned     jumpCnt = bbEhfTarget->bbeCount;
+                BasicBlock** const jumpTab = bbEhfTarget->bbeSuccs;
 
                 for (unsigned i = 0; i < jumpCnt; i++)
                 {
@@ -1168,12 +1168,12 @@ unsigned BasicBlock::NumSucc() const
 
             // We may call this before we've computed the BBJ_EHFINALLYRET successors in the importer. Tolerate.
             //
-            if (bbJumpEhf == nullptr)
+            if (bbEhfTarget == nullptr)
             {
                 return 0;
             }
 
-            return bbJumpEhf->bbeCount;
+            return bbEhfTarget->bbeCount;
 
         case BBJ_SWITCH:
             return bbSwtTarget->bbsCount;
@@ -1217,7 +1217,7 @@ BasicBlock* BasicBlock::GetSucc(unsigned i) const
             }
 
         case BBJ_EHFINALLYRET:
-            return bbJumpEhf->bbeSuccs[i];
+            return bbEhfTarget->bbeSuccs[i];
 
         case BBJ_SWITCH:
             return bbSwtTarget->bbsDstTab[i];
@@ -1257,12 +1257,12 @@ unsigned BasicBlock::NumSucc(Compiler* comp)
 
             // We may call this before we've computed the BBJ_EHFINALLYRET successors in the importer. Tolerate.
             //
-            if (bbJumpEhf == nullptr)
+            if (bbEhfTarget == nullptr)
             {
                 return 0;
             }
 
-            return bbJumpEhf->bbeCount;
+            return bbEhfTarget->bbeCount;
 
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:
@@ -1315,9 +1315,9 @@ BasicBlock* BasicBlock::GetSucc(unsigned i, Compiler* comp)
             return bbTarget;
 
         case BBJ_EHFINALLYRET:
-            assert(bbJumpEhf != nullptr);
-            assert(i < bbJumpEhf->bbeCount);
-            return bbJumpEhf->bbeSuccs[i];
+            assert(bbEhfTarget != nullptr);
+            assert(i < bbEhfTarget->bbeCount);
+            return bbEhfTarget->bbeSuccs[i];
 
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -757,7 +757,7 @@ public:
         bbSwtTarget = swtTarget;
     }
 
-    BBehfDesc* GetEhfTarget() const
+    BBehfDesc* GetEhfTargets() const
     {
         assert(KindIs(BBJ_EHFINALLYRET));
         return bbEhfTarget;
@@ -1945,15 +1945,15 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
             // We don't use the m_succs in-line data; use the existing successor table in the block.
             // We must tolerate iterating successors early in the system, before EH_FINALLYRET successors have
             // been computed.
-            if (block->GetEhfTarget() == nullptr)
+            if (block->GetEhfTargets() == nullptr)
             {
                 m_begin = nullptr;
                 m_end   = nullptr;
             }
             else
             {
-                m_begin = block->GetEhfTarget()->bbeSuccs;
-                m_end   = block->GetEhfTarget()->bbeSuccs + block->GetEhfTarget()->bbeCount;
+                m_begin = block->GetEhfTargets()->bbeSuccs;
+                m_end   = block->GetEhfTargets()->bbeSuccs + block->GetEhfTargets()->bbeCount;
             }
             break;
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -699,8 +699,8 @@ public:
     bool FalseTargetIs(const BasicBlock* target) const
     {
         assert(KindIs(BBJ_COND));
-        assert(target != nullptr);
         assert(bbFalseTarget != nullptr);
+        assert(target != nullptr);
         return (bbFalseTarget == target);
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -743,7 +743,7 @@ public:
         return (bbTarget == bbNext);
     }
 
-    BBswtDesc* GetSwitchTarget() const
+    BBswtDesc* GetSwitchTargets() const
     {
         assert(KindIs(BBJ_SWITCH));
         assert(bbSwtTarget != nullptr);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -769,7 +769,7 @@ public:
         bbEhfTarget = ehfTarget;
     }
 
-    void SetEhfKindAndTarget(BBehfDesc* ehfTarget)
+    void SetEhf(BBehfDesc* ehfTarget)
     {
         assert(ehfTarget != nullptr);
         bbKind      = BBJ_EHFINALLYRET;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -743,7 +743,7 @@ public:
         return (bbTarget == bbNext);
     }
 
-    BBswtDesc* GetSwtTarget() const
+    BBswtDesc* GetSwitchTarget() const
     {
         assert(KindIs(BBJ_SWITCH));
         assert(bbSwtTarget != nullptr);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -529,7 +529,7 @@ private:
         unsigned    bbTargetOffs; // PC offset (temporary only)
         BasicBlock* bbTarget; // basic block
         BBswtDesc*  bbSwtTarget;  // switch descriptor
-        BBehfDesc*  bbJumpEhf;  // BBJ_EHFINALLYRET descriptor
+        BBehfDesc*  bbEhfTarget;  // BBJ_EHFINALLYRET descriptor
     };
 
     // Points to the successor of a BBJ_COND block if bbTarget is not taken
@@ -716,24 +716,24 @@ public:
         bbSwtTarget  = swtTarget;
     }
 
-    BBehfDesc* GetJumpEhf() const
+    BBehfDesc* GetEhfTarget() const
     {
         assert(KindIs(BBJ_EHFINALLYRET));
-        return bbJumpEhf;
+        return bbEhfTarget;
     }
 
-    void SetJumpEhf(BBehfDesc* jumpEhf)
+    void SetEhfTarget(BBehfDesc* ehfTarget)
     {
         assert(KindIs(BBJ_EHFINALLYRET));
-        bbJumpEhf = jumpEhf;
+        bbEhfTarget = ehfTarget;
     }
 
-    void SetKindAndTarget(BBKinds kind, BBehfDesc* ehf)
+    void SetKindAndTarget(BBKinds kind, BBehfDesc* ehfTarget)
     {
         assert(kind == BBJ_EHFINALLYRET);
-        assert(ehf != nullptr);
+        assert(ehfTarget != nullptr);
         bbKind = kind;
-        bbJumpEhf  = ehf;
+        bbEhfTarget  = ehfTarget;
     }
 
 private:
@@ -1043,7 +1043,7 @@ public:
     BBEhfSuccList EHFinallyRetSuccs() const
     {
         assert(bbKind == BBJ_EHFINALLYRET);
-        return BBEhfSuccList(bbJumpEhf);
+        return BBEhfSuccList(bbEhfTarget);
     }
 
     BasicBlock* GetUniquePred(Compiler* comp) const;
@@ -1905,15 +1905,15 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
             // We don't use the m_succs in-line data; use the existing successor table in the block.
             // We must tolerate iterating successors early in the system, before EH_FINALLYRET successors have
             // been computed.
-            if (block->GetJumpEhf() == nullptr)
+            if (block->GetEhfTarget() == nullptr)
             {
                 m_begin = nullptr;
                 m_end   = nullptr;
             }
             else
             {
-                m_begin = block->GetJumpEhf()->bbeSuccs;
-                m_end   = block->GetJumpEhf()->bbeSuccs + block->GetJumpEhf()->bbeCount;
+                m_begin = block->GetEhfTarget()->bbeSuccs;
+                m_end   = block->GetEhfTarget()->bbeSuccs + block->GetEhfTarget()->bbeCount;
             }
             break;
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -526,7 +526,7 @@ private:
 
     /* The following union describes the jump target(s) of this block */
     union {
-        unsigned    bbJumpOffs; // PC offset (temporary only)
+        unsigned    bbTargetOffs; // PC offset (temporary only)
         BasicBlock* bbTarget; // basic block
         BBswtDesc*  bbJumpSwt;  // switch descriptor
         BBehfDesc*  bbJumpEhf;  // BBJ_EHFINALLYRET descriptor
@@ -615,15 +615,15 @@ public:
 
     bool CanRemoveJumpToNext(Compiler* compiler);
 
-    unsigned GetJumpOffs() const
+    unsigned GetTargetOffs() const
     {
-        return bbJumpOffs;
+        return bbTargetOffs;
     }
 
-    void SetKindAndTarget(BBKinds kind, unsigned offs)
+    void SetKindAndTarget(BBKinds kind, unsigned targetOffs)
     {
         bbKind = kind;
-        bbJumpOffs = offs;
+        bbTargetOffs = targetOffs;
         assert(KindIs(BBJ_ALWAYS, BBJ_COND, BBJ_LEAVE));
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -740,7 +740,7 @@ public:
         return bbSwtTarget;
     }
 
-    void SetKindAndTarget(BBswtDesc* swtTarget)
+    void SetSwtKindAndTarget(BBswtDesc* swtTarget)
     {
         assert(swtTarget != nullptr);
         bbKind      = BBJ_SWITCH;
@@ -759,11 +759,10 @@ public:
         bbEhfTarget = ehfTarget;
     }
 
-    void SetKindAndTarget(BBKinds kind, BBehfDesc* ehfTarget)
+    void SetEhfKindAndTarget(BBehfDesc* ehfTarget)
     {
-        assert(kind == BBJ_EHFINALLYRET);
         assert(ehfTarget != nullptr);
-        bbKind      = kind;
+        bbKind      = BBJ_EHFINALLYRET;
         bbEhfTarget = ehfTarget;
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -750,7 +750,7 @@ public:
         return bbSwtTarget;
     }
 
-    void SetSwtKindAndTarget(BBswtDesc* swtTarget)
+    void SetSwitch(BBswtDesc* swtTarget)
     {
         assert(swtTarget != nullptr);
         bbKind      = BBJ_SWITCH;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -533,7 +533,7 @@ private:
     };
 
     // Points to the successor of a BBJ_COND block if bbJumpDest is not taken
-    BasicBlock* bbNormalJumpDest;
+    BasicBlock* bbFalseTarget;
 
 public:
     static BasicBlock* New(Compiler* compiler);
@@ -582,11 +582,11 @@ public:
             next->bbPrev = this;
         }
 
-        // BBJ_COND convenience: This ensures bbNormalJumpDest is always consistent with bbNext.
+        // BBJ_COND convenience: This ensures bbFalseTarget is always consistent with bbNext.
         // For now, if a BBJ_COND's bbJumpDest is not taken, we expect to fall through,
-        // so bbNormalJumpDest must be the next block.
-        // TODO-NoFallThrough: Remove this once we allow bbNormalJumpDest to diverge from bbNext
-        bbNormalJumpDest = next;
+        // so bbFalseTarget must be the next block.
+        // TODO-NoFallThrough: Remove this once we allow bbFalseTarget to diverge from bbNext
+        bbFalseTarget = next;
     }
 
     bool IsFirst() const
@@ -648,31 +648,31 @@ public:
         assert(!HasJumpDest() || HasInitializedJumpDest());
     }
 
-    BasicBlock* GetNormalJumpDest() const
+    BasicBlock* GetFalseTarget() const
     {
         assert(KindIs(BBJ_COND));
 
-        // So long as bbNormalJumpDest tracks bbNext in SetNext(), it is possible for bbNormalJumpDest to be null
+        // So long as bbFalseTarget tracks bbNext in SetNext(), it is possible for bbFalseTarget to be null
         // if this block is unlinked from the block list.
-        // So check bbNext before triggering the assert if bbNormalJumpDest is null.
-        // TODO-NoFallThrough: Remove IsLast() check once bbNormalJumpDest isn't hard-coded to bbNext
-        assert((bbNormalJumpDest != nullptr) || IsLast());
-        return bbNormalJumpDest;
+        // So check bbNext before triggering the assert if bbFalseTarget is null.
+        // TODO-NoFallThrough: Remove IsLast() check once bbFalseTarget isn't hard-coded to bbNext
+        assert((bbFalseTarget != nullptr) || IsLast());
+        return bbFalseTarget;
     }
 
-    void SetNormalJumpDest(BasicBlock* jumpDest)
+    void SetFalseTarget(BasicBlock* jumpDest)
     {
         assert(KindIs(BBJ_COND));
         assert(jumpDest != nullptr);
-        bbNormalJumpDest = jumpDest;
+        bbFalseTarget = jumpDest;
     }
 
-    bool HasNormalJumpTo(BasicBlock* jumpDest) const
+    bool FalseTargetIs(BasicBlock* jumpDest) const
     {
         assert(KindIs(BBJ_COND));
         assert(jumpDest != nullptr);
-        assert(bbNormalJumpDest != nullptr);
-        return (bbNormalJumpDest == jumpDest);
+        assert(bbFalseTarget != nullptr);
+        return (bbFalseTarget == jumpDest);
     }
 
     void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -577,12 +577,17 @@ public:
     void SetNext(BasicBlock* next)
     {
         // TODO: remove
-        bbNormalJumpDest = next;
         bbNext = next;
         if (next)
         {
             next->bbPrev = this;
         }
+
+        // BBJ_COND convenience: This ensures bbNormalJumpDest is always consistent with bbNext.
+        // For now, if a BBJ_COND's bbJumpDest is not taken, we expect to fall through,
+        // so bbNormalJumpDest must be the next block.
+        // TODO: Remove this once we allow bbNormalJumpDest to diverge from bbNext
+        bbNormalJumpDest = next;
     }
 
     bool IsFirst() const
@@ -670,6 +675,12 @@ public:
     {
         bbJumpKind = jumpKind;
         bbJumpDest = jumpDest;
+
+        // BBJ_COND convenience: We might be setting this block's jump kind to BBJ_COND.
+        // In that case, set bbNormalJumpDest to bbNext to ensure they are consistent after setting the jump kind.
+        // TODO: Allow bbNormalJumpDest to diverge from bbNext
+        // assert(!IsLast());
+        // bbNormalJumpDest = bbNext;
 
         // If bbJumpKind indicates this block has a jump, bbJumpDest cannot be null
         assert(!HasJumpDest() || HasInitializedJumpDest());

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -669,7 +669,7 @@ public:
         bbTrueTarget = target;
     }
 
-    bool TrueTargetIs(BasicBlock* target) const
+    bool TrueTargetIs(const BasicBlock* target) const
     {
         assert(KindIs(BBJ_COND));
         assert(HasInitializedTarget());
@@ -696,7 +696,7 @@ public:
         bbFalseTarget = target;
     }
 
-    bool FalseTargetIs(BasicBlock* target) const
+    bool FalseTargetIs(const BasicBlock* target) const
     {
         assert(KindIs(BBJ_COND));
         assert(target != nullptr);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -658,6 +658,14 @@ public:
         bbNormalJumpDest = jumpDest;
     }
 
+    bool HasNormalJumpTo(BasicBlock* jumpDest) const
+    {
+        assert(KindIs(BBJ_COND));
+        assert(jumpDest != nullptr);
+        assert(bbNormalJumpDest != nullptr);
+        return (bbNormalJumpDest == jumpDest);
+    }
+
     void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)
     {
         bbJumpKind = jumpKind;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -704,7 +704,7 @@ public:
         return (bbFalseTarget == target);
     }
 
-    void SetCondKindAndTarget(BasicBlock* target)
+    void SetCond(BasicBlock* target)
     {
         assert(target != nullptr);
         bbKind       = BBJ_COND;
@@ -713,7 +713,7 @@ public:
 
     void SetKindAndTarget(BBKinds kind, BasicBlock* target = nullptr)
     {
-        // To set BBJ_COND, use SetCondKindAndTarget
+        // To set BBJ_COND, use SetCond
         assert(kind != BBJ_COND);
 
         bbKind   = kind;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -537,9 +537,9 @@ private:
 
 public:
     static BasicBlock* New(Compiler* compiler);
-    static BasicBlock* New(Compiler* compiler, BBKinds jumpKind, BasicBlock* jumpDest = nullptr);
-    static BasicBlock* New(Compiler* compiler, BBswtDesc* jumpSwt);
-    static BasicBlock* New(Compiler* compiler, BBKinds jumpKind, unsigned jumpOffs);
+    static BasicBlock* New(Compiler* compiler, BBKinds kind, BasicBlock* target = nullptr);
+    static BasicBlock* New(Compiler* compiler, BBswtDesc* swtTarget);
+    static BasicBlock* New(Compiler* compiler, BBKinds kind, unsigned targetOffs);
 
     BBKinds GetKind() const
     {
@@ -660,19 +660,19 @@ public:
         return bbFalseTarget;
     }
 
-    void SetFalseTarget(BasicBlock* jumpDest)
+    void SetFalseTarget(BasicBlock* target)
     {
         assert(KindIs(BBJ_COND));
-        assert(jumpDest != nullptr);
-        bbFalseTarget = jumpDest;
+        assert(target != nullptr);
+        bbFalseTarget = target;
     }
 
-    bool FalseTargetIs(BasicBlock* jumpDest) const
+    bool FalseTargetIs(BasicBlock* target) const
     {
         assert(KindIs(BBJ_COND));
-        assert(jumpDest != nullptr);
+        assert(target != nullptr);
         assert(bbFalseTarget != nullptr);
-        return (bbFalseTarget == jumpDest);
+        return (bbFalseTarget == target);
     }
 
     void SetKindAndTarget(BBKinds kind, BasicBlock* target = nullptr)
@@ -690,10 +690,10 @@ public:
         return (bbTarget != nullptr);
     }
 
-    bool TargetIs(const BasicBlock* jumpDest) const
+    bool TargetIs(const BasicBlock* target) const
     {
         assert(HasInitializedTarget());
-        return (bbTarget == jumpDest);
+        return (bbTarget == target);
     }
 
     bool JumpsToNext() const
@@ -842,7 +842,7 @@ public:
     unsigned dspPreds();               // Print the predecessors (bbPreds)
     void dspSuccs(Compiler* compiler); // Print the successors. The 'compiler' argument determines whether EH
                                        // regions are printed: see NumSucc() for details.
-    void dspJumpKind();                // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
+    void dspKind();                // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
 
     // Print a simple basic block header for various output, including a list of predecessors and successors.
     void dspBlockHeader(Compiler* compiler, bool showKind = true, bool showFlags = false, bool showPreds = true);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -647,7 +647,7 @@ public:
     BasicBlock* GetNormalJumpDest() const
     {
         assert(KindIs(BBJ_COND));
-        assert(bbNormalJumpDest != nullptr);
+        assert((bbNormalJumpDest != nullptr) || IsLast());
         return bbNormalJumpDest;
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1916,7 +1916,7 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
             break;
 
         case BBJ_COND:
-            m_succs[0] = block->bbNext;
+            m_succs[0] = block->bbFalseTarget;
             m_begin    = &m_succs[0];
 
             // If both fall-through and branch successors are identical, then only include
@@ -1927,7 +1927,7 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
             }
             else
             {
-                m_succs[1] = block->bbTarget;
+                m_succs[1] = block->bbTrueTarget;
                 m_end      = &m_succs[2];
             }
             break;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -690,7 +690,7 @@ public:
         return (bbTarget != nullptr);
     }
 
-    bool HasJumpTo(const BasicBlock* jumpDest) const
+    bool TargetIs(const BasicBlock* jumpDest) const
     {
         assert(HasInitializedTarget());
         return (bbTarget == jumpDest);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -528,7 +528,7 @@ private:
     union {
         unsigned    bbTargetOffs; // PC offset (temporary only)
         BasicBlock* bbTarget; // basic block
-        BBswtDesc*  bbJumpSwt;  // switch descriptor
+        BBswtDesc*  bbSwtTarget;  // switch descriptor
         BBehfDesc*  bbJumpEhf;  // BBJ_EHFINALLYRET descriptor
     };
 
@@ -702,18 +702,18 @@ public:
         return (bbTarget == bbNext);
     }
 
-    BBswtDesc* GetJumpSwt() const
+    BBswtDesc* GetSwtTarget() const
     {
         assert(KindIs(BBJ_SWITCH));
-        assert(bbJumpSwt != nullptr);
-        return bbJumpSwt;
+        assert(bbSwtTarget != nullptr);
+        return bbSwtTarget;
     }
 
-    void SetKindAndTarget(BBswtDesc* swt)
+    void SetKindAndTarget(BBswtDesc* swtTarget)
     {
-        assert(swt != nullptr);
+        assert(swtTarget != nullptr);
         bbKind = BBJ_SWITCH;
-        bbJumpSwt  = swt;
+        bbSwtTarget  = swtTarget;
     }
 
     BBehfDesc* GetJumpEhf() const
@@ -1033,7 +1033,7 @@ public:
     BBSwitchTargetList SwitchTargets() const
     {
         assert(bbKind == BBJ_SWITCH);
-        return BBSwitchTargetList(bbJumpSwt);
+        return BBSwitchTargetList(bbSwtTarget);
     }
 
     // EHFinallyRetSuccs: convenience method for enabling range-based `for` iteration over BBJ_EHFINALLYRET block
@@ -1919,10 +1919,10 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
 
         case BBJ_SWITCH:
             // We don't use the m_succs in-line data for switches; use the existing jump table in the block.
-            assert(block->bbJumpSwt != nullptr);
-            assert(block->bbJumpSwt->bbsDstTab != nullptr);
-            m_begin = block->bbJumpSwt->bbsDstTab;
-            m_end   = block->bbJumpSwt->bbsDstTab + block->bbJumpSwt->bbsCount;
+            assert(block->bbSwtTarget != nullptr);
+            assert(block->bbSwtTarget->bbsDstTab != nullptr);
+            m_begin = block->bbSwtTarget->bbsDstTab;
+            m_end   = block->bbSwtTarget->bbsDstTab + block->bbSwtTarget->bbsCount;
             break;
 
         default:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -527,7 +527,7 @@ private:
     /* The following union describes the jump target(s) of this block */
     union {
         unsigned    bbTargetOffs; // PC offset (temporary only)
-        BasicBlock* bbTarget; // basic block
+        BasicBlock* bbTarget;     // basic block
         BasicBlock* bbTrueTarget; // BBJ_COND jump target when its condition is true (alias for bbTarget)
         BBswtDesc*  bbSwtTarget;  // switch descriptor
         BBehfDesc*  bbEhfTarget;  // BBJ_EHFINALLYRET descriptor
@@ -623,7 +623,7 @@ public:
 
     void SetKindAndTarget(BBKinds kind, unsigned targetOffs)
     {
-        bbKind = kind;
+        bbKind       = kind;
         bbTargetOffs = targetOffs;
         assert(KindIs(BBJ_ALWAYS, BBJ_COND, BBJ_LEAVE));
     }
@@ -666,7 +666,7 @@ public:
     {
         assert(KindIs(BBJ_COND));
         assert(target != nullptr);
-        bbTrueTarget = target;        
+        bbTrueTarget = target;
     }
 
     bool TrueTargetIs(BasicBlock* target) const
@@ -706,7 +706,7 @@ public:
 
     void SetKindAndTarget(BBKinds kind, BasicBlock* target = nullptr)
     {
-        bbKind = kind;
+        bbKind   = kind;
         bbTarget = target;
 
         // If bbKind indicates this block has a jump, bbTarget cannot be null
@@ -743,8 +743,8 @@ public:
     void SetKindAndTarget(BBswtDesc* swtTarget)
     {
         assert(swtTarget != nullptr);
-        bbKind = BBJ_SWITCH;
-        bbSwtTarget  = swtTarget;
+        bbKind      = BBJ_SWITCH;
+        bbSwtTarget = swtTarget;
     }
 
     BBehfDesc* GetEhfTarget() const
@@ -763,8 +763,8 @@ public:
     {
         assert(kind == BBJ_EHFINALLYRET);
         assert(ehfTarget != nullptr);
-        bbKind = kind;
-        bbEhfTarget  = ehfTarget;
+        bbKind      = kind;
+        bbEhfTarget = ehfTarget;
     }
 
 private:
@@ -873,7 +873,7 @@ public:
     unsigned dspPreds();               // Print the predecessors (bbPreds)
     void dspSuccs(Compiler* compiler); // Print the successors. The 'compiler' argument determines whether EH
                                        // regions are printed: see NumSucc() for details.
-    void dspKind();                // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
+    void dspKind();                    // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
 
     // Print a simple basic block header for various output, including a list of predecessors and successors.
     void dspBlockHeader(Compiler* compiler, bool showKind = true, bool showFlags = false, bool showPreds = true);

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -704,8 +704,18 @@ public:
         return (bbFalseTarget == target);
     }
 
+    void SetCondKindAndTarget(BasicBlock* target)
+    {
+        assert(target != nullptr);
+        bbKind       = BBJ_COND;
+        bbTrueTarget = target;
+    }
+
     void SetKindAndTarget(BBKinds kind, BasicBlock* target = nullptr)
     {
+        // To set BBJ_COND, use SetCondKindAndTarget
+        assert(kind != BBJ_COND);
+
         bbKind   = kind;
         bbTarget = target;
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -576,7 +576,6 @@ public:
 
     void SetNext(BasicBlock* next)
     {
-        // TODO: remove
         bbNext = next;
         if (next)
         {
@@ -586,7 +585,7 @@ public:
         // BBJ_COND convenience: This ensures bbNormalJumpDest is always consistent with bbNext.
         // For now, if a BBJ_COND's bbJumpDest is not taken, we expect to fall through,
         // so bbNormalJumpDest must be the next block.
-        // TODO: Remove this once we allow bbNormalJumpDest to diverge from bbNext
+        // TODO-NoFallThrough: Remove this once we allow bbNormalJumpDest to diverge from bbNext
         bbNormalJumpDest = next;
     }
 
@@ -675,12 +674,6 @@ public:
     {
         bbJumpKind = jumpKind;
         bbJumpDest = jumpDest;
-
-        // BBJ_COND convenience: We might be setting this block's jump kind to BBJ_COND.
-        // In that case, set bbNormalJumpDest to bbNext to ensure they are consistent after setting the jump kind.
-        // TODO: Allow bbNormalJumpDest to diverge from bbNext
-        // assert(!IsLast());
-        // bbNormalJumpDest = bbNext;
 
         // If bbJumpKind indicates this block has a jump, bbJumpDest cannot be null
         assert(!HasJumpDest() || HasInitializedJumpDest());

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -532,6 +532,9 @@ private:
         BBehfDesc*  bbJumpEhf;  // BBJ_EHFINALLYRET descriptor
     };
 
+    // Points to the successor of a BBJ_COND block if bbJumpDest is not taken
+    BasicBlock* bbNormalJumpDest;
+
 public:
     static BasicBlock* New(Compiler* compiler);
     static BasicBlock* New(Compiler* compiler, BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr);
@@ -573,6 +576,8 @@ public:
 
     void SetNext(BasicBlock* next)
     {
+        // TODO: remove
+        bbNormalJumpDest = next;
         bbNext = next;
         if (next)
         {
@@ -637,6 +642,20 @@ public:
         // so don't use SetJumpDest() to null bbJumpDest without updating bbJumpKind.
         bbJumpDest = jumpDest;
         assert(!HasJumpDest() || HasInitializedJumpDest());
+    }
+
+    BasicBlock* GetNormalJumpDest() const
+    {
+        assert(KindIs(BBJ_COND));
+        assert(bbNormalJumpDest != nullptr);
+        return bbNormalJumpDest;
+    }
+
+    void SetNormalJumpDest(BasicBlock* jumpDest)
+    {
+        assert(KindIs(BBJ_COND));
+        assert(jumpDest != nullptr);
+        bbNormalJumpDest = jumpDest;
     }
 
     void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -651,6 +651,11 @@ public:
     BasicBlock* GetNormalJumpDest() const
     {
         assert(KindIs(BBJ_COND));
+
+        // So long as bbNormalJumpDest tracks bbNext in SetNext(), it is possible for bbNormalJumpDest to be null
+        // if this block is unlinked from the block list.
+        // So check bbNext before triggering the assert if bbNormalJumpDest is null.
+        // TODO-NoFallThrough: Remove IsLast() check once bbNormalJumpDest isn't hard-coded to bbNext
         assert((bbNormalJumpDest != nullptr) || IsLast());
         return bbNormalJumpDest;
     }

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -530,7 +530,7 @@ private:
         BasicBlock* bbTarget;     // basic block
         BasicBlock* bbTrueTarget; // BBJ_COND jump target when its condition is true (alias for bbTarget)
         BBswtDesc*  bbSwtTargets;  // switch descriptor
-        BBehfDesc*  bbEhfTarget;  // BBJ_EHFINALLYRET descriptor
+        BBehfDesc*  bbEhfTargets;  // BBJ_EHFINALLYRET descriptor
     };
 
     // Points to the successor of a BBJ_COND block if bbTrueTarget is not taken
@@ -760,20 +760,20 @@ public:
     BBehfDesc* GetEhfTargets() const
     {
         assert(KindIs(BBJ_EHFINALLYRET));
-        return bbEhfTarget;
+        return bbEhfTargets;
     }
 
-    void SetEhfTarget(BBehfDesc* ehfTarget)
+    void SetEhfTargets(BBehfDesc* ehfTarget)
     {
         assert(KindIs(BBJ_EHFINALLYRET));
-        bbEhfTarget = ehfTarget;
+        bbEhfTargets = ehfTarget;
     }
 
     void SetEhf(BBehfDesc* ehfTarget)
     {
         assert(ehfTarget != nullptr);
         bbKind      = BBJ_EHFINALLYRET;
-        bbEhfTarget = ehfTarget;
+        bbEhfTargets = ehfTarget;
     }
 
 private:
@@ -1083,7 +1083,7 @@ public:
     BBEhfSuccList EHFinallyRetSuccs() const
     {
         assert(bbKind == BBJ_EHFINALLYRET);
-        return BBEhfSuccList(bbEhfTarget);
+        return BBEhfSuccList(bbEhfTargets);
     }
 
     BasicBlock* GetUniquePred(Compiler* comp) const;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -529,7 +529,7 @@ private:
         unsigned    bbTargetOffs; // PC offset (temporary only)
         BasicBlock* bbTarget;     // basic block
         BasicBlock* bbTrueTarget; // BBJ_COND jump target when its condition is true (alias for bbTarget)
-        BBswtDesc*  bbSwtTarget;  // switch descriptor
+        BBswtDesc*  bbSwtTargets;  // switch descriptor
         BBehfDesc*  bbEhfTarget;  // BBJ_EHFINALLYRET descriptor
     };
 
@@ -746,15 +746,15 @@ public:
     BBswtDesc* GetSwitchTargets() const
     {
         assert(KindIs(BBJ_SWITCH));
-        assert(bbSwtTarget != nullptr);
-        return bbSwtTarget;
+        assert(bbSwtTargets != nullptr);
+        return bbSwtTargets;
     }
 
     void SetSwitch(BBswtDesc* swtTarget)
     {
         assert(swtTarget != nullptr);
         bbKind      = BBJ_SWITCH;
-        bbSwtTarget = swtTarget;
+        bbSwtTargets = swtTarget;
     }
 
     BBehfDesc* GetEhfTargets() const
@@ -1073,7 +1073,7 @@ public:
     BBSwitchTargetList SwitchTargets() const
     {
         assert(bbKind == BBJ_SWITCH);
-        return BBSwitchTargetList(bbSwtTarget);
+        return BBSwitchTargetList(bbSwtTargets);
     }
 
     // EHFinallyRetSuccs: convenience method for enabling range-based `for` iteration over BBJ_EHFINALLYRET block
@@ -1959,10 +1959,10 @@ inline BasicBlock::BBSuccList::BBSuccList(const BasicBlock* block)
 
         case BBJ_SWITCH:
             // We don't use the m_succs in-line data for switches; use the existing jump table in the block.
-            assert(block->bbSwtTarget != nullptr);
-            assert(block->bbSwtTarget->bbsDstTab != nullptr);
-            m_begin = block->bbSwtTarget->bbsDstTab;
-            m_end   = block->bbSwtTarget->bbsDstTab + block->bbSwtTarget->bbsCount;
+            assert(block->bbSwtTargets != nullptr);
+            assert(block->bbSwtTargets->bbsDstTab != nullptr);
+            m_begin = block->bbSwtTargets->bbsDstTab;
+            m_end   = block->bbSwtTargets->bbsDstTab + block->bbSwtTargets->bbsCount;
             break;
 
         default:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -620,10 +620,10 @@ public:
         return bbJumpOffs;
     }
 
-    void SetJumpKindAndTarget(BBjumpKinds jumpKind, unsigned jumpOffs)
+    void SetKindAndTarget(BBjumpKinds kind, unsigned offs)
     {
-        bbJumpKind = jumpKind;
-        bbJumpOffs = jumpOffs;
+        bbJumpKind = kind;
+        bbJumpOffs = offs;
         assert(KindIs(BBJ_ALWAYS, BBJ_COND, BBJ_LEAVE));
     }
 
@@ -642,7 +642,7 @@ public:
 
     void SetTarget(BasicBlock* target)
     {
-        // SetJumpKindAndTarget() nulls target for non-jump kinds,
+        // SetKindAndTarget() nulls target for non-jump kinds,
         // so don't use SetTarget() to null bbTarget without updating bbJumpKind.
         bbTarget = target;
         assert(!HasTarget() || HasInitializedTarget());
@@ -675,10 +675,10 @@ public:
         return (bbFalseTarget == jumpDest);
     }
 
-    void SetJumpKindAndTarget(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr)
+    void SetKindAndTarget(BBjumpKinds kind, BasicBlock* target = nullptr)
     {
-        bbJumpKind = jumpKind;
-        bbTarget = jumpDest;
+        bbJumpKind = kind;
+        bbTarget = target;
 
         // If bbJumpKind indicates this block has a jump, bbTarget cannot be null
         assert(!HasTarget() || HasInitializedTarget());
@@ -709,11 +709,11 @@ public:
         return bbJumpSwt;
     }
 
-    void SetSwitchKindAndTarget(BBswtDesc* jumpSwt)
+    void SetKindAndTarget(BBswtDesc* swt)
     {
-        assert(jumpSwt != nullptr);
+        assert(swt != nullptr);
         bbJumpKind = BBJ_SWITCH;
-        bbJumpSwt  = jumpSwt;
+        bbJumpSwt  = swt;
     }
 
     BBehfDesc* GetJumpEhf() const
@@ -728,12 +728,12 @@ public:
         bbJumpEhf = jumpEhf;
     }
 
-    void SetJumpKindAndTarget(BBjumpKinds jumpKind, BBehfDesc* jumpEhf)
+    void SetKindAndTarget(BBjumpKinds kind, BBehfDesc* ehf)
     {
-        assert(jumpKind == BBJ_EHFINALLYRET);
-        assert(jumpEhf != nullptr);
-        bbJumpKind = jumpKind;
-        bbJumpEhf  = jumpEhf;
+        assert(kind == BBJ_EHFINALLYRET);
+        assert(ehf != nullptr);
+        bbJumpKind = kind;
+        bbJumpEhf  = ehf;
     }
 
 private:

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -533,7 +533,7 @@ private:
         BBehfDesc*  bbEhfTarget;  // BBJ_EHFINALLYRET descriptor
     };
 
-    // Points to the successor of a BBJ_COND block if bbTarget is not taken
+    // Points to the successor of a BBJ_COND block if bbTrueTarget is not taken
     BasicBlock* bbFalseTarget;
 
 public:

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -23,7 +23,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   <Type Name="BasicBlock">
     <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
     <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTarget->bbsCount} cases</DisplayString>
-    <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbJumpEhf->bbeCount} succs</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTarget->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>
   </Type>
 

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -21,10 +21,10 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="BasicBlock">
-    <DisplayString Condition="bbJumpKind==BBJ_COND || bbJumpKind==BBJ_ALWAYS || bbJumpKind==BBJ_LEAVE || bbJumpKind==BBJ_EHCATCHRET || bbJumpKind==BBJ_CALLFINALLY || bbJumpKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbJumpKind,en}</DisplayString>
-    <DisplayString Condition="bbJumpKind==BBJ_SWITCH">BB{bbNum,d}; {bbJumpKind,en}; {bbJumpSwt->bbsCount} cases</DisplayString>
-    <DisplayString Condition="bbJumpKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbJumpKind,en}; {bbJumpEhf->bbeCount} succs</DisplayString>
-    <DisplayString>BB{bbNum,d}; {bbJumpKind,en}</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbJumpSwt->bbsCount} cases</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbJumpEhf->bbeCount} succs</DisplayString>
+    <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>
   </Type>
 
   <Type Name="Compiler::LoopDsc">

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -22,7 +22,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
 
   <Type Name="BasicBlock">
     <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
-    <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbJumpSwt->bbsCount} cases</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTarget->bbsCount} cases</DisplayString>
     <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbJumpEhf->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>
   </Type>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -22,7 +22,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
 
   <Type Name="BasicBlock">
     <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
-    <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTarget->bbsCount} cases</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTargets->bbsCount} cases</DisplayString>
     <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTarget->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>
   </Type>

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -23,7 +23,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   <Type Name="BasicBlock">
     <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
     <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTargets->bbsCount} cases</DisplayString>
-    <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTarget->bbeCount} succs</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTargets->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>
   </Type>
 

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -21,7 +21,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="BasicBlock">
-    <DisplayString Condition="bbJumpKind==BBJ_COND || bbJumpKind==BBJ_ALWAYS || bbJumpKind==BBJ_LEAVE || bbJumpKind==BBJ_EHCATCHRET || bbJumpKind==BBJ_CALLFINALLY || bbJumpKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbJumpDest->bbNum,d}; {bbJumpKind,en}</DisplayString>
+    <DisplayString Condition="bbJumpKind==BBJ_COND || bbJumpKind==BBJ_ALWAYS || bbJumpKind==BBJ_LEAVE || bbJumpKind==BBJ_EHCATCHRET || bbJumpKind==BBJ_CALLFINALLY || bbJumpKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbJumpKind,en}</DisplayString>
     <DisplayString Condition="bbJumpKind==BBJ_SWITCH">BB{bbNum,d}; {bbJumpKind,en}; {bbJumpSwt->bbsCount} cases</DisplayString>
     <DisplayString Condition="bbJumpKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbJumpKind,en}; {bbJumpEhf->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbJumpKind,en}</DisplayString>

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -655,8 +655,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
     unsigned     jmpTabBase;
 
     jmpTabBase = GetEmitter()->emitBBTableDataGenBeg(jumpCount, false);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -1321,7 +1321,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
     inst_RV_RV(INS_tst, reg, reg, genActualType(op));
-    inst_JMP(EJ_ne, compiler->compCurBB->GetTarget());
+    inst_JMP(EJ_ne, compiler->compCurBB->GetTrueTarget());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -655,8 +655,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTargets()->bbsDstTab;
     unsigned     jmpTabBase;
 
     jmpTabBase = GetEmitter()->emitBBTableDataGenBeg(jumpCount, false);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -655,8 +655,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
     unsigned     jmpTabBase;
 
     jmpTabBase = GetEmitter()->emitBBTableDataGenBeg(jumpCount, false);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -117,7 +117,7 @@ bool CodeGen::genStackPointerAdjustment(ssize_t spDelta, regNumber tmpReg)
 //
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
-    GetEmitter()->emitIns_J(INS_bl, block->GetJumpDest());
+    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
 
     BasicBlock* nextBlock = block->Next();
 
@@ -137,7 +137,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetJumpDest();
+        BasicBlock* const jumpDest = nextBlock->GetTarget();
 
         // Now go to where the finally funclet needs to return to.
         if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -157,7 +157,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
 
     // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
+    // jump target using bbTarget - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
     if (!block->HasFlag(BBF_RETLESS_CALL))
@@ -172,7 +172,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 // genEHCatchRet:
 void CodeGen::genEHCatchRet(BasicBlock* block)
 {
-    genMov32RelocatableDisplacement(block->GetJumpDest(), REG_INTRET);
+    genMov32RelocatableDisplacement(block->GetTarget(), REG_INTRET);
 }
 
 //------------------------------------------------------------------------
@@ -1321,7 +1321,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
     inst_RV_RV(INS_tst, reg, reg, genActualType(op));
-    inst_JMP(EJ_ne, compiler->compCurBB->GetJumpDest());
+    inst_JMP(EJ_ne, compiler->compCurBB->GetTarget());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2158,7 +2158,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_Mov(INS_mov, EA_PTRSIZE, REG_R0, REG_SPBASE, /* canSkip */ false);
     }
-    GetEmitter()->emitIns_J(INS_bl_local, block->GetJumpDest());
+    GetEmitter()->emitIns_J(INS_bl_local, block->GetTarget());
 
     BasicBlock* const nextBlock = block->Next();
 
@@ -2181,7 +2181,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetJumpDest();
+        BasicBlock* const jumpDest = nextBlock->GetTarget();
 
         // Now go to where the finally funclet needs to return to.
         if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -2201,7 +2201,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
 
     // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
+    // jump target using bbTarget - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
     if (!block->HasFlag(BBF_RETLESS_CALL))
@@ -2216,7 +2216,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 {
     // For long address (default): `adrp + add` will be emitted.
     // For short address (proven later): `adr` will be emitted.
-    GetEmitter()->emitIns_R_L(INS_adr, EA_PTRSIZE, block->GetJumpDest(), REG_INTRET);
+    GetEmitter()->emitIns_R_L(INS_adr, EA_PTRSIZE, block->GetTarget(), REG_INTRET);
 }
 
 //  move an immediate value into an integer register
@@ -4654,7 +4654,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
-    GetEmitter()->emitIns_J_R(INS_cbnz, emitActualTypeSize(op), compiler->compCurBB->GetJumpDest(), reg);
+    GetEmitter()->emitIns_J_R(INS_cbnz, emitActualTypeSize(op), compiler->compCurBB->GetTarget(), reg);
 }
 
 //------------------------------------------------------------------------
@@ -4872,7 +4872,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
         instruction ins = (cc.GetCode() == GenCondition::EQ) ? INS_tbz : INS_tbnz;
         int         imm = genLog2((size_t)compareImm);
 
-        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->GetJumpDest(), reg, imm);
+        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->GetTarget(), reg, imm);
     }
     else
     {
@@ -4880,7 +4880,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
 
         instruction ins = (cc.GetCode() == GenCondition::EQ) ? INS_cbz : INS_cbnz;
 
-        GetEmitter()->emitIns_J_R(ins, attr, compiler->compCurBB->GetJumpDest(), reg);
+        GetEmitter()->emitIns_J_R(ins, attr, compiler->compCurBB->GetTarget(), reg);
     }
 }
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3752,8 +3752,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3752,8 +3752,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -4654,7 +4654,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
 
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
-    GetEmitter()->emitIns_J_R(INS_cbnz, emitActualTypeSize(op), compiler->compCurBB->GetTarget(), reg);
+    GetEmitter()->emitIns_J_R(INS_cbnz, emitActualTypeSize(op), compiler->compCurBB->GetTrueTarget(), reg);
 }
 
 //------------------------------------------------------------------------
@@ -4872,7 +4872,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
         instruction ins = (cc.GetCode() == GenCondition::EQ) ? INS_tbz : INS_tbnz;
         int         imm = genLog2((size_t)compareImm);
 
-        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->GetTarget(), reg, imm);
+        GetEmitter()->emitIns_J_R_I(ins, attr, compiler->compCurBB->GetTrueTarget(), reg, imm);
     }
     else
     {
@@ -4880,7 +4880,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
 
         instruction ins = (cc.GetCode() == GenCondition::EQ) ? INS_cbz : INS_cbnz;
 
-        GetEmitter()->emitIns_J_R(ins, attr, compiler->compCurBB->GetTarget(), reg);
+        GetEmitter()->emitIns_J_R(ins, attr, compiler->compCurBB->GetTrueTarget(), reg);
     }
 }
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3752,8 +3752,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTargets()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -376,7 +376,7 @@ void CodeGen::genMarkLabelsForCodegen()
 
     for (BasicBlock* const block : compiler->Blocks())
     {
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_ALWAYS: // This will also handle the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair.
             {
@@ -434,7 +434,7 @@ void CodeGen::genMarkLabelsForCodegen()
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
     }

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -390,8 +390,8 @@ void CodeGen::genMarkLabelsForCodegen()
             }
             case BBJ_COND:
             case BBJ_EHCATCHRET:
-                JITDUMP("  " FMT_BB " : branch target\n", block->GetJumpDest()->bbNum);
-                block->GetJumpDest()->SetFlags(BBF_HAS_LABEL);
+                JITDUMP("  " FMT_BB " : branch target\n", block->GetTarget()->bbNum);
+                block->GetTarget()->SetFlags(BBF_HAS_LABEL);
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -388,10 +388,14 @@ void CodeGen::genMarkLabelsForCodegen()
 
                 FALLTHROUGH;
             }
-            case BBJ_COND:
             case BBJ_EHCATCHRET:
                 JITDUMP("  " FMT_BB " : branch target\n", block->GetTarget()->bbNum);
                 block->GetTarget()->SetFlags(BBF_HAS_LABEL);
+                break;
+
+            case BBJ_COND:
+                JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
+                block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -748,11 +748,11 @@ void CodeGen::genCodeForBBlist()
                 // with a jump, do not remove jumps from such blocks.
                 // Do not remove a jump between hot and cold regions.
                 bool isRemovableJmpCandidate =
-                    !block->hasAlign() && !compiler->fgInDifferentRegions(block, block->GetJumpDest());
+                    !block->hasAlign() && !compiler->fgInDifferentRegions(block, block->GetTarget());
 
-                inst_JMP(EJ_jmp, block->GetJumpDest(), isRemovableJmpCandidate);
+                inst_JMP(EJ_jmp, block->GetTarget(), isRemovableJmpCandidate);
 #else
-                inst_JMP(EJ_jmp, block->GetJumpDest());
+                inst_JMP(EJ_jmp, block->GetTarget());
 #endif // TARGET_XARCH
             }
 
@@ -769,14 +769,14 @@ void CodeGen::genCodeForBBlist()
                 // During emitter, this information will be used to calculate the loop size.
                 // Depending on the loop size, decision of whether to align a loop or not will be taken.
                 //
-                // In the emitter, we need to calculate the loop size from `block->bbJumpDest` through
+                // In the emitter, we need to calculate the loop size from `block->bbTarget` through
                 // `block` (inclusive). Thus, we need to ensure there is a label on the lexical fall-through
                 // block, even if one is not otherwise needed, to be able to calculate the size of this
                 // loop (loop size is calculated by walking the instruction groups; see emitter::getLoopSize()).
 
-                if (block->GetJumpDest()->isLoopAlign())
+                if (block->GetTarget()->isLoopAlign())
                 {
-                    GetEmitter()->emitSetLoopBackEdge(block->GetJumpDest());
+                    GetEmitter()->emitSetLoopBackEdge(block->GetTarget());
 
                     if (!block->IsLast())
                     {
@@ -2617,7 +2617,7 @@ void CodeGen::genCodeForJcc(GenTreeCC* jcc)
     assert(compiler->compCurBB->KindIs(BBJ_COND));
     assert(jcc->OperIs(GT_JCC));
 
-    inst_JCC(jcc->gtCondition, compiler->compCurBB->GetJumpDest());
+    inst_JCC(jcc->gtCondition, compiler->compCurBB->GetTarget());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -619,7 +619,7 @@ void CodeGen::genCodeForBBlist()
             {
                 // We only need the NOP if we're not going to generate any more code as part of the block end.
 
-                switch (block->GetJumpKind())
+                switch (block->GetKind())
                 {
                     case BBJ_ALWAYS:
                         // We might skip generating the jump via a peephole optimization.
@@ -644,7 +644,7 @@ void CodeGen::genCodeForBBlist()
                     // These can't have a call as the last instruction!
 
                     default:
-                        noway_assert(!"Unexpected bbJumpKind");
+                        noway_assert(!"Unexpected bbKind");
                         break;
                 }
             }
@@ -653,7 +653,7 @@ void CodeGen::genCodeForBBlist()
 
         /* Do we need to generate a jump or return? */
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_RETURN:
                 genExitCode(block);
@@ -789,7 +789,7 @@ void CodeGen::genCodeForBBlist()
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -2935,8 +2935,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTargets()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -2935,8 +2935,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1518,7 +1518,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_R_R_I(INS_ori, EA_PTRSIZE, REG_A0, REG_SPBASE, 0);
     }
-    GetEmitter()->emitIns_J(INS_bl, block->GetJumpDest());
+    GetEmitter()->emitIns_J(INS_bl, block->GetTarget());
 
     BasicBlock* const nextBlock = block->Next();
 
@@ -1541,7 +1541,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetJumpDest();
+        BasicBlock* const jumpDest = nextBlock->GetTarget();
 
         // Now go to where the finally funclet needs to return to.
         if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -1561,7 +1561,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
 
     // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
+    // jump target using bbTarget - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
     if (!block->HasFlag(BBF_RETLESS_CALL))
@@ -1574,7 +1574,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
 void CodeGen::genEHCatchRet(BasicBlock* block)
 {
-    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, block->GetJumpDest(), REG_INTRET);
+    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, block->GetTarget(), REG_INTRET);
 }
 
 //  move an immediate value into an integer register
@@ -4334,7 +4334,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
     assert(ins != INS_invalid);
     assert(regs != 0);
 
-    emit->emitIns_J(ins, compiler->compCurBB->GetJumpDest(), regs); // 5-bits;
+    emit->emitIns_J(ins, compiler->compCurBB->GetTarget(), regs); // 5-bits;
 }
 
 //---------------------------------------------------------------------
@@ -4910,7 +4910,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_JCC:
         {
-            BasicBlock* tgtBlock = compiler->compCurBB->GetJumpDest();
+            BasicBlock* tgtBlock = compiler->compCurBB->GetTarget();
 #if !FEATURE_FIXED_OUT_ARGS
             assert((tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel) || isFramePointerUsed());
 #endif // !FEATURE_FIXED_OUT_ARGS

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -4334,7 +4334,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
     assert(ins != INS_invalid);
     assert(regs != 0);
 
-    emit->emitIns_J(ins, compiler->compCurBB->GetTarget(), regs); // 5-bits;
+    emit->emitIns_J(ins, compiler->compCurBB->GetTrueTarget(), regs); // 5-bits;
 }
 
 //---------------------------------------------------------------------
@@ -4910,7 +4910,8 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_JCC:
         {
-            BasicBlock* tgtBlock = compiler->compCurBB->GetTarget();
+            BasicBlock* tgtBlock = compiler->compCurBB->KindIs(BBJ_COND) ? compiler->compCurBB->GetTrueTarget()
+                                                                         : compiler->compCurBB->GetTarget();
 #if !FEATURE_FIXED_OUT_ARGS
             assert((tgtBlock->bbTgtStkDepth * sizeof(int) == genStackLevel) || isFramePointerUsed());
 #endif // !FEATURE_FIXED_OUT_ARGS

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -2935,8 +2935,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2577,8 +2577,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2577,8 +2577,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTargets()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1156,7 +1156,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_R_R_I(INS_ori, EA_PTRSIZE, REG_A0, REG_SPBASE, 0);
     }
-    GetEmitter()->emitIns_J(INS_jal, block->GetJumpDest());
+    GetEmitter()->emitIns_J(INS_jal, block->GetTarget());
 
     BasicBlock* const nextBlock = block->Next();
 
@@ -1179,7 +1179,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetJumpDest();
+        BasicBlock* const jumpDest = nextBlock->GetTarget();
 
         // Now go to where the finally funclet needs to return to.
         if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -1199,7 +1199,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
 
     // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
+    // jump target using bbTarget - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
     if (!block->HasFlag(BBF_RETLESS_CALL))
@@ -1212,7 +1212,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 
 void CodeGen::genEHCatchRet(BasicBlock* block)
 {
-    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, block->GetJumpDest(), REG_INTRET);
+    GetEmitter()->emitIns_R_L(INS_lea, EA_PTRSIZE, block->GetTarget(), REG_INTRET);
 }
 
 //  move an immediate value into an integer register
@@ -3985,7 +3985,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
     assert(ins != INS_invalid);
     assert(regs != 0);
 
-    emit->emitIns_J(ins, compiler->compCurBB->GetJumpDest(), regs); // 5-bits;
+    emit->emitIns_J(ins, compiler->compCurBB->GetTarget(), regs); // 5-bits;
 }
 
 //---------------------------------------------------------------------

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2577,8 +2577,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3985,7 +3985,7 @@ void CodeGen::genCodeForJumpCompare(GenTreeOpCC* tree)
     assert(ins != INS_invalid);
     assert(regs != 0);
 
-    emit->emitIns_J(ins, compiler->compCurBB->GetTarget(), regs); // 5-bits;
+    emit->emitIns_J(ins, compiler->compCurBB->GetTrueTarget(), regs); // 5-bits;
 }
 
 //---------------------------------------------------------------------

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4265,8 +4265,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4265,8 +4265,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwitchTargets()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1450,7 +1450,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
     inst_RV_RV(INS_test, reg, reg, genActualType(op));
-    inst_JMP(EJ_jne, compiler->compCurBB->GetTarget());
+    inst_JMP(EJ_jne, compiler->compCurBB->GetTrueTarget());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4265,8 +4265,8 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     noway_assert(compiler->compCurBB->KindIs(BBJ_SWITCH));
     assert(treeNode->OperGet() == GT_JMPTABLE);
 
-    unsigned     jumpCount = compiler->compCurBB->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTable = compiler->compCurBB->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCount = compiler->compCurBB->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTable = compiler->compCurBB->GetSwtTarget()->bbsDstTab;
     unsigned     jmpTabOffs;
     unsigned     jmpTabBase;
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -228,7 +228,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     {
         GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_ARG_0, compiler->lvaPSPSym, 0);
     }
-    GetEmitter()->emitIns_J(INS_call, block->GetJumpDest());
+    GetEmitter()->emitIns_J(INS_call, block->GetTarget());
 
     if (block->HasFlag(BBF_RETLESS_CALL))
     {
@@ -253,7 +253,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         GetEmitter()->emitDisableGC();
 #endif // JIT32_GCENCODER
 
-        BasicBlock* const jumpDest = nextBlock->GetJumpDest();
+        BasicBlock* const jumpDest = nextBlock->GetTarget();
 
         // Now go to where the finally funclet needs to return to.
         if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
@@ -316,7 +316,7 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     if (!block->HasFlag(BBF_RETLESS_CALL))
     {
         assert(block->isBBCallAlwaysPair());
-        GetEmitter()->emitIns_J(INS_push_hide, nextBlock->GetJumpDest());
+        GetEmitter()->emitIns_J(INS_push_hide, nextBlock->GetTarget());
     }
     else
     {
@@ -325,12 +325,12 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
     }
 
     // Jump to the finally BB
-    inst_JMP(EJ_jmp, block->GetJumpDest());
+    inst_JMP(EJ_jmp, block->GetTarget());
 
 #endif // !FEATURE_EH_FUNCLETS
 
     // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbJumpDest - that is already used to point
+    // jump target using bbTarget - that is already used to point
     // to the finally block. So just skip past the BBJ_ALWAYS unless the
     // block is RETLESS.
     if (!block->HasFlag(BBF_RETLESS_CALL))
@@ -348,7 +348,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
     // Generate a RIP-relative
     //         lea reg, [rip + disp32] ; the RIP is implicit
     // which will be position-independent.
-    GetEmitter()->emitIns_R_L(INS_lea, EA_PTR_DSP_RELOC, block->GetJumpDest(), REG_INTRET);
+    GetEmitter()->emitIns_R_L(INS_lea, EA_PTR_DSP_RELOC, block->GetTarget(), REG_INTRET);
 }
 
 #else // !FEATURE_EH_FUNCLETS
@@ -1450,7 +1450,7 @@ void CodeGen::genCodeForJTrue(GenTreeOp* jtrue)
     GenTree*  op  = jtrue->gtGetOp1();
     regNumber reg = genConsumeReg(op);
     inst_RV_RV(INS_test, reg, reg, genActualType(op));
-    inst_JMP(EJ_jne, compiler->compCurBB->GetJumpDest());
+    inst_JMP(EJ_jne, compiler->compCurBB->GetTarget());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5050,13 +5050,13 @@ public:
     void fgExtendEHRegionBefore(BasicBlock* block);
     void fgExtendEHRegionAfter(BasicBlock* block);
 
-    BasicBlock* fgNewBBbefore(BBjumpKinds jumpKind, BasicBlock* block, bool extendRegion, BasicBlock* jumpDest = nullptr);
+    BasicBlock* fgNewBBbefore(BBKinds jumpKind, BasicBlock* block, bool extendRegion, BasicBlock* jumpDest = nullptr);
 
-    BasicBlock* fgNewBBafter(BBjumpKinds jumpKind, BasicBlock* block, bool extendRegion, BasicBlock* jumpDest = nullptr);
+    BasicBlock* fgNewBBafter(BBKinds jumpKind, BasicBlock* block, bool extendRegion, BasicBlock* jumpDest = nullptr);
 
-    BasicBlock* fgNewBBFromTreeAfter(BBjumpKinds jumpKind, BasicBlock* block, GenTree* tree, DebugInfo& debugInfo, BasicBlock* jumpDest = nullptr, bool updateSideEffects = false);
+    BasicBlock* fgNewBBFromTreeAfter(BBKinds jumpKind, BasicBlock* block, GenTree* tree, DebugInfo& debugInfo, BasicBlock* jumpDest = nullptr, bool updateSideEffects = false);
 
-    BasicBlock* fgNewBBinRegion(BBjumpKinds jumpKind,
+    BasicBlock* fgNewBBinRegion(BBKinds jumpKind,
                                 unsigned    tryIndex,
                                 unsigned    hndIndex,
                                 BasicBlock* nearBlk,
@@ -5065,15 +5065,15 @@ public:
                                 bool        runRarely   = false,
                                 bool        insertAtEnd = false);
 
-    BasicBlock* fgNewBBinRegion(BBjumpKinds jumpKind,
+    BasicBlock* fgNewBBinRegion(BBKinds jumpKind,
                                 BasicBlock* srcBlk,
                                 BasicBlock* jumpDest    = nullptr,
                                 bool        runRarely   = false,
                                 bool        insertAtEnd = false);
 
-    BasicBlock* fgNewBBinRegion(BBjumpKinds jumpKind, BasicBlock* jumpDest = nullptr);
+    BasicBlock* fgNewBBinRegion(BBKinds jumpKind, BasicBlock* jumpDest = nullptr);
 
-    BasicBlock* fgNewBBinRegionWorker(BBjumpKinds jumpKind,
+    BasicBlock* fgNewBBinRegionWorker(BBKinds jumpKind,
                                       BasicBlock* afterBlk,
                                       unsigned    xcptnIndex,
                                       bool        putInTryRegion,
@@ -7182,7 +7182,7 @@ protected:
     // Adds "elemType" to the set of modified array element types of "loop" and any parent loops.
     void AddModifiedElemTypeAllContainingLoops(FlowGraphNaturalLoop* loop, CORINFO_CLASS_HANDLE elemType);
 
-    // Requires that "from" and "to" have the same "bbJumpKind" (perhaps because "to" is a clone
+    // Requires that "from" and "to" have the same "bbKind" (perhaps because "to" is a clone
     // of "from".)  Copies the jump destination from "from" to "to".
     void optCopyBlkDest(BasicBlock* from, BasicBlock* to);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6034,7 +6034,7 @@ public:
 
     PhaseStatus fgDetermineFirstColdBlock();
 
-    bool fgIsForwardBranch(BasicBlock* bJump, BasicBlock* bSrc = nullptr);
+    bool fgIsForwardBranch(BasicBlock* bJump, BasicBlock* bDest, BasicBlock* bSrc = nullptr);
 
     bool fgUpdateFlowGraph(bool doTailDup = false, bool isPhase = false);
     PhaseStatus fgUpdateFlowGraphPhase();

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -593,11 +593,11 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted
             // LEAVE into callfinally yet, and haven't added return successors.
-            if (bbEhfTarget != nullptr)
+            if (bbEhfTargets != nullptr)
             {
-                for (unsigned i = 0; i < bbEhfTarget->bbeCount; i++)
+                for (unsigned i = 0; i < bbEhfTargets->bbeCount; i++)
                 {
-                    RETURN_ON_ABORT(func(bbEhfTarget->bbeSuccs[i]));
+                    RETURN_ON_ABORT(func(bbEhfTargets->bbeSuccs[i]));
                 }
             }
 
@@ -676,11 +676,11 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted
             // LEAVE into callfinally yet, and haven't added return successors.
-            if (bbEhfTarget != nullptr)
+            if (bbEhfTargets != nullptr)
             {
-                for (unsigned i = 0; i < bbEhfTarget->bbeCount; i++)
+                for (unsigned i = 0; i < bbEhfTargets->bbeCount; i++)
                 {
-                    RETURN_ON_ABORT(func(bbEhfTarget->bbeSuccs[i]));
+                    RETURN_ON_ABORT(func(bbEhfTargets->bbeSuccs[i]));
                 }
             }
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -628,9 +628,9 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
             return BasicBlockVisit::Continue;
 
         case BBJ_COND:
-            RETURN_ON_ABORT(func(bbNext));
+            RETURN_ON_ABORT(func(bbNormalJumpDest));
 
-            if (bbJumpDest != bbNext)
+            if (bbJumpDest != bbNormalJumpDest)
             {
                 RETURN_ON_ABORT(func(bbJumpDest));
             }
@@ -694,9 +694,9 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
             return func(bbJumpDest);
 
         case BBJ_COND:
-            RETURN_ON_ABORT(func(bbNext));
+            RETURN_ON_ABORT(func(bbNormalJumpDest));
 
-            if (bbJumpDest != bbNext)
+            if (bbJumpDest != bbNormalJumpDest)
             {
                 RETURN_ON_ABORT(func(bbJumpDest));
             }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -537,7 +537,7 @@ static BasicBlockVisit VisitEHSuccs(Compiler* comp, BasicBlock* block, TFunc fun
             {
                 // For BBJ_CALLFINALLY the user may already have processed one of
                 // the EH successors as a regular successor; skip it if requested.
-                if (!skipJumpDest || !block->HasJumpTo(eh->ebdHndBeg))
+                if (!skipJumpDest || !block->TargetIs(eh->ebdHndBeg))
                 {
                     RETURN_ON_ABORT(func(eh->ebdHndBeg));
                 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -593,11 +593,11 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted
             // LEAVE into callfinally yet, and haven't added return successors.
-            if (bbJumpEhf != nullptr)
+            if (bbEhfTarget != nullptr)
             {
-                for (unsigned i = 0; i < bbJumpEhf->bbeCount; i++)
+                for (unsigned i = 0; i < bbEhfTarget->bbeCount; i++)
                 {
-                    RETURN_ON_ABORT(func(bbJumpEhf->bbeSuccs[i]));
+                    RETURN_ON_ABORT(func(bbEhfTarget->bbeSuccs[i]));
                 }
             }
 
@@ -676,11 +676,11 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted
             // LEAVE into callfinally yet, and haven't added return successors.
-            if (bbJumpEhf != nullptr)
+            if (bbEhfTarget != nullptr)
             {
-                for (unsigned i = 0; i < bbJumpEhf->bbeCount; i++)
+                for (unsigned i = 0; i < bbEhfTarget->bbeCount; i++)
                 {
-                    RETURN_ON_ABORT(func(bbJumpEhf->bbeSuccs[i]));
+                    RETURN_ON_ABORT(func(bbEhfTarget->bbeSuccs[i]));
                 }
             }
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -630,9 +630,9 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
         case BBJ_COND:
             RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbTarget != bbFalseTarget)
+            if (bbTrueTarget != bbFalseTarget)
             {
-                RETURN_ON_ABORT(func(bbTarget));
+                RETURN_ON_ABORT(func(bbTrueTarget));
             }
 
             return VisitEHSuccs(comp, func);
@@ -696,9 +696,9 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
         case BBJ_COND:
             RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbTarget != bbFalseTarget)
+            if (bbTrueTarget != bbFalseTarget)
             {
-                RETURN_ON_ABORT(func(bbTarget));
+                RETURN_ON_ABORT(func(bbTrueTarget));
             }
 
             return BasicBlockVisit::Continue;

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -628,9 +628,9 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
             return BasicBlockVisit::Continue;
 
         case BBJ_COND:
-            RETURN_ON_ABORT(func(bbNormalJumpDest));
+            RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbJumpDest != bbNormalJumpDest)
+            if (bbJumpDest != bbFalseTarget)
             {
                 RETURN_ON_ABORT(func(bbJumpDest));
             }
@@ -694,9 +694,9 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
             return func(bbJumpDest);
 
         case BBJ_COND:
-            RETURN_ON_ABORT(func(bbNormalJumpDest));
+            RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbJumpDest != bbNormalJumpDest)
+            if (bbJumpDest != bbFalseTarget)
             {
                 RETURN_ON_ABORT(func(bbJumpDest));
             }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -588,7 +588,7 @@ BasicBlockVisit BasicBlock::VisitEHSuccs(Compiler* comp, TFunc func)
 template <typename TFunc>
 BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
 {
-    switch (bbJumpKind)
+    switch (bbKind)
     {
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted
@@ -671,7 +671,7 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
 template <typename TFunc>
 BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
 {
-    switch (bbJumpKind)
+    switch (bbKind)
     {
         case BBJ_EHFINALLYRET:
             // This can run before import, in which case we haven't converted

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -604,17 +604,17 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
             return VisitEHSuccs(comp, func);
 
         case BBJ_CALLFINALLY:
-            RETURN_ON_ABORT(func(bbJumpDest));
+            RETURN_ON_ABORT(func(bbTarget));
             return ::VisitEHSuccs</* skipJumpDest */ true, TFunc>(comp, this, func);
 
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
-            RETURN_ON_ABORT(func(bbJumpDest));
+            RETURN_ON_ABORT(func(bbTarget));
             return VisitEHSuccs(comp, func);
 
         case BBJ_ALWAYS:
-            RETURN_ON_ABORT(func(bbJumpDest));
+            RETURN_ON_ABORT(func(bbTarget));
 
             // If this is a "leave helper" block (the empty BBJ_ALWAYS block
             // that pairs with a preceding BBJ_CALLFINALLY block to implement a
@@ -630,9 +630,9 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
         case BBJ_COND:
             RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbJumpDest != bbFalseTarget)
+            if (bbTarget != bbFalseTarget)
             {
-                RETURN_ON_ABORT(func(bbJumpDest));
+                RETURN_ON_ABORT(func(bbTarget));
             }
 
             return VisitEHSuccs(comp, func);
@@ -691,14 +691,14 @@ BasicBlockVisit BasicBlock::VisitRegularSuccs(Compiler* comp, TFunc func)
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE:
         case BBJ_ALWAYS:
-            return func(bbJumpDest);
+            return func(bbTarget);
 
         case BBJ_COND:
             RETURN_ON_ABORT(func(bbFalseTarget));
 
-            if (bbJumpDest != bbFalseTarget)
+            if (bbTarget != bbFalseTarget)
             {
-                RETURN_ON_ABORT(func(bbJumpDest));
+                RETURN_ON_ABORT(func(bbTarget));
             }
 
             return BasicBlockVisit::Continue;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5987,7 +5987,7 @@ void emitter::emitSetLoopBackEdge(BasicBlock* loopTopBlock)
     // With (dstIG != nullptr), ensure that only back edges are tracked.
     // If there is forward jump, dstIG is not yet generated.
     //
-    // We don't rely on (block->GetJumpDest()->bbNum <= block->bbNum) because the basic
+    // We don't rely on (block->GetTarget()->bbNum <= block->bbNum) because the basic
     // block numbering is not guaranteed to be sequential.
     if ((dstIG != nullptr) && (dstIG->igNum <= emitCurIG->igNum))
     {

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -362,7 +362,7 @@ void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
     fgRemoveBlockAsPred(block);
 
     // Update jump kind after the scrub.
-    block->SetJumpKindAndTarget(BBJ_THROW);
+    block->SetKindAndTarget(BBJ_THROW);
 
     // Any block with a throw is rare
     block->bbSetRunRarely();
@@ -2938,9 +2938,9 @@ void Compiler::fgLinkBasicBlocks()
                 assert(!(curBBdesc->IsLast() && jumpsToNext));
                 BasicBlock* const jumpDest = jumpsToNext ? curBBdesc->Next() : fgLookupBB(curBBdesc->GetJumpOffs());
 
-                // Redundantly use SetJumpKindAndTarget() instead of SetTarget() just this once,
+                // Redundantly use SetKindAndTarget() instead of SetTarget() just this once,
                 // so we don't break the HasInitializedTarget() invariant of SetTarget().
-                curBBdesc->SetJumpKindAndTarget(curBBdesc->GetJumpKind(), jumpDest);
+                curBBdesc->SetKindAndTarget(curBBdesc->GetJumpKind(), jumpDest);
                 fgAddRefPred<initializingPreds>(jumpDest, curBBdesc, oldEdge);
 
                 if (curBBdesc->GetTarget()->bbNum <= curBBdesc->bbNum)
@@ -4194,7 +4194,7 @@ void Compiler::fgFixEntryFlowForOSR()
     fgEnsureFirstBBisScratch();
     assert(fgFirstBB->KindIs(BBJ_ALWAYS) && fgFirstBB->JumpsToNext());
     fgRemoveRefPred(fgFirstBB->GetTarget(), fgFirstBB);
-    fgFirstBB->SetJumpKindAndTarget(BBJ_ALWAYS, fgOSREntryBB);
+    fgFirstBB->SetKindAndTarget(BBJ_ALWAYS, fgOSREntryBB);
     FlowEdge* const edge = fgAddRefPred(fgOSREntryBB, fgFirstBB);
     edge->setLikelihood(1.0);
 
@@ -4792,7 +4792,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
 
     // Default to fallthru, and add the arc for that.
     curr->SetFlags(BBF_NONE_QUIRK);
-    curr->SetJumpKindAndTarget(BBJ_ALWAYS, newBlock);
+    curr->SetKindAndTarget(BBJ_ALWAYS, newBlock);
     fgAddRefPred(newBlock, curr);
     assert(curr->JumpsToNext());
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5031,7 +5031,7 @@ BasicBlock* Compiler::fgSplitEdge(BasicBlock* curr, BasicBlock* succ)
         // an immediately following block of a BBJ_SWITCH (which has
         // no fall-through path). For this case, simply insert a new
         // fall-through block after 'curr'.
-        // TODO: Once bbNormalJumpDest can diverge from bbNext, this will be unnecessary for BBJ_COND
+        // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, this will be unnecessary for BBJ_COND
         newBlock = fgNewBBafter(BBJ_ALWAYS, curr, true /* extendRegion */, /* jumpDest */ succ);
         newBlock->SetFlags(BBF_NONE_QUIRK);
         assert(newBlock->JumpsToNext());
@@ -6338,7 +6338,7 @@ bool Compiler::fgIsBetterFallThrough(BasicBlock* bCur, BasicBlock* bAlt)
     }
 
     // Currently bNext is the fall through for bCur
-    // TODO: Allow bbNormalJumpDest to diverge from bbNext for BBJ_COND
+    // TODO-NoFallThrough: Allow bbNormalJumpDest to diverge from bbNext for BBJ_COND
     assert(!bCur->KindIs(BBJ_COND) || bCur->NextIs(bCur->GetNormalJumpDest()));
     BasicBlock* bNext = bCur->Next();
     noway_assert(bNext != nullptr);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -568,7 +568,7 @@ void Compiler::fgReplaceEhfSuccessor(BasicBlock* block, BasicBlock* oldSucc, Bas
     assert(block->KindIs(BBJ_EHFINALLYRET));
     assert(fgPredsComputed);
 
-    BBehfDesc* const   ehfDesc   = block->GetJumpEhf();
+    BBehfDesc* const   ehfDesc   = block->GetEhfTarget();
     const unsigned     succCount = ehfDesc->bbeCount;
     BasicBlock** const succTab   = ehfDesc->bbeSuccs;
 
@@ -627,7 +627,7 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, BasicBlock* succ)
 
     fgRemoveRefPred(succ, block);
 
-    BBehfDesc* const ehfDesc   = block->GetJumpEhf();
+    BBehfDesc* const ehfDesc   = block->GetEhfTarget();
     unsigned         succCount = ehfDesc->bbeCount;
     BasicBlock**     succTab   = ehfDesc->bbeSuccs;
     bool             found     = false;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -467,8 +467,8 @@ void Compiler::fgReplaceSwitchJumpTarget(BasicBlock* blockSwitch, BasicBlock* ne
     // For the jump targets values that match oldTarget of our BBJ_SWITCH
     // replace predecessor 'blockSwitch' with 'newTarget'
 
-    unsigned     jumpCnt = blockSwitch->GetJumpSwt()->bbsCount;
-    BasicBlock** jumpTab = blockSwitch->GetJumpSwt()->bbsDstTab;
+    unsigned     jumpCnt = blockSwitch->GetSwtTarget()->bbsCount;
+    BasicBlock** jumpTab = blockSwitch->GetSwtTarget()->bbsDstTab;
 
     unsigned i = 0;
 
@@ -704,8 +704,8 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* newTarget, Bas
 
         case BBJ_SWITCH:
         {
-            unsigned const     jumpCnt = block->GetJumpSwt()->bbsCount;
-            BasicBlock** const jumpTab = block->GetJumpSwt()->bbsDstTab;
+            unsigned const     jumpCnt = block->GetSwtTarget()->bbsCount;
+            BasicBlock** const jumpTab = block->GetSwtTarget()->bbsDstTab;
             bool               changed = false;
 
             for (unsigned i = 0; i < jumpCnt; i++)
@@ -2984,8 +2984,8 @@ void Compiler::fgLinkBasicBlocks()
 
             case BBJ_SWITCH:
             {
-                unsigned     jumpCnt = curBBdesc->GetJumpSwt()->bbsCount;
-                BasicBlock** jumpPtr = curBBdesc->GetJumpSwt()->bbsDstTab;
+                unsigned     jumpCnt = curBBdesc->GetSwtTarget()->bbsCount;
+                BasicBlock** jumpPtr = curBBdesc->GetSwtTarget()->bbsDstTab;
 
                 do
                 {
@@ -4754,7 +4754,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
     else
     {
         // Start the new block with no refs. When we set the preds below, this will get updated correctly.
-        newBlock         = BasicBlock::New(this, curr->GetJumpSwt());
+        newBlock         = BasicBlock::New(this, curr->GetSwtTarget());
         newBlock->bbRefs = 0;
 
         // In the case of a switch statement there's more complicated logic in order to wire up the predecessor lists

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -694,7 +694,7 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* newTarget, Bas
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE: // This function can be called before import, so we still have BBJ_LEAVE
 
-            if (block->HasJumpTo(oldTarget))
+            if (block->TargetIs(oldTarget))
             {
                 block->SetTarget(newTarget);
                 fgRemoveRefPred(oldTarget, block);
@@ -5049,7 +5049,7 @@ BasicBlock* Compiler::fgSplitEdge(BasicBlock* curr, BasicBlock* succ)
     if (curr->KindIs(BBJ_COND))
     {
         fgReplacePred(succ, curr, newBlock);
-        if (curr->HasJumpTo(succ))
+        if (curr->TargetIs(succ))
         {
             // Now 'curr' jumps to newBlock
             curr->SetTarget(newBlock);
@@ -5291,7 +5291,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         noway_assert(block->KindIs(BBJ_ALWAYS));
 
         /* Do not remove a block that jumps to itself - used for while (true){} */
-        noway_assert(!block->HasJumpTo(block));
+        noway_assert(!block->TargetIs(block));
 #endif // DEBUG
 
         BasicBlock* succBlock = block->GetTarget();
@@ -5383,7 +5383,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
                 case BBJ_COND:
                     /* The links for the direct predecessor case have already been updated above */
-                    if (!predBlock->HasJumpTo(block))
+                    if (!predBlock->TargetIs(block))
                     {
                         break;
                     }
@@ -5392,7 +5392,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
                     if (predBlock->FalseTargetIs(succBlock))
                     {
                         // Make sure we are replacing "block" with "succBlock" in predBlock->bbTarget.
-                        noway_assert(predBlock->HasJumpTo(block));
+                        noway_assert(predBlock->TargetIs(block));
                         predBlock->SetTarget(succBlock);
                         fgRemoveConditionalJump(predBlock);
                         break;
@@ -5404,7 +5404,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
                 case BBJ_CALLFINALLY:
                 case BBJ_ALWAYS:
                 case BBJ_EHCATCHRET:
-                    noway_assert(predBlock->HasJumpTo(block));
+                    noway_assert(predBlock->TargetIs(block));
                     predBlock->SetTarget(succBlock);
                     break;
 
@@ -5436,7 +5436,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
             case BBJ_COND:
                 /* Check if both sides of the BBJ_COND now jump to the same block */
-                if (bPrev->HasJumpTo(bPrev->GetFalseTarget()))
+                if (bPrev->TargetIs(bPrev->GetFalseTarget()))
                 {
                     fgRemoveConditionalJump(bPrev);
                 }
@@ -6326,7 +6326,7 @@ bool Compiler::fgIsBetterFallThrough(BasicBlock* bCur, BasicBlock* bAlt)
     }
 
     // if bAlt doesn't jump to bCur it can't be a better fall through than bCur
-    if (!bAlt->HasJumpTo(bCur))
+    if (!bAlt->TargetIs(bCur))
     {
         return false;
     }

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -568,7 +568,7 @@ void Compiler::fgReplaceEhfSuccessor(BasicBlock* block, BasicBlock* oldSucc, Bas
     assert(block->KindIs(BBJ_EHFINALLYRET));
     assert(fgPredsComputed);
 
-    BBehfDesc* const   ehfDesc   = block->GetEhfTarget();
+    BBehfDesc* const   ehfDesc   = block->GetEhfTargets();
     const unsigned     succCount = ehfDesc->bbeCount;
     BasicBlock** const succTab   = ehfDesc->bbeSuccs;
 
@@ -627,7 +627,7 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, BasicBlock* succ)
 
     fgRemoveRefPred(succ, block);
 
-    BBehfDesc* const ehfDesc   = block->GetEhfTarget();
+    BBehfDesc* const ehfDesc   = block->GetEhfTargets();
     unsigned         succCount = ehfDesc->bbeCount;
     BasicBlock**     succTab   = ehfDesc->bbeSuccs;
     bool             found     = false;

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -467,8 +467,8 @@ void Compiler::fgReplaceSwitchJumpTarget(BasicBlock* blockSwitch, BasicBlock* ne
     // For the jump targets values that match oldTarget of our BBJ_SWITCH
     // replace predecessor 'blockSwitch' with 'newTarget'
 
-    unsigned     jumpCnt = blockSwitch->GetSwtTarget()->bbsCount;
-    BasicBlock** jumpTab = blockSwitch->GetSwtTarget()->bbsDstTab;
+    unsigned     jumpCnt = blockSwitch->GetSwitchTarget()->bbsCount;
+    BasicBlock** jumpTab = blockSwitch->GetSwitchTarget()->bbsDstTab;
 
     unsigned i = 0;
 
@@ -714,8 +714,8 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* newTarget, Bas
 
         case BBJ_SWITCH:
         {
-            unsigned const     jumpCnt = block->GetSwtTarget()->bbsCount;
-            BasicBlock** const jumpTab = block->GetSwtTarget()->bbsDstTab;
+            unsigned const     jumpCnt = block->GetSwitchTarget()->bbsCount;
+            BasicBlock** const jumpTab = block->GetSwitchTarget()->bbsDstTab;
             bool               changed = false;
 
             for (unsigned i = 0; i < jumpCnt; i++)
@@ -2996,8 +2996,8 @@ void Compiler::fgLinkBasicBlocks()
 
             case BBJ_SWITCH:
             {
-                unsigned     jumpCnt = curBBdesc->GetSwtTarget()->bbsCount;
-                BasicBlock** jumpPtr = curBBdesc->GetSwtTarget()->bbsDstTab;
+                unsigned     jumpCnt = curBBdesc->GetSwitchTarget()->bbsCount;
+                BasicBlock** jumpPtr = curBBdesc->GetSwitchTarget()->bbsDstTab;
 
                 do
                 {
@@ -4785,7 +4785,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
         assert(curr->KindIs(BBJ_SWITCH));
 
         // Start the new block with no refs. When we set the preds below, this will get updated correctly.
-        newBlock         = BasicBlock::New(this, curr->GetSwtTarget());
+        newBlock         = BasicBlock::New(this, curr->GetSwitchTarget());
         newBlock->bbRefs = 0;
 
         // In the case of a switch statement there's more complicated logic in order to wire up the predecessor lists

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5031,6 +5031,7 @@ BasicBlock* Compiler::fgSplitEdge(BasicBlock* curr, BasicBlock* succ)
         // an immediately following block of a BBJ_SWITCH (which has
         // no fall-through path). For this case, simply insert a new
         // fall-through block after 'curr'.
+        // TODO: Once bbNormalJumpDest can diverge from bbNext, this will be unnecessary for BBJ_COND
         newBlock = fgNewBBafter(BBJ_ALWAYS, curr, true /* extendRegion */, /* jumpDest */ succ);
         newBlock->SetFlags(BBF_NONE_QUIRK);
         assert(newBlock->JumpsToNext());

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -2934,9 +2934,9 @@ void Compiler::fgLinkBasicBlocks()
             {
                 // Avoid fgLookupBB overhead for blocks that jump to next block
                 // (curBBdesc cannot be the last block if it jumps to the next block)
-                const bool jumpsToNext = (curBBdesc->GetJumpOffs() == curBBdesc->bbCodeOffsEnd);
+                const bool jumpsToNext = (curBBdesc->GetTargetOffs() == curBBdesc->bbCodeOffsEnd);
                 assert(!(curBBdesc->IsLast() && jumpsToNext));
-                BasicBlock* const jumpDest = jumpsToNext ? curBBdesc->Next() : fgLookupBB(curBBdesc->GetJumpOffs());
+                BasicBlock* const jumpDest = jumpsToNext ? curBBdesc->Next() : fgLookupBB(curBBdesc->GetTargetOffs());
 
                 // Redundantly use SetKindAndTarget() instead of SetTarget() just this once,
                 // so we don't break the HasInitializedTarget() invariant of SetTarget().

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -467,8 +467,8 @@ void Compiler::fgReplaceSwitchJumpTarget(BasicBlock* blockSwitch, BasicBlock* ne
     // For the jump targets values that match oldTarget of our BBJ_SWITCH
     // replace predecessor 'blockSwitch' with 'newTarget'
 
-    unsigned     jumpCnt = blockSwitch->GetSwitchTarget()->bbsCount;
-    BasicBlock** jumpTab = blockSwitch->GetSwitchTarget()->bbsDstTab;
+    unsigned     jumpCnt = blockSwitch->GetSwitchTargets()->bbsCount;
+    BasicBlock** jumpTab = blockSwitch->GetSwitchTargets()->bbsDstTab;
 
     unsigned i = 0;
 
@@ -714,8 +714,8 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* newTarget, Bas
 
         case BBJ_SWITCH:
         {
-            unsigned const     jumpCnt = block->GetSwitchTarget()->bbsCount;
-            BasicBlock** const jumpTab = block->GetSwitchTarget()->bbsDstTab;
+            unsigned const     jumpCnt = block->GetSwitchTargets()->bbsCount;
+            BasicBlock** const jumpTab = block->GetSwitchTargets()->bbsDstTab;
             bool               changed = false;
 
             for (unsigned i = 0; i < jumpCnt; i++)
@@ -2996,8 +2996,8 @@ void Compiler::fgLinkBasicBlocks()
 
             case BBJ_SWITCH:
             {
-                unsigned     jumpCnt = curBBdesc->GetSwitchTarget()->bbsCount;
-                BasicBlock** jumpPtr = curBBdesc->GetSwitchTarget()->bbsDstTab;
+                unsigned     jumpCnt = curBBdesc->GetSwitchTargets()->bbsCount;
+                BasicBlock** jumpPtr = curBBdesc->GetSwitchTargets()->bbsDstTab;
 
                 do
                 {
@@ -4785,7 +4785,7 @@ BasicBlock* Compiler::fgSplitBlockAtEnd(BasicBlock* curr)
         assert(curr->KindIs(BBJ_SWITCH));
 
         // Start the new block with no refs. When we set the preds below, this will get updated correctly.
-        newBlock         = BasicBlock::New(this, curr->GetSwitchTarget());
+        newBlock         = BasicBlock::New(this, curr->GetSwitchTargets());
         newBlock->bbRefs = 0;
 
         // In the case of a switch statement there's more complicated logic in order to wire up the predecessor lists

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2957,6 +2957,13 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
 
         maxBBNum = max(maxBBNum, block->bbNum);
 
+        // BBJ_COND's normal (false) jump target is expected to be the next block
+        // TODO: Allow bbNormalJumpDest to diverge from bbNext
+        if (block->KindIs(BBJ_COND))
+        {
+            assert(block->NextIs(block->GetNormalJumpDest()));
+        }
+
         // Check that all the successors have the current traversal stamp. Use the 'Compiler*' version of the
         // iterator, but not for BBJ_SWITCH: we don't want to end up calling GetDescriptorForSwitch(), which will
         // dynamically create the unique switch list.

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -95,7 +95,7 @@ void Compiler::fgDebugCheckUpdate()
 
         if (block->isEmpty() && !block->HasFlag(BBF_DONT_REMOVE))
         {
-            switch (block->GetJumpKind())
+            switch (block->GetKind())
             {
                 case BBJ_CALLFINALLY:
                 case BBJ_EHFINALLYRET:
@@ -1007,7 +1007,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
             fprintf(fgxFile, "\n        <block");
             fprintf(fgxFile, "\n            id=\"%d\"", block->bbNum);
             fprintf(fgxFile, "\n            ordinal=\"%d\"", blockOrdinal);
-            fprintf(fgxFile, "\n            jumpKind=\"%s\"", kindImage[block->GetJumpKind()]);
+            fprintf(fgxFile, "\n            jumpKind=\"%s\"", kindImage[block->GetKind()]);
             if (block->hasTryIndex())
             {
                 fprintf(fgxFile, "\n            inTry=\"%s\"", "true");
@@ -1976,7 +1976,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
     }
     else
     {
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_COND:
                 printf("-> " FMT_BB "%*s ( cond )", block->GetTarget()->bbNum,
@@ -2748,7 +2748,7 @@ bool BBPredsChecker::CheckEhHndDsc(BasicBlock* block, BasicBlock* blockPred, EHb
 
 bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
 {
-    switch (blockPred->GetJumpKind())
+    switch (blockPred->GetKind())
     {
         case BBJ_COND:
             assert(blockPred->FalseTargetIs(block) || blockPred->HasJumpTo(block));
@@ -2792,7 +2792,7 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
             break;
 
         default:
-            assert(!"Unexpected bbJumpKind");
+            assert(!"Unexpected bbKind");
             break;
     }
     return false;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2751,7 +2751,7 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
     switch (blockPred->GetJumpKind())
     {
         case BBJ_COND:
-            assert(blockPred->HasNormalJumpTo(block) || blockPred->HasJumpTo(block));
+            assert(blockPred->FalseTargetIs(block) || blockPred->HasJumpTo(block));
             return true;
 
         case BBJ_ALWAYS:
@@ -2958,10 +2958,10 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         maxBBNum = max(maxBBNum, block->bbNum);
 
         // BBJ_COND's normal (false) jump target is expected to be the next block
-        // TODO-NoFallThrough: Allow bbNormalJumpDest to diverge from bbNext
+        // TODO-NoFallThrough: Allow bbFalseTarget to diverge from bbNext
         if (block->KindIs(BBJ_COND))
         {
-            assert(block->NextIs(block->GetNormalJumpDest()));
+            assert(block->NextIs(block->GetFalseTarget()));
         }
 
         // Check that all the successors have the current traversal stamp. Use the 'Compiler*' version of the

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2011,7 +2011,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
                 printf("->");
 
                 int                    ehfWidth = 0;
-                const BBehfDesc* const ehfDesc  = block->GetJumpEhf();
+                const BBehfDesc* const ehfDesc  = block->GetEhfTarget();
                 if (ehfDesc == nullptr)
                 {
                     printf(" ????");

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2751,14 +2751,14 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
     switch (blockPred->GetKind())
     {
         case BBJ_COND:
-            assert(blockPred->FalseTargetIs(block) || blockPred->HasJumpTo(block));
+            assert(blockPred->FalseTargetIs(block) || blockPred->TargetIs(block));
             return true;
 
         case BBJ_ALWAYS:
         case BBJ_CALLFINALLY:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
-            assert(blockPred->HasJumpTo(block));
+            assert(blockPred->TargetIs(block));
             return true;
 
         case BBJ_EHFINALLYRET:
@@ -2827,7 +2827,7 @@ bool BBPredsChecker::CheckEHFinallyRet(BasicBlock* blockPred, BasicBlock* block)
     found = false;
     for (BasicBlock* const bcall : comp->Blocks(firstBlock, lastBlock))
     {
-        if (bcall->KindIs(BBJ_CALLFINALLY) && bcall->HasJumpTo(finBeg) && bcall->NextIs(block))
+        if (bcall->KindIs(BBJ_CALLFINALLY) && bcall->TargetIs(finBeg) && bcall->NextIs(block))
         {
             found = true;
             break;
@@ -2845,7 +2845,7 @@ bool BBPredsChecker::CheckEHFinallyRet(BasicBlock* blockPred, BasicBlock* block)
 
         for (BasicBlock* const bcall : comp->Blocks(comp->fgFirstFuncletBB))
         {
-            if (bcall->KindIs(BBJ_CALLFINALLY) && bcall->HasJumpTo(finBeg) && bcall->NextIs(block) &&
+            if (bcall->KindIs(BBJ_CALLFINALLY) && bcall->TargetIs(finBeg) && bcall->NextIs(block) &&
                 comp->ehCallFinallyInCorrectRegion(bcall, hndIndex))
             {
                 found = true;
@@ -5010,7 +5010,7 @@ void Compiler::fgDebugCheckLoopTable()
             // The pre-header can only be BBJ_ALWAYS and must enter the loop.
             BasicBlock* e = loop.lpEntry;
             assert(h->KindIs(BBJ_ALWAYS));
-            assert(h->HasJumpTo(e));
+            assert(h->TargetIs(e));
 
             // The entry block has a single non-loop predecessor, and it is the pre-header.
             for (BasicBlock* const predBlock : e->PredBlocks())

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2751,7 +2751,7 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
     switch (blockPred->GetJumpKind())
     {
         case BBJ_COND:
-            assert(blockPred->NextIs(block) || blockPred->HasJumpTo(block));
+            assert(blockPred->HasNormalJumpTo(block) || blockPred->HasJumpTo(block));
             return true;
 
         case BBJ_ALWAYS:

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1979,8 +1979,8 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
         switch (block->GetKind())
         {
             case BBJ_COND:
-                printf("-> " FMT_BB "%*s ( cond )", block->GetTarget()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s ( cond )", block->GetTrueTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTrueTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_CALLFINALLY:

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1130,7 +1130,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
                         {
                             fprintf(fgxFile, "\n            switchCases=\"%d\"", edge->getDupCount());
                         }
-                        if (bSource->GetSwitchTarget()->getDefault() == bTarget)
+                        if (bSource->GetSwitchTargets()->getDefault() == bTarget)
                         {
                             fprintf(fgxFile, "\n            switchDefault=\"true\"");
                         }
@@ -2072,7 +2072,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
             {
                 printf("->");
 
-                const BBswtDesc* const jumpSwt     = block->GetSwitchTarget();
+                const BBswtDesc* const jumpSwt     = block->GetSwitchTargets();
                 const unsigned         jumpCnt     = jumpSwt->bbsCount;
                 BasicBlock** const     jumpTab     = jumpSwt->bbsDstTab;
                 int                    switchWidth = 0;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2958,7 +2958,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         maxBBNum = max(maxBBNum, block->bbNum);
 
         // BBJ_COND's normal (false) jump target is expected to be the next block
-        // TODO: Allow bbNormalJumpDest to diverge from bbNext
+        // TODO-NoFallThrough: Allow bbNormalJumpDest to diverge from bbNext
         if (block->KindIs(BBJ_COND))
         {
             assert(block->NextIs(block->GetNormalJumpDest()));

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1130,7 +1130,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
                         {
                             fprintf(fgxFile, "\n            switchCases=\"%d\"", edge->getDupCount());
                         }
-                        if (bSource->GetSwtTarget()->getDefault() == bTarget)
+                        if (bSource->GetSwitchTarget()->getDefault() == bTarget)
                         {
                             fprintf(fgxFile, "\n            switchDefault=\"true\"");
                         }
@@ -2072,7 +2072,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
             {
                 printf("->");
 
-                const BBswtDesc* const jumpSwt     = block->GetSwtTarget();
+                const BBswtDesc* const jumpSwt     = block->GetSwitchTarget();
                 const unsigned         jumpCnt     = jumpSwt->bbsCount;
                 BasicBlock** const     jumpTab     = jumpSwt->bbsDstTab;
                 int                    switchWidth = 0;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2011,7 +2011,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
                 printf("->");
 
                 int                    ehfWidth = 0;
-                const BBehfDesc* const ehfDesc  = block->GetEhfTarget();
+                const BBehfDesc* const ehfDesc  = block->GetEhfTargets();
                 if (ehfDesc == nullptr)
                 {
                     printf(" ????");

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1979,31 +1979,31 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
         switch (block->GetJumpKind())
         {
             case BBJ_COND:
-                printf("-> " FMT_BB "%*s ( cond )", block->GetJumpDest()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s ( cond )", block->GetTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_CALLFINALLY:
-                printf("-> " FMT_BB "%*s (callf )", block->GetJumpDest()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s (callf )", block->GetTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_ALWAYS:
                 if (flags & BBF_KEEP_BBJ_ALWAYS)
                 {
-                    printf("-> " FMT_BB "%*s (ALWAYS)", block->GetJumpDest()->bbNum,
-                           maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                    printf("-> " FMT_BB "%*s (ALWAYS)", block->GetTarget()->bbNum,
+                           maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 }
                 else
                 {
-                    printf("-> " FMT_BB "%*s (always)", block->GetJumpDest()->bbNum,
-                           maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                    printf("-> " FMT_BB "%*s (always)", block->GetTarget()->bbNum,
+                           maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 }
                 break;
 
             case BBJ_LEAVE:
-                printf("-> " FMT_BB "%*s (leave )", block->GetJumpDest()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s (leave )", block->GetTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_EHFINALLYRET:
@@ -2047,13 +2047,13 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
                 break;
 
             case BBJ_EHFILTERRET:
-                printf("-> " FMT_BB "%*s (fltret)", block->GetJumpDest()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s (fltret)", block->GetTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_EHCATCHRET:
-                printf("-> " FMT_BB "%*s ( cret )", block->GetJumpDest()->bbNum,
-                       maxBlockNumWidth - max(CountDigits(block->GetJumpDest()->bbNum), 2), "");
+                printf("-> " FMT_BB "%*s ( cret )", block->GetTarget()->bbNum,
+                       maxBlockNumWidth - max(CountDigits(block->GetTarget()->bbNum), 2), "");
                 break;
 
             case BBJ_THROW:
@@ -3104,9 +3104,9 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         }
 
         // Blocks with these jump kinds must have non-null jump targets
-        if (block->HasJumpDest())
+        if (block->HasTarget())
         {
-            assert(block->HasInitializedJumpDest());
+            assert(block->HasInitializedTarget());
         }
 
         // A branch or fall-through to a BBJ_CALLFINALLY block must come from the `try` region associated
@@ -3124,7 +3124,7 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
         {
             if (succBlock->KindIs(BBJ_CALLFINALLY))
             {
-                BasicBlock* finallyBlock = succBlock->GetJumpDest();
+                BasicBlock* finallyBlock = succBlock->GetTarget();
                 assert(finallyBlock->hasHndIndex());
                 unsigned finallyIndex = finallyBlock->getHndIndex();
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1130,7 +1130,7 @@ bool Compiler::fgDumpFlowGraph(Phases phase, PhasePosition pos)
                         {
                             fprintf(fgxFile, "\n            switchCases=\"%d\"", edge->getDupCount());
                         }
-                        if (bSource->GetJumpSwt()->getDefault() == bTarget)
+                        if (bSource->GetSwtTarget()->getDefault() == bTarget)
                         {
                             fprintf(fgxFile, "\n            switchDefault=\"true\"");
                         }
@@ -2072,7 +2072,7 @@ void Compiler::fgTableDispBasicBlock(BasicBlock* block, int ibcColWidth /* = 0 *
             {
                 printf("->");
 
-                const BBswtDesc* const jumpSwt     = block->GetJumpSwt();
+                const BBswtDesc* const jumpSwt     = block->GetSwtTarget();
                 const unsigned         jumpCnt     = jumpSwt->bbsCount;
                 BasicBlock** const     jumpTab     = jumpSwt->bbsDstTab;
                 int                    switchWidth = 0;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2751,7 +2751,7 @@ bool BBPredsChecker::CheckJump(BasicBlock* blockPred, BasicBlock* block)
     switch (blockPred->GetKind())
     {
         case BBJ_COND:
-            assert(blockPred->FalseTargetIs(block) || blockPred->TargetIs(block));
+            assert(blockPred->FalseTargetIs(block) || blockPred->TrueTargetIs(block));
             return true;
 
         case BBJ_ALWAYS:

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -165,7 +165,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
                 noway_assert(leaveBlock->KindIs(BBJ_ALWAYS));
 
-                currentBlock->SetJumpKindAndTarget(BBJ_ALWAYS, postTryFinallyBlock);
+                currentBlock->SetKindAndTarget(BBJ_ALWAYS, postTryFinallyBlock);
 
                 // Ref count updates.
                 fgAddRefPred(postTryFinallyBlock, currentBlock);
@@ -528,7 +528,7 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
                     GenTree*   finallyRetExpr = finallyRet->GetRootNode();
                     assert(finallyRetExpr->gtOper == GT_RETFILT);
                     fgRemoveStmt(block, finallyRet);
-                    block->SetJumpKindAndTarget(BBJ_ALWAYS, continuation);
+                    block->SetKindAndTarget(BBJ_ALWAYS, continuation);
                     fgAddRefPred(continuation, block);
                     fgRemoveRefPred(leave, block);
                 }
@@ -1110,7 +1110,7 @@ PhaseStatus Compiler::fgCloneFinally()
                 GenTree*   finallyRetExpr = finallyRet->GetRootNode();
                 assert(finallyRetExpr->gtOper == GT_RETFILT);
                 fgRemoveStmt(newBlock, finallyRet);
-                newBlock->SetJumpKindAndTarget(BBJ_ALWAYS, normalCallFinallyReturn);
+                newBlock->SetKindAndTarget(BBJ_ALWAYS, normalCallFinallyReturn);
 
                 fgAddRefPred(normalCallFinallyReturn, newBlock);
             }
@@ -1150,7 +1150,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
                     // This call returns to the expected spot, so
                     // retarget it to branch to the clone.
-                    currentBlock->SetJumpKindAndTarget(BBJ_ALWAYS, firstCloneBlock);
+                    currentBlock->SetKindAndTarget(BBJ_ALWAYS, firstCloneBlock);
 
                     // Ref count updates.
                     fgAddRefPred(firstCloneBlock, currentBlock);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2058,7 +2058,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
                 case BBJ_COND:
                 {
                     // Flow to non canonical block could be via fall through or jump or both.
-                    if (predBlock->HasNormalJumpTo(nonCanonicalBlock))
+                    if (predBlock->FalseTargetIs(nonCanonicalBlock))
                     {
                         fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
                     }
@@ -2135,7 +2135,7 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
                                                   FlowEdge*   predEdge)
 {
     assert(predBlock->KindIs(BBJ_COND));
-    assert(predBlock->HasNormalJumpTo(nonCanonicalBlock));
+    assert(predBlock->FalseTargetIs(nonCanonicalBlock));
 
     BasicBlock* const newBlock = fgNewBBafter(BBJ_ALWAYS, predBlock, true, canonicalBlock);
 

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1209,7 +1209,7 @@ PhaseStatus Compiler::fgCloneFinally()
             {
                 if (block->KindIs(BBJ_EHFINALLYRET))
                 {
-                    assert(block->GetJumpEhf()->bbeCount == 0);
+                    assert(block->GetEhfTarget()->bbeCount == 0);
                     block->SetKind(BBJ_EHFAULTRET);
                 }
             }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -455,7 +455,7 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         //
         // (1) Convert the callfinally to a normal jump to the handler
         assert(callFinally->HasInitializedTarget());
-        callFinally->SetJumpKind(BBJ_ALWAYS);
+        callFinally->SetKind(BBJ_ALWAYS);
 
         // Identify the leave block and the continuation
         BasicBlock* const leave        = callFinally->Next();
@@ -1210,7 +1210,7 @@ PhaseStatus Compiler::fgCloneFinally()
                 if (block->KindIs(BBJ_EHFINALLYRET))
                 {
                     assert(block->GetJumpEhf()->bbeCount == 0);
-                    block->SetJumpKind(BBJ_EHFAULTRET);
+                    block->SetKind(BBJ_EHFAULTRET);
                 }
             }
         }
@@ -2046,7 +2046,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
             BasicBlock* const predBlock = predEdge->getSourceBlock();
             nextPredEdge                = predEdge->getNextPredEdge();
 
-            switch (predBlock->GetJumpKind())
+            switch (predBlock->GetKind())
             {
                 case BBJ_ALWAYS:
                 {

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2063,7 +2063,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
                         fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
                     }
 
-                    if (predBlock->TargetIs(nonCanonicalBlock))
+                    if (predBlock->TrueTargetIs(nonCanonicalBlock))
                     {
                         fgTailMergeThrowsJumpToHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
                     }
@@ -2176,14 +2176,23 @@ void Compiler::fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
                                              BasicBlock* canonicalBlock,
                                              FlowEdge*   predEdge)
 {
-    assert(predBlock->TargetIs(nonCanonicalBlock));
-
     JITDUMP("*** " FMT_BB " now branching to " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
 
     // Remove the old flow
     fgRemoveRefPred(nonCanonicalBlock, predBlock);
 
     // Wire up the new flow
-    predBlock->SetTarget(canonicalBlock);
+    if (predBlock->KindIs(BBJ_ALWAYS))
+    {
+        assert(predBlock->TargetIs(nonCanonicalBlock));
+        predBlock->SetTarget(canonicalBlock);
+    }
+    else
+    {
+        assert(predBlock->KindIs(BBJ_COND));
+        assert(predBlock->TrueTargetIs(nonCanonicalBlock));
+        predBlock->SetTrueTarget(canonicalBlock);
+    }
+
     fgAddRefPred(canonicalBlock, predBlock, predEdge);
 }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2058,7 +2058,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
                 case BBJ_COND:
                 {
                     // Flow to non canonical block could be via fall through or jump or both.
-                    if (predBlock->NextIs(nonCanonicalBlock))
+                    if (predBlock->HasNormalJumpTo(nonCanonicalBlock))
                     {
                         fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
                     }
@@ -2134,7 +2134,8 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
                                                   BasicBlock* canonicalBlock,
                                                   FlowEdge*   predEdge)
 {
-    assert(predBlock->NextIs(nonCanonicalBlock));
+    assert(predBlock->KindIs(BBJ_COND));
+    assert(predBlock->HasNormalJumpTo(nonCanonicalBlock));
 
     BasicBlock* const newBlock = fgNewBBafter(BBJ_ALWAYS, predBlock, true, canonicalBlock);
 

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1209,7 +1209,7 @@ PhaseStatus Compiler::fgCloneFinally()
             {
                 if (block->KindIs(BBJ_EHFINALLYRET))
                 {
-                    assert(block->GetEhfTarget()->bbeCount == 0);
+                    assert(block->GetEhfTargets()->bbeCount == 0);
                     block->SetKind(BBJ_EHFAULTRET);
                 }
             }

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -357,7 +357,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
 
         case BBJ_COND:
             fgRemoveRefPred(block->GetJumpDest(), block);
-            fgRemoveRefPred(block->GetNormalJumpDest(), block);
+            fgRemoveRefPred(block->GetFalseTarget(), block);
             break;
 
         case BBJ_EHFINALLYRET:

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -352,11 +352,11 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
-            fgRemoveRefPred(block->GetJumpDest(), block);
+            fgRemoveRefPred(block->GetTarget(), block);
             break;
 
         case BBJ_COND:
-            fgRemoveRefPred(block->GetJumpDest(), block);
+            fgRemoveRefPred(block->GetTarget(), block);
             fgRemoveRefPred(block->GetFalseTarget(), block);
             break;
 

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -356,7 +356,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
             break;
 
         case BBJ_COND:
-            fgRemoveRefPred(block->GetTarget(), block);
+            fgRemoveRefPred(block->GetTrueTarget(), block);
             fgRemoveRefPred(block->GetFalseTarget(), block);
             break;
 

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -346,7 +346,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
 {
     PREFIX_ASSUME(block != nullptr);
 
-    switch (block->GetJumpKind())
+    switch (block->GetKind())
     {
         case BBJ_CALLFINALLY:
         case BBJ_ALWAYS:
@@ -380,7 +380,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
             break;
 
         default:
-            noway_assert(!"Block doesn't have a valid bbJumpKind!!!!");
+            noway_assert(!"Block doesn't have a valid bbKind!!!!");
             break;
     }
 }

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -357,7 +357,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
 
         case BBJ_COND:
             fgRemoveRefPred(block->GetJumpDest(), block);
-            fgRemoveRefPred(block->Next(), block);
+            fgRemoveRefPred(block->GetNormalJumpDest(), block);
             break;
 
         case BBJ_EHFINALLYRET:

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -675,14 +675,14 @@ private:
 
                 if (condTree->IsIntegralConst(0))
                 {
-                    m_compiler->fgRemoveRefPred(block->GetTarget(), block);
+                    m_compiler->fgRemoveRefPred(block->GetTrueTarget(), block);
                     block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
                     block->SetFlags(BBF_NONE_QUIRK);
                 }
                 else
                 {
+                    m_compiler->fgRemoveRefPred(block->GetFalseTarget(), block);
                     block->SetKind(BBJ_ALWAYS);
-                    m_compiler->fgRemoveRefPred(block->Next(), block);
                 }
             }
         }

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1549,7 +1549,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
 
         // Insert inlinee's blocks into inliner's block list.
         assert(topBlock->KindIs(BBJ_ALWAYS));
-        assert(topBlock->HasJumpTo(bottomBlock));
+        assert(topBlock->TargetIs(bottomBlock));
         topBlock->SetNext(InlineeCompiler->fgFirstBB);
         topBlock->SetTarget(topBlock->Next());
         topBlock->SetFlags(BBF_NONE_QUIRK);

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -681,7 +681,7 @@ private:
                 }
                 else
                 {
-                    block->SetJumpKind(BBJ_ALWAYS);
+                    block->SetKind(BBJ_ALWAYS);
                     m_compiler->fgRemoveRefPred(block->Next(), block);
                 }
             }
@@ -1530,7 +1530,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
             if (block->KindIs(BBJ_RETURN))
             {
                 noway_assert(!block->HasFlag(BBF_HAS_JMP));
-                JITDUMP("\nConvert bbJumpKind of " FMT_BB " to BBJ_ALWAYS to bottomBlock " FMT_BB "\n", block->bbNum,
+                JITDUMP("\nConvert bbKind of " FMT_BB " to BBJ_ALWAYS to bottomBlock " FMT_BB "\n", block->bbNum,
                         bottomBlock->bbNum);
 
                 block->SetKindAndTarget(BBJ_ALWAYS, bottomBlock);

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -676,7 +676,7 @@ private:
                 if (condTree->IsIntegralConst(0))
                 {
                     m_compiler->fgRemoveRefPred(block->GetTarget(), block);
-                    block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
+                    block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
                     block->SetFlags(BBF_NONE_QUIRK);
                 }
                 else
@@ -1533,7 +1533,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
                 JITDUMP("\nConvert bbJumpKind of " FMT_BB " to BBJ_ALWAYS to bottomBlock " FMT_BB "\n", block->bbNum,
                         bottomBlock->bbNum);
 
-                block->SetJumpKindAndTarget(BBJ_ALWAYS, bottomBlock);
+                block->SetKindAndTarget(BBJ_ALWAYS, bottomBlock);
                 fgAddRefPred(bottomBlock, block);
 
                 if (block == InlineeCompiler->fgLastBB)

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -675,7 +675,7 @@ private:
 
                 if (condTree->IsIntegralConst(0))
                 {
-                    m_compiler->fgRemoveRefPred(block->GetJumpDest(), block);
+                    m_compiler->fgRemoveRefPred(block->GetTarget(), block);
                     block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
                     block->SetFlags(BBF_NONE_QUIRK);
                 }
@@ -1551,7 +1551,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
         assert(topBlock->KindIs(BBJ_ALWAYS));
         assert(topBlock->HasJumpTo(bottomBlock));
         topBlock->SetNext(InlineeCompiler->fgFirstBB);
-        topBlock->SetJumpDest(topBlock->Next());
+        topBlock->SetTarget(topBlock->Next());
         topBlock->SetFlags(BBF_NONE_QUIRK);
         fgRemoveRefPred(bottomBlock, topBlock);
         fgAddRefPred(InlineeCompiler->fgFirstBB, topBlock);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -7031,7 +7031,8 @@ bool Compiler::fgTryOneHeadMerge(BasicBlock* block, bool early)
     Statement* nextFirstStmt;
     Statement* destFirstStmt;
 
-    if (!getSuccCandidate(block->GetNormalJumpDest(), &nextFirstStmt) || !getSuccCandidate(block->GetJumpDest(), &destFirstStmt))
+    if (!getSuccCandidate(block->GetNormalJumpDest(), &nextFirstStmt) ||
+        !getSuccCandidate(block->GetJumpDest(), &destFirstStmt))
     {
         return false;
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1759,7 +1759,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                     GenTree* const jumpIfEntryStateZero = gtNewOperNode(GT_JTRUE, TYP_VOID, compareEntryStateToZero);
                     fgNewStmtAtBeg(fromBlock, jumpIfEntryStateZero);
 
-                    fromBlock->SetKindAndTarget(BBJ_COND, toBlock);
+                    fromBlock->SetCondKindAndTarget(toBlock);
                     fgAddRefPred(toBlock, fromBlock);
                     newBlock->inheritWeight(fromBlock);
 
@@ -2315,7 +2315,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_COND:
-            block->SetKindAndTarget(BBJ_COND, bNext->GetTrueTarget());
+            block->SetCondKindAndTarget(bNext->GetTrueTarget());
 
             /* Update the predecessor list for 'bNext->bbTarget' */
             fgReplacePred(bNext->GetTrueTarget(), bNext, block);
@@ -3310,7 +3310,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             fgSetStmtSeq(switchStmt);
         }
 
-        block->SetKindAndTarget(BBJ_COND, block->GetSwtTarget()->bbsDstTab[0]);
+        block->SetCondKindAndTarget(block->GetSwtTarget()->bbsDstTab[0]);
 
         JITDUMP("After:\n");
         DISPNODE(switchTree);
@@ -3720,7 +3720,7 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
 
     // Fix up block's flow
     //
-    block->SetKindAndTarget(BBJ_COND, target->GetTrueTarget());
+    block->SetCondKindAndTarget(target->GetTrueTarget());
     fgAddRefPred(block->GetTrueTarget(), block);
     fgRemoveRefPred(target, block);
 
@@ -4132,7 +4132,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     // We need to update the following flags of the bJump block if they were set in the bDest block
     bJump->CopyFlags(bDest, BBF_COPY_PROPAGATE);
 
-    bJump->SetKindAndTarget(BBJ_COND, bDestNormalTarget);
+    bJump->SetCondKindAndTarget(bDestNormalTarget);
     bJump->SetFalseTarget(bJump->Next());
 
     /* Update bbRefs and bbPreds */
@@ -4293,7 +4293,7 @@ bool Compiler::fgOptimizeSwitchJumps()
 
         // Wire up the new control flow.
         //
-        block->SetKindAndTarget(BBJ_COND, dominantTarget);
+        block->SetCondKindAndTarget(dominantTarget);
         FlowEdge* const blockToTargetEdge   = fgAddRefPred(dominantTarget, block);
         FlowEdge* const blockToNewBlockEdge = newBlock->bbPreds;
         assert(blockToNewBlockEdge->getSourceBlock() == block);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2340,7 +2340,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_SWITCH:
-            block->SetSwitch(bNext->GetSwtTarget());
+            block->SetSwitch(bNext->GetSwitchTarget());
             // We are moving the switch jump from bNext to block.  Examine the jump targets
             // of the BBJ_SWITCH at bNext and replace the predecessor to 'bNext' with ones to 'block'
             fgChangeSwitchBlock(bNext, block);
@@ -3057,8 +3057,8 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
 {
     assert(block->KindIs(BBJ_SWITCH));
 
-    unsigned     jmpCnt = block->GetSwtTarget()->bbsCount;
-    BasicBlock** jmpTab = block->GetSwtTarget()->bbsDstTab;
+    unsigned     jmpCnt = block->GetSwitchTarget()->bbsCount;
+    BasicBlock** jmpTab = block->GetSwitchTarget()->bbsDstTab;
     BasicBlock*  bNewDest; // the new jump target for the current switch case
     BasicBlock*  bDest;
     bool         returnvalue = false;
@@ -3160,8 +3160,8 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
     // At this point all of the case jump targets have been updated such
     // that none of them go to block that is an empty unconditional block
     //
-    jmpTab = block->GetSwtTarget()->bbsDstTab;
-    jmpCnt = block->GetSwtTarget()->bbsCount;
+    jmpTab = block->GetSwitchTarget()->bbsDstTab;
+    jmpCnt = block->GetSwitchTarget()->bbsCount;
 
     // Now check for two trivial switch jumps.
     //
@@ -3246,7 +3246,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         }
 
         // Change the switch jump into a BBJ_ALWAYS
-        block->SetKindAndTarget(BBJ_ALWAYS, block->GetSwtTarget()->bbsDstTab[0]);
+        block->SetKindAndTarget(BBJ_ALWAYS, block->GetSwitchTarget()->bbsDstTab[0]);
         if (jmpCnt > 1)
         {
             for (unsigned i = 1; i < jmpCnt; ++i)
@@ -3257,7 +3257,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
 
         return true;
     }
-    else if ((block->GetSwtTarget()->bbsCount == 2) && block->NextIs(block->GetSwtTarget()->bbsDstTab[1]))
+    else if ((block->GetSwitchTarget()->bbsCount == 2) && block->NextIs(block->GetSwitchTarget()->bbsDstTab[1]))
     {
         /* Use a BBJ_COND(switchVal==0) for a switch with only one
            significant clause besides the default clause, if the
@@ -3310,7 +3310,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             fgSetStmtSeq(switchStmt);
         }
 
-        block->SetCond(block->GetSwtTarget()->bbsDstTab[0]);
+        block->SetCond(block->GetSwitchTarget()->bbsDstTab[0]);
 
         JITDUMP("After:\n");
         DISPNODE(switchTree);
@@ -4234,7 +4234,7 @@ bool Compiler::fgOptimizeSwitchJumps()
             continue;
         }
 
-        if (!block->GetSwtTarget()->bbsHasDominantCase)
+        if (!block->GetSwitchTarget()->bbsHasDominantCase)
         {
             continue;
         }
@@ -4243,14 +4243,14 @@ bool Compiler::fgOptimizeSwitchJumps()
         //
         assert(block->hasProfileWeight());
 
-        const unsigned dominantCase = block->GetSwtTarget()->bbsDominantCase;
+        const unsigned dominantCase = block->GetSwitchTarget()->bbsDominantCase;
 
         JITDUMP(FMT_BB " has switch with dominant case %u, considering peeling\n", block->bbNum, dominantCase);
 
         // The dominant case should not be the default case, as we already peel that one.
         //
-        assert(dominantCase < (block->GetSwtTarget()->bbsCount - 1));
-        BasicBlock* const dominantTarget = block->GetSwtTarget()->bbsDstTab[dominantCase];
+        assert(dominantCase < (block->GetSwitchTarget()->bbsCount - 1));
+        BasicBlock* const dominantTarget = block->GetSwitchTarget()->bbsDstTab[dominantCase];
         Statement* const  switchStmt     = block->lastStmt();
         GenTree* const    switchTree     = switchStmt->GetRootNode();
         assert(switchTree->OperIs(GT_SWITCH));
@@ -4301,7 +4301,7 @@ bool Compiler::fgOptimizeSwitchJumps()
 
         // Update profile data
         //
-        const weight_t fraction              = newBlock->GetSwtTarget()->bbsDominantFraction;
+        const weight_t fraction              = newBlock->GetSwitchTarget()->bbsDominantFraction;
         const weight_t blockToTargetWeight   = block->bbWeight * fraction;
         const weight_t blockToNewBlockWeight = block->bbWeight - blockToTargetWeight;
 
@@ -4351,7 +4351,7 @@ bool Compiler::fgOptimizeSwitchJumps()
         //
         // But it no longer has a dominant case.
         //
-        newBlock->GetSwtTarget()->bbsHasDominantCase = false;
+        newBlock->GetSwitchTarget()->bbsHasDominantCase = false;
 
         if (fgNodeThreading == NodeThreading::AllTrees)
         {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2787,7 +2787,19 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
         }
 
         // Optimize the JUMP to empty unconditional JUMP to go to the new target
-        block->SetTarget(bDest->GetTarget());
+        switch (block->GetKind())
+        {
+            case BBJ_ALWAYS:
+                block->SetTarget(bDest->GetTarget());
+                break;
+
+            case BBJ_COND:
+                block->SetTrueTarget(bDest->GetTarget());
+                break;
+
+            default:
+                unreached();
+        }
 
         fgAddRefPred(bDest->GetTarget(), block, fgRemoveRefPred(bDest, block));
 
@@ -5760,7 +5772,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
             if (bStart2 == nullptr)
             {
                 /* Set the new jump dest for bPrev to the rarely run or uncommon block(s) */
-                bPrev->SetTarget(bStart);
+                bPrev->SetTrueTarget(bStart);
             }
             else
             {
@@ -5768,7 +5780,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                 noway_assert(insertAfterBlk->NextIs(block));
 
                 /* Set the new jump dest for bPrev to the rarely run or uncommon block(s) */
-                bPrev->SetTarget(block);
+                bPrev->SetTrueTarget(block);
             }
         }
 
@@ -6204,7 +6216,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                         }
 
                         // Optimize the Conditional JUMP to go to the new target
-                        block->SetTarget(bNext->GetTarget());
+                        block->SetTrueTarget(bNext->GetTarget());
 
                         fgAddRefPred(bNext->GetTarget(), block, fgRemoveRefPred(bNext->GetTarget(), bNext));
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2328,7 +2328,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetEhf(bNext->GetEhfTarget());
+            block->SetEhf(bNext->GetEhfTargets());
             fgChangeEhfBlock(bNext, block);
             break;
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1759,7 +1759,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                     GenTree* const jumpIfEntryStateZero = gtNewOperNode(GT_JTRUE, TYP_VOID, compareEntryStateToZero);
                     fgNewStmtAtBeg(fromBlock, jumpIfEntryStateZero);
 
-                    fromBlock->SetCondKindAndTarget(toBlock);
+                    fromBlock->SetCond(toBlock);
                     fgAddRefPred(toBlock, fromBlock);
                     newBlock->inheritWeight(fromBlock);
 
@@ -2315,7 +2315,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_COND:
-            block->SetCondKindAndTarget(bNext->GetTrueTarget());
+            block->SetCond(bNext->GetTrueTarget());
 
             /* Update the predecessor list for 'bNext->bbTarget' */
             fgReplacePred(bNext->GetTrueTarget(), bNext, block);
@@ -3310,7 +3310,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             fgSetStmtSeq(switchStmt);
         }
 
-        block->SetCondKindAndTarget(block->GetSwtTarget()->bbsDstTab[0]);
+        block->SetCond(block->GetSwtTarget()->bbsDstTab[0]);
 
         JITDUMP("After:\n");
         DISPNODE(switchTree);
@@ -3720,7 +3720,7 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
 
     // Fix up block's flow
     //
-    block->SetCondKindAndTarget(target->GetTrueTarget());
+    block->SetCond(target->GetTrueTarget());
     fgAddRefPred(block->GetTrueTarget(), block);
     fgRemoveRefPred(target, block);
 
@@ -4132,7 +4132,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     // We need to update the following flags of the bJump block if they were set in the bDest block
     bJump->CopyFlags(bDest, BBF_COPY_PROPAGATE);
 
-    bJump->SetCondKindAndTarget(bDestNormalTarget);
+    bJump->SetCond(bDestNormalTarget);
     bJump->SetFalseTarget(bJump->Next());
 
     /* Update bbRefs and bbPreds */
@@ -4293,7 +4293,7 @@ bool Compiler::fgOptimizeSwitchJumps()
 
         // Wire up the new control flow.
         //
-        block->SetCondKindAndTarget(dominantTarget);
+        block->SetCond(dominantTarget);
         FlowEdge* const blockToTargetEdge   = fgAddRefPred(dominantTarget, block);
         FlowEdge* const blockToNewBlockEdge = newBlock->bbPreds;
         assert(blockToNewBlockEdge->getSourceBlock() == block);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2340,7 +2340,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_SWITCH:
-            block->SetSwtKindAndTarget(bNext->GetSwtTarget());
+            block->SetSwitch(bNext->GetSwtTarget());
             // We are moving the switch jump from bNext to block.  Examine the jump targets
             // of the BBJ_SWITCH at bNext and replace the predecessor to 'bNext' with ones to 'block'
             fgChangeSwitchBlock(bNext, block);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2328,7 +2328,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetEhfKindAndTarget(bNext->GetEhfTarget());
+            block->SetEhf(bNext->GetEhfTarget());
             fgChangeEhfBlock(bNext, block);
             break;
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2572,9 +2572,9 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
     noway_assert(flow->getDupCount() == 2);
 
     // Change the BBJ_COND to BBJ_ALWAYS, and adjust the refCount and dupCount.
+    --block->GetNormalJumpDest()->bbRefs;
     block->SetJumpKind(BBJ_ALWAYS);
     block->SetFlags(BBF_NONE_QUIRK);
-    --block->GetNormalJumpDest()->bbRefs;
     flow->decrementDupCount();
 
 #ifdef DEBUG

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2292,7 +2292,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
 
     /* Set the jump targets */
 
-    switch (bNext->GetJumpKind())
+    switch (bNext->GetKind())
     {
         case BBJ_CALLFINALLY:
             // Propagate RETLESS property
@@ -2309,7 +2309,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         case BBJ_COND:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
-            block->SetKindAndTarget(bNext->GetJumpKind(), bNext->GetTarget());
+            block->SetKindAndTarget(bNext->GetKind(), bNext->GetTarget());
 
             /* Update the predecessor list for 'bNext->bbTarget' */
             fgReplacePred(bNext->GetTarget(), bNext, block);
@@ -2322,7 +2322,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetKindAndTarget(bNext->GetJumpKind(), bNext->GetJumpEhf());
+            block->SetKindAndTarget(bNext->GetKind(), bNext->GetJumpEhf());
             fgChangeEhfBlock(bNext, block);
             break;
 
@@ -2330,7 +2330,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         case BBJ_THROW:
         case BBJ_RETURN:
             /* no jumps or fall through blocks to set here */
-            block->SetJumpKind(bNext->GetJumpKind());
+            block->SetKind(bNext->GetKind());
             break;
 
         case BBJ_SWITCH:
@@ -2341,11 +2341,11 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         default:
-            noway_assert(!"Unexpected bbJumpKind");
+            noway_assert(!"Unexpected bbKind");
             break;
     }
 
-    assert(block->KindIs(bNext->GetJumpKind()));
+    assert(block->KindIs(bNext->GetKind()));
 
     if (bNext->KindIs(BBJ_COND, BBJ_ALWAYS) && bNext->GetTarget()->isLoopAlign())
     {
@@ -2573,7 +2573,7 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
 
     // Change the BBJ_COND to BBJ_ALWAYS, and adjust the refCount and dupCount.
     --block->GetFalseTarget()->bbRefs;
-    block->SetJumpKind(BBJ_ALWAYS);
+    block->SetKind(BBJ_ALWAYS);
     block->SetFlags(BBF_NONE_QUIRK);
     flow->decrementDupCount();
 
@@ -2812,7 +2812,7 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
     bool        madeChanges = false;
     BasicBlock* bPrev       = block->Prev();
 
-    switch (block->GetJumpKind())
+    switch (block->GetKind())
     {
         case BBJ_COND:
         case BBJ_SWITCH:
@@ -3010,7 +3010,7 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
             break;
 
         default:
-            noway_assert(!"Unexpected bbJumpKind");
+            noway_assert(!"Unexpected bbKind");
             break;
     }
 
@@ -3838,7 +3838,7 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
 
     /* Conditional is gone - always jump to the next block */
 
-    block->SetJumpKind(BBJ_ALWAYS);
+    block->SetKind(BBJ_ALWAYS);
 
     /* Update bbRefs and bbNum - Conditional predecessors to the same
         * block are counted twice so we have to remove one of them */
@@ -4483,7 +4483,7 @@ bool Compiler::fgExpandRarelyRunBlocks()
 
         const char* reason = nullptr;
 
-        switch (bPrev->GetJumpKind())
+        switch (bPrev->GetKind())
         {
             case BBJ_ALWAYS:
 
@@ -6341,7 +6341,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
             }
             else if (block->countOfInEdges() == 1)
             {
-                switch (block->GetJumpKind())
+                switch (block->GetKind())
                 {
                     case BBJ_COND:
                     case BBJ_ALWAYS:
@@ -6438,7 +6438,7 @@ unsigned Compiler::fgGetCodeEstimate(BasicBlock* block)
 {
     unsigned costSz = 0; // estimate of block's code size cost
 
-    switch (block->GetJumpKind())
+    switch (block->GetKind())
     {
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
@@ -6464,7 +6464,7 @@ unsigned Compiler::fgGetCodeEstimate(BasicBlock* block)
             costSz = 3;
             break;
         default:
-            noway_assert(!"Bad bbJumpKind");
+            noway_assert(!"Bad bbKind");
             break;
     }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -449,7 +449,7 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
 
             block->RemoveFlags(BBF_REMOVED | BBF_INTERNAL);
             block->SetFlags(BBF_IMPORTED);
-            block->SetJumpKindAndTarget(BBJ_THROW);
+            block->SetKindAndTarget(BBJ_THROW);
             block->bbSetRunRarely();
         }
         else
@@ -470,7 +470,7 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
                 // change the kind to something else. Otherwise, we can hit asserts below in fgRemoveBlock that
                 // the leaveBlk BBJ_ALWAYS is not allowed to be a CallAlwaysPairTail.
                 assert(block->KindIs(BBJ_CALLFINALLY));
-                block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
+                block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
             }
 
             leaveBlk->RemoveFlags(BBF_DONT_REMOVE);
@@ -1622,7 +1622,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                         // plausible flow target. Simplest is to just mark it as a throw.
                         if (bbIsHandlerBeg(newTryEntry->Next()))
                         {
-                            newTryEntry->SetJumpKindAndTarget(BBJ_THROW);
+                            newTryEntry->SetKindAndTarget(BBJ_THROW);
                         }
                         else
                         {
@@ -1759,7 +1759,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
                     GenTree* const jumpIfEntryStateZero = gtNewOperNode(GT_JTRUE, TYP_VOID, compareEntryStateToZero);
                     fgNewStmtAtBeg(fromBlock, jumpIfEntryStateZero);
 
-                    fromBlock->SetJumpKindAndTarget(BBJ_COND, toBlock);
+                    fromBlock->SetKindAndTarget(BBJ_COND, toBlock);
                     fgAddRefPred(toBlock, fromBlock);
                     newBlock->inheritWeight(fromBlock);
 
@@ -2309,7 +2309,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         case BBJ_COND:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
-            block->SetJumpKindAndTarget(bNext->GetJumpKind(), bNext->GetTarget());
+            block->SetKindAndTarget(bNext->GetJumpKind(), bNext->GetTarget());
 
             /* Update the predecessor list for 'bNext->bbTarget' */
             fgReplacePred(bNext->GetTarget(), bNext, block);
@@ -2322,7 +2322,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetJumpKindAndTarget(bNext->GetJumpKind(), bNext->GetJumpEhf());
+            block->SetKindAndTarget(bNext->GetJumpKind(), bNext->GetJumpEhf());
             fgChangeEhfBlock(bNext, block);
             break;
 
@@ -2334,7 +2334,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_SWITCH:
-            block->SetSwitchKindAndTarget(bNext->GetJumpSwt());
+            block->SetKindAndTarget(bNext->GetJumpSwt());
             // We are moving the switch jump from bNext to block.  Examine the jump targets
             // of the BBJ_SWITCH at bNext and replace the predecessor to 'bNext' with ones to 'block'
             fgChangeSwitchBlock(bNext, block);
@@ -3220,7 +3220,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         }
 
         // Change the switch jump into a BBJ_ALWAYS
-        block->SetJumpKindAndTarget(BBJ_ALWAYS, block->GetJumpSwt()->bbsDstTab[0]);
+        block->SetKindAndTarget(BBJ_ALWAYS, block->GetJumpSwt()->bbsDstTab[0]);
         if (jmpCnt > 1)
         {
             for (unsigned i = 1; i < jmpCnt; ++i)
@@ -3284,7 +3284,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             fgSetStmtSeq(switchStmt);
         }
 
-        block->SetJumpKindAndTarget(BBJ_COND, block->GetJumpSwt()->bbsDstTab[0]);
+        block->SetKindAndTarget(BBJ_COND, block->GetJumpSwt()->bbsDstTab[0]);
 
         JITDUMP("After:\n");
         DISPNODE(switchTree);
@@ -3694,7 +3694,7 @@ bool Compiler::fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock*
 
     // Fix up block's flow
     //
-    block->SetJumpKindAndTarget(BBJ_COND, target->GetTarget());
+    block->SetKindAndTarget(BBJ_COND, target->GetTarget());
     fgAddRefPred(block->GetTarget(), block);
     fgRemoveRefPred(target, block);
 
@@ -4106,7 +4106,7 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
     // We need to update the following flags of the bJump block if they were set in the bDest block
     bJump->CopyFlags(bDest, BBF_COPY_PROPAGATE);
 
-    bJump->SetJumpKindAndTarget(BBJ_COND, bDestNormalTarget);
+    bJump->SetKindAndTarget(BBJ_COND, bDestNormalTarget);
     bJump->SetFalseTarget(bJump->Next());
 
     /* Update bbRefs and bbPreds */
@@ -4267,7 +4267,7 @@ bool Compiler::fgOptimizeSwitchJumps()
 
         // Wire up the new control flow.
         //
-        block->SetJumpKindAndTarget(BBJ_COND, dominantTarget);
+        block->SetKindAndTarget(BBJ_COND, dominantTarget);
         FlowEdge* const blockToTargetEdge   = fgAddRefPred(dominantTarget, block);
         FlowEdge* const blockToNewBlockEdge = newBlock->bbPreds;
         assert(blockToNewBlockEdge->getSourceBlock() == block);
@@ -6807,7 +6807,7 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
 
                 // Fix up the flow.
                 //
-                predBlock->SetJumpKindAndTarget(BBJ_ALWAYS, crossJumpTarget);
+                predBlock->SetKindAndTarget(BBJ_ALWAYS, crossJumpTarget);
 
                 if (commSucc != nullptr)
                 {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2322,7 +2322,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetKindAndTarget(bNext->GetKind(), bNext->GetJumpEhf());
+            block->SetKindAndTarget(bNext->GetKind(), bNext->GetEhfTarget());
             fgChangeEhfBlock(bNext, block);
             break;
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2328,7 +2328,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_EHFINALLYRET:
-            block->SetKindAndTarget(bNext->GetKind(), bNext->GetEhfTarget());
+            block->SetEhfKindAndTarget(bNext->GetEhfTarget());
             fgChangeEhfBlock(bNext, block);
             break;
 
@@ -2340,7 +2340,7 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             break;
 
         case BBJ_SWITCH:
-            block->SetKindAndTarget(bNext->GetSwtTarget());
+            block->SetSwtKindAndTarget(bNext->GetSwtTarget());
             // We are moving the switch jump from bNext to block.  Examine the jump targets
             // of the BBJ_SWITCH at bNext and replace the predecessor to 'bNext' with ones to 'block'
             fgChangeSwitchBlock(bNext, block);

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2855,7 +2855,7 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
                     break;
                 }
 
-                // TODO: Once BBJ_COND blocks have pointers to their false branches,
+                // TODO-NoFallThrough: Once BBJ_COND blocks have pointers to their false branches,
                 // allow removing empty BBJ_ALWAYS and pointing bPrev's false branch to block->bbJumpDest.
                 if (bPrev->bbFallsThrough() && !block->JumpsToNext())
                 {
@@ -5998,7 +5998,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                     bDest    = block->GetJumpDest();
                     bNext    = block->GetNormalJumpDest();
 
-                    // TODO: Adjust the above logic once bbNormalJumpDest can diverge from bbNext
+                    // TODO-NoFallThrough: Adjust the above logic once bbNormalJumpDest can diverge from bbNext
                     assert(block->NextIs(bNext));
                 }
             }
@@ -6021,7 +6021,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                 bDest = block->GetJumpDest();
                 if (bDest == bNext)
                 {
-                    // TODO: Fix above condition once bbNormalJumpDest can diverge from bbNext
+                    // TODO-NoFallThrough: Fix above condition once bbNormalJumpDest can diverge from bbNext
                     assert(block->HasNormalJumpTo(bNext));
                     if (fgOptimizeBranchToNext(block, bNext, bPrev))
                     {
@@ -6147,7 +6147,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                             BasicBlock* const bDestNext = bDest->Next();
 
                             // Once bbNormalJumpDest and bbNext can diverge, this assert will hit
-                            // TODO: Remove fall-through for BBJ_COND below
+                            // TODO-NoFallThrough: Remove fall-through for BBJ_COND below
                             assert(!bDest->KindIs(BBJ_COND) || bDest->HasNormalJumpTo(bDestNext));
 
                             // Move bDest

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5059,7 +5059,9 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                         // candidateBlock and have it fall into bTmp
                         //
                         if ((candidateBlock == nullptr) || !candidateBlock->KindIs(BBJ_COND, BBJ_ALWAYS) ||
-                            (candidateBlock->KindIs(BBJ_ALWAYS) && (!candidateBlock->TargetIs(bTmp) || candidateBlock->JumpsToNext())) || (candidateBlock->KindIs(BBJ_COND) && !candidateBlock->TrueTargetIs(bTmp)))
+                            (candidateBlock->KindIs(BBJ_ALWAYS) &&
+                             (!candidateBlock->TargetIs(bTmp) || candidateBlock->JumpsToNext())) ||
+                            (candidateBlock->KindIs(BBJ_COND) && !candidateBlock->TrueTargetIs(bTmp)))
                         {
                             // otherwise we have a new candidateBlock
                             //

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4730,7 +4730,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     weight_t    diff;
                     FlowEdge*   otherEdge;
                     BasicBlock* otherDst;
-                    if (bSrc->NextIs(bDst))
+                    if (bSrc->HasNormalJumpTo(bDst))
                     {
                         otherDst = bSrc->GetJumpDest();
                     }

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3994,8 +3994,8 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
     // If it turns out often we fail at this stage, we might consider building a histogram of switch case
     // values at runtime, similar to what we do for classes at virtual call sites.
     //
-    const unsigned     caseCount    = block->GetSwitchTarget()->bbsCount;
-    BasicBlock** const jumpTab      = block->GetSwitchTarget()->bbsDstTab;
+    const unsigned     caseCount    = block->GetSwitchTargets()->bbsCount;
+    BasicBlock** const jumpTab      = block->GetSwitchTargets()->bbsDstTab;
     unsigned           dominantCase = caseCount;
 
     for (unsigned i = 0; i < caseCount; i++)
@@ -4021,7 +4021,7 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
         return;
     }
 
-    if (block->GetSwitchTarget()->bbsHasDefault && (dominantCase == caseCount - 1))
+    if (block->GetSwitchTargets()->bbsHasDefault && (dominantCase == caseCount - 1))
     {
         // Dominant case is the default case.
         // This effectively gets peeled already, so defer.
@@ -4035,9 +4035,9 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
             "; marking for peeling\n",
             dominantCase, dominantEdge->m_targetBlock->bbNum, fraction);
 
-    block->GetSwitchTarget()->bbsHasDominantCase  = true;
-    block->GetSwitchTarget()->bbsDominantCase     = dominantCase;
-    block->GetSwitchTarget()->bbsDominantFraction = fraction;
+    block->GetSwitchTargets()->bbsHasDominantCase  = true;
+    block->GetSwitchTargets()->bbsDominantCase     = dominantCase;
+    block->GetSwitchTargets()->bbsDominantFraction = fraction;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4736,7 +4736,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     }
                     else
                     {
-                        otherDst = bSrc->Next();
+                        otherDst = bSrc->GetNormalJumpDest();
                     }
                     otherEdge = fgGetPredForBlock(otherDst, bSrc);
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3994,8 +3994,8 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
     // If it turns out often we fail at this stage, we might consider building a histogram of switch case
     // values at runtime, similar to what we do for classes at virtual call sites.
     //
-    const unsigned     caseCount    = block->GetJumpSwt()->bbsCount;
-    BasicBlock** const jumpTab      = block->GetJumpSwt()->bbsDstTab;
+    const unsigned     caseCount    = block->GetSwtTarget()->bbsCount;
+    BasicBlock** const jumpTab      = block->GetSwtTarget()->bbsDstTab;
     unsigned           dominantCase = caseCount;
 
     for (unsigned i = 0; i < caseCount; i++)
@@ -4021,7 +4021,7 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
         return;
     }
 
-    if (block->GetJumpSwt()->bbsHasDefault && (dominantCase == caseCount - 1))
+    if (block->GetSwtTarget()->bbsHasDefault && (dominantCase == caseCount - 1))
     {
         // Dominant case is the default case.
         // This effectively gets peeled already, so defer.
@@ -4035,9 +4035,9 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
             "; marking for peeling\n",
             dominantCase, dominantEdge->m_targetBlock->bbNum, fraction);
 
-    block->GetJumpSwt()->bbsHasDominantCase  = true;
-    block->GetJumpSwt()->bbsDominantCase     = dominantCase;
-    block->GetJumpSwt()->bbsDominantFraction = fraction;
+    block->GetSwtTarget()->bbsHasDominantCase  = true;
+    block->GetSwtTarget()->bbsDominantCase     = dominantCase;
+    block->GetSwtTarget()->bbsDominantFraction = fraction;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3994,8 +3994,8 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
     // If it turns out often we fail at this stage, we might consider building a histogram of switch case
     // values at runtime, similar to what we do for classes at virtual call sites.
     //
-    const unsigned     caseCount    = block->GetSwtTarget()->bbsCount;
-    BasicBlock** const jumpTab      = block->GetSwtTarget()->bbsDstTab;
+    const unsigned     caseCount    = block->GetSwitchTarget()->bbsCount;
+    BasicBlock** const jumpTab      = block->GetSwitchTarget()->bbsDstTab;
     unsigned           dominantCase = caseCount;
 
     for (unsigned i = 0; i < caseCount; i++)
@@ -4021,7 +4021,7 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
         return;
     }
 
-    if (block->GetSwtTarget()->bbsHasDefault && (dominantCase == caseCount - 1))
+    if (block->GetSwitchTarget()->bbsHasDefault && (dominantCase == caseCount - 1))
     {
         // Dominant case is the default case.
         // This effectively gets peeled already, so defer.
@@ -4035,9 +4035,9 @@ void EfficientEdgeCountReconstructor::MarkInterestingSwitches(BasicBlock* block,
             "; marking for peeling\n",
             dominantCase, dominantEdge->m_targetBlock->bbNum, fraction);
 
-    block->GetSwtTarget()->bbsHasDominantCase  = true;
-    block->GetSwtTarget()->bbsDominantCase     = dominantCase;
-    block->GetSwtTarget()->bbsDominantFraction = fraction;
+    block->GetSwitchTarget()->bbsHasDominantCase  = true;
+    block->GetSwitchTarget()->bbsDominantCase     = dominantCase;
+    block->GetSwitchTarget()->bbsDominantFraction = fraction;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1008,7 +1008,7 @@ void Compiler::WalkSpanningTree(SpanningTreeVisitor* visitor)
                     // We're leaving a try or catch, not a handler.
                     // Treat this as a normal edge.
                     //
-                    BasicBlock* const target = block->GetJumpDest();
+                    BasicBlock* const target = block->GetTarget();
 
                     // In some bad IL cases we may not have a target.
                     // In others we may see something other than LEAVE be most-nested in a try.
@@ -3781,8 +3781,8 @@ void EfficientEdgeCountReconstructor::PropagateEdges(BasicBlock* block, BlockInf
     {
         assert(nSucc == 1);
         assert(block == pseudoEdge->m_sourceBlock);
-        assert(block->HasInitializedJumpDest());
-        FlowEdge* const flowEdge = m_comp->fgGetPredForBlock(block->GetJumpDest(), block);
+        assert(block->HasInitializedTarget());
+        FlowEdge* const flowEdge = m_comp->fgGetPredForBlock(block->GetTarget(), block);
         assert(flowEdge != nullptr);
         flowEdge->setLikelihood(1.0);
         return;
@@ -3792,7 +3792,7 @@ void EfficientEdgeCountReconstructor::PropagateEdges(BasicBlock* block, BlockInf
     //
     // This can happen because bome BBJ_LEAVE blocks may have been missed during
     // our spanning tree walk since we don't know where all the finallies can return
-    // to just yet (specially, in WalkSpanningTree, we may not add the bbJumpDest of
+    // to just yet (specially, in WalkSpanningTree, we may not add the bbTarget of
     // a BBJ_LEAVE to the worklist).
     //
     // Worst case those missed blocks dominate other blocks so we can't limit
@@ -4409,7 +4409,7 @@ bool Compiler::fgComputeMissingBlockWeights(weight_t* returnWeight)
                     // Does this block flow into only one other block
                     if (bSrc->KindIs(BBJ_ALWAYS))
                     {
-                        bOnlyNext = bSrc->GetJumpDest();
+                        bOnlyNext = bSrc->GetTarget();
                     }
                     else
                     {
@@ -4426,7 +4426,7 @@ bool Compiler::fgComputeMissingBlockWeights(weight_t* returnWeight)
                 // Does this block flow into only one other block
                 if (bDst->KindIs(BBJ_ALWAYS))
                 {
-                    bOnlyNext = bDst->GetJumpDest();
+                    bOnlyNext = bDst->GetTarget();
                 }
                 else
                 {
@@ -4732,7 +4732,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     BasicBlock* otherDst;
                     if (bSrc->FalseTargetIs(bDst))
                     {
-                        otherDst = bSrc->GetJumpDest();
+                        otherDst = bSrc->GetTarget();
                     }
                     else
                     {

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4732,7 +4732,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     BasicBlock* otherDst;
                     if (bSrc->FalseTargetIs(bDst))
                     {
-                        otherDst = bSrc->GetTarget();
+                        otherDst = bSrc->GetTrueTarget();
                     }
                     else
                     {

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -4730,13 +4730,13 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
                     weight_t    diff;
                     FlowEdge*   otherEdge;
                     BasicBlock* otherDst;
-                    if (bSrc->HasNormalJumpTo(bDst))
+                    if (bSrc->FalseTargetIs(bDst))
                     {
                         otherDst = bSrc->GetJumpDest();
                     }
                     else
                     {
-                        otherDst = bSrc->GetNormalJumpDest();
+                        otherDst = bSrc->GetFalseTarget();
                     }
                     otherEdge = fgGetPredForBlock(otherDst, bSrc);
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -935,7 +935,7 @@ void Compiler::WalkSpanningTree(SpanningTreeVisitor* visitor)
         visitor->VisitBlock(block);
         nBlocks++;
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_CALLFINALLY:
             {
@@ -3900,7 +3900,7 @@ void EfficientEdgeCountReconstructor::PropagateEdges(BasicBlock* block, BlockInf
 //
 void EfficientEdgeCountReconstructor::MarkInterestingBlocks(BasicBlock* block, BlockInfo* info)
 {
-    switch (block->GetJumpKind())
+    switch (block->GetKind())
     {
         case BBJ_SWITCH:
             MarkInterestingSwitches(block, info);
@@ -4657,7 +4657,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
             }
 
             slop = BasicBlock::GetSlopFraction(bSrc, bDst) + 1;
-            switch (bSrc->GetJumpKind())
+            switch (bSrc->GetKind())
             {
                 case BBJ_ALWAYS:
                 case BBJ_EHCATCHRET:
@@ -4681,7 +4681,7 @@ PhaseStatus Compiler::fgComputeEdgeWeights()
 
                 default:
                     // We should never have an edge that starts from one of these jump kinds
-                    noway_assert(!"Unexpected bbJumpKind");
+                    noway_assert(!"Unexpected bbKind");
                     break;
             }
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -1677,7 +1677,7 @@ void EfficientEdgeCountInstrumentor::RelocateProbes()
                 // Ensure this pred always jumps to block
                 //
                 assert(pred->KindIs(BBJ_ALWAYS));
-                assert(pred->HasJumpTo(block));
+                assert(pred->TargetIs(block));
             }
         }
 

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -210,7 +210,7 @@ void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 //
 void ProfileSynthesis::AssignLikelihoodCond(BasicBlock* block)
 {
-    BasicBlock* const jump = block->GetTarget();
+    BasicBlock* const jump = block->GetTrueTarget();
     BasicBlock* const next = block->GetFalseTarget();
 
     // Watch for degenerate case
@@ -861,7 +861,7 @@ void ProfileSynthesis::ComputeCyclicProbabilities(FlowGraphNaturalLoop* loop)
                             " to reflect capping; current likelihood is " FMT_WT "\n",
                             exitBlock->bbNum, exitEdge->getLikelihood());
 
-                    BasicBlock* const jump               = exitBlock->GetTarget();
+                    BasicBlock* const jump               = exitBlock->GetTrueTarget();
                     BasicBlock* const next               = exitBlock->GetFalseTarget();
                     FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                     FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -132,7 +132,7 @@ void ProfileSynthesis::AssignLikelihoods()
 
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_THROW:
             case BBJ_RETURN:
@@ -393,7 +393,7 @@ void ProfileSynthesis::RepairLikelihoods()
 
     for (BasicBlock* const block : m_comp->Blocks())
     {
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_THROW:
             case BBJ_RETURN:
@@ -484,7 +484,7 @@ void ProfileSynthesis::BlendLikelihoods()
     {
         weight_t sum = SumOutgoingLikelihoods(block, &likelihoods);
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_THROW:
             case BBJ_RETURN:

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -190,14 +190,14 @@ void ProfileSynthesis::AssignLikelihoodNext(BasicBlock* block)
 
 //------------------------------------------------------------------------
 // AssignLikelihoodJump: update edge likelihood for a block that always
-//   transfers control to bbJumpDest
+//   transfers control to bbTarget
 //
 // Arguments;
 //   block -- block in question
 //
 void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 {
-    FlowEdge* const edge = m_comp->fgGetPredForBlock(block->GetJumpDest(), block);
+    FlowEdge* const edge = m_comp->fgGetPredForBlock(block->GetTarget(), block);
     edge->setLikelihood(1.0);
 }
 
@@ -210,7 +210,7 @@ void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 //
 void ProfileSynthesis::AssignLikelihoodCond(BasicBlock* block)
 {
-    BasicBlock* const jump = block->GetJumpDest();
+    BasicBlock* const jump = block->GetTarget();
     BasicBlock* const next = block->GetFalseTarget();
 
     // Watch for degenerate case
@@ -861,7 +861,7 @@ void ProfileSynthesis::ComputeCyclicProbabilities(FlowGraphNaturalLoop* loop)
                             " to reflect capping; current likelihood is " FMT_WT "\n",
                             exitBlock->bbNum, exitEdge->getLikelihood());
 
-                    BasicBlock* const jump               = exitBlock->GetJumpDest();
+                    BasicBlock* const jump               = exitBlock->GetTarget();
                     BasicBlock* const next               = exitBlock->GetFalseTarget();
                     FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                     FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -211,7 +211,7 @@ void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 void ProfileSynthesis::AssignLikelihoodCond(BasicBlock* block)
 {
     BasicBlock* const jump = block->GetJumpDest();
-    BasicBlock* const next = block->Next();
+    BasicBlock* const next = block->GetNormalJumpDest();
 
     // Watch for degenerate case
     //
@@ -862,7 +862,7 @@ void ProfileSynthesis::ComputeCyclicProbabilities(FlowGraphNaturalLoop* loop)
                             exitBlock->bbNum, exitEdge->getLikelihood());
 
                     BasicBlock* const jump               = exitBlock->GetJumpDest();
-                    BasicBlock* const next               = exitBlock->Next();
+                    BasicBlock* const next               = exitBlock->GetNormalJumpDest();
                     FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                     FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);
                     weight_t const    exitLikelihood     = (missingExitWeight + currentExitWeight) / exitBlockWeight;

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -211,7 +211,7 @@ void ProfileSynthesis::AssignLikelihoodJump(BasicBlock* block)
 void ProfileSynthesis::AssignLikelihoodCond(BasicBlock* block)
 {
     BasicBlock* const jump = block->GetJumpDest();
-    BasicBlock* const next = block->GetNormalJumpDest();
+    BasicBlock* const next = block->GetFalseTarget();
 
     // Watch for degenerate case
     //
@@ -862,7 +862,7 @@ void ProfileSynthesis::ComputeCyclicProbabilities(FlowGraphNaturalLoop* loop)
                             exitBlock->bbNum, exitEdge->getLikelihood());
 
                     BasicBlock* const jump               = exitBlock->GetJumpDest();
-                    BasicBlock* const next               = exitBlock->GetNormalJumpDest();
+                    BasicBlock* const next               = exitBlock->GetFalseTarget();
                     FlowEdge* const   jumpEdge           = m_comp->fgGetPredForBlock(jump, exitBlock);
                     FlowEdge* const   nextEdge           = m_comp->fgGetPredForBlock(next, exitBlock);
                     weight_t const    exitLikelihood     = (missingExitWeight + currentExitWeight) / exitBlockWeight;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -130,7 +130,7 @@ PhaseStatus Compiler::fgInsertGCPolls()
             JITDUMP("Selecting CALL poll in block " FMT_BB " because it is the single return block\n", block->bbNum);
             pollType = GCPOLL_CALL;
         }
-        else if (BBJ_SWITCH == block->GetJumpKind())
+        else if (BBJ_SWITCH == block->GetKind())
         {
             // We don't want to deal with all the outgoing edges of a switch block.
             //
@@ -278,8 +278,8 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         }
 
         BasicBlock* poll          = fgNewBBafter(BBJ_ALWAYS, top, true);
-        bottom                    = fgNewBBafter(top->GetJumpKind(), poll, true, top->GetTarget());
-        BBjumpKinds   oldJumpKind = top->GetJumpKind();
+        bottom                    = fgNewBBafter(top->GetKind(), poll, true, top->GetTarget());
+        BBKinds   oldJumpKind = top->GetKind();
         unsigned char lpIndex     = top->bbNatLoopNum;
         poll->SetTarget(bottom);
         assert(poll->JumpsToNext());
@@ -2831,7 +2831,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
             // It's a jump from outside the handler; add it to the newHead preds list and remove
             // it from the block preds list.
 
-            switch (predBlock->GetJumpKind())
+            switch (predBlock->GetKind())
             {
                 case BBJ_CALLFINALLY:
                     noway_assert(predBlock->HasJumpTo(block));
@@ -3209,7 +3209,7 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
         //
         if (prevToFirstColdBlock->bbFallsThrough())
         {
-            switch (prevToFirstColdBlock->GetJumpKind())
+            switch (prevToFirstColdBlock->GetKind())
             {
                 default:
                     noway_assert(!"Unhandled jumpkind in fgDetermineFirstColdBlock()");
@@ -3448,7 +3448,7 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
     //
     assert(!fgRngChkThrowAdded);
 
-    const static BBjumpKinds jumpKinds[] = {
+    const static BBKinds jumpKinds[] = {
         BBJ_ALWAYS, // SCK_NONE
         BBJ_THROW,  // SCK_RNGCHK_FAIL
         BBJ_THROW,  // SCK_DIV_BY_ZERO

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -278,10 +278,10 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         }
 
         BasicBlock* poll          = fgNewBBafter(BBJ_ALWAYS, top, true);
-        bottom                    = fgNewBBafter(top->GetJumpKind(), poll, true, top->GetJumpDest());
+        bottom                    = fgNewBBafter(top->GetJumpKind(), poll, true, top->GetTarget());
         BBjumpKinds   oldJumpKind = top->GetJumpKind();
         unsigned char lpIndex     = top->bbNatLoopNum;
-        poll->SetJumpDest(bottom);
+        poll->SetTarget(bottom);
         assert(poll->JumpsToNext());
 
         // Update block flags
@@ -412,7 +412,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 
             case BBJ_ALWAYS:
             case BBJ_CALLFINALLY:
-                fgReplacePred(bottom->GetJumpDest(), top, bottom);
+                fgReplacePred(bottom->GetTarget(), top, bottom);
                 break;
             case BBJ_SWITCH:
                 NO_WAY("SWITCH should be a call rather than an inlined poll.");
@@ -1681,7 +1681,7 @@ void Compiler::fgConvertSyncReturnToLeave(BasicBlock* block)
     if (verbose)
     {
         printf("Synchronized method - convert block " FMT_BB " to BBJ_ALWAYS [targets " FMT_BB "]\n", block->bbNum,
-               block->GetJumpDest()->bbNum);
+               block->GetTarget()->bbNum);
     }
 #endif
 }
@@ -2835,7 +2835,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
             {
                 case BBJ_CALLFINALLY:
                     noway_assert(predBlock->HasJumpTo(block));
-                    predBlock->SetJumpDest(newHead);
+                    predBlock->SetTarget(newHead);
                     fgRemoveRefPred(block, predBlock);
                     fgAddRefPred(newHead, predBlock);
                     break;
@@ -3536,7 +3536,7 @@ PhaseStatus Compiler::fgCreateThrowHelperBlocks()
 #endif // DEBUG
 
         //  Mark the block as added by the compiler and not removable by future flow
-        // graph optimizations. Note that no bbJumpDest points to these blocks.
+        // graph optimizations. Note that no bbTarget points to these blocks.
         //
         newBlk->SetFlags(BBF_IMPORTED | BBF_DONT_REMOVE);
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -388,7 +388,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         }
 #endif
 
-        top->SetJumpKindAndTarget(BBJ_COND, bottom);
+        top->SetKindAndTarget(BBJ_COND, bottom);
         // Bottom has Top and Poll as its predecessors.  Poll has just Top as a predecessor.
         fgAddRefPred(bottom, poll);
         fgAddRefPred(bottom, top);
@@ -1674,7 +1674,7 @@ void Compiler::fgConvertSyncReturnToLeave(BasicBlock* block)
     assert(ehDsc->ebdEnclosingHndIndex == EHblkDsc::NO_ENCLOSING_INDEX);
 
     // Convert the BBJ_RETURN to BBJ_ALWAYS, jumping to genReturnBB.
-    block->SetJumpKindAndTarget(BBJ_ALWAYS, genReturnBB);
+    block->SetKindAndTarget(BBJ_ALWAYS, genReturnBB);
     fgAddRefPred(genReturnBB, block);
 
 #ifdef DEBUG
@@ -2145,7 +2145,7 @@ private:
 
                     // Change BBJ_RETURN to BBJ_ALWAYS targeting const return block.
                     assert((comp->info.compFlags & CORINFO_FLG_SYNCH) == 0);
-                    returnBlock->SetJumpKindAndTarget(BBJ_ALWAYS, constReturnBlock);
+                    returnBlock->SetKindAndTarget(BBJ_ALWAYS, constReturnBlock);
                     comp->fgAddRefPred(constReturnBlock, returnBlock);
 
                     // Remove GT_RETURN since constReturnBlock returns the constant.

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -394,7 +394,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         }
 #endif
 
-        top->SetCondKindAndTarget(bottom);
+        top->SetCond(bottom);
         // Bottom has Top and Poll as its predecessors.  Poll has just Top as a predecessor.
         fgAddRefPred(bottom, poll);
         fgAddRefPred(bottom, top);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2834,7 +2834,7 @@ void Compiler::fgInsertFuncletPrologBlock(BasicBlock* block)
             switch (predBlock->GetKind())
             {
                 case BBJ_CALLFINALLY:
-                    noway_assert(predBlock->HasJumpTo(block));
+                    noway_assert(predBlock->TargetIs(block));
                     predBlock->SetTarget(newHead);
                     fgRemoveRefPred(block, predBlock);
                     fgAddRefPred(newHead, predBlock);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -273,7 +273,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 
         if (top->KindIs(BBJ_COND))
         {
-            topFallThrough     = top->GetNormalJumpDest();
+            topFallThrough     = top->GetFalseTarget();
             lpIndexFallThrough = topFallThrough->bbNatLoopNum;
         }
 
@@ -405,7 +405,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             case BBJ_COND:
                 // replace predecessor in the fall through block.
                 noway_assert(!bottom->IsLast());
-                fgReplacePred(bottom->GetNormalJumpDest(), top, bottom);
+                fgReplacePred(bottom->GetFalseTarget(), top, bottom);
 
                 // fall through for the jump target
                 FALLTHROUGH;
@@ -3230,9 +3230,9 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                     // probably need to insert a block to jump to the cold section.
                     //
 
-                    // TODO-NoFallThrough: Below logic will need additional check once bbNormalJumpDest can diverge from
+                    // TODO-NoFallThrough: Below logic will need additional check once bbFalseTarget can diverge from
                     // bbNext
-                    assert(prevToFirstColdBlock->HasNormalJumpTo(firstColdBlock));
+                    assert(prevToFirstColdBlock->FalseTargetIs(firstColdBlock));
                     if (firstColdBlock->isEmpty() && firstColdBlock->KindIs(BBJ_ALWAYS))
                     {
                         // We can just use this block as the transitionBlock

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -394,7 +394,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         }
 #endif
 
-        top->SetKindAndTarget(BBJ_COND, bottom);
+        top->SetCondKindAndTarget(bottom);
         // Bottom has Top and Poll as its predecessors.  Poll has just Top as a predecessor.
         fgAddRefPred(bottom, poll);
         fgAddRefPred(bottom, top);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3230,7 +3230,8 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                     // probably need to insert a block to jump to the cold section.
                     //
 
-                    // TODO: Below logic will need additional check once bbNormalJumpDest can diverge from bbNext
+                    // TODO-NoFallThrough: Below logic will need additional check once bbNormalJumpDest can diverge from
+                    // bbNext
                     assert(prevToFirstColdBlock->HasNormalJumpTo(firstColdBlock));
                     if (firstColdBlock->isEmpty() && firstColdBlock->KindIs(BBJ_ALWAYS))
                     {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -273,7 +273,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 
         if (top->KindIs(BBJ_COND))
         {
-            topFallThrough     = top->Next();
+            topFallThrough     = top->GetNormalJumpDest();
             lpIndexFallThrough = topFallThrough->bbNatLoopNum;
         }
 
@@ -405,7 +405,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
             case BBJ_COND:
                 // replace predecessor in the fall through block.
                 noway_assert(!bottom->IsLast());
-                fgReplacePred(bottom->Next(), top, bottom);
+                fgReplacePred(bottom->GetNormalJumpDest(), top, bottom);
 
                 // fall through for the jump target
                 FALLTHROUGH;
@@ -3229,6 +3229,9 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                     // This is a slightly more complicated case, because we will
                     // probably need to insert a block to jump to the cold section.
                     //
+
+                    // TODO: Below logic will need additional check once bbNormalJumpDest can diverge from bbNext
+                    assert(prevToFirstColdBlock->HasNormalJumpTo(firstColdBlock));
                     if (firstColdBlock->isEmpty() && firstColdBlock->KindIs(BBJ_ALWAYS))
                     {
                         // We can just use this block as the transitionBlock

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -194,7 +194,7 @@ inline AssertionIndex GetAssertionIndex(unsigned index)
 
 class AssertionInfo
 {
-    // true if the assertion holds on the bbNext edge instead of the bbJumpDest edge (for GT_JTRUE nodes)
+    // true if the assertion holds on the bbNext edge instead of the bbTarget edge (for GT_JTRUE nodes)
     unsigned short m_isNextEdgeAssertion : 1;
     // 1-based index of the assertion
     unsigned short m_assertionIndex : 15;

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -285,8 +285,8 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
 
     // Fallback basic block
     GenTree*    fallbackValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), call);
-    BasicBlock* fallbackBb =
-        fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo, nullcheckBb->GetNormalJumpDest(), true);
+    BasicBlock* fallbackBb       = fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo,
+                                                  nullcheckBb->GetNormalJumpDest(), true);
 
     assert(fallbackBb->JumpsToNext());
     fallbackBb->SetFlags(BBF_NONE_QUIRK);
@@ -1095,7 +1095,8 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     // Fallback basic block
     // TODO-CQ: for JIT we can replace the original call with CORINFO_HELP_INITCLASS
     // that only accepts a single argument
-    BasicBlock* helperCallBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->GetNormalJumpDest(), true);
+    BasicBlock* helperCallBb =
+        fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->GetNormalJumpDest(), true);
     assert(helperCallBb->JumpsToNext());
     helperCallBb->SetFlags(BBF_NONE_QUIRK);
 

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -286,7 +286,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     // Fallback basic block
     GenTree*    fallbackValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), call);
     BasicBlock* fallbackBb =
-        fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo, nullcheckBb->Next(), true);
+        fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo, nullcheckBb->GetNormalJumpDest(), true);
 
     assert(fallbackBb->JumpsToNext());
     fallbackBb->SetFlags(BBF_NONE_QUIRK);
@@ -1095,7 +1095,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     // Fallback basic block
     // TODO-CQ: for JIT we can replace the original call with CORINFO_HELP_INITCLASS
     // that only accepts a single argument
-    BasicBlock* helperCallBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->Next(), true);
+    BasicBlock* helperCallBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->GetNormalJumpDest(), true);
     assert(helperCallBb->JumpsToNext());
     helperCallBb->SetFlags(BBF_NONE_QUIRK);
 
@@ -1450,7 +1450,7 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     // In theory, we could just emit the const U8 data to the data section and use GT_BLK here
     // but that would be a bit less efficient since we would have to load the data from memory.
     //
-    BasicBlock* fastpathBb = fgNewBBafter(BBJ_ALWAYS, lengthCheckBb, true, lengthCheckBb->Next());
+    BasicBlock* fastpathBb = fgNewBBafter(BBJ_ALWAYS, lengthCheckBb, true, lengthCheckBb->GetNormalJumpDest());
     assert(fastpathBb->JumpsToNext());
     fastpathBb->SetFlags(BBF_INTERNAL | BBF_NONE_QUIRK);
 

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -286,7 +286,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     // Fallback basic block
     GenTree*    fallbackValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), call);
     BasicBlock* fallbackBb       = fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo,
-                                                  nullcheckBb->GetNormalJumpDest(), true);
+                                                  nullcheckBb->GetFalseTarget(), true);
 
     assert(fallbackBb->JumpsToNext());
     fallbackBb->SetFlags(BBF_NONE_QUIRK);
@@ -1096,7 +1096,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     // TODO-CQ: for JIT we can replace the original call with CORINFO_HELP_INITCLASS
     // that only accepts a single argument
     BasicBlock* helperCallBb =
-        fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->GetNormalJumpDest(), true);
+        fgNewBBFromTreeAfter(BBJ_ALWAYS, isInitedBb, call, debugInfo, isInitedBb->GetFalseTarget(), true);
     assert(helperCallBb->JumpsToNext());
     helperCallBb->SetFlags(BBF_NONE_QUIRK);
 
@@ -1451,7 +1451,7 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     // In theory, we could just emit the const U8 data to the data section and use GT_BLK here
     // but that would be a bit less efficient since we would have to load the data from memory.
     //
-    BasicBlock* fastpathBb = fgNewBBafter(BBJ_ALWAYS, lengthCheckBb, true, lengthCheckBb->GetNormalJumpDest());
+    BasicBlock* fastpathBb = fgNewBBafter(BBJ_ALWAYS, lengthCheckBb, true, lengthCheckBb->GetFalseTarget());
     assert(fastpathBb->JumpsToNext());
     fastpathBb->SetFlags(BBF_INTERNAL | BBF_NONE_QUIRK);
 

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -285,8 +285,8 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
 
     // Fallback basic block
     GenTree*    fallbackValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), call);
-    BasicBlock* fallbackBb       = fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo,
-                                                  nullcheckBb->GetFalseTarget(), true);
+    BasicBlock* fallbackBb =
+        fgNewBBFromTreeAfter(BBJ_ALWAYS, nullcheckBb, fallbackValueDef, debugInfo, nullcheckBb->GetFalseTarget(), true);
 
     assert(fallbackBb->JumpsToNext());
     fallbackBb->SetFlags(BBF_NONE_QUIRK);

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -292,7 +292,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     fallbackBb->SetFlags(BBF_NONE_QUIRK);
 
     // Set nullcheckBb's real jump target
-    nullcheckBb->SetJumpDest(fallbackBb);
+    nullcheckBb->SetTarget(fallbackBb);
 
     // Fast-path basic block
     GenTree*    fastpathValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), fastPathValueClone);
@@ -352,7 +352,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     if (needsSizeCheck)
     {
         // sizeCheckBb is the first block after prevBb
-        prevBb->SetJumpDest(sizeCheckBb);
+        prevBb->SetTarget(sizeCheckBb);
         fgAddRefPred(sizeCheckBb, prevBb);
         // sizeCheckBb flows into nullcheckBb in case if the size check passes
         fgAddRefPred(nullcheckBb, sizeCheckBb);
@@ -365,7 +365,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     else
     {
         // nullcheckBb is the first block after prevBb
-        prevBb->SetJumpDest(nullcheckBb);
+        prevBb->SetTarget(nullcheckBb);
         fgAddRefPred(nullcheckBb, prevBb);
         // No size check, nullcheckBb jumps to fast path
         fgAddRefPred(fastPathBb, nullcheckBb);
@@ -781,16 +781,16 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     BasicBlock* fastPathBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, fallbackBb, fastPathValueDef, debugInfo, block, true);
 
     // Set maxThreadStaticBlocksCondBB's real jump target
-    maxThreadStaticBlocksCondBB->SetJumpDest(fallbackBb);
+    maxThreadStaticBlocksCondBB->SetTarget(fallbackBb);
 
     // Set threadStaticBlockNullCondBB's real jump target
-    threadStaticBlockNullCondBB->SetJumpDest(fastPathBb);
+    threadStaticBlockNullCondBB->SetTarget(fastPathBb);
 
     //
     // Update preds in all new blocks
     //
     assert(prevBb->KindIs(BBJ_ALWAYS));
-    prevBb->SetJumpDest(maxThreadStaticBlocksCondBB);
+    prevBb->SetTarget(maxThreadStaticBlocksCondBB);
     fgRemoveRefPred(block, prevBb);
     fgAddRefPred(maxThreadStaticBlocksCondBB, prevBb);
 
@@ -1166,7 +1166,7 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
 
     // prevBb always flows into isInitedBb
     assert(prevBb->KindIs(BBJ_ALWAYS));
-    prevBb->SetJumpDest(isInitedBb);
+    prevBb->SetTarget(isInitedBb);
     prevBb->SetFlags(BBF_NONE_QUIRK);
     assert(prevBb->JumpsToNext());
     fgAddRefPred(isInitedBb, prevBb);
@@ -1509,7 +1509,7 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     fgRemoveRefPred(block, prevBb);
     // prevBb flows into lengthCheckBb
     assert(prevBb->KindIs(BBJ_ALWAYS));
-    prevBb->SetJumpDest(lengthCheckBb);
+    prevBb->SetTarget(lengthCheckBb);
     prevBb->SetFlags(BBF_NONE_QUIRK);
     assert(prevBb->JumpsToNext());
     fgAddRefPred(lengthCheckBb, prevBb);

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -291,8 +291,8 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     assert(fallbackBb->JumpsToNext());
     fallbackBb->SetFlags(BBF_NONE_QUIRK);
 
-    // Set nullcheckBb's real jump target
-    nullcheckBb->SetTarget(fallbackBb);
+    // Set nullcheckBb's true jump target
+    nullcheckBb->SetTrueTarget(fallbackBb);
 
     // Fast-path basic block
     GenTree*    fastpathValueDef = gtNewStoreLclVarNode(rtLookupLcl->GetLclNum(), fastPathValueClone);
@@ -780,11 +780,11 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
         gtNewStoreLclVarNode(threadStaticBlockLclNum, gtCloneExpr(threadStaticBlockBaseLclValueUse));
     BasicBlock* fastPathBb = fgNewBBFromTreeAfter(BBJ_ALWAYS, fallbackBb, fastPathValueDef, debugInfo, block, true);
 
-    // Set maxThreadStaticBlocksCondBB's real jump target
-    maxThreadStaticBlocksCondBB->SetTarget(fallbackBb);
+    // Set maxThreadStaticBlocksCondBB's true jump target
+    maxThreadStaticBlocksCondBB->SetTrueTarget(fallbackBb);
 
-    // Set threadStaticBlockNullCondBB's real jump target
-    threadStaticBlockNullCondBB->SetTarget(fastPathBb);
+    // Set threadStaticBlockNullCondBB's true jump target
+    threadStaticBlockNullCondBB->SetTrueTarget(fastPathBb);
 
     //
     // Update preds in all new blocks

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -740,7 +740,7 @@ bool OptIfConversionDsc::optIfConvert()
     // Update the flow from the original block.
     m_comp->fgRemoveAllRefPreds(m_startBlock->GetFalseTarget(), m_startBlock);
     assert(m_startBlock->HasInitializedTarget());
-    m_startBlock->SetJumpKind(BBJ_ALWAYS);
+    m_startBlock->SetKind(BBJ_ALWAYS);
 
 #ifdef DEBUG
     if (m_comp->verbose)

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -122,7 +122,7 @@ bool OptIfConversionDsc::IfConvertCheckInnerBlockFlow(BasicBlock* block)
 bool OptIfConversionDsc::IfConvertCheckThenFlow()
 {
     m_flowFound           = false;
-    BasicBlock* thenBlock = m_startBlock->GetNormalJumpDest();
+    BasicBlock* thenBlock = m_startBlock->GetFalseTarget();
 
     for (int thenLimit = 0; thenLimit < m_checkLimit; thenLimit++)
     {
@@ -571,7 +571,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Check the Then and Else blocks have a single operation each.
-    if (!IfConvertCheckStmts(m_startBlock->GetNormalJumpDest(), &m_thenOperation))
+    if (!IfConvertCheckStmts(m_startBlock->GetFalseTarget(), &m_thenOperation))
     {
         return false;
     }
@@ -738,7 +738,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Update the flow from the original block.
-    m_comp->fgRemoveAllRefPreds(m_startBlock->GetNormalJumpDest(), m_startBlock);
+    m_comp->fgRemoveAllRefPreds(m_startBlock->GetFalseTarget(), m_startBlock);
     assert(m_startBlock->HasInitializedJumpDest());
     m_startBlock->SetJumpKind(BBJ_ALWAYS);
 

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -175,7 +175,7 @@ void OptIfConversionDsc::IfConvertFindFlow()
 {
     // First check for flow with no else case. The final block is the destination of the jump.
     m_doElseConversion = false;
-    m_finalBlock       = m_startBlock->GetTarget();
+    m_finalBlock       = m_startBlock->GetTrueTarget();
     assert(m_finalBlock != nullptr);
     if (!IfConvertCheckThenFlow() || m_flowFound)
     {
@@ -388,7 +388,7 @@ void OptIfConversionDsc::IfConvertDump()
     }
     if (m_doElseConversion)
     {
-        for (BasicBlock* dumpBlock = m_startBlock->GetTarget(); dumpBlock != m_finalBlock;
+        for (BasicBlock* dumpBlock = m_startBlock->GetTrueTarget(); dumpBlock != m_finalBlock;
              dumpBlock             = dumpBlock->GetUniqueSucc())
         {
             m_comp->fgDumpBlock(dumpBlock);
@@ -578,7 +578,7 @@ bool OptIfConversionDsc::optIfConvert()
     assert(m_thenOperation.node->OperIs(GT_STORE_LCL_VAR, GT_RETURN));
     if (m_doElseConversion)
     {
-        if (!IfConvertCheckStmts(m_startBlock->GetTarget(), &m_elseOperation))
+        if (!IfConvertCheckStmts(m_startBlock->GetTrueTarget(), &m_elseOperation))
         {
             return false;
         }

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -175,7 +175,7 @@ void OptIfConversionDsc::IfConvertFindFlow()
 {
     // First check for flow with no else case. The final block is the destination of the jump.
     m_doElseConversion = false;
-    m_finalBlock       = m_startBlock->GetJumpDest();
+    m_finalBlock       = m_startBlock->GetTarget();
     assert(m_finalBlock != nullptr);
     if (!IfConvertCheckThenFlow() || m_flowFound)
     {
@@ -388,7 +388,7 @@ void OptIfConversionDsc::IfConvertDump()
     }
     if (m_doElseConversion)
     {
-        for (BasicBlock* dumpBlock = m_startBlock->GetJumpDest(); dumpBlock != m_finalBlock;
+        for (BasicBlock* dumpBlock = m_startBlock->GetTarget(); dumpBlock != m_finalBlock;
              dumpBlock             = dumpBlock->GetUniqueSucc())
         {
             m_comp->fgDumpBlock(dumpBlock);
@@ -578,7 +578,7 @@ bool OptIfConversionDsc::optIfConvert()
     assert(m_thenOperation.node->OperIs(GT_STORE_LCL_VAR, GT_RETURN));
     if (m_doElseConversion)
     {
-        if (!IfConvertCheckStmts(m_startBlock->GetJumpDest(), &m_elseOperation))
+        if (!IfConvertCheckStmts(m_startBlock->GetTarget(), &m_elseOperation))
         {
             return false;
         }
@@ -739,7 +739,7 @@ bool OptIfConversionDsc::optIfConvert()
 
     // Update the flow from the original block.
     m_comp->fgRemoveAllRefPreds(m_startBlock->GetFalseTarget(), m_startBlock);
-    assert(m_startBlock->HasInitializedJumpDest());
+    assert(m_startBlock->HasInitializedTarget());
     m_startBlock->SetJumpKind(BBJ_ALWAYS);
 
 #ifdef DEBUG

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -122,7 +122,7 @@ bool OptIfConversionDsc::IfConvertCheckInnerBlockFlow(BasicBlock* block)
 bool OptIfConversionDsc::IfConvertCheckThenFlow()
 {
     m_flowFound           = false;
-    BasicBlock* thenBlock = m_startBlock->Next();
+    BasicBlock* thenBlock = m_startBlock->GetNormalJumpDest();
 
     for (int thenLimit = 0; thenLimit < m_checkLimit; thenLimit++)
     {
@@ -571,7 +571,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Check the Then and Else blocks have a single operation each.
-    if (!IfConvertCheckStmts(m_startBlock->Next(), &m_thenOperation))
+    if (!IfConvertCheckStmts(m_startBlock->GetNormalJumpDest(), &m_thenOperation))
     {
         return false;
     }
@@ -738,7 +738,7 @@ bool OptIfConversionDsc::optIfConvert()
     }
 
     // Update the flow from the original block.
-    m_comp->fgRemoveAllRefPreds(m_startBlock->Next(), m_startBlock);
+    m_comp->fgRemoveAllRefPreds(m_startBlock->GetNormalJumpDest(), m_startBlock);
     assert(m_startBlock->HasInitializedJumpDest());
     m_startBlock->SetJumpKind(BBJ_ALWAYS);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2493,7 +2493,7 @@ GenTree* Compiler::impTypeIsAssignable(GenTree* typeTo, GenTree* typeFrom)
 
 void Compiler::verConvertBBToThrowVerificationException(BasicBlock* block DEBUGARG(bool logMsg))
 {
-    block->SetJumpKindAndTarget(BBJ_THROW);
+    block->SetKindAndTarget(BBJ_THROW);
     block->SetFlags(BBF_FAILED_VERIFICATION);
     block->RemoveFlags(BBF_IMPORTED);
 
@@ -4388,7 +4388,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 fgRemoveRefPred(callBlock->GetTarget(), callBlock);
 
                 // callBlock will call the finally handler. Convert the BBJ_LEAVE to BBJ_CALLFINALLY
-                callBlock->SetJumpKindAndTarget(BBJ_CALLFINALLY, HBtab->ebdHndBeg);
+                callBlock->SetKindAndTarget(BBJ_CALLFINALLY, HBtab->ebdHndBeg);
 
                 if (endCatches)
                 {
@@ -4709,7 +4709,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 // which might be in the middle of the "try". In most cases, the BBJ_ALWAYS will jump to the
                 // next block, and flow optimizations will remove it.
                 fgRemoveRefPred(block->GetTarget(), block);
-                block->SetJumpKindAndTarget(BBJ_ALWAYS, callBlock);
+                block->SetKindAndTarget(BBJ_ALWAYS, callBlock);
                 fgAddRefPred(callBlock, block);
 
                 /* The new block will inherit this block's weight */
@@ -4734,7 +4734,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 fgRemoveRefPred(callBlock->GetTarget(), callBlock);
 
                 // callBlock will call the finally handler. Convert the BBJ_LEAVE to BBJ_CALLFINALLY
-                callBlock->SetJumpKindAndTarget(BBJ_CALLFINALLY, HBtab->ebdHndBeg);
+                callBlock->SetKindAndTarget(BBJ_CALLFINALLY, HBtab->ebdHndBeg);
 
 #ifdef DEBUG
                 if (verbose)
@@ -5069,7 +5069,7 @@ void Compiler::impResetLeaveBlock(BasicBlock* block, unsigned jmpAddr)
     fgInitBBLookup();
 
     fgRemoveRefPred(block->GetTarget(), block);
-    block->SetJumpKindAndTarget(BBJ_LEAVE, fgLookupBB(jmpAddr));
+    block->SetKindAndTarget(BBJ_LEAVE, fgLookupBB(jmpAddr));
     fgAddRefPred(block->GetTarget(), block);
 
     // We will leave the BBJ_ALWAYS block we introduced. When it's reimported
@@ -6044,7 +6044,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
             // Change block to BBJ_THROW so we won't trigger importation of successors.
             //
-            block->SetJumpKindAndTarget(BBJ_THROW);
+            block->SetKindAndTarget(BBJ_THROW);
 
             // If this method has a explicit generic context, the only uses of it may be in
             // the IL for this block. So assume it's used.
@@ -7430,7 +7430,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             assert(block->NextIs(block->GetFalseTarget()));
                             JITDUMP("\nThe block jumps to the next " FMT_BB "\n", block->Next()->bbNum);
                             fgRemoveRefPred(block->GetTarget(), block);
-                            block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
+                            block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
 
                             // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense
                             // to set BBF_NONE_QUIRK
@@ -7691,7 +7691,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         if ((val == switchVal) || (!foundVal && (val == jumpCnt - 1)))
                         {
                             // transform the basic block into a BBJ_ALWAYS
-                            block->SetJumpKindAndTarget(BBJ_ALWAYS, curJump);
+                            block->SetKindAndTarget(BBJ_ALWAYS, curJump);
                             foundVal = true;
                         }
                         else

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12229,7 +12229,7 @@ void Compiler::impFixPredLists()
                     continue;
                 }
 
-                // Count the number of predecessors. Then we can allocate the bbEhfTarget table and fill it in.
+                // Count the number of predecessors. Then we can allocate the bbEhfTargets table and fill it in.
                 // We only need to count once, since it's invariant with the finally block.
                 if (predCount == (unsigned)-1)
                 {
@@ -12282,7 +12282,7 @@ void Compiler::impFixPredLists()
                     assert(predNum == predCount);
                 }
 
-                finallyBlock->SetEhfTarget(jumpEhf);
+                finallyBlock->SetEhfTargets(jumpEhf);
             }
         }
     }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7675,8 +7675,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     // Find the jump target
                     size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
-                    unsigned     jumpCnt   = block->GetSwtTarget()->bbsCount;
-                    BasicBlock** jumpTab   = block->GetSwtTarget()->bbsDstTab;
+                    unsigned     jumpCnt   = block->GetSwitchTarget()->bbsCount;
+                    BasicBlock** jumpTab   = block->GetSwitchTarget()->bbsDstTab;
                     bool         foundVal  = false;
 
                     for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7420,7 +7420,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         if (op1->AsIntCon()->gtIconVal)
                         {
                             JITDUMP("\nThe conditional jump becomes an unconditional jump to " FMT_BB "\n",
-                                    block->GetTarget()->bbNum);
+                                    block->GetTrueTarget()->bbNum);
                             fgRemoveRefPred(block->GetFalseTarget(), block);
                             block->SetKind(BBJ_ALWAYS);
                         }
@@ -7429,7 +7429,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             // TODO-NoFallThrough: Update once bbFalseTarget can diverge from bbNext
                             assert(block->NextIs(block->GetFalseTarget()));
                             JITDUMP("\nThe block jumps to the next " FMT_BB "\n", block->Next()->bbNum);
-                            fgRemoveRefPred(block->GetTarget(), block);
+                            fgRemoveRefPred(block->GetTrueTarget(), block);
                             block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
 
                             // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense
@@ -11296,9 +11296,9 @@ SPILLSTACK:
 
                 /* Try the target of the jump then */
 
-                multRef |= block->GetTarget()->bbRefs;
-                baseTmp  = block->GetTarget()->bbStkTempsIn;
-                tgtBlock = block->GetTarget();
+                multRef |= block->GetTrueTarget()->bbRefs;
+                baseTmp  = block->GetTrueTarget()->bbStkTempsIn;
+                tgtBlock = block->GetTrueTarget();
                 break;
 
             case BBJ_ALWAYS:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4484,7 +4484,7 @@ void Compiler::impImportLeave(BasicBlock* block)
     if (encFinallies == 0)
     {
         assert(step == DUMMY_INIT(NULL));
-        block->SetJumpKind(BBJ_ALWAYS); // convert the BBJ_LEAVE to a BBJ_ALWAYS
+        block->SetKind(BBJ_ALWAYS); // convert the BBJ_LEAVE to a BBJ_ALWAYS
 
         if (endCatches)
         {
@@ -4638,7 +4638,7 @@ void Compiler::impImportLeave(BasicBlock* block)
             if (step == nullptr)
             {
                 step = block;
-                step->SetJumpKind(BBJ_EHCATCHRET); // convert the BBJ_LEAVE to BBJ_EHCATCHRET
+                step->SetKind(BBJ_EHCATCHRET); // convert the BBJ_LEAVE to BBJ_EHCATCHRET
                 stepType = ST_Catch;
 
 #ifdef DEBUG
@@ -4958,7 +4958,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
     if (step == nullptr)
     {
-        block->SetJumpKind(BBJ_ALWAYS); // convert the BBJ_LEAVE to a BBJ_ALWAYS
+        block->SetKind(BBJ_ALWAYS); // convert the BBJ_LEAVE to a BBJ_ALWAYS
 
 #ifdef DEBUG
         if (verbose)
@@ -7352,7 +7352,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
                                 block->GetFalseTarget()->bbNum);
                         fgRemoveRefPred(block->GetFalseTarget(), block);
-                        block->SetJumpKind(BBJ_ALWAYS);
+                        block->SetKind(BBJ_ALWAYS);
 
                         // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense to
                         // set BBF_NONE_QUIRK
@@ -7422,7 +7422,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             JITDUMP("\nThe conditional jump becomes an unconditional jump to " FMT_BB "\n",
                                     block->GetTarget()->bbNum);
                             fgRemoveRefPred(block->GetFalseTarget(), block);
-                            block->SetJumpKind(BBJ_ALWAYS);
+                            block->SetKind(BBJ_ALWAYS);
                         }
                         else
                         {
@@ -7608,7 +7608,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
                                 block->GetFalseTarget()->bbNum);
                         fgRemoveRefPred(block->GetFalseTarget(), block);
-                        block->SetJumpKind(BBJ_ALWAYS);
+                        block->SetKind(BBJ_ALWAYS);
 
                         // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense to
                         // set BBF_NONE_QUIRK
@@ -11272,7 +11272,7 @@ SPILLSTACK:
 
         unsigned multRef = impCanReimport ? unsigned(~0) : 0;
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_COND:
 
@@ -11336,7 +11336,7 @@ SPILLSTACK:
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7675,8 +7675,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     // Find the jump target
                     size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
-                    unsigned     jumpCnt   = block->GetSwitchTarget()->bbsCount;
-                    BasicBlock** jumpTab   = block->GetSwitchTarget()->bbsDstTab;
+                    unsigned     jumpCnt   = block->GetSwitchTargets()->bbsCount;
+                    BasicBlock** jumpTab   = block->GetSwitchTargets()->bbsDstTab;
                     bool         foundVal  = false;
 
                     for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7349,12 +7349,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     //
                     if (block->KindIs(BBJ_COND))
                     {
-                        JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n",
-                                block->bbNum, block->GetNormalJumpDest()->bbNum);
+                        JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
+                                block->GetNormalJumpDest()->bbNum);
                         fgRemoveRefPred(block->GetNormalJumpDest(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set BBF_NONE_QUIRK
+                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                        // BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
                     else
@@ -7431,7 +7432,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             fgRemoveRefPred(block->GetJumpDest(), block);
                             block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
 
-                            // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set BBF_NONE_QUIRK
+                            // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                            // BBF_NONE_QUIRK
                             block->SetFlags(BBF_NONE_QUIRK);
                         }
                     }
@@ -7603,12 +7605,13 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     //
                     if (block->KindIs(BBJ_COND))
                     {
-                        JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n",
-                                block->bbNum, block->GetNormalJumpDest()->bbNum);
+                        JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
+                                block->GetNormalJumpDest()->bbNum);
                         fgRemoveRefPred(block->GetNormalJumpDest(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set BBF_NONE_QUIRK
+                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                        // BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
                     else

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7354,7 +7354,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         fgRemoveRefPred(block->GetNormalJumpDest(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                        // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
+                        // set
                         // BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
@@ -7426,13 +7427,14 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         }
                         else
                         {
-                            // TODO: Update once bbNormalJumpDest can diverge from bbNext
+                            // TODO-NoFallThrough: Update once bbNormalJumpDest can diverge from bbNext
                             assert(block->NextIs(block->GetNormalJumpDest()));
                             JITDUMP("\nThe block jumps to the next " FMT_BB "\n", block->Next()->bbNum);
                             fgRemoveRefPred(block->GetJumpDest(), block);
                             block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
 
-                            // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                            // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense
+                            // to set
                             // BBF_NONE_QUIRK
                             block->SetFlags(BBF_NONE_QUIRK);
                         }
@@ -7610,7 +7612,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         fgRemoveRefPred(block->GetNormalJumpDest(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                        // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
+                        // set
                         // BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4665,7 +4665,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                     fgRemoveRefPred(step->GetTarget(), step);
                 }
                 step->SetTarget(exitBlock); // the previous step (maybe a call to a nested finally, or a nested catch
-                                              // exit) returns to this block
+                                            // exit) returns to this block
                 fgAddRefPred(exitBlock, step);
 
                 /* The new block will inherit this block's weight */
@@ -4821,7 +4821,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                     fgRemoveRefPred(step->GetTarget(), step);
                 }
                 step->SetTarget(callBlock); // the previous call to a finally returns to this call (to the next
-                                              // finally in the chain)
+                                            // finally in the chain)
                 fgAddRefPred(callBlock, step);
 
                 /* The new block will inherit this block's weight */

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4466,7 +4466,7 @@ void Compiler::impImportLeave(BasicBlock* block)
             assert(finallyNesting <= compHndBBtabCount);
 
             assert(callBlock->KindIs(BBJ_CALLFINALLY));
-            assert(callBlock->HasJumpTo(HBtab->ebdHndBeg));
+            assert(callBlock->TargetIs(HBtab->ebdHndBeg));
             fgAddRefPred(callBlock->GetTarget(), callBlock);
 
             GenTree* endLFin = new (this, GT_END_LFIN) GenTreeVal(GT_END_LFIN, TYP_VOID, finallyNesting);
@@ -4856,7 +4856,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 #endif
 
             assert(callBlock->KindIs(BBJ_CALLFINALLY));
-            assert(callBlock->HasJumpTo(HBtab->ebdHndBeg));
+            assert(callBlock->TargetIs(HBtab->ebdHndBeg));
             fgAddRefPred(callBlock->GetTarget(), callBlock);
         }
         else if (HBtab->HasCatchHandler() && jitIsBetween(blkAddr, tryBeg, tryEnd) &&

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7355,8 +7355,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         block->SetJumpKind(BBJ_ALWAYS);
 
                         // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
-                        // set
-                        // BBF_NONE_QUIRK
+                        // set BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
                     else
@@ -7434,8 +7433,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
 
                             // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense
-                            // to set
-                            // BBF_NONE_QUIRK
+                            // to set BBF_NONE_QUIRK
                             block->SetFlags(BBF_NONE_QUIRK);
                         }
                     }
@@ -7613,8 +7611,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         block->SetJumpKind(BBJ_ALWAYS);
 
                         // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
-                        // set
-                        // BBF_NONE_QUIRK
+                        // set BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
                     else

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7350,11 +7350,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     if (block->KindIs(BBJ_COND))
                     {
                         JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
-                                block->GetNormalJumpDest()->bbNum);
-                        fgRemoveRefPred(block->GetNormalJumpDest(), block);
+                                block->GetFalseTarget()->bbNum);
+                        fgRemoveRefPred(block->GetFalseTarget(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
+                        // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense to
                         // set BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
@@ -7421,18 +7421,18 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         {
                             JITDUMP("\nThe conditional jump becomes an unconditional jump to " FMT_BB "\n",
                                     block->GetJumpDest()->bbNum);
-                            fgRemoveRefPred(block->GetNormalJumpDest(), block);
+                            fgRemoveRefPred(block->GetFalseTarget(), block);
                             block->SetJumpKind(BBJ_ALWAYS);
                         }
                         else
                         {
-                            // TODO-NoFallThrough: Update once bbNormalJumpDest can diverge from bbNext
-                            assert(block->NextIs(block->GetNormalJumpDest()));
+                            // TODO-NoFallThrough: Update once bbFalseTarget can diverge from bbNext
+                            assert(block->NextIs(block->GetFalseTarget()));
                             JITDUMP("\nThe block jumps to the next " FMT_BB "\n", block->Next()->bbNum);
                             fgRemoveRefPred(block->GetJumpDest(), block);
                             block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
 
-                            // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense
+                            // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense
                             // to set BBF_NONE_QUIRK
                             block->SetFlags(BBF_NONE_QUIRK);
                         }
@@ -7606,11 +7606,11 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     if (block->KindIs(BBJ_COND))
                     {
                         JITDUMP(FMT_BB " always branches to " FMT_BB ", changing to BBJ_ALWAYS\n", block->bbNum,
-                                block->GetNormalJumpDest()->bbNum);
-                        fgRemoveRefPred(block->GetNormalJumpDest(), block);
+                                block->GetFalseTarget()->bbNum);
+                        fgRemoveRefPred(block->GetFalseTarget(), block);
                         block->SetJumpKind(BBJ_ALWAYS);
 
-                        // TODO-NoFallThrough: Once bbNormalJumpDest can diverge from bbNext, it may not make sense to
+                        // TODO-NoFallThrough: Once bbFalseTarget can diverge from bbNext, it may not make sense to
                         // set BBF_NONE_QUIRK
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
@@ -11282,12 +11282,12 @@ SPILLSTACK:
 
                 /* Note if the next block has more than one ancestor */
 
-                multRef |= block->GetNormalJumpDest()->bbRefs;
+                multRef |= block->GetFalseTarget()->bbRefs;
 
                 /* Does the next block have temps assigned? */
 
-                baseTmp  = block->GetNormalJumpDest()->bbStkTempsIn;
-                tgtBlock = block->GetNormalJumpDest();
+                baseTmp  = block->GetFalseTarget()->bbStkTempsIn;
+                tgtBlock = block->GetFalseTarget();
 
                 if (baseTmp != NO_BASE_TMP)
                 {

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7675,8 +7675,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 {
                     // Find the jump target
                     size_t       switchVal = (size_t)op1->AsIntCon()->gtIconVal;
-                    unsigned     jumpCnt   = block->GetJumpSwt()->bbsCount;
-                    BasicBlock** jumpTab   = block->GetJumpSwt()->bbsDstTab;
+                    unsigned     jumpCnt   = block->GetSwtTarget()->bbsCount;
+                    BasicBlock** jumpTab   = block->GetSwtTarget()->bbsDstTab;
                     bool         foundVal  = false;
 
                     for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12229,7 +12229,7 @@ void Compiler::impFixPredLists()
                     continue;
                 }
 
-                // Count the number of predecessors. Then we can allocate the bbJumpEhf table and fill it in.
+                // Count the number of predecessors. Then we can allocate the bbEhfTarget table and fill it in.
                 // We only need to count once, since it's invariant with the finally block.
                 if (predCount == (unsigned)-1)
                 {
@@ -12282,7 +12282,7 @@ void Compiler::impFixPredLists()
                     assert(predNum == predCount);
                 }
 
-                finallyBlock->SetJumpEhf(jumpEhf);
+                finallyBlock->SetEhfTarget(jumpEhf);
             }
         }
     }

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -274,7 +274,7 @@ private:
             if (checkBlock != currBlock)
             {
                 assert(currBlock->KindIs(BBJ_ALWAYS));
-                currBlock->SetJumpDest(checkBlock);
+                currBlock->SetTarget(checkBlock);
                 compiler->fgAddRefPred(checkBlock, currBlock);
             }
 
@@ -1011,7 +1011,7 @@ private:
 
             // Also, thenBlock has a single pred - last checkBlock
             assert(checkBlock->KindIs(BBJ_ALWAYS));
-            checkBlock->SetJumpDest(thenBlock);
+            checkBlock->SetTarget(thenBlock);
             checkBlock->SetFlags(BBF_NONE_QUIRK);
             assert(checkBlock->JumpsToNext());
             compiler->fgAddRefPred(thenBlock, checkBlock);

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -280,7 +280,7 @@ private:
 
             // checkBlock
             assert(checkBlock->KindIs(BBJ_ALWAYS));
-            checkBlock->SetJumpKindAndTarget(BBJ_COND, elseBlock);
+            checkBlock->SetKindAndTarget(BBJ_COND, elseBlock);
             compiler->fgAddRefPred(elseBlock, checkBlock);
             compiler->fgAddRefPred(thenBlock, checkBlock);
 
@@ -593,7 +593,7 @@ private:
                 checkFallsThrough          = false;
 
                 // prevCheckBlock is expected to jump to this new check (if its type check doesn't succeed)
-                prevCheckBlock->SetJumpKindAndTarget(BBJ_COND, checkBlock);
+                prevCheckBlock->SetKindAndTarget(BBJ_COND, checkBlock);
                 compiler->fgAddRefPred(checkBlock, prevCheckBlock);
 
                 // Calculate the total likelihood for this check as a sum of likelihoods
@@ -1033,7 +1033,7 @@ private:
             // where we know the last check is always true (in case of "exact" GDV)
             if (!checkFallsThrough)
             {
-                checkBlock->SetJumpKindAndTarget(BBJ_COND, elseBlock);
+                checkBlock->SetKindAndTarget(BBJ_COND, elseBlock);
                 compiler->fgAddRefPred(elseBlock, checkBlock);
             }
             else
@@ -1156,7 +1156,7 @@ private:
             // not fall through to the check block.
             //
             compiler->fgRemoveRefPred(checkBlock, coldBlock);
-            coldBlock->SetJumpKindAndTarget(BBJ_ALWAYS, elseBlock);
+            coldBlock->SetKindAndTarget(BBJ_ALWAYS, elseBlock);
             compiler->fgAddRefPred(elseBlock, coldBlock);
         }
 

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -278,7 +278,7 @@ private:
 
             // checkBlock
             assert(checkBlock->KindIs(BBJ_ALWAYS));
-            checkBlock->SetKindAndTarget(BBJ_COND, elseBlock);
+            checkBlock->SetCondKindAndTarget(elseBlock);
             compiler->fgAddRefPred(elseBlock, checkBlock);
             compiler->fgAddRefPred(thenBlock, checkBlock);
 
@@ -591,7 +591,7 @@ private:
                 checkFallsThrough          = false;
 
                 // prevCheckBlock is expected to jump to this new check (if its type check doesn't succeed)
-                prevCheckBlock->SetKindAndTarget(BBJ_COND, checkBlock);
+                prevCheckBlock->SetCondKindAndTarget(checkBlock);
                 compiler->fgAddRefPred(checkBlock, prevCheckBlock);
 
                 // Calculate the total likelihood for this check as a sum of likelihoods
@@ -1031,7 +1031,7 @@ private:
             // where we know the last check is always true (in case of "exact" GDV)
             if (!checkFallsThrough)
             {
-                checkBlock->SetKindAndTarget(BBJ_COND, elseBlock);
+                checkBlock->SetCondKindAndTarget(elseBlock);
                 compiler->fgAddRefPred(elseBlock, checkBlock);
             }
             else

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -278,7 +278,7 @@ private:
 
             // checkBlock
             assert(checkBlock->KindIs(BBJ_ALWAYS));
-            checkBlock->SetCondKindAndTarget(elseBlock);
+            checkBlock->SetCond(elseBlock);
             compiler->fgAddRefPred(elseBlock, checkBlock);
             compiler->fgAddRefPred(thenBlock, checkBlock);
 
@@ -591,7 +591,7 @@ private:
                 checkFallsThrough          = false;
 
                 // prevCheckBlock is expected to jump to this new check (if its type check doesn't succeed)
-                prevCheckBlock->SetCondKindAndTarget(checkBlock);
+                prevCheckBlock->SetCond(checkBlock);
                 compiler->fgAddRefPred(checkBlock, prevCheckBlock);
 
                 // Calculate the total likelihood for this check as a sum of likelihoods
@@ -1031,7 +1031,7 @@ private:
             // where we know the last check is always true (in case of "exact" GDV)
             if (!checkFallsThrough)
             {
-                checkBlock->SetCondKindAndTarget(elseBlock);
+                checkBlock->SetCond(elseBlock);
                 compiler->fgAddRefPred(elseBlock, checkBlock);
             }
             else

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -222,9 +222,7 @@ private:
         //
         // Return Value:
         //    new basic block.
-        BasicBlock* CreateAndInsertBasicBlock(BBKinds jumpKind,
-                                              BasicBlock* insertAfter,
-                                              BasicBlock* jumpDest = nullptr)
+        BasicBlock* CreateAndInsertBasicBlock(BBKinds jumpKind, BasicBlock* insertAfter, BasicBlock* jumpDest = nullptr)
         {
             BasicBlock* block = compiler->fgNewBBafter(jumpKind, insertAfter, true, jumpDest);
             block->SetFlags(BBF_IMPORTED);

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -222,7 +222,7 @@ private:
         //
         // Return Value:
         //    new basic block.
-        BasicBlock* CreateAndInsertBasicBlock(BBjumpKinds jumpKind,
+        BasicBlock* CreateAndInsertBasicBlock(BBKinds jumpKind,
                                               BasicBlock* insertAfter,
                                               BasicBlock* jumpDest = nullptr)
         {

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -285,7 +285,7 @@ private:
             compiler->fgAddRefPred(thenBlock, checkBlock);
 
             // thenBlock
-            assert(thenBlock->HasJumpTo(remainderBlock));
+            assert(thenBlock->TargetIs(remainderBlock));
             compiler->fgAddRefPred(remainderBlock, thenBlock);
 
             // elseBlock
@@ -1111,7 +1111,7 @@ private:
 
             BasicBlock* const hotBlock = coldBlock->Prev();
 
-            if (!hotBlock->KindIs(BBJ_ALWAYS) || !hotBlock->HasJumpTo(checkBlock))
+            if (!hotBlock->KindIs(BBJ_ALWAYS) || !hotBlock->TargetIs(checkBlock))
             {
                 JITDUMP("Unexpected flow from hot path " FMT_BB "\n", hotBlock->bbNum);
                 return;

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -3459,7 +3459,7 @@ void Compiler::fgVerifyHandlerTab()
         }
 
         // Check for legal block types
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_EHFINALLYRET:
             {

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4031,7 +4031,7 @@ bool Compiler::fgIsIntraHandlerPred(BasicBlock* predBlock, BasicBlock* block)
                                                           // trying to decide how to split up the predecessor edges.
         if (predBlock->KindIs(BBJ_CALLFINALLY))
         {
-            assert(predBlock->HasJumpTo(block));
+            assert(predBlock->TargetIs(block));
 
             // A BBJ_CALLFINALLY predecessor of the handler can only come from the corresponding try,
             // not from any EH clauses nested in this handler. However, we represent the BBJ_CALLFINALLY
@@ -4329,7 +4329,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
                 BasicBlock* bFilterLast = HBtab->BBFilterLast();
                 assert(bFilterLast != nullptr);
                 assert(bFilterLast->KindIs(BBJ_EHFILTERRET));
-                assert(bFilterLast->HasJumpTo(block));
+                assert(bFilterLast->TargetIs(block));
 #ifdef DEBUG
                 if (verbose)
                 {

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4321,7 +4321,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
 #endif // FEATURE_EH_FUNCLETS
 
             // If this is a handler for a filter, the last block of the filter will end with
-            // a BBJ_EHFILTERRET block that has a bbJumpDest that jumps to the first block of
+            // a BBJ_EHFILTERRET block that has a bbTarget that jumps to the first block of
             // its handler. So we need to update it to keep things in sync.
             //
             if (HBtab->HasFilter())
@@ -4333,13 +4333,13 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
 #ifdef DEBUG
                 if (verbose)
                 {
-                    printf("EH#%u: Updating bbJumpDest for filter ret block: " FMT_BB " => " FMT_BB "\n",
+                    printf("EH#%u: Updating bbTarget for filter ret block: " FMT_BB " => " FMT_BB "\n",
                            ehGetIndex(HBtab), bFilterLast->bbNum, bPrev->bbNum);
                 }
 #endif // DEBUG
-                // Change the bbJumpDest for bFilterLast from the old first 'block' to the new first 'bPrev'
-                fgRemoveRefPred(bFilterLast->GetJumpDest(), bFilterLast);
-                bFilterLast->SetJumpDest(bPrev);
+                // Change the bbTarget for bFilterLast from the old first 'block' to the new first 'bPrev'
+                fgRemoveRefPred(bFilterLast->GetTarget(), bFilterLast);
+                bFilterLast->SetTarget(bPrev);
                 fgAddRefPred(bPrev, bFilterLast);
             }
         }

--- a/src/coreclr/jit/lir.cpp
+++ b/src/coreclr/jit/lir.cpp
@@ -1770,7 +1770,7 @@ void LIR::InsertBeforeTerminator(BasicBlock* block, LIR::Range&& range)
         assert(insertionPoint != nullptr);
 
 #if DEBUG
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_COND:
                 assert(insertionPoint->OperIsConditionalJump());

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -891,7 +891,7 @@ void Compiler::fgExtendDbgLifetimes()
             case BBJ_ALWAYS:
             case BBJ_EHCATCHRET:
             case BBJ_EHFILTERRET:
-                VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
                 break;
 
             case BBJ_CALLFINALLY:
@@ -901,13 +901,13 @@ void Compiler::fgExtendDbgLifetimes()
                     PREFIX_ASSUME(!block->IsLast());
                     VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
                 }
-                VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
                 break;
 
             case BBJ_COND:
                 PREFIX_ASSUME(!block->IsLast());
                 VarSetOps::UnionD(this, initVars, block->GetFalseTarget()->bbScope);
-                VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -906,7 +906,7 @@ void Compiler::fgExtendDbgLifetimes()
 
             case BBJ_COND:
                 PREFIX_ASSUME(!block->IsLast());
-                VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetNormalJumpDest()->bbScope);
                 VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
                 break;
 

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -907,7 +907,7 @@ void Compiler::fgExtendDbgLifetimes()
             case BBJ_COND:
                 PREFIX_ASSUME(!block->IsLast());
                 VarSetOps::UnionD(this, initVars, block->GetFalseTarget()->bbScope);
-                VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetTrueTarget()->bbScope);
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -906,7 +906,7 @@ void Compiler::fgExtendDbgLifetimes()
 
             case BBJ_COND:
                 PREFIX_ASSUME(!block->IsLast());
-                VarSetOps::UnionD(this, initVars, block->GetNormalJumpDest()->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetFalseTarget()->bbScope);
                 VarSetOps::UnionD(this, initVars, block->GetJumpDest()->bbScope);
                 break;
 

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -378,7 +378,7 @@ void Compiler::fgPerBlockLocalVarLiveness()
             block->bbMemoryLiveIn  = fullMemoryKindSet;
             block->bbMemoryLiveOut = fullMemoryKindSet;
 
-            switch (block->GetJumpKind())
+            switch (block->GetKind())
             {
                 case BBJ_EHFINALLYRET:
                 case BBJ_EHFAULTRET:
@@ -886,7 +886,7 @@ void Compiler::fgExtendDbgLifetimes()
     {
         VarSetOps::ClearD(this, initVars);
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_ALWAYS:
             case BBJ_EHCATCHRET:
@@ -930,7 +930,7 @@ void Compiler::fgExtendDbgLifetimes()
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
 

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2232,7 +2232,7 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
         optRedirectBlock(newblk, blockMap);
 
         // Add predecessor edges for the new successors, as well as the fall-through paths.
-        switch (newblk->GetJumpKind())
+        switch (newblk->GetKind())
         {
             case BBJ_ALWAYS:
             case BBJ_CALLFINALLY:

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1884,7 +1884,7 @@ bool Compiler::optIsLoopClonable(FlowGraphNaturalLoop* loop, LoopCloneContext* c
         return false;
     }
 
-    if (!oldLoopBottom->HasJumpTo(oldLoopTop))
+    if (!oldLoopBottom->TargetIs(oldLoopTop))
     {
         JITDUMP("Loop cloning: rejecting loop " FMT_LP ". Branch at loop 'bottom' not looping to 'top'.\n",
                 loop->GetIndex());
@@ -2058,7 +2058,7 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     }
 
     assert(preheader->KindIs(BBJ_ALWAYS));
-    assert(preheader->HasJumpTo(loop->GetHeader()));
+    assert(preheader->TargetIs(loop->GetHeader()));
 
     fgReplacePred(loop->GetHeader(), preheader, fastPreheader);
     JITDUMP("Replace " FMT_BB " -> " FMT_BB " with " FMT_BB " -> " FMT_BB "\n", preheader->bbNum,

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2308,6 +2308,7 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
 
     // Now redirect the old preheader to jump to the first new condition that
     // was inserted by the above function.
+    assert(preheader->KindIs(BBJ_ALWAYS));
     preheader->SetTarget(preheader->Next());
     fgAddRefPred(preheader->Next(), preheader);
     preheader->SetFlags(BBF_NONE_QUIRK);

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1884,7 +1884,7 @@ bool Compiler::optIsLoopClonable(FlowGraphNaturalLoop* loop, LoopCloneContext* c
         return false;
     }
 
-    if (!oldLoopBottom->TargetIs(oldLoopTop))
+    if (!oldLoopBottom->TrueTargetIs(oldLoopTop))
     {
         JITDUMP("Loop cloning: rejecting loop " FMT_LP ". Branch at loop 'bottom' not looping to 'top'.\n",
                 loop->GetIndex());

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -864,8 +864,8 @@ BasicBlock* LoopCloneContext::CondToStmtInBlock(Compiler*                       
             newBlk->inheritWeight(insertAfter);
             newBlk->bbNatLoopNum = insertAfter->bbNatLoopNum;
 
-            JITDUMP("Adding " FMT_BB " -> " FMT_BB "\n", newBlk->bbNum, newBlk->GetTarget()->bbNum);
-            comp->fgAddRefPred(newBlk->GetTarget(), newBlk);
+            JITDUMP("Adding " FMT_BB " -> " FMT_BB "\n", newBlk->bbNum, newBlk->GetTrueTarget()->bbNum);
+            comp->fgAddRefPred(newBlk->GetTrueTarget(), newBlk);
 
             if (insertAfter->bbFallsThrough())
             {
@@ -898,8 +898,8 @@ BasicBlock* LoopCloneContext::CondToStmtInBlock(Compiler*                       
         newBlk->inheritWeight(insertAfter);
         newBlk->bbNatLoopNum = insertAfter->bbNatLoopNum;
 
-        JITDUMP("Adding " FMT_BB " -> " FMT_BB "\n", newBlk->bbNum, newBlk->GetTarget()->bbNum);
-        comp->fgAddRefPred(newBlk->GetTarget(), newBlk);
+        JITDUMP("Adding " FMT_BB " -> " FMT_BB "\n", newBlk->bbNum, newBlk->GetTrueTarget()->bbNum);
+        comp->fgAddRefPred(newBlk->GetTrueTarget(), newBlk);
 
         if (insertAfter->bbFallsThrough())
         {
@@ -2241,7 +2241,7 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
 
             case BBJ_COND:
                 fgAddRefPred(newblk->GetFalseTarget(), newblk);
-                fgAddRefPred(newblk->GetTarget(), newblk);
+                fgAddRefPred(newblk->GetTrueTarget(), newblk);
                 break;
 
             case BBJ_SWITCH:
@@ -2971,9 +2971,9 @@ bool Compiler::optCheckLoopCloningGDVTestProfitable(GenTreeOp* guard, LoopCloneV
     // Check for (4)
     //
     BasicBlock* const hotSuccessor =
-        guard->OperIs(GT_EQ) ? typeTestBlock->GetTarget() : typeTestBlock->GetFalseTarget();
+        guard->OperIs(GT_EQ) ? typeTestBlock->GetTrueTarget() : typeTestBlock->GetFalseTarget();
     BasicBlock* const coldSuccessor =
-        guard->OperIs(GT_EQ) ? typeTestBlock->GetFalseTarget() : typeTestBlock->GetTarget();
+        guard->OperIs(GT_EQ) ? typeTestBlock->GetFalseTarget() : typeTestBlock->GetTrueTarget();
 
     if (!hotSuccessor->hasProfileWeight() || !coldSuccessor->hasProfileWeight())
     {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2969,8 +2969,10 @@ bool Compiler::optCheckLoopCloningGDVTestProfitable(GenTreeOp* guard, LoopCloneV
 
     // Check for (4)
     //
-    BasicBlock* const hotSuccessor  = guard->OperIs(GT_EQ) ? typeTestBlock->GetJumpDest() : typeTestBlock->GetNormalJumpDest();
-    BasicBlock* const coldSuccessor = guard->OperIs(GT_EQ) ? typeTestBlock->GetNormalJumpDest() : typeTestBlock->GetJumpDest();
+    BasicBlock* const hotSuccessor =
+        guard->OperIs(GT_EQ) ? typeTestBlock->GetJumpDest() : typeTestBlock->GetNormalJumpDest();
+    BasicBlock* const coldSuccessor =
+        guard->OperIs(GT_EQ) ? typeTestBlock->GetNormalJumpDest() : typeTestBlock->GetJumpDest();
 
     if (!hotSuccessor->hasProfileWeight() || !coldSuccessor->hasProfileWeight())
     {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -965,7 +965,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
 
     // Turn originalSwitchBB into a BBJ_COND.
-    originalSwitchBB->SetKindAndTarget(BBJ_COND, jumpTab[jumpCnt - 1]);
+    originalSwitchBB->SetCondKindAndTarget(jumpTab[jumpCnt - 1]);
 
     // Fix the pred for the default case: the default block target still has originalSwitchBB
     // as a predecessor, but the fgSplitBlockAfterStatement() moved all predecessors to point
@@ -1100,7 +1100,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             {
                 // Otherwise, it's a conditional branch. Set the branch kind, then add the
                 // condition statement.
-                currentBlock->SetKindAndTarget(BBJ_COND, jumpTab[i]);
+                currentBlock->SetCondKindAndTarget(jumpTab[i]);
 
                 // Now, build the conditional statement for the current case that is
                 // being evaluated:
@@ -1312,7 +1312,7 @@ bool Lowering::TryLowerSwitchToBitTest(
     {
         // GenCondition::C generates JC so we jump to bbCase1 when the bit is set
         bbSwitchCondition = GenCondition::C;
-        bbSwitch->SetKindAndTarget(BBJ_COND, bbCase1);
+        bbSwitch->SetCondKindAndTarget(bbCase1);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);
@@ -1323,7 +1323,7 @@ bool Lowering::TryLowerSwitchToBitTest(
 
         // GenCondition::NC generates JNC so we jump to bbCase0 when the bit is not set
         bbSwitchCondition = GenCondition::NC;
-        bbSwitch->SetKindAndTarget(BBJ_COND, bbCase0);
+        bbSwitch->SetCondKindAndTarget(bbCase0);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -846,8 +846,8 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // jumpCnt is the number of elements in the jump table array.
     // jumpTab is the actual pointer to the jump table array.
     // targetCnt is the number of unique targets in the jump table array.
-    jumpCnt   = originalSwitchBB->GetSwtTarget()->bbsCount;
-    jumpTab   = originalSwitchBB->GetSwtTarget()->bbsDstTab;
+    jumpCnt   = originalSwitchBB->GetSwitchTarget()->bbsCount;
+    jumpTab   = originalSwitchBB->GetSwitchTarget()->bbsDstTab;
     targetCnt = originalSwitchBB->NumSucc(comp);
 
 // GT_SWITCH must be a top-level node with no use.
@@ -959,7 +959,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     assert(originalSwitchBB->KindIs(BBJ_ALWAYS));
     assert(originalSwitchBB->NextIs(afterDefaultCondBlock));
     assert(afterDefaultCondBlock->KindIs(BBJ_SWITCH));
-    assert(afterDefaultCondBlock->GetSwtTarget()->bbsHasDefault);
+    assert(afterDefaultCondBlock->GetSwitchTarget()->bbsHasDefault);
     assert(afterDefaultCondBlock->isEmpty()); // Nothing here yet.
 
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
@@ -1168,7 +1168,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             switchBlockRange.InsertAfter(switchValue, switchTable, switchJump);
 
             // this block no longer branches to the default block
-            afterDefaultCondBlock->GetSwtTarget()->removeDefault();
+            afterDefaultCondBlock->GetSwitchTarget()->removeDefault();
         }
 
         comp->fgInvalidateSwitchDescMapEntry(afterDefaultCondBlock);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -846,8 +846,8 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // jumpCnt is the number of elements in the jump table array.
     // jumpTab is the actual pointer to the jump table array.
     // targetCnt is the number of unique targets in the jump table array.
-    jumpCnt   = originalSwitchBB->GetJumpSwt()->bbsCount;
-    jumpTab   = originalSwitchBB->GetJumpSwt()->bbsDstTab;
+    jumpCnt   = originalSwitchBB->GetSwtTarget()->bbsCount;
+    jumpTab   = originalSwitchBB->GetSwtTarget()->bbsDstTab;
     targetCnt = originalSwitchBB->NumSucc(comp);
 
 // GT_SWITCH must be a top-level node with no use.
@@ -959,7 +959,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     assert(originalSwitchBB->KindIs(BBJ_ALWAYS));
     assert(originalSwitchBB->NextIs(afterDefaultCondBlock));
     assert(afterDefaultCondBlock->KindIs(BBJ_SWITCH));
-    assert(afterDefaultCondBlock->GetJumpSwt()->bbsHasDefault);
+    assert(afterDefaultCondBlock->GetSwtTarget()->bbsHasDefault);
     assert(afterDefaultCondBlock->isEmpty()); // Nothing here yet.
 
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
@@ -1168,7 +1168,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             switchBlockRange.InsertAfter(switchValue, switchTable, switchJump);
 
             // this block no longer branches to the default block
-            afterDefaultCondBlock->GetJumpSwt()->removeDefault();
+            afterDefaultCondBlock->GetSwtTarget()->removeDefault();
         }
 
         comp->fgInvalidateSwitchDescMapEntry(afterDefaultCondBlock);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -846,8 +846,8 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // jumpCnt is the number of elements in the jump table array.
     // jumpTab is the actual pointer to the jump table array.
     // targetCnt is the number of unique targets in the jump table array.
-    jumpCnt   = originalSwitchBB->GetSwitchTarget()->bbsCount;
-    jumpTab   = originalSwitchBB->GetSwitchTarget()->bbsDstTab;
+    jumpCnt   = originalSwitchBB->GetSwitchTargets()->bbsCount;
+    jumpTab   = originalSwitchBB->GetSwitchTargets()->bbsDstTab;
     targetCnt = originalSwitchBB->NumSucc(comp);
 
 // GT_SWITCH must be a top-level node with no use.
@@ -959,7 +959,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     assert(originalSwitchBB->KindIs(BBJ_ALWAYS));
     assert(originalSwitchBB->NextIs(afterDefaultCondBlock));
     assert(afterDefaultCondBlock->KindIs(BBJ_SWITCH));
-    assert(afterDefaultCondBlock->GetSwitchTarget()->bbsHasDefault);
+    assert(afterDefaultCondBlock->GetSwitchTargets()->bbsHasDefault);
     assert(afterDefaultCondBlock->isEmpty()); // Nothing here yet.
 
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
@@ -1168,7 +1168,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             switchBlockRange.InsertAfter(switchValue, switchTable, switchJump);
 
             // this block no longer branches to the default block
-            afterDefaultCondBlock->GetSwitchTarget()->removeDefault();
+            afterDefaultCondBlock->GetSwitchTargets()->removeDefault();
         }
 
         comp->fgInvalidateSwitchDescMapEntry(afterDefaultCondBlock);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -965,7 +965,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
 
     // Turn originalSwitchBB into a BBJ_COND.
-    originalSwitchBB->SetCondKindAndTarget(jumpTab[jumpCnt - 1]);
+    originalSwitchBB->SetCond(jumpTab[jumpCnt - 1]);
 
     // Fix the pred for the default case: the default block target still has originalSwitchBB
     // as a predecessor, but the fgSplitBlockAfterStatement() moved all predecessors to point
@@ -1100,7 +1100,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             {
                 // Otherwise, it's a conditional branch. Set the branch kind, then add the
                 // condition statement.
-                currentBlock->SetCondKindAndTarget(jumpTab[i]);
+                currentBlock->SetCond(jumpTab[i]);
 
                 // Now, build the conditional statement for the current case that is
                 // being evaluated:
@@ -1312,7 +1312,7 @@ bool Lowering::TryLowerSwitchToBitTest(
     {
         // GenCondition::C generates JC so we jump to bbCase1 when the bit is set
         bbSwitchCondition = GenCondition::C;
-        bbSwitch->SetCondKindAndTarget(bbCase1);
+        bbSwitch->SetCond(bbCase1);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);
@@ -1323,7 +1323,7 @@ bool Lowering::TryLowerSwitchToBitTest(
 
         // GenCondition::NC generates JNC so we jump to bbCase0 when the bit is not set
         bbSwitchCondition = GenCondition::NC;
-        bbSwitch->SetCondKindAndTarget(bbCase0);
+        bbSwitch->SetCond(bbCase0);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -867,7 +867,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     {
         JITDUMP("Lowering switch " FMT_BB ": single target; converting to BBJ_ALWAYS\n", originalSwitchBB->bbNum);
         noway_assert(comp->opts.OptimizationDisabled());
-        originalSwitchBB->SetJumpKindAndTarget(BBJ_ALWAYS, jumpTab[0]);
+        originalSwitchBB->SetKindAndTarget(BBJ_ALWAYS, jumpTab[0]);
 
         if (originalSwitchBB->JumpsToNext())
         {
@@ -965,7 +965,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // The GT_SWITCH code is still in originalSwitchBB (it will be removed later).
 
     // Turn originalSwitchBB into a BBJ_COND.
-    originalSwitchBB->SetJumpKindAndTarget(BBJ_COND, jumpTab[jumpCnt - 1]);
+    originalSwitchBB->SetKindAndTarget(BBJ_COND, jumpTab[jumpCnt - 1]);
 
     // Fix the pred for the default case: the default block target still has originalSwitchBB
     // as a predecessor, but the fgSplitBlockAfterStatement() moved all predecessors to point
@@ -1020,7 +1020,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             (void)comp->fgRemoveRefPred(uniqueSucc, afterDefaultCondBlock);
         }
 
-        afterDefaultCondBlock->SetJumpKindAndTarget(BBJ_ALWAYS, uniqueSucc);
+        afterDefaultCondBlock->SetKindAndTarget(BBJ_ALWAYS, uniqueSucc);
 
         if (afterDefaultCondBlock->JumpsToNext())
         {
@@ -1094,13 +1094,13 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
                 // case: there is no need to compare against the case index, since it's
                 // guaranteed to be taken (since the default case was handled first, above).
 
-                currentBlock->SetJumpKindAndTarget(BBJ_ALWAYS, jumpTab[i]);
+                currentBlock->SetKindAndTarget(BBJ_ALWAYS, jumpTab[i]);
             }
             else
             {
                 // Otherwise, it's a conditional branch. Set the branch kind, then add the
                 // condition statement.
-                currentBlock->SetJumpKindAndTarget(BBJ_COND, jumpTab[i]);
+                currentBlock->SetKindAndTarget(BBJ_COND, jumpTab[i]);
 
                 // Now, build the conditional statement for the current case that is
                 // being evaluated:
@@ -1133,7 +1133,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
             JITDUMP("Lowering switch " FMT_BB ": all switch cases were fall-through\n", originalSwitchBB->bbNum);
             assert(currentBlock == afterDefaultCondBlock);
             assert(currentBlock->KindIs(BBJ_SWITCH));
-            currentBlock->SetJumpKindAndTarget(BBJ_ALWAYS, currentBlock->Next());
+            currentBlock->SetKindAndTarget(BBJ_ALWAYS, currentBlock->Next());
             currentBlock->RemoveFlags(BBF_DONT_REMOVE);
             comp->fgRemoveBlock(currentBlock, /* unreachable */ false); // It's an empty block.
         }
@@ -1312,7 +1312,7 @@ bool Lowering::TryLowerSwitchToBitTest(
     {
         // GenCondition::C generates JC so we jump to bbCase1 when the bit is set
         bbSwitchCondition = GenCondition::C;
-        bbSwitch->SetJumpKindAndTarget(BBJ_COND, bbCase1);
+        bbSwitch->SetKindAndTarget(BBJ_COND, bbCase1);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);
@@ -1323,7 +1323,7 @@ bool Lowering::TryLowerSwitchToBitTest(
 
         // GenCondition::NC generates JNC so we jump to bbCase0 when the bit is not set
         bbSwitchCondition = GenCondition::NC;
-        bbSwitch->SetJumpKindAndTarget(BBJ_COND, bbCase0);
+        bbSwitch->SetKindAndTarget(BBJ_COND, bbCase0);
 
         comp->fgAddRefPred(bbCase0, bbSwitch);
         comp->fgAddRefPred(bbCase1, bbSwitch);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2545,7 +2545,7 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 if (predBlock->KindIs(BBJ_COND))
                 {
                     // Special handling to improve matching on backedges.
-                    BasicBlock* otherBlock = predBlock->NextIs(block) ? predBlock->GetJumpDest() : predBlock->Next();
+                    BasicBlock* otherBlock = predBlock->NextIs(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2546,7 +2546,7 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 {
                     // Special handling to improve matching on backedges.
                     BasicBlock* otherBlock =
-                        predBlock->FalseTargetIs(block) ? predBlock->GetJumpDest() : predBlock->GetFalseTarget();
+                        predBlock->FalseTargetIs(block) ? predBlock->GetTarget() : predBlock->GetFalseTarget();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2546,7 +2546,7 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 {
                     // Special handling to improve matching on backedges.
                     BasicBlock* otherBlock =
-                        predBlock->HasNormalJumpTo(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
+                        predBlock->FalseTargetIs(block) ? predBlock->GetJumpDest() : predBlock->GetFalseTarget();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2546,7 +2546,7 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 {
                     // Special handling to improve matching on backedges.
                     BasicBlock* otherBlock =
-                        predBlock->FalseTargetIs(block) ? predBlock->GetTarget() : predBlock->GetFalseTarget();
+                        predBlock->FalseTargetIs(block) ? predBlock->GetTrueTarget() : predBlock->GetFalseTarget();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2545,7 +2545,7 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 if (predBlock->KindIs(BBJ_COND))
                 {
                     // Special handling to improve matching on backedges.
-                    BasicBlock* otherBlock = predBlock->NextIs(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
+                    BasicBlock* otherBlock = predBlock->HasNormalJumpTo(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2545,7 +2545,8 @@ BasicBlock* LinearScan::findPredBlockForLiveIn(BasicBlock* block,
                 if (predBlock->KindIs(BBJ_COND))
                 {
                     // Special handling to improve matching on backedges.
-                    BasicBlock* otherBlock = predBlock->HasNormalJumpTo(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
+                    BasicBlock* otherBlock =
+                        predBlock->HasNormalJumpTo(block) ? predBlock->GetJumpDest() : predBlock->GetNormalJumpDest();
                     noway_assert(otherBlock != nullptr);
                     if (isBlockVisited(otherBlock) && !blockInfo[otherBlock->bbNum].hasEHBoundaryIn)
                     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7465,7 +7465,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     }
 
     // Finish hooking things up.
-    fgAddRefPred(block->GetJumpDest(), block);
+    fgAddRefPred(block->GetTarget(), block);
     block->RemoveFlags(BBF_HAS_JMP);
 }
 
@@ -13159,7 +13159,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
             noway_assert(cond->gtOper == GT_CNS_INT);
             noway_assert((block->GetFalseTarget()->countOfInEdges() > 0) &&
-                         (block->GetJumpDest()->countOfInEdges() > 0));
+                         (block->GetTarget()->countOfInEdges() > 0));
 
             if (condTree != cond)
             {
@@ -13184,7 +13184,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             if (cond->AsIntCon()->gtIconVal != 0)
             {
                 /* JTRUE 1 - transform the basic block into a BBJ_ALWAYS */
-                bTaken    = block->GetJumpDest();
+                bTaken    = block->GetTarget();
                 bNotTaken = block->GetFalseTarget();
                 block->SetJumpKind(BBJ_ALWAYS);
             }
@@ -13193,15 +13193,15 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                 /* Unmark the loop if we are removing a backwards branch */
                 /* dest block must also be marked as a loop head and     */
                 /* We must be able to reach the backedge block           */
-                if (block->GetJumpDest()->isLoopHead() && (block->GetJumpDest()->bbNum <= block->bbNum) &&
-                    fgReachable(block->GetJumpDest(), block))
+                if (block->GetTarget()->isLoopHead() && (block->GetTarget()->bbNum <= block->bbNum) &&
+                    fgReachable(block->GetTarget(), block))
                 {
-                    optUnmarkLoopBlocks(block->GetJumpDest(), block);
+                    optUnmarkLoopBlocks(block->GetTarget(), block);
                 }
 
                 /* JTRUE 0 - transform the basic block into a BBJ_ALWAYS   */
                 bTaken    = block->GetFalseTarget();
-                bNotTaken = block->GetJumpDest();
+                bNotTaken = block->GetTarget();
                 block->SetJumpKindAndTarget(BBJ_ALWAYS, bTaken);
                 block->SetFlags(BBF_NONE_QUIRK);
             }
@@ -13266,7 +13266,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                             FALLTHROUGH;
 
                         case BBJ_ALWAYS:
-                            edge         = fgGetPredForBlock(bUpdated->GetJumpDest(), bUpdated);
+                            edge         = fgGetPredForBlock(bUpdated->GetTarget(), bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
                             edge->setEdgeWeights(newMinWeight, newMaxWeight,
@@ -13291,7 +13291,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             {
                 printf("\nConditional folded at " FMT_BB "\n", block->bbNum);
                 printf(FMT_BB " becomes a %s", block->bbNum, "BBJ_ALWAYS");
-                printf(" to " FMT_BB, block->GetJumpDest()->bbNum);
+                printf(" to " FMT_BB, block->GetTarget()->bbNum);
                 printf("\n");
             }
 #endif
@@ -13440,7 +13440,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             {
                 printf("\nConditional folded at " FMT_BB "\n", block->bbNum);
                 printf(FMT_BB " becomes a %s", block->bbNum, "BBJ_ALWAYS");
-                printf(" to " FMT_BB, block->GetJumpDest()->bbNum);
+                printf(" to " FMT_BB, block->GetTarget()->bbNum);
                 printf("\n");
             }
 #endif
@@ -13900,7 +13900,7 @@ void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorde
 
                     if (useCondAssertions)
                     {
-                        if (block == pred->GetJumpDest())
+                        if (block == pred->GetTarget())
                         {
                             JITDUMP("Using `if true` assertions from pred " FMT_BB "\n", pred->bbNum);
                             assertionsOut = pred->bbAssertionOutIfTrue;
@@ -14677,7 +14677,7 @@ bool Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
 
     // Chain the flow correctly.
     assert(block->KindIs(BBJ_ALWAYS));
-    block->SetJumpDest(asgBlock);
+    block->SetTarget(asgBlock);
     fgAddRefPred(asgBlock, block);
     fgAddRefPred(cond1Block, asgBlock);
     fgAddRefPred(cond2Block, cond1Block);
@@ -14876,9 +14876,9 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     condBlock->inheritWeight(block);
 
     assert(block->KindIs(BBJ_ALWAYS));
-    block->SetJumpDest(condBlock);
-    condBlock->SetJumpDest(elseBlock);
-    elseBlock->SetJumpDest(remainderBlock);
+    block->SetTarget(condBlock);
+    condBlock->SetTarget(elseBlock);
+    elseBlock->SetTarget(remainderBlock);
     assert(condBlock->JumpsToNext());
     assert(elseBlock->JumpsToNext());
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6308,7 +6308,7 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         {
             // We call CORINFO_HELP_TAILCALL which does not return, so we will
             // not need epilogue.
-            compCurBB->SetJumpKindAndTarget(BBJ_THROW);
+            compCurBB->SetKindAndTarget(BBJ_THROW);
         }
 
         if (isRootReplaced)
@@ -7446,7 +7446,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     {
         // Todo: this may not look like a viable loop header.
         // Might need the moral equivalent of a scratch BB.
-        block->SetJumpKindAndTarget(BBJ_ALWAYS, fgEntryBB);
+        block->SetKindAndTarget(BBJ_ALWAYS, fgEntryBB);
     }
     else
     {
@@ -7461,7 +7461,7 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
         // block removal on it.
         //
         fgFirstBB->SetFlags(BBF_DONT_REMOVE);
-        block->SetJumpKindAndTarget(BBJ_ALWAYS, fgFirstBB->Next());
+        block->SetKindAndTarget(BBJ_ALWAYS, fgFirstBB->Next());
     }
 
     // Finish hooking things up.
@@ -13202,7 +13202,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                 /* JTRUE 0 - transform the basic block into a BBJ_ALWAYS   */
                 bTaken    = block->GetFalseTarget();
                 bNotTaken = block->GetTarget();
-                block->SetJumpKindAndTarget(BBJ_ALWAYS, bTaken);
+                block->SetKindAndTarget(BBJ_ALWAYS, bTaken);
                 block->SetFlags(BBF_NONE_QUIRK);
             }
 
@@ -13419,7 +13419,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
                 if ((val == switchVal) || (!foundVal && (val == jumpCnt - 1)))
                 {
-                    block->SetJumpKindAndTarget(BBJ_ALWAYS, curJump);
+                    block->SetKindAndTarget(BBJ_ALWAYS, curJump);
                     foundVal = true;
                 }
                 else
@@ -14180,7 +14180,7 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
         else
 #endif // !TARGET_X86
         {
-            block->SetJumpKindAndTarget(BBJ_ALWAYS, genReturnBB);
+            block->SetKindAndTarget(BBJ_ALWAYS, genReturnBB);
             fgAddRefPred(genReturnBB, block);
             fgReturnCount--;
         }
@@ -14901,7 +14901,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetJumpKindAndTarget(BBJ_COND, elseBlock);
+        condBlock->SetKindAndTarget(BBJ_COND, elseBlock);
 
         thenBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true, remainderBlock);
         thenBlock->SetFlags(propagateFlagsToAll);
@@ -14926,7 +14926,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetJumpKindAndTarget(BBJ_COND, remainderBlock);
+        condBlock->SetKindAndTarget(BBJ_COND, remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
         // Since we have no false expr, use the one we'd already created.
         thenBlock = elseBlock;
@@ -14942,7 +14942,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              +-->------------+
         //              bbj_cond(true)
         //
-        condBlock->SetJumpKindAndTarget(BBJ_COND, remainderBlock);
+        condBlock->SetKindAndTarget(BBJ_COND, remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
 
         elseBlock->inheritWeightPercentage(condBlock, 50);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13407,8 +13407,8 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
             // Find the actual jump target
             size_t       switchVal = (size_t)cond->AsIntCon()->gtIconVal;
-            unsigned     jumpCnt   = block->GetSwitchTarget()->bbsCount;
-            BasicBlock** jumpTab   = block->GetSwitchTarget()->bbsDstTab;
+            unsigned     jumpCnt   = block->GetSwitchTargets()->bbsCount;
+            BasicBlock** jumpTab   = block->GetSwitchTargets()->bbsDstTab;
             bool         foundVal  = false;
 
             for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13263,7 +13263,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
                             edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->GetFalseTarget());
-                            
+
                             edge         = fgGetPredForBlock(bUpdated->GetTrueTarget(), bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13158,7 +13158,8 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
              * Remove the conditional statement */
 
             noway_assert(cond->gtOper == GT_CNS_INT);
-            noway_assert((block->GetNormalJumpDest()->countOfInEdges() > 0) && (block->GetJumpDest()->countOfInEdges() > 0));
+            noway_assert((block->GetNormalJumpDest()->countOfInEdges() > 0) &&
+                         (block->GetJumpDest()->countOfInEdges() > 0));
 
             if (condTree != cond)
             {
@@ -13268,7 +13269,9 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                             edge         = fgGetPredForBlock(bUpdated->GetJumpDest(), bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
-                            edge->setEdgeWeights(newMinWeight, newMaxWeight, (bUpdated->KindIs(BBJ_COND) ? bUpdated->GetNormalJumpDest() : bUpdated->Next()));
+                            edge->setEdgeWeights(newMinWeight, newMaxWeight,
+                                                 (bUpdated->KindIs(BBJ_COND) ? bUpdated->GetNormalJumpDest()
+                                                                             : bUpdated->Next()));
                             break;
 
                         default:

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14904,7 +14904,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetKindAndTarget(BBJ_COND, elseBlock);
+        condBlock->SetCondKindAndTarget(elseBlock);
 
         thenBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true, remainderBlock);
         thenBlock->SetFlags(propagateFlagsToAll);
@@ -14929,7 +14929,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetKindAndTarget(BBJ_COND, remainderBlock);
+        condBlock->SetCondKindAndTarget(remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
         // Since we have no false expr, use the one we'd already created.
         thenBlock = elseBlock;
@@ -14945,7 +14945,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              +-->------------+
         //              bbj_cond(true)
         //
-        condBlock->SetKindAndTarget(BBJ_COND, remainderBlock);
+        condBlock->SetCondKindAndTarget(remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
 
         elseBlock->inheritWeightPercentage(condBlock, 50);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -6156,8 +6156,8 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         // Many tailcalls will have call and ret in the same block, and thus be
         // BBJ_RETURN, but if the call falls through to a ret, and we are doing a
         // tailcall, change it here.
-        // (compCurBB may have a jump target, so use SetJumpKind() to avoid nulling it)
-        compCurBB->SetJumpKind(BBJ_RETURN);
+        // (compCurBB may have a jump target, so use SetKind() to avoid nulling it)
+        compCurBB->SetKind(BBJ_RETURN);
     }
 
     GenTree* stmtExpr = fgMorphStmt->GetRootNode();
@@ -13186,7 +13186,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                 /* JTRUE 1 - transform the basic block into a BBJ_ALWAYS */
                 bTaken    = block->GetTarget();
                 bNotTaken = block->GetFalseTarget();
-                block->SetJumpKind(BBJ_ALWAYS);
+                block->SetKind(BBJ_ALWAYS);
             }
             else
             {
@@ -13256,7 +13256,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
                     FlowEdge* edge;
                     // Now fix the weights of the edges out of 'bUpdated'
-                    switch (bUpdated->GetJumpKind())
+                    switch (bUpdated->GetKind())
                     {
                         case BBJ_COND:
                             edge         = fgGetPredForBlock(bUpdated->GetFalseTarget(), bUpdated);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13158,7 +13158,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
              * Remove the conditional statement */
 
             noway_assert(cond->gtOper == GT_CNS_INT);
-            noway_assert((block->GetNormalJumpDest()->countOfInEdges() > 0) &&
+            noway_assert((block->GetFalseTarget()->countOfInEdges() > 0) &&
                          (block->GetJumpDest()->countOfInEdges() > 0));
 
             if (condTree != cond)
@@ -13185,7 +13185,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
             {
                 /* JTRUE 1 - transform the basic block into a BBJ_ALWAYS */
                 bTaken    = block->GetJumpDest();
-                bNotTaken = block->GetNormalJumpDest();
+                bNotTaken = block->GetFalseTarget();
                 block->SetJumpKind(BBJ_ALWAYS);
             }
             else
@@ -13200,7 +13200,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                 }
 
                 /* JTRUE 0 - transform the basic block into a BBJ_ALWAYS   */
-                bTaken    = block->GetNormalJumpDest();
+                bTaken    = block->GetFalseTarget();
                 bNotTaken = block->GetJumpDest();
                 block->SetJumpKindAndTarget(BBJ_ALWAYS, bTaken);
                 block->SetFlags(BBF_NONE_QUIRK);
@@ -13259,10 +13259,10 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                     switch (bUpdated->GetJumpKind())
                     {
                         case BBJ_COND:
-                            edge         = fgGetPredForBlock(bUpdated->GetNormalJumpDest(), bUpdated);
+                            edge         = fgGetPredForBlock(bUpdated->GetFalseTarget(), bUpdated);
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
-                            edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->GetNormalJumpDest());
+                            edge->setEdgeWeights(newMinWeight, newMaxWeight, bUpdated->GetFalseTarget());
                             FALLTHROUGH;
 
                         case BBJ_ALWAYS:
@@ -13270,7 +13270,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
                             newMaxWeight = bUpdated->bbWeight;
                             newMinWeight = min(edge->edgeWeightMin(), newMaxWeight);
                             edge->setEdgeWeights(newMinWeight, newMaxWeight,
-                                                 (bUpdated->KindIs(BBJ_COND) ? bUpdated->GetNormalJumpDest()
+                                                 (bUpdated->KindIs(BBJ_COND) ? bUpdated->GetFalseTarget()
                                                                              : bUpdated->Next()));
                             break;
 
@@ -13907,7 +13907,7 @@ void Compiler::fgMorphBlock(BasicBlock* block, unsigned highestReachablePostorde
                         }
                         else
                         {
-                            assert(block == pred->GetNormalJumpDest());
+                            assert(block == pred->GetFalseTarget());
                             JITDUMP("Using `if false` assertions from pred " FMT_BB "\n", pred->bbNum);
                             assertionsOut = pred->bbAssertionOutIfFalse;
                         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13407,8 +13407,8 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
             // Find the actual jump target
             size_t       switchVal = (size_t)cond->AsIntCon()->gtIconVal;
-            unsigned     jumpCnt   = block->GetSwtTarget()->bbsCount;
-            BasicBlock** jumpTab   = block->GetSwtTarget()->bbsDstTab;
+            unsigned     jumpCnt   = block->GetSwitchTarget()->bbsCount;
+            BasicBlock** jumpTab   = block->GetSwitchTarget()->bbsDstTab;
             bool         foundVal  = false;
 
             for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13404,8 +13404,8 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 
             // Find the actual jump target
             size_t       switchVal = (size_t)cond->AsIntCon()->gtIconVal;
-            unsigned     jumpCnt   = block->GetJumpSwt()->bbsCount;
-            BasicBlock** jumpTab   = block->GetJumpSwt()->bbsDstTab;
+            unsigned     jumpCnt   = block->GetSwtTarget()->bbsCount;
+            BasicBlock** jumpTab   = block->GetSwtTarget()->bbsDstTab;
             bool         foundVal  = false;
 
             for (unsigned val = 0; val < jumpCnt; val++, jumpTab++)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14904,7 +14904,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetCondKindAndTarget(elseBlock);
+        condBlock->SetCond(elseBlock);
 
         thenBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true, remainderBlock);
         thenBlock->SetFlags(propagateFlagsToAll);
@@ -14929,7 +14929,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              bbj_cond(true)
         //
         gtReverseCond(condExpr);
-        condBlock->SetCondKindAndTarget(remainderBlock);
+        condBlock->SetCond(remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
         // Since we have no false expr, use the one we'd already created.
         thenBlock = elseBlock;
@@ -14945,7 +14945,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         //              +-->------------+
         //              bbj_cond(true)
         //
-        condBlock->SetCondKindAndTarget(remainderBlock);
+        condBlock->SetCond(remainderBlock);
         fgAddRefPred(remainderBlock, condBlock);
 
         elseBlock->inheritWeightPercentage(condBlock, 50);

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -125,7 +125,7 @@ bool OptBoolsDsc::optOptimizeBoolsCondBlock()
 
     // Check if m_b1 and m_b2 have the same bbTarget
 
-    if (m_b1->HasJumpTo(m_b2->GetTarget()))
+    if (m_b1->TargetIs(m_b2->GetTarget()))
     {
         // Given the following sequence of blocks :
         //        B1: brtrue(t1, BX)
@@ -741,7 +741,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
         return false;
     }
 
-    if (m_b1->HasJumpTo(m_b1) || m_b1->HasJumpTo(m_b2) || m_b2->HasJumpTo(m_b2) || m_b2->HasJumpTo(m_b1))
+    if (m_b1->TargetIs(m_b1) || m_b1->TargetIs(m_b2) || m_b2->TargetIs(m_b2) || m_b2->TargetIs(m_b1))
     {
         // Ignoring weird cases like a condition jumping to itself or when JumpDest == Next
         return false;
@@ -800,7 +800,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
     const bool cmp1IsReversed = true;
 
     // cmp2 can be either reversed or not
-    const bool cmp2IsReversed = m_b2->HasJumpTo(notInRangeBb);
+    const bool cmp2IsReversed = m_b2->TargetIs(notInRangeBb);
 
     if (!FoldRangeTests(m_comp, cmp1, cmp1IsReversed, cmp2, cmp2IsReversed))
     {
@@ -907,7 +907,7 @@ bool OptBoolsDsc::optOptimizeCompareChainCondBlock()
         // The final condition has been inverted.
         foundEndOfOrConditions = true;
     }
-    else if (m_b1->FalseTargetIs(m_b2) && m_b1->HasJumpTo(m_b2->GetTarget()))
+    else if (m_b1->FalseTargetIs(m_b2) && m_b1->TargetIs(m_b2->GetTarget()))
     {
         // Found two conditions connected together.
     }
@@ -1307,7 +1307,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
     {
         assert(m_b1->KindIs(BBJ_COND));
         assert(m_b2->KindIs(BBJ_COND));
-        assert(m_b1->HasJumpTo(m_b2->GetTarget()));
+        assert(m_b1->TargetIs(m_b2->GetTarget()));
         assert(m_b1->FalseTargetIs(m_b2));
         assert(!m_b2->IsLast());
     }
@@ -1912,7 +1912,7 @@ PhaseStatus Compiler::optOptimizeBools()
 
             if (b2->KindIs(BBJ_COND))
             {
-                if (!b1->HasJumpTo(b2->GetTarget()) && !b2->FalseTargetIs(b1->GetTarget()))
+                if (!b1->TargetIs(b2->GetTarget()) && !b2->FalseTargetIs(b1->GetTarget()))
                 {
                     continue;
                 }

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -811,7 +811,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
     if (!cmp2IsReversed)
     {
         // Re-direct firstBlock to jump to inRangeBb
-        m_b1->SetTarget(inRangeBb);
+        m_b1->SetTrueTarget(inRangeBb);
     }
 
     // Remove the 2nd condition block as we no longer need it
@@ -1274,7 +1274,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
 
             m_comp->fgRemoveRefPred(m_b1->GetTarget(), m_b1);
 
-            m_b1->SetTarget(m_b2->GetTarget());
+            m_b1->SetTrueTarget(m_b2->GetTarget());
 
             m_comp->fgAddRefPred(m_b2->GetTarget(), m_b1);
         }

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -81,7 +81,7 @@ private:
 };
 
 //-----------------------------------------------------------------------------
-//  optOptimizeBoolsCondBlock:  Optimize boolean when bbJumpKind of both m_b1 and m_b2 are BBJ_COND
+//  optOptimizeBoolsCondBlock:  Optimize boolean when bbKind of both m_b1 and m_b2 are BBJ_COND
 //
 //  Returns:
 //      true if boolean optimization is done and m_b1 and m_b2 are folded into m_b1, else false.

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -125,7 +125,7 @@ bool OptBoolsDsc::optOptimizeBoolsCondBlock()
 
     // Check if m_b1 and m_b2 have the same bbTarget
 
-    if (m_b1->TargetIs(m_b2->GetTrueTarget()))
+    if (m_b1->TrueTargetIs(m_b2->GetTrueTarget()))
     {
         // Given the following sequence of blocks :
         //        B1: brtrue(t1, BX)
@@ -741,7 +741,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
         return false;
     }
 
-    if (m_b1->TargetIs(m_b1) || m_b1->TargetIs(m_b2) || m_b2->TargetIs(m_b2) || m_b2->TargetIs(m_b1))
+    if (m_b1->TrueTargetIs(m_b1) || m_b1->TrueTargetIs(m_b2) || m_b2->TrueTargetIs(m_b2) || m_b2->TrueTargetIs(m_b1))
     {
         // Ignoring weird cases like a condition jumping to itself or when JumpDest == Next
         return false;
@@ -800,7 +800,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
     const bool cmp1IsReversed = true;
 
     // cmp2 can be either reversed or not
-    const bool cmp2IsReversed = m_b2->TargetIs(notInRangeBb);
+    const bool cmp2IsReversed = m_b2->TrueTargetIs(notInRangeBb);
 
     if (!FoldRangeTests(m_comp, cmp1, cmp1IsReversed, cmp2, cmp2IsReversed))
     {

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1008,7 +1008,7 @@ bool OptBoolsDsc::optOptimizeCompareChainCondBlock()
 
     // Update the flow.
     m_comp->fgRemoveRefPred(m_b1->GetTarget(), m_b1);
-    m_b1->SetJumpKindAndTarget(BBJ_ALWAYS, m_b1->GetFalseTarget());
+    m_b1->SetKindAndTarget(BBJ_ALWAYS, m_b1->GetFalseTarget());
     m_b1->SetFlags(BBF_NONE_QUIRK);
 
     // Fixup flags.
@@ -1301,7 +1301,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         assert(m_b2->KindIs(BBJ_RETURN));
         assert(m_b1->FalseTargetIs(m_b2));
         assert(m_b3 != nullptr);
-        m_b1->SetJumpKindAndTarget(BBJ_RETURN);
+        m_b1->SetKindAndTarget(BBJ_RETURN);
     }
     else
     {

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -107,7 +107,7 @@ private:
 //              B3: GT_RETURN (BBJ_RETURN)
 //              B4: GT_RETURN (BBJ_RETURN)
 //
-//      Case 2: if B2->NextIs(B1.bbJumpDest), it transforms
+//      Case 2: if B2->HasNormalJumpTo(B1.bbJumpDest), it transforms
 //          B1 : brtrue(t1, B3)
 //          B2 : brtrue(t2, Bx)
 //          B3 :
@@ -137,7 +137,7 @@ bool OptBoolsDsc::optOptimizeBoolsCondBlock()
 
         m_sameTarget = true;
     }
-    else if (m_b2->NextIs(m_b1->GetJumpDest()))
+    else if (m_b2->HasNormalJumpTo(m_b1->GetJumpDest()))
     {
         // Given the following sequence of blocks :
         //        B1: brtrue(t1, B3)
@@ -726,7 +726,7 @@ bool OptBoolsDsc::optOptimizeRangeTests()
 {
     // At this point we have two consecutive conditional blocks (BBJ_COND): m_b1 and m_b2
     assert((m_b1 != nullptr) && (m_b2 != nullptr) && (m_b3 == nullptr));
-    assert(m_b1->KindIs(BBJ_COND) && m_b2->KindIs(BBJ_COND) && m_b1->NextIs(m_b2));
+    assert(m_b1->KindIs(BBJ_COND) && m_b2->KindIs(BBJ_COND) && m_b1->HasNormalJumpTo(m_b2));
 
     if (m_b2->isRunRarely())
     {
@@ -763,9 +763,9 @@ bool OptBoolsDsc::optOptimizeRangeTests()
         //
         // InRange:
         // ...
-        inRangeBb = m_b2->Next();
+        inRangeBb = m_b2->GetNormalJumpDest();
     }
-    else if (notInRangeBb == m_b2->Next())
+    else if (notInRangeBb == m_b2->GetNormalJumpDest())
     {
         // Shape 2: 2nd block jumps to InRange
         //
@@ -901,13 +901,13 @@ bool OptBoolsDsc::optOptimizeCompareChainCondBlock()
     m_t3 = nullptr;
 
     bool foundEndOfOrConditions = false;
-    if (m_b1->NextIs(m_b2) && m_b2->NextIs(m_b1->GetJumpDest()))
+    if (m_b1->HasNormalJumpTo(m_b2) && m_b2->HasNormalJumpTo(m_b1->GetJumpDest()))
     {
         // Found the end of two (or more) conditions being ORed together.
         // The final condition has been inverted.
         foundEndOfOrConditions = true;
     }
-    else if (m_b1->NextIs(m_b2) && m_b1->HasJumpTo(m_b2->GetJumpDest()))
+    else if (m_b1->HasNormalJumpTo(m_b2) && m_b1->HasJumpTo(m_b2->GetJumpDest()))
     {
         // Found two conditions connected together.
     }
@@ -1008,7 +1008,7 @@ bool OptBoolsDsc::optOptimizeCompareChainCondBlock()
 
     // Update the flow.
     m_comp->fgRemoveRefPred(m_b1->GetJumpDest(), m_b1);
-    m_b1->SetJumpKindAndTarget(BBJ_ALWAYS, m_b1->Next());
+    m_b1->SetJumpKindAndTarget(BBJ_ALWAYS, m_b1->GetNormalJumpDest());
     m_b1->SetFlags(BBF_NONE_QUIRK);
 
     // Fixup flags.
@@ -1270,7 +1270,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         }
         else
         {
-            edge2 = m_comp->fgGetPredForBlock(m_b2->Next(), m_b2);
+            edge2 = m_comp->fgGetPredForBlock(m_b2->GetNormalJumpDest(), m_b2);
 
             m_comp->fgRemoveRefPred(m_b1->GetJumpDest(), m_b1);
 
@@ -1298,17 +1298,17 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
 
     if (optReturnBlock)
     {
-        m_b1->SetJumpKindAndTarget(BBJ_RETURN);
         assert(m_b2->KindIs(BBJ_RETURN));
-        assert(m_b1->NextIs(m_b2));
+        assert(m_b1->HasNormalJumpTo(m_b2));
         assert(m_b3 != nullptr);
+        m_b1->SetJumpKindAndTarget(BBJ_RETURN);
     }
     else
     {
         assert(m_b1->KindIs(BBJ_COND));
         assert(m_b2->KindIs(BBJ_COND));
         assert(m_b1->HasJumpTo(m_b2->GetJumpDest()));
-        assert(m_b1->NextIs(m_b2));
+        assert(m_b1->HasNormalJumpTo(m_b2));
         assert(!m_b2->IsLast());
     }
 
@@ -1318,7 +1318,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         //
         // Replace pred 'm_b2' for 'm_b2->bbNext' with 'm_b1'
         // Remove  pred 'm_b2' for 'm_b2->bbJumpDest'
-        m_comp->fgReplacePred(m_b2->Next(), m_b2, m_b1);
+        m_comp->fgReplacePred(m_b2->GetNormalJumpDest(), m_b2, m_b1);
         m_comp->fgRemoveRefPred(m_b2->GetJumpDest(), m_b2);
     }
 
@@ -1894,7 +1894,7 @@ PhaseStatus Compiler::optOptimizeBools()
 
             // If there is no next block, we're done
 
-            BasicBlock* b2 = b1->Next();
+            BasicBlock* b2 = b1->GetNormalJumpDest();
             if (b2 == nullptr)
             {
                 break;
@@ -1912,7 +1912,7 @@ PhaseStatus Compiler::optOptimizeBools()
 
             if (b2->KindIs(BBJ_COND))
             {
-                if (!b1->HasJumpTo(b2->GetJumpDest()) && !b2->NextIs(b1->GetJumpDest()))
+                if (!b1->HasJumpTo(b2->GetJumpDest()) && !b2->HasNormalJumpTo(b1->GetJumpDest()))
                 {
                     continue;
                 }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2840,7 +2840,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetKind())
     {
         case BBJ_SWITCH:
-            to->SetSwtKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
+            to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
             break;
         case BBJ_EHFINALLYRET:
             to->SetEhfKindAndTarget(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2846,7 +2846,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetEhfKindAndTarget(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
         case BBJ_COND:
-            to->SetKindAndTarget(BBJ_COND, from->GetTrueTarget());
+            to->SetCondKindAndTarget(from->GetTrueTarget());
             break;
         default:
             to->SetKindAndTarget(from->GetKind(), from->GetTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2794,9 +2794,9 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
         case BBJ_SWITCH:
         {
             bool redirected = false;
-            for (unsigned i = 0; i < blk->GetSwitchTarget()->bbsCount; i++)
+            for (unsigned i = 0; i < blk->GetSwitchTargets()->bbsCount; i++)
             {
-                BasicBlock* const switchDest = blk->GetSwitchTarget()->bbsDstTab[i];
+                BasicBlock* const switchDest = blk->GetSwitchTargets()->bbsDstTab[i];
                 if (redirectMap->Lookup(switchDest, &newJumpDest))
                 {
                     if (updatePreds)
@@ -2807,7 +2807,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
                     {
                         fgAddRefPred(newJumpDest, blk);
                     }
-                    blk->GetSwitchTarget()->bbsDstTab[i] = newJumpDest;
+                    blk->GetSwitchTargets()->bbsDstTab[i] = newJumpDest;
                     redirected                           = true;
                 }
                 else if (addPreds)
@@ -2840,7 +2840,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetKind())
     {
         case BBJ_SWITCH:
-            to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwitchTarget()));
+            to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwitchTargets()));
             break;
         case BBJ_EHFINALLYRET:
             to->SetEhf(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
@@ -8336,9 +8336,9 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
             case BBJ_SWITCH:
                 unsigned jumpCnt;
-                jumpCnt = predBlock->GetSwitchTarget()->bbsCount;
+                jumpCnt = predBlock->GetSwitchTargets()->bbsCount;
                 BasicBlock** jumpTab;
-                jumpTab = predBlock->GetSwitchTarget()->bbsDstTab;
+                jumpTab = predBlock->GetSwitchTargets()->bbsDstTab;
 
                 do
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2843,7 +2843,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
             break;
         case BBJ_EHFINALLYRET:
-            to->SetEhfKindAndTarget(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
+            to->SetEhf(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
         case BBJ_COND:
             to->SetCond(from->GetTrueTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1372,7 +1372,7 @@ void Compiler::optCheckPreds()
                 }
             }
             noway_assert(bb);
-            switch (bb->GetJumpKind())
+            switch (bb->GetKind())
             {
                 case BBJ_COND:
                     if (bb->HasJumpTo(block))
@@ -2356,7 +2356,7 @@ private:
     {
         BasicBlock* exitPoint;
 
-        switch (block->GetJumpKind())
+        switch (block->GetKind())
         {
             case BBJ_COND:
             case BBJ_CALLFINALLY:
@@ -2414,7 +2414,7 @@ private:
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
 
@@ -2693,7 +2693,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
 
     BasicBlock* newJumpDest = nullptr;
 
-    switch (blk->GetJumpKind())
+    switch (blk->GetKind())
     {
         case BBJ_THROW:
         case BBJ_RETURN:
@@ -2806,7 +2806,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
 void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
 {
     // copy the jump destination(s) from "from" to "to".
-    switch (from->GetJumpKind())
+    switch (from->GetKind())
     {
         case BBJ_SWITCH:
             to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetJumpSwt()));
@@ -2815,12 +2815,12 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetJumpEhf()));
             break;
         default:
-            to->SetKindAndTarget(from->GetJumpKind(), from->GetTarget());
+            to->SetKindAndTarget(from->GetKind(), from->GetTarget());
             to->CopyFlags(from, BBF_NONE_QUIRK);
             break;
     }
 
-    assert(to->KindIs(from->GetJumpKind()));
+    assert(to->KindIs(from->GetKind()));
 }
 
 // Returns true if 'block' is an entry block for any loop in 'optLoopTable'
@@ -4405,7 +4405,7 @@ PhaseStatus Compiler::optUnrollLoops()
 
                 // Now redirect any branches within the newly-cloned iteration.
                 // Don't include `bottom` in the iteration, since we've already changed the
-                // newBlock->bbJumpKind, above.
+                // newBlock->bbKind, above.
                 for (BasicBlock* block = loop.lpTop; block != loop.lpBottom; block = block->Next())
                 {
                     // Jump kind/target should not be set yet
@@ -8276,7 +8276,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
             continue;
         }
 
-        switch (predBlock->GetJumpKind())
+        switch (predBlock->GetKind())
         {
             case BBJ_COND:
                 if (predBlock->HasJumpTo(entry))
@@ -8322,7 +8322,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
                 break;
 
             default:
-                noway_assert(!"Unexpected bbJumpKind");
+                noway_assert(!"Unexpected bbKind");
                 break;
         }
     }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2794,9 +2794,9 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
         case BBJ_SWITCH:
         {
             bool redirected = false;
-            for (unsigned i = 0; i < blk->GetSwtTarget()->bbsCount; i++)
+            for (unsigned i = 0; i < blk->GetSwitchTarget()->bbsCount; i++)
             {
-                BasicBlock* const switchDest = blk->GetSwtTarget()->bbsDstTab[i];
+                BasicBlock* const switchDest = blk->GetSwitchTarget()->bbsDstTab[i];
                 if (redirectMap->Lookup(switchDest, &newJumpDest))
                 {
                     if (updatePreds)
@@ -2807,8 +2807,8 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
                     {
                         fgAddRefPred(newJumpDest, blk);
                     }
-                    blk->GetSwtTarget()->bbsDstTab[i] = newJumpDest;
-                    redirected                        = true;
+                    blk->GetSwitchTarget()->bbsDstTab[i] = newJumpDest;
+                    redirected                           = true;
                 }
                 else if (addPreds)
                 {
@@ -2840,7 +2840,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetKind())
     {
         case BBJ_SWITCH:
-            to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
+            to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwitchTarget()));
             break;
         case BBJ_EHFINALLYRET:
             to->SetEhf(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
@@ -8336,9 +8336,9 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
             case BBJ_SWITCH:
                 unsigned jumpCnt;
-                jumpCnt = predBlock->GetSwtTarget()->bbsCount;
+                jumpCnt = predBlock->GetSwitchTarget()->bbsCount;
                 BasicBlock** jumpTab;
-                jumpTab = predBlock->GetSwtTarget()->bbsDstTab;
+                jumpTab = predBlock->GetSwitchTarget()->bbsDstTab;
 
                 do
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2808,7 +2808,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
                         fgAddRefPred(newJumpDest, blk);
                     }
                     blk->GetSwitchTargets()->bbsDstTab[i] = newJumpDest;
-                    redirected                           = true;
+                    redirected                            = true;
                 }
                 else if (addPreds)
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -497,24 +497,24 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
         reportAfter();
     }
 
-    if (!skipUnmarkLoop && // If we want to unmark this loop...
+    if (!skipUnmarkLoop &&                      // If we want to unmark this loop...
         (fgCurBBEpochSize == fgBBNumMax + 1) && // We didn't add new blocks since last renumber...
-        fgDomsComputed && // Given the doms are computed and valid...
-        (fgCurBBEpochSize == fgDomBBcount + 1)) //
+        fgDomsComputed &&                       // Given the doms are computed and valid...
+        (fgCurBBEpochSize == fgDomBBcount + 1))
     {
         // This block must reach conditionally or always
 
-        if (block->KindIs(BBJ_ALWAYS) && // This block always reaches
-            block->GetTarget()->isLoopHead() && // to a loop head...
+        if (block->KindIs(BBJ_ALWAYS) &&                   // This block always reaches
+            block->GetTarget()->isLoopHead() &&            // to a loop head...
             (block->GetTarget()->bbNum <= block->bbNum) && // This is a backedge...
-            fgReachable(block->GetTarget(), block)) // Block's destination (target of back edge) can reach block...
+            fgReachable(block->GetTarget(), block))        // Block's back edge target can reach block...
         {
             optUnmarkLoopBlocks(block->GetTarget(), block); // Unscale the blocks in such loop.
         }
-        else if (block->KindIs(BBJ_COND) && // This block conditionally reaches
-                 block->GetTrueTarget()->isLoopHead() && // to a loop head...
+        else if (block->KindIs(BBJ_COND) &&                         // This block conditionally reaches
+                 block->GetTrueTarget()->isLoopHead() &&            // to a loop head...
                  (block->GetTrueTarget()->bbNum <= block->bbNum) && // This is a backedge...
-                 fgReachable(block->GetTrueTarget(), block)) // Block's destination (target of back edge) can reach block...
+                 fgReachable(block->GetTrueTarget(), block))        // Block's back edge target can reach block...
         {
             optUnmarkLoopBlocks(block->GetTrueTarget(), block); // Unscale the blocks in such loop.
         }
@@ -2125,7 +2125,8 @@ private:
 
         if (newMoveAfter->KindIs(BBJ_ALWAYS, BBJ_COND))
         {
-            unsigned int destNum = newMoveAfter->KindIs(BBJ_ALWAYS) ? newMoveAfter->GetTarget()->bbNum : newMoveAfter->GetTrueTarget()->bbNum;
+            unsigned int destNum = newMoveAfter->KindIs(BBJ_ALWAYS) ? newMoveAfter->GetTarget()->bbNum
+                                                                    : newMoveAfter->GetTrueTarget()->bbNum;
             if ((destNum >= top->bbNum) && (destNum <= bottom->bbNum) && !loopBlocks.IsMember(destNum))
             {
                 // Reversing this branch out of block `newMoveAfter` could confuse this algorithm
@@ -2807,7 +2808,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
                         fgAddRefPred(newJumpDest, blk);
                     }
                     blk->GetSwtTarget()->bbsDstTab[i] = newJumpDest;
-                    redirected                      = true;
+                    redirected                        = true;
                 }
                 else if (addPreds)
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4530,7 +4530,8 @@ PhaseStatus Compiler::optUnrollLoops()
                 fgRemoveRefPred(initBlock->GetJumpDest(), initBlock);
                 initBlock->SetJumpKindAndTarget(BBJ_ALWAYS, initBlock->GetNormalJumpDest());
 
-                // TODO: If bbNormalJumpDest can diverge from bbNext, it may not make sense to set BBF_NONE_QUIRK
+                // TODO-NoFallThrough: If bbNormalJumpDest can diverge from bbNext, it may not make sense to set
+                // BBF_NONE_QUIRK
                 initBlock->SetFlags(BBF_NONE_QUIRK);
             }
             else

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2763,9 +2763,9 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
         case BBJ_SWITCH:
         {
             bool redirected = false;
-            for (unsigned i = 0; i < blk->GetJumpSwt()->bbsCount; i++)
+            for (unsigned i = 0; i < blk->GetSwtTarget()->bbsCount; i++)
             {
-                BasicBlock* const switchDest = blk->GetJumpSwt()->bbsDstTab[i];
+                BasicBlock* const switchDest = blk->GetSwtTarget()->bbsDstTab[i];
                 if (redirectMap->Lookup(switchDest, &newJumpDest))
                 {
                     if (updatePreds)
@@ -2776,7 +2776,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
                     {
                         fgAddRefPred(newJumpDest, blk);
                     }
-                    blk->GetJumpSwt()->bbsDstTab[i] = newJumpDest;
+                    blk->GetSwtTarget()->bbsDstTab[i] = newJumpDest;
                     redirected                      = true;
                 }
                 else if (addPreds)
@@ -2809,7 +2809,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetKind())
     {
         case BBJ_SWITCH:
-            to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetJumpSwt()));
+            to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
             break;
         case BBJ_EHFINALLYRET:
             to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetJumpEhf()));
@@ -8302,9 +8302,9 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
             case BBJ_SWITCH:
                 unsigned jumpCnt;
-                jumpCnt = predBlock->GetJumpSwt()->bbsCount;
+                jumpCnt = predBlock->GetSwtTarget()->bbsCount;
                 BasicBlock** jumpTab;
-                jumpTab = predBlock->GetJumpSwt()->bbsDstTab;
+                jumpTab = predBlock->GetSwtTarget()->bbsDstTab;
 
                 do
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2846,7 +2846,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetEhfKindAndTarget(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
         case BBJ_COND:
-            to->SetCondKindAndTarget(from->GetTrueTarget());
+            to->SetCond(from->GetTrueTarget());
             break;
         default:
             to->SetKindAndTarget(from->GetKind(), from->GetTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2735,7 +2735,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
 
         case BBJ_EHFINALLYRET:
         {
-            BBehfDesc*  ehfDesc = blk->GetJumpEhf();
+            BBehfDesc*  ehfDesc = blk->GetEhfTarget();
             BasicBlock* newSucc = nullptr;
             for (unsigned i = 0; i < ehfDesc->bbeCount; i++)
             {
@@ -2812,7 +2812,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
             break;
         case BBJ_EHFINALLYRET:
-            to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetJumpEhf()));
+            to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
         default:
             to->SetKindAndTarget(from->GetKind(), from->GetTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1379,7 +1379,7 @@ void Compiler::optCheckPreds()
                     {
                         break;
                     }
-                    noway_assert(bb->NextIs(block));
+                    noway_assert(bb->HasNormalJumpTo(block));
                     break;
                 case BBJ_EHFILTERRET:
                 case BBJ_ALWAYS:
@@ -3015,7 +3015,7 @@ bool Compiler::optCanonicalizeLoop(unsigned char loopInd)
             //
             BasicBlock* const t = optLoopTable[loopInd].lpTop;
             assert(siblingB->KindIs(BBJ_COND));
-            assert(siblingB->NextIs(t));
+            assert(siblingB->HasNormalJumpTo(t));
 
             JITDUMP(FMT_LP " head " FMT_BB " is also " FMT_LP " bottom\n", loopInd, h->bbNum, sibling);
 
@@ -3190,7 +3190,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
     // Because of this, introducing a block before t automatically gives us
     // the right flow out of h.
     //
-    assert(h->NextIs(t) || !h->KindIs(BBJ_COND));
+    assert(!h->KindIs(BBJ_COND) || h->HasNormalJumpTo(t));
     assert(h->HasJumpTo(t) || !h->KindIs(BBJ_ALWAYS));
     assert(h->KindIs(BBJ_ALWAYS, BBJ_COND));
 
@@ -8178,7 +8178,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
         {
             // Allow for either the fall-through or branch to target 'entry'.
             BasicBlock* skipLoopBlock;
-            if (head->NextIs(entry))
+            if (head->HasNormalJumpTo(entry))
             {
                 skipLoopBlock = head->GetJumpDest();
             }
@@ -8281,11 +8281,11 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
                 if (predBlock->HasJumpTo(entry))
                 {
                     predBlock->SetJumpDest(preHead);
-                    noway_assert(!predBlock->NextIs(preHead));
+                    noway_assert(!predBlock->HasNormalJumpTo(preHead));
                 }
                 else
                 {
-                    noway_assert((entry == top) && (predBlock == head) && predBlock->NextIs(preHead));
+                    noway_assert((entry == top) && (predBlock == head) && predBlock->HasNormalJumpTo(preHead));
                 }
                 fgRemoveRefPred(entry, predBlock);
                 fgAddRefPred(preHead, predBlock);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2840,10 +2840,10 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetKind())
     {
         case BBJ_SWITCH:
-            to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
+            to->SetSwtKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwtTarget()));
             break;
         case BBJ_EHFINALLYRET:
-            to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
+            to->SetEhfKindAndTarget(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
         case BBJ_COND:
             to->SetKindAndTarget(BBJ_COND, from->GetTrueTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -1386,7 +1386,7 @@ void Compiler::optCheckPreds()
             switch (bb->GetKind())
             {
                 case BBJ_COND:
-                    if (bb->TargetIs(block))
+                    if (bb->TrueTargetIs(block))
                     {
                         break;
                     }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -742,7 +742,7 @@ bool Compiler::optPopulateInitInfo(unsigned loopInd, BasicBlock* initBlock, GenT
             bool initBlockOk = (predBlock == initBlock);
             if (!initBlockOk)
             {
-                if (predBlock->KindIs(BBJ_ALWAYS) && predBlock->HasJumpTo(optLoopTable[loopInd].lpEntry) &&
+                if (predBlock->KindIs(BBJ_ALWAYS) && predBlock->TargetIs(optLoopTable[loopInd].lpEntry) &&
                     (predBlock->countOfInEdges() == 1) && (predBlock->firstStmt() == nullptr) &&
                     !predBlock->IsFirst() && predBlock->Prev()->bbFallsThrough())
                 {
@@ -1137,7 +1137,7 @@ bool Compiler::optExtractInitTestIncr(
         // If we are rebuilding the loop table, we would already have the pre-header block introduced
         // the first time, which might be empty if no hoisting has yet occurred. In this case, look a
         // little harder for the possible loop initialization statement.
-        if (initBlock->KindIs(BBJ_ALWAYS) && initBlock->HasJumpTo(top) && (initBlock->countOfInEdges() == 1) &&
+        if (initBlock->KindIs(BBJ_ALWAYS) && initBlock->TargetIs(top) && (initBlock->countOfInEdges() == 1) &&
             !initBlock->IsFirst() && initBlock->Prev()->bbFallsThrough())
         {
             initBlock = initBlock->Prev();
@@ -1375,7 +1375,7 @@ void Compiler::optCheckPreds()
             switch (bb->GetKind())
             {
                 case BBJ_COND:
-                    if (bb->HasJumpTo(block))
+                    if (bb->TargetIs(block))
                     {
                         break;
                     }
@@ -1384,7 +1384,7 @@ void Compiler::optCheckPreds()
                 case BBJ_EHFILTERRET:
                 case BBJ_ALWAYS:
                 case BBJ_EHCATCHRET:
-                    noway_assert(bb->HasJumpTo(block));
+                    noway_assert(bb->TargetIs(block));
                     break;
                 default:
                     break;
@@ -2263,7 +2263,7 @@ private:
         {
             // Need to reconnect the flow from `block` to `oldNext`.
 
-            if (block->KindIs(BBJ_COND) && block->HasJumpTo(newNext))
+            if (block->KindIs(BBJ_COND) && block->TargetIs(newNext))
             {
                 // Reverse the jump condition
                 GenTree* test = block->lastNode();
@@ -2290,7 +2290,7 @@ private:
                 noway_assert((newBlock == nullptr) || loopBlocks.CanRepresent(newBlock->bbNum));
             }
         }
-        else if (block->KindIs(BBJ_ALWAYS) && block->HasJumpTo(newNext))
+        else if (block->KindIs(BBJ_ALWAYS) && block->TargetIs(newNext))
         {
             // If block is newNext's only predecessor, move the IR from block to newNext,
             // but keep the now-empty block around.
@@ -2919,7 +2919,7 @@ bool Compiler::optCanonicalizeLoop(unsigned char loopInd)
     // entry block. If the `head` branches to `top` because it is the BBJ_ALWAYS of a
     // BBJ_CALLFINALLY/BBJ_ALWAYS pair, we canonicalize by introducing a new fall-through
     // head block. See FindEntry() for the logic that allows this.
-    if (h->KindIs(BBJ_ALWAYS) && h->HasJumpTo(t) && h->HasFlag(BBF_KEEP_BBJ_ALWAYS))
+    if (h->KindIs(BBJ_ALWAYS) && h->TargetIs(t) && h->HasFlag(BBF_KEEP_BBJ_ALWAYS))
     {
         // Insert new head
 
@@ -3191,7 +3191,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
     // the right flow out of h.
     //
     assert(!h->KindIs(BBJ_COND) || h->FalseTargetIs(t));
-    assert(h->HasJumpTo(t) || !h->KindIs(BBJ_ALWAYS));
+    assert(h->TargetIs(t) || !h->KindIs(BBJ_ALWAYS));
     assert(h->KindIs(BBJ_ALWAYS, BBJ_COND));
 
     // If the bottom block is in the same "try" region, then we extend the EH
@@ -3352,7 +3352,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
         {
             assert(newT->KindIs(BBJ_ALWAYS));
             if ((optLoopTable[childLoop].lpEntry == origE) && (optLoopTable[childLoop].lpHead == h) &&
-                newT->HasJumpTo(origE))
+                newT->TargetIs(origE))
             {
                 optUpdateLoopHead(childLoop, h, newT);
 
@@ -8279,7 +8279,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
         switch (predBlock->GetKind())
         {
             case BBJ_COND:
-                if (predBlock->HasJumpTo(entry))
+                if (predBlock->TargetIs(entry))
                 {
                     predBlock->SetTarget(preHead);
                     noway_assert(!predBlock->FalseTargetIs(preHead));
@@ -8294,7 +8294,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
 
             case BBJ_ALWAYS:
             case BBJ_EHCATCHRET:
-                noway_assert(predBlock->HasJumpTo(entry));
+                noway_assert(predBlock->TargetIs(entry));
                 predBlock->SetTarget(preHead);
                 fgRemoveRefPred(entry, predBlock);
                 fgAddRefPred(preHead, predBlock);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2809,13 +2809,13 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
     switch (from->GetJumpKind())
     {
         case BBJ_SWITCH:
-            to->SetSwitchKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetJumpSwt()));
+            to->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetJumpSwt()));
             break;
         case BBJ_EHFINALLYRET:
-            to->SetJumpKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetJumpEhf()));
+            to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetJumpEhf()));
             break;
         default:
-            to->SetJumpKindAndTarget(from->GetJumpKind(), from->GetTarget());
+            to->SetKindAndTarget(from->GetJumpKind(), from->GetTarget());
             to->CopyFlags(from, BBF_NONE_QUIRK);
             break;
     }
@@ -4483,7 +4483,7 @@ PhaseStatus Compiler::optUnrollLoops()
                     fgRemoveAllRefPreds(succ, block);
                 }
 
-                block->SetJumpKindAndTarget(BBJ_ALWAYS, block->Next());
+                block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
                 block->bbStmtList   = nullptr;
                 block->bbNatLoopNum = newLoopNum;
                 block->SetFlags(BBF_NONE_QUIRK);
@@ -4528,7 +4528,7 @@ PhaseStatus Compiler::optUnrollLoops()
                 noway_assert(initBlockBranchStmt->GetRootNode()->OperIs(GT_JTRUE));
                 fgRemoveStmt(initBlock, initBlockBranchStmt);
                 fgRemoveRefPred(initBlock->GetTarget(), initBlock);
-                initBlock->SetJumpKindAndTarget(BBJ_ALWAYS, initBlock->GetFalseTarget());
+                initBlock->SetKindAndTarget(BBJ_ALWAYS, initBlock->GetFalseTarget());
 
                 // TODO-NoFallThrough: If bbFalseTarget can diverge from bbNext, it may not make sense to set
                 // BBF_NONE_QUIRK
@@ -5002,7 +5002,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
 
     // Create a new block after `block` to put the copied condition code.
     BasicBlock* bNewCond = fgNewBBafter(BBJ_COND, block, /*extendRegion*/ true, bJoin);
-    block->SetJumpKindAndTarget(BBJ_ALWAYS, bNewCond);
+    block->SetKindAndTarget(BBJ_ALWAYS, bNewCond);
     block->SetFlags(BBF_NONE_QUIRK);
     assert(block->JumpsToNext());
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2766,7 +2766,7 @@ void Compiler::optRedirectBlock(BasicBlock* blk, BlockToBlockMap* redirectMap, R
 
         case BBJ_EHFINALLYRET:
         {
-            BBehfDesc*  ehfDesc = blk->GetEhfTarget();
+            BBehfDesc*  ehfDesc = blk->GetEhfTargets();
             BasicBlock* newSucc = nullptr;
             for (unsigned i = 0; i < ehfDesc->bbeCount; i++)
             {
@@ -2843,7 +2843,7 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
             to->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc(this, from->GetSwitchTargets()));
             break;
         case BBJ_EHFINALLYRET:
-            to->SetEhf(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
+            to->SetEhf(new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTargets()));
             break;
         case BBJ_COND:
             to->SetCond(from->GetTrueTarget());

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -497,16 +497,27 @@ void Compiler::optUpdateLoopsBeforeRemoveBlock(BasicBlock* block, bool skipUnmar
         reportAfter();
     }
 
-    if ((skipUnmarkLoop == false) &&                     // If we want to unmark this loop...
-        block->KindIs(BBJ_ALWAYS, BBJ_COND) &&           // This block reaches conditionally or always
-        block->GetTarget()->isLoopHead() &&            // to a loop head...
-        (fgCurBBEpochSize == fgBBNumMax + 1) &&          // We didn't add new blocks since last renumber...
-        (block->GetTarget()->bbNum <= block->bbNum) && // This is a backedge...
-        fgDomsComputed &&                                // Given the doms are computed and valid...
-        (fgCurBBEpochSize == fgDomBBcount + 1) &&        //
-        fgReachable(block->GetTarget(), block))        // Block's destination (target of back edge) can reach block...
+    if (!skipUnmarkLoop && // If we want to unmark this loop...
+        (fgCurBBEpochSize == fgBBNumMax + 1) && // We didn't add new blocks since last renumber...
+        fgDomsComputed && // Given the doms are computed and valid...
+        (fgCurBBEpochSize == fgDomBBcount + 1)) //
     {
-        optUnmarkLoopBlocks(block->GetTarget(), block); // Unscale the blocks in such loop.
+        // This block must reach conditionally or always
+
+        if (block->KindIs(BBJ_ALWAYS) && // This block always reaches
+            block->GetTarget()->isLoopHead() && // to a loop head...
+            (block->GetTarget()->bbNum <= block->bbNum) && // This is a backedge...
+            fgReachable(block->GetTarget(), block)) // Block's destination (target of back edge) can reach block...
+        {
+            optUnmarkLoopBlocks(block->GetTarget(), block); // Unscale the blocks in such loop.
+        }
+        else if (block->KindIs(BBJ_COND) && // This block conditionally reaches
+                 block->GetTrueTarget()->isLoopHead() && // to a loop head...
+                 (block->GetTrueTarget()->bbNum <= block->bbNum) && // This is a backedge...
+                 fgReachable(block->GetTrueTarget(), block)) // Block's destination (target of back edge) can reach block...
+        {
+            optUnmarkLoopBlocks(block->GetTrueTarget(), block); // Unscale the blocks in such loop.
+        }
     }
 }
 
@@ -2114,7 +2125,7 @@ private:
 
         if (newMoveAfter->KindIs(BBJ_ALWAYS, BBJ_COND))
         {
-            unsigned int destNum = newMoveAfter->GetTarget()->bbNum;
+            unsigned int destNum = newMoveAfter->KindIs(BBJ_ALWAYS) ? newMoveAfter->GetTarget()->bbNum : newMoveAfter->GetTrueTarget()->bbNum;
             if ((destNum >= top->bbNum) && (destNum <= bottom->bbNum) && !loopBlocks.IsMember(destNum))
             {
                 // Reversing this branch out of block `newMoveAfter` could confuse this algorithm
@@ -2363,7 +2374,7 @@ private:
             case BBJ_ALWAYS:
             case BBJ_EHCATCHRET:
                 assert(block->HasInitializedTarget());
-                exitPoint = block->GetTarget();
+                exitPoint = block->KindIs(BBJ_COND) ? block->GetTrueTarget() : block->GetTarget();
 
                 if (!loopBlocks.IsMember(exitPoint->bbNum))
                 {
@@ -2833,6 +2844,9 @@ void Compiler::optCopyBlkDest(BasicBlock* from, BasicBlock* to)
         case BBJ_EHFINALLYRET:
             to->SetKindAndTarget(BBJ_EHFINALLYRET, new (this, CMK_BasicBlock) BBehfDesc(this, from->GetEhfTarget()));
             break;
+        case BBJ_COND:
+            to->SetKindAndTarget(BBJ_COND, from->GetTrueTarget());
+            break;
         default:
             to->SetKindAndTarget(from->GetKind(), from->GetTarget());
             to->CopyFlags(from, BBF_NONE_QUIRK);
@@ -3222,7 +3236,7 @@ bool Compiler::optCanonicalizeLoopCore(unsigned char loopInd, LoopCanonicalizati
 
     if (h->KindIs(BBJ_COND))
     {
-        BasicBlock* const hj = h->GetTarget();
+        BasicBlock* const hj = h->GetTrueTarget();
         assert((hj->bbNum < t->bbNum) || (hj->bbNum > b->bbNum));
     }
     else
@@ -4546,7 +4560,7 @@ PhaseStatus Compiler::optUnrollLoops()
                 Statement* initBlockBranchStmt = initBlock->lastStmt();
                 noway_assert(initBlockBranchStmt->GetRootNode()->OperIs(GT_JTRUE));
                 fgRemoveStmt(initBlock, initBlockBranchStmt);
-                fgRemoveRefPred(initBlock->GetTarget(), initBlock);
+                fgRemoveRefPred(initBlock->GetTrueTarget(), initBlock);
                 initBlock->SetKindAndTarget(BBJ_ALWAYS, initBlock->GetFalseTarget());
 
                 // TODO-NoFallThrough: If bbFalseTarget can diverge from bbNext, it may not make sense to set
@@ -4801,7 +4815,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     // bTest must be a backwards jump to block->bbNext
     // This will be the top of the loop.
     //
-    BasicBlock* const bTop = bTest->GetTarget();
+    BasicBlock* const bTop = bTest->GetTrueTarget();
 
     if (!block->NextIs(bTop))
     {
@@ -4833,7 +4847,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     // are done, since it iterates forward in the block list looking for bbTarget.
     //  TODO-CQ: Check if we can also optimize the backwards jump as well.
     //
-    if (!fgIsForwardBranch(block))
+    if (!fgIsForwardBranch(block, block->GetTarget()))
     {
         return false;
     }
@@ -5180,15 +5194,15 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
         weight_t const blockToAfterWeight = weightBlock * blockToAfterLikelihood;
 
         FlowEdge* const edgeBlockToNext  = fgGetPredForBlock(bNewCond->GetFalseTarget(), bNewCond);
-        FlowEdge* const edgeBlockToAfter = fgGetPredForBlock(bNewCond->GetTarget(), bNewCond);
+        FlowEdge* const edgeBlockToAfter = fgGetPredForBlock(bNewCond->GetTrueTarget(), bNewCond);
 
         JITDUMP("Setting weight of " FMT_BB " -> " FMT_BB " to " FMT_WT " (enter loop)\n", bNewCond->bbNum,
                 bNewCond->GetFalseTarget()->bbNum, blockToNextWeight);
         JITDUMP("Setting weight of " FMT_BB " -> " FMT_BB " to " FMT_WT " (avoid loop)\n", bNewCond->bbNum,
-                bNewCond->GetTarget()->bbNum, blockToAfterWeight);
+                bNewCond->GetTrueTarget()->bbNum, blockToAfterWeight);
 
         edgeBlockToNext->setEdgeWeights(blockToNextWeight, blockToNextWeight, bNewCond->GetFalseTarget());
-        edgeBlockToAfter->setEdgeWeights(blockToAfterWeight, blockToAfterWeight, bNewCond->GetTarget());
+        edgeBlockToAfter->setEdgeWeights(blockToAfterWeight, blockToAfterWeight, bNewCond->GetTrueTarget());
 
 #ifdef DEBUG
         // If we're checkig profile data, see if profile for the two target blocks is consistent.
@@ -5197,7 +5211,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
         {
             const ProfileChecks checks        = (ProfileChecks)JitConfig.JitProfileChecks();
             const bool          nextProfileOk = fgDebugCheckIncomingProfileData(bNewCond->GetFalseTarget(), checks);
-            const bool          jumpProfileOk = fgDebugCheckIncomingProfileData(bNewCond->GetTarget(), checks);
+            const bool          jumpProfileOk = fgDebugCheckIncomingProfileData(bNewCond->GetTrueTarget(), checks);
 
             if (hasFlag(checks, ProfileChecks::RAISE_ASSERT))
             {
@@ -8200,7 +8214,7 @@ bool Compiler::fgCreateLoopPreHeader(unsigned lnum)
             BasicBlock* skipLoopBlock;
             if (head->FalseTargetIs(entry))
             {
-                skipLoopBlock = head->GetTarget();
+                skipLoopBlock = head->GetTrueTarget();
             }
             else
             {

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -105,7 +105,7 @@ private:
     //
     // Return Value:
     //    new basic block.
-    BasicBlock* CreateAndInsertBasicBlock(BBjumpKinds jumpKind, BasicBlock* insertAfter, BasicBlock* jumpDest = nullptr)
+    BasicBlock* CreateAndInsertBasicBlock(BBKinds jumpKind, BasicBlock* insertAfter, BasicBlock* jumpDest = nullptr)
     {
         BasicBlock* block = compiler->fgNewBBafter(jumpKind, insertAfter, true, jumpDest);
         block->SetFlags(BBF_IMPORTED);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -146,7 +146,7 @@ private:
         BasicBlock* helperBlock    = CreateAndInsertBasicBlock(BBJ_ALWAYS, block, block->Next());
 
         // Update flow and flags
-        block->SetCondKindAndTarget(remainderBlock);
+        block->SetCond(remainderBlock);
         block->SetFlags(BBF_INTERNAL);
 
         helperBlock->SetFlags(BBF_BACKWARD_JUMP | BBF_NONE_QUIRK);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -146,7 +146,7 @@ private:
         BasicBlock* helperBlock    = CreateAndInsertBasicBlock(BBJ_ALWAYS, block, block->Next());
 
         // Update flow and flags
-        block->SetKindAndTarget(BBJ_COND, remainderBlock);
+        block->SetCondKindAndTarget(remainderBlock);
         block->SetFlags(BBF_INTERNAL);
 
         helperBlock->SetFlags(BBF_BACKWARD_JUMP | BBF_NONE_QUIRK);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -146,7 +146,7 @@ private:
         BasicBlock* helperBlock    = CreateAndInsertBasicBlock(BBJ_ALWAYS, block, block->Next());
 
         // Update flow and flags
-        block->SetJumpKindAndTarget(BBJ_COND, remainderBlock);
+        block->SetKindAndTarget(BBJ_COND, remainderBlock);
         block->SetFlags(BBF_INTERNAL);
 
         helperBlock->SetFlags(BBF_BACKWARD_JUMP | BBF_NONE_QUIRK);
@@ -233,7 +233,7 @@ private:
         }
 
         // Update flow
-        block->SetJumpKindAndTarget(BBJ_THROW);
+        block->SetKindAndTarget(BBJ_THROW);
 
         // Add helper call
         //

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -941,7 +941,7 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
             JITDUMP("Merge assertions from pred " FMT_BB " edge: ", pred->bbNum);
             Compiler::optDumpAssertionIndices(assertions, "\n");
         }
-        else if (pred->KindIs(BBJ_COND, BBJ_ALWAYS) && pred->HasJumpTo(block))
+        else if (pred->KindIs(BBJ_COND, BBJ_ALWAYS) && pred->TargetIs(block))
         {
             if (m_pCompiler->bbJtrueAssertionOut != nullptr)
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -941,7 +941,8 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
             JITDUMP("Merge assertions from pred " FMT_BB " edge: ", pred->bbNum);
             Compiler::optDumpAssertionIndices(assertions, "\n");
         }
-        else if ((pred->KindIs(BBJ_ALWAYS) && pred->TargetIs(block)) || (pred->KindIs(BBJ_COND) && pred->TrueTargetIs(block)))
+        else if ((pred->KindIs(BBJ_ALWAYS) && pred->TargetIs(block)) ||
+                 (pred->KindIs(BBJ_COND) && pred->TrueTargetIs(block)))
         {
             if (m_pCompiler->bbJtrueAssertionOut != nullptr)
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -941,7 +941,7 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
             JITDUMP("Merge assertions from pred " FMT_BB " edge: ", pred->bbNum);
             Compiler::optDumpAssertionIndices(assertions, "\n");
         }
-        else if (pred->KindIs(BBJ_COND, BBJ_ALWAYS) && pred->TargetIs(block))
+        else if ((pred->KindIs(BBJ_ALWAYS) && pred->TargetIs(block)) || (pred->KindIs(BBJ_COND) && pred->TrueTargetIs(block)))
         {
             if (m_pCompiler->bbJtrueAssertionOut != nullptr)
             {

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1454,7 +1454,7 @@ bool Compiler::optJumpThreadCore(JumpThreadInfo& jti)
                     jti.m_block->bbNum, fallThroughIsTruePred ? "true" : "false",
                     fallThroughIsTruePred ? "false" : "true", jti.m_fallThroughPred->bbNum);
 
-            assert(jti.m_fallThroughPred->HasJumpTo(jti.m_block));
+            assert(jti.m_fallThroughPred->TargetIs(jti.m_block));
         }
         else
         {

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1523,7 +1523,7 @@ bool Compiler::optJumpThreadCore(JumpThreadInfo& jti)
         fgRemoveStmt(jti.m_block, lastStmt);
         JITDUMP("  repurposing " FMT_BB " to always jump to " FMT_BB "\n", jti.m_block->bbNum, jti.m_trueTarget->bbNum);
         fgRemoveRefPred(jti.m_falseTarget, jti.m_block);
-        jti.m_block->SetJumpKind(BBJ_ALWAYS);
+        jti.m_block->SetKind(BBJ_ALWAYS);
     }
     else if (falsePredsWillReuseBlock)
     {

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -48,7 +48,7 @@ PhaseStatus Compiler::optRedundantBranches()
                 bool madeChangesThisBlock = m_compiler->optRedundantRelop(block);
 
                 BasicBlock* const bbNext = block->GetFalseTarget();
-                BasicBlock* const bbJump = block->GetTarget();
+                BasicBlock* const bbJump = block->GetTrueTarget();
 
                 madeChangesThisBlock |= m_compiler->optRedundantBranch(block);
 
@@ -566,7 +566,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                     const bool domIsSameRelop = (rii.vnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Same) ||
                                                 (rii.vnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Swap);
 
-                    BasicBlock* const trueSuccessor  = domBlock->GetTarget();
+                    BasicBlock* const trueSuccessor  = domBlock->GetTrueTarget();
                     BasicBlock* const falseSuccessor = domBlock->GetFalseTarget();
 
                     // If we can trace the flow from the dominating relop, we can infer its value.
@@ -601,7 +601,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                         //
                         const bool relopIsTrue = rii.reverseSense ^ (domIsSameRelop | domIsInferredRelop);
                         JITDUMP("Jump successor " FMT_BB " of " FMT_BB " reaches, relop [%06u] must be %s\n",
-                                domBlock->GetTarget()->bbNum, domBlock->bbNum, dspTreeID(tree),
+                                domBlock->GetTrueTarget()->bbNum, domBlock->bbNum, dspTreeID(tree),
                                 relopIsTrue ? "true" : "false");
                         relopValue = relopIsTrue ? 1 : 0;
                         break;
@@ -709,7 +709,7 @@ struct JumpThreadInfo
 {
     JumpThreadInfo(Compiler* comp, BasicBlock* block)
         : m_block(block)
-        , m_trueTarget(block->GetTarget())
+        , m_trueTarget(block->GetTrueTarget())
         , m_falseTarget(block->GetFalseTarget())
         , m_fallThroughPred(nullptr)
         , m_ambiguousVNBlock(nullptr)
@@ -1071,8 +1071,8 @@ bool Compiler::optJumpThreadDom(BasicBlock* const block, BasicBlock* const domBl
     // latter should prove useful in subsequent work, where we aim to enable jump
     // threading in cases where block has side effects.
     //
-    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetTarget() : domBlock->GetFalseTarget();
-    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->GetFalseTarget() : domBlock->GetTarget();
+    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetTrueTarget() : domBlock->GetFalseTarget();
+    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->GetFalseTarget() : domBlock->GetTrueTarget();
     JumpThreadInfo    jti(this, block);
 
     for (BasicBlock* const predBlock : block->PredBlocks())

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -48,7 +48,7 @@ PhaseStatus Compiler::optRedundantBranches()
                 bool madeChangesThisBlock = m_compiler->optRedundantRelop(block);
 
                 BasicBlock* const bbNext = block->GetFalseTarget();
-                BasicBlock* const bbJump = block->GetJumpDest();
+                BasicBlock* const bbJump = block->GetTarget();
 
                 madeChangesThisBlock |= m_compiler->optRedundantBranch(block);
 
@@ -566,7 +566,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                     const bool domIsSameRelop = (rii.vnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Same) ||
                                                 (rii.vnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Swap);
 
-                    BasicBlock* const trueSuccessor  = domBlock->GetJumpDest();
+                    BasicBlock* const trueSuccessor  = domBlock->GetTarget();
                     BasicBlock* const falseSuccessor = domBlock->GetFalseTarget();
 
                     // If we can trace the flow from the dominating relop, we can infer its value.
@@ -601,7 +601,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                         //
                         const bool relopIsTrue = rii.reverseSense ^ (domIsSameRelop | domIsInferredRelop);
                         JITDUMP("Jump successor " FMT_BB " of " FMT_BB " reaches, relop [%06u] must be %s\n",
-                                domBlock->GetJumpDest()->bbNum, domBlock->bbNum, dspTreeID(tree),
+                                domBlock->GetTarget()->bbNum, domBlock->bbNum, dspTreeID(tree),
                                 relopIsTrue ? "true" : "false");
                         relopValue = relopIsTrue ? 1 : 0;
                         break;
@@ -709,7 +709,7 @@ struct JumpThreadInfo
 {
     JumpThreadInfo(Compiler* comp, BasicBlock* block)
         : m_block(block)
-        , m_trueTarget(block->GetJumpDest())
+        , m_trueTarget(block->GetTarget())
         , m_falseTarget(block->GetFalseTarget())
         , m_fallThroughPred(nullptr)
         , m_ambiguousVNBlock(nullptr)
@@ -1071,8 +1071,8 @@ bool Compiler::optJumpThreadDom(BasicBlock* const block, BasicBlock* const domBl
     // latter should prove useful in subsequent work, where we aim to enable jump
     // threading in cases where block has side effects.
     //
-    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetJumpDest() : domBlock->GetFalseTarget();
-    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->GetFalseTarget() : domBlock->GetJumpDest();
+    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetTarget() : domBlock->GetFalseTarget();
+    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->GetFalseTarget() : domBlock->GetTarget();
     JumpThreadInfo    jti(this, block);
 
     for (BasicBlock* const predBlock : block->PredBlocks())

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1532,7 +1532,7 @@ bool Compiler::optJumpThreadCore(JumpThreadInfo& jti)
         JITDUMP("  repurposing " FMT_BB " to always fall through to " FMT_BB "\n", jti.m_block->bbNum,
                 jti.m_falseTarget->bbNum);
         fgRemoveRefPred(jti.m_trueTarget, jti.m_block);
-        jti.m_block->SetJumpKindAndTarget(BBJ_ALWAYS, jti.m_falseTarget);
+        jti.m_block->SetKindAndTarget(BBJ_ALWAYS, jti.m_falseTarget);
         jti.m_block->SetFlags(BBF_NONE_QUIRK);
         assert(jti.m_block->JumpsToNext());
     }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -47,7 +47,7 @@ PhaseStatus Compiler::optRedundantBranches()
             {
                 bool madeChangesThisBlock = m_compiler->optRedundantRelop(block);
 
-                BasicBlock* const bbNext = block->Next();
+                BasicBlock* const bbNext = block->GetNormalJumpDest();
                 BasicBlock* const bbJump = block->GetJumpDest();
 
                 madeChangesThisBlock |= m_compiler->optRedundantBranch(block);
@@ -567,7 +567,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                                                 (rii.vnRelation == ValueNumStore::VN_RELATION_KIND::VRK_Swap);
 
                     BasicBlock* const trueSuccessor  = domBlock->GetJumpDest();
-                    BasicBlock* const falseSuccessor = domBlock->Next();
+                    BasicBlock* const falseSuccessor = domBlock->GetNormalJumpDest();
 
                     // If we can trace the flow from the dominating relop, we can infer its value.
                     //
@@ -612,7 +612,7 @@ bool Compiler::optRedundantBranch(BasicBlock* const block)
                         //
                         const bool relopIsFalse = rii.reverseSense ^ (domIsSameRelop | domIsInferredRelop);
                         JITDUMP("Fall through successor " FMT_BB " of " FMT_BB " reaches, relop [%06u] must be %s\n",
-                                domBlock->Next()->bbNum, domBlock->bbNum, dspTreeID(tree),
+                                domBlock->GetNormalJumpDest()->bbNum, domBlock->bbNum, dspTreeID(tree),
                                 relopIsFalse ? "false" : "true");
                         relopValue = relopIsFalse ? 0 : 1;
                         break;
@@ -710,7 +710,7 @@ struct JumpThreadInfo
     JumpThreadInfo(Compiler* comp, BasicBlock* block)
         : m_block(block)
         , m_trueTarget(block->GetJumpDest())
-        , m_falseTarget(block->Next())
+        , m_falseTarget(block->GetNormalJumpDest())
         , m_fallThroughPred(nullptr)
         , m_ambiguousVNBlock(nullptr)
         , m_truePreds(BlockSetOps::MakeEmpty(comp))
@@ -1071,8 +1071,8 @@ bool Compiler::optJumpThreadDom(BasicBlock* const block, BasicBlock* const domBl
     // latter should prove useful in subsequent work, where we aim to enable jump
     // threading in cases where block has side effects.
     //
-    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetJumpDest() : domBlock->Next();
-    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->Next() : domBlock->GetJumpDest();
+    BasicBlock* const domTrueSuccessor  = domIsSameRelop ? domBlock->GetJumpDest() : domBlock->GetNormalJumpDest();
+    BasicBlock* const domFalseSuccessor = domIsSameRelop ? domBlock->GetNormalJumpDest() : domBlock->GetJumpDest();
     JumpThreadInfo    jti(this, block);
 
     for (BasicBlock* const predBlock : block->PredBlocks())

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -320,7 +320,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert(isTest);
 
     // Convert firstBlock to a switch block
-    firstBlock->SetSwitchKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc);
+    firstBlock->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc);
     firstBlock->bbCodeOffsEnd = lastBlock->bbCodeOffsEnd;
     firstBlock->lastStmt()->GetRootNode()->ChangeOper(GT_SWITCH);
 

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -352,9 +352,9 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     const auto jmpTab = new (this, CMK_BasicBlock) BasicBlock*[jumpCount + 1 /*default case*/];
 
     fgHasSwitch                             = true;
-    firstBlock->GetJumpSwt()->bbsCount      = jumpCount + 1;
-    firstBlock->GetJumpSwt()->bbsHasDefault = true;
-    firstBlock->GetJumpSwt()->bbsDstTab     = jmpTab;
+    firstBlock->GetSwtTarget()->bbsCount      = jumpCount + 1;
+    firstBlock->GetSwtTarget()->bbsHasDefault = true;
+    firstBlock->GetSwtTarget()->bbsDstTab     = jmpTab;
     firstBlock->SetNext(isReversed ? blockIfTrue : blockIfFalse);
 
     // Splitting doesn't work well with jump-tables currently

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -352,9 +352,9 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     const auto jmpTab = new (this, CMK_BasicBlock) BasicBlock*[jumpCount + 1 /*default case*/];
 
     fgHasSwitch                                  = true;
-    firstBlock->GetSwitchTarget()->bbsCount      = jumpCount + 1;
-    firstBlock->GetSwitchTarget()->bbsHasDefault = true;
-    firstBlock->GetSwitchTarget()->bbsDstTab     = jmpTab;
+    firstBlock->GetSwitchTargets()->bbsCount      = jumpCount + 1;
+    firstBlock->GetSwitchTargets()->bbsHasDefault = true;
+    firstBlock->GetSwitchTargets()->bbsDstTab     = jmpTab;
     firstBlock->SetNext(isReversed ? blockIfTrue : blockIfFalse);
 
     // Splitting doesn't work well with jump-tables currently

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -98,7 +98,7 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetTarget();
                 *blockIfFalse = *isReversed ? block->GetTarget() : block->GetFalseTarget();
 
-                if (block->JumpsToNext() || block->HasJumpTo(block))
+                if (block->JumpsToNext() || block->TargetIs(block))
                 {
                     // Ignoring weird cases like a condition jumping to itself
                     return false;

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -95,8 +95,8 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 }
 
                 *isReversed   = rootNode->gtGetOp1()->OperIs(GT_NE);
-                *blockIfTrue  = *isReversed ? block->Next() : block->GetJumpDest();
-                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->Next();
+                *blockIfTrue  = *isReversed ? block->GetNormalJumpDest() : block->GetJumpDest();
+                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->GetNormalJumpDest();
 
                 if (block->JumpsToNext() || block->HasJumpTo(block))
                 {

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -95,8 +95,8 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 }
 
                 *isReversed   = rootNode->gtGetOp1()->OperIs(GT_NE);
-                *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetTarget();
-                *blockIfFalse = *isReversed ? block->GetTarget() : block->GetFalseTarget();
+                *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetTrueTarget();
+                *blockIfFalse = *isReversed ? block->GetTrueTarget() : block->GetFalseTarget();
 
                 if (block->JumpsToNext() || block->TargetIs(block))
                 {
@@ -351,7 +351,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert((jumpCount > 0) && (jumpCount <= SWITCH_MAX_DISTANCE + 1));
     const auto jmpTab = new (this, CMK_BasicBlock) BasicBlock*[jumpCount + 1 /*default case*/];
 
-    fgHasSwitch                             = true;
+    fgHasSwitch                               = true;
     firstBlock->GetSwtTarget()->bbsCount      = jumpCount + 1;
     firstBlock->GetSwtTarget()->bbsHasDefault = true;
     firstBlock->GetSwtTarget()->bbsDstTab     = jmpTab;

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -98,7 +98,7 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetTrueTarget();
                 *blockIfFalse = *isReversed ? block->GetTrueTarget() : block->GetFalseTarget();
 
-                if (block->JumpsToNext() || block->TargetIs(block))
+                if (block->FalseTargetIs(block) || block->TrueTargetIs(block))
                 {
                     // Ignoring weird cases like a condition jumping to itself
                     return false;

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -351,10 +351,10 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert((jumpCount > 0) && (jumpCount <= SWITCH_MAX_DISTANCE + 1));
     const auto jmpTab = new (this, CMK_BasicBlock) BasicBlock*[jumpCount + 1 /*default case*/];
 
-    fgHasSwitch                               = true;
-    firstBlock->GetSwtTarget()->bbsCount      = jumpCount + 1;
-    firstBlock->GetSwtTarget()->bbsHasDefault = true;
-    firstBlock->GetSwtTarget()->bbsDstTab     = jmpTab;
+    fgHasSwitch                                  = true;
+    firstBlock->GetSwitchTarget()->bbsCount      = jumpCount + 1;
+    firstBlock->GetSwitchTarget()->bbsHasDefault = true;
+    firstBlock->GetSwitchTarget()->bbsDstTab     = jmpTab;
     firstBlock->SetNext(isReversed ? blockIfTrue : blockIfFalse);
 
     // Splitting doesn't work well with jump-tables currently

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -320,7 +320,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert(isTest);
 
     // Convert firstBlock to a switch block
-    firstBlock->SetSwtKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc);
+    firstBlock->SetSwitch(new (this, CMK_BasicBlock) BBswtDesc);
     firstBlock->bbCodeOffsEnd = lastBlock->bbCodeOffsEnd;
     firstBlock->lastStmt()->GetRootNode()->ChangeOper(GT_SWITCH);
 

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -95,8 +95,8 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 }
 
                 *isReversed   = rootNode->gtGetOp1()->OperIs(GT_NE);
-                *blockIfTrue  = *isReversed ? block->GetNormalJumpDest() : block->GetJumpDest();
-                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->GetNormalJumpDest();
+                *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetJumpDest();
+                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->GetFalseTarget();
 
                 if (block->JumpsToNext() || block->HasJumpTo(block))
                 {

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -320,7 +320,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert(isTest);
 
     // Convert firstBlock to a switch block
-    firstBlock->SetKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc);
+    firstBlock->SetSwtKindAndTarget(new (this, CMK_BasicBlock) BBswtDesc);
     firstBlock->bbCodeOffsEnd = lastBlock->bbCodeOffsEnd;
     firstBlock->lastStmt()->GetRootNode()->ChangeOper(GT_SWITCH);
 

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -95,8 +95,8 @@ bool IsConstantTestCondBlock(const BasicBlock* block,
                 }
 
                 *isReversed   = rootNode->gtGetOp1()->OperIs(GT_NE);
-                *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetJumpDest();
-                *blockIfFalse = *isReversed ? block->GetJumpDest() : block->GetFalseTarget();
+                *blockIfTrue  = *isReversed ? block->GetFalseTarget() : block->GetTarget();
+                *blockIfFalse = *isReversed ? block->GetTarget() : block->GetFalseTarget();
 
                 if (block->JumpsToNext() || block->HasJumpTo(block))
                 {

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -351,7 +351,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     assert((jumpCount > 0) && (jumpCount <= SWITCH_MAX_DISTANCE + 1));
     const auto jmpTab = new (this, CMK_BasicBlock) BasicBlock*[jumpCount + 1 /*default case*/];
 
-    fgHasSwitch                                  = true;
+    fgHasSwitch                                   = true;
     firstBlock->GetSwitchTargets()->bbsCount      = jumpCount + 1;
     firstBlock->GetSwitchTargets()->bbsHasDefault = true;
     firstBlock->GetSwitchTargets()->bbsDstTab     = jmpTab;

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9738,7 +9738,7 @@ public:
         }
 
         bool        isTaken         = normalVN != m_comp->vnStore->VNZeroForType(TYP_INT);
-        BasicBlock* unreachableSucc = isTaken ? predBlock->Next() : predBlock->GetTarget();
+        BasicBlock* unreachableSucc = isTaken ? predBlock->GetFalseTarget() : predBlock->GetTrueTarget();
         return block != unreachableSucc;
     }
 };

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -9738,7 +9738,7 @@ public:
         }
 
         bool        isTaken         = normalVN != m_comp->vnStore->VNZeroForType(TYP_INT);
-        BasicBlock* unreachableSucc = isTaken ? predBlock->Next() : predBlock->GetJumpDest();
+        BasicBlock* unreachableSucc = isTaken ? predBlock->Next() : predBlock->GetTarget();
         return block != unreachableSucc;
     }
 };


### PR DESCRIPTION
Part of #93020. Currently, if a `BBJ_COND` block's `bbJumpDest` branch is not taken, control falls through into the next block. Because we plan to remove this fall-through requirement, `BBJ_COND` blocks need a pointer to their "not-taken" branch target, as the target may no longer be the next block. This new pointer, `bbNormalJumpDest`, may also be used in the future to represent the finally continuation of a `BBJ_CALLFINALLY/BBJ_ALWAYS` pair, once this pattern is consolidated into one block with no implicit fall-through via #95355.

For now, `bbNormalJumpDest` models current behavior by always pointing to the next block. Follow-up work will introduce behavioral changes by allowing `bbNormalJumpDest` to diverge from `bbNext`.