### PR TITLE
Fix lifetime management of certificates with keys on macOS

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Security.Cryptography.Apple;
+using System.Security.Cryptography.X509Certificates;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -32,6 +33,14 @@ namespace System.Security.Cryptography
             internal DSASecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
             {
                 SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+            }
+
+            internal DSASecurityTransforms(
+                SafeSecKeyRefHandle publicKey,
+                SafeSecKeyRefHandle privateKey,
+                SafeSecCertificateHandle owningCertificate)
+            {
+                SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey, owningCertificate));
             }
 
             public override KeySizes[] LegalKeySizes

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDiffieHellmanSecurityTransforms.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Security.Cryptography.Apple;
+using System.Security.Cryptography.X509Certificates;
 
 namespace System.Security.Cryptography
 {
@@ -25,6 +26,14 @@ namespace System.Security.Cryptography
             internal ECDiffieHellmanSecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+            }
+
+            internal ECDiffieHellmanSecurityTransforms(
+                SafeSecKeyRefHandle publicKey,
+                SafeSecKeyRefHandle privateKey,
+                SafeSecCertificateHandle owningCertificate)
+            {
+                KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey, owningCertificate));
             }
 
             // Return the three sizes that can be explicitly set (for backwards compatibility)

--- a/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/ECDsaSecurityTransforms.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Security.Cryptography.Apple;
+using System.Security.Cryptography.X509Certificates;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -26,6 +27,14 @@ namespace System.Security.Cryptography
             internal ECDsaSecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
             {
                 KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+            }
+
+            internal ECDsaSecurityTransforms(
+                SafeSecKeyRefHandle publicKey,
+                SafeSecKeyRefHandle privateKey,
+                SafeSecCertificateHandle owningCertificate)
+            {
+                KeySizeValue = _ecc.SetKeyAndGetSize(SecKeyPair.PublicPrivatePair(publicKey, privateKey, owningCertificate));
             }
 
             // Return the three sizes that can be explicitly set (for backwards compatibility)

--- a/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSASecurityTransforms.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Apple;
 using System.Security.Cryptography.Asn1;
+using System.Security.Cryptography.X509Certificates;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -36,6 +37,14 @@ namespace System.Security.Cryptography
             internal RSASecurityTransforms(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
             {
                 SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey));
+            }
+
+            internal RSASecurityTransforms(
+                SafeSecKeyRefHandle publicKey,
+                SafeSecKeyRefHandle privateKey,
+                SafeSecCertificateHandle owningCertificate)
+            {
+                SetKey(SecKeyPair.PublicPrivatePair(publicKey, privateKey, owningCertificate));
             }
 
             public override KeySizes[] LegalKeySizes

--- a/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
@@ -24,9 +24,13 @@ namespace System.Security.Cryptography
             PrivateKey = null;
             PublicKey?.Dispose();
             PublicKey = null!;
-            OwningCertificate?.Dispose();
-            OwningCertificate = null;
 
+            if (OwningCertificate is not null)
+            {
+                // We don't dispose here. Callers that supply a certificate to the key pair are expected to pass
+                // an existing certificate with that has been incremented.
+                OwningCertificate.DangerousRelease();
+            }
         }
 
         internal static SecKeyPair PublicPrivatePair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Keys.macOS.cs
@@ -19,6 +19,9 @@ namespace System.Security.Cryptography.X509Certificates
             if (_identityHandle == null)
                 return null;
 
+            bool ignored = false;
+            _certHandle.DangerousAddRef(ref ignored);
+
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
@@ -29,7 +32,7 @@ namespace System.Security.Cryptography.X509Certificates
                 publicKey = Interop.AppleCrypto.ImportEphemeralKey(_certData.SubjectPublicKeyInfo, false);
             }
 
-            return new DSAImplementation.DSASecurityTransforms(publicKey, privateKey);
+            return new DSAImplementation.DSASecurityTransforms(publicKey, privateKey, _certHandle);
         }
 
         public ICertificatePal CopyWithPrivateKey(DSA privateKey)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.cs
@@ -327,12 +327,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (_identityHandle == null)
                 return null;
 
+            bool ignored = false;
+            _certHandle.DangerousAddRef(ref ignored);
+
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
-            return new RSAImplementation.RSASecurityTransforms(publicKey, privateKey);
+            return new RSAImplementation.RSASecurityTransforms(publicKey, privateKey, _certHandle);
         }
 
         public ECDsa? GetECDsaPrivateKey()
@@ -340,12 +343,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (_identityHandle == null)
                 return null;
 
+            bool ignored = false;
+            _certHandle.DangerousAddRef(ref ignored);
+
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
-            return new ECDsaImplementation.ECDsaSecurityTransforms(publicKey, privateKey);
+            return new ECDsaImplementation.ECDsaSecurityTransforms(publicKey, privateKey, _certHandle);
         }
 
         public ECDiffieHellman? GetECDiffieHellmanPrivateKey()
@@ -353,12 +359,15 @@ namespace System.Security.Cryptography.X509Certificates
             if (_identityHandle == null)
                 return null;
 
+            bool ignored = false;
+            _certHandle.DangerousAddRef(ref ignored);
+
             Debug.Assert(!_identityHandle.IsInvalid);
             SafeSecKeyRefHandle publicKey = Interop.AppleCrypto.X509GetPublicKey(_certHandle);
             SafeSecKeyRefHandle privateKey = Interop.AppleCrypto.X509GetPrivateKeyFromIdentity(_identityHandle);
             Debug.Assert(!publicKey.IsInvalid);
 
-            return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(publicKey, privateKey);
+            return new ECDiffieHellmanImplementation.ECDiffieHellmanSecurityTransforms(publicKey, privateKey, _certHandle);
         }
 
         public string GetNameInfo(X509NameType nameType, bool forIssuer)


### PR DESCRIPTION
This is an attempt to address the certificate and key lifetime management issue reported in #94959.

The gist of the change is that now the certificate is up-refed and key along side with a public/private key pair. This seems to be the most reliable thing I was able to identify as a fix.