### PR TITLE
Optimize circular buffers

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerReadContextComplexJson.cs
@@ -48,22 +48,28 @@ namespace System.Runtime.Serialization.Json
             int length = memberNames.Length;
             if (length != 0)
             {
-                for (int i = 0, index = (memberIndex + 1) % length; i < length; i++, index = (index + 1) % length)
+                for (int i = 0, index = (memberIndex + 1) % length; i < length; i++)
                 {
                     if (xmlReader.IsStartElement(memberNames[index], XmlDictionaryString.Empty))
                     {
                         return index;
                     }
+                    index++;
+                    if (index >= length)
+                        index = 0;
                 }
                 string? name;
                 if (TryGetJsonLocalName(xmlReader, out name))
                 {
-                    for (int i = 0, index = (memberIndex + 1) % length; i < length; i++, index = (index + 1) % length)
+                    for (int i = 0, index = (memberIndex + 1) % length; i < length; i++)
                     {
                         if (memberNames[index].Value == name)
                         {
                             return index;
                         }
+                        index++;
+                        if (index >= length)
+                            index = 0;
                     }
                 }
             }

--- a/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
+++ b/src/libraries/System.Runtime.Caching/src/System/Runtime/Caching/MemoryMonitor.cs
@@ -77,7 +77,10 @@ namespace System.Runtime.Caching
         {
             int pressure = GetCurrentPressure();
 
-            _i0 = (_i0 + 1) % HISTORY_COUNT;
+            _i0++;
+            if  (_i0 >= HISTORY_COUNT)
+                _i0 = 0;
+
             _pressureTotal -= _pressureHist[_i0];
             _pressureTotal += pressure;
             _pressureHist[_i0] = pressure;


### PR DESCRIPTION
If we know an index can only be at most between 1 and n, and n is not a power of 2, it is faster to do the comparison to length rather than do the modulus.