### PR TITLE
Revert "Build tests as self-contained for native AOT"

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -33,9 +33,6 @@
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>true</SuppressTrimAnalysisWarnings>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>
-
-    <!-- Forced by ILLink targets -->
-    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <!-- Needed for the amd64 -> amd64 musl cross-build to pass the target flag. -->

--- a/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
+++ b/src/mono/msbuild/apple/data/ProxyProjectForAOTOnHelix.proj
@@ -20,9 +20,6 @@
     <_IsApplePlatform>true</_IsApplePlatform>
     <TargetsAppleMobile>true</TargetsAppleMobile>
     <_targetOS>$(TargetOS)</_targetOS>
-
-    <!-- Forced by ILLink targets -->
-    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(UseNativeAOTRuntime)' == 'true'">

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -567,11 +567,6 @@
     <BuildNativeAotFrameworkObjects Condition="'$(IlcMultiModule)' == 'true'">true</BuildNativeAotFrameworkObjects>
     <DisableFrameworkLibGeneration Condition="'$(BuildNativeAotFrameworkObjects)' == 'true'">true</DisableFrameworkLibGeneration>
     <FrameworkLibPath Condition="'$(BuildNativeAotFrameworkObjects)' == 'true'">$(IlcSdkPath)</FrameworkLibPath>
-
-    <!-- Forced by ILLink targets -->
-    <SelfContained>true</SelfContained>
-    <HasRuntimeOutput>false</HasRuntimeOutput>
-    <_UsingDefaultForHasRuntimeOutput>false</_UsingDefaultForHasRuntimeOutput>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TestBuildMode)' == 'nativeaot'">


### PR DESCRIPTION
Reverts dotnet/runtime#95718

This is blocking SDK integration: https://github.com/dotnet/sdk/pull/37350. I tried fixing the test failures (that are due to every single test doing `t:Publish`), but there are still failures and the logs are useless and offer no way to corelate failures to a single test.

We don't really need erroring out that much. Ideally SDK owners will make `/t:Publish` to not be weird.