### PR TITLE
JIT: Remove BBJ_ALWAYS fall-through check in Compiler::fgFindInsertPoint

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6662,14 +6662,14 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
         // Look for an insert location:
         // 1. We want blocks that don't end with a fall through,
         // 2. Also, when blk equals nearBlk we may want to insert here.
-        const bool blkJumpsToNext = blk->KindIs(BBJ_ALWAYS) && blk->HasFlag(BBF_NONE_QUIRK) && blk->JumpsToNext();
-        if ((!blk->bbFallsThrough() && !blkJumpsToNext) || (blk == nearBlk))
+        // const bool blkJumpsToNext = blk->KindIs(BBJ_ALWAYS) && blk->HasInitializedTarget() && blk->JumpsToNext();
+        if (!blk->bbFallsThrough() || (blk == nearBlk))
         {
             bool updateBestBlk = true; // We will probably update the bestBlk
 
             // If blk falls through then we must decide whether to use the nearBlk
             // hint
-            if (blk->bbFallsThrough() || blkJumpsToNext)
+            if (blk->bbFallsThrough())
             {
                 noway_assert(blk == nearBlk);
                 if (jumpBlk != nullptr)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6662,7 +6662,6 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
         // Look for an insert location:
         // 1. We want blocks that don't end with a fall through,
         // 2. Also, when blk equals nearBlk we may want to insert here.
-        // const bool blkJumpsToNext = blk->KindIs(BBJ_ALWAYS) && blk->HasInitializedTarget() && blk->JumpsToNext();
         if (!blk->bbFallsThrough() || (blk == nearBlk))
         {
             bool updateBestBlk = true; // We will probably update the bestBlk


### PR DESCRIPTION
Part of #95998. This reverts the behavior of `Compiler::fgFindInsertPoint` to how it was before BBJ_NONE was removed. In order to remove the `BBF_NONE_QUIRK` check, I initially tried to adapt `fgFindInsertPoint` to not insert new blocks after `BBJ_ALWAYS` blocks that jump to the next block (i.e. mimicking `BBJ_NONE` behavior), but `fgFindInsertPoint` is called in numerous phases (importation, block reordering, etc.) where block layout is not finalized, so it might be premature to try to keep `BBJ_ALWAYS` blocks contiguous with their jump targets. I'd like to try our previous approach of checking only for implicit fall-through instead. This produced dramatic diffs on win-x64 locally; every collection was still a significant net size improvement, and most regressions are due to changes in block ordering resulting in more/longer jumps. In one method, this change enabled the JIT to do more loop cloning, resulting in massive size increases. I'm opening this now for visibility, and will update with explanations of example diffs.