### PR TITLE
Fix disable of loop table

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4840,6 +4840,8 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // The loop table is no longer valid.
         optLoopTableValid = false;
         optLoopTable      = nullptr;
+        optLoopCount      = 0;
+
         // Old dominators and reachability sets are no longer valid.
         fgDomsComputed         = false;
         fgCompactRenumberQuirk = true;
@@ -5913,6 +5915,7 @@ void Compiler::RecomputeFlowGraphAnnotations()
     // anymore.
     optLoopTableValid = false;
     optLoopTable      = nullptr;
+    optLoopCount      = 0;
     fgDomsComputed    = false;
 }
 


### PR DESCRIPTION
Some clients look at `optLoopCount` so zero that out when nulling out `optLoopTable`.

Fixes #95987