### PR TITLE
Add a note on unoptimized IL to feature checks doc

### DIFF
--- a/docs/design/tools/illink/feature-checks.md
+++ b/docs/design/tools/illink/feature-checks.md
@@ -165,7 +165,7 @@ else if (Feature.IsSupported)
 
 ### Short-circuiting boolean guard
 
-Short-circuiting can only be done if the C# source code was compiled with optimizations enabled. 
+Short-circuiting can only be done if the C# source code was compiled with optimizations enabled.
 
 ```csharp
 var a = Feature.IsSupported && Feature.Run();

--- a/docs/design/tools/illink/feature-checks.md
+++ b/docs/design/tools/illink/feature-checks.md
@@ -164,6 +164,9 @@ else if (Feature.IsSupported)
 ```
 
 ### Short-circuiting boolean guard
+
+Short-circuiting can only be done if the C# source code was compiled with optimizations enabled. 
+
 ```csharp
 var a = Feature.IsSupported && Feature.Run();
 ```


### PR DESCRIPTION
Ran into this one. Compile the following without optimizations, but with EventSource disabled and notice the `Console.WriteLine` wasn't removed.

```csharp
class Program
{
    static EventSource s_my;
    static int s_options;

    static void Main(string[] args)
    {
        if (s_my.IsEnabled() && (s_options & 1) == 0)
        {
            Console.WriteLine("This is unreached");
        }
    }
}
```

This is because the IL looks like this:

```
.method private hidebysig static 
	void Main (
		string[] args
	) cil managed 
{
	// Method begins at RVA 0x2048
	// Header size: 12
	// Code size: 44 (0x2c)
	.maxstack 2
	.entrypoint
	.locals init (
		[0] bool
	)

	IL_0000: nop
	IL_0001: ldsfld class [System.Diagnostics.Tracing]System.Diagnostics.Tracing.EventSource Program::s_my
	IL_0006: callvirt instance bool [System.Diagnostics.Tracing]System.Diagnostics.Tracing.EventSource::IsEnabled()
	IL_000b: brfalse.s IL_0019

	IL_000d: ldsfld int32 Program::s_options
	IL_0012: ldc.i4.1
	IL_0013: and
	IL_0014: ldc.i4.0
	IL_0015: ceq
	IL_0017: br.s IL_001a

	IL_0019: ldc.i4.0

	IL_001a: stloc.0
	IL_001b: ldloc.0
	IL_001c: brfalse.s IL_002b

	IL_001e: nop
	IL_001f: ldstr "This is unreached"
	IL_0024: call void [System.Console]System.Console::WriteLine(string)
	IL_0029: nop
	IL_002a: nop

	IL_002b: ret
} // end of method Program::Main
```

Notice the weird pattern Roslyn generated around offset 0x17 that makes it a bit harder to prove the brfalse at 0x1c is constant.

I don't know how safe it is to assume that we can constprop _anything_, frankly.