### PR TITLE
[NativeAOT] More filtering in EnumGcRefConservatively

### DIFF
--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -291,6 +291,7 @@ void MethodTable::InitializeAsGcFreeType()
 #endif // !DACCESS_COMPILE
 
 extern void GcEnumObject(PTR_OBJECTREF pObj, uint32_t flags, EnumGcRefCallbackFunc * fnGcEnumRef, EnumGcRefScanContext * pSc);
+extern void GcEnumObjectConservatively(PTR_PTR_Object ppObj, EnumGcRefCallbackFunc* fnGcEnumRef, EnumGcRefScanContext* pSc);
 extern void GcEnumObjectsConservatively(PTR_OBJECTREF pLowerBound, PTR_OBJECTREF pUpperBound, EnumGcRefCallbackFunc * fnGcEnumRef, EnumGcRefScanContext * pSc);
 extern void GcBulkEnumObjects(PTR_OBJECTREF pObjs, DWORD cObjs, EnumGcRefCallbackFunc * fnGcEnumRef, EnumGcRefScanContext * pSc);
 
@@ -356,7 +357,7 @@ void RedhawkGCInterface::EnumGcRef(PTR_RtuObjectRef pRef, GCRefKind kind, void *
 // static
 void RedhawkGCInterface::EnumGcRefConservatively(PTR_RtuObjectRef pRef, void* pfnEnumCallback, void* pvCallbackData)
 {
-    GcEnumObject((PTR_OBJECTREF)pRef, GC_CALL_INTERIOR | GC_CALL_PINNED, (EnumGcRefCallbackFunc*)pfnEnumCallback, (EnumGcRefScanContext*)pvCallbackData);
+    GcEnumObjectConservatively((PTR_OBJECTREF)pRef, (EnumGcRefCallbackFunc*)pfnEnumCallback, (EnumGcRefScanContext*)pvCallbackData);
 }
 
 #ifndef DACCESS_COMPILE


### PR DESCRIPTION
A simple change.

I was looking at profile differences between precise and conservative stack reporting and noticed that conservative does some unnecessary work. - Like reporting for relocation register roots that we have pinned, reporting refs that point to stack. 
That is valid, but redundant and adds some noise to the comparisons.
