### PR TITLE
Add runtime module address to SpecialDiagInfo block in createdump

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -9,6 +9,9 @@ typedef HINSTANCE (PALAPI_NOEXPORT *PFN_REGISTER_MODULE)(LPCSTR);           /* u
 // This is for the PAL_VirtualUnwindOutOfProc read memory adapter.
 CrashInfo* g_crashInfo;
 
+// This is the NativeAOT DotNetRuntimeDebugHeader signature
+uint8_t g_debugHeaderCookie[4] = { 0x44, 0x4E, 0x44, 0x48 };
+
 static bool ModuleInfoCompare(const ModuleInfo* lhs, const ModuleInfo* rhs) { return lhs->BaseAddress() < rhs->BaseAddress(); }
 
 CrashInfo::CrashInfo(const CreateDumpOptions& options) :
@@ -30,6 +33,7 @@ CrashInfo::CrashInfo(const CreateDumpOptions& options) :
     m_enumMemoryPagesAdded(0)
 {
     g_crashInfo = this;
+    m_runtimeBaseAddress = 0;
 #ifdef __APPLE__
     m_task = 0;
 #else

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -8,6 +8,7 @@
 #endif
 
 extern CrashInfo* g_crashInfo;
+extern uint8_t g_debugHeaderCookie[4];
 
 int g_readProcessMemoryErrno = 0;
 
@@ -378,6 +379,27 @@ CrashInfo::VisitModule(uint64_t baseAddress, std::string& moduleName)
                         if (strcmp(runtimeInfo.Signature, RUNTIME_INFO_SIGNATURE) == 0)
                         {
                             TRACE("Found valid single-file runtime info\n");
+                        }
+                    }
+                }
+            }
+        }
+        else if (m_appModel == AppModelType::NativeAOT)
+        {
+            if (PopulateForSymbolLookup(baseAddress))
+            {
+                uint64_t symbolOffset;
+                if (TryLookupSymbol("DotNetRuntimeDebugHeader", &symbolOffset))
+                {
+                    m_coreclrPath = GetDirectory(moduleName);
+                    m_runtimeBaseAddress = baseAddress;
+
+                    uint8_t cookie[sizeof(g_debugHeaderCookie)];
+                    if (ReadMemory((void*)(baseAddress + symbolOffset), cookie, sizeof(cookie)))
+                    {
+                        if (memcmp(cookie, g_debugHeaderCookie, sizeof(g_debugHeaderCookie)) == 0)
+                        {
+                            TRACE("Found valid NativeAOT runtime module\n");
                         }
                     }
                 }

--- a/src/coreclr/debug/createdump/dumpwriter.cpp
+++ b/src/coreclr/debug/createdump/dumpwriter.cpp
@@ -39,7 +39,8 @@ DumpWriter::WriteDiagInfo(size_t size)
     SpecialDiagInfoHeader header = {
         {SPECIAL_DIAGINFO_SIGNATURE},
         SPECIAL_DIAGINFO_VERSION,
-        m_crashInfo.ExceptionRecord()
+        m_crashInfo.ExceptionRecord(),
+        m_crashInfo.RuntimeBaseAddress()
     };
     if (!WriteData(&header, sizeof(header))) {
         return false;

--- a/src/coreclr/debug/createdump/specialdiaginfo.h
+++ b/src/coreclr/debug/createdump/specialdiaginfo.h
@@ -8,11 +8,11 @@
 // ******************************************************************************
 
 // This is a special memory region added to ELF and MachO dumps that contains extra diagnostics
-// information like the exception record for a crash for a NativeAOT app. The exception record
-// contains the pointer to the JSON formatted crash info.
+// information like the exception record address for a NativeAOT app crash or the runtime module
+// base address. The exception record contains the pointer to the JSON formatted crash info.
 
 #define SPECIAL_DIAGINFO_SIGNATURE "DIAGINFOHEADER"
-#define SPECIAL_DIAGINFO_VERSION 1
+#define SPECIAL_DIAGINFO_VERSION 2
 
 #ifdef __APPLE__
 const uint64_t SpecialDiagInfoAddress = 0x7fffffff10000000;
@@ -31,4 +31,5 @@ struct SpecialDiagInfoHeader
     char Signature[16];
     int32_t Version;
     uint64_t ExceptionRecordAddress;
+    uint64_t RuntimeBaseAddress;
 };

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -81,7 +81,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <NativeObject>$(NativeIntermediateOutputPath)$(TargetName)$(NativeObjectExt)</NativeObject>
     <NativeBinary>$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)</NativeBinary>
     <IlcExportUnmanagedEntrypoints Condition="'$(IlcExportUnmanagedEntrypoints)' == '' and '$(NativeLib)' == 'Shared'">true</IlcExportUnmanagedEntrypoints>
-    <ExportsFile Condition="$(IlcExportUnmanagedEntrypoints) == 'true' and $(ExportsFile) == ''">$(NativeIntermediateOutputPath)$(TargetName)$(ExportsFileExt)</ExportsFile>
+    <ExportsFile Condition="$(ExportsFile) == ''">$(NativeIntermediateOutputPath)$(TargetName)$(ExportsFileExt)</ExportsFile>
 
     <IlcCompileOutput>$(NativeObject)</IlcCompileOutput>
 
@@ -240,7 +240,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(TrimmerRootDescriptor->'--descriptor:%(FullPath)')" />
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
       <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--splitinit" />
-      <IlcArg Condition="$(ExportsFile) != ''" Include="--exportsfile:$(ExportsFile)" />
+      <IlcArg Condition="'$(ExportsFile)' != ''" Include="--exportsfile:$(ExportsFile)" />
+      <IlcArg Condition="'$(_targetOS)' != 'win' and '$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader" />
+      <IlcArg Condition="'$(IlcExportUnmanagedEntrypoints)' == 'true'" Include="--export-unmanaged-entrypoints" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />
       <IlcArg Include="@(DirectPInvokeList->'--directpinvokelist:%(Identity)')" />
@@ -333,8 +335,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="/LIBPATH:&quot;%(AdditionalNativeLibraryDirectories.Identity)&quot;" Condition="'$(_targetOS)' == 'win' and '@(AdditionalNativeLibraryDirectories->Count())' &gt; 0" />
       <CustomLinkerArg Include="-exported_symbols_list &quot;$(ExportsFile)&quot;" Condition="'$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />
-      <CustomLinkerArg Include="-Wl,--version-script=$(ExportsFile)" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and $(ExportsFile) != ''" />
-      <CustomLinkerArg Include="-Wl,--export-dynamic" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(IlcExportUnmanagedEntrypoints)' == 'true' and '$(NativeLib)' == ''" />
+      <CustomLinkerArg Include="-Wl,--version-script=$(ExportsFile)" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
+      <CustomLinkerArg Include="-Wl,--export-dynamic" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>
     <ItemGroup Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true'">

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -241,7 +241,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
       <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--splitinit" />
       <IlcArg Condition="'$(ExportsFile)' != ''" Include="--exportsfile:$(ExportsFile)" />
-      <IlcArg Condition="'$(_targetOS)' != 'win' and '$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader" />
+      <IlcArg Condition="'$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader,DATA" />
       <IlcArg Condition="'$(IlcExportUnmanagedEntrypoints)' == 'true'" Include="--export-unmanaged-entrypoints" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />
@@ -331,7 +331,6 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-o &quot;$(NativeBinary)&quot;" Condition="'$(_targetOS)' != 'win'" />
       <CustomLinkerArg Include="/OUT:&quot;$(NativeBinary)&quot;" Condition="'$(_targetOS)' == 'win'" />
       <CustomLinkerArg Include="/DEF:&quot;$(ExportsFile)&quot;" Condition="'$(_targetOS)' == 'win' and $(ExportsFile) != ''" />
-      <CustomLinkerArg Include="/EXPORT:DotNetRuntimeDebugHeader,DATA" Condition="'$(_targetOS)' == 'win' and '$(DebuggerSupport)' != 'false'" />
       <CustomLinkerArg Include="/LIBPATH:&quot;%(AdditionalNativeLibraryDirectories.Identity)&quot;" Condition="'$(_targetOS)' == 'win' and '@(AdditionalNativeLibraryDirectories->Count())' &gt; 0" />
       <CustomLinkerArg Include="-exported_symbols_list &quot;$(ExportsFile)&quot;" Condition="'$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -241,7 +241,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(NativeLib)' != ''" Include="--nativelib" />
       <IlcArg Condition="'$(CustomNativeMain)' == 'true'" Include="--splitinit" />
       <IlcArg Condition="'$(ExportsFile)' != ''" Include="--exportsfile:$(ExportsFile)" />
-      <IlcArg Condition="'$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader,DATA" />
+      <IlcArg Condition="'$(_targetOS)' == 'win' and '$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader,DATA" />
+      <IlcArg Condition="'$(_targetOS)' != 'win' and '$(DebuggerSupport)' != 'false'" Include="--export-dynamic-symbol:DotNetRuntimeDebugHeader" />
       <IlcArg Condition="'$(IlcExportUnmanagedEntrypoints)' == 'true'" Include="--export-unmanaged-entrypoints" />
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -108,6 +108,10 @@ struct DotNetRuntimeDebugHeader
 };
 
 extern "C" struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader;
+
+#ifdef HOST_UNIX
+__attribute__ ((visibility ("default")))
+#endif
 struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
 
 #define MAKE_DEBUG_ENTRY(TypeName, FieldName, Value)                             \

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -36,7 +36,7 @@ struct GlobalValueEntry
 
 // This size should be one bigger than the number of entries since a null entry
 // signifies the end of the array.
-static constexpr size_t DebugTypeEntriesArraySize = 128;
+static constexpr size_t DebugTypeEntriesArraySize = 100;
 static DebugTypeEntry s_DebugEntries[DebugTypeEntriesArraySize];
 
 // This size should be one bigger than the number of entries since a null entry
@@ -119,7 +119,7 @@ struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
     {                                                                            \
         s_DebugEntries[currentDebugPos] = { #TypeName, #FieldName, Value, 0  };  \
         ++currentDebugPos;                                                       \
-        ASSERT(currentDebugPos <= DebugTypeEntriesArraySize);                    \
+        ASSERT(currentDebugPos < DebugTypeEntriesArraySize);                     \
     } while(0)
 
 #define MAKE_DEBUG_FIELD_ENTRY(TypeName, FieldName) MAKE_DEBUG_ENTRY(TypeName, FieldName, offsetof(TypeName, FieldName))
@@ -133,7 +133,7 @@ struct DotNetRuntimeDebugHeader DotNetRuntimeDebugHeader = {};
     {                                                                             \
         s_GlobalEntries[currentGlobalPos] = { #Name, Name };                      \
         ++currentGlobalPos;                                                       \
-        ASSERT(currentGlobalPos <= GlobalEntriesArraySize);                       \
+        ASSERT(currentGlobalPos < GlobalEntriesArraySize);                        \
     } while(0)                                                                    \
 
 extern "C" void PopulateDebugHeaders()

--- a/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
+++ b/src/coreclr/nativeaot/Runtime/DebugHeader.cpp
@@ -36,12 +36,12 @@ struct GlobalValueEntry
 
 // This size should be one bigger than the number of entries since a null entry
 // signifies the end of the array.
-static constexpr size_t DebugTypeEntriesArraySize = 96;
+static constexpr size_t DebugTypeEntriesArraySize = 128;
 static DebugTypeEntry s_DebugEntries[DebugTypeEntriesArraySize];
 
 // This size should be one bigger than the number of entries since a null entry
 // signifies the end of the array.
-static constexpr size_t GlobalEntriesArraySize = 6;
+static constexpr size_t GlobalEntriesArraySize = 8;
 static GlobalValueEntry s_GlobalEntries[GlobalEntriesArraySize];
 
 // This structure is part of a in-memory serialization format that is used by diagnostic tools to

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -37,25 +37,57 @@ namespace ILCompiler
                 {
                     streamWriter.WriteLine("EXPORTS");
                     foreach (string symbol in _exportSymbols)
-                        streamWriter.WriteLine($"   {symbol}");
+                    {
+                        streamWriter.WriteLine($"   {symbol.Replace(',', ' ')}");
+                    }
                     foreach (var method in _methods)
+                    {
                         streamWriter.WriteLine($"   {method.GetUnmanagedCallersOnlyExportName()}");
+                    }
                 }
-                else if(_context.Target.IsOSXLike)
+                else if (_context.Target.IsOSXLike)
                 {
                     foreach (string symbol in _exportSymbols)
-                        streamWriter.WriteLine($"_{symbol}");
+                    {
+                        string export;
+                        int comma = symbol.IndexOf(',');
+                        if (comma > 0)
+                        {
+                            export = symbol.Remove(comma);
+                        }
+                        else
+                        {
+                            export = symbol;
+                        }
+                        streamWriter.WriteLine($"_{export}");
+                    }
                     foreach (var method in _methods)
+                    {
                         streamWriter.WriteLine($"_{method.GetUnmanagedCallersOnlyExportName()}");
+                    }
                 }
                 else
                 {
                     streamWriter.WriteLine("V1.0 {");
                     streamWriter.WriteLine("    global: _init; _fini;");
                     foreach (string symbol in _exportSymbols)
-                        streamWriter.WriteLine($"        {symbol};");
+                    {
+                        string export;
+                        int comma = symbol.IndexOf(',');
+                        if (comma > 0)
+                        {
+                            export = symbol.Remove(comma);
+                        }
+                        else
+                        {
+                            export = symbol;
+                        }
+                        streamWriter.WriteLine($"        {export};");
+                    }
                     foreach (var method in _methods)
+                    {
                         streamWriter.WriteLine($"        {method.GetUnmanagedCallersOnlyExportName()};");
+                    }
                     streamWriter.WriteLine("    local: *;");
                     streamWriter.WriteLine("};");
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -12,13 +12,15 @@ namespace ILCompiler
 {
     public class ExportsFileWriter
     {
-        private string _exportsFile;
-        private List<EcmaMethod> _methods;
-        private TypeSystemContext _context;
+        private readonly string _exportsFile;
+        private readonly IEnumerable<string> _exportSymbols;
+        private readonly List<EcmaMethod> _methods;
+        private readonly TypeSystemContext _context;
 
-        public ExportsFileWriter(TypeSystemContext context, string exportsFile)
+        public ExportsFileWriter(TypeSystemContext context, string exportsFile, IEnumerable<string> exportSymbols)
         {
             _exportsFile = exportsFile;
+            _exportSymbols = exportSymbols;
             _context = context;
             _methods = new List<EcmaMethod>();
         }
@@ -34,11 +36,15 @@ namespace ILCompiler
                 if (_context.Target.IsWindows)
                 {
                     streamWriter.WriteLine("EXPORTS");
+                    foreach (string symbol in _exportSymbols)
+                        streamWriter.WriteLine($"   {symbol}");
                     foreach (var method in _methods)
                         streamWriter.WriteLine($"   {method.GetUnmanagedCallersOnlyExportName()}");
                 }
                 else if(_context.Target.IsOSXLike)
                 {
+                    foreach (string symbol in _exportSymbols)
+                        streamWriter.WriteLine($"_{symbol}");
                     foreach (var method in _methods)
                         streamWriter.WriteLine($"_{method.GetUnmanagedCallersOnlyExportName()}");
                 }
@@ -46,6 +52,8 @@ namespace ILCompiler
                 {
                     streamWriter.WriteLine("V1.0 {");
                     streamWriter.WriteLine("    global: _init; _fini;");
+                    foreach (string symbol in _exportSymbols)
+                        streamWriter.WriteLine($"        {symbol};");
                     foreach (var method in _methods)
                         streamWriter.WriteLine($"        {method.GetUnmanagedCallersOnlyExportName()};");
                     streamWriter.WriteLine("    local: *;");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExportsFileWriter.cs
@@ -37,57 +37,25 @@ namespace ILCompiler
                 {
                     streamWriter.WriteLine("EXPORTS");
                     foreach (string symbol in _exportSymbols)
-                    {
                         streamWriter.WriteLine($"   {symbol.Replace(',', ' ')}");
-                    }
                     foreach (var method in _methods)
-                    {
                         streamWriter.WriteLine($"   {method.GetUnmanagedCallersOnlyExportName()}");
-                    }
                 }
-                else if (_context.Target.IsOSXLike)
+                else if(_context.Target.IsOSXLike)
                 {
                     foreach (string symbol in _exportSymbols)
-                    {
-                        string export;
-                        int comma = symbol.IndexOf(',');
-                        if (comma > 0)
-                        {
-                            export = symbol.Remove(comma);
-                        }
-                        else
-                        {
-                            export = symbol;
-                        }
-                        streamWriter.WriteLine($"_{export}");
-                    }
+                        streamWriter.WriteLine($"_{symbol}");
                     foreach (var method in _methods)
-                    {
                         streamWriter.WriteLine($"_{method.GetUnmanagedCallersOnlyExportName()}");
-                    }
                 }
                 else
                 {
                     streamWriter.WriteLine("V1.0 {");
                     streamWriter.WriteLine("    global: _init; _fini;");
                     foreach (string symbol in _exportSymbols)
-                    {
-                        string export;
-                        int comma = symbol.IndexOf(',');
-                        if (comma > 0)
-                        {
-                            export = symbol.Remove(comma);
-                        }
-                        else
-                        {
-                            export = symbol;
-                        }
-                        streamWriter.WriteLine($"        {export};");
-                    }
+                        streamWriter.WriteLine($"        {symbol};");
                     foreach (var method in _methods)
-                    {
                         streamWriter.WriteLine($"        {method.GetUnmanagedCallersOnlyExportName()};");
-                    }
                     streamWriter.WriteLine("    local: *;");
                     streamWriter.WriteLine("};");
                 }

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -38,7 +38,11 @@ namespace ILCompiler
         public CliOption<bool> SplitExeInitialization { get; } =
             new("--splitinit") { Description = "Split initialization of an executable between the library entrypoint and a main entrypoint" };
         public CliOption<string> ExportsFile { get; } =
-            new("--exportsfile") { Description = "File to write exported method definitions" };
+            new("--exportsfile") { Description = "File to write exported symbol and method definitions" };
+        public CliOption<bool> ExportUnmanagedEntryPoints { get; } =
+            new("--export-unmanaged-entrypoints") { Description = "Controls whether the exported method definitions are exported" };
+        public CliOption<string[]> ExportDynamicSymbols { get; } =
+            new("--export-dynamic-symbol") { Description = "Add dynamic export symbol to exports file" };
         public CliOption<string> DgmlLogFileName { get; } =
             new("--dgmllog") { Description = "Save result of dependency analysis as DGML" };
         public CliOption<bool> GenerateFullDgmlLog { get; } =
@@ -176,6 +180,8 @@ namespace ILCompiler
             Options.Add(NativeLib);
             Options.Add(SplitExeInitialization);
             Options.Add(ExportsFile);
+            Options.Add(ExportDynamicSymbols);
+            Options.Add(ExportUnmanagedEntryPoints);
             Options.Add(DgmlLogFileName);
             Options.Add(GenerateFullDgmlLog);
             Options.Add(ScanDgmlLogFileName);

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -40,7 +40,7 @@ namespace ILCompiler
         public CliOption<string> ExportsFile { get; } =
             new("--exportsfile") { Description = "File to write exported symbol and method definitions" };
         public CliOption<bool> ExportUnmanagedEntryPoints { get; } =
-            new("--export-unmanaged-entrypoints") { Description = "Controls whether the exported method definitions are exported" };
+            new("--export-unmanaged-entrypoints") { Description = "Controls whether the named UnmanagedCallersOnly methods are exported" };
         public CliOption<string[]> ExportDynamicSymbols { get; } =
             new("--export-dynamic-symbol") { Description = "Add dynamic export symbol to exports file" };
         public CliOption<string> DgmlLogFileName { get; } =

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -574,11 +574,15 @@ namespace ILCompiler
             string exportsFile = Get(_command.ExportsFile);
             if (exportsFile != null)
             {
-                ExportsFileWriter defFileWriter = new ExportsFileWriter(typeSystemContext, exportsFile);
-                foreach (var compilationRoot in compilationRoots)
+                ExportsFileWriter defFileWriter = new ExportsFileWriter(typeSystemContext, exportsFile, Get(_command.ExportDynamicSymbols));
+
+                if (Get(_command.ExportUnmanagedEntryPoints))
                 {
-                    if (compilationRoot is UnmanagedEntryPointsRootProvider provider)
-                        defFileWriter.AddExportedMethods(provider.ExportedMethods);
+                    foreach (var compilationRoot in compilationRoots)
+                    {
+                        if (compilationRoot is UnmanagedEntryPointsRootProvider provider)
+                            defFileWriter.AddExportedMethods(provider.ExportedMethods);
+                    }
                 }
 
                 defFileWriter.EmitExportedMethods();


### PR DESCRIPTION
Fix missing DotNetRuntimeDebugHeader export:

  Add ILC options:
    --export-dynamic-symbol - Add dynamic export symbol to export file. Used to add DotNetRuntimeDebugHeader export.
    --export-unmanaged-entrypoints - controls whether the exported method definitions are exported

  Change Native AOT build integration to always pass an export file to ILC and linker.