### PR TITLE
[PERF] Update osx.1015 queue to osx.13 queue.

### DIFF
--- a/eng/testing/performance/performance-setup.sh
+++ b/eng/testing/performance/performance-setup.sh
@@ -275,7 +275,7 @@ if [[ "$internal" == true ]]; then
     extra_benchmark_dotnet_arguments=
 
     if [[ "$logical_machine" == "perfiphone12mini" ]]; then
-        queue=OSX.1015.Amd64.Iphone.Perf
+        queue=OSX.13.Amd64.Iphone.Perf
     elif [[ "$logical_machine" == "perfampere" ]]; then
         queue=Ubuntu.2004.Arm64.Perf
     elif [[ "$logical_machine" == "cloudvm" ]]; then


### PR DESCRIPTION
Runtime PR to go along with performance PR: https://github.com/dotnet/performance/pull/3630. Update the queues from pointing to the OSX.1015 devices to the OSX.13 devices.
Successful Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2336631&view=results