### PR TITLE
Intrinsify Interlocked.And and Interlocked.Or on XARCH

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3247,6 +3247,12 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 if (compOpportunisticallyDependsOn(InstructionSet_Atomics))
 #endif
                 {
+#if defined(TARGET_X86)
+                    if (genActualType(callType) == TYP_LONG)
+                    {
+                        break;
+                    }
+#endif
                     assert(sig->numArgs == 2);
                     GenTree*   op2 = impPopStack().val;
                     GenTree*   op1 = impPopStack().val;

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3239,13 +3239,13 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 break;
             }
 
-#if defined(TARGET_ARM64) || defined(TARGET_RISCV64)
-            // Intrinsify Interlocked.Or and Interlocked.And only for arm64-v8.1 (and newer) and for RV64A
-            // TODO-CQ: Implement for XArch (https://github.com/dotnet/runtime/issues/32239).
+#if defined(TARGET_ARM64) || defined(TARGET_RISCV64) || defined(TARGET_XARCH)
             case NI_System_Threading_Interlocked_Or:
             case NI_System_Threading_Interlocked_And:
             {
-                ARM64_ONLY(if (compOpportunisticallyDependsOn(InstructionSet_Atomics)))
+#if defined(TARGET_ARM64)
+                if (compOpportunisticallyDependsOn(InstructionSet_Atomics))
+#endif
                 {
                     assert(sig->numArgs == 2);
                     GenTree*   op2 = impPopStack().val;

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -640,8 +640,6 @@ GenTree* Lowering::LowerNode(GenTree* node)
             CheckImmedAndMakeContained(node, node->AsOp()->gtOp2);
             break;
 #elif defined(TARGET_XARCH)
-        case GT_XORR:
-        case GT_XAND:
         case GT_XADD:
             if (node->IsUnusedValue())
             {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -439,10 +439,11 @@ int LinearScan::BuildNode(GenTree* tree)
             if (!tree->IsUnusedValue())
             {
                 // if value is unused, we'll emit a cmpxchg-loop idiom (requires RAX)
+                buildInternalIntRegisterDefForNode(tree, availableIntRegs & ~RBM_RAX);
                 BuildUse(tree->gtGetOp1(), availableIntRegs & ~RBM_RAX);
                 BuildUse(tree->gtGetOp2(), availableIntRegs & ~RBM_RAX);
-                buildInternalIntRegisterDefForNode(tree, availableIntRegs & ~RBM_RAX);
                 BuildDef(tree, RBM_RAX);
+                buildInternalRegisterUses();
                 srcCount = 2;
                 assert(dstCount == 1);
                 break;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -438,7 +438,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_XAND:
             if (!tree->IsUnusedValue())
             {
-                // if value is unused, we'll emit a cmpxchg-loop idiom (requires RAX)
+                // if tree's value is used, we'll emit a cmpxchg-loop idiom (requires RAX)
                 buildInternalIntRegisterDefForNode(tree, availableIntRegs & ~RBM_RAX);
                 BuildUse(tree->gtGetOp1(), availableIntRegs & ~RBM_RAX);
                 BuildUse(tree->gtGetOp2(), availableIntRegs & ~RBM_RAX);

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -445,6 +445,7 @@ int LinearScan::BuildNode(GenTree* tree)
                 BuildDef(tree, RBM_RAX);
                 srcCount = 2;
                 assert(dstCount == 1);
+                break;
             }
             FALLTHROUGH;
         case GT_XADD:

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -436,6 +436,17 @@ int LinearScan::BuildNode(GenTree* tree)
 
         case GT_XORR:
         case GT_XAND:
+            if (!tree->IsUnusedValue())
+            {
+                // if value is unused, we'll emit a cmpxchg-loop idiom (requires RAX)
+                BuildUse(tree->gtGetOp1(), availableIntRegs & ~RBM_RAX);
+                BuildUse(tree->gtGetOp2(), availableIntRegs & ~RBM_RAX);
+                buildInternalIntRegisterDefForNode(tree, availableIntRegs & ~RBM_RAX);
+                BuildDef(tree, RBM_RAX);
+                srcCount = 2;
+                assert(dstCount == 1);
+            }
+            FALLTHROUGH;
         case GT_XADD:
         case GT_XCHG:
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/32239

These were only implemented on ARM64 (and RISC-V). Unlike other Interlocked APIs, these return original value so it makes them impossible to optimize on XARCH when that original value is used. Looks like all usages of it in BCL don't need return value so we can optimize this case. Example: https://github.com/dotnet/runtime/blob/0cf461b302f58c7add3f6dc405873fb2212b513f/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L756


```cs
void Test1(ref int x, int y) => Interlocked.Or(ref x, y); // return value is not used
int  Test2(ref int x, int y) => Interlocked.Or(ref x, y); // return value is used
```
### Was:
```asm
; Method Tests:Test1(byref,int):this (FullOpts)
G_M7530_IG01:
       push     rax
G_M7530_IG02:
       mov      eax, dword ptr [rdx]
       jmp      SHORT G_M7530_IG03
       align    [0 bytes for IG03]
G_M7530_IG03:
       mov      ecx, eax
       or       ecx, r8d
       mov      dword ptr [rsp+0x04], eax
       lock     
       cmpxchg  dword ptr [rdx], ecx
       mov      ecx, dword ptr [rsp+0x04]
       cmp      eax, ecx
       je       SHORT G_M7530_IG05
G_M7530_IG04:
       mov      ecx, eax
       mov      eax, ecx
       jmp      SHORT G_M7530_IG03
G_M7530_IG05:
       add      rsp, 8
       ret      
; Total bytes of code: 37


; Method Tests:Test2(byref,int):int:this (FullOpts)
G_M30720_IG01:
       push     rax
G_M30720_IG02:
       mov      eax, dword ptr [rdx]
       jmp      SHORT G_M30720_IG03
       align    [0 bytes for IG03]
G_M30720_IG03:
       mov      ecx, eax
       or       ecx, r8d
       mov      dword ptr [rsp+0x04], eax
       lock     
       cmpxchg  dword ptr [rdx], ecx
       mov      ecx, dword ptr [rsp+0x04]
       cmp      eax, ecx
       je       SHORT G_M30720_IG05
G_M30720_IG04:
       mov      ecx, eax
       mov      eax, ecx
       jmp      SHORT G_M30720_IG03
G_M30720_IG05:
       mov      eax, ecx
G_M30720_IG06:
       add      rsp, 8
       ret      
; Total bytes of code: 39

```
### Now:
```asm
; Method Tests:Test1(byref,int):this (FullOpts)
G_M7530_IG01:
G_M7530_IG02:
       lock     
       or       dword ptr [rdx], r8d
G_M7530_IG03:
       ret      
; Total bytes of code: 5


; Method Tests:Test2(byref,int):int:this (FullOpts)
G_M30720_IG01:
G_M30720_IG02:
       mov      eax, dword ptr [rdx]
G_M30720_IG03:
       mov      ecx, eax
       or       ecx, r8d
       lock     
       cmpxchg  dword ptr [rdx], ecx
       jne      SHORT G_M30720_IG03
G_M30720_IG04:
       ret      
; Total bytes of code: 14
```