### PR TITLE
Add option to disable log message queue behavior (performance issue)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -100,5 +100,19 @@ namespace Microsoft.Extensions.Logging.Console
                 _maxQueuedMessages = value;
             }
         }
+
+        private bool _disableMessageQueue = false;
+
+        /// <summary>
+        /// Enable or disable the message queue behavior. Default false.
+        /// </summary>
+        public bool DisableMessageQueue
+        {
+            get => _disableMessageQueue;
+            set
+            {
+                _disableMessageQueue = value;
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Extensions.Logging.Console
                 console,
                 errorConsole,
                 options.CurrentValue.QueueFullMode,
-                options.CurrentValue.MaxQueueLength);
+                options.CurrentValue.MaxQueueLength,
+                options.CurrentValue.DisableMessageQueue);
 
             ReloadLoggerOptions(options.CurrentValue);
             _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);


### PR DESCRIPTION
When using K6 to do a performance test in an API with default console logger, the application can do 3.000 request in 60 seconds. When i remove the logger the application do 30.000 in 60 seconds. Removing the queue behavior from console logger i get the same 30.000 request result.