### PR TITLE
[browser] Minimal legacy support for Blazor renderBatch

### DIFF
--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -100,7 +100,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_get_i32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f64_unaligned", "number", ["number"]],
-    [true, "mono_wasm_read_value_if_bool_unsafe", "number", ["number"]],
+    [true, "mono_wasm_read_as_bool_or_null_unsafe", "number", ["number"]],
 
     // jiterpreter
     [true, "mono_jiterp_trace_bailout", "void", ["number"]],
@@ -241,7 +241,7 @@ export interface t_Cwraps {
     mono_wasm_get_i32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f64_unaligned(source: VoidPtr): number;
-    mono_wasm_read_value_if_bool_unsafe(obj: MonoObject): number;
+    mono_wasm_read_as_bool_or_null_unsafe(obj: MonoObject): number;
 
     mono_jiterp_trace_bailout(reason: number): void;
     mono_jiterp_get_trace_bailout_count(reason: number): number;

--- a/src/mono/wasm/runtime/cwraps.ts
+++ b/src/mono/wasm/runtime/cwraps.ts
@@ -100,6 +100,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_wasm_get_i32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f32_unaligned", "number", ["number"]],
     [true, "mono_wasm_get_f64_unaligned", "number", ["number"]],
+    [true, "mono_wasm_read_value_if_bool_unsafe", "number", ["number"]],
 
     // jiterpreter
     [true, "mono_jiterp_trace_bailout", "void", ["number"]],
@@ -240,6 +241,7 @@ export interface t_Cwraps {
     mono_wasm_get_i32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f32_unaligned(source: VoidPtr): number;
     mono_wasm_get_f64_unaligned(source: VoidPtr): number;
+    mono_wasm_read_value_if_bool_unsafe(obj: MonoObject): number;
 
     mono_jiterp_trace_bailout(reason: number): void;
     mono_jiterp_get_trace_bailout_count(reason: number): number;

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -969,6 +969,28 @@ mono_wasm_get_type_aqn (MonoType * typePtr) {
 	return mono_type_get_name_full (typePtr, MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED);
 }
 
+EMSCRIPTEN_KEEPALIVE int
+mono_wasm_read_value_if_bool_unsafe (PVOLATILE(MonoObject) obj) {
+	MONO_ENTER_GC_UNSAFE;
+
+	MonoClass *klass = mono_object_get_class (obj);
+	if (!klass)
+		return MARSHAL_ERROR_NULL_CLASS_POINTER;
+
+	MonoType *type = mono_class_get_type (klass), *original_type = type;
+	if (!type)
+		return MARSHAL_ERROR_NULL_TYPE_POINTER;
+
+	int mono_type = mono_type_get_type (type);
+	if (MONO_TYPE_BOOLEAN == mono_type) {
+		return ((signed char*)mono_object_unbox (obj) == 0 ? 0 : 1);
+	}
+
+	return -1;
+
+	MONO_EXIT_GC_UNSAFE;
+}
+
 // This code runs inside a gc unsafe region
 static int
 _mono_wasm_try_unbox_primitive_and_get_type_ref_impl (PVOLATILE(MonoObject) obj, void *result, int result_capacity) {

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -971,16 +971,14 @@ mono_wasm_get_type_aqn (MonoType * typePtr) {
 
 // this will return bool value if the object is a bool, otherwise it will return -1 or error
 EMSCRIPTEN_KEEPALIVE int
-mono_wasm_read_value_if_bool_unsafe (PVOLATILE(MonoObject) obj) {
+mono_wasm_read_as_bool_or_null_unsafe (PVOLATILE(MonoObject) obj) {
 	MONO_ENTER_GC_UNSAFE;
 
 	MonoClass *klass = mono_object_get_class (obj);
-	if (!klass)
-		return MARSHAL_ERROR_NULL_CLASS_POINTER;
+	if (!klass) return -1;
 
-	MonoType *type = mono_class_get_type (klass), *original_type = type;
-	if (!type)
-		return MARSHAL_ERROR_NULL_TYPE_POINTER;
+	MonoType *type = mono_class_get_type (klass);
+	if (!type) return -1;
 
 	int mono_type = mono_type_get_type (type);
 	if (MONO_TYPE_BOOLEAN == mono_type) {

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -972,22 +972,29 @@ mono_wasm_get_type_aqn (MonoType * typePtr) {
 // this will return bool value if the object is a bool, otherwise it will return -1 or error
 EMSCRIPTEN_KEEPALIVE int
 mono_wasm_read_as_bool_or_null_unsafe (PVOLATILE(MonoObject) obj) {
+
+	int result = -1;
+
 	MONO_ENTER_GC_UNSAFE;
 
 	MonoClass *klass = mono_object_get_class (obj);
-	if (!klass) return -1;
+	if (!klass) {
+		goto end;
+	}
 
 	MonoType *type = mono_class_get_type (klass);
-	if (!type) return -1;
+	if (!type) {
+		goto end;
+	}
 
 	int mono_type = mono_type_get_type (type);
 	if (MONO_TYPE_BOOLEAN == mono_type) {
-		return ((signed char*)mono_object_unbox (obj) == 0 ? 0 : 1);
+		result = ((signed char*)mono_object_unbox (obj) == 0 ? 0 : 1);
 	}
 
-	return -1;
-
+	end:
 	MONO_EXIT_GC_UNSAFE;
+	return result;
 }
 
 // This code runs inside a gc unsafe region

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -969,6 +969,7 @@ mono_wasm_get_type_aqn (MonoType * typePtr) {
 	return mono_type_get_name_full (typePtr, MONO_TYPE_NAME_FORMAT_ASSEMBLY_QUALIFIED);
 }
 
+// this will return bool value if the object is a bool, otherwise it will return -1 or error
 EMSCRIPTEN_KEEPALIVE int
 mono_wasm_read_value_if_bool_unsafe (PVOLATILE(MonoObject) obj) {
 	MONO_ENTER_GC_UNSAFE;

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -18,6 +18,8 @@ import { loadLazyAssembly } from "./lazyLoading";
 import { loadSatelliteAssemblies } from "./satelliteAssemblies";
 import { forceDisposeProxies } from "./gc-handles";
 import { mono_wasm_get_func_id_to_name_mappings } from "./logging";
+import { MonoObject } from "./types/internal";
+import { monoStringToStringUnsafe } from "./strings";
 
 export function export_internal(): any {
     return {
@@ -96,6 +98,10 @@ export function export_internal(): any {
         mono_wasm_gc_lock,
         mono_wasm_gc_unlock,
 
+        // Blazor legacy replacement
+        monoObjectValueIfBoolUnsafe,
+        monoStringToStringUnsafe,
+
         loadLazyAssembly,
         loadSatelliteAssemblies
     };
@@ -109,4 +115,14 @@ export function cwraps_internal(internal: any): void {
         mono_wasm_profiler_init_browser: profiler_c_functions.mono_wasm_profiler_init_browser,
         mono_wasm_exec_regression: cwraps.mono_wasm_exec_regression,
     });
+}
+
+/* @deprecated not GC safe, legacy support for Blazor */
+export function monoObjectValueIfBoolUnsafe(obj: MonoObject): boolean | null {
+    const res = cwraps.mono_wasm_read_value_if_bool_unsafe(obj);
+    if (res === 0)
+        return false;
+    if (res === 1)
+        return true;
+    return null;
 }

--- a/src/mono/wasm/runtime/exports-internal.ts
+++ b/src/mono/wasm/runtime/exports-internal.ts
@@ -18,7 +18,7 @@ import { loadLazyAssembly } from "./lazyLoading";
 import { loadSatelliteAssemblies } from "./satelliteAssemblies";
 import { forceDisposeProxies } from "./gc-handles";
 import { mono_wasm_get_func_id_to_name_mappings } from "./logging";
-import { MonoObject } from "./types/internal";
+import { MonoObject, MonoObjectNull } from "./types/internal";
 import { monoStringToStringUnsafe } from "./strings";
 
 export function export_internal(): any {
@@ -99,7 +99,7 @@ export function export_internal(): any {
         mono_wasm_gc_unlock,
 
         // Blazor legacy replacement
-        monoObjectValueIfBoolUnsafe,
+        monoObjectAsBoolOrNullUnsafe,
         monoStringToStringUnsafe,
 
         loadLazyAssembly,
@@ -118,11 +118,16 @@ export function cwraps_internal(internal: any): void {
 }
 
 /* @deprecated not GC safe, legacy support for Blazor */
-export function monoObjectValueIfBoolUnsafe(obj: MonoObject): boolean | null {
-    const res = cwraps.mono_wasm_read_value_if_bool_unsafe(obj);
-    if (res === 0)
+export function monoObjectAsBoolOrNullUnsafe(obj: MonoObject): boolean | null {
+    if (obj === MonoObjectNull) {
+        return null;
+    }
+    const res = cwraps.mono_wasm_read_as_bool_or_null_unsafe(obj);
+    if (res === 0) {
         return false;
-    if (res === 1)
+    }
+    if (res === 1) {
         return true;
+    }
     return null;
 }

--- a/src/mono/wasm/runtime/exports.ts
+++ b/src/mono/wasm/runtime/exports.ts
@@ -101,9 +101,11 @@ function initializeExports(globalObjects: GlobalObjects): RuntimeAPI {
                 }
             });
         };
-        globalThisAny.MONO = globals.mono;
-        globalThisAny.BINDING = globals.binding;
-        globalThisAny.INTERNAL = globals.internal;
+        if (WasmEnableLegacyJsInterop && !linkerDisableLegacyJsInterop) {
+            globalThisAny.MONO = globals.mono;
+            globalThisAny.BINDING = globals.binding;
+            globalThisAny.INTERNAL = globals.internal;
+        }
         globalThisAny.Module = module;
 
         // Blazor back compat

--- a/src/mono/wasm/runtime/net6-legacy/cs-to-js.ts
+++ b/src/mono/wasm/runtime/net6-legacy/cs-to-js.ts
@@ -10,13 +10,12 @@ import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
 import { ManagedObject } from "../marshal";
 import { getU32, getI32, getF32, getF64, setI32_unchecked } from "../memory";
 import { mono_wasm_new_root, mono_wasm_new_external_root } from "../roots";
-import { monoStringToString } from "../strings";
+import { monoStringToString, monoStringToStringUnsafe } from "../strings";
 import { legacyManagedExports } from "./corebindings";
 import { legacyHelpers } from "./globals";
 import { js_to_mono_obj_root } from "./js-to-cs";
 import { assert_legacy_interop, mono_bind_method, mono_method_get_call_signature_ref } from "./method-binding";
 import { createPromiseController } from "../globals";
-import { monoStringToStringUnsafe } from "./strings";
 
 const delegate_invoke_symbol = Symbol.for("wasm delegate_invoke");
 

--- a/src/mono/wasm/runtime/net6-legacy/strings.ts
+++ b/src/mono/wasm/runtime/net6-legacy/strings.ts
@@ -3,10 +3,9 @@
 
 import { mono_assert } from "../globals";
 import { mono_wasm_new_root } from "../roots";
-import { interned_string_table, monoStringToString, mono_wasm_empty_string, stringToInternedMonoStringRoot, stringToMonoStringRoot } from "../strings";
-import { MonoString, MonoStringNull, is_nullish } from "../types/internal";
+import { interned_string_table, mono_wasm_empty_string, stringToInternedMonoStringRoot, stringToMonoStringRoot } from "../strings";
+import { MonoString, is_nullish } from "../types/internal";
 
-let mono_wasm_string_root: any;
 import { assert_legacy_interop } from "./method-binding";
 
 /**
@@ -38,17 +37,4 @@ export function stringToMonoStringIntern(string: string): string {
     finally {
         root.release();
     }
-}
-/* @deprecated not GC safe, use monoStringToString */
-export function monoStringToStringUnsafe(mono_string: MonoString): string | null {
-    if (mono_string === MonoStringNull)
-        return null;
-    assert_legacy_interop();
-    if (!mono_wasm_string_root)
-        mono_wasm_string_root = mono_wasm_new_root();
-
-    mono_wasm_string_root.value = mono_string;
-    const result = monoStringToString(mono_wasm_string_root);
-    mono_wasm_string_root.value = MonoStringNull;
-    return result;
 }

--- a/src/mono/wasm/runtime/strings.ts
+++ b/src/mono/wasm/runtime/strings.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { mono_wasm_new_root_buffer } from "./roots";
+import { mono_wasm_new_root, mono_wasm_new_root_buffer } from "./roots";
 import { MonoString, MonoStringNull, WasmRoot, WasmRootBuffer } from "./types/internal";
 import { Module } from "./globals";
 import cwraps from "./cwraps";
@@ -248,4 +248,20 @@ export function viewOrCopy(view: Uint8Array, start: CharPtr, end: CharPtr): Uint
     return needsCopy
         ? view.slice(<any>start, <any>end)
         : view.subarray(<any>start, <any>end);
+}
+
+// below is minimal legacy support for Blazor
+let mono_wasm_string_root: any;
+
+/* @deprecated not GC safe, use monoStringToString */
+export function monoStringToStringUnsafe(mono_string: MonoString): string | null {
+    if (mono_string === MonoStringNull)
+        return null;
+    if (!mono_wasm_string_root)
+        mono_wasm_string_root = mono_wasm_new_root();
+
+    mono_wasm_string_root.value = mono_string;
+    const result = monoStringToString(mono_wasm_string_root);
+    mono_wasm_string_root.value = MonoStringNull;
+    return result;
 }


### PR DESCRIPTION
This will allow us to reduce dependency of Blazor internal on legacy interop to last 2 methods.

Contributes to https://github.com/dotnet/aspnetcore/issues/48042
To be used by https://github.com/dotnet/aspnetcore/pull/52732