### PR TITLE
JIT: Fix OSR DFS assert, and update entry BB for try regions

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4976,7 +4976,6 @@ unsigned Compiler::fgRunDfs(VisitPreorder visitPreorder, VisitPostorder visitPos
         // patchpoint, but during morph we may transform to something that
         // requires the original entry (fgEntryBB).
         assert(opts.IsOSR());
-        assert((fgEntryBB->bbRefs == 1) && (fgEntryBB->bbPreds == nullptr));
         dfsFrom(fgEntryBB);
     }
 

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -2168,6 +2168,12 @@ bool Compiler::fgNormalizeEHCase2()
                             newTryStart->bbRefs++;
                         }
 
+                        // Same for OSR's protected entry BB.
+                        if (insertBeforeBlk == fgEntryBB)
+                        {
+                            fgEntryBB = newTryStart;
+                        }
+
                         JITDUMP("'try' begin for EH#%u and EH#%u are same block; inserted new " FMT_BB " before " FMT_BB
                                 " "
                                 "as new 'try' begin for EH#%u.\n",


### PR DESCRIPTION
There is nothing that stops an edge into the original entry BB from existing, so this assert is overzealous.

The asserting case, however, was because of `fgNormalizeEH` not taking care to update `fgEntryBB`; also fix that.