### PR TITLE
Test with EventPipe CFG library in Windows

### DIFF
--- a/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.csproj
+++ b/src/tests/tracing/eventpipe/simpleruntimeeventvalidation/simpleruntimeeventvalidation.csproj
@@ -9,6 +9,12 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
+
+  <!-- Test coverage for EventPipe CFG library, eventpipe-enabled.GuardCF.lib -->
+  <PropertyGroup Condition="'$(TestBuildMode)' == 'nativeaot' and '$(TargetsWindows)' == 'true'">
+    <ControlFlowGuard>guard</ControlFlowGuard>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
     <ProjectReference Include="../common/eventpipe_common.csproj" />


### PR DESCRIPTION
Enabling an EventPipe test to run under CFG as requested [here](https://github.com/dotnet/runtime/pull/95721#issuecomment-1849452843).