### PR TITLE
Use a sorted module order for metadata generation

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Sorting/TypeSystemComparer.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Sorting/TypeSystemComparer.cs
@@ -25,7 +25,7 @@ namespace Internal.TypeSystem
     // to sort itself with respect to other instances of the same type.
     // Comparisons between different categories of types are centralized to a single location that
     // can provide rules to sort them.
-    public class TypeSystemComparer : IComparer<TypeDesc>, IComparer<MethodDesc>, IComparer<FieldDesc>, IComparer<MethodSignature>
+    public class TypeSystemComparer : IComparer<TypeDesc>, IComparer<MethodDesc>, IComparer<FieldDesc>, IComparer<MethodSignature>, IComparer<ModuleDesc>
     {
         public static TypeSystemComparer Instance { get; } = new TypeSystemComparer();
 
@@ -127,6 +127,11 @@ namespace Internal.TypeSystem
         public int Compare(MethodSignature x, MethodSignature y)
         {
             return x.CompareTo(y, this);
+        }
+
+        public int Compare(ModuleDesc x, ModuleDesc y)
+        {
+            return Compare(x.GetGlobalModuleType(), y.GetGlobalModuleType());
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -50,7 +50,7 @@ namespace ILCompiler
             };
 
         private readonly List<TypeDesc> _typesWithForcedEEType = new List<TypeDesc>();
-        private readonly List<ModuleDesc> _modulesWithMetadata = new List<ModuleDesc>();
+        private readonly SortedSet<ModuleDesc> _modulesWithMetadata = new SortedSet<ModuleDesc>(CompilerComparer.Instance);
         private readonly List<FieldDesc> _fieldsWithMetadata = new List<FieldDesc>();
         private readonly List<MethodDesc> _methodsWithMetadata = new List<MethodDesc>();
         private readonly List<MetadataType> _typesWithMetadata = new List<MetadataType>();


### PR DESCRIPTION
The reflection metadata generation within the compiler follows a simple algorithm: foreach module in compilation, for each type in the module, if the type generates metadata, generate metadata for it. But it turns out the list of modules that we start with is not sorted. This is not a problem for multithreaded stability, because none of this happens in the multithreaded phase, but it is a problem for delta patching - small change in a program can perturb the metadata blob for no good reason.

This sorts the list.

Cc @dotnet/ilc-contrib 