### PR TITLE
[Mono][full-aot] Fix runtime invoke with delegate parameter

### DIFF
--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -2761,6 +2761,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 		switch (t->type) {
 		case MONO_TYPE_OBJECT:
 		case MONO_TYPE_PTR:
+		case MONO_TYPE_FNPTR:
 		case MONO_TYPE_I:
 		case MONO_TYPE_U:
 #if !defined(MONO_ARCH_ILP32)

--- a/src/mono/mono/mini/mini-arm.c
+++ b/src/mono/mono/mini/mini-arm.c
@@ -3001,6 +3001,7 @@ mono_arch_start_dyn_call (MonoDynCallInfo *info, gpointer **args, guint8 *ret, g
 		switch (t->type) {
 		case MONO_TYPE_OBJECT:
 		case MONO_TYPE_PTR:
+		case MONO_TYPE_FNPTR:
 		case MONO_TYPE_I:
 		case MONO_TYPE_U:
 			p->regs [slot] = (host_mgreg_t)(gsize)*arg;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3622,7 +3622,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 
 			if (m_type_is_byref (t)) {
 				args [pindex ++] = &params [i];
-			} else if (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR) {
+			} else if (MONO_TYPE_IS_REFERENCE (t) || t->type == MONO_TYPE_PTR || t->type == MONO_TYPE_FNPTR) {
 				args [pindex ++] = &params [i];
 			} else {
 				args [pindex ++] = params [i];


### PR DESCRIPTION
A follow up fix for the runtime invoke issue found in #95469

**TLDR**: This bug only affected iOS target in release build. The following library test needs to run on iOS or full-aot on arm64 platform to lockdown this behavior:
https://github.com/dotnet/runtime/blob/701428f04d14b9e02331a6ef7faecc32bd81f9ea/src/libraries/System.Runtime/tests/System.Reflection.Tests/MethodCommonTests.cs#L280

This issue is only reproducible when `dyn_call_info` field is set. `dyn_call_info` field is only set when condition `!mono_llvm_only && (mono_aot_only || mini_debug_options.dyn_runtime_invoke)` is met and `MONO_ARCH_DYN_CALL_SUPPORTED` is set.

1. `MONO_ARCH_DYN_CALL_SUPPORTED` is only set for 
    - amd64, arm64 and amd platforms
3. Only the following modes have `mono_llvm_only` setting to false, and `mono_aot_only` setting to true
    -  `MONO_AOT_MODE_FULL`
        - This mode is set when using `--full-aot` switch
    -  `MONO_AOT_MODE_INTERP`
        - This mode is only set when AOT is not enabled for WASM and WASI.

