### PR TITLE
Disable IEnumerator test on Mono

### DIFF
--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
@@ -40,6 +40,7 @@ namespace PInvokeTests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled))]
+    [SkipOnMono("PInvoke IEnumerator/IEnumarable marshalling not supported on Mono")]
     public static class IEnumeratorTests
     {
         [Fact]

--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorTest.cs
@@ -40,7 +40,7 @@ namespace PInvokeTests
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled))]
-    [SkipOnMono("PInvoke IEnumerator/IEnumarable marshalling not supported on Mono")]
+    [SkipOnMono("PInvoke IEnumerator/IEnumerable marshalling not supported on Mono")]
     public static class IEnumeratorTests
     {
         [Fact]

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1831,9 +1831,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Variant/VariantTestComWrappers/*">
             <Issue>Requires COM support, disabled on all Mono platforms</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/IEnumerator/IEnumeratorTest/*">
-            <Issue>PInvoke IEnumerator/IEnumarable marshalling not supported on Mono</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StructMarshalling/ReversePInvoke/MarshalExpStruct/DelegatePInvoke/DelegatePInvokeTest/*">
             <Issue>https://github.com/dotnet/runtime/issues/65695</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95792

With the recent interop test refactoring, the disabling of this test was lost.