### PR TITLE
Add option to disable log message queue behavior (performance issue)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -101,18 +101,9 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private bool _disableMessageQueue = false;
-
         /// <summary>
         /// Enable or disable the message queue behavior. Default false.
         /// </summary>
-        public bool DisableMessageQueue
-        {
-            get => _disableMessageQueue;
-            set
-            {
-                _disableMessageQueue = value;
-            }
-        }
+        public bool DisableMessageQueue { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -100,5 +100,19 @@ namespace Microsoft.Extensions.Logging.Console
                 _maxQueuedMessages = value;
             }
         }
+
+        private bool _disableMessageQueue = false;
+
+        /// <summary>
+        /// Enable or disable the message queue behavior. Default false.
+        /// </summary>
+        public bool DisableMessageQueue
+        {
+            get => _disableMessageQueue;
+            set
+            {
+                _disableMessageQueue = value;
+            }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Runtime.Versioning;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Logging.Console
 {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.Logging.Console
                 DirectWriteMessage(message);
                 return;
             }
-            
+
             // cannot enqueue when adding is completed
             if (!Enqueue(message))
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Extensions.Logging.Console
                     console.Write(entry.Message);
                 }
                 catch (Exception) { } //Ignore to protect application
-            });
+            }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
         }
 
         // internal for testing

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        internal void DirectWriteMessage(BmgLogMessageEntry entry)
+        internal void DirectWriteMessage(LogMessageEntry entry)
         {
             _ = Task.Factory.StartNew(() =>
             {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Logging.Console
         public IConsole Console { get; }
         public IConsole ErrorConsole { get; }
 
-        public ConsoleLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerQueueFullMode fullMode, int maxQueueLength, bool disableMessageQueue)
+        public ConsoleLoggerProcessor(IConsole console, IConsole errorConsole, ConsoleLoggerQueueFullMode fullMode, int maxQueueLength, bool disableMessageQueue = false)
         {
             _disableMessageQueue = disableMessageQueue;
             _messageQueue = new Queue<LogMessageEntry>();

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Extensions.Logging.Console
                 console,
                 errorConsole,
                 options.CurrentValue.QueueFullMode,
-                options.CurrentValue.MaxQueueLength);
+                options.CurrentValue.MaxQueueLength,
+                options.CurrentValue.DisableMessageQueue);
 
             ReloadLoggerOptions(options.CurrentValue);
             _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);


### PR DESCRIPTION
When using K6 to do a performance test in an API with default console logger, the application can do 3.000 request in 60 seconds. When i remove the logger the application do 30.000 in 60 seconds. Removing the queue behavior from console logger i get the same 30.000 request result.