### PR TITLE
Respect ResponseHeaderEncodingSelector for the Location header

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -161,7 +161,8 @@ namespace System.Net.Http.Headers
                 else if (knownHeader == KnownHeaders.Location)
                 {
                     // Normally Location should be in ISO-8859-1 but occasionally some servers respond with UTF-8.
-                    if (TryDecodeUtf8(headerValue, out string? decoded))
+                    // If the user set the ResponseHeaderEncodingSelector, we give that priority instead.
+                    if (valueEncoding is null && TryDecodeUtf8(headerValue, out string? decoded))
                     {
                         return decoded;
                     }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Headers.cs
@@ -441,7 +441,8 @@ namespace System.Net.Http.Functional.Tests
             ("Cookie",          Encoding.UTF8,      "; ", new[] { "Cookies", "\uD83C\uDF6A", "everywhere" }),
             ("Set-Cookie",      Encoding.UTF8,      ", ", new[] { "\uD83C\uDDF8\uD83C\uDDEE" }),
             ("header-5",        Encoding.UTF8,      ", ", new[] { "\uD83D\uDE48\uD83D\uDE49\uD83D\uDE4A", "foo", "\uD83D\uDE03", "bar" }),
-            ("bar",             Encoding.UTF8,      ", ", new[] { "foo" })
+            ("bar",             Encoding.UTF8,      ", ", new[] { "foo" }),
+            ("Location",        Encoding.Latin1,    ", ", new[] { "\u00D0\u00A4" })
         };
 
         [Fact]
@@ -538,7 +539,7 @@ namespace System.Net.Http.Functional.Tests
                     foreach ((string name, Encoding valueEncoding, string separator, string[] values) in s_nonAsciiHeaders)
                     {
                         Assert.Contains(name, seenHeaderNames);
-                        IEnumerable<string> receivedValues = Assert.Single(response.Headers, h => h.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value;
+                        IEnumerable<string> receivedValues = Assert.Single(response.Headers.NonValidated, h => h.Key.Equals(name, StringComparison.OrdinalIgnoreCase)).Value;
                         string value = Assert.Single(receivedValues);
 
                         string expected = valueEncoding.GetString(valueEncoding.GetBytes(string.Join(separator, values)));


### PR DESCRIPTION
Fixes #95799

If the user sets the `ResponseHeaderEncodingSelector` and the callback gives us an encoding for the location header, use that before trying to guess whether the bytes are UTF-8 or not.