### PR TITLE
JIT: remove bound check for negated ranges

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1358,9 +1358,9 @@ bool RangeCheck::ComputeDoesOverflow(BasicBlock* block, GenTree* expr)
     {
         overflows = DoesBinOpOverflow(block, expr->AsOp());
     }
-    // GT_AND, GT_UMOD, GT_LSH and GT_RSH don't overflow
+    // These operators don't overflow.
     // Actually, GT_LSH can overflow so it depends on the analysis done in ComputeRangeForBinOp
-    else if (expr->OperIs(GT_AND, GT_RSH, GT_LSH, GT_UMOD))
+    else if (expr->OperIs(GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_NEG))
     {
         overflows = false;
     }
@@ -1457,6 +1457,12 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
     else if (expr->OperIs(GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_MUL))
     {
         range = ComputeRangeForBinOp(block, expr->AsOp(), monIncreasing DEBUGARG(indent + 1));
+    }
+    else if (expr->OperIs(GT_NEG))
+    {
+        // Compute range for negation, e.g.: [0..8] -> [-8..0]
+        Range op1Range = GetRange(block, expr->gtGetOp1(), monIncreasing DEBUGARG(indent + 1));
+        range          = RangeOps::Negate(op1Range);
     }
     // If phi, then compute the range for arguments, calling the result "dependent" when looping begins.
     else if (expr->OperIs(GT_PHI))

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -546,6 +546,19 @@ struct RangeOps
         result.uLimit = Limit(Limit::keConstant, 1 << r1hiConstant);
         return result;
     }
+
+    static Range Negate(Range& range)
+    {
+        // Only constant ranges can be negated.
+        if (!range.LowerLimit().IsConstant() || !range.UpperLimit().IsConstant())
+        {
+            return Limit(Limit::keUnknown);
+        }
+        Range result  = Limit(Limit::keConstant);
+        result.lLimit = Limit(Limit::keConstant, -range.UpperLimit().GetConstant());
+        result.uLimit = Limit(Limit::keConstant, -range.LowerLimit().GetConstant());
+        return result;
+    }
 };
 
 class RangeCheck

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -554,9 +554,20 @@ struct RangeOps
         {
             return Limit(Limit::keUnknown);
         }
+
+        const int hi = range.UpperLimit().GetConstant();
+        const int lo = range.LowerLimit().GetConstant();
+
+        // Give up on edge cases
+        if ((hi == INT_MIN) || (lo == INT_MIN))
+        {
+            return Limit(Limit::keUnknown);
+        }
+
+        // Example: [0..7] => [-7..0]
         Range result  = Limit(Limit::keConstant);
-        result.lLimit = Limit(Limit::keConstant, -range.UpperLimit().GetConstant());
-        result.uLimit = Limit(Limit::keConstant, -range.LowerLimit().GetConstant());
+        result.lLimit = Limit(Limit::keConstant, -hi);
+        result.uLimit = Limit(Limit::keConstant, -lo);
         return result;
     }
 };


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/96046

```cs
byte Test(int a) => rva[8 - (a & 7)];

static ReadOnlySpan<byte> rva => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
```
Was:
```asm
; Method Program:Test(int):ubyte:this (FullOpts)
       sub      rsp, 40
       and      ecx, 7
       mov      eax, ecx
       neg      eax
       add      eax, 8
       cmp      eax, 10
       jae      SHORT G_M949_IG04
       mov      rcx, 0x1735CBE29D0
       movzx    rax, byte  ptr [rax+rcx]
       add      rsp, 40
       ret
G_M949_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3
; Total bytes of code 44
```
Now:
```asm
; Method Program:Test(int):ubyte:this (FullOpts)
       sub      rsp, 40
       and      edx, 7
       mov      eax, edx
       neg      eax
       add      eax, 8
       mov      rcx, 0x228C6572A20
       movzx    rax, byte  ptr [rax+rcx]
       add      rsp, 40
       ret      
; Total bytes of code: 33
```