### PR TITLE
extract side-effects from op1 of GT_COMMA

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16927,13 +16927,19 @@ void Compiler::gtExtractSideEffList(GenTree*     expr,
 
         fgWalkResult PreOrderVisit(GenTree** use, GenTree* user)
         {
-            GenTree* node = *use;
+            GenTree*     node  = *use;
+            GenTreeFlags flags = m_flags;
+
+            if ((user != nullptr) && (user->OperIs(GT_COMMA)) && (user->AsOp()->gtGetOp1() == node))
+            {
+                flags &= ~GTF_IS_IN_CSE;
+            }
 
             bool treeHasSideEffects = m_compiler->gtTreeHasSideEffects(node, m_flags);
 
             if (treeHasSideEffects)
             {
-                if (m_compiler->gtNodeHasSideEffects(node, m_flags))
+                if (m_compiler->gtNodeHasSideEffects(node, flags))
                 {
                     if (node->OperIsBlk() && !node->OperIsStoreBlk())
                     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -16932,6 +16932,7 @@ void Compiler::gtExtractSideEffList(GenTree*     expr,
 
             if ((user != nullptr) && (user->OperIs(GT_COMMA)) && (user->AsOp()->gtGetOp1() == node))
             {
+                // If this is `op1` is a GT_COMMA node, make sure to extract the side-effects of it.
                 flags &= ~GTF_IS_IN_CSE;
             }
 


### PR DESCRIPTION
In `GT_COMMA(op1, op2)` `op1` is a side-effect tree, where as `op2` is considered as value and side-effect tree. As such, we should always extract the side effects for `op1` otherwise in cases where there is a cctor call needed, we might accidently remove the `op1` if it is not used anywhere else.

Thanks @AndyAyersMS for suggesting the fix.