### PR TITLE
Introduce BBJ_CALLFINALLYRET block kind

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -21,7 +21,7 @@ Documentation for VS debugger format specifiers: https://docs.microsoft.com/en-u
   </Type>
 
   <Type Name="BasicBlock">
-    <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
+    <DisplayString Condition="bbKind==BBJ_COND || bbKind==BBJ_ALWAYS || bbKind==BBJ_LEAVE || bbKind==BBJ_EHCATCHRET || bbKind==BBJ_CALLFINALLY || bbKind==BBJ_CALLFINALLYRET || bbKind==BBJ_EHFILTERRET">BB{bbNum,d}->BB{bbTarget->bbNum,d}; {bbKind,en}</DisplayString>
     <DisplayString Condition="bbKind==BBJ_SWITCH">BB{bbNum,d}; {bbKind,en}; {bbSwtTargets->bbsCount} cases</DisplayString>
     <DisplayString Condition="bbKind==BBJ_EHFINALLYRET">BB{bbNum,d}; {bbKind,en}; {bbEhfTargets->bbeCount} succs</DisplayString>
     <DisplayString>BB{bbNum,d}; {bbKind,en}</DisplayString>

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -2144,6 +2144,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
+    assert(block->KindIs(BBJ_CALLFINALLY));
+
     // Generate a call to the finally, like this:
     //      mov         x0,qword ptr [fp + 10H] / sp    // Load x0 with PSPSym, or sp if PSPSym is not used
     //      bl          finally-funclet
@@ -2173,6 +2175,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         {
             instGen(INS_BREAKPOINT); // This should never get executed
         }
+
+        return block;
     }
     else
     {
@@ -2181,10 +2185,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetTarget();
+        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
 
         // Now go to where the finally funclet needs to return to.
-        if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
+        if (nextBlock->NextIs(finallyContinuation) && !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
         {
             // Fall-through.
             // TODO-ARM64-CQ: Can we get rid of this instruction, and just have the call return directly
@@ -2194,22 +2198,13 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-            inst_JMP(EJ_jmp, jumpDest);
+            inst_JMP(EJ_jmp, finallyContinuation);
         }
 
         GetEmitter()->emitEnableGC();
-    }
 
-    // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbTarget - that is already used to point
-    // to the finally block. So just skip past the BBJ_ALWAYS unless the
-    // block is RETLESS.
-    if (!block->HasFlag(BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
-        block = nextBlock;
+        return nextBlock;
     }
-    return block;
 }
 
 void CodeGen::genEHCatchRet(BasicBlock* block)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -378,8 +378,7 @@ void CodeGen::genMarkLabelsForCodegen()
     {
         switch (block->GetKind())
         {
-            case BBJ_ALWAYS: // This will also handle the BBJ_ALWAYS of a BBJ_CALLFINALLY/BBJ_ALWAYS pair.
-            {
+            case BBJ_ALWAYS:
                 // If we can skip this jump, don't create a label for the target
                 if (block->CanRemoveJumpToNext(compiler))
                 {
@@ -387,7 +386,7 @@ void CodeGen::genMarkLabelsForCodegen()
                 }
 
                 FALLTHROUGH;
-            }
+
             case BBJ_EHCATCHRET:
                 JITDUMP("  " FMT_BB " : branch target\n", block->GetTarget()->bbNum);
                 block->GetTarget()->SetFlags(BBF_HAS_LABEL);
@@ -401,7 +400,7 @@ void CodeGen::genMarkLabelsForCodegen()
             case BBJ_SWITCH:
                 for (BasicBlock* const bTarget : block->SwitchTargets())
                 {
-                    JITDUMP("  " FMT_BB " : branch target\n", bTarget->bbNum);
+                    JITDUMP("  " FMT_BB " : switch target\n", bTarget->bbNum);
                     bTarget->SetFlags(BBF_HAS_LABEL);
                 }
                 break;
@@ -413,12 +412,12 @@ void CodeGen::genMarkLabelsForCodegen()
 
 #if FEATURE_EH_CALLFINALLY_THUNKS
                 {
-                    // For callfinally thunks, we need to mark the block following the callfinally/always pair,
+                    // For callfinally thunks, we need to mark the block following the callfinally/callfinallyret pair,
                     // as that's needed for identifying the range of the "duplicate finally" region in EH data.
                     BasicBlock* bbToLabel = block->Next();
-                    if (block->isBBCallAlwaysPair())
+                    if (block->isBBCallFinallyPair())
                     {
-                        bbToLabel = bbToLabel->Next(); // skip the BBJ_ALWAYS
+                        bbToLabel = bbToLabel->Next(); // skip the BBJ_CALLFINALLYRET
                     }
                     if (bbToLabel != nullptr)
                     {
@@ -430,9 +429,14 @@ void CodeGen::genMarkLabelsForCodegen()
 
                 break;
 
+            case BBJ_CALLFINALLYRET:
+                JITDUMP("  " FMT_BB " : finally continuation\n", block->GetFinallyContinuation()->bbNum);
+                block->GetFinallyContinuation()->SetFlags(BBF_HAS_LABEL);
+                break;
+
             case BBJ_EHFINALLYRET:
             case BBJ_EHFAULTRET:
-            case BBJ_EHFILTERRET:
+            case BBJ_EHFILTERRET: // The filter-handler will get marked when processing the EH handlers, below.
             case BBJ_RETURN:
             case BBJ_THROW:
                 break;
@@ -2559,12 +2563,12 @@ void CodeGen::genReportEH()
 
                 hndBeg = compiler->ehCodeOffset(block);
 
-                // How big is it? The BBJ_ALWAYS has a null bbEmitCookie! Look for the block after, which must be
-                // a label or jump target, since the BBJ_CALLFINALLY doesn't fall through.
+                // How big is it? The BBJ_CALLFINALLYRET has a null bbEmitCookie! Look for the block after, which must
+                // be a label or jump target, since the BBJ_CALLFINALLY doesn't fall through.
                 BasicBlock* bbLabel = block->Next();
-                if (block->isBBCallAlwaysPair())
+                if (block->isBBCallFinallyPair())
                 {
-                    bbLabel = bbLabel->Next(); // skip the BBJ_ALWAYS
+                    bbLabel = bbLabel->Next(); // skip the BBJ_CALLFINALLYRET
                 }
                 if (bbLabel == nullptr)
                 {

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -543,7 +543,7 @@ void CodeGen::genCodeForBBlist()
         /* Is this the last block, and are there any open scopes left ? */
 
         bool isLastBlockProcessed;
-        if (block->isBBCallAlwaysPair())
+        if (block->isBBCallFinallyPair())
         {
             isLastBlockProcessed = block->Next()->IsLast();
         }
@@ -814,7 +814,7 @@ void CodeGen::genCodeForBBlist()
             // and 16 bytes for arm64.
 
             assert(ShouldAlignLoops());
-            assert(!block->isBBCallAlwaysPairTail());
+            assert(!block->isBBCallFinallyPairTail());
 #if FEATURE_EH_CALLFINALLY_THUNKS
             assert(!block->KindIs(BBJ_CALLFINALLY));
 #endif // FEATURE_EH_CALLFINALLY_THUNKS

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1504,6 +1504,8 @@ void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
 
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
 {
+    assert(block->KindIs(BBJ_CALLFINALLY));
+
     // Generate a call to the finally, like this:
     //      mov  a0,qword ptr [fp + 10H] / sp    // Load a0 with PSPSym, or sp if PSPSym is not used
     //      bl  finally-funclet
@@ -1533,6 +1535,8 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         {
             instGen(INS_break); // This should never get executed
         }
+
+        return block;
     }
     else
     {
@@ -1541,10 +1545,10 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         // handler.  So turn off GC reporting for this single instruction.
         GetEmitter()->emitDisableGC();
 
-        BasicBlock* const jumpDest = nextBlock->GetTarget();
+        BasicBlock* const finallyContinuation = nextBlock->GetFinallyContinuation();
 
         // Now go to where the finally funclet needs to return to.
-        if (nextBlock->NextIs(jumpDest) && !compiler->fgInDifferentRegions(nextBlock, jumpDest))
+        if (nextBlock->NextIs(finallyContinuation) && !compiler->fgInDifferentRegions(nextBlock, finallyContinuation))
         {
             // Fall-through.
             // TODO-LOONGARCH64-CQ: Can we get rid of this instruction, and just have the call return directly
@@ -1554,22 +1558,13 @@ BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
         }
         else
         {
-            inst_JMP(EJ_jmp, jumpDest);
+            inst_JMP(EJ_jmp, finallyContinuation);
         }
 
         GetEmitter()->emitEnableGC();
-    }
 
-    // The BBJ_ALWAYS is used because the BBJ_CALLFINALLY can't point to the
-    // jump target using bbTarget - that is already used to point
-    // to the finally block. So just skip past the BBJ_ALWAYS unless the
-    // block is RETLESS.
-    if (!block->HasFlag(BBF_RETLESS_CALL))
-    {
-        assert(block->isBBCallAlwaysPair());
-        block = nextBlock;
+        return nextBlock;
     }
-    return block;
 }
 
 void CodeGen::genEHCatchRet(BasicBlock* block)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4530,6 +4530,11 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         return;
     }
 
+    // Convert BBJ_CALLFINALLY/BBJ_ALWAYS pairs to BBJ_CALLFINALLY/BBJ_CALLFINALLYRET.
+    // Temporary: eventually, do this immediately in impImportLeave
+    //
+    DoPhase(this, PHASE_UPDATE_CALLFINALLY, &Compiler::fgUpdateCallFinally);
+
     // If instrumenting, add block and class probes.
     //
     if (compileFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))
@@ -5348,7 +5353,7 @@ void Compiler::optIdentifyLoopsForAlignment(FlowGraphNaturalLoops* loops, BlockT
             if (top->Prev()->KindIs(BBJ_CALLFINALLY))
             {
                 // It must be a retless BBJ_CALLFINALLY if we get here.
-                assert(!top->Prev()->isBBCallAlwaysPair());
+                assert(!top->Prev()->isBBCallFinallyPair());
 
                 // If the block before the loop start is a retless BBJ_CALLFINALLY
                 // with FEATURE_EH_CALLFINALLY_THUNKS, we can't add alignment
@@ -5361,10 +5366,10 @@ void Compiler::optIdentifyLoopsForAlignment(FlowGraphNaturalLoops* loops, BlockT
             }
 #endif // FEATURE_EH_CALLFINALLY_THUNKS
 
-            if (top->Prev()->isBBCallAlwaysPairTail())
+            if (top->Prev()->isBBCallFinallyPairTail())
             {
-                // If the previous block is the BBJ_ALWAYS of a
-                // BBJ_CALLFINALLY/BBJ_ALWAYS pair, then we can't add alignment
+                // If the previous block is the BBJ_CALLFINALLYRET of a
+                // BBJ_CALLFINALLY/BBJ_CALLFINALLYRET pair, then we can't add alignment
                 // because we can't add instructions in that block. In the
                 // FEATURE_EH_CALLFINALLY_THUNKS case, it would affect the
                 // reported EH, as above.
@@ -5478,9 +5483,8 @@ PhaseStatus Compiler::placeLoopAlignInstructions()
             }
         }
 
-        // If there is an unconditional jump (which is not part of callf/always pair, and isn't to the next block)
-        if (opts.compJitHideAlignBehindJmp && block->KindIs(BBJ_ALWAYS) && !block->isBBCallAlwaysPairTail() &&
-            !block->HasFlag(BBF_NONE_QUIRK))
+        // If there is an unconditional jump (which isn't to the next block)
+        if (opts.compJitHideAlignBehindJmp && block->KindIs(BBJ_ALWAYS) && !block->HasFlag(BBF_NONE_QUIRK))
         {
             // Track the lower weight blocks
             if (block->bbWeight < minBlockSoFar)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5198,6 +5198,8 @@ public:
 
     PhaseStatus fgImport();
 
+    PhaseStatus fgUpdateCallFinally();
+
     PhaseStatus fgTransformIndirectCalls();
 
     PhaseStatus fgTransformPatchpoints();
@@ -5983,7 +5985,9 @@ public:
 
     void fgUnlinkRange(BasicBlock* bBeg, BasicBlock* bEnd);
 
-    void fgRemoveBlock(BasicBlock* block, bool unreachable);
+    BasicBlock* fgRemoveBlock(BasicBlock* block, bool unreachable);
+
+    void fgPrepareCallFinallyRetForRemoval(BasicBlock* block);
 
     bool fgCanCompactBlocks(BasicBlock* block, BasicBlock* bNext);
 
@@ -7201,10 +7205,6 @@ protected:
 
     // Adds "elemType" to the set of modified array element types of "loop" and any parent loops.
     void AddModifiedElemTypeAllContainingLoops(FlowGraphNaturalLoop* loop, CORINFO_CLASS_HANDLE elemType);
-
-    // Requires that "from" and "to" have the same "bbKind" (perhaps because "to" is a clone
-    // of "from".)  Copies the jump destination from "from" to "to".
-    void optCopyBlkDest(BasicBlock* from, BasicBlock* to);
 
     // Returns true if 'block' is an entry block for any loop in 'optLoopTable'
     bool optIsLoopEntry(BasicBlock* block) const;

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -25,6 +25,7 @@
 //                                                                                                measureIR
 CompPhaseNameMacro(PHASE_PRE_IMPORT,                 "Pre-import",                     false, -1, false)
 CompPhaseNameMacro(PHASE_IMPORTATION,                "Importation",                    false, -1, true)
+CompPhaseNameMacro(PHASE_UPDATE_CALLFINALLY,         "Update callfinally/always pairs",false, -1, true)
 CompPhaseNameMacro(PHASE_INDXCALL,                   "Indirect call transform",        false, -1, true)
 CompPhaseNameMacro(PHASE_PATCHPOINTS,                "Expand patchpoints",             false, -1, true)
 CompPhaseNameMacro(PHASE_POST_IMPORT,                "Post-import",                    false, -1, false)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -358,37 +358,24 @@ void Compiler::fgConvertBBToThrowBB(BasicBlock* block)
     assert(fgPredsComputed);
 
     // Ordering of the following operations matters.
-    // First, note if we are looking at the first block of a call always pair.
-    const bool isCallAlwaysPair = block->isBBCallAlwaysPair();
+    // First, if we are looking at the first block of a callfinally pair, remove the pairing.
+    // Don't actually remove the BBJ_CALLFINALLYRET as that might affect block iteration in
+    // the callers.
+    if (block->isBBCallFinallyPair())
+    {
+        BasicBlock* const leaveBlock = block->Next();
+        fgPrepareCallFinallyRetForRemoval(leaveBlock);
+    }
 
     // Scrub this block from the pred lists of any successors
     fgRemoveBlockAsPred(block);
 
     // Update jump kind after the scrub.
     block->SetKindAndTarget(BBJ_THROW);
+    block->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
     // Any block with a throw is rare
     block->bbSetRunRarely();
-
-    // If we've converted a BBJ_CALLFINALLY block to a BBJ_THROW block,
-    // then mark the subsequent BBJ_ALWAYS block as unreferenced.
-    //
-    // Must do this after we update bbKind of block.
-    if (isCallAlwaysPair)
-    {
-        BasicBlock* leaveBlk = block->Next();
-        noway_assert(leaveBlk->KindIs(BBJ_ALWAYS));
-
-        leaveBlk->RemoveFlags(BBF_DONT_REMOVE);
-
-        // leaveBlk is now unreachable, so scrub the pred lists.
-        for (BasicBlock* const leavePredBlock : leaveBlk->PredBlocks())
-        {
-            fgRemoveEhfSuccessor(leavePredBlock, leaveBlk);
-        }
-        assert(leaveBlk->bbRefs == 0);
-        assert(leaveBlk->bbPreds == nullptr);
-    }
 }
 
 /*****************************************************************************
@@ -556,7 +543,9 @@ void Compiler::fgChangeEhfBlock(BasicBlock* oldBlock, BasicBlock* newBlock)
 //------------------------------------------------------------------------
 // fgReplaceEhfSuccessor: update BBJ_EHFINALLYRET block so that all control
 //   that previously flowed to oldSucc now flows to newSucc. It is assumed
-//   that oldSucc is currently a successor of `block`.
+//   that oldSucc is currently a successor of `block`. We only allow a successor
+//   block to appear once in the successor list. Thus, if the new successor
+//   already exists in the list, we simply remove the old successor.
 //
 // Arguments:
 //   block   - BBJ_EHFINALLYRET block
@@ -575,39 +564,50 @@ void Compiler::fgReplaceEhfSuccessor(BasicBlock* block, BasicBlock* oldSucc, Bas
     const unsigned     succCount = ehfDesc->bbeCount;
     BasicBlock** const succTab   = ehfDesc->bbeSuccs;
 
-    // Walk the successor table looking for blocks to update the preds for
-    bool      found   = false;
-    FlowEdge* newEdge = nullptr;
+    // Walk the successor table looking for the old successor, which we expect to find.
+    unsigned oldSuccNum = UINT_MAX;
+    unsigned newSuccNum = UINT_MAX;
     for (unsigned i = 0; i < succCount; i++)
     {
-        if (succTab[i] != oldSucc)
+        if (succTab[i] == newSucc)
         {
-            continue;
+            newSuccNum = i;
         }
 
-        found = true;
-
-        // Change the succTab entry to branch to the new location
-        //
-        succTab[i] = newSucc;
-
-        if (newEdge == nullptr)
+        if (succTab[i] == oldSucc)
         {
-            // Remove the old edge [block => oldSucc]
-            //
-            fgRemoveAllRefPreds(oldSucc, block);
-
-            // Create the new edge [block => newSucc]
-            //
-            newEdge = fgAddRefPred(newSucc, block);
-        }
-        else
-        {
-            newSucc->bbRefs++;
-            newEdge->incrementDupCount();
+            oldSuccNum = i;
         }
     }
-    noway_assert(found && "Did not find oldSucc in succTab[]");
+
+    noway_assert((oldSuccNum != UINT_MAX) && "Did not find oldSucc in succTab[]");
+
+    if (newSuccNum != UINT_MAX)
+    {
+        // The new successor is already in the table; simply remove the old one.
+        fgRemoveEhfSuccessor(block, oldSucc);
+
+        JITDUMP("Remove existing BBJ_EHFINALLYRET " FMT_BB " successor " FMT_BB "; replacement successor " FMT_BB
+                " already exists in list\n",
+                block->bbNum, oldSucc->bbNum, newSucc->bbNum);
+    }
+    else
+    {
+        // Replace the old one with the new one.
+
+        succTab[oldSuccNum] = newSucc;
+
+        // Remove the old edge [block => oldSucc]
+        //
+        fgRemoveAllRefPreds(oldSucc, block);
+
+        // Create the new edge [block => newSucc]
+        //
+        fgAddRefPred(newSucc, block);
+
+        JITDUMP("Replace BBJ_EHFINALLYRET " FMT_BB " successor " FMT_BB " with " FMT_BB "\n", block->bbNum,
+                oldSucc->bbNum, newSucc->bbNum);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -625,8 +625,8 @@ void Compiler::fgRemoveEhfSuccessor(BasicBlock* block, BasicBlock* succ)
     assert(fgPredsComputed);
     assert(block->KindIs(BBJ_EHFINALLYRET));
 
-    // Don't `assert(succ->isBBCallAlwaysPairTail())`; we've already unlinked the CALLFINALLY
-    assert(succ->KindIs(BBJ_ALWAYS));
+    // Don't `assert(succ->isBBCallFinallyPairTail())`; we've already unlinked the CALLFINALLY
+    assert(succ->KindIs(BBJ_CALLFINALLYRET));
 
     fgRemoveRefPred(succ, block);
 
@@ -691,6 +691,7 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* newTarget, Bas
     switch (block->GetKind())
     {
         case BBJ_CALLFINALLY:
+        case BBJ_CALLFINALLYRET:
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:
@@ -5226,22 +5227,26 @@ void Compiler::fgUnlinkRange(BasicBlock* bBeg, BasicBlock* bEnd)
 #endif // FEATURE_EH_FUNCLETS
 }
 
-/*****************************************************************************************************
- *
- *  Function called to remove a basic block
- */
-
-void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
+//------------------------------------------------------------------------
+// fgRemoveBlock: Remove a basic block. The block must be either unreachable or empty.
+// If the block is a non-retless BBJ_CALLFINALLY then the paired BBJ_CALLFINALLYRET is also removed.
+//
+// Arguments:
+//   block       - the block to remove
+//   unreachable - the block to remove
+//
+// Return Value:
+//   The block after the block, or blocks, removed.
+//
+BasicBlock* Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 {
-    /* The block has to be either unreachable or empty */
-
-    PREFIX_ASSUME(block != nullptr);
-
-    BasicBlock* bPrev = block->Prev();
+    assert(block != nullptr);
+    assert(unreachable || !optLoopsRequirePreHeaders || !block->HasFlag(BBF_LOOP_PREHEADER));
 
     JITDUMP("fgRemoveBlock " FMT_BB ", unreachable=%s\n", block->bbNum, dspBool(unreachable));
 
-    assert(unreachable || !optLoopsRequirePreHeaders || !block->HasFlag(BBF_LOOP_PREHEADER));
+    BasicBlock* bPrev = block->Prev();
+    BasicBlock* bNext = block->Next();
 
     // If we've cached any mappings from switch blocks to SwitchDesc's (which contain only the
     // *unique* successors of the switch block), invalidate that cache, since an entry in one of
@@ -5268,16 +5273,29 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         }
 #endif // FEATURE_EH_FUNCLETS
 
-        if (bPrev->KindIs(BBJ_CALLFINALLY))
-        {
-            // bPrev CALL becomes RETLESS as the BBJ_ALWAYS block is unreachable
-            bPrev->SetFlags(BBF_RETLESS_CALL);
-        }
-
         // If this is the first Cold basic block update fgFirstColdBlock
         if (block->IsFirstColdBlock(this))
         {
             fgFirstColdBlock = block->Next();
+        }
+
+        // A BBJ_CALLFINALLY is usually paired with a BBJ_CALLFINALLYRET.
+        // If we delete such a BBJ_CALLFINALLY we also delete the BBJ_CALLFINALLYRET.
+        if (block->isBBCallFinallyPair())
+        {
+            BasicBlock* const leaveBlock = block->Next();
+            bNext                        = leaveBlock->Next();
+            fgPrepareCallFinallyRetForRemoval(leaveBlock);
+            fgRemoveBlock(leaveBlock, /* unreachable */ true);
+        }
+        else if (block->isBBCallFinallyPairTail())
+        {
+            // bPrev CALLFINALLY becomes RETLESS as the BBJ_CALLFINALLYRET block is unreachable
+            bPrev->SetFlags(BBF_RETLESS_CALL);
+        }
+        else if (block->KindIs(BBJ_RETURN))
+        {
+            fgRemoveReturnBlock(block);
         }
 
         /* Unlink this block from the bbNext chain */
@@ -5285,41 +5303,13 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
         /* At this point the bbPreds and bbRefs had better be zero */
         noway_assert((block->bbRefs == 0) && (block->bbPreds == nullptr));
-
-        /*  A BBJ_CALLFINALLY is usually paired with a BBJ_ALWAYS.
-         *  If we delete such a BBJ_CALLFINALLY we also delete the BBJ_ALWAYS
-         */
-        if (block->isBBCallAlwaysPair())
-        {
-            BasicBlock* leaveBlk = block->Next();
-            noway_assert(leaveBlk->KindIs(BBJ_ALWAYS));
-
-            leaveBlk->RemoveFlags(BBF_DONT_REMOVE);
-
-            // The BBJ_ALWAYS normally has a reference count of 1 and a single predecessor.
-            // However, we might not have marked it as BBF_RETLESS_CALL even though it is.
-            // (Some early flow optimization should probably aggressively mark these as BBF_RETLESS_CALL
-            // and not depend on fgRemoveBlock() to do that.)
-            for (BasicBlock* const leavePredBlock : leaveBlk->PredBlocks())
-            {
-                fgRemoveEhfSuccessor(leavePredBlock, leaveBlk);
-            }
-            assert(leaveBlk->bbRefs == 0);
-            assert(leaveBlk->bbPreds == nullptr);
-
-            fgRemoveBlock(leaveBlk, /* unreachable */ true);
-        }
-        else if (block->KindIs(BBJ_RETURN))
-        {
-            fgRemoveReturnBlock(block);
-        }
     }
     else // block is empty
     {
         noway_assert(block->isEmpty());
 
         // The block cannot follow a non-retless BBJ_CALLFINALLY (because we don't know who may jump to it).
-        noway_assert(!block->isBBCallAlwaysPairTail());
+        noway_assert(!block->isBBCallFinallyPairTail());
 
         /* This cannot be the last basic block */
         noway_assert(block != fgLastBB);
@@ -5331,10 +5321,10 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
         }
 
         /* Some extra checks for the empty case */
-        noway_assert(block->KindIs(BBJ_ALWAYS));
+        assert(block->KindIs(BBJ_ALWAYS));
 
         /* Do not remove a block that jumps to itself - used for while (true){} */
-        noway_assert(!block->TargetIs(block));
+        assert(!block->TargetIs(block));
 #endif // DEBUG
 
         BasicBlock* succBlock = block->GetTarget();
@@ -5446,6 +5436,7 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
                     break;
 
                 case BBJ_CALLFINALLY:
+                case BBJ_CALLFINALLYRET:
                 case BBJ_ALWAYS:
                 case BBJ_EHCATCHRET:
                     noway_assert(predBlock->TargetIs(block));
@@ -5489,6 +5480,46 @@ void Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
         ehUpdateForDeletedBlock(block);
     }
+
+    return bNext;
+}
+
+//------------------------------------------------------------------------
+// fgPrepareCallFinallyRetForRemoval: Prepare an unreachable BBJ_CALLFINALLYRET block for removal
+// from the flow graph. Remove the block as a successor to predecessor BBJ_EHFINALLYRET blocks.
+// Don't actually remove the block: change it to a BBJ_ALWAYS. The caller can either remove it
+// directly, or wait for an unreachable code pass to remove it. This is done to avoid altering
+// caller flow graph iteration. Note that this must be called before changing/removing the
+// paired BBJ_CALLFINALLY.
+//
+// Arguments:
+//   block - the block to process
+//
+void Compiler::fgPrepareCallFinallyRetForRemoval(BasicBlock* block)
+{
+    assert(block->KindIs(BBJ_CALLFINALLYRET));
+
+    BasicBlock* const bCallFinally = block->Prev();
+    assert(bCallFinally != nullptr);
+    assert(bCallFinally->KindIs(BBJ_CALLFINALLY));
+
+    block->RemoveFlags(BBF_DONT_REMOVE);
+
+    // The BBJ_CALLFINALLYRET normally has a reference count of 1 and a single predecessor.
+    // However, we might not have marked the BBJ_CALLFINALLY as BBF_RETLESS_CALL even though it is.
+    // (Some early flow optimization should probably aggressively mark these as BBF_RETLESS_CALL
+    // and not depend on fgRemoveBlock() to do that.)
+    for (BasicBlock* const leavePredBlock : block->PredBlocks())
+    {
+        fgRemoveEhfSuccessor(leavePredBlock, block);
+    }
+    assert(block->bbRefs == 0);
+    assert(block->bbPreds == nullptr);
+
+    // If the BBJ_CALLFINALLYRET is unreachable, then the BBJ_CALLFINALLY must be retless.
+    // Set to retless flag to avoid future asserts.
+    bCallFinally->SetFlags(BBF_RETLESS_CALL);
+    block->SetKind(BBJ_ALWAYS);
 }
 
 //------------------------------------------------------------------------
@@ -5581,8 +5612,7 @@ BasicBlock* Compiler::fgConnectFallThrough(BasicBlock* bSrc, BasicBlock* bDst)
                     break;
             }
         }
-        else if (bSrc->KindIs(BBJ_ALWAYS) && !bSrc->HasFlag(BBF_KEEP_BBJ_ALWAYS) && bSrc->HasInitializedTarget() &&
-                 bSrc->JumpsToNext())
+        else if (bSrc->KindIs(BBJ_ALWAYS) && bSrc->HasInitializedTarget() && bSrc->JumpsToNext())
         {
             bSrc->SetFlags(BBF_NONE_QUIRK);
         }
@@ -5702,7 +5732,7 @@ bool Compiler::fgRenumberBlocks()
  */
 bool Compiler::fgIsForwardBranch(BasicBlock* bJump, BasicBlock* bDest, BasicBlock* bSrc /* = NULL */)
 {
-    assert((bJump->KindIs(BBJ_ALWAYS) && bJump->TargetIs(bDest)) ||
+    assert((bJump->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) && bJump->TargetIs(bDest)) ||
            (bJump->KindIs(BBJ_COND) && bJump->TrueTargetIs(bDest)));
 
     bool        result = false;
@@ -6380,8 +6410,8 @@ bool Compiler::fgIsBetterFallThrough(BasicBlock* bCur, BasicBlock* bAlt)
         return false;
     }
 
-    // BBJ_CALLFINALLY shouldn't have a flow edge into the next (BBJ_ALWAYS) block
-    if (bCur->isBBCallAlwaysPair())
+    // BBJ_CALLFINALLY shouldn't have a flow edge into the next (BBJ_CALLFINALLYRET) block
+    if (bCur->isBBCallFinallyPair())
     {
         return false;
     }
@@ -6693,12 +6723,18 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
 
         // Set the current block as a "good enough" insertion point, if it meets certain criteria.
         // We'll return this block if we don't find a "best" block in the search range. The block
-        // can't be a BBJ_CALLFINALLY of a BBJ_CALLFINALLY/BBJ_ALWAYS pair (since we don't want
+        // can't be a BBJ_CALLFINALLY of a BBJ_CALLFINALLY/BBJ_CALLFINALLYRET pair (since we don't want
         // to insert anything between these two blocks). Otherwise, we can use it. However,
         // if we'd previously chosen a BBJ_COND block, then we'd prefer the "good" block to be
         // something else. We keep updating it until we've reached the 'nearBlk', to push it as
         // close to endBlk as possible.
-        if (!blk->isBBCallAlwaysPair())
+        //
+        // TODO-Quirk: we can't use isBBCallFinallyPair because this function is called during the importer
+        // before we've replaced BBJ_CALLFINALLY/BBJ_ALWAYS with BBJ_CALLFINALLY/BBJ_CALLFINALLYRET, which
+        // leads to asserts.
+        //
+        // if (!blk->isBBCallFinallyPair())
+        if (!blk->KindIs(BBJ_CALLFINALLY) || blk->HasFlag(BBF_RETLESS_CALL))
         {
             if (goodBlk == nullptr)
             {

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -48,7 +48,7 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
     if (opts.MinOpts())
     {
-        JITDUMP("Method compiled with minOpts, no removal.\n");
+        JITDUMP("Method compiled with MinOpts, no removal.\n");
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
@@ -147,15 +147,14 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
 
             if (currentBlock->KindIs(BBJ_CALLFINALLY) && currentBlock->TargetIs(firstBlock))
             {
-                // Retarget the call finally to jump to the return
-                // point.
+                // Retarget the call finally to jump to the return point.
                 //
                 // We don't expect to see retless finallys here, since
                 // the finally is empty.
-                noway_assert(currentBlock->isBBCallAlwaysPair());
+                noway_assert(currentBlock->isBBCallFinallyPair());
 
                 BasicBlock* const leaveBlock          = currentBlock->Next();
-                BasicBlock* const postTryFinallyBlock = leaveBlock->GetTarget();
+                BasicBlock* const postTryFinallyBlock = leaveBlock->GetFinallyContinuation();
 
                 JITDUMP("Modifying callfinally " FMT_BB " leave " FMT_BB " finally " FMT_BB " continuation " FMT_BB
                         "\n",
@@ -163,23 +162,17 @@ PhaseStatus Compiler::fgRemoveEmptyFinally()
                 JITDUMP("so that " FMT_BB " jumps to " FMT_BB "; then remove " FMT_BB "\n", currentBlock->bbNum,
                         postTryFinallyBlock->bbNum, leaveBlock->bbNum);
 
-                noway_assert(leaveBlock->KindIs(BBJ_ALWAYS));
+                // Remove the `leaveBlock` first.
+                nextBlock = leaveBlock->Next();
+                fgPrepareCallFinallyRetForRemoval(leaveBlock);
+                fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                 currentBlock->SetKindAndTarget(BBJ_ALWAYS, postTryFinallyBlock);
+                currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
                 // Ref count updates.
                 fgAddRefPred(postTryFinallyBlock, currentBlock);
                 fgRemoveRefPred(firstBlock, currentBlock);
-
-                // Delete the leave block, which should be marked as
-                // keep always and have the sole finally block as a pred.
-                // Remove `leaveBlock` as a successor of the finally `lastBlock`, which also removes the predecessor
-                // edge in `leaveBlock` from the finally return.
-                assert(leaveBlock->HasFlag(BBF_KEEP_BBJ_ALWAYS));
-                nextBlock = leaveBlock->Next();
-                fgRemoveEhfSuccessor(lastBlock, leaveBlock);
-                leaveBlock->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
-                fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                 // Cleanup the postTryFinallyBlock
                 fgCleanupContinuation(postTryFinallyBlock);
@@ -309,7 +302,7 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
 
     if (opts.MinOpts())
     {
-        JITDUMP("Method compiled with minOpts, no removal.\n");
+        JITDUMP("Method compiled with MinOpts, no removal.\n");
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
@@ -376,10 +369,10 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
 
         BasicBlock* const callFinally = firstTryBlock->GetTarget();
 
-        // Look for call always pair. Note this will also disqualify
+        // Look for call finally pair. Note this will also disqualify
         // empty try removal in cases where the finally doesn't
         // return.
-        if (!callFinally->isBBCallAlwaysPair() || !callFinally->TargetIs(firstHandlerBlock))
+        if (!callFinally->isBBCallFinallyPair() || !callFinally->TargetIs(firstHandlerBlock))
         {
             JITDUMP("EH#%u first try block " FMT_BB " always jumps but not to a callfinally; skipping.\n", XTnum,
                     firstTryBlock->bbNum);
@@ -397,10 +390,10 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         }
 
 #else
-        // Look for call always pair within the try itself. Note this
+        // Look for call finally pair within the try itself. Note this
         // will also disqualify empty try removal in cases where the
         // finally doesn't return.
-        if (!firstTryBlock->isBBCallAlwaysPair() || !firstTryBlock->TargetIs(firstHandlerBlock))
+        if (!firstTryBlock->isBBCallFinallyPair() || !firstTryBlock->TargetIs(firstHandlerBlock))
         {
             JITDUMP("EH#%u first try block " FMT_BB " not a callfinally; skipping.\n", XTnum, firstTryBlock->bbNum);
             XTnum++;
@@ -432,7 +425,7 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
         {
             if (block->KindIs(BBJ_CALLFINALLY) && block->TargetIs(firstHandlerBlock))
             {
-                assert(block->isBBCallAlwaysPair());
+                assert(block->isBBCallFinallyPair());
 
                 if (block != callFinally)
                 {
@@ -453,22 +446,12 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
 
         // Time to optimize.
         //
-        // (1) Convert the callfinally to a normal jump to the handler
-        assert(callFinally->HasInitializedTarget());
-        callFinally->SetKind(BBJ_ALWAYS);
 
         // Identify the leave block and the continuation
         BasicBlock* const leave        = callFinally->Next();
-        BasicBlock* const continuation = leave->GetTarget();
+        BasicBlock* const continuation = leave->GetFinallyContinuation();
 
-        // (2) Cleanup the leave so it can be deleted by subsequent opts
-        assert(leave->HasFlag(BBF_KEEP_BBJ_ALWAYS));
-        leave->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
-
-        // (3) Cleanup the continuation
-        fgCleanupContinuation(continuation);
-
-        // (4) Find enclosing try region for the try, if any, and
+        // (1) Find enclosing try region for the try, if any, and
         // update the try region for the blocks in the try. Note the
         // handler region (if any) won't change.
         //
@@ -498,6 +481,19 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
                 break;
             }
         }
+
+        // (2) Cleanup the leave. Don't do this earlier, as removing the block might remove the
+        // last block of the `try`, and that could affect the block iteration above.
+        fgPrepareCallFinallyRetForRemoval(leave);
+        fgRemoveBlock(leave, /* unreachable */ true);
+
+        // (3) Convert the callfinally to a normal jump to the handler
+        assert(callFinally->HasInitializedTarget());
+        callFinally->SetKind(BBJ_ALWAYS);
+        callFinally->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
+
+        // (4) Cleanup the continuation
+        fgCleanupContinuation(continuation);
 
         // (5) Update the directly contained handler blocks' handler index.
         // Handler index of any nested blocks will update when we
@@ -530,7 +526,6 @@ PhaseStatus Compiler::fgRemoveEmptyTry()
                     fgRemoveStmt(block, finallyRet);
                     block->SetKindAndTarget(BBJ_ALWAYS, continuation);
                     fgAddRefPred(continuation, block);
-                    fgRemoveRefPred(leave, block);
                 }
             }
 
@@ -641,7 +636,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
     if (opts.MinOpts())
     {
-        JITDUMP("Method compiled with minOpts, no cloning.\n");
+        JITDUMP("Method compiled with MinOpts, no cloning.\n");
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
@@ -805,10 +800,11 @@ PhaseStatus Compiler::fgCloneFinally()
 #if FEATURE_EH_CALLFINALLY_THUNKS
             // Blocks that transfer control to callfinallies are usually
             // BBJ_ALWAYS blocks, but the last block of a try may fall
-            // through to a callfinally.
+            // through to a callfinally, or could be the target of a BBJ_CALLFINALLYRET,
+            // indicating a chained callfinally.
             BasicBlock* jumpDest = nullptr;
 
-            if (block->KindIs(BBJ_ALWAYS))
+            if (block->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
             {
                 jumpDest = block->GetTarget();
             }
@@ -823,7 +819,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
             // The jumpDest must be a callfinally that in turn invokes the
             // finally of interest.
-            if (!jumpDest->isBBCallAlwaysPair() || !jumpDest->TargetIs(firstBlock))
+            if (!jumpDest->isBBCallFinallyPair() || !jumpDest->TargetIs(firstBlock))
             {
                 continue;
             }
@@ -831,7 +827,7 @@ PhaseStatus Compiler::fgCloneFinally()
             // Found a block that invokes the finally.
             //
             BasicBlock* const finallyReturnBlock  = jumpDest->Next();
-            BasicBlock* const postTryFinallyBlock = finallyReturnBlock->GetTarget();
+            BasicBlock* const postTryFinallyBlock = finallyReturnBlock->GetFinallyContinuation();
             bool              isUpdate            = false;
 
             // See if this is the one we want to use to inspire cloning.
@@ -945,7 +941,7 @@ PhaseStatus Compiler::fgCloneFinally()
 
             for (BasicBlock* const block : Blocks(firstCallFinallyRangeBlock, lastCallFinallyRangeBlock))
             {
-                if (block->isBBCallAlwaysPair() && block->TargetIs(firstBlock))
+                if (block->isBBCallFinallyPair() && block->TargetIs(firstBlock))
                 {
                     firstCallFinallyBlock = block;
                     break;
@@ -1116,7 +1112,7 @@ PhaseStatus Compiler::fgCloneFinally()
             }
             else
             {
-                optCopyBlkDest(block, newBlock);
+                newBlock->CopyTarget(this, block);
                 optRedirectBlock(newBlock, &blockMap, RedirectBlockOption::AddToPredLists);
             }
         }
@@ -1134,10 +1130,10 @@ PhaseStatus Compiler::fgCloneFinally()
         {
             BasicBlock* nextBlockToScan = currentBlock->Next();
 
-            if (currentBlock->isBBCallAlwaysPair() && currentBlock->TargetIs(firstBlock))
+            if (currentBlock->isBBCallFinallyPair() && currentBlock->TargetIs(firstBlock))
             {
                 BasicBlock* const leaveBlock          = currentBlock->Next();
-                BasicBlock* const postTryFinallyBlock = leaveBlock->GetTarget();
+                BasicBlock* const postTryFinallyBlock = leaveBlock->GetFinallyContinuation();
 
                 // Note we must retarget all callfinallies that have this
                 // continuation, or we can't clean up the continuation
@@ -1148,30 +1144,18 @@ PhaseStatus Compiler::fgCloneFinally()
                     JITDUMP("Retargeting callfinally " FMT_BB " to clone entry " FMT_BB "\n", currentBlock->bbNum,
                             firstCloneBlock->bbNum);
 
-                    // This call returns to the expected spot, so
-                    // retarget it to branch to the clone.
+                    // Remove the `leaveBlock` first, to avoid asserts.
+                    nextBlockToScan = leaveBlock->Next();
+                    fgPrepareCallFinallyRetForRemoval(leaveBlock);
+                    fgRemoveBlock(leaveBlock, /* unreachable */ true);
+
+                    // This call returns to the expected spot, so retarget it to branch to the clone.
                     currentBlock->SetKindAndTarget(BBJ_ALWAYS, firstCloneBlock);
+                    currentBlock->RemoveFlags(BBF_RETLESS_CALL); // no longer a BBJ_CALLFINALLY
 
                     // Ref count updates.
                     fgAddRefPred(firstCloneBlock, currentBlock);
                     fgRemoveRefPred(firstBlock, currentBlock);
-
-                    // Delete the leave block, which should be marked as
-                    // keep always.
-                    assert(leaveBlock->HasFlag(BBF_KEEP_BBJ_ALWAYS));
-                    nextBlock = leaveBlock->Next();
-
-                    // All preds should be BBJ_EHFINALLYRETs from the finally.
-                    for (BasicBlock* const leavePred : leaveBlock->PredBlocks())
-                    {
-                        assert(leavePred->getHndIndex() == XTnum);
-                        fgRemoveEhfSuccessor(leavePred, leaveBlock);
-                    }
-
-                    assert(leaveBlock->bbRefs == 0);
-                    assert(leaveBlock->bbPreds == nullptr);
-                    leaveBlock->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
-                    fgRemoveBlock(leaveBlock, /* unreachable */ true);
 
                     // Make sure iteration isn't going off the deep end.
                     assert(leaveBlock != endCallFinallyRangeBlock);
@@ -1394,9 +1378,8 @@ void Compiler::fgDebugCheckTryFinallyExits()
                 // (a2) via a callfinally (only for finallys, only for !call finally thunks)
                 // (b) via a jump to a begin finally clone block
                 // (c) via a jump to an empty block to (b)
-                // (d) via a fallthrough to an empty block to (b)
-                // (e) via the always half of a callfinally pair
-                // (f) via an always jump clonefinally exit
+                // (d) via the callfinallyret half of a callfinally pair
+                // (e) via an always jump clonefinally exit
                 bool isCallToFinally = false;
 
 #if FEATURE_EH_CALLFINALLY_THUNKS
@@ -1405,13 +1388,13 @@ void Compiler::fgDebugCheckTryFinallyExits()
                     // case (a1)
                     isCallToFinally = isFinally && succBlock->TargetIs(finallyBlock);
                 }
-#else
+#else  // !FEATURE_EH_CALLFINALLY_THUNKS
                 if (block->KindIs(BBJ_CALLFINALLY))
                 {
                     // case (a2)
                     isCallToFinally = isFinally && block->TargetIs(finallyBlock);
                 }
-#endif // FEATURE_EH_CALLFINALLY_THUNKS
+#endif // !FEATURE_EH_CALLFINALLY_THUNKS
 
                 bool isJumpToClonedFinally = false;
 
@@ -1434,21 +1417,21 @@ void Compiler::fgDebugCheckTryFinallyExits()
                     }
                 }
 
-                // ~~case (d) via a fallthrough to an empty block to (b)~~ [no longer possible]
-
                 bool isReturnFromFinally = false;
 
-                // Case (e). Ideally we'd have something stronger to
+                // Case (d). Ideally we'd have something stronger to
                 // check here -- eg that we are returning from a call
-                // to the right finally -- but there are odd cases
-                // like orphaned second halves of callfinally pairs
-                // that we need to tolerate.
+                // to the right finally.
+                if (block->KindIs(BBJ_CALLFINALLYRET))
+                {
+                    isReturnFromFinally = true;
+                }
                 if (block->HasFlag(BBF_KEEP_BBJ_ALWAYS))
                 {
                     isReturnFromFinally = true;
                 }
 
-                // Case (f)
+                // Case (e)
                 if (block->HasFlag(BBF_CLONED_FINALLY_END))
                 {
                     isReturnFromFinally = true;
@@ -1458,7 +1441,7 @@ void Compiler::fgDebugCheckTryFinallyExits()
 
                 if (!thisExitValid)
                 {
-                    JITDUMP("fgCheckTryFinallyExitS: EH#%u exit via " FMT_BB " -> " FMT_BB " is invalid\n", XTnum,
+                    JITDUMP("fgCheckTryFinallyExits: EH#%u exit via " FMT_BB " -> " FMT_BB " is invalid\n", XTnum,
                             block->bbNum, succBlock->bbNum);
                 }
 
@@ -1482,23 +1465,19 @@ void Compiler::fgDebugCheckTryFinallyExits()
 //
 // Notes:
 //    The continuation is the block targeted by the second half of
-//    a callfinally/always pair.
+//    a callfinally pair.
 //
 //    Used by finally cloning, empty try removal, and empty
 //    finally removal.
 //
-//    BBF_FINALLY_TARGET bbFlag is left unchanged by this method
-//    since it cannot be incrementally updated. Proper updates happen
-//    when fgUpdateFinallyTargetFlags runs after all finally optimizations.
-//
 void Compiler::fgCleanupContinuation(BasicBlock* continuation)
 {
+#if !defined(FEATURE_EH_FUNCLETS)
     // The continuation may be a finalStep block.
     // It is now a normal block, so clear the special keep
     // always flag.
     continuation->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
 
-#if !defined(FEATURE_EH_FUNCLETS)
     // Remove the GT_END_LFIN from the continuation,
     // Note we only expect to see one such statement.
     bool foundEndLFin = false;
@@ -1528,7 +1507,7 @@ void Compiler::fgCleanupContinuation(BasicBlock* continuation)
 //    (callfinallys) and merges them. These typically arise from
 //    try-finallys where there are multiple exit points in the try
 //    that have the same target.
-
+//
 PhaseStatus Compiler::fgMergeFinallyChains()
 {
 #if defined(FEATURE_EH_FUNCLETS)
@@ -1547,7 +1526,7 @@ PhaseStatus Compiler::fgMergeFinallyChains()
 
     if (opts.MinOpts())
     {
-        JITDUMP("Method compiled with minOpts, no merging.\n");
+        JITDUMP("Method compiled with MinOpts, no merging.\n");
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
@@ -1569,7 +1548,7 @@ PhaseStatus Compiler::fgMergeFinallyChains()
 #endif // !FEATURE_EH_FUNCLETS
 
 #if !FEATURE_EH_CALLFINALLY_THUNKS
-    // For non-thunk EH models (arm32) the callfinallys may contain
+    // For non-thunk EH models (x86) the callfinallys may contain
     // statements, and merging is not safe unless the callfinally
     // blocks are split.
     JITDUMP("EH using non-callfinally thunk model; merging not yet implemented.\n");
@@ -1645,7 +1624,7 @@ PhaseStatus Compiler::fgMergeFinallyChains()
         for (BasicBlock* const currentBlock : Blocks(firstCallFinallyRangeBlock, lastCallFinallyRangeBlock))
         {
             // Ignore "retless" callfinallys (where the finally doesn't return).
-            if (currentBlock->isBBCallAlwaysPair() && currentBlock->TargetIs(beginHandlerBlock))
+            if (currentBlock->isBBCallFinallyPair() && currentBlock->TargetIs(beginHandlerBlock))
             {
                 // The callfinally must be empty, so that we can
                 // safely retarget anything that branches here to
@@ -1657,7 +1636,7 @@ PhaseStatus Compiler::fgMergeFinallyChains()
 
                 // Locate the continuation
                 BasicBlock* const leaveBlock        = currentBlock->Next();
-                BasicBlock* const continuationBlock = leaveBlock->GetTarget();
+                BasicBlock* const continuationBlock = leaveBlock->GetFinallyContinuation();
 
                 // If this is the first time we've seen this
                 // continuation, register this callfinally as the
@@ -1690,8 +1669,9 @@ PhaseStatus Compiler::fgMergeFinallyChains()
         // callfinally.
         for (BasicBlock* const currentBlock : Blocks(firstCallFinallyRangeBlock, lastCallFinallyRangeBlock))
         {
-            bool merged = fgRetargetBranchesToCanonicalCallFinally(currentBlock, beginHandlerBlock, continuationMap);
-            didMerge    = didMerge || merged;
+            const bool merged =
+                fgRetargetBranchesToCanonicalCallFinally(currentBlock, beginHandlerBlock, continuationMap);
+            didMerge = didMerge || merged;
         }
     }
 
@@ -1743,14 +1723,14 @@ PhaseStatus Compiler::fgMergeFinallyChains()
 //
 // Returns:
 //     true iff the block's branch was retargeted.
-
+//
 bool Compiler::fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
                                                         BasicBlock*      handler,
                                                         BlockToBlockMap& continuationMap)
 {
     // We expect callfinallys to be invoked by a BBJ_ALWAYS at this
-    // stage in compilation.
-    if (!block->KindIs(BBJ_ALWAYS))
+    // stage in compilation, or BBJ_CALLFINALLYRET in the case of a chain of callfinallys.
+    if (!block->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
     {
         // Possible paranoia assert here -- no flow successor of
         // this block should be a callfinally for this try.
@@ -1761,7 +1741,7 @@ bool Compiler::fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
     // handler.
     BasicBlock* const callFinally = block->GetTarget();
 
-    if (!callFinally->isBBCallAlwaysPair())
+    if (!callFinally->isBBCallFinallyPair())
     {
         return false;
     }
@@ -1774,7 +1754,7 @@ bool Compiler::fgRetargetBranchesToCanonicalCallFinally(BasicBlock*      block,
     // Ok, this is a callfinally that invokes the right handler.
     // Get its continuation.
     BasicBlock* const leaveBlock        = callFinally->Next();
-    BasicBlock* const continuationBlock = leaveBlock->GetTarget();
+    BasicBlock* const continuationBlock = leaveBlock->GetFinallyContinuation();
 
     // Find the canonical callfinally for that continuation.
     BasicBlock* const canonicalCallFinally = continuationMap[continuationBlock];

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -349,6 +349,7 @@ void Compiler::fgRemoveBlockAsPred(BasicBlock* block)
     switch (block->GetKind())
     {
         case BBJ_CALLFINALLY:
+        case BBJ_CALLFINALLYRET:
         case BBJ_ALWAYS:
         case BBJ_EHCATCHRET:
         case BBJ_EHFILTERRET:

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -435,7 +435,7 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
 
             JITDUMP("Converting BBF_DONT_REMOVE block " FMT_BB " to BBJ_THROW\n", block->bbNum);
 
-            // If the CALLFINALLY is being replace by a throw, then the CALLFINALLYRET is unreachable.
+            // If the CALLFINALLY is being replaced by a throw, then the CALLFINALLYRET is unreachable.
             if (block->isBBCallFinallyPair())
             {
                 BasicBlock* const leaveBlock = block->Next();

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -322,9 +322,6 @@ void Compiler::fgComputeReturnBlocks()
 //
 // Initialize fgEnterBlks to the set of blocks for which we don't have explicit control
 // flow edges. These are the entry basic block and each of the EH handler blocks.
-// For ARM, also include the BBJ_ALWAYS block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair,
-// to avoid creating "retless" calls, since we need the BBJ_ALWAYS for the purpose
-// of unwinding, even if the call doesn't return (due to an explicit throw, for example).
 //
 void Compiler::fgComputeEnterBlocksSet()
 {
@@ -392,8 +389,8 @@ void Compiler::fgComputeEnterBlocksSet()
 //    or not is based on the reachability sets, and hence it must be computed and valid.
 //
 //    During late phase, all the reachable blocks from fgFirstBB are traversed and everything
-//    else are marked as unreachable (with exceptions of handler/filter blocks and BBJ_ALWAYS
-//    blocks in Arm). As such, it is not dependent on the validity of reachability sets.
+//    else are marked as unreachable (with exceptions of handler/filter blocks). As such, it
+//    is not dependent on the validity of reachability sets.
 //
 template <typename CanRemoveBlockBody>
 bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
@@ -401,10 +398,10 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
     bool hasUnreachableBlocks = false;
     bool changed              = false;
 
-    /* Record unreachable blocks */
+    // Mark unreachable blocks with BBF_REMOVED.
     for (BasicBlock* const block : Blocks())
     {
-        /* Internal throw blocks are also reachable */
+        // Internal throw blocks are always reachable.
         if (fgIsThrowHlpBlk(block))
         {
             continue;
@@ -432,17 +429,18 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
         // Make sure that the block was marked as removed */
         noway_assert(block->HasFlag(BBF_REMOVED));
 
-        // Some blocks mark the end of trys and catches and can't be removed. We convert these into
-        // empty blocks of type BBJ_THROW.
-
-        const bool  bIsBBCallAlwaysPair = block->isBBCallAlwaysPair();
-        BasicBlock* leaveBlk            = bIsBBCallAlwaysPair ? block->Next() : nullptr;
-
         if (block->HasFlag(BBF_DONT_REMOVE))
         {
-            // Unmark the block as removed, clear BBF_INTERNAL, and set BBJ_IMPORTED
+            // Unmark the block as removed, clear BBF_INTERNAL, and set BBF_IMPORTED
 
             JITDUMP("Converting BBF_DONT_REMOVE block " FMT_BB " to BBJ_THROW\n", block->bbNum);
+
+            // If the CALLFINALLY is being replace by a throw, then the CALLFINALLYRET is unreachable.
+            if (block->isBBCallFinallyPair())
+            {
+                BasicBlock* const leaveBlock = block->Next();
+                fgPrepareCallFinallyRetForRemoval(leaveBlock);
+            }
 
             // The successors may be unreachable after this change.
             changed |= block->NumSucc() > 0;
@@ -458,59 +456,22 @@ bool Compiler::fgRemoveUnreachableBlocks(CanRemoveBlockBody canRemoveBlock)
             hasUnreachableBlocks = true;
             changed              = true;
         }
-
-        // If this is a <BBJ_CALLFINALLY, BBJ_ALWAYS> pair, get rid of the BBJ_ALWAYS block which is now dead.
-        if (bIsBBCallAlwaysPair)
-        {
-            assert(leaveBlk->KindIs(BBJ_ALWAYS));
-
-            if (!block->KindIs(BBJ_THROW))
-            {
-                // We didn't convert the BBJ_CALLFINALLY to a throw, above. Since we already marked it as removed,
-                // change the kind to something else. Otherwise, we can hit asserts below in fgRemoveBlock that
-                // the leaveBlk BBJ_ALWAYS is not allowed to be a CallAlwaysPairTail.
-                assert(block->KindIs(BBJ_CALLFINALLY));
-                block->SetKindAndTarget(BBJ_ALWAYS, block->Next());
-            }
-
-            leaveBlk->RemoveFlags(BBF_DONT_REMOVE);
-
-            for (BasicBlock* const leavePredBlock : leaveBlk->PredBlocks())
-            {
-                fgRemoveEhfSuccessor(leavePredBlock, leaveBlk);
-            }
-            assert(leaveBlk->bbRefs == 0);
-            assert(leaveBlk->bbPreds == nullptr);
-
-            fgRemoveBlock(leaveBlk, /* unreachable */ true);
-
-            // Note: `changed` will already have been set to true by processing the BBJ_CALLFINALLY.
-            // `hasUnreachableBlocks` doesn't need to be set for the leaveBlk itself because we've already called
-            // `fgRemoveBlock` on it.
-        }
     }
 
     if (hasUnreachableBlocks)
     {
-        // Now remove the unreachable blocks
-        for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->Next())
+        // Now remove the unreachable blocks: if we marked a block with BBF_REMOVED then we need to
+        // call fgRemoveBlock() on it.
+        BasicBlock* bNext;
+        for (BasicBlock* block = fgFirstBB; block != nullptr; block = bNext)
         {
-            // If we marked a block with BBF_REMOVED then we need to call fgRemoveBlock() on it
-
             if (block->HasFlag(BBF_REMOVED))
             {
-                fgRemoveBlock(block, /* unreachable */ true);
-
-                // TODO: couldn't we have fgRemoveBlock() return the block after the (last)one removed
-                // so we don't need the code below?
-
-                // When we have a BBJ_CALLFINALLY, BBJ_ALWAYS pair; fgRemoveBlock will remove
-                // both blocks, so we must advance 1 extra place in the block list
-                //
-                if (block->isBBCallAlwaysPair())
-                {
-                    block = block->Next();
-                }
+                bNext = fgRemoveBlock(block, /* unreachable */ true);
+            }
+            else
+            {
+                bNext = block->Next();
             }
         }
     }
@@ -608,9 +569,6 @@ PhaseStatus Compiler::fgComputeReachability()
 
 //------------------------------------------------------------------------
 // fgRemoveDeadBlocks: Identify all the unreachable blocks and remove them.
-//         Handler and filter blocks are considered as reachable and hence won't
-//         be removed. For Arm32, do not remove BBJ_ALWAYS block of
-//         BBJ_CALLFINALLY/BBJ_ALWAYS pair.
 //
 bool Compiler::fgRemoveDeadBlocks()
 {
@@ -686,11 +644,9 @@ bool Compiler::fgRemoveDeadBlocks()
     // or not.
     bool hasUnreachableBlock = false;
 
-    // A block is unreachable if no path was found from
-    // any of the fgFirstBB, handler, filter or BBJ_ALWAYS (Arm) blocks.
     auto isBlockRemovable = [&](BasicBlock* block) -> bool {
-        bool isVisited   = BlockSetOps::IsMember(this, visitedBlocks, block->bbNum);
-        bool isRemovable = !isVisited || (block->bbRefs == 0);
+        const bool isVisited   = BlockSetOps::IsMember(this, visitedBlocks, block->bbNum);
+        const bool isRemovable = !isVisited || (block->bbRefs == 0);
 
         hasUnreachableBlock |= isRemovable;
         return isRemovable;
@@ -2043,7 +1999,6 @@ void Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNext)
 
     assert(block->KindIs(BBJ_ALWAYS));
     assert(block->TargetIs(bNext));
-    assert(!block->isBBCallAlwaysPairTail());
     assert(!fgInDifferentRegions(block, bNext));
 
     // Make sure the second block is not the start of a TRY block or an exception handler
@@ -2839,6 +2794,7 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
         switch (block->GetKind())
         {
             case BBJ_ALWAYS:
+            case BBJ_CALLFINALLYRET:
                 block->SetTarget(bDest->GetTarget());
                 break;
 
@@ -2884,6 +2840,7 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
 
         case BBJ_THROW:
         case BBJ_CALLFINALLY:
+        case BBJ_CALLFINALLYRET:
         case BBJ_RETURN:
         case BBJ_EHCATCHRET:
         case BBJ_EHFINALLYRET:
@@ -2899,7 +2856,7 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
         case BBJ_ALWAYS:
 
             /* Special case for first BB */
-            if (!bPrev)
+            if (bPrev == nullptr)
             {
                 assert(block == fgFirstBB);
                 if (!block->JumpsToNext())
@@ -2909,13 +2866,6 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
             }
             else
             {
-                /* If this block follows a BBJ_CALLFINALLY do not remove it
-                 * (because we don't know who may jump to it) */
-                if (bPrev->KindIs(BBJ_CALLFINALLY))
-                {
-                    break;
-                }
-
                 // TODO-NoFallThrough: Once BBJ_COND blocks have pointers to their false branches,
                 // allow removing empty BBJ_ALWAYS and pointing bPrev's false branch to block->bbTarget.
                 if (bPrev->bbFallsThrough() && !block->JumpsToNext())
@@ -4440,21 +4390,13 @@ bool Compiler::fgExpandRarelyRunBlocks()
         BasicBlock* bPrevPrev = nullptr;
         BasicBlock* tmpbb;
 
-        if (bPrev->HasFlag(BBF_KEEP_BBJ_ALWAYS))
+        if (bPrev->KindIs(BBJ_CALLFINALLYRET))
         {
-            // If we've got a BBJ_CALLFINALLY/BBJ_ALWAYS pair, treat the BBJ_CALLFINALLY as an
-            // additional predecessor for the BBJ_ALWAYS block
+            // If we've got a BBJ_CALLFINALLY/BBJ_CALLFINALLYRET pair, treat the BBJ_CALLFINALLY as an
+            // additional predecessor for the BBJ_CALLFINALLYRET block
             tmpbb = bPrev->Prev();
-            noway_assert(tmpbb != nullptr);
-#if defined(FEATURE_EH_FUNCLETS)
-            noway_assert(tmpbb->isBBCallAlwaysPair());
+            noway_assert(tmpbb->isBBCallFinallyPair());
             bPrevPrev = tmpbb;
-#else
-            if (tmpbb->KindIs(BBJ_CALLFINALLY))
-            {
-                bPrevPrev = tmpbb;
-            }
-#endif
         }
 
         FlowEdge* pred = bPrev->bbPreds;
@@ -4542,31 +4484,40 @@ bool Compiler::fgExpandRarelyRunBlocks()
             continue;
         }
 
-        const char* reason = nullptr;
+        INDEBUG(const char* reason = nullptr);
+        bool setRarelyRun = false;
 
         switch (bPrev->GetKind())
         {
             case BBJ_ALWAYS:
-
                 if (bPrev->GetTarget()->isRunRarely())
                 {
-                    reason = "Unconditional jump to a rarely run block";
+                    INDEBUG(reason = "Unconditional jump to a rarely run block");
+                    setRarelyRun = true;
                 }
                 break;
 
             case BBJ_CALLFINALLY:
-
-                if (bPrev->isBBCallAlwaysPair() && block->isRunRarely())
+                if (bPrev->isBBCallFinallyPair() && block->isRunRarely())
                 {
-                    reason = "Call of finally followed by a rarely run block";
+                    INDEBUG(reason = "Call of finally followed rarely run continuation block");
+                    setRarelyRun = true;
+                }
+                break;
+
+            case BBJ_CALLFINALLYRET:
+                if (bPrev->GetFinallyContinuation()->isRunRarely())
+                {
+                    INDEBUG(reason = "Finally continuation is a rarely run block");
+                    setRarelyRun = true;
                 }
                 break;
 
             case BBJ_COND:
-
                 if (block->isRunRarely() && bPrev->GetTrueTarget()->isRunRarely())
                 {
-                    reason = "Both sides of a conditional jump are rarely run";
+                    INDEBUG(reason = "Both sides of a conditional jump are rarely run");
+                    setRarelyRun = true;
                 }
                 break;
 
@@ -4574,7 +4525,7 @@ bool Compiler::fgExpandRarelyRunBlocks()
                 break;
         }
 
-        if (reason != nullptr)
+        if (setRarelyRun)
         {
             JITDUMP("%s, marking " FMT_BB " as rarely run\n", reason, bPrev->bbNum);
 
@@ -4650,9 +4601,9 @@ bool Compiler::fgExpandRarelyRunBlocks()
 #endif // DEBUG
 
                 // When marking a BBJ_CALLFINALLY as rarely run we also mark
-                // the BBJ_ALWAYS that comes after it as rarely run
+                // the BBJ_CALLFINALLYRET that comes after it as rarely run
                 //
-                if (block->isBBCallAlwaysPair())
+                if (block->isBBCallFinallyPair())
                 {
                     BasicBlock* bNext = block->Next();
                     PREFIX_ASSUME(bNext != nullptr);
@@ -4660,7 +4611,7 @@ bool Compiler::fgExpandRarelyRunBlocks()
 #ifdef DEBUG
                     if (verbose)
                     {
-                        printf("Also marking the BBJ_ALWAYS at " FMT_BB " as rarely run\n", bNext->bbNum);
+                        printf("Also marking the BBJ_CALLFINALLYRET at " FMT_BB " as rarely run\n", bNext->bbNum);
                     }
 #endif // DEBUG
                 }
@@ -4679,16 +4630,16 @@ bool Compiler::fgExpandRarelyRunBlocks()
         // if bPrev->bbWeight is not based upon profile data we can adjust
         // the weights of bPrev and block
         //
-        else if (bPrev->isBBCallAlwaysPair() &&          // we must have a BBJ_CALLFINALLY and BBK_ALWAYS pair
+        else if (bPrev->isBBCallFinallyPair() &&         // we must have a BBJ_CALLFINALLY and BBJ_CALLFINALLYRET pair
                  (bPrev->bbWeight != block->bbWeight) && // the weights are currently different
-                 !bPrev->hasProfileWeight())             // and the BBJ_CALLFINALLY block is not using profiled
-                                                         // weights
+                 !bPrev->hasProfileWeight())             // and the BBJ_CALLFINALLY block is not using profiled weights
         {
             if (block->isRunRarely())
             {
-                bPrev->bbWeight =
-                    block->bbWeight; // the BBJ_CALLFINALLY block now has the same weight as the BBJ_ALWAYS block
-                bPrev->SetFlags(BBF_RUN_RARELY); // and is now rarely run
+                // Set the BBJ_CALLFINALLY block to the same weight as the BBJ_CALLFINALLYRET block and
+                // mark it rarely run.
+                bPrev->bbWeight = block->bbWeight;
+                bPrev->SetFlags(BBF_RUN_RARELY);
 #ifdef DEBUG
                 if (verbose)
                 {
@@ -4700,13 +4651,14 @@ bool Compiler::fgExpandRarelyRunBlocks()
             }
             else if (bPrev->isRunRarely())
             {
-                block->bbWeight =
-                    bPrev->bbWeight; // the BBJ_ALWAYS block now has the same weight as the BBJ_CALLFINALLY block
-                block->SetFlags(BBF_RUN_RARELY); // and is now rarely run
+                // Set the BBJ_CALLFINALLYRET block to the same weight as the BBJ_CALLFINALLY block and
+                // mark it rarely run.
+                block->bbWeight = bPrev->bbWeight;
+                block->SetFlags(BBF_RUN_RARELY);
 #ifdef DEBUG
                 if (verbose)
                 {
-                    printf("Marking the BBJ_ALWAYS block at " FMT_BB " as rarely run because " FMT_BB
+                    printf("Marking the BBJ_CALLFINALLYRET block at " FMT_BB " as rarely run because " FMT_BB
                            " is rarely run\n",
                            block->bbNum, bPrev->bbNum);
                 }
@@ -4714,8 +4666,8 @@ bool Compiler::fgExpandRarelyRunBlocks()
             }
             else // Both blocks are hot, bPrev is known not to be using profiled weight
             {
-                bPrev->bbWeight =
-                    block->bbWeight; // the BBJ_CALLFINALLY block now has the same weight as the BBJ_ALWAYS block
+                // Set the BBJ_CALLFINALLY block to the same weight as the BBJ_CALLFINALLYRET block
+                bPrev->bbWeight = block->bbWeight;
             }
             noway_assert(block->bbWeight == bPrev->bbWeight);
         }
@@ -4810,6 +4762,12 @@ bool Compiler::fgReorderBlocks(bool useProfile)
         // We also consider reversing conditional branches so that they become a not taken forwards branch.
         //
 
+        // Don't consider BBJ_CALLFINALLYRET; it should be processed together with BBJ_CALLFINALLY.
+        if (block->KindIs(BBJ_CALLFINALLYRET))
+        {
+            continue;
+        }
+
         // If block is marked with a BBF_KEEP_BBJ_ALWAYS flag then we don't move the block
         if (block->HasFlag(BBF_KEEP_BBJ_ALWAYS))
         {
@@ -4818,19 +4776,19 @@ bool Compiler::fgReorderBlocks(bool useProfile)
 
         // Finally and handlers blocks are to be kept contiguous.
         // TODO-CQ: Allow reordering within the handler region
-        if (block->hasHndIndex() == true)
+        if (block->hasHndIndex())
         {
             continue;
         }
 
         bool        reorderBlock   = useProfile;
-        bool        isRare         = block->isRunRarely();
+        const bool  isRare         = block->isRunRarely();
         BasicBlock* bDest          = nullptr;
         bool        forwardBranch  = false;
         bool        backwardBranch = false;
 
         // Setup bDest
-        if (bPrev->KindIs(BBJ_ALWAYS))
+        if (bPrev->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
         {
             bDest          = bPrev->GetTarget();
             forwardBranch  = fgIsForwardBranch(bPrev, bDest);
@@ -4863,7 +4821,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
             //
             if (forwardBranch)
             {
-                if (bPrev->KindIs(BBJ_ALWAYS))
+                if (bPrev->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
                 {
                     if (bPrev->JumpsToNext())
                     {
@@ -5067,9 +5025,9 @@ bool Compiler::fgReorderBlocks(bool useProfile)
 
                 while (bTmp != nullptr)
                 {
-                    // Don't try to split a Call/Always pair
+                    // Don't try to split a call finally pair
                     //
-                    if (bTmp->isBBCallAlwaysPair())
+                    if (bTmp->isBBCallFinallyPair())
                     {
                         // Move bTmp forward
                         bTmp = bTmp->Next();
@@ -5090,11 +5048,11 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                     if ((bTmp->bbWeight > highestWeight) && fgEhAllowsMoveBlock(bPrev, bTmp))
                     {
                         // When we have a current candidateBlock that is a conditional (or unconditional) jump
-                        // to bTmp (which is a higher weighted block) then it is better to keep out current
+                        // to bTmp (which is a higher weighted block) then it is better to keep our current
                         // candidateBlock and have it fall into bTmp
                         //
                         if ((candidateBlock == nullptr) || !candidateBlock->KindIs(BBJ_COND, BBJ_ALWAYS) ||
-                            (candidateBlock->KindIs(BBJ_ALWAYS) &&
+                            (candidateBlock->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) &&
                              (!candidateBlock->TargetIs(bTmp) || candidateBlock->JumpsToNext())) ||
                             (candidateBlock->KindIs(BBJ_COND) && !candidateBlock->TrueTargetIs(bTmp)))
                         {
@@ -5105,7 +5063,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                         }
                     }
 
-                    const bool bTmpJumpsToNext = bTmp->KindIs(BBJ_ALWAYS) && bTmp->JumpsToNext();
+                    const bool bTmpJumpsToNext = bTmp->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) && bTmp->JumpsToNext();
                     if ((!bTmp->bbFallsThrough() && !bTmpJumpsToNext) || (bTmp->bbWeight == BB_ZERO_WEIGHT))
                     {
                         lastNonFallThroughBlock = bTmp;
@@ -5149,7 +5107,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
             /* (bPrev is known to be a normal block at this point) */
             if (!isRare)
             {
-                if (block->NextIs(bDest) && block->KindIs(BBJ_RETURN) && bPrev->KindIs(BBJ_ALWAYS))
+                if (block->NextIs(bDest) && block->KindIs(BBJ_RETURN) && bPrev->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
                 {
                     // This is a common case with expressions like "return Expr1 && Expr2" -- move the return
                     // to establish fall-through.
@@ -5228,9 +5186,9 @@ bool Compiler::fgReorderBlocks(bool useProfile)
         {
             while (true)
             {
-                // Don't try to split a Call/Always pair
+                // Don't try to split a call finally pair
                 //
-                if (bEnd->isBBCallAlwaysPair())
+                if (bEnd->isBBCallFinallyPair())
                 {
                     // Move bEnd and bNext forward
                     bEnd  = bNext;
@@ -5356,11 +5314,11 @@ bool Compiler::fgReorderBlocks(bool useProfile)
 
                 while (true)
                 {
-                    // Don't try to split a Call/Always pair
+                    // Don't try to split a call finally pair
                     //
-                    if (bEnd2->isBBCallAlwaysPair())
+                    if (bEnd2->isBBCallFinallyPair())
                     {
-                        noway_assert(bNext->KindIs(BBJ_ALWAYS));
+                        noway_assert(bNext->KindIs(BBJ_CALLFINALLYRET));
                         // Move bEnd2 and bNext forward
                         bEnd2 = bNext;
                         bNext = bNext->Next();
@@ -5373,7 +5331,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                         break;
                     }
 
-                    if (bEnd2->KindIs(BBJ_ALWAYS) && bEnd2->JumpsToNext())
+                    if (bEnd2->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) && bEnd2->JumpsToNext())
                     {
                         // Treat jumps to next block as fall-through
                     }
@@ -5448,7 +5406,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                     printf("Decided to reverse conditional branch at block " FMT_BB " branch to " FMT_BB " ",
                            bPrev->bbNum, bDest->bbNum);
                 }
-                else if (bPrev->KindIs(BBJ_ALWAYS))
+                else if (bPrev->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
                 {
                     printf("Decided to straighten unconditional branch at block " FMT_BB " branch to " FMT_BB " ",
                            bPrev->bbNum, bDest->bbNum);
@@ -5532,8 +5490,8 @@ bool Compiler::fgReorderBlocks(bool useProfile)
 
         if (compHndBBtabCount > 0)
         {
-            fStartIsInTry = new (this, CMK_Unknown) bool[compHndBBtabCount];
-            fStartIsInHnd = new (this, CMK_Unknown) bool[compHndBBtabCount];
+            fStartIsInTry = new (this, CMK_Generic) bool[compHndBBtabCount];
+            fStartIsInHnd = new (this, CMK_Generic) bool[compHndBBtabCount];
 
             for (XTnum = 0, HBtab = compHndBBtab; XTnum < compHndBBtabCount; XTnum++, HBtab++)
             {
@@ -5668,7 +5626,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
                     BasicBlock* nearBlk = nullptr;
                     BasicBlock* jumpBlk = nullptr;
 
-                    if (bEnd->KindIs(BBJ_ALWAYS) && !bEnd->JumpsToNext() &&
+                    if (bEnd->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) && !bEnd->JumpsToNext() &&
                         (!isRare || bEnd->GetTarget()->isRunRarely()) &&
                         fgIsForwardBranch(bEnd, bEnd->GetTarget(), bPrev))
                     {
@@ -6072,16 +6030,15 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                 }
             }
 
-            // Remove jumps to the following block
-            // and optimize any JUMPS to JUMPS
+            // Remove jumps to the following block and optimize any JUMPS to JUMPS
 
-            if (block->KindIs(BBJ_ALWAYS))
+            if (block->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET))
             {
                 bDest = block->GetTarget();
                 if (bDest == bNext)
                 {
                     // Skip jump optimizations, and try to compact block and bNext later
-                    if (!block->isBBCallAlwaysPairTail())
+                    if (!block->isBBCallFinallyPairTail())
                     {
                         block->SetFlags(BBF_NONE_QUIRK);
                     }
@@ -6200,7 +6157,7 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication, bool isPhase)
                         // In the join free case, we also need to move bDest right after bNext
                         // to create same flow as in the isJumpAroundEmpty case.
                         //
-                        if (!fgEhAllowsMoveBlock(bNext, bDest) || bDest->isBBCallAlwaysPair())
+                        if (!fgEhAllowsMoveBlock(bNext, bDest) || bDest->isBBCallFinallyPair())
                         {
                             optimizeJump = false;
                         }
@@ -6548,7 +6505,7 @@ PhaseStatus Compiler::fgDfsBlocksAndRemove()
             fgRemoveUnreachableBlocks([=, &anyCallFinallyPairs](BasicBlock* block) {
                 if (!m_dfsTree->Contains(block))
                 {
-                    anyCallFinallyPairs |= block->isBBCallAlwaysPair();
+                    anyCallFinallyPairs |= block->isBBCallFinallyPair();
                     return true;
                 }
 
@@ -6593,6 +6550,9 @@ unsigned Compiler::fgGetCodeEstimate(BasicBlock* block)
             break;
         case BBJ_CALLFINALLY:
             costSz = 5;
+            break;
+        case BBJ_CALLFINALLYRET:
+            costSz = 0;
             break;
         case BBJ_SWITCH:
             costSz = 10;

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -152,6 +152,7 @@ void ProfileSynthesis::AssignLikelihoods()
                 break;
 
             case BBJ_ALWAYS:
+            case BBJ_CALLFINALLYRET:
             case BBJ_LEAVE:
             case BBJ_EHCATCHRET:
             case BBJ_EHFILTERRET:
@@ -410,6 +411,7 @@ void ProfileSynthesis::RepairLikelihoods()
                 break;
 
             case BBJ_ALWAYS:
+            case BBJ_CALLFINALLYRET:
             case BBJ_LEAVE:
             case BBJ_EHCATCHRET:
             case BBJ_EHFILTERRET:
@@ -501,6 +503,7 @@ void ProfileSynthesis::BlendLikelihoods()
                 break;
 
             case BBJ_ALWAYS:
+            case BBJ_CALLFINALLYRET:
             case BBJ_LEAVE:
             case BBJ_EHCATCHRET:
             case BBJ_EHFILTERRET:

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -614,6 +614,44 @@ PhaseStatus Compiler::fgImport()
     return PhaseStatus::MODIFIED_EVERYTHING;
 }
 
+//------------------------------------------------------------------------
+// fgUpdateCallFinally: For BBJ_CALLFINALLY/BBJ_ALWAYS pairs, replace BBJ_ALWAYS with BBJ_CALLFINALLYRET.
+//
+// This should be temporary. Later, fix impImportLeave to do this directly.
+//
+// Returns:
+//    phase status
+//
+PhaseStatus Compiler::fgUpdateCallFinally()
+{
+    if (info.compXcptnsCount == 0)
+    {
+        return PhaseStatus::MODIFIED_NOTHING;
+    }
+
+    for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->Next())
+    {
+        if (block->KindIs(BBJ_CALLFINALLY))
+        {
+            // There are no ret-less callfinally yet (this is run early), so there must be a matching
+            // BBJ_ALWAYS block.
+            BasicBlock* blockAlways = block->Next();
+            assert(blockAlways != nullptr);
+            assert(blockAlways->KindIs(BBJ_ALWAYS));
+            assert(blockAlways->isEmpty());
+            assert(blockAlways->HasFlag(BBF_KEEP_BBJ_ALWAYS));
+
+            blockAlways->SetKind(BBJ_CALLFINALLYRET);
+            blockAlways->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
+
+            JITDUMP("Replaced BBJ_ALWAYS " FMT_BB " of BBJ_CALLFINALLY " FMT_BB " pair with BBJ_CALLFINALLYRET.\n",
+                    blockAlways->bbNum, block->bbNum);
+        }
+    }
+
+    return PhaseStatus::MODIFIED_EVERYTHING;
+}
+
 /*****************************************************************************
  * This function returns true if tree is a node with a call
  * that unconditionally throws an exception
@@ -1633,8 +1671,8 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
 // Convert a BBJ_RETURN block in a synchronized method to a BBJ_ALWAYS.
 // We've previously added a 'try' block around the original program code using fgAddSyncMethodEnterExit().
 // Thus, we put BBJ_RETURN blocks inside a 'try'. In IL this is illegal. Instead, we would
-// see a 'leave' inside a 'try' that would get transformed into BBJ_CALLFINALLY/BBJ_ALWAYS blocks
-// during importing, and the BBJ_ALWAYS would point at an outer block with the BBJ_RETURN.
+// see a 'leave' inside a 'try' that would get transformed into BBJ_CALLFINALLY/BBJ_CALLFINALLYRET blocks
+// during importing, and the BBJ_CALLFINALLYRET would point at an outer block with the BBJ_RETURN.
 // Here, we mimic some of the logic of importing a LEAVE to get the same effect for synchronized methods.
 void Compiler::fgConvertSyncReturnToLeave(BasicBlock* block)
 {
@@ -3202,9 +3240,9 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
 
                 case BBJ_CALLFINALLY:
                     // A BBJ_CALLFINALLY that falls through is always followed
-                    // by an empty BBJ_ALWAYS.
+                    // by an empty BBJ_CALLFINALLYRET.
                     //
-                    assert(prevToFirstColdBlock->isBBCallAlwaysPair());
+                    assert(prevToFirstColdBlock->isBBCallFinallyPair());
                     firstColdBlock =
                         firstColdBlock->Next(); // Note that this assignment could make firstColdBlock == nullptr
                     break;
@@ -4340,6 +4378,7 @@ FlowGraphNaturalLoops* FlowGraphNaturalLoops::Find(const FlowGraphDfsTree* dfsTr
 
 #ifdef DEBUG
     JITDUMP("Identifying loops in DFS tree with following reverse post order:\n");
+    JITDUMP("RPO -> BB [pre, post]\n");
     for (unsigned i = dfsTree->GetPostOrderCount(); i != 0; i--)
     {
         unsigned          rpoNum = dfsTree->GetPostOrderCount() - i;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12197,7 +12197,7 @@ void Compiler::impImport()
 //
 // Notes:
 //   These edges were not added during the initial pred list computation,
-//   because the initial flow graph does not contain the callfinally/always
+//   because the initial flow graph does not contain the callfinally
 //   block pairs; those blocks are added during importation.
 //
 //   We rely on handler blocks being lexically contiguous between begin and last.
@@ -12238,7 +12238,7 @@ void Compiler::impFixPredLists()
                     {
                         // We only care about preds that are callfinallies.
                         //
-                        if (!predBlock->isBBCallAlwaysPair())
+                        if (!predBlock->KindIs(BBJ_CALLFINALLY))
                         {
                             continue;
                         }
@@ -12262,7 +12262,7 @@ void Compiler::impFixPredLists()
                     {
                         // We only care about preds that are callfinallies.
                         //
-                        if (!predBlock->isBBCallAlwaysPair())
+                        if (!predBlock->KindIs(BBJ_CALLFINALLY))
                         {
                             continue;
                         }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1035,7 +1035,7 @@ DONE:
 #ifdef DEBUG
     // In debug we want to be able to register callsites with the EE.
     assert(call->AsCall()->callSig == nullptr);
-    call->AsCall()->callSig  = new (this, CMK_Generic) CORINFO_SIG_INFO;
+    call->AsCall()->callSig  = new (this, CMK_DebugOnly) CORINFO_SIG_INFO;
     *call->AsCall()->callSig = *sig;
 #endif
 

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -88,7 +88,7 @@ void Compiler::lvaInit()
     lvaCallSpCheck = BAD_VAR_NUM;
 #endif
 
-    structPromotionHelper = new (this, CMK_Generic) StructPromotionHelper(this);
+    structPromotionHelper = new (this, CMK_Promotion) StructPromotionHelper(this);
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -891,17 +891,13 @@ void Compiler::fgExtendDbgLifetimes()
             case BBJ_ALWAYS:
             case BBJ_EHCATCHRET:
             case BBJ_EHFILTERRET:
+            case BBJ_CALLFINALLY:
                 VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
                 break;
 
-            case BBJ_CALLFINALLY:
-                if (!block->HasFlag(BBF_RETLESS_CALL))
-                {
-                    assert(block->isBBCallAlwaysPair());
-                    PREFIX_ASSUME(!block->IsLast());
-                    VarSetOps::UnionD(this, initVars, block->Next()->bbScope);
-                }
-                VarSetOps::UnionD(this, initVars, block->GetTarget()->bbScope);
+            case BBJ_CALLFINALLYRET:
+                VarSetOps::UnionD(this, initVars, block->bbScope);
+                VarSetOps::UnionD(this, initVars, block->GetFinallyContinuation()->bbScope);
                 break;
 
             case BBJ_COND:

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -944,9 +944,9 @@ void LinearScan::setBlockSequence()
         }
 #endif // TRACK_LSRA_STATS
 
-        // We treat BBCallAlwaysPairTail blocks as having EH flow, since we can't
+        // We treat CALLFINALLYRET blocks as having EH flow, since we can't
         // insert resolution moves into those blocks.
-        if (block->isBBCallAlwaysPairTail())
+        if (block->isBBCallFinallyPairTail())
         {
             blockInfo[block->bbNum].hasEHBoundaryIn  = true;
             blockInfo[block->bbNum].hasEHBoundaryOut = true;
@@ -968,11 +968,9 @@ void LinearScan::setBlockSequence()
                 }
             }
 
-            if (!block->isBBCallAlwaysPairTail() &&
-                (predBlock->hasEHBoundaryOut() || predBlock->isBBCallAlwaysPairTail()))
+            if (!block->isBBCallFinallyPairTail() &&
+                (predBlock->hasEHBoundaryOut() || predBlock->isBBCallFinallyPairTail()))
             {
-                assert(!block->isBBCallAlwaysPairTail());
-
                 if (hasUniquePred)
                 {
                     // A unique pred with an EH out edge won't allow us to keep any variables enregistered.
@@ -1482,13 +1480,13 @@ void LinearScan::recordVarLocationsAtStartOfBB(BasicBlock* bb)
             count++;
 
             BasicBlock* prevReportedBlock = bb->Prev();
-            if (!bb->IsFirst() && bb->Prev()->isBBCallAlwaysPairTail())
+            if (!bb->IsFirst() && bb->Prev()->isBBCallFinallyPairTail())
             {
-                // For callf+always pair we generate the code for the always
-                // block in genCallFinally and skip it, so we don't report
+                // For call finally pair we generate the code for the call finally
+                // block in genCallFinally and skip the pair, so we don't report
                 // anything for it (it has only trivial instructions, so that
                 // does not matter much). So whether we need to rehome or not
-                // depends on what we reported at the end of the callf block.
+                // depends on what we reported at the end of the call finally block.
                 prevReportedBlock = bb->Prev()->Prev();
             }
 
@@ -8108,8 +8106,8 @@ void LinearScan::addResolution(BasicBlock* block,
     JITDUMP(": move V%02u from %s to %s (%s)\n", interval->varNum, getRegName(fromReg), getRegName(toReg), reason);
 #endif // DEBUG
 
-    // We should never add resolution move inside BBCallAlwaysPairTail.
-    noway_assert(!block->isBBCallAlwaysPairTail());
+    // We should never add resolution move inside BBCallFinallyPairTail.
+    noway_assert(!block->isBBCallFinallyPairTail());
 
     insertMove(block, insertionPoint, interval->varNum, fromReg, toReg);
     if (fromReg == REG_STK || toReg == REG_STK)

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -781,8 +781,8 @@ void SsaBuilder::AddMemoryDefToEHSuccessorPhis(MemoryKind memoryKind, BasicBlock
 {
     assert(block->HasPotentialEHSuccs(m_pCompiler));
 
-    // Don't do anything for a compiler-inserted BBJ_ALWAYS that is a "leave helper".
-    if (block->HasFlag(BBF_INTERNAL) && block->isBBCallAlwaysPairTail())
+    // Don't do anything for a compiler-inserted BBJ_CALLFINALLYRET that is a "leave helper".
+    if (block->isBBCallFinallyPairTail())
     {
         return;
     }

--- a/src/coreclr/jit/switchrecognition.cpp
+++ b/src/coreclr/jit/switchrecognition.cpp
@@ -342,9 +342,7 @@ bool Compiler::optSwitchConvert(BasicBlock* firstBlock, int testsCount, ssize_t*
     fgRemoveRefPred(blockToRemove, firstBlock);
     while (!lastBlock->NextIs(blockToRemove))
     {
-        BasicBlock* nextBlock = blockToRemove->Next();
-        fgRemoveBlock(blockToRemove, true);
-        blockToRemove = nextBlock;
+        blockToRemove = fgRemoveBlock(blockToRemove, true);
     }
 
     const auto jumpCount = static_cast<unsigned>(maxValue - minValue + 1);


### PR DESCRIPTION
Non-exceptional calls to finally blocks are represented in the JIT IR
as a pair of blocks:
1. `BBJ_CALLFINALLY` targets the finally block
2. `BBJ_ALWAYS` targets the finally "continuation", namely, the location
where execution should continue after calling the finally. It is different
from normal `BBJ_ALWAYS`, as it must be empty of code, must be the `bbNext`
successor of the `BBJ_CALLFINALLY`, and must have the
`BBF_KEEP_BBJ_ALWAYS` flag.

If the JIT knows the finally never returns (e.g., it unconditionally
throws), the paired `BBJ_ALWAYS` will not exist, and the `BBJ_CALLFINALLY`
will have the `BBF_RETLESS_CALL` flag.

This structure is unique in the JIT IR and leads to a lot of special
case code to maintain the pair relationship.

This PR makes a small change to the IR by introducing a new `BBJ_CALLFINALLYRET`
block type to be used instead of `BBJ_ALWAYS` when paired with a `BBJ_CALLFINALLY`.
The idea is to reduce overloading the semantics of `BBJ_ALWAYS` in this case,
so code that checks for `BBJ_ALWAYS` can do so knowing it always means the same
thing, without checking whether it is one of the special pair.

There one remaining "special" `BBJ_ALWAYS`: the "final step" block of an x86
callfinally. It is the only block that still uses the `BBF_KEEP_BBJ_ALWAYS` flag.

This change has a very few diffs where a slight difference in the order of
block removal (especially, in `fgRemoveEmptyTry`) leads to different
downstream optimizations.

Currently, this is implemented by running a pass to convert paired `BBJ_ALWAYS`
to `BBJ_CALLFINALLYRET` after the importer (namely, after importing `LEAVE`).
I'll go back and fix the LEAVE implementation if this is merged, to generate
the new IR form directly in the importer, and remove a few `TODO-Quirk` left
as a result (e.g., in `fgFindInsertPoint`, `BBPredsChecker::CheckEhTryDsc`,
`fgComputeMissingBlockWeights`).

The benefit of this change is the IR is more explicit; asserts can be better;
and there should be less confusion about `BBJ_ALWAYS` cases "accidentally"
kicking in for callfinally pairs.

Addresses #95355