### PR TITLE
Revert "Avoid a few array allocations with DefaultBinder (#93115)"

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
             Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
             return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
@@ -28,7 +28,7 @@ namespace System.Reflection
             Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
             return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
@@ -38,7 +38,7 @@ namespace System.Reflection
             Debug.Assert(target is not null);
 
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule(), target.MetadataToken);
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
             return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
@@ -87,13 +87,13 @@ namespace System.Reflection
         {
             Debug.Assert(target is not null);
 
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             IList<CustomAttributeData> cad = GetCustomAttributes(target.GetRuntimeModule()!, target.MetadataToken);
             PseudoCustomAttribute.GetCustomAttributes(target, (RuntimeType)typeof(object), ref pcas);
             return pcas.Count > 0 ? GetCombinedList(cad, ref pcas) : cad;
         }
 
-        private static ReadOnlyCollection<CustomAttributeData> GetCombinedList(IList<CustomAttributeData> customAttributes, ref ListBuilder<Attribute> pseudoAttributes)
+        private static ReadOnlyCollection<CustomAttributeData> GetCombinedList(IList<CustomAttributeData> customAttributes, ref RuntimeType.ListBuilder<Attribute> pseudoAttributes)
         {
             Debug.Assert(pseudoAttributes.Count != 0);
 
@@ -922,7 +922,7 @@ namespace System.Reflection
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 type = (type.GetGenericTypeDefinition() as RuntimeType)!;
 
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(type, caType, ref pcas);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -935,7 +935,7 @@ namespace System.Reflection
                 return attributes;
             }
 
-            ListBuilder<object> result = default;
+            RuntimeType.ListBuilder<object> result = default;
             bool mustBeInheritable = false;
 
             for (int i = 0; i < pcas.Count; i++)
@@ -964,7 +964,7 @@ namespace System.Reflection
             if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
                 method = (method.GetGenericMethodDefinition() as RuntimeMethodInfo)!;
 
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(method, caType, ref pcas);
 
             // if we are asked to go up the hierarchy chain we have to do it now and regardless of the
@@ -977,7 +977,7 @@ namespace System.Reflection
                 return attributes;
             }
 
-            ListBuilder<object> result = default;
+            RuntimeType.ListBuilder<object> result = default;
             bool mustBeInheritable = false;
 
             for (int i = 0; i < pcas.Count; i++)
@@ -1033,7 +1033,7 @@ namespace System.Reflection
             Debug.Assert(field is not null);
             Debug.Assert(caType is not null);
 
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(field, caType, ref pcas);
             object[] attributes = GetCustomAttributes(field.GetRuntimeModule(), field.MetadataToken, pcas.Count, caType);
             if (pcas.Count > 0) pcas.CopyTo(attributes, attributes.Length - pcas.Count);
@@ -1045,7 +1045,7 @@ namespace System.Reflection
             Debug.Assert(parameter is not null);
             Debug.Assert(caType is not null);
 
-            ListBuilder<Attribute> pcas = default;
+            RuntimeType.ListBuilder<Attribute> pcas = default;
             PseudoCustomAttribute.GetCustomAttributes(parameter, caType, ref pcas);
             object[] attributes = GetCustomAttributes(parameter.GetRuntimeModule()!, parameter.MetadataToken, pcas.Count, caType);
             if (pcas.Count > 0) pcas.CopyTo(attributes, attributes.Length - pcas.Count);
@@ -1101,7 +1101,7 @@ namespace System.Reflection
             {
                 Debug.Assert(attributeCtorToken == 0);
 
-                ListBuilder<object> derivedAttributes = default;
+                RuntimeType.ListBuilder<object> derivedAttributes = default;
 
                 for (int i = 0; i < attributeTokens.Length; i++)
                 {
@@ -1139,7 +1139,7 @@ namespace System.Reflection
         private static object[] GetCustomAttributes(
             RuntimeModule decoratedModule, int decoratedMetadataToken, int pcaCount, RuntimeType attributeFilterType)
         {
-            ListBuilder<object> attributes = default;
+            RuntimeType.ListBuilder<object> attributes = default;
 
             AddCustomAttributes(ref attributes, decoratedModule, decoratedMetadataToken, attributeFilterType, false, default);
 
@@ -1156,11 +1156,11 @@ namespace System.Reflection
                             "attribute instantiation which is present in the code linker has analyzed." +
                             "As such the reflection usage in this method will never fail as those methods/fields will be present.")]
         private static void AddCustomAttributes(
-            ref ListBuilder<object> attributes,
+            ref RuntimeType.ListBuilder<object> attributes,
             RuntimeModule decoratedModule, int decoratedMetadataToken,
             RuntimeType? attributeFilterType, bool mustBeInheritable,
             // The derivedAttributes list must be passed by value so that it is not modified with the discovered attributes
-            ListBuilder<object> derivedAttributes)
+            RuntimeType.ListBuilder<object> derivedAttributes)
         {
             CustomAttributeRecord[] car = RuntimeCustomAttributeData.GetCustomAttributeRecords(decoratedModule, decoratedMetadataToken);
 
@@ -1295,7 +1295,7 @@ namespace System.Reflection
             MetadataToken decoratedToken,
             RuntimeType attributeFilterType,
             bool mustBeInheritable,
-            ref ListBuilder<object> derivedAttributes,
+            ref RuntimeType.ListBuilder<object> derivedAttributes,
             out RuntimeType attributeType,
             out IRuntimeMethodInfo? ctorWithParameters,
             out bool isVarArg)
@@ -1409,7 +1409,7 @@ namespace System.Reflection
 
         #region Private Static Methods
         private static bool AttributeUsageCheck(
-            RuntimeType attributeType, bool mustBeInheritable, ref ListBuilder<object> derivedAttributes)
+            RuntimeType attributeType, bool mustBeInheritable, ref RuntimeType.ListBuilder<object> derivedAttributes)
         {
             AttributeUsageAttribute? attributeUsageAttribute = null;
 
@@ -1595,7 +1595,7 @@ namespace System.Reflection
         #endregion
 
         #region Internal Static
-        internal static void GetCustomAttributes(RuntimeType type, RuntimeType caType, ref ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeType type, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
             Debug.Assert(type is not null);
             Debug.Assert(caType is not null);
@@ -1639,7 +1639,7 @@ namespace System.Reflection
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeMethodInfo method, RuntimeType caType, ref ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeMethodInfo method, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
             Debug.Assert(method is not null);
             Debug.Assert(caType is not null);
@@ -1679,7 +1679,7 @@ namespace System.Reflection
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeParameterInfo parameter, RuntimeType caType, ref ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeParameterInfo parameter, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
             Debug.Assert(parameter is not null);
             Debug.Assert(caType is not null);
@@ -1735,7 +1735,7 @@ namespace System.Reflection
             return false;
         }
 
-        internal static void GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType, ref ListBuilder<Attribute> pcas)
+        internal static void GetCustomAttributes(RuntimeFieldInfo field, RuntimeType caType, ref RuntimeType.ListBuilder<Attribute> pcas)
         {
             Debug.Assert(field is not null);
             Debug.Assert(caType is not null);

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -53,6 +53,87 @@ namespace System
             HandleToInfo
         }
 
+        // Helper to build lists of MemberInfos. Special cased to avoid allocations for lists of one element.
+        internal struct ListBuilder<T> where T : class
+        {
+            private T[]? _items;
+            private T _item;
+            private int _count;
+            private int _capacity;
+
+            public ListBuilder(int capacity)
+            {
+                _items = null;
+                _item = null!;
+                _count = 0;
+                _capacity = capacity;
+            }
+
+            public T this[int index]
+            {
+                get
+                {
+                    Debug.Assert(index < Count);
+                    return (_items != null) ? _items[index] : _item;
+                }
+            }
+
+            public T[] ToArray()
+            {
+                if (_count == 0)
+                    return Array.Empty<T>();
+                if (_count == 1)
+                    return new T[1] { _item };
+
+                Array.Resize(ref _items, _count);
+                _capacity = _count;
+                return _items!;
+            }
+
+            public void CopyTo(object[] array, int index)
+            {
+                if (_count == 0)
+                    return;
+
+                if (_count == 1)
+                {
+                    array[index] = _item;
+                    return;
+                }
+
+                Array.Copy(_items!, 0, array, index, _count);
+            }
+
+            public int Count => _count;
+
+            public void Add(T item)
+            {
+                if (_count == 0)
+                {
+                    _item = item;
+                }
+                else
+                {
+                    if (_count == 1)
+                    {
+                        if (_capacity < 2)
+                            _capacity = 4;
+                        _items = new T[_capacity];
+                        _items[0] = _item;
+                    }
+                    else if (_capacity == _count)
+                    {
+                        int newCapacity = 2 * _capacity;
+                        Array.Resize(ref _items, newCapacity);
+                        _capacity = newCapacity;
+                    }
+
+                    _items![_count] = item;
+                }
+                _count++;
+            }
+        }
+
         internal sealed class RuntimeTypeCache
         {
             private const int MAXNAMELEN = 1024;
@@ -2745,7 +2826,7 @@ namespace System
                     }
 
                     // All the methods have the exact same name and sig so return the most derived one.
-                    return System.DefaultBinder.FindMostDerivedNewSlotMeth(candidates.AsSpan());
+                    return System.DefaultBinder.FindMostDerivedNewSlotMeth(candidates.ToArray(), candidates.Count) as MethodInfo;
                 }
             }
 
@@ -2774,7 +2855,7 @@ namespace System
             }
 
             if ((bindingAttr & BindingFlags.ExactBinding) != 0)
-                return System.DefaultBinder.ExactBinding(candidates.AsSpan(), types);
+                return System.DefaultBinder.ExactBinding(candidates.ToArray(), types) as ConstructorInfo;
 
             binder ??= DefaultBinder;
             return binder.SelectMethod(bindingAttr, candidates.ToArray(), types, modifiers) as ConstructorInfo;
@@ -2812,7 +2893,7 @@ namespace System
             }
 
             if ((bindingAttr & BindingFlags.ExactBinding) != 0)
-                return System.DefaultBinder.ExactPropertyBinding(candidates.AsSpan(), returnType, types);
+                return System.DefaultBinder.ExactPropertyBinding(candidates.ToArray(), returnType, types);
 
             binder ??= DefaultBinder;
             return binder.SelectProperty(bindingAttr, candidates.ToArray(), returnType, types, modifiers);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -419,6 +419,7 @@
     <Compile Include="System\Reflection\Runtime\General\Helpers.cs" />
     <Compile Include="System\Reflection\Runtime\General\IRuntimeMemberInfoWithNoMetadataDefinition.cs" />
     <Compile Include="System\Reflection\Runtime\General\LegacyCustomAttributeApis.cs" />
+    <Compile Include="System\Reflection\Runtime\General\ListBuilder.cs" />
     <Compile Include="System\Reflection\Runtime\General\MetadataReaderExtensions.cs" />
     <Compile Include="System\Reflection\Runtime\General\MetadataReaderExtensions.NativeFormat.cs" />
     <Compile Include="System\Reflection\Runtime\General\NamespaceChain.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/RuntimeTypeInfo.BindingFlags.cs
@@ -35,7 +35,7 @@ namespace System.Reflection.Runtime.TypeInfos
             }
 
             if ((bindingAttr & BindingFlags.ExactBinding) != 0)
-                return DefaultBinder.ExactBinding(candidates.AsSpan(), types);
+                return System.DefaultBinder.ExactBinding(candidates.ToArray(), types) as ConstructorInfo;
 
             binder ??= Type.DefaultBinder;
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -713,7 +713,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\InvokeUtils.cs" Condition="'$(FeatureNativeAot)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\IReflect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\IReflectableType.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ListBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\LocalVariableInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\ManifestResourceInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Reflection\MemberFilter.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DefaultBinder.cs
@@ -3,10 +3,9 @@
 
 #pragma warning disable CA1852 // DefaultBinder is derived from in some targets
 
-using System.Collections.Generic;
+using System.Reflection;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using CultureInfo = System.Globalization.CultureInfo;
 
@@ -789,10 +788,12 @@ namespace System
 
         // Return any exact bindings that may exist. (This method is not defined on the
         //  Binder and is used by RuntimeType.)
-        public static T? ExactBinding<T>(ReadOnlySpan<T> match, Type[] types) where T : MethodBase
+        public static MethodBase? ExactBinding(MethodBase[] match, Type[] types)
         {
-            T singleMatch = default!;
-            using ValueListBuilder<T> exactMatches = new(new Span<T>(ref singleMatch));
+            ArgumentNullException.ThrowIfNull(match);
+
+            MethodBase[] aExactMatches = new MethodBase[match.Length];
+            int cExactMatches = 0;
 
             for (int i = 0; i < match.Length; i++)
             {
@@ -801,7 +802,6 @@ namespace System
                 {
                     continue;
                 }
-
                 int j;
                 for (j = 0; j < types.Length; j++)
                 {
@@ -811,27 +811,29 @@ namespace System
                     if (!pCls.Equals(types[j]))
                         break;
                 }
-
                 if (j < types.Length)
                     continue;
 
                 // Add the exact match to the array of exact matches.
-                exactMatches.Append(match[i]);
+                aExactMatches[cExactMatches] = match[i];
+                cExactMatches++;
             }
 
-            if (exactMatches.Length == 0)
+            if (cExactMatches == 0)
                 return null;
 
-            if (exactMatches.Length == 1)
-                return exactMatches[0];
+            if (cExactMatches == 1)
+                return aExactMatches[0];
 
-            return FindMostDerivedNewSlotMeth(exactMatches.AsSpan());
+            return FindMostDerivedNewSlotMeth(aExactMatches, cExactMatches);
         }
 
         // Return any exact bindings that may exist. (This method is not defined on the
         //  Binder and is used by RuntimeType.)
-        public static PropertyInfo? ExactPropertyBinding(ReadOnlySpan<PropertyInfo> match, Type? returnType, Type[]? types)
+        public static PropertyInfo? ExactPropertyBinding(PropertyInfo[] match, Type? returnType, Type[]? types)
         {
+            ArgumentNullException.ThrowIfNull(match);
+
             PropertyInfo? bestMatch = null;
             int typesLength = (types != null) ? types.Length : 0;
             for (int i = 0; i < match.Length; i++)
@@ -1124,12 +1126,12 @@ namespace System
             return depth;
         }
 
-        internal static T? FindMostDerivedNewSlotMeth<T>(ReadOnlySpan<T> match) where T : MethodBase
+        internal static MethodBase? FindMostDerivedNewSlotMeth(MethodBase[] match, int cMatches)
         {
             int deepestHierarchy = 0;
-            T? methodWithDeepestHierarchy = null;
+            MethodBase? methWithDeepestHierarchy = null;
 
-            for (int i = 0; i < match.Length; i++)
+            for (int i = 0; i < cMatches; i++)
             {
                 // Calculate the depth of the hierarchy of the declaring type of the
                 // current method.
@@ -1139,18 +1141,18 @@ namespace System
                 // This can only happen if at least one is vararg or generic.
                 if (currentHierarchyDepth == deepestHierarchy)
                 {
-                    throw ThrowHelper.GetAmbiguousMatchException(methodWithDeepestHierarchy!);
+                    throw ThrowHelper.GetAmbiguousMatchException(methWithDeepestHierarchy!);
                 }
 
                 // Check to see if this method is on the most derived class.
                 if (currentHierarchyDepth > deepestHierarchy)
                 {
                     deepestHierarchy = currentHierarchyDepth;
-                    methodWithDeepestHierarchy = match[i];
+                    methWithDeepestHierarchy = match[i];
                 }
             }
 
-            return methodWithDeepestHierarchy;
+            return methWithDeepestHierarchy;
         }
 
         // This method will sort the vars array into the mapping order stored

--- a/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -49,6 +49,94 @@ namespace System
             HandleToInfo
         }
 
+        // Helper to build lists of MemberInfos. Special cased to avoid allocations for lists of one element.
+        private struct ListBuilder<T> where T : class?
+        {
+            private T[]? _items;
+            private T _item;
+            private int _count;
+            private int _capacity;
+
+            public ListBuilder(int capacity)
+            {
+                _items = null;
+                _item = null!;
+                _count = 0;
+                _capacity = capacity;
+            }
+
+            public T this[int index]
+            {
+                get
+                {
+                    Debug.Assert(index < Count);
+                    return (_items != null) ? _items[index] : _item;
+                }
+            }
+
+            public T[] ToArray()
+            {
+                if (_count == 0)
+                    return Array.Empty<T>();
+                if (_count == 1)
+                    return new T[1] { _item };
+
+                Array.Resize(ref _items, _count);
+                _capacity = _count;
+                return _items;
+            }
+
+            public void CopyTo(object?[] array, int index)
+            {
+                if (_count == 0)
+                    return;
+
+                if (_count == 1)
+                {
+                    array[index] = _item;
+                    return;
+                }
+
+                Array.Copy(_items!, 0, array, index, _count);
+            }
+
+            public int Count
+            {
+                get
+                {
+                    return _count;
+                }
+            }
+
+            public void Add(T item)
+            {
+                if (_count == 0)
+                {
+                    _item = item;
+                }
+                else
+                {
+                    if (_count == 1)
+                    {
+                        if (_capacity < 2)
+                            _capacity = 4;
+                        _items = new T[_capacity];
+                        _items[0] = _item;
+                    }
+                    else
+                    if (_capacity == _count)
+                    {
+                        int newCapacity = 2 * _capacity;
+                        Array.Resize(ref _items, newCapacity);
+                        _capacity = newCapacity;
+                    }
+
+                    _items![_count] = item;
+                }
+                _count++;
+            }
+        }
+
         #endregion
 
         #region Static Members
@@ -710,7 +798,7 @@ namespace System
                     }
 
                     // All the methods have the exact same name and sig so return the most derived one.
-                    return System.DefaultBinder.FindMostDerivedNewSlotMeth(candidates.AsSpan());
+                    return System.DefaultBinder.FindMostDerivedNewSlotMeth(candidates.ToArray(), candidates.Count) as MethodInfo;
                 }
             }
 
@@ -739,7 +827,7 @@ namespace System
             }
 
             if ((bindingAttr & BindingFlags.ExactBinding) != 0)
-                return System.DefaultBinder.ExactBinding(candidates.AsSpan(), types);
+                return System.DefaultBinder.ExactBinding(candidates.ToArray(), types) as ConstructorInfo;
 
             binder ??= DefaultBinder;
 


### PR DESCRIPTION
This reverts commit 565ee96fa4a73021a16b66d8abacd7e616cb7246.

Fixes https://github.com/dotnet/runtime/issues/93741. I've not investigated deeply enough to know why this regressed as it did, so I'm reverting this for now.