### PR TITLE
Fix incorrect docstring on List.EnsureCapacity

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -426,7 +426,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Ensures that the capacity of this list is at least the specified <paramref name="capacity"/>.
         /// If the current capacity of the list is less than specified <paramref name="capacity"/>,
-        /// the capacity is increased to at least twice the current capacity, and to at least <paramref name="capactity"/>.
+        /// the capacity is increased to at least twice the current capacity, and to at least <paramref name="capacity"/>.
         /// </summary>
         /// <param name="capacity">The minimum capacity to ensure.</param>
         /// <returns>The new capacity of this list.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -426,7 +426,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Ensures that the capacity of this list is at least the specified <paramref name="capacity"/>.
         /// If the current capacity of the list is less than specified <paramref name="capacity"/>,
-        /// the capacity is increased to at least twice the current capacity, and to at least <paramref name="capacity"/>.
+        /// the capacity is increased to at least <paramref name="capacity"/>.
         /// </summary>
         /// <param name="capacity">The minimum capacity to ensure.</param>
         /// <returns>The new capacity of this list.</returns>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/List.cs
@@ -426,7 +426,7 @@ namespace System.Collections.Generic
         /// <summary>
         /// Ensures that the capacity of this list is at least the specified <paramref name="capacity"/>.
         /// If the current capacity of the list is less than specified <paramref name="capacity"/>,
-        /// the capacity is increased by continuously twice current capacity until it is at least the specified <paramref name="capacity"/>.
+        /// the capacity is increased to at least twice the current capacity, and to at least <paramref name="capactity"/>.
         /// </summary>
         /// <param name="capacity">The minimum capacity to ensure.</param>
         /// <returns>The new capacity of this list.</returns>


### PR DESCRIPTION
The current docstring is false. The new capacity is computed as "twice the current capacity, and if that's still not enough, the user-specified capacity", as demonstrated in net8.0.100:

```
> open System;;
> let arr = ResizeArray<int> 3;;
val arr: ResizeArray<int>

> arr.Capacity;;
val it: int = 3

> arr.EnsureCapacity 9;;
val it: int = 9

> arr.Capacity;;
val it: int = 9

> arr.EnsureCapacity 11;;
val it: int = 18
```