### PR TITLE
Upgrade Perf Owl queues to the new queues.

### DIFF
--- a/eng/testing/performance/performance-setup.ps1
+++ b/eng/testing/performance/performance-setup.ps1
@@ -52,7 +52,7 @@ if ($Internal) {
     switch ($LogicalMachine) {
         "perftiger" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
         "perftiger_crossgen" { $Queue = "Windows.10.Amd64.19H1.Tiger.Perf" }
-        "perfowl" { $Queue = "Windows.10.Amd64.20H2.Owl.Perf" }
+        "perfowl" { $Queue = "Windows.11.Amd64.Owl.Perf" }
         "perfsurf" { $Queue = "Windows.10.Arm64.Perf.Surf" }
         "perfpixel4a" { $Queue = "Windows.11.Amd64.Pixel.Perf" }
         "perfampere" { $Queue = "Windows.Server.Arm64.Perf" }

--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -307,7 +307,7 @@ if [[ "$internal" == true ]]; then
         queue=Ubuntu.1804.Arm64.Perf
     else
         if [[ "$logical_machine" == "perfowl" ]]; then
-            queue=Ubuntu.1804.Amd64.Owl.Perf
+            queue=Ubuntu.2204.Amd64.Owl.Perf
         elif [[ "$logical_machine" == "perftiger_crossgen" ]]; then
             queue=Ubuntu.1804.Amd64.Tiger.Perf
         else


### PR DESCRIPTION
With the Perf Owl machines being moved to new queues, this PR updates the runtime repo queues to use the new queues. This will also keep the old queues from taking on new items despite them not having any machines. Once merged, we should also have the old queues purged.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2334468&view=results (the 'canceled' windows perf owl runs are marked as finished but took longer than the allotted time on this run).