### PR TITLE
Make sorting of modules more stable in the compiler

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.Sorting.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.Sorting.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -14,11 +15,30 @@ namespace Internal.TypeSystem.Ecma
             if (this == other)
                 return 0;
 
-            Guid thisMvid = _metadataReader.GetGuid(_metadataReader.GetModuleDefinition().Mvid);
-            Guid otherMvid = other._metadataReader.GetGuid(other.MetadataReader.GetModuleDefinition().Mvid);
+            IAssemblyDesc thisAssembly = Assembly;
+            IAssemblyDesc otherAssembly = other.Assembly;
+            if (thisAssembly != otherAssembly)
+            {
+                // Each module comes from a different assembly: compare the assemblies
+                AssemblyName thisAssemblyName = thisAssembly.GetName();
+                AssemblyName otherAssemblyName = otherAssembly.GetName();
 
-            Debug.Assert(thisMvid.CompareTo(otherMvid) != 0, "Different instance of EcmaModule but same MVID?");
-            return thisMvid.CompareTo(otherMvid);
+                int compare = StringComparer.Ordinal.Compare(thisAssemblyName.Name, otherAssemblyName.Name);
+                if (compare != 0)
+                    return compare;
+
+                compare = StringComparer.Ordinal.Compare(thisAssemblyName.CultureName, otherAssemblyName.CultureName);
+                Debug.Assert(compare != 0);
+                return compare;
+            }
+            else
+            {
+                // Multi-module assembly: compare two modules that are part of same assembly
+                string thisName = _metadataReader.GetString(_metadataReader.GetModuleDefinition().Name);
+                string otherName = other._metadataReader.GetString(other._metadataReader.GetModuleDefinition().Name);
+                Debug.Assert(StringComparer.Ordinal.Compare(thisName, otherName) != 0);
+                return StringComparer.Ordinal.Compare(thisName, otherName);
+            }
         }
     }
 }


### PR DESCRIPTION
The compiler is multithreaded and to achieve stable outputs, it needs to sort everything before writing it to disk. The way we sort modules currently is by looking at the module MVID. It's a very simple, reliable, and efficient way.

Except this causes disproportionally large differences in the compiler outputs when a small part of the program was changed - changing something small in an assembly could result in large blocks of methods being shifted in the output executable. This makes delta patching very inefficient.

I'm changing the sorting to use assembly names instead. It's less efficient, but doesn't cause problems for delta patching.

Cc @dotnet/ilc-contrib 