### PR TITLE
Various no-diff cleanups and debugging additions/fixes

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -457,7 +457,7 @@ void BasicBlock::dspBlockILRange() const
 //------------------------------------------------------------------------
 // dspFlags: Print out the block's flags
 //
-void BasicBlock::dspFlags()
+void BasicBlock::dspFlags() const
 {
     static const struct
     {
@@ -524,7 +524,7 @@ void BasicBlock::dspFlags()
  *  Returns the number of characters printed.
  */
 
-unsigned BasicBlock::dspPreds()
+unsigned BasicBlock::dspPreds() const
 {
     unsigned count = 0;
     for (FlowEdge* const pred : PredEdges())
@@ -592,7 +592,7 @@ void BasicBlock::dspSuccs(Compiler* compiler)
     }
     else
     {
-        for (BasicBlock* const succ : Succs(compiler))
+        for (const BasicBlock* const succ : Succs(compiler))
         {
             printf("%s" FMT_BB, first ? "" : ",", succ->bbNum);
             first = false;
@@ -603,7 +603,7 @@ void BasicBlock::dspSuccs(Compiler* compiler)
 // Display a compact representation of the bbKind, that is, where this block branches.
 // This is similar to code in Compiler::fgTableDispBasicBlock(), but doesn't have that code's requirements to align
 // things strictly.
-void BasicBlock::dspKind()
+void BasicBlock::dspKind() const
 {
     switch (bbKind)
     {
@@ -717,7 +717,7 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
                                 bool      showFlags /*= false*/,
                                 bool      showPreds /*= true*/)
 {
-    printf(FMT_BB " ", bbNum);
+    printf("%s ", dspToString());
     dspBlockILRange();
     if (showKind)
     {
@@ -741,7 +741,7 @@ void BasicBlock::dspBlockHeader(Compiler* compiler,
     printf("\n");
 }
 
-const char* BasicBlock::dspToString(int blockNumPadding /* = 0 */)
+const char* BasicBlock::dspToString(int blockNumPadding /* = 0 */) const
 {
     static char buffers[3][64]; // static array of 3 to allow 3 concurrent calls in one printf()
     static int  nextBufferIndex = 0;

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -896,16 +896,16 @@ public:
     }
 
 #ifdef DEBUG
-    void     dspFlags();               // Print the flags
-    unsigned dspPreds();               // Print the predecessors (bbPreds)
+    void     dspFlags() const;         // Print the flags
+    unsigned dspPreds() const;         // Print the predecessors (bbPreds)
     void dspSuccs(Compiler* compiler); // Print the successors. The 'compiler' argument determines whether EH
                                        // regions are printed: see NumSucc() for details.
-    void dspKind();                    // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
+    void dspKind() const;              // Print the block jump kind (e.g., BBJ_ALWAYS, BBJ_COND, etc.).
 
     // Print a simple basic block header for various output, including a list of predecessors and successors.
     void dspBlockHeader(Compiler* compiler, bool showKind = true, bool showFlags = false, bool showPreds = true);
 
-    const char* dspToString(int blockNumPadding = 0);
+    const char* dspToString(int blockNumPadding = 0) const;
 #endif // DEBUG
 
 #define BB_UNITY_WEIGHT 100.0        // how much a normal execute once block weighs

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9401,6 +9401,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  *      cNewLoop,    dNewLoop       : Display a single loop (call FlowGraphNaturalLoop::Dump()) with given
  *                                    loop arg.
  *      cTreeFlags,  dTreeFlags     : Display tree flags for a specified tree.
+ *      cVN,         dVN            : Display a ValueNum (call vnPrint()).
  *
  * The following don't require a Compiler* to work:
  *      dRegMask                    : Display a regMaskTP (call dspRegMask(mask)).
@@ -9459,6 +9460,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma comment(linker, "/include:cNewLoopsA")
 #pragma comment(linker, "/include:cNewLoop")
 #pragma comment(linker, "/include:cTreeFlags")
+#pragma comment(linker, "/include:cVN")
 
 // Functions which call the c* functions getting Compiler* using `JitTls::GetCompiler()`
 #pragma comment(linker, "/include:dBlock")
@@ -9487,6 +9489,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma comment(linker, "/include:dNewLoopsA")
 #pragma comment(linker, "/include:dNewLoop")
 #pragma comment(linker, "/include:dTreeFlags")
+#pragma comment(linker, "/include:dVN")
 
 // Functions which don't require a Compiler*
 #pragma comment(linker, "/include:dRegMask")
@@ -9524,7 +9527,11 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma comment(linker, "/include:_cLoop")
 #pragma comment(linker, "/include:_cLoopPtr")
 #pragma comment(linker, "/include:_cLoops")
+#pragma comment(linker, "/include:_cNewLoops")
+#pragma comment(linker, "/include:_cNewLoopsA")
+#pragma comment(linker, "/include:_cNewLoop")
 #pragma comment(linker, "/include:_cTreeFlags")
+#pragma comment(linker, "/include:_cVN")
 
 // Functions which call the c* functions getting Compiler* using `JitTls:_:GetCompiler()`
 #pragma comment(linker, "/include:_dBlock")
@@ -9549,7 +9556,11 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #pragma comment(linker, "/include:_dLoop")
 #pragma comment(linker, "/include:_dLoopPtr")
 #pragma comment(linker, "/include:_dLoops")
+#pragma comment(linker, "/include:_dNewLoops")
+#pragma comment(linker, "/include:_dNewLoopsA")
+#pragma comment(linker, "/include:_dNewLoop")
 #pragma comment(linker, "/include:_dTreeFlags")
+#pragma comment(linker, "/include:_dVN")
 
 // Functions which don't require a Compiler*
 #pragma comment(linker, "/include:_dRegMask")
@@ -9981,102 +9992,11 @@ JITDBGAPI void __cdecl cTreeFlags(Compiler* comp, GenTree* tree)
             case GT_CNS_INT:
             {
                 GenTreeFlags handleKind = (tree->gtFlags & GTF_ICON_HDL_MASK);
-
-                switch (handleKind)
+                if (handleKind != 0)
                 {
-                    case GTF_ICON_SCOPE_HDL:
-
-                        chars += printf("[ICON_SCOPE_HDL]");
-                        break;
-
-                    case GTF_ICON_CLASS_HDL:
-
-                        chars += printf("[ICON_CLASS_HDL]");
-                        break;
-
-                    case GTF_ICON_METHOD_HDL:
-
-                        chars += printf("[ICON_METHOD_HDL]");
-                        break;
-
-                    case GTF_ICON_FIELD_HDL:
-
-                        chars += printf("[ICON_FIELD_HDL]");
-                        break;
-
-                    case GTF_ICON_STATIC_HDL:
-
-                        chars += printf("[ICON_STATIC_HDL]");
-                        break;
-
-                    case GTF_ICON_STR_HDL:
-
-                        chars += printf("[ICON_STR_HDL]");
-                        break;
-
-                    case GTF_ICON_OBJ_HDL:
-
-                        chars += printf("[ICON_OBJ_HDL]");
-                        break;
-
-                    case GTF_ICON_CONST_PTR:
-
-                        chars += printf("[ICON_CONST_PTR]");
-                        break;
-
-                    case GTF_ICON_GLOBAL_PTR:
-
-                        chars += printf("[ICON_GLOBAL_PTR]");
-                        break;
-
-                    case GTF_ICON_VARG_HDL:
-
-                        chars += printf("[ICON_VARG_HDL]");
-                        break;
-
-                    case GTF_ICON_PINVKI_HDL:
-
-                        chars += printf("[ICON_PINVKI_HDL]");
-                        break;
-
-                    case GTF_ICON_TOKEN_HDL:
-
-                        chars += printf("[ICON_TOKEN_HDL]");
-                        break;
-
-                    case GTF_ICON_TLS_HDL:
-
-                        chars += printf("[ICON_TLD_HDL]");
-                        break;
-
-                    case GTF_ICON_FTN_ADDR:
-
-                        chars += printf("[ICON_FTN_ADDR]");
-                        break;
-
-                    case GTF_ICON_CIDMID_HDL:
-
-                        chars += printf("[ICON_CIDMID_HDL]");
-                        break;
-
-                    case GTF_ICON_BBC_PTR:
-
-                        chars += printf("[ICON_BBC_PTR]");
-                        break;
-
-                    case GTF_ICON_STATIC_BOX_PTR:
-
-                        chars += printf("[GTF_ICON_STATIC_BOX_PTR]");
-                        break;
-
-                    case GTF_ICON_STATIC_ADDR_PTR:
-
-                        chars += printf("[GTF_ICON_STATIC_ADDR_PTR]");
-                        break;
-
-                    default:
-                        assert(!"a forgotten handle flag");
-                        break;
+                    chars += printf("[");
+                    chars += GenTree::gtDispHandleKind(handleKind);
+                    chars += printf("]");
                 }
             }
             break;
@@ -10335,6 +10255,14 @@ JITDBGAPI void __cdecl cTreeFlags(Compiler* comp, GenTree* tree)
     }
 }
 
+JITDBGAPI void __cdecl cVN(Compiler* comp, ValueNum vn)
+{
+    static unsigned sequenceNumber = 0; // separate calls with a number to indicate this function has been called
+    printf("===================================================================== *VN %u\n", sequenceNumber++);
+    comp->vnPrint(vn, 1);
+    printf("\n");
+}
+
 JITDBGAPI void __cdecl dBlock(BasicBlock* block)
 {
     cBlock(JitTls::GetCompiler(), block);
@@ -10463,6 +10391,11 @@ JITDBGAPI void __cdecl dNewLoop(FlowGraphNaturalLoop* loop)
 JITDBGAPI void __cdecl dTreeFlags(GenTree* tree)
 {
     cTreeFlags(JitTls::GetCompiler(), tree);
+}
+
+JITDBGAPI void __cdecl dVN(ValueNum vn)
+{
+    cVN(JitTls::GetCompiler(), vn);
 }
 
 JITDBGAPI void __cdecl dRegMask(regMaskTP mask)

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9994,9 +9994,7 @@ JITDBGAPI void __cdecl cTreeFlags(Compiler* comp, GenTree* tree)
                 GenTreeFlags handleKind = (tree->gtFlags & GTF_ICON_HDL_MASK);
                 if (handleKind != 0)
                 {
-                    chars += printf("[");
-                    chars += GenTree::gtDispHandleKind(handleKind);
-                    chars += printf("]");
+                    chars += printf("[%s]", GenTree::gtGetHandleKindString(handleKind));
                 }
             }
             break;

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -2492,12 +2492,12 @@ void Compiler::fgDispBasicBlocks(bool dumpTrees)
 // fgDumpStmtTree: dump the statement and the basic block number.
 //
 // Arguments:
-//    stmt  - the statement to dump;
-//    bbNum - the basic block number to dump.
+//    block - the basic block that contains the statement to dump.
+//    stmt  - the statement to dump.
 //
-void Compiler::fgDumpStmtTree(Statement* stmt, unsigned bbNum)
+void Compiler::fgDumpStmtTree(const BasicBlock* block, Statement* stmt)
 {
-    printf("\n***** " FMT_BB "\n", bbNum);
+    printf("\n***** %s\n", block->dspToString());
     gtDispStmt(stmt);
 }
 
@@ -2521,7 +2521,7 @@ void Compiler::fgDumpBlock(BasicBlock* block)
     {
         for (Statement* const stmt : block->Statements())
         {
-            fgDumpStmtTree(stmt, block->bbNum);
+            fgDumpStmtTree(block, stmt);
         }
     }
     else

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -10709,54 +10709,54 @@ void GenTree::SetIndirExceptionFlags(Compiler* comp)
     return charsDisplayed;
 }
 
-/* static */ int GenTree::gtDispHandleKind(GenTreeFlags flags)
+/* static */
+const char* GenTree::gtGetHandleKindString(GenTreeFlags flags)
 {
     GenTreeFlags handleKind = flags & GTF_ICON_HDL_MASK;
     switch (handleKind)
     {
         case 0:
-            return 0;
+            return "";
         case GTF_ICON_SCOPE_HDL:
-            return printf("GTF_ICON_SCOPE_HDL");
+            return "GTF_ICON_SCOPE_HDL";
         case GTF_ICON_CLASS_HDL:
-            return printf("GTF_ICON_CLASS_HDL");
+            return "GTF_ICON_CLASS_HDL";
         case GTF_ICON_METHOD_HDL:
-            return printf("GTF_ICON_METHOD_HDL");
+            return "GTF_ICON_METHOD_HDL";
         case GTF_ICON_FIELD_HDL:
-            return printf("GTF_ICON_FIELD_HDL");
+            return "GTF_ICON_FIELD_HDL";
         case GTF_ICON_STATIC_HDL:
-            return printf("GTF_ICON_STATIC_HDL");
+            return "GTF_ICON_STATIC_HDL";
         case GTF_ICON_STR_HDL:
-            return printf("GTF_ICON_STR_HDL");
+            return "GTF_ICON_STR_HDL";
         case GTF_ICON_OBJ_HDL:
-            return printf("GTF_ICON_OBJ_HDL");
+            return "GTF_ICON_OBJ_HDL";
         case GTF_ICON_CONST_PTR:
-            return printf("GTF_ICON_CONST_PTR");
+            return "GTF_ICON_CONST_PTR";
         case GTF_ICON_GLOBAL_PTR:
-            return printf("GTF_ICON_GLOBAL_PTR");
+            return "GTF_ICON_GLOBAL_PTR";
         case GTF_ICON_VARG_HDL:
-            return printf("GTF_ICON_VARG_HDL");
+            return "GTF_ICON_VARG_HDL";
         case GTF_ICON_PINVKI_HDL:
-            return printf("GTF_ICON_PINVKI_HDL");
+            return "GTF_ICON_PINVKI_HDL";
         case GTF_ICON_TOKEN_HDL:
-            return printf("GTF_ICON_TOKEN_HDL");
+            return "GTF_ICON_TOKEN_HDL";
         case GTF_ICON_TLS_HDL:
-            return printf("GTF_ICON_TLS_HDL");
+            return "GTF_ICON_TLS_HDL";
         case GTF_ICON_FTN_ADDR:
-            return printf("GTF_ICON_FTN_ADDR");
+            return "GTF_ICON_FTN_ADDR";
         case GTF_ICON_CIDMID_HDL:
-            return printf("GTF_ICON_CIDMID_HDL");
+            return "GTF_ICON_CIDMID_HDL";
         case GTF_ICON_BBC_PTR:
-            return printf("GTF_ICON_BBC_PTR");
+            return "GTF_ICON_BBC_PTR";
         case GTF_ICON_STATIC_BOX_PTR:
-            return printf("GTF_ICON_STATIC_BOX_PTR");
+            return "GTF_ICON_STATIC_BOX_PTR";
         case GTF_ICON_FIELD_SEQ:
-            return printf("GTF_ICON_FIELD_SEQ");
+            return "GTF_ICON_FIELD_SEQ";
         case GTF_ICON_STATIC_ADDR_PTR:
-            return printf("GTF_ICON_STATIC_ADDR_PTR");
+            return "GTF_ICON_STATIC_ADDR_PTR";
         default:
-            assert(!"a forgotten handle flag");
-            return 0;
+            return "ILLEGAL!";
     }
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7487,13 +7487,12 @@ GenTreeFlags Compiler::gtTokenToIconFlags(unsigned token)
 //    isInvariant - The indNode should also be marked as invariant
 //
 // Return Value:
-//    Returns a GT_IND node representing value at the address provided by 'value'
+//    Returns a GT_IND node representing value at the address provided by 'addr'
 //
 // Notes:
 //    The GT_IND node is marked as non-faulting
 //    If the indType is GT_REF we also mark the indNode as GTF_GLOB_REF
 //
-
 GenTree* Compiler::gtNewIndOfIconHandleNode(var_types indType, size_t addr, GenTreeFlags iconFlags, bool isInvariant)
 {
     GenTree*     addrNode   = gtNewIconHandleNode(addr, iconFlags);
@@ -10708,6 +10707,57 @@ void GenTree::SetIndirExceptionFlags(Compiler* comp)
                      : ((flags & GTF_SPILLED) ? 'z' : ((flags & GTF_SPILL) ? 'Z' : '-')));
 
     return charsDisplayed;
+}
+
+/* static */ int GenTree::gtDispHandleKind(GenTreeFlags flags)
+{
+    GenTreeFlags handleKind = flags & GTF_ICON_HDL_MASK;
+    switch (handleKind)
+    {
+        case 0:
+            return 0;
+        case GTF_ICON_SCOPE_HDL:
+            return printf("GTF_ICON_SCOPE_HDL");
+        case GTF_ICON_CLASS_HDL:
+            return printf("GTF_ICON_CLASS_HDL");
+        case GTF_ICON_METHOD_HDL:
+            return printf("GTF_ICON_METHOD_HDL");
+        case GTF_ICON_FIELD_HDL:
+            return printf("GTF_ICON_FIELD_HDL");
+        case GTF_ICON_STATIC_HDL:
+            return printf("GTF_ICON_STATIC_HDL");
+        case GTF_ICON_STR_HDL:
+            return printf("GTF_ICON_STR_HDL");
+        case GTF_ICON_OBJ_HDL:
+            return printf("GTF_ICON_OBJ_HDL");
+        case GTF_ICON_CONST_PTR:
+            return printf("GTF_ICON_CONST_PTR");
+        case GTF_ICON_GLOBAL_PTR:
+            return printf("GTF_ICON_GLOBAL_PTR");
+        case GTF_ICON_VARG_HDL:
+            return printf("GTF_ICON_VARG_HDL");
+        case GTF_ICON_PINVKI_HDL:
+            return printf("GTF_ICON_PINVKI_HDL");
+        case GTF_ICON_TOKEN_HDL:
+            return printf("GTF_ICON_TOKEN_HDL");
+        case GTF_ICON_TLS_HDL:
+            return printf("GTF_ICON_TLS_HDL");
+        case GTF_ICON_FTN_ADDR:
+            return printf("GTF_ICON_FTN_ADDR");
+        case GTF_ICON_CIDMID_HDL:
+            return printf("GTF_ICON_CIDMID_HDL");
+        case GTF_ICON_BBC_PTR:
+            return printf("GTF_ICON_BBC_PTR");
+        case GTF_ICON_STATIC_BOX_PTR:
+            return printf("GTF_ICON_STATIC_BOX_PTR");
+        case GTF_ICON_FIELD_SEQ:
+            return printf("GTF_ICON_FIELD_SEQ");
+        case GTF_ICON_STATIC_ADDR_PTR:
+            return printf("GTF_ICON_STATIC_ADDR_PTR");
+        default:
+            assert(!"a forgotten handle flag");
+            return 0;
+    }
 }
 
 #ifdef TARGET_X86
@@ -18849,7 +18899,7 @@ GenTreeLclVarCommon* Compiler::gtCallGetDefinedRetBufLclAddr(GenTreeCall* call)
 // Arguments:
 //    comp    - The Compiler instance
 //    pArr    - [out] parameter for the tree representing the array instance
-//              (either an array object pointer, or perhaps a byref to the some element)
+//              (either an array object pointer, or perhaps a byref to some element)
 //    pInxVN  - [out] parameter for the value number representing the index
 //
 // Return Value:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2244,7 +2244,7 @@ public:
 
 #ifdef DEBUG
     static int gtDispFlags(GenTreeFlags flags, GenTreeDebugFlags debugFlags);
-    static int gtDispHandleKind(GenTreeFlags flags);
+    static const char* gtGetHandleKindString(GenTreeFlags flags);
 #endif
 
     // cast operations

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -454,7 +454,7 @@ enum GenTreeFlags : unsigned int
     GTF_LIVENESS_MASK     = GTF_VAR_DEF | GTF_VAR_USEASG | GTF_VAR_DEATH_MASK,
 
     GTF_VAR_ITERATOR      = 0x01000000, // GT_LCL_VAR -- this is a iterator reference in the loop condition
-    GTF_VAR_MOREUSES      = 0x00800000, // GT_LCL_VAR -- this node has additonal uses, for example due to cloning
+    GTF_VAR_MOREUSES      = 0x00800000, // GT_LCL_VAR -- this node has additional uses, for example due to cloning
     GTF_VAR_CONTEXT       = 0x00400000, // GT_LCL_VAR -- this node is part of a runtime lookup
     GTF_VAR_EXPLICIT_INIT = 0x00200000, // GT_LCL_VAR -- this node is an "explicit init" store. Valid until rationalization.
 
@@ -2244,6 +2244,7 @@ public:
 
 #ifdef DEBUG
     static int gtDispFlags(GenTreeFlags flags, GenTreeDebugFlags debugFlags);
+    static int gtDispHandleKind(GenTreeFlags flags);
 #endif
 
     // cast operations

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -482,7 +482,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         // We don't share small offset constants when they require a reloc
         // Also, we don't share non-null const gc handles
         //
-        if (!tree->AsIntConCommon()->ImmedValNeedsReloc(this) && ((tree->IsIntegralConst(0)) || !varTypeIsGC(tree)))
+        if (!tree->AsIntConCommon()->ImmedValNeedsReloc(this) && (tree->IsIntegralConst(0) || !varTypeIsGC(tree)))
         {
             // Here we make constants that have the same upper bits use the same key
             //

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -754,11 +754,11 @@ bool Compiler::optPopulateInitInfo(unsigned loopInd, BasicBlock* initBlock, GenT
 }
 
 //----------------------------------------------------------------------------------
-// optCheckIterInLoopTest: Check if iter var is used in loop test.
+// optCheckIterInLoopTest: Check if iteration variable is used in loop test.
 //
 // Arguments:
-//      loopInd - loopIndex
-//      test    - "jtrue" tree or an store of the loop iter termination condition
+//      loopInd - loop index
+//      test    - "jtrue" tree or a store of the loop iteration termination condition
 //      iterVar - loop iteration variable.
 //
 //  Operation:
@@ -2861,7 +2861,7 @@ bool Compiler::optCanonicalizeLoopNest(unsigned char loopInd)
 // This method will split the loop top into two or three blocks depending on
 // whether (1) or (3) is non-empty, and redirect the edges accordingly.
 //
-// Loops are canoncalized outer to inner, so inner loops should never see outer loop
+// Loops are canonicalized outer to inner, so inner loops should never see outer loop
 // non-backedges, as the parent loop canonicalization should have handled them.
 //
 bool Compiler::optCanonicalizeLoop(unsigned char loopInd)

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -476,7 +476,7 @@ void SsaBuilder::InsertPhiFunctions()
         }
 
         // Now make a similar phi definition if the block defines memory.
-        if (block->bbMemoryDef != 0)
+        if (block->bbMemoryDef != emptyMemoryKindSet)
         {
             // For each block "bbInDomFront" that is in the dominance frontier of "block".
             for (BasicBlock* bbInDomFront : blockIDF)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -8932,8 +8932,7 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
     {
         ssize_t            val         = ConstantValue<ssize_t>(vn);
         const GenTreeFlags handleFlags = GetHandleFlags(vn);
-        printf("Hnd const: 0x%p ", dspPtr(val));
-        GenTree::gtDispHandleKind(handleFlags);
+        printf("Hnd const: 0x%p %s", dspPtr(val), GenTree::gtGetHandleKindString(handleFlags));
     }
     else if (IsVNConstant(vn))
     {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4017,66 +4017,66 @@ ValueNum ValueNumStore::EvalCastForConstantArgs(var_types typ, VNFunc func, Valu
             }
             break;
         }
-            {
 #ifdef TARGET_64BIT
-                case TYP_REF:
-                case TYP_BYREF:
+        case TYP_REF:
+        case TYP_BYREF:
 #endif
-                case TYP_LONG:
-                    INT64 arg0Val = GetConstantInt64(arg0VN);
-                    assert(!checkedCast || !CheckedOps::CastFromLongOverflows(arg0Val, castToType, srcIsUnsigned));
+        case TYP_LONG:
+        {
+            INT64 arg0Val = GetConstantInt64(arg0VN);
+            assert(!checkedCast || !CheckedOps::CastFromLongOverflows(arg0Val, castToType, srcIsUnsigned));
 
-                    switch (castToType)
+            switch (castToType)
+            {
+                case TYP_BYTE:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(INT8(arg0Val));
+                case TYP_UBYTE:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(UINT8(arg0Val));
+                case TYP_SHORT:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(INT16(arg0Val));
+                case TYP_USHORT:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(UINT16(arg0Val));
+                case TYP_INT:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(INT32(arg0Val));
+                case TYP_UINT:
+                    assert(typ == TYP_INT);
+                    return VNForIntCon(UINT32(arg0Val));
+                case TYP_LONG:
+                case TYP_ULONG:
+                    assert(typ == TYP_LONG);
+                    return arg0VN;
+                case TYP_BYREF:
+                    assert(typ == TYP_BYREF);
+                    return VNForByrefCon((target_size_t)arg0Val);
+                case TYP_FLOAT:
+                    assert(typ == TYP_FLOAT);
+                    if (srcIsUnsigned)
                     {
-                        case TYP_BYTE:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(INT8(arg0Val));
-                        case TYP_UBYTE:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(UINT8(arg0Val));
-                        case TYP_SHORT:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(INT16(arg0Val));
-                        case TYP_USHORT:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(UINT16(arg0Val));
-                        case TYP_INT:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(INT32(arg0Val));
-                        case TYP_UINT:
-                            assert(typ == TYP_INT);
-                            return VNForIntCon(UINT32(arg0Val));
-                        case TYP_LONG:
-                        case TYP_ULONG:
-                            assert(typ == TYP_LONG);
-                            return arg0VN;
-                        case TYP_BYREF:
-                            assert(typ == TYP_BYREF);
-                            return VNForByrefCon((target_size_t)arg0Val);
-                        case TYP_FLOAT:
-                            assert(typ == TYP_FLOAT);
-                            if (srcIsUnsigned)
-                            {
-                                return VNForFloatCon(FloatingPointUtils::convertUInt64ToFloat(UINT64(arg0Val)));
-                            }
-                            else
-                            {
-                                return VNForFloatCon(float(arg0Val));
-                            }
-                        case TYP_DOUBLE:
-                            assert(typ == TYP_DOUBLE);
-                            if (srcIsUnsigned)
-                            {
-                                return VNForDoubleCon(FloatingPointUtils::convertUInt64ToDouble(UINT64(arg0Val)));
-                            }
-                            else
-                            {
-                                return VNForDoubleCon(double(arg0Val));
-                            }
-                        default:
-                            unreached();
+                        return VNForFloatCon(FloatingPointUtils::convertUInt64ToFloat(UINT64(arg0Val)));
                     }
+                    else
+                    {
+                        return VNForFloatCon(float(arg0Val));
+                    }
+                case TYP_DOUBLE:
+                    assert(typ == TYP_DOUBLE);
+                    if (srcIsUnsigned)
+                    {
+                        return VNForDoubleCon(FloatingPointUtils::convertUInt64ToDouble(UINT64(arg0Val)));
+                    }
+                    else
+                    {
+                        return VNForDoubleCon(double(arg0Val));
+                    }
+                default:
+                    unreached();
             }
+        }
         case TYP_FLOAT:
         {
             float arg0Val = GetConstantSingle(arg0VN);
@@ -6062,10 +6062,12 @@ bool ValueNumStore::IsVNNeverNegative(ValueNum vn)
 GenTreeFlags ValueNumStore::GetHandleFlags(ValueNum vn)
 {
     assert(IsVNHandle(vn));
-    Chunk*    c      = m_chunks.GetNoExpand(GetChunkNum(vn));
-    unsigned  offset = ChunkOffset(vn);
-    VNHandle* handle = &reinterpret_cast<VNHandle*>(c->m_defs)[offset];
-    return handle->m_flags;
+    Chunk*             c           = m_chunks.GetNoExpand(GetChunkNum(vn));
+    unsigned           offset      = ChunkOffset(vn);
+    VNHandle*          handle      = &reinterpret_cast<VNHandle*>(c->m_defs)[offset];
+    const GenTreeFlags handleFlags = handle->m_flags;
+    assert((handleFlags & ~GTF_ICON_HDL_MASK) == 0);
+    return handleFlags;
 }
 
 GenTreeFlags ValueNumStore::GetFoldedArithOpResultHandleFlags(ValueNum vn)
@@ -6114,7 +6116,7 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
 
 bool ValueNumStore::IsVNObjHandle(ValueNum vn)
 {
-    return IsVNHandle(vn) && GetHandleFlags(vn) == GTF_ICON_OBJ_HDL;
+    return IsVNHandle(vn) && (GetHandleFlags(vn) == GTF_ICON_OBJ_HDL);
 }
 
 //------------------------------------------------------------------------
@@ -8928,8 +8930,10 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
     }
     else if (IsVNHandle(vn))
     {
-        ssize_t val = ConstantValue<ssize_t>(vn);
-        printf("Hnd const: 0x%p", dspPtr(val));
+        ssize_t            val         = ConstantValue<ssize_t>(vn);
+        const GenTreeFlags handleFlags = GetHandleFlags(vn);
+        printf("Hnd const: 0x%p ", dspPtr(val));
+        GenTree::gtDispHandleKind(handleFlags);
     }
     else if (IsVNConstant(vn))
     {
@@ -8972,7 +8976,7 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
                 }
                 else
                 {
-                    printf("LngCns: ");
+                    printf("LngCns");
                     if ((val > -1000) && (val < 1000))
                     {
                         printf(" %ld", val);
@@ -10577,8 +10581,8 @@ void Compiler::fgValueNumberRegisterConstFieldSeq(GenTreeIntCon* tree)
 //------------------------------------------------------------------------
 // fgValueNumberStore: Does value numbering for a store.
 //
-// While this methods does indeed give a VN to the store tree itself, its
-// main objective is to update the various state that holds values, i. e.
+// While this method does indeed give a VN to the store tree itself, its
+// main objective is to update the various state that holds values, i.e.
 // the per-SSA VNs for tracked variables and the heap states for analyzable
 // (to fields and arrays) stores.
 //


### PR DESCRIPTION
1. Add debugging cVN/dVN dumpers of value numbers
2. Fix new loop debugging dumpers on x86
3. Display the bbID, not just bbNum, in more places
4. For ValueNum handle constants, display the handle constant type
5. Fix some grammar nits and try to rewrite some comments to read better