### PR TITLE
Enable ETW::GCLog::ForceGCForDiagnostics thread to be walked by the GC

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -298,7 +298,7 @@ extends:
               - template: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
                 parameters:
                   creator: dotnet-bot
-                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;" /p:BuildNativeAotFrameworkObjects=true'
+                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
                   liveLibrariesBuildConfig: Release
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -298,7 +298,7 @@ extends:
               - template: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
                 parameters:
                   creator: dotnet-bot
-                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;tracing;" /p:BuildNativeAotFrameworkObjects=true'
+                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;" /p:BuildNativeAotFrameworkObjects=true'
                   liveLibrariesBuildConfig: Release
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
+++ b/src/coreclr/nativeaot/Runtime/eventtrace_gcheap.cpp
@@ -461,7 +461,9 @@ HRESULT ETW::GCLog::ForceGCForDiagnostics()
     Thread* pThread = ThreadStore::GetCurrentThread();
 
     // While doing the GC, much code assumes & asserts the thread doing the GC is in
-    // cooperative mode.
+    // cooperative mode (but DisablePreemptiveMode cannot be used until a valid deferred
+    // transition frame is put into place).
+    pThread->SetDeferredTransitionFrameForNativeHelperThread();
     pThread->DisablePreemptiveMode();
 
     hr = GCHeapUtilities::GetGCHeap()->GarbageCollect(

--- a/src/coreclr/nativeaot/Runtime/thread.cpp
+++ b/src/coreclr/nativeaot/Runtime/thread.cpp
@@ -146,6 +146,9 @@ void Thread::EnablePreemptiveMode()
     VolatileStoreWithoutBarrier(&m_pTransitionFrame, m_pDeferredTransitionFrame);
 }
 
+// NOTE: In general, this function can only be used in contexts where explicit actions have been taken to
+// ensure that valid m_pDeferredTransitionFrame setting is in place (since this setting is not generally
+// guaranteed to be valid).
 void Thread::DisablePreemptiveMode()
 {
     ASSERT(ThreadStore::GetCurrentThread() == this);
@@ -156,6 +159,24 @@ void Thread::DisablePreemptiveMode()
     if (ThreadStore::IsTrapThreadsRequested() && (this != ThreadStore::GetSuspendingThread()))
     {
         WaitForGC(m_pDeferredTransitionFrame);
+    }
+}
+
+// Setup the m_pDeferredTransitionFrame field for GC helpers entered from native helper thread
+// code (e.g. ETW or EventPipe threads). Do not use anywhere else.
+void Thread::SetDeferredTransitionFrameForNativeHelperThread()
+{
+    ASSERT(ThreadStore::GetCurrentThread() == this);
+    ASSERT(!Thread::IsCurrentThreadInCooperativeMode());
+    m_pDeferredTransitionFrame = m_pTransitionFrame;
+
+    // This function can only be used when there is no managed code anywhere on the current stack (i.e., when
+    // the current thread has the simplest possible transition frame configuration). A real transition (and
+    // the implied possibility of ancestor managed code on this thread) can be deferred only in the restricted
+    // set of cases which are allowed to use DeferTransitionFrame or SetDeferredTransitionFrame.
+    if (m_pDeferredTransitionFrame != TOP_OF_STACK_MARKER)
+    {
+        RhFailFast();
     }
 }
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/nativeaot/Runtime/thread.h
+++ b/src/coreclr/nativeaot/Runtime/thread.h
@@ -273,6 +273,10 @@ public:
     // Do not use anywhere else.
     void                DeferTransitionFrame();
 
+    // Setup the m_pDeferredTransitionFrame field for GC helpers entered from native helper thread
+    // code (e.g. ETW or EventPipe threads). Do not use anywhere else.
+    void                SetDeferredTransitionFrameForNativeHelperThread();
+
     //
     // GC support APIs - do not use except from GC itself
     //

--- a/src/coreclr/nativeaot/Runtime/thread.inl
+++ b/src/coreclr/nativeaot/Runtime/thread.inl
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #ifndef DACCESS_COMPILE
+// Set the m_pDeferredTransitionFrame field for GC allocation helpers that setup transition frame
+// in assembly code. Do not use anywhere else.
 inline void Thread::SetDeferredTransitionFrame(PInvokeTransitionFrame* pTransitionFrame)
 {
     ASSERT(ThreadStore::GetCurrentThread() == this);
@@ -10,6 +12,8 @@ inline void Thread::SetDeferredTransitionFrame(PInvokeTransitionFrame* pTransiti
     m_pDeferredTransitionFrame = pTransitionFrame;
 }
 
+// Setup the m_pDeferredTransitionFrame field for GC helpers entered via regular PInvoke.
+// Do not use anywhere else.
 inline void Thread::DeferTransitionFrame()
 {
     ASSERT(ThreadStore::GetCurrentThread() == this);


### PR DESCRIPTION
Fix for #95606 as suggested by @ChrisAhna (who has worked in adding the asserts in the `StackFrameIterator`), based on the below root cause analysis.

The method, `ForceGCForDiagnostics`. will make the GC `stackwalk `all threads (except dedicated GC threads) including the thread that is invoking `ForceGCForDiagnostics`. However, this thread is not in a state to be walked since it's `m_pDeferredTransitionFrame `is "stale" and points to random "stomped on" stack content which does not describe any kind of valid "starting location" that the `StackFrameIterator `can use to carry out the `stackwalk`.