### PR TITLE
ServiceKey comparisons use Equals for matching

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             for (int i = collection.Count - 1; i >= 0; i--)
             {
                 ServiceDescriptor? descriptor = collection[i];
-                if (descriptor.ServiceType == serviceType && descriptor.ServiceKey == serviceKey)
+                if (descriptor.ServiceType == serviceType && object.Equals(descriptor.ServiceKey, serviceKey))
                 {
                     collection.RemoveAt(i);
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             for (int i = 0; i < count; i++)
             {
                 if (collection[i].ServiceType == descriptor.ServiceType
-                    && collection[i].ServiceKey == descriptor.ServiceKey)
+                    && object.Equals(collection[i].ServiceKey, descriptor.ServiceKey))
                 {
                     // Already added
                     return;
@@ -474,7 +474,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
                 ServiceDescriptor service = services[i];
                 if (service.ServiceType == descriptor.ServiceType &&
                     service.GetImplementationType() == implementationType &&
-                    service.ServiceKey == descriptor.ServiceKey)
+                    object.Equals(service.ServiceKey, descriptor.ServiceKey))
                 {
                     // Already added
                     return;
@@ -532,7 +532,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             int count = collection.Count;
             for (int i = 0; i < count; i++)
             {
-                if (collection[i].ServiceType == descriptor.ServiceType && collection[i].ServiceKey == descriptor.ServiceKey)
+                if (collection[i].ServiceType == descriptor.ServiceType && object.Equals(collection[i].ServiceKey, descriptor.ServiceKey))
                 {
                     collection.RemoveAt(i);
                     break;

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
@@ -431,6 +431,62 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.Equal(new[] { descriptor }, collection);
         }
 
+        private enum ServiceKeyEnum { First, Second }
+
+        [Fact]
+        public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsEnum()
+        {
+            var collection = new ServiceCollection
+            {
+                new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.First, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.Second, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.Second, typeof(FakeService), ServiceLifetime.Transient),
+            };
+
+            // Act
+            collection.RemoveAllKeyed<IFakeService>(ServiceKeyEnum.Second);
+
+            // Assert
+            Assert.Contains(collection, x => ServiceKeyEnum.First.Equals(x.ServiceKey));
+            Assert.DoesNotContain(collection, x => ServiceKeyEnum.Second.Equals(x.ServiceKey));
+        }
+
+        [Fact]
+        public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsInt()
+        {
+            var collection = new ServiceCollection
+            {
+                new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), 2, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), 2, typeof(FakeService), ServiceLifetime.Transient),
+            };
+
+            // Act
+            collection.RemoveAllKeyed<IFakeService>(2);
+
+            // Assert
+            Assert.Contains(collection, x => 1.Equals(x.ServiceKey));
+            Assert.DoesNotContain(collection, x => 2.Equals(x.ServiceKey));
+        }
+
+        [Fact]
+        public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsDouble()
+        {
+            var collection = new ServiceCollection
+            {
+                new ServiceDescriptor(typeof(IFakeService), 1.0, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), 2.0, typeof(FakeService), ServiceLifetime.Transient),
+                new ServiceDescriptor(typeof(IFakeService), 2.0, typeof(FakeService), ServiceLifetime.Transient),
+            };
+
+            // Act
+            collection.RemoveAllKeyed<IFakeService>(2.0);
+
+            // Assert
+            Assert.Contains(collection, x => 1.0.Equals(x.ServiceKey));
+            Assert.DoesNotContain(collection, x => 2.0.Equals(x.ServiceKey));
+        }
+
         public static TheoryData NullServiceKeyData
         {
             get

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionKeyedServiceExtensionsTest.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     { collection => collection.TryAddKeyedTransient<IFakeService, FakeService>("key-2"), serviceType, "key-2", implementationType, ServiceLifetime.Transient },
                     { collection => collection.TryAddKeyedTransient<IFakeService>("key-3"), serviceType, "key-3", serviceType, ServiceLifetime.Transient },
                     { collection => collection.TryAddKeyedTransient(implementationType, "key-4"), implementationType, "key-4", implementationType, ServiceLifetime.Transient },
+                    { collection => collection.TryAddKeyedTransient(implementationType, 9), implementationType, 9, implementationType, ServiceLifetime.Transient },
 
                     { collection => collection.TryAddKeyedScoped(serviceType, "key-1", implementationType), serviceType, "key-1", implementationType, ServiceLifetime.Scoped },
                     { collection => collection.TryAddKeyedScoped<IFakeService, FakeService>("key-2"), serviceType, "key-2", implementationType, ServiceLifetime.Scoped },
@@ -325,6 +326,40 @@ namespace Microsoft.Extensions.DependencyInjection
             Assert.Equal(expectedLifetime, d.Lifetime);
         }
 
+        [Fact]
+        public void TryAddEnumerable_DoesNotAddDuplicateWhenKeyIsInt()
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            var descriptor1 = ServiceDescriptor.KeyedTransient<IFakeService, FakeService>(1);
+            collection.TryAddEnumerable(descriptor1);
+            var descriptor2 = ServiceDescriptor.KeyedTransient<IFakeService, FakeService>(1);
+
+            // Act
+            collection.TryAddEnumerable(descriptor2);
+
+            // Assert
+            var d = Assert.Single(collection);
+            Assert.Same(descriptor1, d);
+        }
+
+        [Fact]
+        public void TryAddEnumerable_DoesNotAddDuplicateWhenKeyIsString()
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            var descriptor1 = ServiceDescriptor.KeyedTransient<IFakeService, FakeService>("service1");
+            collection.TryAddEnumerable(descriptor1);
+            var descriptor2 = ServiceDescriptor.KeyedTransient<IFakeService, FakeService>("service1");
+
+            // Act
+            collection.TryAddEnumerable(descriptor2);
+
+            // Assert
+            var d = Assert.Single(collection);
+            Assert.Same(descriptor1, d);
+        }
+
         public static TheoryData TryAddEnumerableInvalidImplementationTypeData
         {
             get
@@ -413,6 +448,24 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [Fact]
+        public void Replace_ReplacesFirstServiceWithMatchingServiceTypeWhenKeyIsInt()
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+            var descriptor1 = new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Transient);
+            var descriptor2 = new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Transient);
+            collection.Add(descriptor1);
+            collection.Add(descriptor2);
+            var descriptor3 = new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Singleton);
+
+            // Act
+            collection.Replace(descriptor3);
+
+            // Assert
+            Assert.Equal(new[] { descriptor2, descriptor3 }, collection);
+        }
+
+        [Fact]
         public void RemoveAll_RemovesAllServicesWithMatchingServiceType()
         {
             // Arrange
@@ -436,9 +489,10 @@ namespace Microsoft.Extensions.DependencyInjection
         [Fact]
         public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsEnum()
         {
+            var descriptor = new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.First, typeof(FakeService), ServiceLifetime.Transient);
             var collection = new ServiceCollection
             {
-                new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.First, typeof(FakeService), ServiceLifetime.Transient),
+                descriptor,
                 new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.Second, typeof(FakeService), ServiceLifetime.Transient),
                 new ServiceDescriptor(typeof(IFakeService), ServiceKeyEnum.Second, typeof(FakeService), ServiceLifetime.Transient),
             };
@@ -447,16 +501,16 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.RemoveAllKeyed<IFakeService>(ServiceKeyEnum.Second);
 
             // Assert
-            Assert.Contains(collection, x => ServiceKeyEnum.First.Equals(x.ServiceKey));
-            Assert.DoesNotContain(collection, x => ServiceKeyEnum.Second.Equals(x.ServiceKey));
+            Assert.Equal(new[] { descriptor }, collection);
         }
 
         [Fact]
         public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsInt()
         {
+            var descriptor = new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Transient);
             var collection = new ServiceCollection
             {
-                new ServiceDescriptor(typeof(IFakeService), 1, typeof(FakeService), ServiceLifetime.Transient),
+                descriptor,
                 new ServiceDescriptor(typeof(IFakeService), 2, typeof(FakeService), ServiceLifetime.Transient),
                 new ServiceDescriptor(typeof(IFakeService), 2, typeof(FakeService), ServiceLifetime.Transient),
             };
@@ -465,26 +519,7 @@ namespace Microsoft.Extensions.DependencyInjection
             collection.RemoveAllKeyed<IFakeService>(2);
 
             // Assert
-            Assert.Contains(collection, x => 1.Equals(x.ServiceKey));
-            Assert.DoesNotContain(collection, x => 2.Equals(x.ServiceKey));
-        }
-
-        [Fact]
-        public void RemoveAll_RemovesAllMatchingServicesWhenKeyIsDouble()
-        {
-            var collection = new ServiceCollection
-            {
-                new ServiceDescriptor(typeof(IFakeService), 1.0, typeof(FakeService), ServiceLifetime.Transient),
-                new ServiceDescriptor(typeof(IFakeService), 2.0, typeof(FakeService), ServiceLifetime.Transient),
-                new ServiceDescriptor(typeof(IFakeService), 2.0, typeof(FakeService), ServiceLifetime.Transient),
-            };
-
-            // Act
-            collection.RemoveAllKeyed<IFakeService>(2.0);
-
-            // Assert
-            Assert.Contains(collection, x => 1.0.Equals(x.ServiceKey));
-            Assert.DoesNotContain(collection, x => 2.0.Equals(x.ServiceKey));
+            Assert.Equal(new[] { descriptor }, collection);
         }
 
         public static TheoryData NullServiceKeyData


### PR DESCRIPTION
Fix #95754

I assume here that the issue (currently untriaged) is confirmed as a bug.

Based on documentation: https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection#keyed-services
> The key isn't limited to string, it can be any object you want, as long as the type correctly implements Equals.

Also based on comparison for resolving in `ServiceProvider.GetRequiredKeyedService`.
That is implemented in `Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceIdentifier`
```csharp
public bool Equals(ServiceIdentifier other)
{
	if (ServiceKey == null && other.ServiceKey == null)
	{
		return ServiceType == other.ServiceType;
	}
	else if (ServiceKey != null && other.ServiceKey != null)
	{
		return ServiceType == other.ServiceType && ServiceKey.Equals(other.ServiceKey);
	}
	return false;
}
```