### PR TITLE
superpmi: fix failureLimit

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/superpmi.cpp
@@ -448,7 +448,7 @@ int __cdecl main(int argc, char* argv[])
                 {
                     LogError("More than %d methods failed%s. Skip compiling remaining methods.",
                         o.failureLimit, (o.nameOfJit2 == nullptr) ? "" : " by JIT1");
-                    break;
+                    goto doneRepeatCount;
                 }
                 if ((o.reproName != nullptr) && (o.indexCount == -1))
                 {
@@ -507,7 +507,7 @@ int __cdecl main(int argc, char* argv[])
                     if (errorCount2 == o.failureLimit)
                     {
                         LogError("More than %d methods compilation failed by JIT2. Skip compiling remaining methods.", o.failureLimit);
-                        break;
+                        goto doneRepeatCount;
                     }
                 }
             }
@@ -735,6 +735,7 @@ int __cdecl main(int argc, char* argv[])
 
         delete mc;
     }
+doneRepeatCount:
     delete reader;
 
     // NOTE: these output status strings are parsed by parallelsuperpmi.cpp::ProcessChildStdOut().


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/94503, we added another loop to repeat the compilation inside the existing loop that goes through the list of methods. Because of this, when `failureLimit` was hit, we were just breaking from the inner "repeat compilation" loop and not from "list of methods" loop.