### PR TITLE
Fix JSON crashinfo exception object address

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
@@ -172,7 +172,7 @@ namespace System
             if (!OpenValue(key, '{'))
                 return false;
 
-            ulong address = *(nuint*)Unsafe.AsPointer(ref exception);
+            ulong address = Unsafe.As<Exception, nuint>(ref exception);
             if (!WriteHexValue("address"u8, address))
                 return false;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/CrashInfo.cs
@@ -172,7 +172,8 @@ namespace System
             if (!OpenValue(key, '{'))
                 return false;
 
-            if (!WriteHexValue("address"u8, (ulong)Unsafe.AsPointer(ref exception)))
+            ulong address = *(nuint*)Unsafe.AsPointer(ref exception);
+            if (!WriteHexValue("address"u8, address))
                 return false;
 
             if (!WriteHexValue("hr"u8, exception.HResult))


### PR DESCRIPTION
The exception object address wasn't being render correctly in the JSON crash info.