### PR TITLE
Longer item expiry for debug builds in System.Runtime.Caching.Tests

### DIFF
--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -1541,7 +1541,7 @@ namespace MonoTests.System.Runtime.Caching
             var config = new NameValueCollection();
             config["cacheMemoryLimitMegabytes"] = 0.ToString();
             config["physicalMemoryLimitPercentage"] = 100.ToString();
-            config["pollingInterval"] = new TimeSpan(0, 0, 1).ToString();
+            config["pollingInterval"] = new TimeSpan(0, 0, 1 * PlatformDetection.SlowRuntimeTimeoutModifier).ToString();
 
             using (var mc = new MemoryCache("TestCacheShrink", config))
             {
@@ -1550,7 +1550,7 @@ namespace MonoTests.System.Runtime.Caching
                 // add some short duration entries
                 for (int i = 0; i < HEAP_RESIZE_SHORT_ENTRIES; i++)
                 {
-                    var expireAt = DateTimeOffset.Now.AddSeconds(3);
+                    var expireAt = DateTimeOffset.Now.AddSeconds(3 * PlatformDetection.SlowRuntimeTimeoutModifier);
                     mc.Add("short-" + i, i.ToString(), expireAt);
                 }
 
@@ -1559,14 +1559,14 @@ namespace MonoTests.System.Runtime.Caching
                 // add some long duration entries
                 for (int i = 0; i < HEAP_RESIZE_LONG_ENTRIES; i++)
                 {
-                    var expireAt = DateTimeOffset.Now.AddSeconds(42);
+                    var expireAt = DateTimeOffset.Now.AddSeconds(42 * PlatformDetection.SlowRuntimeTimeoutModifier);
                     mc.Add("long-" + i, i.ToString(), expireAt);
                 }
 
                 Assert.Equal(HEAP_RESIZE_LONG_ENTRIES + HEAP_RESIZE_SHORT_ENTRIES, mc.GetCount());
 
                 // wait past the short duration items expiration time
-                await Task.Delay(4000);
+                await Task.Delay(4000 * PlatformDetection.SlowRuntimeTimeoutModifier);
 
                 /// the following will also shrink the size of the cache
                 for (int i = 0; i < HEAP_RESIZE_SHORT_ENTRIES; i++)
@@ -1578,7 +1578,7 @@ namespace MonoTests.System.Runtime.Caching
                 // add some new items into the cache, this will grow the cache again
                 for (int i = 0; i < HEAP_RESIZE_LONG_ENTRIES; i++)
                 {
-                    mc.Add("final-" + i, i.ToString(), DateTimeOffset.Now.AddSeconds(4));
+                    mc.Add("final-" + i, i.ToString(), DateTimeOffset.Now.AddSeconds(4 * PlatformDetection.SlowRuntimeTimeoutModifier));
                 }
 
                 Assert.Equal(HEAP_RESIZE_LONG_ENTRIES + HEAP_RESIZE_LONG_ENTRIES, mc.GetCount());
@@ -1598,7 +1598,7 @@ namespace MonoTests.System.Runtime.Caching
             var config = new NameValueCollection();
             config["cacheMemoryLimitMegabytes"] = 0.ToString();
             config["physicalMemoryLimitPercentage"] = 100.ToString();
-            config["pollingInterval"] = new TimeSpan(0, 0, 1).ToString();
+            config["pollingInterval"] = new TimeSpan(0, 0, 1 * PlatformDetection.SlowRuntimeTimeoutModifier).ToString();
 
             using (var mc = new MemoryCache("TestCacheExpiryOrdering", config))
             {
@@ -1608,7 +1608,7 @@ namespace MonoTests.System.Runtime.Caching
                 for (int i = 0; i < 100; i++)
                 {
                     var cip = new CacheItemPolicy();
-                    cip.SlidingExpiration = new TimeSpan(0, 0, 4);
+                    cip.SlidingExpiration = new TimeSpan(0, 0, 4 * PlatformDetection.SlowRuntimeTimeoutModifier);
                     mc.Add("long-" + i, i, cip);
                 }
 
@@ -1618,13 +1618,13 @@ namespace MonoTests.System.Runtime.Caching
                 for (int i = 0; i < 100; i++)
                 {
                     var cip = new CacheItemPolicy();
-                    cip.SlidingExpiration = new TimeSpan(0, 0, 1);
+                    cip.SlidingExpiration = new TimeSpan(0, 0, 1 * PlatformDetection.SlowRuntimeTimeoutModifier);
                     mc.Add("short-" + i, i, cip);
                 }
 
                 Assert.Equal(200, mc.GetCount());
 
-                await Task.Delay(2000);
+                await Task.Delay(2000 * PlatformDetection.SlowRuntimeTimeoutModifier);
 
                 for (int i = 0; i < 100; i++)
                 {


### PR DESCRIPTION
Fixes System.Runtime.Caching.Tests:
 * MonoTests.System.Runtime.Caching.MemoryCacheTestExpires5.TestCacheExpiryOrdering
 * MonoTests.System.Runtime.Caching.MemoryCacheTestExpires4.TestCacheShrink

The tests failed intermittently due to cache item expiry on a debug testhost on weaker hardware (VisionFive 2 RISC-V board). I saw similar use of PlatformDetection.SlowRuntimeTimeoutModifier in System.Diagnostics.Process tests.

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @bajtazar
