### PR TITLE
Use lowercase arm64 in CMakePresets.json

### DIFF
--- a/src/coreclr/CMakePresets.json
+++ b/src/coreclr/CMakePresets.json
@@ -77,11 +77,11 @@
       "name": "ARM64",
       "hidden": true,
       "architecture": {
-        "value": "ARM64",
+        "value": "arm64",
         "strategy": "external"
       },
       "cacheVariables": {
-        "CLR_CMAKE_HOST_ARCH": "ARM64"
+        "CLR_CMAKE_HOST_ARCH": "arm64"
       }
     },
     {


### PR DESCRIPTION
Fixes ARM64 building in Visual Studio.