### PR TITLE
[NativeAOT/Apple] Map the thunks using vm_allocate/vm_remap

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -127,10 +127,6 @@ The .NET Foundation licenses this file to you under the MIT license.
     </ItemGroup>
 
     <ItemGroup>
-      <ExtraLinkerArg Include="-segprot,__THUNKS,rx,rx" Condition="'$(_IsApplePlatform)' == 'true'" />
-    </ItemGroup>
-
-    <ItemGroup>
       <LinkerArg Include="-gz=zlib" Condition="'$(CompressSymbols)' != 'false'" />
       <LinkerArg Include="-fuse-ld=$(LinkerFlavor)" Condition="'$(LinkerFlavor)' != ''" />
       <LinkerArg Include="@(NativeLibrary)" />

--- a/src/coreclr/nativeaot/Runtime/PalRedhawk.h
+++ b/src/coreclr/nativeaot/Runtime/PalRedhawk.h
@@ -686,7 +686,7 @@ REDHAWK_PALIMPORT void REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_opt_ void* p
 REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalRegisterHijackCallback(_In_ PalHijackCallback callback);
 
 REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalAllocateThunksFromTemplate(_In_ HANDLE hTemplateModule, uint32_t templateRva, size_t templateSize, _Outptr_result_bytebuffer_(templateSize) void** newThunksOut);
-REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalFreeThunksFromTemplate(_In_ void *pBaseAddress);
+REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalFreeThunksFromTemplate(_In_ void *pBaseAddress, size_t templateSize);
 
 REDHAWK_PALIMPORT UInt32_BOOL REDHAWK_PALAPI PalMarkThunksAsValidCallTargets(
     void *virtualAddress,

--- a/src/coreclr/nativeaot/Runtime/amd64/ThunkPoolThunks.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/ThunkPoolThunks.S
@@ -38,21 +38,14 @@
 .endm
 
 #ifdef TARGET_APPLE
-    // Create two segments in the Mach-O file:
-    // __THUNKS with executable permissions
-    // __THUNKS_DATA with read/write permissions
-
-    .section __THUNKS,__thunks,regular,pure_instructions
+// Thunk pool
+    .text
     .p2align PAGE_SIZE_LOG2
 PATCH_LABEL ThunkPool
     .rept (THUNKS_MAP_SIZE / PAGE_SIZE)
     .p2align PAGE_SIZE_LOG2
     THUNKS_PAGE_BLOCK
     .endr
-    .p2align PAGE_SIZE_LOG2
-    .section __THUNKS_DATA,__thunks,regular
-    .p2align PAGE_SIZE_LOG2
-    .space THUNKS_MAP_SIZE
     .p2align PAGE_SIZE_LOG2
 #else
 #error Unsupported OS

--- a/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/ThunkPoolThunks.S
@@ -46,21 +46,14 @@
 .endm
 
 #ifdef TARGET_APPLE
-    // Create two segments in the Mach-O file:
-    // __THUNKS with executable permissions
-    // __THUNKS_DATA with read/write permissions
-
-    .section __THUNKS,__thunks,regular,pure_instructions
+// Thunk pool
+    .text
     .p2align PAGE_SIZE_LOG2
 PATCH_LABEL ThunkPool
     .rept (THUNKS_MAP_SIZE / PAGE_SIZE)
     .p2align PAGE_SIZE_LOG2
     THUNKS_PAGE_BLOCK
     .endr
-    .p2align PAGE_SIZE_LOG2
-    .section __THUNKS_DATA,__thunks,regular
-    .p2align PAGE_SIZE_LOG2
-    .space THUNKS_MAP_SIZE
     .p2align PAGE_SIZE_LOG2
 #else
 #error Unsupported OS

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -258,7 +258,7 @@ cleanup:
 #endif
 }
 
-REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalFreeThunksFromTemplate(_In_ void *pBaseAddress)
+REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalFreeThunksFromTemplate(_In_ void *pBaseAddress, size_t templateSize)
 {
 #ifdef XBOX_ONE
     return TRUE;


### PR DESCRIPTION
Map the thunks using vm_allocate/vm_remap to avoid need for specific executable segment layout.

Fixes #94655