### PR TITLE
JIT: Use 'compOpportunisticallyDependsOn' to determine if we can use ArmBase_Arm64_MultiplyLongAdd/MultiplyLongSub/MultiplyLongNeg intrinsics in lowering

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2774,7 +2774,7 @@ GenTree* Lowering::TryLowerAddSubToMulLongOp(GenTreeOp* op)
     if (!comp->opts.OptimizationEnabled())
         return nullptr;
 
-    if (!JitConfig.EnableHWIntrinsic())
+    if (!comp->compOpportunisticallyDependsOn(InstructionSet_ArmBase_Arm64))
         return nullptr;
 
     if (op->isContained())
@@ -2880,7 +2880,7 @@ GenTree* Lowering::TryLowerNegToMulLongOp(GenTreeOp* op)
     if (!comp->opts.OptimizationEnabled())
         return nullptr;
 
-    if (!JitConfig.EnableHWIntrinsic())
+    if (!comp->compOpportunisticallyDependsOn(InstructionSet_ArmBase_Arm64))
         return nullptr;
 
     if (op->isContained())


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95081

Do not use `JitConfig.EnableHWIntrinsic` to determine whether or not we can use a HW intrinsic. Instead, we should use `compOpportunisticallyDependsOn` on the specific instruction set, in this case `ArmBase_Arm64`.

When SuperPMI records a JITted method, it also records the JITFlags as it came from the VM - the JIT itself does not determine those flags. The JITFlags contains information of whether an ISA is supported or not.

The original issue occurred because when we set EnableHWIntrinsic=1 and re-JIT using SuperPMI, the original JITFlags did not support the `ArmBase_Arm64` ISA. There were two optimizations that used an `ArmBase_Arm64` intrinsic but only checked it with `JitConfig.EnableHWIntrinsic() != 0` - which isn't sufficient because it doesn't take into account what the VM said was supported. Instead, use `compOpportunisticallyDependsOn` to perform the check - this fixes the issue. 

