### PR TITLE
Sockets: update tests for Linux 6.6 fix.

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -137,9 +137,10 @@ namespace System.Net.Sockets.Tests
         [InlineData("[::ffff:1.1.1.1]", true, false)]
         public async Task ConnectGetsCanceledByDispose(string addressString, bool useDns, bool owning)
         {
-            if (UsesSync && PlatformDetection.IsLinux)
+            // Skip test on Linux kernels that may have a regression that was fixed in 6.6.
+            // See TcpReceiveSendGetsCanceledByDispose test for additional information.
+            if (UsesSync && PlatformDetection.IsLinux && Environment.OSVersion.Version < new Version(6, 6))
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1034,9 +1034,12 @@ namespace System.Net.Sockets.Tests
             // .NET uses connect(AF_UNSPEC) to abort on-going operations on Linux.
             // Linux 6.4+ introduced a change (4faeee0cf8a5d88d63cdbc3bab124fb0e6aed08c) which disallows
             // this operation while operations are on-going.
+            // Some distros backported the change to earlier kernel versions.
             // When the connect fails, .NET falls back to use shutdown(SHUT_RDWR).
             // This causes the receive on socket2 to succeed instead of failing with ConnectionReset.
-            bool mayShutdownGraceful = UsesSync && PlatformDetection.IsLinux && receiveOrSend;
+            // The original behavior was restored in Linux 6.6 (419ce133ab928ab5efd7b50b2ef36ddfd4eadbd2).
+            bool mayShutdownGraceful = UsesSync && receiveOrSend && (ipv6Server || dualModeClient) &&
+                                       PlatformDetection.IsLinux && Environment.OSVersion.Version < new Version(6, 6);
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens
             // before the operation is started, the peer won't see a ConnectionReset SocketException and we won't

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1038,7 +1038,7 @@ namespace System.Net.Sockets.Tests
             // When the connect fails, .NET falls back to use shutdown(SHUT_RDWR).
             // This causes the receive on socket2 to succeed instead of failing with ConnectionReset.
             // The original behavior was restored in Linux 6.6 (419ce133ab928ab5efd7b50b2ef36ddfd4eadbd2).
-            bool mayShutdownGraceful = UsesSync && receiveOrSend && (ipv6Server || dualModeClient) &&
+            bool mayShutdownGraceful = UsesSync && receiveOrSend &&
                                        PlatformDetection.IsLinux && Environment.OSVersion.Version < new Version(6, 6);
 
             // We try this a couple of times to deal with a timing race: if the Dispose happens

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TelemetryTest.cs
@@ -193,9 +193,10 @@ namespace System.Net.Sockets.Tests
         [MemberData(nameof(SocketMethods_WithBools_MemberData))]
         public void EventSource_SocketConnectFailure_LogsConnectFailed(string connectMethod, bool useDnsEndPoint)
         {
-            if (connectMethod == "Sync" && PlatformDetection.IsLinux)
+            // Skip test on Linux kernels that may have a regression that was fixed in 6.6.
+            // See TcpReceiveSendGetsCanceledByDispose test for additional information.
+            if (connectMethod == "Sync" && PlatformDetection.IsLinux && Environment.OSVersion.Version < new Version(6, 6))
             {
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/94149", TestPlatforms.Linux)]
                 return;
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94149.

@antonfirsov @liveans ptal.