### PR TITLE
[mono] Remove custom attribute support for System.DateTime

### DIFF
--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -393,18 +393,8 @@ handle_enum:
 			type = mono_class_enum_basetype_internal (t->data.klass)->type;
 			goto handle_enum;
 		} else {
-			MonoClass *k =	t->data.klass;
-
-			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
-				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
-				if (!bcheck_blob (p, 7, boundp, error))
-					return NULL;
-				*val = read64 (p);
-				*end = p + 8;
-				return val;
-			}
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		}
-		g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		break;
 
 	case MONO_TYPE_STRING: {
@@ -733,19 +723,8 @@ handle_enum:
 			type = mono_class_enum_basetype_internal (t->data.klass)->type;
 			goto handle_enum;
 		} else {
-			MonoClass *k =	t->data.klass;
-
-			if (mono_is_corlib_image (m_class_get_image (k)) && strcmp (m_class_get_name_space (k), "System") == 0 && strcmp (m_class_get_name (k), "DateTime") == 0){
-				guint64 *val = (guint64 *)g_malloc (sizeof (guint64));
-				if (!bcheck_blob (p, 7, boundp, error))
-					return NULL;
-				*val = read64 (p);
-				*end = p + 8;
-				result->value.primitive = val;
-				return result;
-			}
+			g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		}
-		g_error ("generic valutype %s not handled in custom attr value decoding", m_class_get_name (t->data.klass));
 		break;
 
 	case MONO_TYPE_STRING: {


### PR DESCRIPTION
This reverts part of ce061259cab1b8cf20742fff015c52af17a28388

> * reflection.c (load_cattr_value): Add support for encoding
>	DateTime constants into the blob.    Turns out that this is
>	required by .NET, it was only documented post 1.0.

As far as I can tell support for DateTime in custom attribtues was never part of .NET

(DateTime is supported as a default value for parameters/fields/properties for System.Reflection.Emit, and I think that's what Mono was trying to add - the custom attribute decoding looks like it was added for symmetry)