### PR TITLE
Tweak new API template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_api_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02_api_proposal.yml
@@ -1,12 +1,12 @@
 name: API Suggestion
-description: Propose a change to the public API surface
+description: Propose adding a new API to the public API surface
 title: "[API Proposal]: "
 labels: [api-suggestion]
 body:
   - type: markdown
     attributes:
       value: |
-        We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/dotnet/runtime/blob/main/docs/project/api-review-process.md). This template will help us gather the information we need to start the review process.
+        We welcome API proposals! We have a process to evaluate the value and shape of new APIs. There is an overview of our process [here](https://github.com/dotnet/runtime/blob/main/docs/project/api-review-process.md). This template will help us gather the information we need to start the review process.
   - type: textarea
     id: background
     attributes:


### PR DESCRIPTION
This is an attempt to, maybe, clarify that this issue template should be used for new APIs. This issue template gets used often for "I just want API Foo.Bar to behave differently".

While the API proposal template has _some_ use cases beyond adding new APIs (obsoletion, attribute and annotation changes) the vast majority of public interest for API surface changes is new APIs. This case is much less frequent than people using the API proposal template for things that do not require API review.

