### PR TITLE
Fix assert in BaseBucketParamsManager

### DIFF
--- a/src/coreclr/vm/dwbucketmanager.hpp
+++ b/src/coreclr/vm/dwbucketmanager.hpp
@@ -961,7 +961,7 @@ bool BaseBucketParamsManager::GetFileVersionInfoForModule(Module* pModule, USHOR
         if (!succeeded)
         {
             const SString& modulePath = pPEAssembly->GetPath();
-            _ASSERTE(modulePath.IsNormalized());
+            _ASSERTE(modulePath.IsEmpty() || modulePath.IsNormalized());
             succeeded = !modulePath.IsEmpty() && SUCCEEDED(DwGetFileVersionInfo(modulePath.GetUnicode(), major, minor, build, revision));
         }
     }


### PR DESCRIPTION
The assert was breaking couple of MDBG diagnostic tests. The modulePath was empty in that case and modulePath.IsNormalized() was returning false.