### PR TITLE
JIT: clear loop iter info after rebuilding loops for opt repeat

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5766,7 +5766,9 @@ void Compiler::RecomputeLoopInfo()
     fgComputeReachability();
     optSetBlockWeights();
     // Rebuild the loop tree annotations themselves
+    // But don't leave the iter info lying around.
     optFindLoops();
+    optClearLoopIterInfo();
 
     m_dfsTree = fgComputeDfs();
     optFindNewLoops();


### PR DESCRIPTION
This info gets computed when finding loops but is not used by the general optimizer (it only cares about loop structure, not iteration details). If we leave it built it can go stale.

Fixes #95843.