### PR TITLE
[RISC-V] Simplify codegen for div/mod

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2124,7 +2124,7 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
             assert(emitter::isGeneralRegister(divisorReg));
         }
 
-        emitAttr size = EA_ATTR(genTypeSize(genActualType(tree->TypeGet())));
+        emitAttr size = EA_ATTR(genTypeSize(genActualType(tree)));
         bool     is4  = (size == EA_4BYTE);
         assert(is4 || (size == EA_8BYTE));
 
@@ -5425,7 +5425,7 @@ void CodeGen::genRangeCheck(GenTree* oper)
     genConsumeRegs(index);
     genConsumeRegs(length);
 
-    if (genActualType(index->TypeGet()) == TYP_INT)
+    if (genActualType(index) == TYP_INT)
     {
         regNumber tempReg = oper->GetSingleTempReg();
         GetEmitter()->emitIns_R_R_I(INS_addiw, EA_4BYTE, tempReg, indexReg, 0); // sign-extend
@@ -5433,8 +5433,8 @@ void CodeGen::genRangeCheck(GenTree* oper)
     }
 
 #ifdef DEBUG
-    var_types lengthType = genActualType(length->TypeGet());
-    var_types indexType  = genActualType(index->TypeGet());
+    var_types lengthType = genActualType(length);
+    var_types indexType  = genActualType(index);
     // Bounds checks can only be 32 or 64 bit sized comparisons.
     assert(lengthType == TYP_INT || lengthType == TYP_LONG);
     assert(indexType == TYP_INT || indexType == TYP_LONG);

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2210,10 +2210,6 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
                 {
                     ins = INS_remuw;
                 }
-
-                // TODO-RISCV64: here is just for signed-extension ?
-                emit->emitIns_R_R_I(INS_slliw, EA_4BYTE, dividendReg, dividendReg, 0);
-                emit->emitIns_R_R_I(INS_slliw, EA_4BYTE, divisorReg, divisorReg, 0);
             }
             else
             {

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -605,7 +605,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_BOUNDS_CHECK:
         {
             GenTreeBoundsChk* node = tree->AsBoundsChk();
-            if (genActualType(node->GetIndex()->TypeGet()) == TYP_INT)
+            if (genActualType(node->GetIndex()) == TYP_INT)
             {
                 buildInternalIntRegisterDefForNode(tree);
                 buildInternalRegisterUses();

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -300,7 +300,7 @@ int LinearScan::BuildNode(GenTree* tree)
 
             if (!varTypeIsFloating(tree->TypeGet()) &&
                 !((exceptions & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None &&
-                  (divisorOp->IsIntegralConst(0) || divisorOp->GetRegNum() == REG_R0)))
+                  (divisorOp->IsIntegralConst(0) || divisorOp->GetRegNum() == REG_ZERO)))
             {
                 bool needTemp = false;
                 if (divisorOp->isContainedIntOrIImmed())

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -295,38 +295,24 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = BuildBinaryUses(tree->AsOp());
 
             GenTree* divisorOp = tree->gtGetOp2();
+
+            ExceptionSetFlags exceptions = tree->OperExceptions(compiler);
+
             if (!varTypeIsFloating(tree->TypeGet()) &&
-                !(divisorOp->IsIntegralConst(0) || divisorOp->GetRegNum() == REG_R0))
+                !((exceptions & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None &&
+                  (divisorOp->IsIntegralConst(0) || divisorOp->GetRegNum() == REG_R0)))
             {
                 bool needTemp = false;
                 if (divisorOp->isContainedIntOrIImmed())
                 {
-                    needTemp = true; // divisorReg
-                }
-                else if (tree->OperIsCommutative())
-                {
-                    if (tree->gtGetOp1()->isContainedIntOrIImmed())
-                        needTemp = true; // reg1
+                    if (!emitter::isGeneralRegister(divisorOp->GetRegNum()))
+                        needTemp = true;
                 }
 
                 if (!needTemp && (tree->gtOper == GT_DIV || tree->gtOper == GT_MOD))
                 {
-                    bool checkDividend = true;
-                    // Do we have an immediate for the 'divisorOp'?
-                    if (divisorOp->IsCnsIntOrI())
-                    {
-                        ssize_t intConstValue = divisorOp->AsIntCon()->gtIconVal;
-                        if (intConstValue != -1)
-                        {
-                            checkDividend = false; // We statically know that the dividend is not -1
-                        }
-                    }
-                    ExceptionSetFlags exSetFlags = tree->OperExceptions(compiler);
-                    if (checkDividend &&
-                        ((exSetFlags & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None))
-                    {
+                    if ((exceptions & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
                         needTemp = true;
-                    }
                 }
 
                 if (needTemp)


### PR DESCRIPTION
After #82924 some testing can be simplified. Change analogous to #85140.

Also, remove sign-extending for divuw/remuw. These instructions take only the lower 32 bits of the argument registers anyway.

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @bajtazar