### PR TITLE
[RISC-V] Fix ProcessWaitingTests.WaitChain and ProcessWaitingTests.Wa…

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -106,9 +106,20 @@ namespace System
         public static bool IsReleaseLibrary(Assembly assembly) => !IsDebuggable(assembly);
         public static bool IsDebugLibrary(Assembly assembly) => IsDebuggable(assembly);
 
-        // For use as needed on tests that time out when run on a Debug runtime.
+        // For use as needed on tests that time out when run on a Debug or Checked runtime.
         // Not relevant for timeouts on external activities, such as network timeouts.
-        public static int SlowRuntimeTimeoutModifier = (PlatformDetection.IsDebugRuntime ? 5 : 1);
+        public static int SlowRuntimeTimeoutModifier
+        {
+            get
+            {
+                if (IsReleaseRuntime)
+                    return 1;
+                if (IsRiscV64Process)
+                    return IsDebugRuntime? 10 : 2;
+                else
+                    return IsDebugRuntime? 5 : 1;
+            }
+        }
 
         public static bool IsCaseInsensitiveOS => IsWindows || IsOSX || IsMacCatalyst;
         public static bool IsCaseSensitiveOS => !IsCaseInsensitiveOS;


### PR DESCRIPTION
…itAsyncChain

Since WaitChain and WaitAsyncChain test cases perform quadruple nested chain of corerun invocation, and rely on execution time, they are pretty sensitive to corerun startup time. On RISC-V we experience test failures due to the fact that WaitInMS timeout is too aggressive for Checked and Debug builds in the case of R2R absence. It seems that without System.Private.CoreLib R2R artifacts CoreCLR need to jit 2x-3x more functions (Checked build). We think it's reasonable to expect tests working even in case of lack of R2R. This change fixes mentioned test cases by bumping waiting timeouts for RISC-V architecture.

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @ashaurtaev @sirntar @tomeksowi @Bajtazar @viewizard