### PR TITLE
[browser] Disable crashing tests on HybridGlobalization

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -217,7 +217,7 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: true
       scenarios:
-        # - normal // https://github.com/dotnet/runtime/issues/95981
+        - normal
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
@@ -234,7 +234,7 @@ jobs:
   #     isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
   #     alwaysRun: true
   #     scenarios:
-  #       - normal // https://github.com/dotnet/runtime/issues/95981
+  #       - normal
   #       - WasmTestOnBrowser
   #       - WasmTestOnNodeJS
 

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -217,7 +217,7 @@ jobs:
       isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
       alwaysRun: true
       scenarios:
-        - normal
+        # - normal // https://github.com/dotnet/runtime/issues/95981
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
@@ -234,7 +234,7 @@ jobs:
   #     isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
   #     alwaysRun: true
   #     scenarios:
-  #       - normal
+  #       - normal // https://github.com/dotnet/runtime/issues/95981
   #       - WasmTestOnBrowser
   #       - WasmTestOnNodeJS
 

--- a/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.Serialization.Schema.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73961", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96028", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/95981", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
         public void RountTripTest()
         {
             // AppContext SetSwitch seems to be unreliable in the unit test case. So let's not rely on it

--- a/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
@@ -21,6 +21,7 @@ namespace System.Runtime.Serialization.Schema.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73961", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming), nameof(PlatformDetection.IsBrowser))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/96028", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
         public void RountTripTest()
         {
             // AppContext SetSwitch seems to be unreliable in the unit test case. So let's not rely on it

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
@@ -8,8 +8,7 @@ using Xunit;
 namespace System.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
-    
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/96028", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/95981", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
     public class StackTraceHiddenAttributeTests
     {
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/StackTraceHiddenAttributeTests.cs
@@ -8,6 +8,8 @@ using Xunit;
 namespace System.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+    
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/96028", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]
     public class StackTraceHiddenAttributeTests
     {
         [Fact]


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/95981.
The crashes are caused by only two tests, blocked them.