### PR TITLE
Fix JitOptRepeat around shared constants

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1510,7 +1510,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
             // Ngen case
             if (op2->gtOper == GT_IND)
             {
-                if (!optIsTreeKnownIntValue(!optLocalAssertionProp, op2->AsOp()->gtOp1, &cnsValue, &iconFlags))
+                if (!optIsTreeKnownIntValue(!optLocalAssertionProp, op2->AsOp()->gtOp1, &cnsValue, &iconFlags) &&
+                    (iconFlags == GTF_ICON_CLASS_HDL))
                 {
                     goto DONE_ASSERTION; // Don't make an assertion
                 }
@@ -1519,13 +1520,11 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
                 assertion.op2.kind       = O2K_IND_CNS_INT;
                 assertion.op2.u1.iconVal = cnsValue;
                 assertion.op2.vn         = optConservativeNormalVN(op2->AsOp()->gtOp1);
-
-                /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
-                assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
-                assertion.op2.SetIconFlag(iconFlags);
+                assertion.op2.SetIconFlag(GTF_ICON_CLASS_HDL);
             }
             // JIT case
-            else if (optIsTreeKnownIntValue(!optLocalAssertionProp, op2, &cnsValue, &iconFlags))
+            else if (optIsTreeKnownIntValue(!optLocalAssertionProp, op2, &cnsValue, &iconFlags) &&
+                     (iconFlags == GTF_ICON_CLASS_HDL))
             {
                 assertion.assertionKind  = assertionKind;
                 assertion.op2.kind       = O2K_CONST_INT;
@@ -1534,7 +1533,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
 
                 /* iconFlags should only contain bits in GTF_ICON_HDL_MASK */
                 assert((iconFlags & ~GTF_ICON_HDL_MASK) == 0);
-                assertion.op2.SetIconFlag(iconFlags);
+                assertion.op2.SetIconFlag(GTF_ICON_CLASS_HDL);
             }
             else
             {

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4919,6 +4919,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         while (iterations > 0)
         {
+            opts.optRepeatLastIteration = iterations == 1;
             if (doSsa)
             {
                 // Build up SSA form for the IR

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4919,7 +4919,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         while (iterations > 0)
         {
+#if defined(OPT_CONFIG)
             opts.optRepeatLastIteration = iterations == 1;
+#endif // defined(OPT_CONFIG)
+
             if (doSsa)
             {
                 // Build up SSA form for the IR

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10125,7 +10125,9 @@ public:
         bool altJit;     // True if we are an altjit and are compiling this method
 
 #ifdef OPT_CONFIG
-        bool optRepeat; // Repeat optimizer phases k times
+        bool optRepeat;              // Repeat optimizer phases k times
+        bool optRepeatLastIteration; // Just a hint for optimization passes that we're on the last iteration
+                                     // in optRepeat mode.
 #endif
 
         bool disAsm;       // Display native code as it is generated

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -422,6 +422,13 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         enableSharedConstCSE = true;
     }
 
+    // Only do shared const CSE on the last iteration of the CSE phase to avoid producing
+    // random ADD(CNS, CNS) too soon
+    if (!opts.optRepeatLastIteration)
+    {
+        enableSharedConstCSE = false;
+    }
+
     // We use the liberal Value numbers when building the set of CSE
     ValueNum vnLib     = tree->GetVN(VNK_Liberal);
     ValueNum vnLibNorm = vnStore->VNNormalValue(vnLib);

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -422,12 +422,14 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         enableSharedConstCSE = true;
     }
 
+#if defined(OPT_CONFIG)
     // Only do shared const CSE on the last iteration of the CSE phase to avoid producing
     // random ADD(CNS, CNS) too soon
     if (!opts.optRepeatLastIteration)
     {
         enableSharedConstCSE = false;
     }
+#endif // defined(OPT_CONFIG)
 
     // We use the liberal Value numbers when building the set of CSE
     ValueNum vnLib     = tree->GetVN(VNK_Liberal);


### PR DESCRIPTION
With SharedConstCse we can convert a handle e.g.:
```
CNS_INT(h) long   0x7ffb48d0ef70 class $1c0
```
to an ADD node (`0x7ffb48d0ee44 + 300` = `0x7ffb48d0ef70`):
```
\--*  COMMA     long   $1c0
   +--*  STORE_LCL_VAR long   V03 cse0         d:1 $VN.Void
   |  \--*  CNS_INT   long   0x7ffb48d0ee44 $240
   \--*  ADD       long   $1c0
      +--*  LCL_VAR   long   V03 cse0         u:1 $240
      \--*  CNS_INT   long   300
```

where `0x7ffb48d0ee44` is picked as a shared base constant (and it's not a handle) -- it's ok since our `ADD` (and `COMMA`) nodes have a VN that has ICON flag encoded into it. However, we completely erase that info if we do multiple passes of Value Numbering (JitOptRepeat) so our `ADD` node will no longer have an ICON flag after 2nd pass of VN.

There are two fixes:
1) `optCreateAssertion` doesn't create "Exact type" assertion if it doesn't see the handle flag
2) CSE is only allowed to use Shared Const CSE at the last iteration - it should improve TP/Diffs for OptRepeat mode.


A test case where it easily reproduces: https://github.com/dotnet/runtime/blob/main/src/tests/JIT/Regression/JitBlue/Runtime_70790/Runtime_70790.cs (`s_intType` is folded to a constant, also, note ` - 300` there).