### PR TITLE
Fix unhandled exception with no managed frames

### DIFF
--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -735,7 +735,11 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 #endif
 
     st = unw_step(&cursor);
-    if (st < 0)
+    if (st == -UNW_ESTOPUNWIND)
+    {
+        st = 0;
+    }
+    else if (st < 0)
     {
         return FALSE;
     }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -5869,7 +5869,7 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
         //
         INDEBUG(Thread *pThread = GetThread());
         {
-            _ASSERTE(pThread->GetFrame()->GetVTablePtr() == InlinedCallFrame::GetMethodFrameVPtr()
+            _ASSERTE((pThread->GetFrame() != FRAME_TOP && pThread->GetFrame()->GetVTablePtr() == InlinedCallFrame::GetMethodFrameVPtr())
                 || pMD->ShouldSuppressGCTransition());
 
             CONSISTENCY_CHECK(pMD->IsNDirect());

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4935,9 +4935,11 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex, bool isHar
 
                 if (Thread::VirtualUnwindToFirstManagedCallFrame(&frameContext) == 0)
                 {
-                    // There are no managed frames on the stack, so we need to continue unwinding using C++ exception
-                    // handling
-                    break;
+                    // There are no managed frames on the stack, so the exception was not handled
+                    LONG disposition = InternalUnhandledExceptionFilter_Worker(&ex.ExceptionPointers);
+                    _ASSERTE(disposition == EXCEPTION_CONTINUE_SEARCH);
+                    CrashDumpAndTerminateProcess(1);
+                    UNREACHABLE();
                 }
 
                 UINT_PTR firstManagedFrameSP = GetSP(&frameContext);

--- a/src/tests/baseservices/exceptions/unhandled/CMakeLists.txt
+++ b/src/tests/baseservices/exceptions/unhandled/CMakeLists.txt
@@ -1,0 +1,20 @@
+project (foreignunhandled)
+
+include_directories(${INC_PLATFORM_DIR})
+
+if(CLR_CMAKE_HOST_OSX)
+  # Enable non-POSIX pthreads APIs, which by default are not included in the pthreads header
+  add_definitions(-D_DARWIN_C_SOURCE)
+endif(CLR_CMAKE_HOST_OSX)
+
+set(SOURCES foreignunhandled.cpp)
+
+if(NOT CLR_CMAKE_HOST_WIN32)
+    add_compile_options(-pthread)
+endif()
+
+# add the executable
+add_library (foreignunhandled SHARED ${SOURCES})
+
+# add the install targets
+install (TARGETS foreignunhandled DESTINATION bin)

--- a/src/tests/baseservices/exceptions/unhandled/foreignunhandled.cpp
+++ b/src/tests/baseservices/exceptions/unhandled/foreignunhandled.cpp
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "stdio.h"
+#include <stdlib.h>
+
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable:4265 4577)
+#include <thread>
+#pragma warning(pop)
+#else // _WIN32
+#include <pthread.h>
+#endif // _WIN32
+
+// Work around typedef redefinition: platformdefines.h defines error_t
+// as unsigned while it's defined as int in errno.h.
+#define error_t error_t_ignore
+#include <platformdefines.h>
+#undef error_t
+
+typedef void (*PFNACTION1)();
+extern "C" DLL_EXPORT void InvokeCallback(PFNACTION1 callback)
+{
+    callback();
+}
+
+#ifndef _WIN32
+void* InvokeCallbackUnix(void* callback)
+{
+    InvokeCallback((PFNACTION1)callback);
+    return NULL;
+}
+
+#define AbortIfFail(st) if (st != 0) abort()
+
+#endif // !_WIN32
+
+extern "C" DLL_EXPORT void InvokeCallbackOnNewThread(PFNACTION1 callback)
+{
+#ifdef _WIN32
+    std::thread t1(InvokeCallback, callback);
+    t1.join();
+#else // _WIN32
+    // For Unix, we need to use pthreads to create the thread so that we can set its stack size.
+    // We need to set the stack size due to the very small (80kB) default stack size on MUSL
+    // based Linux distros.
+    pthread_attr_t attr;
+    int st = pthread_attr_init(&attr);
+    AbortIfFail(st);
+
+    // set stack size to 1.5MB
+    st = pthread_attr_setstacksize(&attr, 0x180000);
+    AbortIfFail(st);
+
+    pthread_t t;
+    st = pthread_create(&t, &attr, InvokeCallbackUnix, (void*)callback);
+    AbortIfFail(st);
+
+    st = pthread_join(t, NULL);
+    AbortIfFail(st);
+#endif // _WIN32
+}

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.cs
@@ -2,14 +2,51 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace TestUnhandledException
 {
-    class Program
+    public delegate void MyCallback();
+
+    unsafe class Program
     {
-        static void Main()
+        [DllImport("foreignunhandled")]
+        public static extern void InvokeCallbackOnNewThread(delegate*unmanaged<void> callBack);
+
+        private const string INTERNAL_CALL = "__internal";
+
+        [SuppressGCTransition]
+        [DllImport(INTERNAL_CALL, EntryPoint = "HelloCpp")]
+        private static extern void Test();
+
+        [UnmanagedCallersOnly]
+        static void ThrowException()
         {
-            throw new Exception("Test");
+            SetDllResolver();
+            Test();
+        }
+
+        private static void SetDllResolver()
+        {
+            NativeLibrary.SetDllImportResolver(
+                Assembly.GetExecutingAssembly(),
+                static (library, _, _) =>
+                    library == INTERNAL_CALL ? NativeLibrary.GetMainProgramHandle() : IntPtr.Zero
+            );
+        }
+
+        static void Main(string[] args)
+        {
+            if (args[0] == "main")
+            {
+                throw new Exception("Test");
+            }
+            else if (args[0] == "foreign")
+            {
+                InvokeCallbackOnNewThread(&ThrowException);
+            }
         }
     }
 }

--- a/src/tests/baseservices/exceptions/unhandled/unhandled.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandled.csproj
@@ -4,8 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
     <CLRTestKind>BuildOnly</CLRTestKind>
-
-    <Optimize>false</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unhandled.cs" />

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -69,9 +69,19 @@ namespace TestUnhandledExceptionTester
                 {
                     throw new Exception("Missing Unhandled exception header");
                 }
-                if (lines[1] != "System.Exception: Test")
+                if (unhandledType == "main")
                 {
-                    throw new Exception("Missing exception type and message");
+                    if (lines[1] != "System.Exception: Test")
+                    {
+                        throw new Exception("Missing exception type and message");
+                    }
+                }
+                else if (unhandledType == "foreign")
+                {
+                    if (lines[1] != "System.EntryPointNotFoundException: HelloCpp")
+                    {
+                        throw new Exception("Missing exception type and message");
+                    }
                 }
 
                 exceptionStackFrameLine = 2;
@@ -87,7 +97,7 @@ namespace TestUnhandledExceptionTester
                 }
                 else if (unhandledType == "foreign")
                 {
-                    if (lines[0] != "Unhandled exception. System.EntryPointNotFoundException: Unable to find an entry point named 'HelloCpp' in shared library '__internal'.")
+                    if (!lines[0].StartsWith("Unhandled exception. System.DllNotFoundException:"))
                     {
                         throw new Exception("Missing Unhandled exception header");
                     }

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -23,6 +23,8 @@ namespace TestUnhandledExceptionTester
             testProcess.StartInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
             testProcess.StartInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "unhandled.dll") + " " + unhandledType;
             testProcess.StartInfo.RedirectStandardError = true;
+            // Disable creating dump since the target process is expected to fail with an unhandled exception
+            testProcess.StartInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
             testProcess.ErrorDataReceived += (sender, line) => 
             {
                 Console.WriteLine($"\"{line.Data}\"");

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-
     <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unhandledTester.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />


### PR DESCRIPTION
There is a case when there are no managed frames on the stack nor a native unhandled exception trap in the native code. For example when a custom host invokes a delegate and it ends up jitting an pinvoke code and calls NDirectImportWorker that throws because of a problem with the pinvoke.

The exception handling code in DispatchManagedException was expecting that there is either an unhandled managed exception trap installed or managed code on the stack that would both "handle" the exception properly. But in the case of a delegate invoked by a custom or a thread with purely native code it is not the case and the runtime ends up crashing with PAL_SEHException leaking out of the runtime.

This change fixes it by adding explicit call to the unhandled exception filter to the DispatchManagedException when it doesn't find any managed frames on the stack.

Close #94029