### PR TITLE
[debugger][mono] Fix failing test `CheckVSCodeTestFunction1`

### DIFF
--- a/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
@@ -949,11 +949,15 @@ namespace DebuggerTests
                     return;
 
                 if (res_array_len < 0)
+                {
                     await CheckValue(result.Value["result"], TObject("Object"), $"cfo-res");
+                }
                 else
-                    // using TArrayJS instead of TArray because "result" value is purely JS and 
-                    // might differ from debuggerProxy's messages on each devtool protocol change
-                    await CheckValue(result.Value["result"], TArrayJS("Array", $"Array({res_array_len})"), $"cfo-res");
+                {
+                    // "result" value is purely JS and might diverge from debuggerProxy's messages on each devtool protocol change
+                    var jsArray = JObject.FromObject(new { type = "object", className = "Array", description = $"Array({res_array_len})" });
+                    await CheckValue(result.Value["result"], jsArray, $"cfo-res");
+                }
             }
         }
     }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/CallFunctionOnTests.cs
@@ -951,9 +951,10 @@ namespace DebuggerTests
                 if (res_array_len < 0)
                     await CheckValue(result.Value["result"], TObject("Object"), $"cfo-res");
                 else
-                    await CheckValue(result.Value["result"], TArray("Array", $"Array({res_array_len})"), $"cfo-res");
+                    // using TArrayJS instead of TArray because "result" value is purely JS and 
+                    // might differ from debuggerProxy's messages on each devtool protocol change
+                    await CheckValue(result.Value["result"], TArrayJS("Array", $"Array({res_array_len})"), $"cfo-res");
             }
         }
     }
-
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1363,7 +1363,6 @@ namespace DebuggerTests
             JObject.FromObject(new { type = "object", className = className, description = description ?? className });
 
         internal static JObject TArray(string className, string description) => JObject.FromObject(new { type = "object", className, description, subtype = "array" });
-        internal static JObject TArrayJS(string className, string description) => JObject.FromObject(new { type = "object", className, description });
 
         internal static JObject TBool(bool value) => JObject.FromObject(new { type = "boolean", value = @value, description = @value ? "true" : "false" });
 

--- a/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -1363,6 +1363,7 @@ namespace DebuggerTests
             JObject.FromObject(new { type = "object", className = className, description = description ?? className });
 
         internal static JObject TArray(string className, string description) => JObject.FromObject(new { type = "object", className, description, subtype = "array" });
+        internal static JObject TArrayJS(string className, string description) => JObject.FromObject(new { type = "object", className, description });
 
         internal static JObject TBool(bool value) => JObject.FromObject(new { type = "boolean", value = @value, description = @value ? "true" : "false" });
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95950. After updating chrome to new version, the messages about Arrays we are getting from chrome are different.
This is fixing error:
```
 Expected: {
   "type": "object",
   "className": "Array",
   "description": "Array(10)"
 } 
 Actual: {
   "type": "object",
   "className": "Array",
   "description": "Array",
   "objectId": "5084384295708308525.1.9"
 }
```