### PR TITLE
Remove outdated TODO in JsonWriterHelper.Escaping.cs

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/JsonWriterHelper.Escaping.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
-    // TODO: Replace the escaping logic with publicly shipping APIs from https://github.com/dotnet/runtime/issues/27919
     internal static partial class JsonWriterHelper
     {
         // Only allow ASCII characters between ' ' (0x20) and '~' (0x7E), inclusively,


### PR DESCRIPTION
Remove TODO referencing an API issue that was closed and never implemented.