### PR TITLE
Allow preinitializing `AppContext.TryGetSwitch`

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -244,6 +244,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Include="@(AutoInitializedAssemblies->'--initassembly:%(Identity)')" />
       <IlcArg Include="@(DirectPInvoke->'--directpinvoke:%(Identity)')" />
       <IlcArg Include="@(DirectPInvokeList->'--directpinvokelist:%(Identity)')" />
+      <IlcArg Include="--feature:System.Resources.UseSystemResourceKeys=false" />
       <IlcArg Include="@(_TrimmerFeatureSettings->'--feature:%(Identity)=%(Value)')" />
       <IlcArg Include="@(RuntimeHostConfigurationOption->'--runtimeknob:%(Identity)=%(Value)')" />
       <IlcArg Include="--runtimeknob:RUNTIME_IDENTIFIER=$(RuntimeIdentifier)" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilationBuilder.Aot.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 
 namespace ILCompiler
 {
@@ -132,7 +133,7 @@ namespace ILCompiler
         protected PreinitializationManager GetPreinitializationManager()
         {
             if (_preinitializationManager == null)
-                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new StaticReadOnlyFieldPolicy());
+                return new PreinitializationManager(_context, _compilationGroup, GetILProvider(), new TypePreinit.DisabledPreinitializationPolicy(), new StaticReadOnlyFieldPolicy(), new Dictionary<string, bool>());
             return _preinitializationManager;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -436,7 +436,7 @@ namespace ILCompiler
             TypePreinit.TypePreinitializationPolicy preinitPolicy = preinitStatics ?
                 new TypePreinit.TypeLoaderAwarePreinitializationPolicy() : new TypePreinit.DisabledPreinitializationPolicy();
 
-            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new StaticReadOnlyFieldPolicy());
+            var preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, preinitPolicy, new StaticReadOnlyFieldPolicy(), featureSwitches);
             builder
                 .UseILProvider(ilProvider)
                 .UsePreinitializationManager(preinitManager);
@@ -515,7 +515,7 @@ namespace ILCompiler
                 {
                     var readOnlyFieldPolicy = scanResults.GetReadOnlyFieldPolicy();
                     preinitManager = new PreinitializationManager(typeSystemContext, compilationGroup, ilProvider, scanResults.GetPreinitializationPolicy(),
-                        readOnlyFieldPolicy);
+                        readOnlyFieldPolicy, featureSwitches);
                     builder.UsePreinitializationManager(preinitManager)
                         .UseReadOnlyFieldPolicy(readOnlyFieldPolicy);
                 }

--- a/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
+++ b/src/tests/nativeaot/SmokeTests/FrameworkStrings/UseSystemResourceKeys.csproj
@@ -3,16 +3,14 @@
     <OutputType>Exe</OutputType>
     <CLRTestPriority>0</CLRTestPriority>
     <DefineConstants>$(DefineConstants);RESOURCE_KEYS</DefineConstants>
+
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
     
     <!-- Requires the framework to also be compiled with UseSystemResourceKeys -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
     <!-- Test infra issue on apple devices: https://github.com/dotnet/runtime/issues/89917 -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAppleMobile)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
-
-  <ItemGroup>
-    <IlcArg Include="--feature:System.Resources.UseSystemResourceKeys=true" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Program.cs" />


### PR DESCRIPTION
Interpret this in the static constructor interpreter. Allows compile-time initializing ~30 extra types in the Stage1 app. 99% of them are the SR class.

To actually preinitialize the SR class I had to pass `--feature:System.Resources.UseSystemResourceKeys=false` on the ILC command line. This will get overwritten by `--feature:System.Resources.UseSystemResourceKeys=true` if it shows up on the command line after this.

I considered doing this in the substitution IL rewriter (so that RyuJIT-produced code can also benefit), but the API shape (returning bool and taking ref to a bool) makes this really awkward to rewrite in IL. Much easier to interpret.

Cc @dotnet/ilc-contrib 