### PR TITLE
JIT: Merge more stores/loads

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -7942,11 +7942,11 @@ static bool GetLoadStoreCoalescingData(Compiler* comp, GenTreeIndir* ind, LoadSt
 }
 
 //------------------------------------------------------------------------
-// GetLoadStoreCoalescingData: perform legality check for store coalescing.
+// GetLoadStoreCoalescingData: perform legality check for load/store coalescing.
 //
 // Arguments:
-//    data1 - the data needed for store coalescing for the first load
-//    data2 - the data needed for store coalescing for the second node
+//    data1 - the data needed for store coalescing for the first load/store
+//    data2 - the data needed for store coalescing for the second load/store
 //
 // Return Value:
 //    true if two stores or two loads can be coalesced, false otherwise.
@@ -7973,6 +7973,7 @@ static bool CanBeCoalesced(const LoadStoreCoalescingData& data1, const LoadStore
     }
 
     // Offset is the same - we can just remove the previous store.
+    // Alignment doesn't matter here.
     if (data1.offset == data2.offset)
     {
         return true;
@@ -8154,14 +8155,8 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
 
         // Get coalescing data for the previous STOREIND
         GenTreeStoreInd* prevInd = prevTree->AsStoreInd();
-        if (!GetLoadStoreCoalescingData(comp, prevInd->AsStoreInd(), &prevData))
+        if (!GetLoadStoreCoalescingData(comp, prevInd->AsStoreInd(), &prevData) || !CanBeCoalesced(prevData, currData))
         {
-            return;
-        }
-
-        if (!CanBeCoalesced(prevData, currData))
-        {
-            CanBeCoalesced(prevData, currData);
             return;
         }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8307,7 +8307,7 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
 
             // Update offset to be the minimum of the two
             assert((prevData.offset > currData.offset) == (prevValueData.offset > currValueData.offset));
-            destInd->Addr()->AsAddrMode()->SetOffset(min(prevData.offset, currData.offset));
+            destInd->Addr()->AsAddrMode()->SetOffset(min(prevValueData.offset, currValueData.offset));
 
             if (genTypeSize(oldType) == 1)
             {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8004,7 +8004,7 @@ static bool CanBeCoalesced(const LoadStoreCoalescingData& data1, const LoadStore
 
         // Check whether the combined indir is still aligned.
         bool isCombinedIndirAtomic = (genTypeSize(data1.targetType) < TARGET_POINTER_SIZE) &&
-                                     (min(data2.offset, data1.offset) % (genTypeSize(data1.targetType) * 2)) == 0;
+                                     (min(data1.offset, data2.offset) % (genTypeSize(data1.targetType) * 2)) == 0;
 
         if (genTypeSize(data1.targetType) == TARGET_POINTER_SIZE)
         {
@@ -8180,8 +8180,8 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeStoreInd* ind)
                 return;
             }
 
-            // Make sure that we're storing in the same direction as we're loading
-            if ((prevData.offset > currData.offset) != (prevValueData.offset > currValueData.offset))
+            // Make sure the difference between offsets is the same (and direction)
+            if ((prevData.offset - currData.offset) != (prevValueData.offset - currValueData.offset))
             {
                 return;
             }


### PR DESCRIPTION
```cs
class MyClass
{
    public byte A;
    public byte B;
    public char C;
    public int D;
}

void Test(MyClass c1, MyClass c2)
{
    c1.A = c2.A;
    c1.B = c2.B;
    c1.C = c2.C;
    c1.D = c2.D;
}
```
Codegen diff for `Test`:
```diff
; Method Program:Test(MyClass,MyClass):this (FullOpts)
-      movzx    rax, byte  ptr [r8+0x0E]
-      mov      byte  ptr [rdx+0x0E], al
-      movzx    rax, byte  ptr [r8+0x0F]
-      mov      byte  ptr [rdx+0x0F], al
-      movzx    rax, word  ptr [r8+0x0C]
-      mov      word  ptr [rdx+0x0C], ax
-      mov      eax, dword ptr [r8+0x08]
-      mov      dword ptr [rdx+0x08], eax
+      mov      rax, qword ptr [r8+0x08]
+      mov      qword ptr [rdx+0x08], rax
       ret      
-; Total bytes of code: 33
+; Total bytes of code: 9
```

For more diffs it needs a sort of "forward sub" in lowering to handle cases like
```cs
a[0] = b[0];
a[1] = b[1]
```