### PR TITLE
[doc] HybridGlobalization, add not supported APIs

### DIFF
--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -20,18 +20,37 @@ Hybrid has higher priority than sharding or custom modes, described in globaliza
 **SortKey**
 
 Affected public APIs:
-- CompareInfo.GetSortKey
-- CompareInfo.GetSortKeyLength
-- CompareInfo.GetHashCode
+- System.Globalization.CompareInfo.GetSortKey
+- System.Globalization.CompareInfo.GetSortKeyLength
+- System.Globalization.CompareInfo.GetHashCode
+Indirectly affected APIs (the list might not be complete):
+- Microsoft.VisualBasic.Collection.Add
+- System.Collections.Hashtable.Add
+- System.Collections.Hashtable.GetHash
+- System.Collections.CaseInsensitiveHashCodeProvider.GetHashCode
+- System.Collections.Specialized.NameObjectCollectionBase.BaseAdd
+- System.Collections.Specialized.NameValueCollection.Add
+- System.Collections.Specialized.NameObjectCollectionBase.BaseGet
+- System.Collections.Specialized.NameValueCollection.Get
+- System.Collections.Specialized.NameObjectCollectionBase.BaseRemove
+- System.Collections.Specialized.NameValueCollection.Remove
+- System.Collections.Specialized.OrderedDictionary.Add
+- System.Collections.Specialized.NameObjectCollectionBase.BaseSet
+- System.Collections.Specialized.NameValueCollection.Set
+- System.Data.DataColumnCollection.Add
+- System.Collections.Generic.HashSet
+- System.Collections.Generic.Dictionary
+- System.Net.Mail.MailAddress.GetHashCode
+- System.Xml.Xsl.XslCompiledTransform.Transform
 
 Web API does not have an equivalent, so they throw `PlatformNotSupportedException`.
 
 **Case change**
 
 Affected public APIs:
-- TextInfo.ToLower,
-- TextInfo.ToUpper,
-- TextInfo.ToTitleCase.
+- System.Globalization.TextInfo.ToLower,
+- System.Globalization.TextInfo.ToUpper,
+- System.Globalization.TextInfo.ToTitleCase.
 
 Case change with invariant culture uses `toUpperCase` / `toLoweCase` functions that do not guarantee a full match with the original invariant culture.
 Hybrid case change, same as ICU-based, does not support code points expansion e.g. "straße" -> "STRAßE".
@@ -49,9 +68,26 @@ Dependencies:
 **String comparison**
 
 Affected public APIs:
-- CompareInfo.Compare,
-- String.Compare,
-- String.Equals.
+- System.Globalization.CompareInfo.Compare,
+- System.String.Compare,
+- System.String.Equals.
+Indirectly affected APIs (the list might not be complete):
+- Microsoft.VisualBasic.Strings.InStrRev
+- Microsoft.VisualBasic.Strings.Replace
+- Microsoft.VisualBasic.Strings.InStr
+- Microsoft.VisualBasic.Strings.Split
+- Microsoft.VisualBasic.Strings.StrComp
+- Microsoft.VisualBasic.CompilerServices.LikeOperator.LikeObject
+- Microsoft.VisualBasic.CompilerServices.LikeOperator.LikeString
+- Microsoft.VisualBasic.CompilerServices.ObjectType.ObjTst
+- Microsoft.VisualBasic.CompilerServices.ObjectType.LikeObj
+- Microsoft.VisualBasic.CompilerServices.StringType.StrLike
+- Microsoft.VisualBasic.CompilerServices.Operators.ConditionalCompareObjectEqual
+- Microsoft.VisualBasic.CompilerServices.StringType.StrLike
+- Microsoft.VisualBasic.CompilerServices.StringType.StrLikeText
+- Microsoft.VisualBasic.CompilerServices.StringType.StrCmp
+- System.Data.DataSet.ReadXml
+- System.Data.DataTableCollection.Add
 
 Dependencies:
 - [String.prototype.localeCompare()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare)


### PR DESCRIPTION
Follow up for https://github.com/dotnet/runtime/pull/95324#discussion_r1423097698. It will require a fix, there is too many public APIs that are throwing, especially among methods connected to collections. Connected issue: https://github.com/dotnet/runtime/issues/95921