### PR TITLE
Rename IsOSXLike to IsApplePlatform in libraries

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/LoopbackServer.cs
@@ -147,7 +147,7 @@ namespace System.Net.Test.Common
                     socket.NoDelay = true;
                 }
                 // OSX can throw if socket is in weird state during close or cancellation
-                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.InvalidArgument && PlatformDetection.IsOSXLike) { }
+                catch (SocketException ex) when (ex.SocketErrorCode == SocketError.InvalidArgument && PlatformDetection.IsApplePlatform) { }
 
                 stream = new NetworkStream(socket, ownsSocket: false);
 #endif

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -32,11 +32,9 @@ namespace System
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
 
         // OSX family
-        public static bool IsOSXLike => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
+        public static bool IsApplePlatform => IsOSX || IsiOS || IstvOS || IsMacCatalyst;
         public static bool IsOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNotOSX => !IsOSX;
-        public static bool IsMacOsMojaveOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 14);
-        public static bool IsMacOsCatalinaOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 15);
         public static bool IsMacOsAppleSilicon => IsOSX && IsArm64Process;
         public static bool IsNotMacOsAppleSilicon => !IsMacOsAppleSilicon;
         public static bool IsAppSandbox => Environment.GetEnvironmentVariable("APP_SANDBOX_CONTAINER_ID") != null;
@@ -50,12 +48,12 @@ namespace System
         public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
         public static bool IsNotDebian10 => !IsDebian10;
 
-        public static Version OpenSslVersion => !IsOSXLike && !IsWindows && !IsAndroid ?
+        public static Version OpenSslVersion => !IsApplePlatform && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :
             throw new PlatformNotSupportedException();
 
         private static readonly Version s_openssl3Version = new Version(3, 0, 0);
-        public static bool IsOpenSsl3 => !IsOSXLike && !IsWindows && !IsAndroid && !IsBrowser ?
+        public static bool IsOpenSsl3 => !IsApplePlatform && !IsWindows && !IsAndroid && !IsBrowser ?
             GetOpenSslVersion() >= s_openssl3Version :
             false;
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -55,7 +55,7 @@ namespace System
         public static bool IsAppleMobile => IsMacCatalyst || IsiOS || IstvOS;
         public static bool IsNotAppleMobile => !IsAppleMobile;
         public static bool IsNotNetFramework => !IsNetFramework;
-        public static bool IsBsdLike => IsOSXLike || IsFreeBSD || IsNetBSD;
+        public static bool IsBsdLike => IsApplePlatform || IsFreeBSD || IsNetBSD;
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
@@ -526,7 +526,7 @@ namespace System
         private static bool GetTls10Support()
         {
             // on macOS and Android TLS 1.0 is supported.
-            if (IsOSXLike || IsAndroid)
+            if (IsApplePlatform || IsAndroid)
             {
                 return true;
             }
@@ -554,7 +554,7 @@ namespace System
                 return GetProtocolSupportFromWindowsRegistry(SslProtocols.Tls11, defaultProtocolSupport: true) && !IsWindows10Version20348OrGreater;
             }
             // on macOS and Android TLS 1.1 is supported.
-            else if (IsOSXLike || IsAndroid)
+            else if (IsApplePlatform || IsAndroid)
             {
                 return true;
             }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -25,7 +25,7 @@ namespace System.DirectoryServices.Protocols.Tests
 #if NETCOREAPP
                 if (!_isLibLdapInstalled.HasValue)
                 {
-                    if (PlatformDetection.IsOSXLike)
+                    if (PlatformDetection.IsApplePlatform)
                     {
                         _isLibLdapInstalled = NativeLibrary.TryLoad("libldap.dylib", out _);
                     }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -232,7 +232,7 @@ namespace System.IO.Tests
             watcher.Filter = "abc.dll";
             Assert.Equal("abc.dll", watcher.Filter);
 
-            if (!PlatformDetection.IsOSXLike)
+            if (!PlatformDetection.IsApplePlatform)
             {
                 watcher.Filter = "ABC.DLL";
                 Assert.Equal("ABC.DLL", watcher.Filter);

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -73,7 +73,7 @@ namespace System.Net.NetworkInformation.Tests
 
         private static byte[] GetPingPayload(AddressFamily addressFamily)
             // On Unix, Non-root processes cannot send arbitrary data in the ping packet payload
-            => Capability.CanUseRawSockets(addressFamily) || PlatformDetection.IsOSXLike
+            => Capability.CanUseRawSockets(addressFamily) || PlatformDetection.IsApplePlatform
                 ? TestSettings.PayloadAsBytes
                 : Array.Empty<byte>();
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -236,7 +236,7 @@ namespace System.Net.Sockets.Tests
             await ConnectAsync(s, new IPEndPoint(listenAt, ((IPEndPoint)listener.LocalEndPoint).Port));
             Assert.True(s.Connected);
             // According to the OSX man page, it's enough connecting to an invalid address to dissolve the connection. (0 port connection returns error on OSX)
-            await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsOSXLike ? 1 : 0));
+            await ConnectAsync(s, new IPEndPoint(secondConnection, PlatformDetection.IsApplePlatform ? 1 : 0));
             Assert.True(s.Connected);
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -144,7 +144,7 @@ namespace System.Net.Sockets.Tests
 
                         // OOB data read, read pointer at mark.
                         Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                        Assert.Equal(PlatformDetection.IsOSXLike ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
+                        Assert.Equal(PlatformDetection.IsApplePlatform ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
                     }
                 }
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveFrom.cs
@@ -96,7 +96,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(true)]
         public async Task ReceiveSent_TCP_Success(bool ipv6)
         {
-            if (ipv6 && PlatformDetection.IsOSXLike)
+            if (ipv6 && PlatformDetection.IsApplePlatform)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/47335")]
                 // accept() will create a (seemingly) DualMode socket on Mac,

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ReceiveMessageFrom.cs
@@ -89,7 +89,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(true)]
         public async Task ReceiveSent_TCP_Success(bool ipv6)
         {
-            if (ipv6 && PlatformDetection.IsOSXLike)
+            if (ipv6 && PlatformDetection.IsApplePlatform)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/47335")]
                 // accept() will create a (seemingly) DualMode socket on Mac,

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -236,7 +236,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/73536", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/80169", typeof(PlatformDetection), nameof(PlatformDetection.IsOSXLike))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/80169", typeof(PlatformDetection), nameof(PlatformDetection.IsApplePlatform))]
         public async Task SendFileGetsCanceledByDispose(bool owning)
         {
             // Aborting sync operations for non-owning handles is not supported on Unix.
@@ -300,7 +300,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!(UsesSync && PlatformDetection.IsOSXLike))
+                    if (!(UsesSync && PlatformDetection.IsApplePlatform))
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new byte[4096];

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceive.cs
@@ -1109,7 +1109,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!(UsesSync && PlatformDetection.IsOSXLike))
+                    if (!(UsesSync && PlatformDetection.IsApplePlatform))
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new ArraySegment<byte>(new byte[4096]);

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -14,8 +14,8 @@
   <PropertyGroup>
     <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
     <Nullable>enable</Nullable>
-    <IsOSXLike Condition="'$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</IsOSXLike>
     <IsiOSLike Condition="'$(TargetsMacCatalyst)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">true</IsiOSLike>
+    <IsApplePlatform Condition="'$(TargetsOSX)' == 'true' or '$(IsiOSLike)' == 'true'">true</IsApplePlatform>
     <IsMobileLike Condition="'$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true' or '$(IsiOSLike)' == 'true' or '$(TargetsAndroid)' == 'true'">true</IsMobileLike>
     <SupportsArmIntrinsics Condition="'$(Platform)' == 'arm64'">true</SupportsArmIntrinsics>
     <SupportsWasmIntrinsics Condition="'$(Platform)' == 'wasm'">true</SupportsWasmIntrinsics>
@@ -62,7 +62,7 @@
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.NoArmIntrinsics.xml" Condition="'$(SupportsArmIntrinsics)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.NoX86Intrinsics.xml" Condition="'$(SupportsX86Intrinsics)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.NoWasmIntrinsics.xml" Condition="'$(SupportsWasmIntrinsics)' != 'true'" />
-    <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.OSX.xml" Condition="'$(IsOSXLike)' == 'true'" />
+    <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.OSX.xml" Condition="'$(IsApplePlatform)' == 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.Windows.xml" Condition="'$(TargetsWindows)' == 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.Browser.xml" Condition="'$(TargetsBrowser)' == 'true'" />
     <ILLinkLinkAttributesXmls Include="$(ILLinkSharedDirectory)ILLink.LinkAttributes.Shared.xml" />
@@ -2459,7 +2459,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Android.cs" Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.NoRegistry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.UnixOrBrowser.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.OSX.cs" Condition="'$(IsOSXLike)' == 'true' AND '$(TargetsMacCatalyst)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.OSX.cs" Condition="'$(IsApplePlatform)' == 'true' AND '$(TargetsMacCatalyst)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.MacCatalyst.cs" Condition="'$(TargetsMacCatalyst)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.GetFolderPathCore.Unix.cs" Condition="'$(IsiOSLike)' != 'true' and '$(TargetsAndroid)' != 'true' and '$(TargetsLinuxBionic)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Variables.Unix.cs" Condition="'$(FeatureCoreCLR)' != 'true'" />
@@ -2501,7 +2501,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.Unix.Android.cs" Condition="'$(TargetsAndroid)' == 'true' or '$(TargetsLinuxBionic)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.Unix.NonAndroid.cs" Condition="'$(TargetsAndroid)' != 'true' and '$(TargetsLinuxBionic)' != 'true'" />
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true') and '$(IsOSXLike)' != 'true'">
+  <ItemGroup Condition="('$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true') and '$(IsApplePlatform)' != 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStatus.SetTimes.OtherUnix.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
@@ -2525,7 +2525,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.Linux.cs" Condition="'$(TargetsLinux)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSX.cs" Condition="'$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.iOS.cs" Condition="'$(IsiOSLike)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.Unix.cs" Condition="'$(IsOSXLike)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Environment.OSVersion.Unix.cs" Condition="'$(IsApplePlatform)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Environment.SunOS.cs" Condition="'$(Targetsillumos)' == 'true' or '$(TargetsSolaris)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.FullGlobalizationData.Unix.cs" Condition="'$(UseMinimalGlobalizationData)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DriveInfoInternal.Unix.cs" />
@@ -2546,7 +2546,7 @@
   <ItemGroup Condition="'$(UseMinimalGlobalizationData)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\TimeZoneInfo.MinimalGlobalizationData.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsOSXLike)' == 'true'">
+  <ItemGroup Condition="'$(IsApplePlatform)' == 'true'">
     <Compile Include="$(CommonPath)Interop\OSX\Interop.libobjc.cs">
       <Link>Common\Interop\OSX\Interop.libobjc.cs</Link>
     </Compile>
@@ -2559,7 +2559,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileStatus.SetTimes.OSX.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\FileSystem.TryCloneFile.OSX.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsiOSLike)' == 'true' or '$(IsOSXLike)' == 'true'">
+  <ItemGroup Condition="'$(IsApplePlatform)' == 'true'">
     <Compile Include="$(CommonPath)Interop\OSX\System.Native\Interop.SearchPath.cs">
       <Link>Common\Interop\OSX\Interop.SearchPath.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Strategies/FileStreamHelpers.Unix.cs
@@ -58,7 +58,7 @@ namespace System.IO.Strategies
 
         internal static void Lock(SafeFileHandle handle, bool canWrite, long position, long length)
         {
-            if (OperatingSystem.IsOSXLike() || OperatingSystem.IsFreeBSD())
+            if (OperatingSystem.IsApplePlatform() || OperatingSystem.IsFreeBSD())
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_OSXFileLocking);
             }
@@ -68,7 +68,7 @@ namespace System.IO.Strategies
 
         internal static void Unlock(SafeFileHandle handle, long position, long length)
         {
-            if (OperatingSystem.IsOSXLike() || OperatingSystem.IsFreeBSD())
+            if (OperatingSystem.IsApplePlatform() || OperatingSystem.IsFreeBSD())
             {
                 throw new PlatformNotSupportedException(SR.PlatformNotSupported_OSXFileLocking);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -242,7 +242,7 @@ namespace System
             false;
 #endif
 
-        internal static bool IsOSXLike() =>
+        internal static bool IsApplePlatform() =>
 #if TARGET_OSX || TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
             true;
 #else

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -163,7 +163,7 @@ namespace System.Globalization.Tests
                 Assert.NotNull(CultureInfo.CurrentCulture);
                 Assert.NotNull(CultureInfo.CurrentUICulture);
 
-                if (PlatformDetection.IsOSXLike)
+                if (PlatformDetection.IsApplePlatform)
                 {
                     Assert.NotEqual("", CultureInfo.CurrentCulture.Name);
                     Assert.NotEqual("", CultureInfo.CurrentUICulture.Name);

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/GetSetTimes.cs
@@ -11,7 +11,7 @@ namespace System.IO.Tests
     {
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
-        protected static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsOSXLike);
+        protected static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (!PlatformDetection.Is32BitProcess && !PlatformDetection.IsApplePlatform);
 
         protected override bool CanBeReadOnly => true;
 

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/FileInfo/GetSetTimes.cs
@@ -52,7 +52,7 @@ namespace System.IO.Tests
 
             if (!HasNonZeroNanoseconds(fileinfo.LastWriteTime))
             {
-                if (PlatformDetection.IsOSXLike)
+                if (PlatformDetection.IsApplePlatform)
                     return null;
 
                 DateTime dt = fileinfo.LastWriteTime;

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/PortedCommon/IOInputs.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/PortedCommon/IOInputs.cs
@@ -8,8 +8,8 @@ using System.Linq;
 
 internal static class IOInputs
 {
-    public static bool SupportsSettingCreationTime => PlatformDetection.IsWindows || PlatformDetection.IsOSXLike;
-    public static bool SupportsGettingCreationTime => PlatformDetection.IsWindows || PlatformDetection.IsOSXLike;
+    public static bool SupportsSettingCreationTime => PlatformDetection.IsWindows || PlatformDetection.IsApplePlatform;
+    public static bool SupportsGettingCreationTime => PlatformDetection.IsWindows || PlatformDetection.IsApplePlatform;
 
     // Max path length (minus trailing \0). Unix values vary system to system; just using really long values here likely to be more than on the average system.
     public static readonly int MaxPath = OperatingSystem.IsWindows() ? 259 : 10000;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
@@ -1226,7 +1226,7 @@ namespace System.Tests
             Assert.Equal(expected, DateTime.Parse(expectedString, cultureInfo));
         }
 
-        private static bool IsNotOSXOrBrowser => !PlatformDetection.IsOSXLike && !PlatformDetection.IsBrowser;
+        private static bool IsNotOSXOrBrowser => !PlatformDetection.IsApplePlatform && !PlatformDetection.IsBrowser;
 
         [ConditionalTheory(nameof(IsNotOSXOrBrowser))]
         [InlineData("ar")]

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         public bool SupportsFips186_3 => false;
-        public bool SupportsKeyGeneration => !PlatformDetection.IsOSXLike;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsApplePlatform;
     }
 
     public partial class DSAFactory

--- a/src/libraries/System.Security.Cryptography/tests/DefaultDSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultDSAProvider.cs
@@ -25,11 +25,11 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsOSXLike);
+                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsApplePlatform);
             }
         }
 
-        public bool SupportsKeyGeneration => !PlatformDetection.IsOSXLike;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsApplePlatform;
     }
 
     public partial class DSAFactory

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsOSXLike)
+            if (PlatformDetection.IsApplePlatform)
             {
                 return false;
             }
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         {
             get
             {
-                if (PlatformDetection.IsOSXLike)
+                if (PlatformDetection.IsApplePlatform)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Android.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Android.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsOSXLike)
+                if (PlatformDetection.IsApplePlatform)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultECDsaProvider.Unix.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsOSXLike)
+            if (PlatformDetection.IsApplePlatform)
             {
                 return false;
             }
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsOSXLike)
+                if (PlatformDetection.IsApplePlatform)
                 {
                     return false;
                 }


### PR DESCRIPTION
Consolidates the name we use across runtime (after https://github.com/dotnet/runtime/pull/96090) and libraries.