### PR TITLE
Precise reflection-visible delegate target analysis

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DelegateCreationInfo.cs
@@ -170,10 +170,16 @@ namespace ILCompiler
             get;
         }
 
-        private DelegateCreationInfo(IMethodNode constructor, MethodDesc targetMethod, TypeDesc constrainedType, TargetKind targetKind, IMethodNode thunk = null)
+        public TypeDesc DelegateType
+        {
+            get;
+        }
+
+        private DelegateCreationInfo(TypeDesc delegateType, IMethodNode constructor, MethodDesc targetMethod, TypeDesc constrainedType, TargetKind targetKind, IMethodNode thunk = null)
         {
             Debug.Assert(targetKind != TargetKind.VTableLookup
                 || MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(targetMethod) == targetMethod);
+            DelegateType = delegateType;
             Constructor = constructor;
             _targetMethod = targetMethod;
             _constrainedType = constrainedType;
@@ -230,6 +236,7 @@ namespace ILCompiler
                     invokeThunk = context.GetMethodForInstantiatedType(invokeThunk, instantiatedDelegateType);
 
                 return new DelegateCreationInfo(
+                    delegateType,
                     factory.MethodEntrypoint(initMethod),
                     targetMethod,
                     constrainedType,
@@ -289,6 +296,7 @@ namespace ILCompiler
 
                 Debug.Assert(constrainedType == null);
                 return new DelegateCreationInfo(
+                    delegateType,
                     factory.MethodEntrypoint(systemDelegate.GetKnownMethod(initializeMethodName, null)),
                     targetMethod,
                     constrainedType,

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenObjectNode.cs
@@ -60,13 +60,7 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
-            GetNonRelocationDependencies(ref dependencies, factory);
-
             return dependencies;
-        }
-
-        public virtual void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
-        {
         }
 
         public abstract void EncodeContents(ref ObjectDataBuilder dataBuilder, NodeFactory factory, bool relocsOnly);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -304,6 +304,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new DelegateTargetVirtualMethodNode(method);
             });
 
+            _reflectedDelegates = new NodeCache<TypeDesc, ReflectedDelegateNode>(type =>
+            {
+                return new ReflectedDelegateNode(type);
+            });
+
             _reflectedMethods = new NodeCache<MethodDesc, ReflectedMethodNode>(method =>
             {
                 return new ReflectedMethodNode(method);
@@ -994,6 +999,16 @@ namespace ILCompiler.DependencyAnalysis
         public DelegateTargetVirtualMethodNode DelegateTargetVirtualMethod(MethodDesc method)
         {
             return _delegateTargetMethods.GetOrAdd(method);
+        }
+
+        private ReflectedDelegateNode _unknownReflectedDelegate = new ReflectedDelegateNode(null);
+        private NodeCache<TypeDesc, ReflectedDelegateNode> _reflectedDelegates;
+        public ReflectedDelegateNode ReflectedDelegate(TypeDesc type)
+        {
+            if (type == null)
+                return _unknownReflectedDelegate;
+
+            return _reflectedDelegates.GetOrAdd(type);
         }
 
         private NodeCache<MethodDesc, ReflectedMethodNode> _reflectedMethods;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunGenericHelperNode.cs
@@ -219,12 +219,6 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(new DependencyListEntry(dependency, "GenericLookupResultDependency"));
             }
 
-            if (_id == ReadyToRunHelperId.DelegateCtor)
-            {
-                MethodDesc targetMethod = ((DelegateCreationInfo)_target).PossiblyUnresolvedTargetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref dependencies, factory, targetMethod);
-            }
-
             return dependencies;
         }
 
@@ -261,6 +255,13 @@ namespace ILCompiler.DependencyAnalysis
                                                                 templateLayout,
                                                                 "Type loader template"));
                 }
+            }
+
+            if (_id == ReadyToRunHelperId.DelegateCtor)
+            {
+                var delegateCreationInfo = (DelegateCreationInfo)_target;
+                MethodDesc targetMethod = delegateCreationInfo.PossiblyUnresolvedTargetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
+                factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref conditionalDependencies, factory, delegateCreationInfo.DelegateType, targetMethod);
             }
 
             return conditionalDependencies;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReadyToRunHelperNode.cs
@@ -160,12 +160,20 @@ namespace ILCompiler.DependencyAnalysis
 #endif
                 }
 
-                factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref dependencyList, factory, info.PossiblyUnresolvedTargetMethod);
-
                 return dependencyList;
             }
 
             return null;
+        }
+
+        public override bool HasConditionalStaticDependencies => _id == ReadyToRunHelperId.DelegateCtor;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
+        {
+            List<CombinedDependencyListEntry> dependencyList = new List<CombinedDependencyListEntry>();
+            var info = (DelegateCreationInfo)_target;
+            factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref dependencyList, factory, info.DelegateType, info.PossiblyUnresolvedTargetMethod);
+            return dependencyList;
         }
 
         IEnumerable<NativeSequencePoint> INodeWithDebugInfo.GetNativeSequencePoints()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedDelegateNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedDelegateNode.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Represents a delegate type that was reflected on using <see cref="System.Delegate.Method"/>.
+    /// </summary>
+    public class ReflectedDelegateNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly TypeDesc _delegateType;
+
+        public ReflectedDelegateNode(TypeDesc delegateType)
+        {
+            Debug.Assert(delegateType is null || delegateType.IsDelegate);
+
+            // We accept 3 kinds of types:
+            // * Null: Delegate.get_Method was used on an unknown type. All delegate targets are reflection-visible.
+            // * A type definition: An unknown instantiation of the delegate was reflected on. Typically caused by dataflow analysis analyzing uninstantiated code.
+            // * Canonical form: Some canonical form was reflected on.
+            Debug.Assert(delegateType is null
+                || delegateType.IsGenericDefinition
+                || delegateType.ConvertToCanonForm(CanonicalFormKind.Specific) == delegateType);
+
+            _delegateType = delegateType;
+        }
+
+        protected override string GetName(NodeFactory factory)
+        {
+            return "Reflectable delegate type: " + _delegateType?.ToString() ?? "All delegates";
+        }
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SerializedFrozenObjectNode.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 
 using Internal.Text;
 using Internal.TypeSystem;
+
+using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
 
 namespace ILCompiler.DependencyAnalysis
 {
@@ -53,9 +56,13 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);
 
-        public override void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
+        public override bool HasConditionalStaticDependencies => _data.HasConditionalDependencies;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory)
         {
-            _data.GetNonRelocationDependencies(ref dependencies, factory);
+            CombinedDependencyList result = null;
+            _data.GetConditionalDependencies(ref result, factory);
+            return result;
         }
 
         public override int ClassCode => 1789429316;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -548,7 +548,7 @@ namespace ILCompiler
         /// <summary>
         /// This method is an extension point that can provide additional metadata-based dependencies to delegate targets.
         /// </summary>
-        public virtual void GetDependenciesDueToDelegateCreation(ref DependencyList dependencies, NodeFactory factory, MethodDesc target)
+        public virtual void GetDependenciesDueToDelegateCreation(ref CombinedDependencyList dependencies, NodeFactory factory, TypeDesc delegateType, MethodDesc target)
         {
             // MetadataManagers can override this to provide additional dependencies caused by the construction
             // of a delegate to a method.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -11,7 +11,7 @@ using ILCompiler.DependencyAnalysis;
 using Internal.IL;
 using Internal.TypeSystem;
 
-using DependencyList = ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.DependencyList;
+using CombinedDependencyList = System.Collections.Generic.List<ILCompiler.DependencyAnalysisFramework.DependencyNodeCore<ILCompiler.DependencyAnalysis.NodeFactory>.CombinedDependencyListEntry>;
 
 namespace ILCompiler
 {
@@ -2144,7 +2144,8 @@ namespace ILCompiler
         {
             TypeDesc Type { get; }
             void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory);
-            void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory);
+            bool HasConditionalDependencies { get; }
+            void GetConditionalDependencies(ref CombinedDependencyList dependencies, NodeFactory factory);
             bool IsKnownImmutable { get; }
             int ArrayLength { get; }
         }
@@ -2694,7 +2695,9 @@ namespace ILCompiler
                 return false;
             }
 
-            public virtual void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
+            public virtual bool HasConditionalDependencies => false;
+
+            public virtual void GetConditionalDependencies(ref CombinedDependencyList dependencies, NodeFactory factory)
             {
             }
         }
@@ -2719,12 +2722,16 @@ namespace ILCompiler
                     factory,
                     followVirtualDispatch: false);
 
-            public override void GetNonRelocationDependencies(ref DependencyList dependencies, NodeFactory factory)
+            public override bool HasConditionalDependencies => true;
+
+            public override void GetConditionalDependencies(ref CombinedDependencyList dependencies, NodeFactory factory)
             {
+                dependencies ??= new CombinedDependencyList();
+
                 DelegateCreationInfo creationInfo = GetDelegateCreationInfo(factory);
 
                 MethodDesc targetMethod = creationInfo.PossiblyUnresolvedTargetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
-                factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref dependencies, factory, targetMethod);
+                factory.MetadataManager.GetDependenciesDueToDelegateCreation(ref dependencies, factory, creationInfo.DelegateType, targetMethod);
             }
 
             public void WriteContent(ref ObjectDataBuilder builder, ISymbolNode thisNode, NodeFactory factory)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -425,6 +425,7 @@
     <Compile Include="Compiler\DependencyAnalysis\NotReadOnlyFieldNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ObjectGetTypeFlowDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\PointerTypeMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReflectedDelegateNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectedFieldNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectedTypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionInvokeSupportDependencyAlgorithm.cs" />

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -70,6 +70,7 @@ internal static class ReflectionTest
         TestGenericLdtoken.Run();
         TestAbstractGenericLdtoken.Run();
         TestTypeHandlesVisibleFromIDynamicInterfaceCastable.Run();
+        TestCompilerGeneratedCode.Run();
 
         //
         // Mostly functionality tests
@@ -2539,6 +2540,62 @@ internal static class ReflectionTest
             Console.WriteLine(nameof(TestEntryPoint));
             if (Assembly.GetEntryAssembly().EntryPoint == null)
                 throw new Exception();
+        }
+    }
+
+    class TestCompilerGeneratedCode
+    {
+        class Canary1 { }
+        class Canary2 { }
+        class Canary3 { }
+        class Canary4 { }
+
+        private static void ReflectionInLambda()
+        {
+            var func = () => {
+                Type helpersType = Type.GetType(nameof(ReflectionTest) + "+" + nameof(TestCompilerGeneratedCode) + "+" + nameof(Canary1));
+                Assert.NotNull(helpersType);
+            };
+
+            func();
+        }
+
+        private static void ReflectionInLocalFunction()
+        {
+            func();
+
+            void func()
+            {
+                Type helpersType = Type.GetType(nameof(ReflectionTest) + "+" + nameof(TestCompilerGeneratedCode) + "+" + nameof(Canary2));
+                Assert.NotNull(helpersType);
+            };
+        }
+
+        private static async void ReflectionInAsync()
+        {
+            await System.Threading.Tasks.Task.Delay(100);
+            Type helpersType = Type.GetType(nameof(ReflectionTest) + "+" + nameof(TestCompilerGeneratedCode) + "+" + nameof(Canary3));
+            Assert.NotNull(helpersType);
+        }
+
+        private static async void ReflectionInLambdaAsync()
+        {
+            await System.Threading.Tasks.Task.Delay(100);
+
+            var func = () => {
+                Type helpersType = Type.GetType(nameof(ReflectionTest) + "+" + nameof(TestCompilerGeneratedCode) + "+" + nameof(Canary4));
+                Assert.NotNull(helpersType);
+            };
+
+            func();
+        }
+
+        public static void Run()
+        {
+            ReflectionInLambda();
+            ReflectionInLocalFunction();
+            ReflectionInAsync();
+            ReflectionInLambdaAsync();
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
@@ -26,7 +26,6 @@ class Dataflow
         TestDynamicDependencyWithGenerics.Run();
         TestObjectGetTypeDataflow.Run();
         TestMarshalIntrinsics.Run();
-        TestCompilerGeneratedCode.Run();
 
         return 100;
     }
@@ -630,57 +629,6 @@ class Dataflow
                 if (!thrown)
                     throw new Exception();
             }
-        }
-    }
-
-    class TestCompilerGeneratedCode
-    {
-        private static void ReflectionInLambda()
-        {
-            var func = () => {
-                Type helpersType = Type.GetType(nameof(Helpers));
-                Assert.NotNull(helpersType);
-            };
-
-            func();
-        }
-
-        private static void ReflectionInLocalFunction()
-        {
-            func();
-
-            void func()
-            {
-                Type helpersType = Type.GetType(nameof(Helpers));
-                Assert.NotNull(helpersType);
-            };
-        }
-
-        private static async void ReflectionInAsync()
-        {
-            await System.Threading.Tasks.Task.Delay(100);
-            Type helpersType = Type.GetType(nameof(Helpers));
-            Assert.NotNull(helpersType);
-        }
-
-        private static async void ReflectionInLambdaAsync()
-        {
-            await System.Threading.Tasks.Task.Delay(100);
-
-            var func = () => {
-                Type helpersType = Type.GetType(nameof(Helpers));
-                Assert.NotNull(helpersType);
-            };
-
-            func();
-        }
-
-        public static void Run()
-        {
-            ReflectionInLambda();
-            ReflectionInLocalFunction();
-            ReflectionInAsync();
-            ReflectionInLambdaAsync();
         }
     }
 }

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -309,6 +309,10 @@ namespace ILLink.Shared.TrimAnalysis
 		/// </summary>
 		AssemblyName_get_EscapedCodeBase,
 		/// <summary>
+		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetMethodInfo(System.Delegate)"/>
+		/// </summary>
+		RuntimeReflectionExtensions_GetMethodInfo,
+		/// <summary>
 		/// <see cref="System.Reflection.RuntimeReflectionExtensions.GetRuntimeEvent(System.Type, string)"/>
 		/// </summary>
 		RuntimeReflectionExtensions_GetRuntimeEvent,
@@ -335,6 +339,10 @@ namespace ILLink.Shared.TrimAnalysis
 		/// <summary>
 		/// <see cref="System.Nullable.GetUnderlyingType(System.Type)"/>
 		/// </summary>
-		Nullable_GetUnderlyingType
+		Nullable_GetUnderlyingType,
+		/// <summary>
+		/// <see cref="System.Delegate.Method"/>
+		/// </summary>
+		Delegate_get_Method,
 	}
 }

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
@@ -38,6 +38,11 @@ namespace ILLink.Shared.TrimAnalysis
 				// static System.Type.MakeGenericType (Type [] typeArguments)
 				"MakeGenericType" when calledMethod.IsDeclaredOnType ("System.Type") => IntrinsicId.Type_MakeGenericType,
 
+				// static System.Reflection.RuntimeReflectionExtensions.GetMethodInfo (this Delegate del)
+				"GetMethodInfo" when calledMethod.IsDeclaredOnType ("System.Reflection.RuntimeReflectionExtensions")
+					&& calledMethod.HasParameterOfType ((ParameterIndex) 0, "System.Delegate")
+					=> IntrinsicId.RuntimeReflectionExtensions_GetMethodInfo,
+
 				// static System.Reflection.RuntimeReflectionExtensions.GetRuntimeEvent (this Type type, string name)
 				"GetRuntimeEvent" when calledMethod.IsDeclaredOnType ("System.Reflection.RuntimeReflectionExtensions")
 					&& calledMethod.HasParameterOfType ((ParameterIndex) 0, "System.Type")
@@ -395,6 +400,12 @@ namespace ILLink.Shared.TrimAnalysis
 					&& calledMethod.IsStatic ()
 					&& calledMethod.HasParameterOfType ((ParameterIndex) 0, "System.Type")
 					=> IntrinsicId.Nullable_GetUnderlyingType,
+
+				// static System.Delegate.Method getter
+				"get_Method" when calledMethod.IsDeclaredOnType ("System.Delegate")
+					&& calledMethod.HasImplicitThis ()
+					&& calledMethod.HasMetadataParametersCount (0)
+					=> IntrinsicId.Delegate_get_Method,
 
 				_ => IntrinsicId.None,
 			};

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -274,6 +274,8 @@ namespace Mono.Linker.Dataflow
 			case IntrinsicId.Assembly_GetFiles:
 			case IntrinsicId.AssemblyName_get_CodeBase:
 			case IntrinsicId.AssemblyName_get_EscapedCodeBase:
+			case IntrinsicId.RuntimeReflectionExtensions_GetMethodInfo:
+			case IntrinsicId.Delegate_get_Method:
 				// These intrinsics are not interesting for trimmer (they are interesting for AOT and that's why they are recognized)
 				break;
 


### PR DESCRIPTION
Before this change, the compiler considered all methods that are target of a delegate reflection-visible. This is because one can just call `Delegate.Method` on a delegate instance to obtain a `MethodBase` of the target. This is rather annoying because most delegates are not actually used with reflection.

In this PR I'm adding analysis of places that use `Delegate.Method` to reflect on certain delegate type. This builds on top of the existing dataflow analysis within the compiler - we can often see the exact delegate type that was reflected on. When we see that, we make all targets of that specific type reflection-visible.

The advantage is that if nobody ever calls `Delegate.Method`, no delegates are made reflection visible. If this is used with a certain known delegate type, only the methods pointed to by that specific delegate type are made reflection visible. And if this is used with something typed as `Delegate` or `MulticastDelegate`, we fall back to the old behavior that just makes everything reflection visible.

I was hoping this would help ASP.NET but ASP.NET actually uses something typed as `Delegate` to obtain the `MethodInfo` and there's more code somewhere in the `Task` infrastructure (under `EventSourceSupport`) that also does it. So it unfortunately can't help there.

Cc @dotnet/ilc-contrib 