### PR TITLE
Clarify OS and Arch ownership

### DIFF
--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -167,7 +167,7 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 | Operating System | Lead          | Owners (area experts to tag in PRs and issues)                      | Description     |
 |------------------|---------------|---------------------------------------------------------------------|-----------------|
 | os-android       | @steveisok    | @akoeplinger                                                        |                 |
-| os-freebsd       |               | @wfurt @Thefrank @sec                                               | Community owned |
+| os-freebsd       |               | @wfurt @Thefrank @sec                                               |                 |
 | os-maccatalyst   | @steveisok    | @kotlarmilos                                                        |                 |
 | os-ios           | @steveisok    | @vargaz, @kotlarmilos                                               |                 |
 | os-tizen         | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |                 |

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -181,8 +181,8 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 > [!NOTE]
 > Ownership isn't the same as supported. See [operating systems](#operating-systems) for details.
 
-| Architecture     | Lead          | Owners (area experts to tag in PRs and issues)        | Description  |
-|------------------|---------------|-------------------------------------------------------|--------------|
+| Architecture     | Lead          | Owners (area experts to tag in PRs and issues)                      | Description  |
+|------------------|---------------|---------------------------------------------------------------------|--------------|
 | arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                                         |              |
 | arch-riscv       | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |              |
 | arch-s390x       | @uweigand     | @uweigand                                                           |              |

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -167,7 +167,7 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 | Operating System | Lead          | Owners (area experts to tag in PRs and issues)                      | Description     |
 |------------------|---------------|---------------------------------------------------------------------|-----------------|
 | os-android       | @steveisok    | @akoeplinger                                                        |                 |
-| os-freebsd       |               |  @wfurt @Thefrank @sec                                              | Community owned |
+| os-freebsd       |               | @wfurt @Thefrank @sec                                               | Community owned |
 | os-maccatalyst   | @steveisok    | @kotlarmilos                                                        |                 |
 | os-ios           | @steveisok    | @vargaz, @kotlarmilos                                               |                 |
 | os-tizen         | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |                 |

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -156,10 +156,18 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 
 `os-` labels not listed here do not have explicit ownership.
 
+> [!NOTE]
+> In this context, ownership is purely for the purposes of identifying which part of
+> of our engineering team (or the community) is on the hook for fixing issues labeled
+> with them. This isn't the same as supported. For example, we don't track `os-windows`
+> here because the regular area owners are on the hook for fixing bugs so there is no
+> dedicated OS lead/owner, rather ownership falls back to the `area-*` label. However,
+> Windows is a supported operating system of course.
+
 | Operating System | Lead          | Owners (area experts to tag in PRs and issues)                      | Description     |
 |------------------|---------------|---------------------------------------------------------------------|-----------------|
 | os-android       | @steveisok    | @akoeplinger                                                        |                 |
-| os-freebsd       |               |                                                                     | Community owned |
+| os-freebsd       |               |  @wfurt @Thefrank @sec                                              | Community owned |
 | os-maccatalyst   | @steveisok    | @kotlarmilos                                                        |                 |
 | os-ios           | @steveisok    | @vargaz, @kotlarmilos                                               |                 |
 | os-tizen         | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |                 |
@@ -170,9 +178,15 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 
 `arch-` labels not listed here do not have explicit ownership.
 
+> [!NOTE]
+> Ownership isn't the same as supported. See [operating systems](#operating-systems) for details.
+
 | Architecture     | Lead          | Owners (area experts to tag in PRs and issues)        | Description  |
 |------------------|---------------|-------------------------------------------------------|--------------|
-| arch-wasm        | @lewing       | @lewing @BrzVlad                                      |              |
+| arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                                     |              |
+| arch-riscv       | @gbalykov | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |              |
+| arch-s390x       | @uweigand     | @uweigand                                                       |              |
+| arch-wasm        | @lewing       | @lewing @BrzVlad                                                |              |
 
 ## Community Triagers
 

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -154,19 +154,21 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 
 ## Operating Systems
 
-| Operating System | Lead          | Owners (area experts to tag in PRs and issues)                      | Description  |
-|------------------|---------------|---------------------------------------------------------------------|--------------|
-| os-alpine        |               |                                                                     |              |
-| os-android       | @steveisok    | @akoeplinger                                                        |              |
-| os-freebsd       |               |                                                                     |              |
-| os-mac-os-x      |               |                                                                     |              |
-| os-maccatalyst   | @steveisok    | @kotlarmilos                                                        |              |
-| os-ios           | @steveisok    | @vargaz, @kotlarmilos                                               |              |
-| os-tizen         | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |              |
-| os-tvos          | @steveisok    | @vargaz, @kotlarmilos                                               |              |
-| os-wasi          | @lewing       | @pavelsavara                                                        |              |
+`os-` labels not listed here do not have explicit ownership.
+
+| Operating System | Lead          | Owners (area experts to tag in PRs and issues)                      | Description     |
+|------------------|---------------|---------------------------------------------------------------------|-----------------|
+| os-android       | @steveisok    | @akoeplinger                                                        |                 |
+| os-freebsd       |               |                                                                     | Community owned |
+| os-maccatalyst   | @steveisok    | @kotlarmilos                                                        |                 |
+| os-ios           | @steveisok    | @vargaz, @kotlarmilos                                               |                 |
+| os-tizen         | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |                 |
+| os-tvos          | @steveisok    | @vargaz, @kotlarmilos                                               |                 |
+| os-wasi          | @lewing       | @pavelsavara                                                        |                 |
 
 ## Architectures
+
+`arch-` labels not listed here do not have explicit ownership.
 
 | Architecture     | Lead          | Owners (area experts to tag in PRs and issues)        | Description  |
 |------------------|---------------|-------------------------------------------------------|--------------|

--- a/docs/area-owners.md
+++ b/docs/area-owners.md
@@ -183,10 +183,10 @@ Note: Editing this file doesn't update the mapping used by `@msftbot` for area-s
 
 | Architecture     | Lead          | Owners (area experts to tag in PRs and issues)        | Description  |
 |------------------|---------------|-------------------------------------------------------|--------------|
-| arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                                     |              |
-| arch-riscv       | @gbalykov | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |              |
-| arch-s390x       | @uweigand     | @uweigand                                                       |              |
-| arch-wasm        | @lewing       | @lewing @BrzVlad                                                |              |
+| arch-loongarch64 | @shushanhf    | @LuckyXu-HF                                                         |              |
+| arch-riscv       | @gbalykov     | @hjleee, @wscho77, @clamp03, @JongHeonChoi, @t-mustafin, @viewizard |              |
+| arch-s390x       | @uweigand     | @uweigand                                                           |              |
+| arch-wasm        | @lewing       | @lewing @BrzVlad                                                    |              |
 
 ## Community Triagers
 


### PR DESCRIPTION
Any label listed in area-owners for arch or os should indicate exclusive ownership of issues in that label.

We had listed `os-alpine` and `os-mac-os-x` - which I don't believe have explicit ownership.  So I've removed these.

I've also added a comment to indicate the purpose of the table.

@terrajobst I believe with this change it will make it so that issuesof.net can trust the ownership information in this doc.  For any label that's not mentioned (unmapped) you may ignore it from the ownership evaluation.  In other words if an issue has `os-windows` and `area-System.Runtime` it should be assigned to the owner of System.Runtime, since `os-windows` doesn't have a mapped owner.