### PR TITLE
Remove use of `string.Split` from reflection

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -554,7 +554,7 @@ namespace System.Reflection.Runtime.General
         //
         public static bool IsCustomAttributeOfType(this CustomAttributeHandle customAttributeHandle,
                                                    MetadataReader reader,
-                                                   string[] namespaceParts,
+                                                   ReadOnlySpan<string> namespaceParts,
                                                    string name)
         {
             Handle typeHandle = customAttributeHandle.GetCustomAttribute(reader).GetAttributeTypeHandle(reader);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/General/MetadataReaderExtensions.NativeFormat.cs
@@ -554,10 +554,9 @@ namespace System.Reflection.Runtime.General
         //
         public static bool IsCustomAttributeOfType(this CustomAttributeHandle customAttributeHandle,
                                                    MetadataReader reader,
-                                                   string ns,
+                                                   string[] namespaceParts,
                                                    string name)
         {
-            string[] namespaceParts = ns.Split('.');
             Handle typeHandle = customAttributeHandle.GetCustomAttribute(reader).GetAttributeTypeHandle(reader);
             HandleType handleType = typeHandle.HandleType;
             if (handleType == HandleType.TypeDefinition)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -48,9 +48,10 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                     return Internal.Runtime.Augments.RuntimeAugments.IsByRefLike(typeHandle);
 
                 // Otherwise fall back to attributes
+                string[]? isByRefLikeAttributeNamespaceParts = null;
                 foreach (CustomAttributeHandle cah in _typeDefinition.CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(_reader, "System.Runtime.CompilerServices", "IsByRefLikeAttribute"))
+                    if (cah.IsCustomAttributeOfType(_reader, isByRefLikeAttributeNamespaceParts ??= ["System", "Runtime", "CompilerServices"], "IsByRefLikeAttribute"))
                         return true;
                 }
                 return false;
@@ -62,13 +63,14 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             //
             // Look for a [Guid] attribute. If found, return that.
             //
+            string[]? guidAttributeNamespaceParts = null;
             foreach (CustomAttributeHandle cah in _typeDefinition.CustomAttributes)
             {
                 // We can't reference the GuidAttribute class directly as we don't have an official dependency on System.Runtime.InteropServices.
                 // Following age-old CLR tradition, we search for the custom attribute using a name-based search. Since this makes it harder
                 // to be sure we won't run into custom attribute constructors that comply with the GuidAttribute(String) signature,
                 // we'll check that it does and silently skip the CA if it doesn't match the expected pattern.
-                if (cah.IsCustomAttributeOfType(_reader, "System.Runtime.InteropServices", "GuidAttribute"))
+                if (cah.IsCustomAttributeOfType(_reader, guidAttributeNamespaceParts ??= ["System", "Runtime", "InteropServices"], "GuidAttribute"))
                 {
                     CustomAttribute ca = cah.GetCustomAttribute(_reader);
                     HandleCollection.Enumerator fahEnumerator = ca.FixedArguments.GetEnumerator();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/TypeInfos/NativeFormat/NativeFormatRuntimeNamedTypeInfo.cs
@@ -48,10 +48,9 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
                     return Internal.Runtime.Augments.RuntimeAugments.IsByRefLike(typeHandle);
 
                 // Otherwise fall back to attributes
-                string[]? isByRefLikeAttributeNamespaceParts = null;
                 foreach (CustomAttributeHandle cah in _typeDefinition.CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(_reader, isByRefLikeAttributeNamespaceParts ??= ["System", "Runtime", "CompilerServices"], "IsByRefLikeAttribute"))
+                    if (cah.IsCustomAttributeOfType(_reader, ["System", "Runtime", "CompilerServices"], "IsByRefLikeAttribute"))
                         return true;
                 }
                 return false;
@@ -63,14 +62,13 @@ namespace System.Reflection.Runtime.TypeInfos.NativeFormat
             //
             // Look for a [Guid] attribute. If found, return that.
             //
-            string[]? guidAttributeNamespaceParts = null;
             foreach (CustomAttributeHandle cah in _typeDefinition.CustomAttributes)
             {
                 // We can't reference the GuidAttribute class directly as we don't have an official dependency on System.Runtime.InteropServices.
                 // Following age-old CLR tradition, we search for the custom attribute using a name-based search. Since this makes it harder
                 // to be sure we won't run into custom attribute constructors that comply with the GuidAttribute(String) signature,
                 // we'll check that it does and silently skip the CA if it doesn't match the expected pattern.
-                if (cah.IsCustomAttributeOfType(_reader, guidAttributeNamespaceParts ??= ["System", "Runtime", "InteropServices"], "GuidAttribute"))
+                if (cah.IsCustomAttributeOfType(_reader, ["System", "Runtime", "InteropServices"], "GuidAttribute"))
                 {
                     CustomAttribute ca = cah.GetCustomAttribute(_reader);
                     HandleCollection.Enumerator fahEnumerator = ca.FixedArguments.GetEnumerator();

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -58,9 +58,10 @@ namespace Internal.Reflection.Execution
             }
 
             isFlags = false;
+            string[]? flagsAttributeNamespaceParts = null;
             foreach (CustomAttributeHandle cah in typeDef.CustomAttributes)
             {
-                if (cah.IsCustomAttributeOfType(reader, "System", "FlagsAttribute"))
+                if (cah.IsCustomAttributeOfType(reader, flagsAttributeNamespaceParts ??= ["System"], "FlagsAttribute"))
                 {
                     isFlags = true;
                     break;

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/NativeFormatEnumInfo.cs
@@ -58,10 +58,9 @@ namespace Internal.Reflection.Execution
             }
 
             isFlags = false;
-            string[]? flagsAttributeNamespaceParts = null;
             foreach (CustomAttributeHandle cah in typeDef.CustomAttributes)
             {
-                if (cah.IsCustomAttributeOfType(reader, flagsAttributeNamespaceParts ??= ["System"], "FlagsAttribute"))
+                if (cah.IsCustomAttributeOfType(reader, ["System"], "FlagsAttribute"))
                 {
                     isFlags = true;
                     break;

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -65,10 +65,9 @@ namespace Internal.StackTraceMetadata
                 out TypeDefinitionHandle typeHandle,
                 out MethodHandle methodHandle))
             {
-                string[]? systemDiagnosticsNamespaceParts = null;
                 foreach (CustomAttributeHandle cah in reader.GetTypeDefinition(typeHandle).CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(reader, systemDiagnosticsNamespaceParts ??= ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
+                    if (cah.IsCustomAttributeOfType(reader, ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
                     {
                         isStackTraceHidden = true;
                         break;
@@ -77,7 +76,7 @@ namespace Internal.StackTraceMetadata
 
                 foreach (CustomAttributeHandle cah in reader.GetMethod(methodHandle).CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(reader, systemDiagnosticsNamespaceParts ??= ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
+                    if (cah.IsCustomAttributeOfType(reader, ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
                     {
                         isStackTraceHidden = true;
                         break;

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/StackTraceMetadata.cs
@@ -65,9 +65,10 @@ namespace Internal.StackTraceMetadata
                 out TypeDefinitionHandle typeHandle,
                 out MethodHandle methodHandle))
             {
+                string[]? systemDiagnosticsNamespaceParts = null;
                 foreach (CustomAttributeHandle cah in reader.GetTypeDefinition(typeHandle).CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(reader, "System.Diagnostics", "StackTraceHiddenAttribute"))
+                    if (cah.IsCustomAttributeOfType(reader, systemDiagnosticsNamespaceParts ??= ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
                     {
                         isStackTraceHidden = true;
                         break;
@@ -76,7 +77,7 @@ namespace Internal.StackTraceMetadata
 
                 foreach (CustomAttributeHandle cah in reader.GetMethod(methodHandle).CustomAttributes)
                 {
-                    if (cah.IsCustomAttributeOfType(reader, "System.Diagnostics", "StackTraceHiddenAttribute"))
+                    if (cah.IsCustomAttributeOfType(reader, systemDiagnosticsNamespaceParts ??= ["System", "Diagnostics"], "StackTraceHiddenAttribute"))
                     {
                         isStackTraceHidden = true;
                         break;


### PR DESCRIPTION
Saves 1.2% on a Hello World. `dotnet new console --aot && dotnet publish /p:OptimizationPreference=Size` is now under 1 MB.

This is actually also a throughput optimization, not just size optimization.

Cc @dotnet/ilc-contrib 