### PR TITLE
SuperPMI: Skip 'aotsdk' assemblies for collections in non-nativeaot runs

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -843,6 +843,9 @@ class SuperPMICollect:
                 def filter_file(file):
                     if self.coreclr_args.nativeaot:
                         extensions = [".ilc.rsp"]
+                    # Skip assemblies in the 'aotsdk' folder when not running 'nativeaot'.
+                    elif "aotsdk" in file.lower():
+                        return False
                     else:
                         extensions = [".dll", ".exe"]
                     return any(file.endswith(extension) for extension in extensions) and (self.exclude is None or not any(e.lower() in file.lower() for e in self.exclude))

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -844,7 +844,7 @@ class SuperPMICollect:
                     if self.coreclr_args.nativeaot:
                         extensions = [".ilc.rsp"]
                     # Skip assemblies in the 'aotsdk' folder when not running 'nativeaot'.
-                    elif "aotsdk" in file.lower():
+                    elif os.path.dirname(file.lower()).endswith("aotsdk"):
                         return False
                     else:
                         extensions = [".dll", ".exe"]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93846

SuperPMI crossgen2 was hanging on linux when trying to crossgen `aotsdk/System.Private.TypeLoader.dll`. No error gets reported, it just freezes. The reason why it freezes is unknown, but it can be resolved if the nativeaot assemblies are referenced properly when doing the crossgen.

The `aotsdk` assemblies were recently added as part of the tests output in https://github.com/dotnet/runtime/pull/91037 - so that's the reason why this started failing.

There were two options to solve this:
1. Reference the nativeaot assemblies when doing crossgen2 if we encounter one of the assemblies in the `aotsdk` folder.
2. Simply skip assemblies in the `aotsdk` folder when doing non-nativeaot collections.

I chose **2** as to not make referencing assemblies in crossgen2 more complicated for collections.