### PR TITLE
[wasm] Tasks: Delete temp files

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -1101,8 +1101,8 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         Directory.CreateDirectory(Path.GetDirectoryName(outputFile)!);
 
-        string tmpAotModulesTablePath = Path.GetTempFileName();
-        using (var writer = File.CreateText(tmpAotModulesTablePath))
+        using TempFileName tmpAotModulesTablePath = new();
+        using (var writer = File.CreateText(tmpAotModulesTablePath.Path))
         {
             if (parsedAotModulesTableLanguage == MonoAotModulesTableLanguage.C)
             {
@@ -1165,7 +1165,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             }
         }
 
-        if (Utils.CopyIfDifferent(tmpAotModulesTablePath, outputFile, useHash: false))
+        if (Utils.CopyIfDifferent(tmpAotModulesTablePath.Path, outputFile, useHash: false))
         {
             _fileWrites.Add(outputFile);
             Log.LogMessage(MessageImportance.Low, $"Generated {outputFile}");

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.csproj
@@ -23,6 +23,7 @@
     <Compile Include="..\Common\FileCache.cs" />
     <Compile Include="..\Common\Utils.cs" />
     <Compile Include="..\Common\LogAsErrorException.cs" />
+    <Compile Include="..\Common\TempFileName.cs" />
     <Compile Include="$(RepoRoot)src\libraries\System.Private.CoreLib\src\System\Diagnostics\CodeAnalysis\NullableAttributes.cs" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/tasks/Common/TempFileName.cs
+++ b/src/tasks/Common/TempFileName.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+
+internal sealed class TempFileName : IDisposable
+{
+    public string Path { get; private set; }
+    public TempFileName() => Path = System.IO.Path.GetTempFileName();
+    public void Dispose() => File.Delete(Path);
+}

--- a/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/IcallTableGenerator.cs
@@ -46,21 +46,14 @@ internal sealed class IcallTableGenerator
     {
         if (outputPath != null)
         {
-            string tmpFileName = Path.GetTempFileName();
-            try
-            {
-                using (var w = File.CreateText(tmpFileName))
-                    EmitTable(w);
+            using TempFileName tmpFileName = new();
+            using (var w = File.CreateText(tmpFileName.Path))
+                EmitTable(w);
 
-                if (Utils.CopyIfDifferent(tmpFileName, outputPath, useHash: false))
-                    Log.LogMessage(MessageImportance.Low, $"Generating icall table to '{outputPath}'.");
-                else
-                    Log.LogMessage(MessageImportance.Low, $"Icall table in {outputPath} is unchanged.");
-            }
-            finally
-            {
-                File.Delete(tmpFileName);
-            }
+            if (Utils.CopyIfDifferent(tmpFileName.Path, outputPath, useHash: false))
+                Log.LogMessage(MessageImportance.Low, $"Generating icall table to '{outputPath}'.");
+            else
+                Log.LogMessage(MessageImportance.Low, $"Icall table in {outputPath} is unchanged.");
         }
 
         return _signatures;

--- a/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
+++ b/src/tasks/WasmAppBuilder/PInvokeTableGenerator.cs
@@ -42,24 +42,17 @@ internal sealed class PInvokeTableGenerator
         foreach (var module in pinvokeModules)
             modules[module] = module;
 
-        string tmpFileName = Path.GetTempFileName();
-        try
+        using TempFileName tmpFileName = new();
+        using (var w = File.CreateText(tmpFileName.Path))
         {
-            using (var w = File.CreateText(tmpFileName))
-            {
-                EmitPInvokeTable(w, modules, pinvokes);
-                EmitNativeToInterp(w, callbacks);
-            }
+            EmitPInvokeTable(w, modules, pinvokes);
+            EmitNativeToInterp(w, callbacks);
+        }
 
-            if (Utils.CopyIfDifferent(tmpFileName, outputPath, useHash: false))
-                Log.LogMessage(MessageImportance.Low, $"Generating pinvoke table to '{outputPath}'.");
-            else
-                Log.LogMessage(MessageImportance.Low, $"PInvoke table in {outputPath} is unchanged.");
-        }
-        finally
-        {
-            File.Delete(tmpFileName);
-        }
+        if (Utils.CopyIfDifferent(tmpFileName.Path, outputPath, useHash: false))
+            Log.LogMessage(MessageImportance.Low, $"Generating pinvoke table to '{outputPath}'.");
+        else
+            Log.LogMessage(MessageImportance.Low, $"PInvoke table in {outputPath} is unchanged.");
 
         return signatures;
     }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -131,11 +131,11 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         {
             if (UseWebcil)
             {
-                var tmpWebcil = Path.GetTempFileName();
-                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil, logger: Log);
+                using TempFileName tmpWebcil = new();
+                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: assembly, outputPath: tmpWebcil.Path, logger: Log);
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.Combine(runtimeAssetsPath, Path.ChangeExtension(Path.GetFileName(assembly), Utils.WebcilInWasmExtension));
-                if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+                if (Utils.CopyIfDifferent(tmpWebcil.Path, finalWebcil, useHash: true))
                     Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
                 else
                     Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
@@ -229,11 +229,11 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             Directory.CreateDirectory(cultureDirectory);
             if (UseWebcil)
             {
-                var tmpWebcil = Path.GetTempFileName();
-                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: args.fullPath, outputPath: tmpWebcil, logger: Log);
+                using TempFileName tmpWebcil = new();
+                var webcilWriter = Microsoft.WebAssembly.Build.Tasks.WebcilConverter.FromPortableExecutable(inputPath: args.fullPath, outputPath: tmpWebcil.Path, logger: Log);
                 webcilWriter.ConvertToWebcil();
                 var finalWebcil = Path.Combine(cultureDirectory, Path.ChangeExtension(name, Utils.WebcilInWasmExtension));
-                if (Utils.CopyIfDifferent(tmpWebcil, finalWebcil, useHash: true))
+                if (Utils.CopyIfDifferent(tmpWebcil.Path, finalWebcil, useHash: true))
                     Log.LogMessage(MessageImportance.Low, $"Generated {finalWebcil} .");
                 else
                     Log.LogMessage(MessageImportance.Low, $"Skipped generating {finalWebcil} as the contents are unchanged.");
@@ -371,8 +371,8 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             };
         }
 
-        string tmpMonoConfigPath = Path.GetTempFileName();
-        using (var sw = File.CreateText(tmpMonoConfigPath))
+        using TempFileName tmpMonoConfigPath = new();
+        using (var sw = File.CreateText(tmpMonoConfigPath.Path))
         {
             helper.ComputeResourcesHash(bootConfig);
 
@@ -381,7 +381,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         }
 
         string monoConfigPath = Path.Combine(runtimeAssetsPath, "blazor.boot.json"); // TODO: Unify with Wasm SDK
-        Utils.CopyIfDifferent(tmpMonoConfigPath, monoConfigPath, useHash: false);
+        Utils.CopyIfDifferent(tmpMonoConfigPath.Path, monoConfigPath, useHash: false);
         _fileWrites.Add(monoConfigPath);
 
         foreach (ITaskItem item in ExtraFilesToDeploy!)

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="..\Common\Utils.cs" />
     <Compile Include="..\Common\LogAsErrorException.cs" />
+    <Compile Include="..\Common\TempFileName.cs" />
     <Compile Include="..\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\BootJsonData.cs" />
     <Compile Include="..\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\BootJsonBuilderHelper.cs" />
 


### PR DESCRIPTION
Prompted by https://github.com/dotnet/runtime/issues/95933 . The original issue of running out of temporary names was fixed in .net8 . But these files should be cleaned up anyway, and it makes it slower to find new names as the number of existing ones on disk grow.