### PR TITLE
[PERF][Release/7.0] Add newer container for performance Android testing

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -580,6 +580,29 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+- ${{ if containsValue(parameters.platforms, 'Android_arm64_perf_specific') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: Android
+      archType: arm64
+      targetRid: android-arm64
+      platform: Android_arm64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container:
+        image: cbl-mariner-2.0-cross-android-amd64
+        registry: mcr
+      jobParameters:
+        runtimeFlavor: mono
+        stagedBuild: ${{ parameters.stagedBuild }}
+        buildConfig: ${{ parameters.buildConfig }}
+        ${{ if eq(parameters.passPlatforms, true) }}:
+          platforms: ${{ parameters.platforms }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # Mac Catalyst x64
 
 - ${{ if containsValue(parameters.platforms, 'MacCatalyst_x64') }}:

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -65,7 +65,7 @@ jobs:
       buildConfig: release
       runtimeFlavor: mono
       platforms:
-      - Android_arm64
+      - Android_arm64_perf_specific
       jobParameters:
         buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
         nameSuffix: AndroidMono


### PR DESCRIPTION
Fixes: https://github.com/dotnet/performance/issues/3527
Successful test run (Android only): https://dev.azure.com/dnceng/internal/_build/results?buildId=2333679&view=results

Add performance android build specific platform-matrix entry with specific image to fix android app build/run issues. This only impacts performance testing and is an infra only change.

I added to the platform-matrix rather that updating the previously used platform-matrix entry to remove chance of any other impacts from changing the container image. I am not set on this way so let me know if a different approach is preferred.

@dotnet/runtime-infrastructure can I get this 'servicing-approved'? This only impacts performance testing infra. I am also open to any preferences on better ways to do this container update. Thanks!