### PR TITLE
Fix calculation of channel bindings hash in managed NTLM implementation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Authentication.ExtendedProtection;
@@ -425,7 +424,7 @@ namespace System.Net
             {
                 if (_channelBinding != null)
                 {
-                    int appDataOffset = Unsafe.SizeOf<SecChannelBindings>();
+                    int appDataOffset = sizeof(SecChannelBindings);
                     IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + appDataOffset;
                     int cbtDataSize = _channelBinding.Size - appDataOffset;
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Authentication.ExtendedProtection;
@@ -424,7 +425,7 @@ namespace System.Net
             {
                 if (_channelBinding != null)
                 {
-                    int appDataOffset = sizeof(SecChannelBindings);
+                    int appDataOffset = Unsafe.SizeOf<SecChannelBindings>();
                     IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + appDataOffset;
                     int cbtDataSize = _channelBinding.Size - appDataOffset;
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -424,10 +424,23 @@ namespace System.Net
             {
                 if (_channelBinding != null)
                 {
-                    IntPtr cbtData = _channelBinding.DangerousGetHandle();
-                    int cbtDataSize = _channelBinding.Size;
-                    int written = MD5.HashData(new Span<byte>((void*)cbtData, cbtDataSize), hashBuffer);
-                    Debug.Assert(written == MD5.HashSizeInBytes);
+                    int secChannelBindingsSize = Marshal.SizeOf<SecChannelBindings>();
+                    IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + secChannelBindingsSize;
+                    int cbtDataSize = _channelBinding.Size - secChannelBindingsSize;
+
+                    // Channel bindings are calculated according to RFC 4121, section 4.1.1.2,
+                    // so we need to include zeroed initiator fields and length prefix for the
+                    // application data.
+                    Span<byte> prefix = stackalloc byte[sizeof(uint) * 5];
+                    prefix.Clear();
+                    BinaryPrimitives.WriteInt32LittleEndian(prefix.Slice(sizeof(uint) * 4), cbtDataSize);
+                    using (var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5))
+                    {
+                        md5.AppendData(prefix);
+                        md5.AppendData(new Span<byte>((void*)cbtData, cbtDataSize));
+                        int written = md5.GetHashAndReset(hashBuffer);
+                        Debug.Assert(written == MD5.HashSizeInBytes);
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -424,9 +424,9 @@ namespace System.Net
             {
                 if (_channelBinding != null)
                 {
-                    int secChannelBindingsSize = Marshal.SizeOf<SecChannelBindings>();
-                    IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + secChannelBindingsSize;
-                    int cbtDataSize = _channelBinding.Size - secChannelBindingsSize;
+                    int appDataOffset = sizeof(SecChannelBindings);
+                    IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + appDataOffset;
+                    int cbtDataSize = _channelBinding.Size - appDataOffset;
 
                     // Channel bindings are calculated according to RFC 4121, section 4.1.1.2,
                     // so we need to include zeroed initiator fields and length prefix for the

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -587,7 +587,7 @@ namespace System.Net
                     {
                         // If a TLS channel binding token (cbt) is available then get the pointer
                         // to the application specific data.
-                        int appDataOffset = Marshal.SizeOf<SecChannelBindings>();
+                        int appDataOffset = sizeof(SecChannelBindings);
                         Debug.Assert(appDataOffset < channelBinding.Size);
                         IntPtr cbtAppData = channelBinding.DangerousGetHandle() + appDataOffset;
                         int cbtAppDataSize = channelBinding.Size - appDataOffset;

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Authentication.ExtendedProtection;
@@ -587,7 +588,7 @@ namespace System.Net
                     {
                         // If a TLS channel binding token (cbt) is available then get the pointer
                         // to the application specific data.
-                        int appDataOffset = sizeof(SecChannelBindings);
+                        int appDataOffset = Unsafe.SizeOf<SecChannelBindings>();
                         Debug.Assert(appDataOffset < channelBinding.Size);
                         IntPtr cbtAppData = channelBinding.DangerousGetHandle() + appDataOffset;
                         int cbtAppDataSize = channelBinding.Size - appDataOffset;

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.Security;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Authentication.ExtendedProtection;
@@ -544,7 +543,7 @@ namespace System.Net
                 }
             }
 
-            private NegotiateAuthenticationStatusCode InitializeSecurityContext(
+            private unsafe NegotiateAuthenticationStatusCode InitializeSecurityContext(
                 ref SafeGssCredHandle credentialsHandle,
                 ref SafeGssContextHandle? contextHandle,
                 ref SafeGssNameHandle? targetNameHandle,
@@ -588,7 +587,7 @@ namespace System.Net
                     {
                         // If a TLS channel binding token (cbt) is available then get the pointer
                         // to the application specific data.
-                        int appDataOffset = Unsafe.SizeOf<SecChannelBindings>();
+                        int appDataOffset = sizeof(SecChannelBindings);
                         Debug.Assert(appDataOffset < channelBinding.Size);
                         IntPtr cbtAppData = channelBinding.DangerousGetHandle() + appDataOffset;
                         int cbtAppDataSize = channelBinding.Size - appDataOffset;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
@@ -11,7 +11,7 @@ namespace System.Net.Security
     internal sealed class SafeChannelBindingHandle : ChannelBinding
     {
         private const int CertHashMaxSize = 128;
-        private static readonly int s_secChannelBindingSize = Marshal.SizeOf<SecChannelBindings>();
+        private static readonly int s_secChannelBindingSize = sizeof(SecChannelBindings);
 
         private readonly int _cbtPrefixByteArraySize;
         internal int Length { get; private set; }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
@@ -12,7 +11,7 @@ namespace System.Net.Security
     internal sealed class SafeChannelBindingHandle : ChannelBinding
     {
         private const int CertHashMaxSize = 128;
-        private static int SecChannelBindingSize => Unsafe.SizeOf<SecChannelBindings>();
+        private static unsafe int SecChannelBindingSize => sizeof(SecChannelBindings);
 
         private readonly int _cbtPrefixByteArraySize;
         internal int Length { get; private set; }


### PR DESCRIPTION
Fixes #95725

Tested on linux-x64 with Managed NTLM against Windows Server 2022 21H2 with Extended Protection set to Required.