### PR TITLE
Change impImportLeave to directly import BBJ_CALLFINALLYRET

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4530,11 +4530,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         return;
     }
 
-    // Convert BBJ_CALLFINALLY/BBJ_ALWAYS pairs to BBJ_CALLFINALLY/BBJ_CALLFINALLYRET.
-    // Temporary: eventually, do this immediately in impImportLeave
-    //
-    DoPhase(this, PHASE_UPDATE_CALLFINALLY, &Compiler::fgUpdateCallFinally);
-
     // If instrumenting, add block and class probes.
     //
     if (compileFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR))

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5208,8 +5208,6 @@ public:
 
     PhaseStatus fgImport();
 
-    PhaseStatus fgUpdateCallFinally();
-
     PhaseStatus fgTransformIndirectCalls();
 
     PhaseStatus fgTransformPatchpoints();

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -25,7 +25,6 @@
 //                                                                                                measureIR
 CompPhaseNameMacro(PHASE_PRE_IMPORT,                 "Pre-import",                     false, -1, false)
 CompPhaseNameMacro(PHASE_IMPORTATION,                "Importation",                    false, -1, true)
-CompPhaseNameMacro(PHASE_UPDATE_CALLFINALLY,         "Update callfinally/always pairs",false, -1, true)
 CompPhaseNameMacro(PHASE_INDXCALL,                   "Indirect call transform",        false, -1, true)
 CompPhaseNameMacro(PHASE_PATCHPOINTS,                "Expand patchpoints",             false, -1, true)
 CompPhaseNameMacro(PHASE_POST_IMPORT,                "Post-import",                    false, -1, false)

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6729,12 +6729,7 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
         // something else. We keep updating it until we've reached the 'nearBlk', to push it as
         // close to endBlk as possible.
         //
-        // TODO-Quirk: we can't use isBBCallFinallyPair because this function is called during the importer
-        // before we've replaced BBJ_CALLFINALLY/BBJ_ALWAYS with BBJ_CALLFINALLY/BBJ_CALLFINALLYRET, which
-        // leads to asserts.
-        //
-        // if (!blk->isBBCallFinallyPair())
-        if (!blk->KindIs(BBJ_CALLFINALLY) || blk->HasFlag(BBF_RETLESS_CALL))
+        if (!blk->isBBCallFinallyPair())
         {
             if (goodBlk == nullptr)
             {

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2776,9 +2776,7 @@ bool BBPredsChecker::CheckEhTryDsc(BasicBlock* block, BasicBlock* blockPred, EHb
     // block that does a local call to the finally. This BBJ_CALLFINALLYRET is within
     // the try region protected by the finally (for x86), but that's ok.
     BasicBlock* prevBlock = block->Prev();
-    // TODO-Quirk: the BBJ_ALWAYS below is a quirk, until fgUpdateCallFinally is removed
-    if (prevBlock->KindIs(BBJ_CALLFINALLY) && block->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET) &&
-        blockPred->KindIs(BBJ_EHFINALLYRET))
+    if (prevBlock->KindIs(BBJ_CALLFINALLY) && block->KindIs(BBJ_CALLFINALLYRET) && blockPred->KindIs(BBJ_EHFINALLYRET))
     {
         return true;
     }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -614,44 +614,6 @@ PhaseStatus Compiler::fgImport()
     return PhaseStatus::MODIFIED_EVERYTHING;
 }
 
-//------------------------------------------------------------------------
-// fgUpdateCallFinally: For BBJ_CALLFINALLY/BBJ_ALWAYS pairs, replace BBJ_ALWAYS with BBJ_CALLFINALLYRET.
-//
-// This should be temporary. Later, fix impImportLeave to do this directly.
-//
-// Returns:
-//    phase status
-//
-PhaseStatus Compiler::fgUpdateCallFinally()
-{
-    if (info.compXcptnsCount == 0)
-    {
-        return PhaseStatus::MODIFIED_NOTHING;
-    }
-
-    for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->Next())
-    {
-        if (block->KindIs(BBJ_CALLFINALLY))
-        {
-            // There are no ret-less callfinally yet (this is run early), so there must be a matching
-            // BBJ_ALWAYS block.
-            BasicBlock* blockAlways = block->Next();
-            assert(blockAlways != nullptr);
-            assert(blockAlways->KindIs(BBJ_ALWAYS));
-            assert(blockAlways->isEmpty());
-            assert(blockAlways->HasFlag(BBF_KEEP_BBJ_ALWAYS));
-
-            blockAlways->SetKind(BBJ_CALLFINALLYRET);
-            blockAlways->RemoveFlags(BBF_KEEP_BBJ_ALWAYS);
-
-            JITDUMP("Replaced BBJ_ALWAYS " FMT_BB " of BBJ_CALLFINALLY " FMT_BB " pair with BBJ_CALLFINALLYRET.\n",
-                    blockAlways->bbNum, block->bbNum);
-        }
-    }
-
-    return PhaseStatus::MODIFIED_EVERYTHING;
-}
-
 /*****************************************************************************
  * This function returns true if tree is a node with a call
  * that unconditionally throws an exception

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4281,10 +4281,11 @@ GenTree* Compiler::impFixupStructReturnType(GenTree* op)
 //   finally-protected try. We find the finally blocks protecting the current
 //   offset (in order) by walking over the complete exception table and
 //   finding enclosing clauses. This assumes that the table is sorted.
-//   This will create a series of BBJ_CALLFINALLY -> BBJ_CALLFINALLY ... -> BBJ_ALWAYS.
+//   This will create a series of BBJ_CALLFINALLY/BBJ_CALLFINALLYRET ->
+//   BBJ_CALLFINALLY/BBJ_CALLFINALLYRET ... -> BBJ_ALWAYS.
 //
 //   If we are leaving a catch handler, we need to attach the
-//   CPX_ENDCATCHes to the correct BBJ_CALLFINALLY blocks.
+//   ENDCATCHes to the correct BBJ_CALLFINALLY blocks.
 //
 //   After this function, the BBJ_LEAVE block has been converted to a different type.
 //
@@ -4331,15 +4332,15 @@ void Compiler::impImportLeave(BasicBlock* block)
         IL_OFFSET hndBeg = HBtab->ebdHndBegOffs();
         IL_OFFSET hndEnd = HBtab->ebdHndEndOffs();
 
-        /* Is this a catch-handler we are CEE_LEAVEing out of?
-         * If so, we need to call CORINFO_HELP_ENDCATCH.
-         */
+        // Is this a catch-handler we are CEE_LEAVE'ing out of? If so, we need to call CORINFO_HELP_ENDCATCH.
 
         if (jitIsBetween(blkAddr, hndBeg, hndEnd) && !jitIsBetween(jmpAddr, hndBeg, hndEnd))
         {
             // Can't CEE_LEAVE out of a finally/fault handler
             if (HBtab->HasFinallyOrFaultHandler())
+            {
                 BADCODE("leave out of fault/finally block");
+            }
 
             // Create the call to CORINFO_HELP_ENDCATCH
             GenTree* endCatch = gtNewHelperCallNode(CORINFO_HELP_ENDCATCH, TYP_VOID);
@@ -4366,18 +4367,16 @@ void Compiler::impImportLeave(BasicBlock* block)
         else if (HBtab->HasFinallyHandler() && jitIsBetween(blkAddr, tryBeg, tryEnd) &&
                  !jitIsBetween(jmpAddr, tryBeg, tryEnd))
         {
-            /* This is a finally-protected try we are jumping out of */
-
-            /* If there are any pending endCatches, and we have already
-               jumped out of a finally-protected try, then the endCatches
-               have to be put in a block in an outer try for async
-               exceptions to work correctly.
-               Else, just use append to the original block */
+            // This is a finally-protected try we are jumping out of.
+            //
+            // If there are any pending endCatches, and we have already jumped out of a finally-protected try,
+            // then the endCatches have to be put in a block in an outer try for async exceptions to work correctly.
+            // Else, just append to the original block.
 
             BasicBlock* callBlock;
 
-            assert(!encFinallies ==
-                   !endLFinStmt); // if we have finallies, we better have an endLFin tree, and vice-versa
+            // If we have finallies, we better have an endLFin tree, and vice-versa.
+            assert(!encFinallies == !endLFinStmt);
 
             if (encFinallies == 0)
             {
@@ -4387,7 +4386,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 assert(callBlock->HasInitializedTarget());
                 fgRemoveRefPred(callBlock->GetTarget(), callBlock);
 
-                // callBlock will call the finally handler. Convert the BBJ_LEAVE to BBJ_CALLFINALLY
+                // callBlock will call the finally handler. Convert the BBJ_LEAVE to BBJ_CALLFINALLY.
                 callBlock->SetKindAndTarget(BBJ_CALLFINALLY, HBtab->ebdHndBeg);
 
                 if (endCatches)
@@ -4408,7 +4407,7 @@ void Compiler::impImportLeave(BasicBlock* block)
             {
                 assert(step != DUMMY_INIT(NULL));
 
-                /* Calling the finally block */
+                // Calling the finally block.
 
                 // callBlock will call the finally handler
                 callBlock = fgNewBBinRegion(BBJ_CALLFINALLY, XTnum + 1, 0, step, HBtab->ebdHndBeg);
@@ -4420,7 +4419,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 step->SetTarget(callBlock);
                 fgAddRefPred(callBlock, step);
 
-                /* The new block will inherit this block's weight */
+                // The new block will inherit this block's weight.
                 callBlock->inheritWeight(block);
 
 #ifdef DEBUG
@@ -4449,15 +4448,16 @@ void Compiler::impImportLeave(BasicBlock* block)
             }
 
             // Note: we don't know the jump target yet
-            step = fgNewBBafter(BBJ_ALWAYS, callBlock, true);
-            /* The new block will inherit this block's weight */
+            step = fgNewBBafter(BBJ_CALLFINALLYRET, callBlock, true);
+            // The new block will inherit this block's weight.
             step->inheritWeight(block);
-            step->SetFlags(BBF_IMPORTED | BBF_KEEP_BBJ_ALWAYS);
+            step->SetFlags(BBF_IMPORTED);
 
 #ifdef DEBUG
             if (verbose)
             {
-                printf("impImportLeave - jumping out of a finally-protected try, created step (BBJ_ALWAYS) block %s\n",
+                printf("impImportLeave - jumping out of a finally-protected try, created step (BBJ_CALLFINALLYRET) "
+                       "block %s\n",
                        step->dspToString());
             }
 #endif
@@ -4477,7 +4477,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         }
     }
 
-    /* Append any remaining endCatches, if any */
+    // Append any remaining endCatches, if any.
 
     assert(!encFinallies == !endLFinStmt);
 
@@ -4519,7 +4519,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         step->SetTarget(finalStep);
         fgAddRefPred(finalStep, step);
 
-        /* The new block will inherit this block's weight */
+        // The new block will inherit this block's weight.
         finalStep->inheritWeight(block);
 
 #ifdef DEBUG
@@ -4598,8 +4598,8 @@ void Compiler::impImportLeave(BasicBlock* block)
         // No step type; step == NULL.
         ST_None,
 
-        // Is the step block the BBJ_ALWAYS block of a BBJ_CALLFINALLY/BBJ_ALWAYS pair?
-        // That is, is step->bbTarget where a finally will return to?
+        // The step block is the BBJ_CALLFINALLYRET block of a BBJ_CALLFINALLY/BBJ_CALLFINALLYRET pair.
+        // That is, is step->GetFinallyContinuation() is where a finally will return to.
         ST_FinallyReturn,
 
         // The step block is a catch return.
@@ -4622,8 +4622,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         IL_OFFSET hndBeg = HBtab->ebdHndBegOffs();
         IL_OFFSET hndEnd = HBtab->ebdHndEndOffs();
 
-        /* Is this a catch-handler we are CEE_LEAVEing out of?
-         */
+        // Is this a catch-handler we are CEE_LEAVE'ing out of?
 
         if (jitIsBetween(blkAddr, hndBeg, hndEnd) && !jitIsBetween(jmpAddr, hndBeg, hndEnd))
         {
@@ -4633,7 +4632,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 BADCODE("leave out of fault/finally block");
             }
 
-            /* We are jumping out of a catch */
+            // We are jumping out of a catch.
 
             if (step == nullptr)
             {
@@ -4645,20 +4644,19 @@ void Compiler::impImportLeave(BasicBlock* block)
                 if (verbose)
                 {
                     printf("impImportLeave - jumping out of a catch (EH#%u), convert block " FMT_BB
-                           " to BBJ_EHCATCHRET "
-                           "block\n",
+                           " to BBJ_EHCATCHRET block\n",
                            XTnum, step->bbNum);
                 }
 #endif
             }
             else
             {
-                /* Create a new catch exit block in the catch region for the existing step block to jump to in this
-                 * scope */
+                // Create a new catch exit block in the catch region for the existing step block to jump to in this
+                // scope.
                 // Note: we don't know the jump target yet
                 BasicBlock* exitBlock = fgNewBBinRegion(BBJ_EHCATCHRET, 0, XTnum + 1, step);
 
-                assert(step->KindIs(BBJ_ALWAYS, BBJ_EHCATCHRET));
+                assert(step->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET, BBJ_EHCATCHRET));
                 assert((step == block) || !step->HasInitializedTarget());
                 if (step == block)
                 {
@@ -4668,11 +4666,11 @@ void Compiler::impImportLeave(BasicBlock* block)
                                             // exit) returns to this block
                 fgAddRefPred(exitBlock, step);
 
-                /* The new block will inherit this block's weight */
+                // The new block will inherit this block's weight.
                 exitBlock->inheritWeight(block);
                 exitBlock->SetFlags(BBF_IMPORTED);
 
-                /* This exit block is the new step */
+                // This exit block is the new step.
                 step     = exitBlock;
                 stepType = ST_Catch;
 
@@ -4688,7 +4686,7 @@ void Compiler::impImportLeave(BasicBlock* block)
         else if (HBtab->HasFinallyHandler() && jitIsBetween(blkAddr, tryBeg, tryEnd) &&
                  !jitIsBetween(jmpAddr, tryBeg, tryEnd))
         {
-            /* We are jumping out of a finally-protected try */
+            // We are jumping out of a finally-protected try.
 
             BasicBlock* callBlock;
 
@@ -4712,7 +4710,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 block->SetKindAndTarget(BBJ_ALWAYS, callBlock);
                 fgAddRefPred(callBlock, block);
 
-                /* The new block will inherit this block's weight */
+                // The new block will inherit this block's weight.
                 callBlock->inheritWeight(block);
                 callBlock->SetFlags(BBF_IMPORTED);
 
@@ -4720,8 +4718,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 if (verbose)
                 {
                     printf("impImportLeave - jumping out of a finally-protected try (EH#%u), convert block " FMT_BB
-                           " to "
-                           "BBJ_ALWAYS, add BBJ_CALLFINALLY block " FMT_BB "\n",
+                           " to BBJ_ALWAYS, add BBJ_CALLFINALLY block " FMT_BB "\n",
                            XTnum, block->bbNum, callBlock->bbNum);
                 }
 #endif
@@ -4740,8 +4737,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 if (verbose)
                 {
                     printf("impImportLeave - jumping out of a finally-protected try (EH#%u), convert block " FMT_BB
-                           " to "
-                           "BBJ_CALLFINALLY block\n",
+                           " to BBJ_CALLFINALLY block\n",
                            XTnum, callBlock->bbNum);
                 }
 #endif
@@ -4766,7 +4762,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 // never returns to the call-to-finally call, and the finally-protected 'try' region doesn't appear on
                 // stack walks.)
 
-                assert(step->KindIs(BBJ_ALWAYS, BBJ_EHCATCHRET));
+                assert(step->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET, BBJ_EHCATCHRET));
                 assert((step == block) || !step->HasInitializedTarget());
 
 #if FEATURE_EH_CALLFINALLY_THUNKS
@@ -4810,7 +4806,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 unsigned callFinallyHndIndex = 0; // don't care
 #endif // !FEATURE_EH_CALLFINALLY_THUNKS
 
-                assert(step->KindIs(BBJ_ALWAYS, BBJ_EHCATCHRET));
+                assert(step->KindIs(BBJ_ALWAYS, BBJ_CALLFINALLYRET, BBJ_EHCATCHRET));
                 assert((step == block) || !step->HasInitializedTarget());
 
                 // callBlock will call the finally handler
@@ -4824,7 +4820,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                                             // finally in the chain)
                 fgAddRefPred(callBlock, step);
 
-                /* The new block will inherit this block's weight */
+                // The new block will inherit this block's weight.
                 callBlock->inheritWeight(block);
                 callBlock->SetFlags(BBF_IMPORTED);
 
@@ -4839,17 +4835,18 @@ void Compiler::impImportLeave(BasicBlock* block)
             }
 
             // Note: we don't know the jump target yet
-            step     = fgNewBBafter(BBJ_ALWAYS, callBlock, true);
+            step     = fgNewBBafter(BBJ_CALLFINALLYRET, callBlock, true);
             stepType = ST_FinallyReturn;
 
-            /* The new block will inherit this block's weight */
+            // The new block will inherit this block's weight.
             step->inheritWeight(block);
-            step->SetFlags(BBF_IMPORTED | BBF_KEEP_BBJ_ALWAYS);
+            step->SetFlags(BBF_IMPORTED);
 
 #ifdef DEBUG
             if (verbose)
             {
-                printf("impImportLeave - jumping out of a finally-protected try (EH#%u), created step (BBJ_ALWAYS) "
+                printf("impImportLeave - jumping out of a finally-protected try (EH#%u), created step "
+                       "(BBJ_CALLFINALLYRET) "
                        "block " FMT_BB "\n",
                        XTnum, step->bbNum);
             }
@@ -4907,7 +4904,7 @@ void Compiler::impImportLeave(BasicBlock* block)
 
                 if (stepType == ST_FinallyReturn)
                 {
-                    assert(step->KindIs(BBJ_ALWAYS));
+                    assert(step->KindIs(BBJ_CALLFINALLYRET));
                 }
                 else
                 {
@@ -4915,7 +4912,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                     assert(step->KindIs(BBJ_EHCATCHRET));
                 }
 
-                /* Create a new exit block in the try region for the existing step block to jump to in this scope */
+                // Create a new exit block in the try region for the existing step block to jump to in this scope.
                 // Note: we don't know the jump target yet
                 BasicBlock* catchStep = fgNewBBinRegion(BBJ_ALWAYS, XTnum + 1, 0, step);
 
@@ -4926,7 +4923,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 step->SetTarget(catchStep);
                 fgAddRefPred(catchStep, step);
 
-                /* The new block will inherit this block's weight */
+                // The new block will inherit this block's weight.
                 catchStep->inheritWeight(block);
                 catchStep->SetFlags(BBF_IMPORTED);
 
@@ -4949,7 +4946,7 @@ void Compiler::impImportLeave(BasicBlock* block)
                 }
 #endif // DEBUG
 
-                /* This block is the new step */
+                // This block is the new step.
                 step     = catchStep;
                 stepType = ST_Try;
             }
@@ -11088,6 +11085,21 @@ inline void Compiler::impReimportMarkBlock(BasicBlock* block)
         printf("\n" FMT_BB " will be reimported\n", block->bbNum);
     }
 #endif
+
+    // We shouldn't be re-importing one of these special blocks.
+    assert(!block->KindIs(BBJ_CALLFINALLYRET));
+
+    if (block->isBBCallFinallyPair())
+    {
+        // If we're going to re-import a BBJ_CALLFINALLY that has a paired BBJ_CALLFINALLYRET,
+        // remove the BBJ_CALLFINALLYRET.
+        BasicBlock* const leaveBlock = block->Next();
+        fgPrepareCallFinallyRetForRemoval(leaveBlock);
+        fgRemoveBlock(leaveBlock, /* unreachable */ true);
+
+        // The above code marked the BBJ_CALLFINALLY as retless. Remove that.
+        block->RemoveFlags(BBF_RETLESS_CALL);
+    }
 
     block->RemoveFlags(BBF_IMPORTED);
 }


### PR DESCRIPTION
Remove the post-import pass that was creating this block type.

I (trivially) updated a bunch of comments in `impImportLeave` while there.

I updated the import clique code to remove a `BBJ_CALLFINALLYRET` if the corresponding `BBJ_CALLFINALLY` is being re-imported. Otherwise, we end up with an orphaned `BBJ_CALLFINALLYRET` which eventually leads to asserts.