### PR TITLE
[PERF] Temporarily disable PerfBDN app testing on main

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -305,29 +305,30 @@ jobs:
             parameters:
               name: MonoRuntimePacks
 
-  # build PerfBDN app
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - ios_arm64
-      jobParameters:
-        dependsOn:
-         - Build_android_arm64_release_Mono_Packs
-        buildArgs: -s mono -c $(_BuildConfig)
-        nameSuffix: PerfBDNApp
-        isOfficialBuild: false
-        pool:
-          vmImage: 'macos-12'
-        postBuildSteps:
-          - template: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Android BDN App Artifacts
-              artifactName: PerfBDNAppArm
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+  # Disabled due to: https://github.com/dotnet/performance/issues/3655
+  # # build PerfBDN app
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - ios_arm64
+  #     jobParameters:
+  #       dependsOn:
+  #        - Build_android_arm64_release_Mono_Packs
+  #       buildArgs: -s mono -c $(_BuildConfig)
+  #       nameSuffix: PerfBDNApp
+  #       isOfficialBuild: false
+  #       pool:
+  #         vmImage: 'macos-12'
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/coreclr/templates/build-perf-bdn-app.yml
+  #           parameters:
+  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #             includeRootFolder: true
+  #             displayName: Android BDN App Artifacts
+  #             artifactName: PerfBDNAppArm
+  #             archiveExtension: '.tar.gz'
+  #             archiveType: tar
+  #             tarCompression: gz

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -90,7 +90,7 @@ jobs:
         - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.codeGenType) }}
       - ${{ if eq(parameters.runtimeType, 'AndroidMono')}}:
         - ${{ 'build_android_arm64_release_AndroidMono' }}
-        - ${{ 'Build_ios_arm64_release_PerfBDNApp' }}
+        # - ${{ 'Build_ios_arm64_release_PerfBDNApp' }} Disabled per: https://github.com/dotnet/performance/issues/3655
       - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
         - ${{ 'build_ios_arm64_release_iOSMono' }}
       - ${{ if eq(parameters.runtimeType, 'iOSNativeAOT')}}:
@@ -228,13 +228,14 @@ jobs:
           artifactFileName: 'AndroidMonoarm64.tar.gz'
           artifactName: 'AndroidMonoarm64'
           displayName: 'Mono Android HelloWorld'
-      - template: /eng/pipelines/common/download-artifact-step.yml
-        parameters:
-          unpackFolder: $(Build.SourcesDirectory)
-          cleanUnpackFolder: false
-          artifactFileName: 'AndroidBDNApk.tar.gz'
-          artifactName: 'AndroidBDNApk'
-          displayName: 'Mono Android BDN Apk'
+      # Disabled per: https://github.com/dotnet/performance/issues/3655
+      # - template: /eng/pipelines/common/download-artifact-step.yml
+      #   parameters:
+      #     unpackFolder: $(Build.SourcesDirectory)
+      #     cleanUnpackFolder: false
+      #     artifactFileName: 'AndroidBDNApk.tar.gz'
+      #     artifactName: 'AndroidBDNApk'
+      #     displayName: 'Mono Android BDN Apk'
 
     # Download iOSMono and Native AOT tests
     - ${{ if or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:

--- a/eng/testing/performance/android_scenarios.proj
+++ b/eng/testing/performance/android_scenarios.proj
@@ -35,18 +35,18 @@
         <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="SOD - Android Benchmarks.Droid APK Size">
+    <!-- <HelixWorkItem Include="SOD - Android Benchmarks.Droid APK Size">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-        <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py --apk-name MonoBenchmarksDroid.apk</PreCommands>
-        <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+        <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
+        <Command>$(Python) test.py sod -1-scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
     <HelixWorkItem Include="SOD - Android Benchmarks.Droid Extracted Size">
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-        <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py --unzip --apk-name MonoBenchmarksDroid.apk</PreCommands>
-        <Command>$(Python) test.py sod --scenario-name &quot;%(Identity)&quot;</Command>
+        <PreCommands>cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-unzip -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
+        <Command>$(Python) test.py sod -1-scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
-    </HelixWorkItem>
+    </HelixWorkItem> -->
     <HelixWorkItem Include="Device Startup - Android Mono HelloWorld">
       <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
       <PreCommands>echo on;set XHARNESSPATH=$(XharnessPath);cd $(ScenarioDirectory)helloandroid;copy %HELIX_CORRELATION_PAYLOAD%\HelloAndroid.apk .;$(Python) pre.py --apk-name HelloAndroid.apk</PreCommands>
@@ -59,12 +59,12 @@
       <Command>$(Python) test.py devicestartup --device-type android --package-path pub\HelloAndroid.apk --package-name net.dot.HelloAndroid --scenario-name &quot;%(Identity)&quot; --disable-animations</Command>
       <PostCommands>$(Python) post.py</PostCommands>
     </HelixWorkItem>
-    <HelixWorkItem Include="Mobile Benchmark - Android Benchmarks.Droid Benchmark Run">
+    <!-- <HelixWorkItem Include="Mobile Benchmark - Android Benchmarks.Droid Benchmark Run"> Disabled per https://github.com/dotnet/performance/issues/3655
         <PayloadDirectory>$(WorkItemDirectory)</PayloadDirectory>
-        <PreCommands>echo on;set XHARNESSPATH=$(XharnessPath);cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py --apk-name MonoBenchmarksDroid.apk</PreCommands>
-        <Command>$(Python) test.py androidinstrumentation --package-path .\pub\MonoBenchmarksDroid.apk --package-name com.microsoft.maui.benchmarks --instrumentation-name com.microsoft.maui.MainInstrumentation --scenario-name &quot;%(Identity)&quot;</Command>
+        <PreCommands>echo on;set XHARNESSPATH=$(XharnessPath);cd $(ScenarioDirectory)bdnandroid;copy %HELIX_CORRELATION_PAYLOAD%\MonoBenchmarksDroid.apk .;$(Python) pre.py -1-apk-name MonoBenchmarksDroid.apk</PreCommands>
+        <Command>$(Python) test.py androidinstrumentation -1-package-path .\pub\MonoBenchmarksDroid.apk -1-package-name com.microsoft.maui.benchmarks -1-instrumentation-name com.microsoft.maui.MainInstrumentation -1-scenario-name &quot;%(Identity)&quot;</Command>
         <PostCommands>$(Python) post.py</PostCommands>
         <Timeout>00:30:00</Timeout>
-    </HelixWorkItem>
+    </HelixWorkItem> -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Temporarily disable PerfBDN app testing until Maui is ready for net9.0 due to https://github.com/dotnet/performance/issues/3655.

Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2339362&view=results