### PR TITLE
JIT: Generalize check for cycles when finding loops

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1969,12 +1969,14 @@ class FlowGraphDfsTree
     // that all predecessors are visited before successors whenever possible.
     BasicBlock** m_postOrder;
     unsigned m_postOrderCount;
+    bool m_hasCycle;
 
 public:
-    FlowGraphDfsTree(Compiler* comp, BasicBlock** postOrder, unsigned postOrderCount)
+    FlowGraphDfsTree(Compiler* comp, BasicBlock** postOrder, unsigned postOrderCount, bool hasCycle)
         : m_comp(comp)
         , m_postOrder(postOrder)
         , m_postOrderCount(postOrderCount)
+        , m_hasCycle(hasCycle)
     {
     }
 
@@ -2002,6 +2004,11 @@ public:
     BitVecTraits PostOrderTraits() const
     {
         return BitVecTraits(m_postOrderCount, m_comp);
+    }
+
+    bool HasCycle() const
+    {
+        return m_hasCycle;
     }
 
     bool Contains(BasicBlock* block) const;
@@ -2246,10 +2253,6 @@ class FlowGraphNaturalLoops
     // Collection of loops that were found.
     jitstd::vector<FlowGraphNaturalLoop*> m_loops;
 
-    // Whether or not we saw any non-natural loop cycles, also known as
-    // irreducible loops.
-    unsigned m_improperLoopHeaders = 0;
-
     FlowGraphNaturalLoops(const FlowGraphDfsTree* dfs);
 
     static bool FindNaturalLoopBlocks(FlowGraphNaturalLoop* loop, ArrayStack<BasicBlock*>& worklist);
@@ -2262,11 +2265,6 @@ public:
     size_t NumLoops()
     {
         return m_loops.size();
-    }
-
-    bool HaveNonNaturalLoopCycles()
-    {
-        return m_improperLoopHeaders > 0;
     }
 
     FlowGraphNaturalLoop* GetLoopByIndex(unsigned index);
@@ -6076,8 +6074,8 @@ public:
     PhaseStatus fgSetBlockOrder();
     bool fgHasCycleWithoutGCSafePoint();
 
-    template<typename TFuncAssignPreorder, typename TFuncAssignPostorder>
-    unsigned fgRunDfs(TFuncAssignPreorder assignPreorder, TFuncAssignPostorder assignPostorder);
+    template<typename VisitPreorder, typename VisitPostorder, typename VisitEdge>
+    unsigned fgRunDfs(VisitPreorder assignPreorder, VisitPostorder assignPostorder, VisitEdge visitEdge);
 
     FlowGraphDfsTree* fgComputeDfs();
     void fgInvalidateDfsTree();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1969,6 +1969,8 @@ class FlowGraphDfsTree
     // that all predecessors are visited before successors whenever possible.
     BasicBlock** m_postOrder;
     unsigned m_postOrderCount;
+
+    // Whether the DFS that produced the tree found any backedges.
     bool m_hasCycle;
 
 public:

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4913,16 +4913,19 @@ inline bool Compiler::compCanHavePatchpoints(const char** reason)
 // Type parameters:
 //   VisitPreorder  - Functor type that takes a BasicBlock* and its preorder number
 //   VisitPostorder - Functor type that takes a BasicBlock* and its postorder number
+//   VisitEdge      - Functor type that takes two BasicBlock*.
 //
 // Parameters:
 //   visitPreorder  - Functor to visit block in its preorder
 //   visitPostorder - Functor to visit block in its postorder
+//   visitEdge      - Functor to visit an edge. Called after visitPreorder (if
+//                    this is the first time the successor is seen).
 //
 // Returns:
 //   Number of blocks visited.
 //
-template <typename VisitPreorder, typename VisitPostorder>
-unsigned Compiler::fgRunDfs(VisitPreorder visitPreorder, VisitPostorder visitPostorder)
+template <typename VisitPreorder, typename VisitPostorder, typename VisitEdge>
+unsigned Compiler::fgRunDfs(VisitPreorder visitPreorder, VisitPostorder visitPostorder, VisitEdge visitEdge)
 {
     BitVecTraits traits(fgBBNumMax + 1, this);
     BitVec       visited(BitVecOps::MakeEmpty(&traits));
@@ -4950,6 +4953,8 @@ unsigned Compiler::fgRunDfs(VisitPreorder visitPreorder, VisitPostorder visitPos
                     blocks.Emplace(this, succ);
                     visitPreorder(succ, preOrderIndex++);
                 }
+
+                visitEdge(block, succ);
             }
             else
             {

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -5210,7 +5210,8 @@ void Compiler::fgDebugCheckDfsTree()
                  [=](BasicBlock* block, unsigned postorderNum) {
                      assert(block->bbNewPostorderNum == postorderNum);
                      assert(m_dfsTree->GetPostOrder(postorderNum) == block);
-                 });
+                 },
+                 [](BasicBlock* block, BasicBlock* succ) {});
 
     assert(m_dfsTree->GetPostOrderCount() == count);
 }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4413,7 +4413,7 @@ FlowGraphNaturalLoops* FlowGraphNaturalLoops::Find(const FlowGraphDfsTree* dfsTr
 
     if (!dfsTree->HasCycle())
     {
-        JITDUMP("DFS tree has no cycles; skipping identification of natural loops\n");
+        JITDUMP("Flow graph has no cycles; skipping identification of natural loops\n");
         return loops;
     }
 


### PR DESCRIPTION
`optFindNewLoops` tries to leave a breadcrumb for loop alignment about whether it needs to bother with identifying loops. It does so by checking for whether any natural loops were found, but also whether any irreducible loops were found (i.e. any cycle). The idea is that optimizations that run between finding loops and loop alignment can easily remove edges that make irreducible loops into natural loops.

However, the check for "any cycle" was not precise enough; it made the assumption that `NumLoops() > 0 || NumImproperLoopHeaders > 0` was equivalent to there being a cycle in the flow graph. But that is not true, specifically because we only consider blocks to be loop headers when their backedges are non-exceptional. Odd loop structures can exist that iterate through required exception throws, like in the case of #96145. In that case we have a cycle through the handler, which ends up being a natural loop after some optimizations run.  ([Flowgraph](https://gist.github.com/jakobbotsch/61d074c95127b1c9ba46b8ff10ef2a36) -- the cycle is `BB08 -> BB09 -> BB12 -> BB05 -> BB08`. The entry edge would be `BB02 -> BB08`.). But since the backedge is exceptional, we do not consider it as a loop during loop finding, and we do not consider it as an improper loop header either.

To fix the situation we generalize `fgComputeDfs` to identify when the flow graph has a cycle, which is the fully general property we want for the breadcrumb. As a bonus we can skip identifying loops if we know the flow graph has no cycles.

Fix #96145