### PR TITLE
[RISC-V] Fix 16 byte stack alignment in asm helpers.

### DIFF
--- a/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
@@ -256,7 +256,11 @@ C_FUNC(\Name\()_End):
 
     __PWTB_FloatArgumentRegisters = \extraLocals
 
-    .if ((__PWTB_FloatArgumentRegisters % 16) != 0)
+    // Note, stack (see __PWTB_StackAlloc variable) must be 16 byte aligned,
+    // SIZEOF__FloatArgumentRegisters (0x40) is 16 byte aligned, that mean initial
+    // __PWTB_FloatArgumentRegisters value must be not 16 byte aligned and
+    // after add (120 + 64) provide 16 byte aligned result.
+    .if ((__PWTB_FloatArgumentRegisters % 16) == 0)
         __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 8
     .endif
 

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -687,7 +687,7 @@ LEAF_END JIT_GetSharedGCStaticBaseNoCtor_SingleAppDomain, _TEXT
 // ------------------------------------------------------------------
 // Hijack function for functions which return a scalar type or a struct (value type)
 NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 0x88
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 0x90
 
     // Spill callee saved registers
     PROLOG_SAVE_REG_PAIR   s1, s2, 16
@@ -724,7 +724,7 @@ NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
     EPILOG_RESTORE_REG_PAIR   s7, s8, 64
     EPILOG_RESTORE_REG_PAIR   s9, s10, 80
     EPILOG_RESTORE_REG  s11, 96 
-    EPILOG_RESTORE_REG_PAIR_INDEXED  fp, ra, 0x88
+    EPILOG_RESTORE_REG_PAIR_INDEXED  fp, ra, 0x90
     EPILOG_RETURN
 NESTED_END OnHijackTripThread, _TEXT
 
@@ -756,7 +756,7 @@ NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler
     // a3 = address of the location where the SP of funclet's caller (i.e. this helper) should be saved.
     //
 
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 120, 0
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 128, 0
 
     // Spill callee saved registers
     PROLOG_SAVE_REG_PAIR   s1, s2, 16
@@ -796,7 +796,7 @@ NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler
     EPILOG_RESTORE_REG_PAIR   s11, gp, 96
     EPILOG_RESTORE_REG tp, 112
 
-    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, ra, 120 
+    EPILOG_RESTORE_REG_PAIR_INDEXED   fp, ra, 128
     EPILOG_RETURN
 NESTED_END CallEHFunclet, _TEXT
 


### PR DESCRIPTION
During CoreCLR Debug API testing with netcoredbg, I found, that in case of step/breakpoint inside `catch` block eval setup return `0x80131313` (`CORDBG_E_FUNC_EVAL_BAD_START_POINT`) error.
The code lines related to returned error is:
https://github.com/dotnet/runtime/blob/0a940f90ebc8465791870799dd496d1a524a5381/src/coreclr/debug/ee/debugger.cpp#L14971-L14976
that mean, inside `catch` block we have not 16 byte aligned stack (and this is wrong for sure, since we stop at breakpoint or step).
During investigation, I found asm helpers that make not 16 byte aligned stack and call with such stack other methods (that also have not 16 byte aligned stacks in this case).

Also please note, even if now all is ok with native code execution, we need 16 byte aligned stack, since in future we may have native code compiled with Q extension.

CC @clamp03 @wscho77 @HJLeee @JongHeonChoi @t-mustafin @gbalykov @brucehoult