### PR TITLE
JIT: Recanonicalize entry BB in JitOptRepeat scenarios

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5011,9 +5011,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
                 break;
             }
 
-            // We optimized away the canonical entry BB that SSA depends on
-            // above, if so we are going for another iteration then make sure
-            // we still have a canonical entry.
+            // We may have optimized away the canonical entry BB that SSA
+            // depends on above, so if we are going for another iteration then
+            // make sure we still have a canonical entry.
             //
             DoPhase(this, PHASE_CANONICALIZE_ENTRY, &Compiler::fgCanonicalizeFirstBB);
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5012,8 +5012,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             }
 
             // We optimized away the canonical entry BB that SSA depends on
-            // above, so we are going for another iteration then make sure we
-            // still have a canonical entry.
+            // above, if so we are going for another iteration then make sure
+            // we still have a canonical entry.
             //
             DoPhase(this, PHASE_CANONICALIZE_ENTRY, &Compiler::fgCanonicalizeFirstBB);
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5010,6 +5010,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             {
                 break;
             }
+
+            // We optimized away the canonical entry BB that SSA depends on
+            // above, so we are going for another iteration then make sure we
+            // still have a canonical entry.
+            //
+            DoPhase(this, PHASE_CANONICALIZE_ENTRY, &Compiler::fgCanonicalizeFirstBB);
+
             ResetOptAnnotations();
             RecomputeLoopInfo();
         }


### PR DESCRIPTION
I inadvertently broke the canonicalization for JitOptRepeat scenarios in #95809 where I introduced a separate phase to canonicalize the entry BB; this fixes it again.