### PR TITLE
Fix InternalMethodImplTest w/ R2R

### DIFF
--- a/src/tests/Loader/classloader/MethodImpl/InternalMethodImplTest.cs
+++ b/src/tests/Loader/classloader/MethodImpl/InternalMethodImplTest.cs
@@ -33,6 +33,7 @@ public class InternalMethodImplTest
 
 class F1
 {
+    [MethodImpl(MethodImplOptions.NoInlining)] // The exception is thrown when restoring the caller with R2R
     public F1()
     {
         var f2 = new F2();


### PR DESCRIPTION
Add NoInlining to the method that throws the exception.

Fixes #96113