### PR TITLE
Remove Android from UnsupportedOSPlatforms in System.IO.Ports

### DIFF
--- a/src/libraries/System.IO.Ports/Directory.Build.props
+++ b/src/libraries/System.IO.Ports/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <IncludePlatformAttributes>true</IncludePlatformAttributes>
-    <UnsupportedOSPlatforms>browser;android;ios;tvos</UnsupportedOSPlatforms>
+    <UnsupportedOSPlatforms>browser;ios;tvos</UnsupportedOSPlatforms>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Forgot to do this when I enabled Android in https://github.com/dotnet/runtime/pull/95749