### PR TITLE
A few optimizations for the gcinfodecoder construction

### DIFF
--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -592,6 +592,8 @@ private:
 #endif
     UINT32 m_Version;
 
+    bool PredecodeFatHeader(int remainingFlags);
+
     static bool SetIsInterruptibleCB (UINT32 startOffset, UINT32 stopOffset, void * hCallback);
 
     OBJECTREF* GetRegisterSlot(

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -265,6 +265,7 @@ public:
 
         m_pCurrent = m_pBuffer = dac_cast<PTR_size_t>((size_t)dac_cast<TADDR>(pBuffer) & ~((size_t)sizeof(size_t)-1));
         m_RelPos = m_InitialRelPos = (int)((size_t)dac_cast<TADDR>(pBuffer) % sizeof(size_t)) * 8/*BITS_PER_BYTE*/;
+        m_current = *m_pCurrent >> m_RelPos;
     }
 
     BitStreamReader(const BitStreamReader& other)
@@ -275,6 +276,7 @@ public:
         m_InitialRelPos = other.m_InitialRelPos;
         m_pCurrent = other.m_pCurrent;
         m_RelPos = other.m_RelPos;
+        m_current = other.m_current;
     }
 
     const BitStreamReader& operator=(const BitStreamReader& other)
@@ -285,6 +287,7 @@ public:
         m_InitialRelPos = other.m_InitialRelPos;
         m_pCurrent = other.m_pCurrent;
         m_RelPos = other.m_RelPos;
+        m_current = other.m_current;
         return *this;
     }
 
@@ -295,33 +298,35 @@ public:
 
         _ASSERTE(numBits > 0 && numBits <= BITS_PER_SIZE_T);
 
-        size_t result = (*m_pCurrent) >> m_RelPos;
+        size_t result = m_current;
+        m_current >>= numBits;
         int newRelPos = m_RelPos + numBits;
         if(newRelPos >= BITS_PER_SIZE_T)
         {
             m_pCurrent++;
+            m_current = *m_pCurrent;
             newRelPos -= BITS_PER_SIZE_T;
-            if(newRelPos > 0)
-            {
-                size_t extraBits = (*m_pCurrent) << (numBits - newRelPos);
-                result ^= extraBits;
-            }
+            size_t extraBits = m_current << (numBits - newRelPos);
+            result |= extraBits;
+            m_current >>= newRelPos;
         }
         m_RelPos = newRelPos;
-        result &= SAFE_SHIFT_LEFT(1, numBits) - 1;
+        result &= ((size_t)-1 >> (BITS_PER_SIZE_T - numBits));
         return result;
     }
 
-    // This version reads one bit, returning zero/non-zero (not 0/1)
+    // This version reads one bit
     // NOTE: This routine is perf-critical
     __forceinline size_t ReadOneFast()
     {
         SUPPORTS_DAC;
 
-        size_t result = (*m_pCurrent) & (((size_t)1) << m_RelPos);
+        size_t result = m_current & 1;
+        m_current >>= 1;
         if(++m_RelPos == BITS_PER_SIZE_T)
         {
             m_pCurrent++;
+            m_current = *m_pCurrent;
             m_RelPos = 0;
         }
         return result;
@@ -339,6 +344,7 @@ public:
         size_t adjPos = pos + m_InitialRelPos;
         m_pCurrent = m_pBuffer + adjPos / BITS_PER_SIZE_T;
         m_RelPos = (int)(adjPos % BITS_PER_SIZE_T);
+        m_current = *m_pCurrent >> m_RelPos;
         _ASSERTE(GetCurrentPos() == pos);
     }
 
@@ -347,19 +353,6 @@ public:
         SUPPORTS_DAC;
 
         SetCurrentPos(GetCurrentPos() + numBitsToSkip);
-    }
-
-    __forceinline void AlignUpToByte()
-    {
-        if(m_RelPos <= BITS_PER_SIZE_T - 8)
-        {
-            m_RelPos = (m_RelPos + 7) & ~7;
-        }
-        else
-        {
-            m_RelPos = 0;
-            m_pCurrent++;
-        }
     }
 
     __forceinline size_t ReadBitAtPos( size_t pos )
@@ -422,6 +415,7 @@ private:
     int m_InitialRelPos;
     PTR_size_t m_pCurrent;
     int m_RelPos;
+    size_t m_current;
 };
 
 struct GcSlotDesc

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -559,15 +559,8 @@ private:
     UINT32  m_InstructionOffset;
 
     // Pre-decoded information
+    GcInfoHeaderFlags m_headerFlags;
     bool    m_IsInterruptible;
-    bool    m_IsVarArg;
-    bool    m_GenericSecretParamIsMD;
-    bool    m_GenericSecretParamIsMT;
-#ifdef TARGET_AMD64
-    bool    m_WantsReportOnlyLeaf;
-#elif defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-    bool    m_HasTailCalls;
-#endif // TARGET_AMD64
     INT32   m_GSCookieStackSlot;
     INT32   m_ReversePInvokeFrameStackSlot;
     UINT32  m_ValidRangeStart;

--- a/src/coreclr/inc/gcinfodecoder.h
+++ b/src/coreclr/inc/gcinfodecoder.h
@@ -584,7 +584,8 @@ private:
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
     UINT32  m_NumSafePoints;
     UINT32  m_SafePointIndex;
-    UINT32 FindSafePoint(UINT32 codeOffset);
+    UINT32  NarrowSafePointSearch(size_t savedPos, UINT32 breakOffset, UINT32* searchEnd);
+    UINT32  FindSafePoint(UINT32 codeOffset);
 #endif
     UINT32  m_NumInterruptibleRanges;
 

--- a/src/coreclr/inc/gcinfoencoder.h
+++ b/src/coreclr/inc/gcinfoencoder.h
@@ -285,7 +285,7 @@ private:
     // Writes bits knowing that they will all fit in the current memory slot
     inline void WriteInCurrentSlot( size_t data, UINT32 count )
     {
-        data &= SAFE_SHIFT_LEFT(1, count) - 1;
+        data &= ((size_t)-1 >> (BITS_PER_SIZE_T - count));
         data <<= (BITS_PER_SIZE_T - m_FreeBitsInCurrentSlot);
         *m_pCurrentSlot |= data;
     }

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -26,25 +26,6 @@
 
 #define BITS_PER_SIZE_T ((int)sizeof(size_t)*8)
 
-
-//--------------------------------------------------------------------------------
-// It turns out, that ((size_t)x) << y == x, when y is not a literal
-//      and its value is BITS_PER_SIZE_T
-// I guess the processor only shifts of the right operand modulo BITS_PER_SIZE_T
-// In many cases, we want the above operation to yield 0,
-//      hence the following macros
-//--------------------------------------------------------------------------------
-__forceinline size_t SAFE_SHIFT_LEFT(size_t x, size_t count)
-{
-    _ASSERTE(count <= BITS_PER_SIZE_T);
-    return (x << 1) << (count - 1);
-}
-__forceinline size_t SAFE_SHIFT_RIGHT(size_t x, size_t count)
-{
-    _ASSERTE(count <= BITS_PER_SIZE_T);
-    return (x >> 1) >> (count - 1);
-}
-
 inline UINT32 CeilOfLog2(size_t x)
 {
     // it is ok to use bsr or clz unconditionally

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -47,19 +47,22 @@ __forceinline size_t SAFE_SHIFT_RIGHT(size_t x, size_t count)
 
 inline UINT32 CeilOfLog2(size_t x)
 {
-    // we are ok even if bsr is used vs. lzcnt
+    // we want lzcnt, but bsr is ok too
     _ASSERTE(x > 0);
 
     x = (x << 1) - 1;
+
 #ifdef TARGET_64BIT
 #ifdef _MSC_VER
-    UINT32 lzcountCeil = (UINT32)__lzcnt64((unsigned __int64)x);
+    DWORD lzcountCeil;
+    _BitScanReverse64(&lzcountCeil, (unsigned long)x);
 #else // _MSC_VER
     UINT32 lzcountCeil = (UINT32)__builtin_clzl((unsigned long)x);
 #endif // _MSC_VER
 #else // TARGET_64BIT
 #ifdef _MSC_VER
-    UINT32 lzcountCeil = (UINT32)__lzcnt((unsigned int)x);
+    DWORD lzcountCeil;
+    _BitScanReverse(&lzcountCeil, (unsigned long)x);
 #else // _MSC_VER
     UINT32 lzcountCeil = (UINT32)__builtin_clz((unsigned int)x);
 #endif // _MSC_VER

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -59,7 +59,7 @@ inline UINT32 CeilOfLog2(size_t x)
     return (UINT32)result;
 #else // _MSC_VER
     // LZCNT returns index starting from MSB, whereas BSR gives the index from LSB.
-    // 63 ^ BSR here is equivalent to 63 - BSR since the BSR result is always between 0 and 63.
+    // 63 ^ LZCNT here is equivalent to 63 - LZCNT since the LZCNT result is always between 0 and 63.
     // This saves an instruction, as subtraction from constant requires either MOV/SUB or NEG/ADD.
     return (UINT32)63 ^ (UINT32)__builtin_clzl((unsigned long)x);
 #endif // _MSC_VER

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -415,9 +415,10 @@ bool GcInfoDecoder::IsSafePoint(UINT32 codeOffset)
     if(m_NumSafePoints == 0)
         return false;
 
+#if defined(TARGET_AMD64) || defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     // Safepoints are encoded with a -1 adjustment
     codeOffset--;
-
+#endif
     size_t savedPos = m_Reader.GetCurrentPos();
     UINT32 safePointIndex = FindSafePoint(codeOffset);
     m_Reader.SetCurrentPos(savedPos);

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -350,6 +350,7 @@ GcInfoDecoder::GcInfoDecoder(
 
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
     m_NumSafePoints = (UINT32) DENORMALIZE_NUM_SAFE_POINTS(m_Reader.DecodeVarLengthUnsigned(NUM_SAFE_POINTS_ENCBASE));
+    m_SafePointIndex = m_NumSafePoints;
 #endif
 
     if (slimHeader)
@@ -362,18 +363,14 @@ GcInfoDecoder::GcInfoDecoder(
     }
 
 #ifdef PARTIALLY_INTERRUPTIBLE_GC_SUPPORTED
-    if(flags & (DECODE_INTERRUPTIBILITY | DECODE_GC_LIFETIMES))
+    if(flags & (DECODE_GC_LIFETIMES))
     {
         if(m_NumSafePoints)
         {
             m_SafePointIndex = FindSafePoint(m_InstructionOffset);
         }
-        else
-        {
-            m_SafePointIndex = 0;
-        }
     }
-    else if(flags & DECODE_FOR_RANGES_CALLBACK)
+    else if(flags & (DECODE_FOR_RANGES_CALLBACK | DECODE_INTERRUPTIBILITY))
     {
         // Note that normalization as a code offset can be different than
         //  normalization as code length

--- a/src/coreclr/vm/gcinfodecoder.cpp
+++ b/src/coreclr/vm/gcinfodecoder.cpp
@@ -602,7 +602,7 @@ bool GcInfoDecoder::GetIsVarArg()
 bool GcInfoDecoder::HasTailCalls()
 {
     _ASSERTE( m_Flags & DECODE_HAS_TAILCALLS );
-    return ((headerFlags & GC_INFO_HAS_TAILCALLS) != 0);
+    return ((m_headerFlags & GC_INFO_HAS_TAILCALLS) != 0);
 }
 #endif // TARGET_ARM || TARGET_ARM64 || TARGET_LOONGARCH64 || TARGET_RISCV64
 


### PR DESCRIPTION
Constructing gcinfodecoder performs some initial decoding. While the time spent in initial decoding is typically less than the time spent enumerating live slots, it is not insignificant. There are some opportunities to do initial decoding a bit cheaper.

