### PR TITLE
JIT: Fix duplicate subgraph clauses in flow graph dumping, minor loop cleanup

### DIFF
--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -1846,6 +1846,11 @@ void Compiler::fgDumpFlowGraphLoops(FILE* file)
             fprintf(m_file, "%*s", m_indent, "");
 
             loop->VisitLoopBlocksReversePostOrder([=](BasicBlock* block) {
+                if (BitVecOps::IsMember(&m_traits, m_outputBlocks, block->bbNewPostorderNum))
+                {
+                    return BasicBlockVisit::Continue;
+                }
+
                 if (block != loop->GetHeader())
                 {
                     FlowGraphNaturalLoop* childLoop = m_loops->GetLoopByHeader(block);
@@ -1858,10 +1863,8 @@ void Compiler::fgDumpFlowGraphLoops(FILE* file)
                     }
                 }
 
-                if (BitVecOps::TryAddElemD(&m_traits, m_outputBlocks, block->bbPostorderNum))
-                {
-                    fprintf(m_file, FMT_BB ";", block->bbNum);
-                }
+                fprintf(m_file, FMT_BB ";", block->bbNum);
+                BitVecOps::AddElemD(&m_traits, m_outputBlocks, block->bbNewPostorderNum);
 
                 return BasicBlockVisit::Continue;
             });

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -6579,10 +6579,6 @@ PhaseStatus Compiler::optHoistLoopCode()
 
     // Consider all the loops, visiting child loops first.
     //
-    // TODO-Quirk: Switch this to postorder over the loops, instead of this
-    // loop tree based thing. It is not the exact same order, but it will still
-    // process child loops before parent loops.
-
     bool             modified = false;
     LoopHoistContext hoistCtxt(this);
     for (FlowGraphNaturalLoop* loop : m_loops->InPostOrder())
@@ -6798,7 +6794,7 @@ bool Compiler::optHoistThisLoop(FlowGraphNaturalLoop* loop, LoopHoistContext* ho
         }
 
         assert(childLoop->EntryEdges().size() == 1);
-        BasicBlock* childPreHead = childLoop->EntryEdges()[0]->getSourceBlock();
+        BasicBlock* childPreHead = childLoop->EntryEdge(0)->getSourceBlock();
         if (loop->ExitEdges().size() == 1)
         {
             if (fgSsaDomTree->Dominates(childPreHead, loop->ExitEdges()[0]->getSourceBlock()))


### PR DESCRIPTION
We should avoid the recursive call when we've already dumped the header block of a child loop, otherwise we end up with a bunch of empty "subgraph" clauses:

```diff
@@ -43,19 +43,13 @@ digraph FlowGraph {
             label = "L01 (old: L01)";
             color = blue;
             BB05;BB06;
             subgraph cluster_2 {
                 label = "L02 (old: L02)";
                 color = blue;
                 BB07;
             }
             BB08;
         }
-
-        subgraph cluster_3 {
-            label = "L02 (old: L02)";
-            color = blue;
-
-        }
         BB09;
     }
 }
```

Also some minor clean ups in hoisting.