### PR TITLE
Fix hardcoded ILAsm package version in Microsoft.NET.SDK.IL

### DIFF
--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.pkgproj
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.pkgproj
@@ -15,5 +15,29 @@
     </File>
   </ItemGroup>
 
+  <PropertyGroup>
+    <ILTargetsTemplateFile>Microsoft.NET.Sdk.IL.targets.template</ILTargetsTemplateFile>
+    <ILTargetsOutputFile>$(IntermediateOutputPath)Microsoft.NET.Sdk.IL.targets</ILTargetsOutputFile>
+  </PropertyGroup>
+
+  <Target Name="ReplaceTemplateParametersInILTargetsTemplate"
+          Inputs="$(ILTargetsTemplateFile)"
+          Outputs="$(ILTargetsOutputFile)"
+          BeforeTargets="GetPackageFiles"
+          DependsOnTargets="CalculatePackageVersion">
+
+    <GenerateFileFromTemplate TemplateFile="$(ILTargetsTemplateFile)"
+                              OutputPath="$(ILTargetsOutputFile)"
+                              Properties="IlAsmVersion=$(PackageVersion)">
+      <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
+    </GenerateFileFromTemplate>
+
+    <ItemGroup>
+      <File Include="$(ILTargetsOutputFile)">
+        <TargetPath>targets</TargetPath>
+      </File>
+    </ItemGroup>
+  </Target>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.targets.template
@@ -28,7 +28,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <PropertyGroup>
     <MicrosoftNetCoreIlasmPackageRuntimeId Condition="'$(MicrosoftNetCoreIlasmPackageRuntimeId)' == ''">$(NETCoreSdkPortableRuntimeIdentifier)</MicrosoftNetCoreIlasmPackageRuntimeId>
-    <MicrosoftNETCoreILAsmVersion Condition="'$(MicrosoftNETCoreILAsmVersion)' == ''">6.0.0</MicrosoftNETCoreILAsmVersion>
+    <MicrosoftNETCoreILAsmVersion Condition="'$(MicrosoftNETCoreILAsmVersion)' == ''">${IlAsmVersion}</MicrosoftNETCoreILAsmVersion>
     <MicrosoftNetCoreIlasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ilasm</MicrosoftNetCoreIlasmPackageName>
     <MicrosoftNetCoreIldasmPackageName>runtime.$(MicrosoftNetCoreIlasmPackageRuntimeId).microsoft.netcore.ildasm</MicrosoftNetCoreIldasmPackageName>
 


### PR DESCRIPTION
We were still hardcoding version 6.0.0 of ILAsm in the targets, fix it by using a template and injecting the ProductVersion.

Fixes https://github.com/dotnet/runtime/issues/49135