### PR TITLE
[mono][docs] Reflect current workflow of building individual runtime tests

### DIFF
--- a/docs/workflow/testing/mono/testing.md
+++ b/docs/workflow/testing/mono/testing.md
@@ -20,8 +20,8 @@ cd src/tests
 ./build.sh mono <release|debug>
 ```
 
-To build an individual test, test directory, or a whole subdirectory tree, use the `-test:`, `-dir:` or `-tree:` options (without the src/tests prefix)
-For example: `./build.sh mono release -test:JIT/opt/InstructionCombining/DivToMul.csproj`
+To build an individual test, test directory, or a whole subdirectory tree, use the `-test:`, `-dir:` or `-tree:` options (without the src/tests prefix).
+For example: `./build.sh mono release -test:JIT/opt/InstructionCombining/DivToMul.csproj`. To generate executable `.sh` files for tests that are not set to be run individualy it is necessary to `export BuildAsStandalone=true` before building the tests.
 
 
 Run individual test:


### PR DESCRIPTION
Due to optimizing effort of building and running runtime tests https://github.com/dotnet/runtime/issues/54512, some tests don't generate `*.sh` files by default after build. It is necessary to `export BuildAsStandalone=true` or modify the test's `.csproj` file before building to generate executable `.sh` file.

---

Contributes to: https://github.com/dotnet/runtime/issues/90254