### PR TITLE
Manually optimize a rem 64 instruction to avoid regression on Mono

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -166,7 +166,7 @@ namespace System.Collections.Frozen
                 {
                     if (key.Length < minLength) minLength = key.Length;
                     if (key.Length > maxLength) maxLength = key.Length;
-                    lengthFilter |= (1UL << (key.Length % 64));
+                    lengthFilter |= (1UL << (key.Length & 0x3F));
                 }
                 Debug.Assert(minLength >= 0 && maxLength >= minLength);
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
@@ -114,7 +114,7 @@ namespace System.Collections.Frozen
                 {
                     if (s.Length < minLength) minLength = s.Length;
                     if (s.Length > maxLength) maxLength = s.Length;
-                    lengthFilter |= (1UL << (s.Length % 64));
+                    lengthFilter |= (1UL << (s.Length & 0x3F));
                 }
                 Debug.Assert(minLength >= 0 && maxLength >= minLength);
 

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_Full.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_Full.cs
@@ -28,6 +28,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => string.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinal(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitive.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitive.cs
@@ -28,6 +28,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => StringComparer.OrdinalIgnoreCase.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinalIgnoreCase(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenDictionary_FullCaseInsensitiveAscii.cs
@@ -28,6 +28,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => StringComparer.OrdinalIgnoreCase.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinalIgnoreCaseAscii(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_Full.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_Full.cs
@@ -27,6 +27,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => string.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinal(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_FullCaseInsensitive.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_FullCaseInsensitive.cs
@@ -27,6 +27,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => StringComparer.OrdinalIgnoreCase.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinalIgnoreCase(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_FullCaseInsensitiveAscii.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/OrdinalStringFrozenSet_FullCaseInsensitiveAscii.cs
@@ -27,6 +27,6 @@ namespace System.Collections.Frozen
 
         private protected override bool Equals(string? x, string? y) => StringComparer.OrdinalIgnoreCase.Equals(x, y);
         private protected override int GetHashCode(string s) => Hashing.GetHashCodeOrdinalIgnoreCaseAscii(s.AsSpan());
-        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length % 64))) > 0;
+        private protected override bool CheckLengthQuick(string key) => (_lengthFilter & (1UL << (key.Length & 0x3F))) > 0;
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/perf-autofiling-issues/issues/26185#issuecomment-1863266913

cc @adamsitnik as requested