### PR TITLE
[mono] Disable Vector3Interop_r/ro tests on osx-arm64

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2760,6 +2760,16 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- These are known failures on mono-arm64 on OSX -->
+    <ItemGroup Condition=" '$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'arm64' and '$(TargetsOSX)' == 'true'" >
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_r/**">
+            <Issue>https://github.com/dotnet/runtime/issues/96051</Issue>
+        </ExcludeList>
+        <ExcludeList Include = "$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/**">
+            <Issue>https://github.com/dotnet/runtime/issues/96051</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsAppleMobile)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/finalization/CriticalFinalizer/**">
             <Issue>https://github.com/dotnet/runtime/issues/75756</Issue>


### PR DESCRIPTION
This PR disables `JIT/SIMD/Vector3Interop_r/ro` tests when running on osx-arm64. 

These failures were discovered while preparing osx-arm64 Interpreter `runtime-extra-platform` job https://github.com/dotnet/runtime/pull/96023.


Tracking issue for the failure: https://github.com/dotnet/runtime/issues/96051