### PR TITLE
Fix potential NREs in ConfigurationBindingGenerator

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Parser.cs
@@ -895,7 +895,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             private void RecordTypeDiagnostic(TypeParseInfo typeParseInfo, DiagnosticDescriptor descriptor)
             {
-                RecordDiagnostic(descriptor, typeParseInfo.BinderInvocation.Location, [typeParseInfo.FullName]);
+                RecordDiagnostic(descriptor, typeParseInfo.BinderInvocation?.Location, [typeParseInfo.FullName]);
                 ReportContainingTypeDiagnosticIfRequired(typeParseInfo);
             }
 
@@ -911,7 +911,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         ? new[] { memberName, containingTypeName }
                         : new[] { containingTypeName };
 
-                    RecordDiagnostic(containingTypeDiagInfo.Descriptor, typeParseInfo.BinderInvocation.Location, messageArgs);
+                    RecordDiagnostic(containingTypeDiagInfo.Descriptor, typeParseInfo.BinderInvocation?.Location, messageArgs);
 
                     containingTypeDiagInfo = containingTypeDiagInfo.ContainingTypeInfo;
                 }


### PR DESCRIPTION
The TypeParseInfo.BinderInvocation is a nullable property. If it happens to be null, these two places will throw a null ref.

.NET Aspire is reusing this code to generate JSON schemas for appsettings.json files. See https://github.com/dotnet/aspire/pull/1383. The plan is to keep this in sync using automated PRs to dotnet/aspire when the dotnet/runtime code is updated. (https://github.com/dotnet/aspire/issues/1424). Contributing this fix back so these two code bases can stay in sync.