### PR TITLE
Delete `Diagnostics.DisableMetadataStackTraceResolution`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/DeveloperExperience/DeveloperExperience.cs
@@ -18,20 +18,6 @@ namespace Internal.DeveloperExperience
 {
     public class DeveloperExperience
     {
-        /// <summary>
-        /// Check the AppCompat switch 'Diagnostics.DisableMetadataStackTraceResolution'.
-        /// Some customers use DIA-based tooling to translate stack traces in the raw format
-        /// (module)+RVA - for them, stack trace and reflection metadata-based resolution
-        /// constitutes technically a regression because these two resolution methods today cannot
-        /// provide file name and line number information; PDB-based tooling can easily do that
-        /// based on the RVA information.
-        /// </summary>
-        private static bool IsMetadataStackTraceResolutionDisabled()
-        {
-            AppContext.TryGetSwitch("Diagnostics.DisableMetadataStackTraceResolution", out bool disableMetadata);
-            return disableMetadata;
-        }
-
         public virtual string CreateStackTraceString(IntPtr ip, bool includeFileInfo, out bool isStackTraceHidden)
         {
             string methodName = GetMethodName(ip, out IntPtr methodStart, out isStackTraceHidden);
@@ -61,16 +47,13 @@ namespace Internal.DeveloperExperience
         internal static string GetMethodName(IntPtr ip, out IntPtr methodStart, out bool isStackTraceHidden)
         {
             methodStart = IntPtr.Zero;
-            if (!IsMetadataStackTraceResolutionDisabled())
+            StackTraceMetadataCallbacks stackTraceCallbacks = RuntimeAugments.StackTraceCallbacksIfAvailable;
+            if (stackTraceCallbacks != null)
             {
-                StackTraceMetadataCallbacks stackTraceCallbacks = RuntimeAugments.StackTraceCallbacksIfAvailable;
-                if (stackTraceCallbacks != null)
+                methodStart = RuntimeImports.RhFindMethodStartAddress(ip);
+                if (methodStart != IntPtr.Zero)
                 {
-                    methodStart = RuntimeImports.RhFindMethodStartAddress(ip);
-                    if (methodStart != IntPtr.Zero)
-                    {
-                        return stackTraceCallbacks.TryGetMethodNameFromStartAddress(methodStart, out isStackTraceHidden);
-                    }
+                    return stackTraceCallbacks.TryGetMethodNameFromStartAddress(methodStart, out isStackTraceHidden);
                 }
             }
             isStackTraceHidden = false;


### PR DESCRIPTION
This is an escape hatch to disable stack trace strings that was inherited from .NET Native (https://github.com/microsoft/dotnet/blob/main/releases/UWP/net-native2.1/README.md#uwp-614-net-native-tools-218-may-7th-2018). It doesn't make sense to have it in Native AOT. We have the documented `<StackTraceSupport>false</StackTraceSupport>`. If set, it will make us skip the `if` right below the one I'm deleting.

Cc @dotnet/ilc-contrib 