### PR TITLE
[NativeAOT] Faster lookup for method infos on Windows.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -308,6 +308,7 @@ struct CoffNativeMethodInfo
 // Ensure that CoffNativeMethodInfo fits into the space reserved by MethodInfo
 static_assert(sizeof(CoffNativeMethodInfo) <= sizeof(MethodInfo), "CoffNativeMethodInfo too big");
 
+FORCEINLINE
 int CoffNativeCodeManager::LookupUnwindInfoIdx(uint32_t relativePc)
 {
     uint32_t** indices = m_initializedIndices;

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -264,9 +264,13 @@ int CoffNativeCodeManager::LookupUnwindInfoIdx(uint32_t relativePc)
             return idx - 1;
     }
 
-    // We can only get here if called with invalid address or m_pRuntimeFunctionTable is corrupted.
-    // Either way we cannot recover as we expect every managed method to have a method info.
-    UNREACHABLE();
+    // we can only get here if we are looking for a location inside the very last managed function.
+    _ASSERTE(m_pRuntimeFunctionTable[idx - 1].BeginAddress < relativePc);
+#if defined(TARGET_AMD64)
+    _ASSERTE(m_pRuntimeFunctionTable[idx - 1].EndAddress > relativePc);
+#endif
+
+    return idx - 1;
 }
 
 bool CoffNativeCodeManager::FindMethodInfo(PTR_VOID        ControlPC,

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
@@ -44,6 +44,8 @@ class CoffNativeCodeManager : public ICodeManager
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
 
+    // used to publish a reference to the index once initialized.
+    // if the reference is not null, the index can be accessed through it.
     uint32_t** volatile m_initializedIndices;
     uint32_t m_indexCount;
     uint32_t* m_indices[8];

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
@@ -44,7 +44,7 @@ class CoffNativeCodeManager : public ICodeManager
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
 
-    int m_indexCount;
+    uint32_t m_indexCount;
     uint32_t* m_indices[8];
 
     int LookupUnwindInfoIdx(uint32_t relativePc);
@@ -55,6 +55,8 @@ public:
                           PTR_RUNTIME_FUNCTION pRuntimeFunctionTable, uint32_t nRuntimeFunctionTable,
                           PTR_PTR_VOID pClasslibFunctions, uint32_t nClasslibFunctions);
     ~CoffNativeCodeManager();
+
+    bool InitFuncTableIndex();
 
     //
     // Code manager methods

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
@@ -44,6 +44,7 @@ class CoffNativeCodeManager : public ICodeManager
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
 
+    uint32_t** volatile m_initializedIndices;
     uint32_t m_indexCount;
     uint32_t* m_indices[8];
 
@@ -56,7 +57,8 @@ public:
                           PTR_PTR_VOID pClasslibFunctions, uint32_t nClasslibFunctions);
     ~CoffNativeCodeManager();
 
-    bool InitFuncTableIndex();
+    bool AllocFuncTableIndex();
+    uint32_t** InitFuncTableIndex();
 
     //
     // Code manager methods

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.h
@@ -44,6 +44,11 @@ class CoffNativeCodeManager : public ICodeManager
     PTR_PTR_VOID m_pClasslibFunctions;
     uint32_t m_nClasslibFunctions;
 
+    int m_indexCount;
+    uint32_t* m_indices[8];
+
+    int LookupUnwindInfoIdx(uint32_t relativePc);
+
 public:
     CoffNativeCodeManager(TADDR moduleBase,
                           PTR_VOID pvManagedCodeStartRange, uint32_t cbManagedCodeRange,


### PR DESCRIPTION
Binary search in an array of tens of thousands records jumps all over the place and is not cache friendly. It is a noticeable expense when we stack walk and need to query for lots of function infos.

A B+ tree-like 16-ary index, where each node fits in a cache line, could reduce the number of cache misses by about 3X times.