### PR TITLE
Fix some BBF_NONE_QUIRK cases

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2222,8 +2222,6 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
         }
     }
 
-    /* set the right links */
-
     VarSetOps::AssignAllowUninitRhs(this, block->bbLiveOut, bNext->bbLiveOut);
 
     // Update the beginning and ending IL offsets (bbCodeOffs and bbCodeOffsEnd).
@@ -2294,11 +2292,6 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
             FALLTHROUGH;
 
         case BBJ_ALWAYS:
-            // Propagate BBF_NONE_QUIRK flag
-            block->CopyFlags(bNext, BBF_NONE_QUIRK);
-
-            FALLTHROUGH;
-
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
             block->SetKindAndTarget(bNext->GetKind(), bNext->GetTarget());
@@ -2345,6 +2338,17 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
     }
 
     assert(block->KindIs(bNext->GetKind()));
+
+    if (block->KindIs(BBJ_ALWAYS))
+    {
+        // Propagate BBF_NONE_QUIRK flag
+        block->CopyFlags(bNext, BBF_NONE_QUIRK);
+    }
+    else
+    {
+        // It's no longer a BBJ_ALWAYS; remove the BBF_NONE_QUIRK flag.
+        block->RemoveFlags(BBF_NONE_QUIRK);
+    }
 
     // If we're collapsing a block created after the dominators are
     // computed, copy block number the block and reuse dominator
@@ -6026,7 +6030,10 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                 if (bDest == bNext)
                 {
                     // Skip jump optimizations, and try to compact block and bNext later
-                    block->SetFlags(BBF_NONE_QUIRK);
+                    if (!block->isBBCallAlwaysPairTail())
+                    {
+                        block->SetFlags(BBF_NONE_QUIRK);
+                    }
                     bDest = nullptr;
                 }
             }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -302,7 +302,7 @@ BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
         bottom->SetFlags(originalFlags &
                          (BBF_SPLIT_GAINED | BBF_IMPORTED | BBF_GC_SAFE_POINT | BBF_LOOP_PREHEADER | BBF_RETLESS_CALL));
         bottom->inheritWeight(top);
-        poll->SetFlags(originalFlags & (BBF_SPLIT_GAINED | BBF_IMPORTED | BBF_GC_SAFE_POINT | BBF_NONE_QUIRK));
+        poll->SetFlags(originalFlags & (BBF_SPLIT_GAINED | BBF_IMPORTED | BBF_GC_SAFE_POINT));
 
         // Mark Poll as rarely run.
         poll->bbSetRunRarely();


### PR DESCRIPTION
Fix fgCompactBlocks to not propagate the BBF_NONE_QUIRK flag to non-BBJ_ALWAYS blocks.

Fix fgUpdateFlowGraph to not set BBF_NONE_QUIRK on the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair.

Remove explicit addition of BBF_NONE_QUIRK in a case using BBF_SPLIT_GAINED, as BBF_SPLIT_GAINED already has BBF_NONE_QUIRK.

There are a few diffs where fgReorderBlocks makes different decisions on this flag being in different places.