### PR TITLE
[wasi] Add build support for using `wasm-opt`

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -221,7 +221,7 @@
         $(LibrariesNativeArtifactsPath)src\*.js;
         $(LibrariesNativeArtifactsPath)src\emcc-default.rsp;
         $(LibrariesNativeArtifactsPath)src\emcc-link.rsp;
-        $(LibrariesNativeArtifactsPath)src\emcc-props.json;"
+        $(LibrariesNativeArtifactsPath)src\wasm-props.json;"
         NativeSubDirectory="src"
         IsNative="true" />
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser'"
@@ -246,6 +246,7 @@
       <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)src\wasi-default.rsp;
         $(LibrariesNativeArtifactsPath)src\wasi-link.rsp;
+        $(LibrariesNativeArtifactsPath)src\wasm-props.json;
         $(LibrariesNativeArtifactsPath)src\*.c"
         NativeSubDirectory="src"
         IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -230,7 +230,7 @@
     <PlatformManifestFileEntry Include="wasm-config.h" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-default.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="emcc-link.rsp" IsNative="true" />
-    <PlatformManifestFileEntry Include="emcc-props.json" IsNative="true" />
+    <PlatformManifestFileEntry Include="wasm-props.json" IsNative="true" />
     <PlatformManifestFileEntry Include="wasi-default.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="wasi-link.rsp" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.WasmIntrinsics.xml" IsNative="true" />

--- a/src/mono/wasi/build/WasiApp.targets
+++ b/src/mono/wasi/build/WasiApp.targets
@@ -23,14 +23,13 @@
       _WasmGenerateNodeScripts;
     </WasmGenerateAppBundleDependsOn>
 
-    <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">false</WasmEnableExceptionHandling>
-    <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
-
     <SelfContained Condition="'$(IsWasiProject)' == 'true'">true</SelfContained>
 
     <!-- Temporarily `false`, till sdk gets a fix for supporting the new file -->
     <WasmEmitSymbolMap Condition="'$(WasmEmitSymbolMap)' == '' and '$(RunAOTCompilation)' != 'true'">false</WasmEmitSymbolMap>
     <TrimMode Condition="'$(TrimMode)' == ''">partial</TrimMode>
+
+    <WasmRunWasmOpt Condition="'$(WasmRunWasmOpt)' == ''">false</WasmRunWasmOpt>
 
     <!--<WasiBundleAssemblies Condition="'$(WasiBundleAssemblies)' == ''">true</WasiBundleAssemblies>-->
     <!-- FIXME: rename to WasmHost?? -->
@@ -112,8 +111,6 @@
       <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','wasi-wasm'))</_MonoAotCrossCompilerPath>
       <_WasmDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'wasi-default.rsp'))</_WasmDefaultFlagsRsp>
       <_WasmDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'wasi-link.rsp'))</_WasmDefaultLinkFlagsRsp>
-      <WasmNativeStrip Condition="'$(WasmNativeStrip)' == '' and '$(Configuration)' == 'Debug' and '$(WasmBuildingForNestedPublish)' != 'true'">false</WasmNativeStrip>
-      <WasmNativeStrip Condition="'$(WasmNativeStrip)' == ''">true</WasmNativeStrip>
       <WasmNativeDebugSymbols Condition="'$(WasmNativeDebugSymbols)' == ''">true</WasmNativeDebugSymbols>
       <WasmLinkIcalls Condition="'$(WasmLinkIcalls)' == ''">$(WasmBuildNative)</WasmLinkIcalls>
 
@@ -239,6 +236,7 @@
     </ItemGroup>
 
     <Error Text="Could not find NativeFileReference %(NativeFileReference.Identity)" Condition="'%(NativeFileReference.Identity)' != '' and !Exists(%(NativeFileReference.Identity))" />
+    <Error Condition="'$(WasmSingleFileBundle)' == 'true' and '$(WasmMainAssemblyFileName)' == ''" Text="%24(WasmMainAssemblyFileName) is not set" />
   </Target>
 
   <Target Name="_WasiWriteCompileRsp" BeforeTargets="_WasmWriteRspForCompilingNativeSourceFiles">
@@ -322,21 +320,21 @@
 
       <_WasmLinkDependencies Include="@(_WasiFilePathForFixup)" />
 
-      <_WasiSdkClangArgs Condition="'$(OS)' == 'Windows_NT'" Include="&quot;$([System.String]::new(%(_WasiFilePathForFixup.Identity)).Replace('\', '/'))&quot;" />
-      <_WasiSdkClangArgs Condition="'$(OS)' != 'Windows_NT'" Include="@(_WasiFilePathForFixup -> '&quot;%(Identity)&quot;')" />
+      <_WasiLinkStepArgs Condition="'$(OS)' == 'Windows_NT'" Include="&quot;$([System.String]::new(%(_WasiFilePathForFixup.Identity)).Replace('\', '/'))&quot;" />
+      <_WasiLinkStepArgs Condition="'$(OS)' != 'Windows_NT'" Include="@(_WasiFilePathForFixup -> '&quot;%(Identity)&quot;')" />
 
-      <_WasiSdkClangArgs Include="-Wl,--export=malloc,--export=free,--export=__heap_base,--export=__data_end" />
+      <_WasiLinkStepArgs Include="-Wl,--export=malloc,--export=free,--export=__heap_base,--export=__data_end" />
       <!-- keep in sync with src\mono\wasi\wasi.proj -->
-      <_WasiSdkClangArgs Include="-Wl,-z,stack-size=8388608,-lwasi-emulated-process-clocks,-lwasi-emulated-signal,-lwasi-emulated-mman"/>
-      <_WasiSdkClangArgs Include="-Wl,-s" Condition="'$(WasmNativeStrip)' == 'true'"/>
+      <_WasiLinkStepArgs Include="-Wl,-z,stack-size=8388608,-lwasi-emulated-process-clocks,-lwasi-emulated-signal,-lwasi-emulated-mman"/>
+      <_WasiLinkStepArgs Include="-Wl,-s" Condition="'$(WasmNativeStrip)' == 'true'"/>
 
-      <_WasiSdkClangArgs Include="&quot;@$(_WasmDefaultLinkFlagsRsp.Replace('\', '/'))&quot;" />
-      <_WasiSdkClangArgs Include="@(_WasiClangXLinkerFlags -> '-Xlinker %(Identity)', ' ')" />
-      <_WasiSdkClangArgs Include="@(_WasiClangLDFlags)" />
+      <_WasiLinkStepArgs Include="&quot;@$(_WasmDefaultLinkFlagsRsp.Replace('\', '/'))&quot;" />
+      <_WasiLinkStepArgs Include="@(_WasiClangXLinkerFlags -> '-Xlinker %(Identity)', ' ')" />
+      <_WasiLinkStepArgs Include="@(_WasiClangLDFlags)" />
 
-      <_WasiSdkClangArgs Include="-o &quot;$(_WasiOutputFileName.Replace('\', '/'))&quot;" />
+      <_WasiLinkStepArgs Include="-o &quot;$(_WasiOutputFileName.Replace('\', '/'))&quot;" />
 
-      <_WasmLinkStepArgs Include="@(_WasiSdkClangArgs)" />
+      <_WasmLinkStepArgs Include="@(_WasiLinkStepArgs)" />
     </ItemGroup>
   </Target>
 
@@ -351,6 +349,8 @@
 
     <Message Importance="High" Text="Performing WASI SDK build: &quot;$(WasiClang)&quot; &quot;$(_WasmLinkRsp)&quot;" />
     <Exec Command="&quot;$(WasiClang)&quot; &quot;@$(_WasmLinkRsp)&quot;" />
+
+    <CallTarget Targets="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'" />
 
     <!-- FIXME: this will be done by the bundler -->
     <Copy SourceFiles="$(_WasiOutputFileName)" DestinationFolder="$(WasmAppDir)" />
@@ -370,9 +370,7 @@
     <Error Condition="'$(_WasiOutputFileName)' == ''" Text="Could not determine $(_WasiOutputFileName)" />
   </Target>
 
-  <Target Name="_CheckToolchainIsExpectedVersion">
-    <Message Text="** TODO: Implement wasiclang version check target" Importance="High" />
-  </Target>
+  <Target Name="_CheckToolchainIsExpectedVersion" />
 
   <Target Name="_GenerateRunWasmtimeScript">
     <PropertyGroup>

--- a/src/mono/wasi/build/WasiSdk.Defaults.props
+++ b/src/mono/wasi/build/WasiSdk.Defaults.props
@@ -7,4 +7,7 @@
 
     <WasiSdkBinPath>$([MSBuild]::NormalizeDirectory($(WasiSdkRoot), 'bin'))</WasiSdkBinPath>
   </PropertyGroup>
+  <ItemGroup>
+    <WasmToolchainEnvVars Include="PATH=$(WasiSdkBinPath)$(_PathSeparator)$([MSBuild]::Escape($(PATH)))" />
+  </ItemGroup>
 </Project>

--- a/src/mono/wasi/wasi.proj
+++ b/src/mono/wasi/wasi.proj
@@ -115,7 +115,7 @@
 
   <Target Name="GenerateWasiPropsAndRspFiles">
 
-    <!-- Generate wasi-props.json -->
+    <!-- Generate wasm-props.json -->
     <ItemGroup>
       <!-- TODOWASI
       <_WasiLinkFlags Include="-Wl, - - allow-undefined"/>
@@ -146,21 +146,18 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags, '%3B ') </_WasmOptConfigurationFlags>
       <_WasiPropsJson>
 <![CDATA[
 {
   "items": {
-    "WasmOptConfigurationFlags": [
-      { "identity": "WasmOptConfigurationFlags", "value": "$(_WasmOptConfigurationFlags)" }
-    ]
+    "WasmOptConfigurationFlags": [@(WasmOptConfigurationFlags -> '%22%(Identity)%22', ',')],
   }
 }
 ]]>
       </_WasiPropsJson>
     </PropertyGroup>
 
-    <WriteLinesToFile File="$(NativeBinDir)src\emcc-props.json"
+    <WriteLinesToFile File="$(NativeBinDir)src\wasm-props.json"
                       Lines="$(_WasiPropsJson)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
@@ -266,7 +263,7 @@
     <ItemGroup>
       <IcuDataFiles Include="$(NativeBinDir)*.dat" />
       <WasmSrcFiles Include="$(NativeBinDir)src\*.c;" />
-      <WasmSrcFiles Include="$(_WasiDefaultsRspPath);$(_WasiCompileRspPath);$(_WasiLinkRspPath)" />
+      <WasmSrcFiles Include="$(_WasiDefaultsRspPath);$(_WasiCompileRspPath);$(_WasiLinkRspPath);$(NativeBinDir)src\wasm-props.json" />
       <WasmHeaderFiles Include="$(NativeBinDir)include\wasm\*.h" />
     </ItemGroup>
 

--- a/src/mono/wasm/build/BrowserWasmApp.targets
+++ b/src/mono/wasm/build/BrowserWasmApp.targets
@@ -10,11 +10,6 @@
   <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.WasmAppBuilder" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
 
   <PropertyGroup>
-    <PrepareInputsForWasmBuildDependsOn>
-      $(PrepareInputsForWasmBuildDependsOn);
-      _ReadEmccProps
-    </PrepareInputsForWasmBuildDependsOn>
-
     <PrepareForWasmBuildNativeDependsOn>
       _CheckToolchainIsExpectedVersion;
       _PrepareForBrowserWasmBuildNative;
@@ -545,33 +540,6 @@
 
     <Warning Condition="'$(RuntimeEmccVersionRaw)' != '$(ActualEmccVersionRaw)'" Text="$(_VersionMismatchMessage)" />
     <Error Condition="'$(RuntimeEmccVersionRaw)' != '$(ActualEmccVersionRaw)'" Text="$(_VersionMismatchMessage)" />
-  </Target>
-
-  <UsingTask TaskName="ReadEmccProps" AssemblyFile="$(MonoTargetsTasksAssemblyPath)"
-             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
-    <ParameterGroup>
-      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-      <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-      <EmccDefaultExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-      <EmccDefaultExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
-    </ParameterGroup>
-  </UsingTask>
-
-  <Target Name="_ReadEmccProps" Condition="'$(_IsToolchainMissing)' != 'true'">
-    <ReadEmccProps JsonFilePath="$(_WasmRuntimePackSrcDir)emcc-props.json">
-      <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
-      <Output TaskParameter="WasmOptConfigurationFlags" ItemName="_WasmOptConfigurationFlagsItems" />
-      <Output TaskParameter="EmccDefaultExportedFunctions" ItemName="EmccExportedFunction" />
-      <Output TaskParameter="EmccDefaultExportedRuntimeMethods" ItemName="EmccExportedRuntimeMethod" />
-    </ReadEmccProps>
-
-    <CreateProperty Value="%(_EmccPropItems.Value)">
-      <Output TaskParameter="Value" PropertyName="%(_EmccPropItems.Identity)" />
-    </CreateProperty>
-
-    <CreateProperty Value="%(_WasmOptConfigurationFlagsItems.Value)">
-      <Output TaskParameter="Value" PropertyName="%(_WasmOptConfigurationFlagsItems.Identity)" />
-    </CreateProperty>
   </Target>
 
   <Target Name="_CompleteWasmBuildNative" AfterTargets="WasmLinkDotNet">

--- a/src/mono/wasm/build/BrowserWasmApp.targets
+++ b/src/mono/wasm/build/BrowserWasmApp.targets
@@ -1,4 +1,10 @@
 <Project>
+  <PropertyGroup>
+    <!-- Post Wasm MVP features -->
+    <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">true</WasmEnableExceptionHandling>
+    <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">$(WasmEnableExceptionHandling)</WasmEnableSIMD>
+  </PropertyGroup>
+
   <Import Project="$(WasmCommonTargetsPath)WasmApp.Common.targets" />
 
   <UsingTask TaskName="Microsoft.WebAssembly.Build.Tasks.WasmAppBuilder" AssemblyFile="$(WasmAppBuilderTasksAssemblyPath)" />
@@ -27,9 +33,6 @@
       _WasmGenerateRunV8Script;
     </WasmGenerateAppBundleDependsOn>
 
-    <!-- Post Wasm MVP features -->
-    <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">true</WasmEnableExceptionHandling>
-    <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">$(WasmEnableExceptionHandling)</WasmEnableSIMD>
     <WasmEnableLegacyJsInterop Condition="'$(WasmEnableLegacyJsInterop)' == ''">true</WasmEnableLegacyJsInterop>
     <WasmEnableJsInteropByValue Condition="'$(WasmEnableJsInteropByValue)' == '' and ( '$(WasmEnableThreads)' == 'true' or '$(MonoWasmBuildVariant)' == 'multithread' )">true</WasmEnableJsInteropByValue>
     <WasmEnableJsInteropByValue Condition="'$(WasmEnableJsInteropByValue)' == ''">false</WasmEnableJsInteropByValue>
@@ -59,6 +62,8 @@
     <_WasmDefaultFlags Condition="'$(WasmEnableExceptionHandling)' == 'false'">-fexceptions</_WasmDefaultFlags>
     <_WasmDefaultFlags Condition="'$(WasmEnableExceptionHandling)' != 'false'">-fwasm-exceptions</_WasmDefaultFlags>
     <_WasmDefaultFlags Condition="'$(WasmEnableSIMD)' == 'true'">-msimd128</_WasmDefaultFlags>
+
+    <_WasmOutputFileName Condition="'$(WasmSingleFileBundle)' != 'true'">dotnet.native.wasm</_WasmOutputFileName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -208,15 +213,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <!-- semicolon is a msbuild property separator. It is also the path separator on windows.
-           So, we need to escape it here, so the paths don't get split up when converting
-           to string[] for passing to Exec task -->
-      <_PathSeparator Condition="'$(OS)' == 'Windows_NT'">%3B</_PathSeparator>
-      <_PathSeparator Condition="'$(OS)' != 'Windows_NT'">:</_PathSeparator>
-
       <_EmscriptenPrependPATHProperty>@(EmscriptenPrependPATH -> '%(Identity)', '$(_PathSeparator)')</_EmscriptenPrependPATHProperty>
     </PropertyGroup>
-
     <ItemGroup>
       <EmscriptenEnvVars Include="PATH=$(_EmscriptenPrependPATHProperty)$(_PathSeparator)$([MSBuild]::Escape($(PATH)))" />
 
@@ -246,6 +244,8 @@
       <_WasmDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-link.rsp'))</_WasmDefaultLinkFlagsRsp>
       <!--<_WasmLLVMPathForAOT>$(EmscriptenUpstreamBinPath)</_WasmLLVMPathForAOT>-->
       <WasmLinkIcalls Condition="'$(WasmLinkIcalls)' == ''">$(WasmBuildNative)</WasmLinkIcalls>
+      <WasmRunWasmOpt Condition="'$(WasmRunWasmOpt)' == '' and '$(WasmNativeStrip)' == 'true'">true</WasmRunWasmOpt>
+      <WasmRunWasmOpt Condition="'$(WasmRunWasmOpt)' == ''">false</WasmRunWasmOpt>
 
       <_WasmICallTablePath>$(_WasmIntermediateOutputPath)icall-table.h</_WasmICallTablePath>
       <_WasmRuntimeICallTablePath>$(_WasmIntermediateOutputPath)runtime-icall-table.h</_WasmRuntimeICallTablePath>
@@ -500,16 +500,7 @@
       <FileWrites Include="$(_WasmIntermediateOutputPath)dotnet.native.js.symbols" Condition="'$(WasmEmitSymbolMap)' == 'true'" />
     </ItemGroup>
 
-    <ItemGroup>
-      <!-- WasmOptConfigurationFlags property is set by reading from emcc-props.json -->
-      <WasmOptConfigurationFlags Condition="'$(WasmOptConfigurationFlags)' != ''" Include="$(WasmOptConfigurationFlags)" />
-    </ItemGroup>
-
-    <Message Text="Stripping symbols from dotnet.native.wasm ..." Importance="High" Condition="'$(WasmNativeStrip)' == 'true'" />
-    <Exec Command="wasm-opt$(_ExeExt) --enable-simd --enable-exception-handling @(WasmOptConfigurationFlags, ' ') --strip-dwarf &quot;$(_WasmIntermediateOutputPath)dotnet.native.wasm&quot; -o &quot;$(_WasmIntermediateOutputPath)dotnet.native.wasm&quot;"
-          Condition="'$(WasmNativeStrip)' == 'true'"
-          IgnoreStandardErrorWarningFormat="true"
-          EnvironmentVariables="@(EmscriptenEnvVars)" />
+    <CallTarget Targets="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'" />
 
     <OnError ExecuteTargets="_OnError_WasmLinkDotNet_UndefinedSymbols"
              Condition="'$(WasmAllowUndefinedSymbols)' != 'true' and '$(_EmccLinkStepExitCode)' != '0' and $([System.Text.RegularExpressions.Regex]::IsMatch($(_EmccLinkStepConsoleOutput), 'wasm-ld *: *error *:.*undefined symbol:'))" />

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -120,6 +120,7 @@
       _SetWasmNativeStripDefault;
       _GetDefaultWasmAssembliesToBundle;
       _WasmGetRuntimeConfigPath;
+      _ReadWasmProps;
     </PrepareInputsForWasmBuildDependsOn>
 
     <WasmGenerateAppBundleDependsOn>
@@ -130,13 +131,14 @@
     <!-- FIXME: TMP: added _PrepareForWasmBuildNative as it used by emsdk cache as beforeTargets -->
     <_WasmBuildNativeCoreDependsOn>
       $(_WasmBuildNativeCoreDependsOn);
-      _PrepareForWasmBuildNative;
+      _WasmCommonPrepareForWasmBuildNative;
       PrepareForWasmBuildNative;
       _ScanAssembliesDecideLightweightMarshaler;
       _WasmAotCompileApp;
       _WasmStripAOTAssemblies;
       _GenerateManagedToNative;
       WasmLinkDotNet;
+      WasmAfterLinkSteps;
     </_WasmBuildNativeCoreDependsOn>
 
     <WasmLinkDotNetDependsOn>
@@ -175,10 +177,20 @@
     <!-- if DebuggerSupport==true, then ensure that WasmDebugLevel isn't disabling debugging -->
     <WasmDebugLevel Condition="('$(WasmDebugLevel)' == '' or '$(WasmDebugLevel)' == '0') and ('$(DebuggerSupport)' == 'true' or '$(Configuration)' == 'Debug')">-1</WasmDebugLevel>
 
+    <!-- Post Wasm MVP features -->
+    <WasmEnableExceptionHandling Condition="'$(WasmEnableExceptionHandling)' == ''">false</WasmEnableExceptionHandling>
+    <WasmEnableSIMD Condition="'$(WasmEnableSIMD)' == ''">false</WasmEnableSIMD>
+
     <WasmStripAOTAssemblies>false</WasmStripAOTAssemblies>
     <WasmSingleFileBundle Condition="'$(WasmSingleFileBundle)' == ''">false</WasmSingleFileBundle>
     <WasmStripILAfterAOT Condition="'$(WasmStripILAfterAOT)' == ''">true</WasmStripILAfterAOT>
     <WasmRuntimeAssetsLocation Condition="'$(WasmRuntimeAssetsLocation)' == ''">_framework</WasmRuntimeAssetsLocation>
+
+    <!-- semicolon is a msbuild property separator. It is also the path separator on windows.
+         So, we need to escape it here, so the paths don't get split up when converting
+         to string[] for passing to Exec task -->
+    <_PathSeparator Condition="'$(OS)' == 'Windows_NT'">%3B</_PathSeparator>
+    <_PathSeparator Condition="'$(OS)' != 'Windows_NT'">:</_PathSeparator>
   </PropertyGroup>
 
   <ItemGroup>
@@ -294,6 +306,12 @@
       <WasmMainAssemblyFileName Condition="'$(WasmMainAssemblyFileName)' != ''">$([System.IO.Path]::GetFileName($(WasmMainAssemblyFileName)))</WasmMainAssemblyFileName>
 
       <WasmAppDir>$([MSBuild]::NormalizeDirectory($(WasmAppDir)))</WasmAppDir>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(WasmMainAssemblyFileName)' != '' and '$(_WasmOutputFileName)' == ''">
+      <_WasmOutputFileName Condition="'$(WasmSingleFileBundle)' == 'true'">$([System.IO.Path]::GetFileNameWithoutExtension('$(WasmMainAssemblyFileName)')).wasm</_WasmOutputFileName>
+      <_WasmOutputFileName Condition="'$(WasmSingleFileBundle)' != 'true'">dotnet.wasm</_WasmOutputFileName>
+      <_WasmOutputFileName Condition="'$(_WasmOutputFileName)' != ''">$([System.IO.Path]::Combine($(_WasiIntermediateOutputPath), $(_WasmOutputFileName)))</_WasmOutputFileName>
     </PropertyGroup>
 
     <MakeDir Directories="$(_WasmIntermediateOutputPath)" />
@@ -849,5 +867,15 @@
   </Target>
 
   <Target Name="WasmLinkDotNet" DependsOnTargets="$(WasmLinkDotNetDependsOn)" Condition="'$(WasmBuildNative)' == 'true'" />
-  <Target Name="_PrepareForWasmBuildNative" />
+
+  <Target Name="WasmAfterLinkSteps" DependsOnTargets="$(WasmAfterLinkStepsDependsOn)" Condition="'$(WasmBuildNative)' == 'true'" />
+
+  <Target Name="_RunWasmOptPostLink" Condition="'$(WasmRunWasmOpt)' == 'true'">
+    <Error Condition="'$(_WasmOutputFileName)' == ''" Text="Could not determine %24(_WasmOutputFileName)" />
+
+    <Exec Command="wasm-opt$(_ExeExt) @(WasmOptConfigurationFlags, ' ') &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot; -o &quot;$(_WasmIntermediateOutputPath)$(_WasmOutputFileName)&quot;"
+          IgnoreStandardErrorWarningFormat="true"
+          EnvironmentVariables="@(WasmToolchainEnvVars)" />
+  </Target>
+
 </Project>

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -376,6 +376,31 @@
     </ItemGroup>
   </Target>
 
+  <UsingTask TaskName="ReadWasmProps" AssemblyFile="$(MonoTargetsTasksAssemblyPath)"
+             TaskFactory="JsonToItemsTaskFactory.JsonToItemsTaskFactory">
+    <ParameterGroup>
+      <EmccProperties ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <WasmOptConfigurationFlags ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccDefaultExportedFunctions ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+      <EmccDefaultExportedRuntimeMethods ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" Output="true" />
+    </ParameterGroup>
+  </UsingTask>
+
+  <Target Name="_ReadWasmProps" Condition="'$(_IsToolchainMissing)' != 'true'">
+    <ReadWasmProps JsonFilePath="$(_WasmRuntimePackSrcDir)wasm-props.json">
+      <Output TaskParameter="EmccProperties" ItemName="_EmccPropItems" />
+      <Output TaskParameter="EmccDefaultExportedFunctions" ItemName="EmccExportedFunction" />
+      <Output TaskParameter="EmccDefaultExportedRuntimeMethods" ItemName="EmccExportedRuntimeMethod" />
+
+      <!-- shared by browser/wasi -->
+      <Output TaskParameter="WasmOptConfigurationFlags" ItemName="_DefaulWasmOptConfigurationFlags" />
+    </ReadWasmProps>
+
+    <CreateProperty Value="%(_EmccPropItems.Value)" Condition="%(_EmccPropItems.Identity) != ''">
+      <Output TaskParameter="Value" PropertyName="%(_EmccPropItems.Identity)" />
+    </CreateProperty>
+  </Target>
+
   <Target Name="WasmGenerateAppBundle" DependsOnTargets="$(WasmGenerateAppBundleDependsOn)" Condition="'$(WasmGenerateAppBundle)' == 'true'" />
 
   <Target Name="_WasmGenerateRuntimeConfig"
@@ -447,6 +472,17 @@
     <ItemGroup>
       <WasmAssembliesFinal Include="@(_WasmAssembliesInternal)" LlvmBitCodeFile="" />
       <WasmAssembliesFinal Include="@(_WasmSatelliteAssemblies)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_WasmCommonPrepareForWasmBuildNative" Condition="'$(WasmBuildNative)' == 'true'">
+    <ItemGroup>
+      <WasmOptConfigurationFlags Include="--enable-simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
+      <WasmOptConfigurationFlags Include="--enable-exception-handling" Condition="'$(WasmExceptionHandling)' == 'true'" />
+      <WasmOptConfigurationFlags Include="--strip-dwarf" Condition="'$(WasmNativeStrip)' == 'true'" />
+
+      <!-- WasmOptConfigurationFlags property is set by reading from wasm-props.json -->
+      <WasmOptConfigurationFlags Include="@(_DefaulWasmOptConfigurationFlags)" />
     </ItemGroup>
   </Target>
 

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -152,7 +152,7 @@
 
   <Target Name="GenerateEmccPropsAndRspFiles">
 
-    <!-- Generate emcc-props.json -->
+    <!-- Generate wasm-props.json -->
 
     <RunWithEmSdkEnv Command="$(EmccCmd) --version"
           ConsoleToMsBuild="true"
@@ -312,7 +312,6 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <_WasmOptConfigurationFlags>@(WasmOptConfigurationFlags, '%3B ') </_WasmOptConfigurationFlags>
       <_EmccPropsJson>
 <![CDATA[
 {
@@ -322,9 +321,7 @@
       { "identity": "RuntimeEmccVersionRaw",  "value": "$(_EmccVersionRaw)" },
       { "identity": "RuntimeEmccVersionHash", "value": "$(_EmccVersionHash)" }
     ],
-    "WasmOptConfigurationFlags": [
-      { "identity": "WasmOptConfigurationFlags", "value": "$(_WasmOptConfigurationFlags)" }
-    ],
+    "WasmOptConfigurationFlags": [@(WasmOptConfigurationFlags -> '%22%(Identity)%22', ',')],
     "EmccDefaultExportedFunctions": [@(EmccExportedFunction -> '%22%(Identity)%22', ',')],
     "EmccDefaultExportedRuntimeMethods": [@(EmccExportedRuntimeMethod -> '%22%(Identity)%22', ',')]
   }
@@ -333,7 +330,7 @@
       </_EmccPropsJson>
     </PropertyGroup>
 
-    <WriteLinesToFile File="$(NativeBinDir)src\emcc-props.json"
+    <WriteLinesToFile File="$(NativeBinDir)src\wasm-props.json"
                       Lines="$(_EmccPropsJson)"
                       Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
@@ -471,7 +468,7 @@
                              $(_EmccDefaultsRspPath);
                              $(_EmccCompileRspPath);
                              $(_EmccLinkRspPath);
-                             $(NativeBinDir)src\emcc-props.json" />
+                             $(NativeBinDir)src\wasm-props.json" />
       <WasmSrcFilesEs6 Include="$(NativeBinDir)src\es6\*.js;" />
       <WasmHeaderFiles Include="$(NativeBinDir)include\wasm\*.h" />
     </ItemGroup>


### PR DESCRIPTION
This adds the build support but does not enable it by default which can be enabled with `$(WasmRunWasmOpt)=true`.
Also, a new `wasm-props.json` file is added to the `wasi` runtime pack. For `browser` this is `emcc-props.json` with a new name.

- [wasm/wasi] Add new wasm-props.json to the runtime pack
   For browser this is `emcc-props.json` renamed. And for wasi, it's a new
   file.
- [wasm/wasi] Extract target for running wasm-opt, and use for both browser, and wasi