### PR TITLE
[wasm] CI: Surface failures for MT job when runtime has changes

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -312,6 +312,15 @@ jobs:
       include:
       - ${{ parameters._const_paths._wasm_chrome }}
 
+    - subset: wasm_runtime_mt
+      include:
+      - src/libraries/System.Net.WebSockets.Client/*
+      - src/libraries/System.Runtime.InteropServices.JavaScript/*
+      - src/libraries/System.Runtime.InteropServices/*
+      - src/mono/mono/**/*wasm*
+      - src/mono/mono/mini/interp/jiterpreter*
+      - src/mono/wasm/runtime/*
+
     # anything other than mono, or wasm specific paths
     - subset: non_mono_and_wasm
       exclude:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -130,8 +130,8 @@ jobs:
       # Always run for runtime-wasm because tests are not run in runtime
       alwaysRun: ${{ parameters.isWasmOnlyBuild }}
 
-      # NOTE - Since threading is experimental, we don't want to block mainline work
-      shouldContinueOnError: true
+      # NOTE - shouldContinueOnError: true if there are multithread runtime related changes
+      shouldContinueOnError: $[ ne(dependencies.evaluate_paths.outputs['SetPathVars_wasm_runtime_mt.containsChange'], true) ]
       scenarios:
         - WasmTestOnBrowser
         #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592


### PR DESCRIPTION
`runtime-wasm` has a job for running tests with multithreaded runtime,
but since that is not stable yet, it uses `shouldContinueOnError: true`.
IOW, the test failures don't cause the job to fail, and instead just
show up as `orange`. And this does not show up in github at all.

Instead, to help with devs working on the mt runtime, turn this to
`false` if there are any wasm runtime related changes.
