### PR TITLE
Revert "Error out if SelfContained is not specified for Native AOT publish"

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -196,8 +196,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- The defaults currently root non-framework assemblies, which
          is a no-op for portable apps. If we later support more ways
          to customize the behavior we can allow linking portable apps
-         in some cases. -->
-    <NETSdkError Condition="'$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
+         in some cases. If we're not running ILLink because e.g. this
+         is a NativeAOT app, value of SelfContained doesn't matter. -->
+    <NETSdkError Condition="'$(RunILLink)' != 'false' And '$(SelfContained)' != 'true'" ResourceName="ILLinkNotSupportedError" />
 
     <Warning Condition="'$(SuppressILLinkExplicitPackageReferenceWarning)' != 'true' And
                         '%(PackageReference.Identity)' == 'Microsoft.NET.ILLink.Tasks' And '%(PackageReference.IsImplicitlyDefined)' != 'true'"


### PR DESCRIPTION
Reverts dotnet/runtime#95496

This is blocking SDK integration: https://github.com/dotnet/sdk/pull/37350. I tried fixing the test failures (that are due to every single test doing `t:Publish`), but there are still failures and the logs are useless and offer no way to corelate failures to a single test.

We don't really need erroring out that much. Ideally SDK owners will make `/t:Publish` to not be weird.