### PR TITLE
Fix visibility error XUW1003 in tests:

### DIFF
--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.cs
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.cs
@@ -643,7 +643,7 @@ public class ComVisibleServer
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Requires COM support")]
-    private static void RunComVisibleTests()
+    public static void RunComVisibleTests()
     {
         int fooSuccessVal = 0;
         //

--- a/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.cs
+++ b/src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.cs
@@ -643,7 +643,7 @@ public class ComVisibleServer
     [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     [PlatformSpecific(TestPlatforms.Windows)]
     [SkipOnMono("Requires COM support")]
-    private static void RunComVisibleTests()
+    public static void RunComVisibleTests()
     {
         int fooSuccessVal = 0;
         //


### PR DESCRIPTION
- src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyTrue/AssemblyTrueTest.cs(646,25): error XUW1003: Test methods must be public. Add or change the visibility modifier of the test method to public.
- src/tests/Interop/PInvoke/NativeCallManagedComVisible/AssemblyWithoutComVisible/AssemblyWithoutComVisibleTest.cs(646,25): error XUW1003: Test methods must be public. Add or change the visibility modifier of the test method to public.

Related PR: https://github.com/dotnet/runtime/pull/94109

cc @t-mustafin @clamp03 @jkoritzinsky