### PR TITLE
Update coredistools

### DIFF
--- a/src/coreclr/inc/coredistools.h
+++ b/src/coreclr/inc/coredistools.h
@@ -3,7 +3,7 @@
 
 //===--------- coredistools.h - Disassembly tools for CoreClr ------------===//
 //
-//  Core Disassembly Tools API Version 1.3.0
+//  Core Disassembly Tools API Version 1.4.0
 //  Disassembly tools required by CoreCLR for utilities like
 //  GCStress, SuperPMI, and R2RDump.
 //===----------------------------------------------------------------------===//
@@ -26,10 +26,6 @@
 #define DllIface EXTERN_C __declspec(dllimport)
 #endif // defined(DllInterfaceExporter)
 #else
-
-// Disable "warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]"
-#pragma clang diagnostic ignored "-Wcovered-switch-default"
-
 #if !defined(__cdecl)
 #if defined(__i386__)
 #define __cdecl __attribute__((cdecl))

--- a/src/coreclr/inc/coredistools.h
+++ b/src/coreclr/inc/coredistools.h
@@ -3,9 +3,9 @@
 
 //===--------- coredistools.h - Dissassembly tools for CoreClr ------------===//
 //
-//  Core Disassembly Tools API Version 1.0.1-prerelease
+//  Core Disassembly Tools API Version 1.2.0
 //  Disassembly tools required by CoreCLR for utilities like
-//  GCStress and SuperPMI
+//  GCStress, SuperPMI, and R2RDump.
 //===----------------------------------------------------------------------===//
 
 #if !defined(_COREDISTOOLS_H_)
@@ -26,6 +26,10 @@
 #define DllIface EXTERN_C __declspec(dllimport)
 #endif // defined(DllInterfaceExporter)
 #else
+
+// Disable "warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]"
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+
 #if !defined(__cdecl)
 #if defined(__i386__)
 #define __cdecl __attribute__((cdecl))
@@ -41,7 +45,8 @@ enum TargetArch {
     Target_X86,
     Target_X64,
     Target_Thumb,
-    Target_Arm64
+    Target_Arm64,
+    Target_LoongArch64
 };
 
 struct CorDisasm;
@@ -60,13 +65,27 @@ struct PrintControl {
 // The type of a custom function provided by the user to determine
 // if two offsets are considered equivalent wrt diffing code blocks.
 // Offset1 and Offset2 are the two offsets to be compared.
-// BlockOffset is the offest of the instructions (that contain Offset1
+// BlockOffset is the offset of the instructions (that contain Offset1
 // and Offset2) from the beginning of their respective code blocks.
 // InstructionLength is the length of the current instruction being
 // compared for equivalency.
 typedef bool(__cdecl *OffsetComparator)(const void *UserData, size_t BlockOffset,
     size_t InstructionLength, uint64_t Offset1,
     uint64_t Offset2);
+
+// If an OffsetMunger function is defined, it is called before the OffsetComparator.
+// If it returns `true` then:
+// 1. the instructions are considered equivalent
+// 2. the offsets have been decoded and "munged" (changed), and
+//    *Offset1 and *Offset2 are set to the values to use.
+// 3. *SkipInstructions1 instructions in code stream 1 are skipped
+// 4. *SkipInstructions2 instructions in code stream 2 are skipped
+//
+// This is typically used on arm32 to treat "movw/movt" as a single instruction
+// generating a single constant. Similarly, for arm64 mov/movk/movk/movk sequences.
+typedef bool(__cdecl *OffsetMunger)(const void *UserData, size_t BlockOffset,
+    size_t InstructionLength, uint64_t* Offset1, uint64_t* Offset2,
+    uint32_t* SkipInstructions1, uint32_t* SkipInstructions2);
 
 // The Export/Import definitions for CoreDistools library are defined below.
 // A typedef for each interface function's type is defined in order to aid
@@ -76,6 +95,10 @@ typedef bool(__cdecl *OffsetComparator)(const void *UserData, size_t BlockOffset
 typedef CorDisasm * __cdecl InitDisasm_t(enum TargetArch Target);
 DllIface InitDisasm_t InitDisasm;
 
+// Initialize the disassembler, using buffered print controls
+typedef CorDisasm * __cdecl InitBufferedDisasm_t(enum TargetArch Target);
+DllIface InitBufferedDisasm_t InitBufferedDisasm;
+
 // Initialize the disassembler using custom print controls
 typedef CorDisasm * __cdecl NewDisasm_t(enum TargetArch Target,
     const PrintControl *PControl);
@@ -84,6 +107,28 @@ DllIface NewDisasm_t NewDisasm;
 // Delete the disassembler
 typedef void __cdecl FinishDisasm_t(const CorDisasm *Disasm);
 DllIface FinishDisasm_t FinishDisasm;
+
+// Initialize a code differ using buffered output.
+typedef CorDisasm * __cdecl InitBufferedDiffer_t(enum TargetArch Target,
+                               const OffsetComparator Comparator);
+DllIface InitBufferedDiffer_t InitBufferedDiffer;
+
+// Initialize the Code Differ
+typedef CorAsmDiff * __cdecl NewDiffer_t(enum TargetArch Target,
+    const PrintControl *PControl,
+    const OffsetComparator Comparator);
+DllIface NewDiffer_t NewDiffer;
+
+// Initialize the Code Differ, with an offset munger.
+typedef CorAsmDiff * __cdecl NewDiffer2_t(enum TargetArch Target,
+    const PrintControl *PControl,
+    const OffsetComparator Comparator,
+    const OffsetMunger Munger);
+DllIface NewDiffer2_t NewDiffer2;
+
+// Delete the Code Differ
+typedef void __cdecl FinishDiff_t(const CorAsmDiff *AsmDiff);
+DllIface FinishDiff_t FinishDiff;
 
 // DisasmInstruction -- Disassemble one instruction
 // Arguments:
@@ -100,22 +145,27 @@ typedef size_t __cdecl DisasmInstruction_t(const CorDisasm *Disasm,
     const uint8_t *Bytes, size_t Maxlength);
 DllIface DisasmInstruction_t DisasmInstruction;
 
-// Initialize the Code Differ
-typedef CorAsmDiff * __cdecl NewDiffer_t(enum TargetArch Target,
-    const PrintControl *PControl,
-    const OffsetComparator Comparator);
-DllIface NewDiffer_t NewDiffer;
-
-// Delete the Code Differ
-typedef void __cdecl FinishDiff_t(const CorAsmDiff *AsmDiff);
-DllIface FinishDiff_t FinishDiff;
+// DumpInstruction -- Disassemble one instruction and output it
+// Arguments:
+// Disasm -- The Disassembler
+// Address -- The address at which the bytes of the instruction
+//            are intended to execute
+// Bytes -- Pointer to the actual bytes which need to be disassembled
+// MaxLength -- Number of bytes available in Bytes buffer
+// Returns:
+//   -- The Size of the disassembled instruction
+//   -- Zero on failure
+typedef size_t __cdecl DumpInstruction_t(const CorDisasm *Disasm,
+	const uint8_t *Address, const uint8_t *Bytes,
+	size_t Maxlength);
+DllIface DumpInstruction_t DumpInstruction;
 
 // NearDiffCodeBlocks -- Compare two code blocks for semantic
 //                       equivalence
 // Arguments:
 // AsmDiff -- The Asm-differ
 // UserData -- Any data the user wishes to pass through into
-//             the OffsetComparator
+//             the OffsetComparator/OffsetMunger
 // Address1 -- Address at which first block will execute
 // Bytes1 -- Pointer to the actual bytes of the first block
 // Size1 -- The size of the first block
@@ -144,5 +194,13 @@ typedef void __cdecl DumpDiffBlocks_t(const CorAsmDiff *AsmDiff,
     size_t Size1, const uint8_t *Address2,
     const uint8_t *Bytes2, size_t Size2);
 DllIface DumpDiffBlocks_t DumpDiffBlocks;
+
+// Get a pointer to the buffered output buffer.
+typedef const char* __cdecl GetOutputBuffer_t();
+DllIface GetOutputBuffer_t GetOutputBuffer;
+
+// Clear the buffered output buffer.
+typedef void __cdecl ClearOutputBuffer_t();
+DllIface ClearOutputBuffer_t ClearOutputBuffer;
 
 #endif // !defined(_COREDISTOOLS_H_)

--- a/src/coreclr/inc/coredistools.h
+++ b/src/coreclr/inc/coredistools.h
@@ -1,9 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-//===--------- coredistools.h - Dissassembly tools for CoreClr ------------===//
+//===--------- coredistools.h - Disassembly tools for CoreClr ------------===//
 //
-//  Core Disassembly Tools API Version 1.2.0
+//  Core Disassembly Tools API Version 1.3.0
 //  Disassembly tools required by CoreCLR for utilities like
 //  GCStress, SuperPMI, and R2RDump.
 //===----------------------------------------------------------------------===//

--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -24,7 +24,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
  */
 void CodeGen::genArm64EmitterUnitTestsGeneral()
 {
-    assert(verbose);
     emitter* theEmitter = GetEmitter();
 
     //
@@ -1824,7 +1823,6 @@ void CodeGen::genArm64EmitterUnitTestsGeneral()
  */
 void CodeGen::genArm64EmitterUnitTestsAdvSimd()
 {
-    assert(verbose);
     emitter* theEmitter = GetEmitter();
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -4557,7 +4555,6 @@ void CodeGen::genArm64EmitterUnitTestsAdvSimd()
  */
 void CodeGen::genArm64EmitterUnitTestsSve()
 {
-    assert(verbose);
     emitter* theEmitter = GetEmitter();
 
     //

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2682,7 +2682,7 @@ void CodeGen::genEmitterUnitTests()
 {
     const WCHAR* unitTestSection = JitConfig.JitDumpEmitUnitTests();
 
-    if ((!verbose) || (unitTestSection == nullptr))
+    if (unitTestSection == nullptr)
     {
         return;
     }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2668,8 +2668,8 @@ void CodeGen::genCodeForSetcc(GenTreeCC* setcc)
 /*****************************************************************************
  * Unit testing of the emitter: If JitDumpEmitUnitTests is set, generate
  * a bunch of instructions, then:
- * Use DOTNET_JitLateDisasm=* to see if the late disassembler thinks the instructions as the same as we do.
- * Or, use DOTNET_JitRawHexCode and DOTNET_JitRawHexCodeFile and dissassemble the output file.
+ * Use DOTNET_JitLateDisasm=* to see if the late disassembler thinks the instructions are the same as we do.
+ * Or, use DOTNET_JitRawHexCode and DOTNET_JitRawHexCodeFile and disassemble the output file.
  *
  * Possible values for JitDumpEmitUnitTests:
  * Amd64: all, sse2

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1994,6 +1994,12 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
 
 void Compiler::compDone()
 {
+#ifdef LATE_DISASM
+    if (codeGen != nullptr)
+    {
+        codeGen->getDisAssembler().disDone();
+    }
+#endif // LATE_DISASM
 }
 
 void* Compiler::compGetHelperFtn(CorInfoHelpFunc ftnNum,        /* IN  */

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1480,7 +1480,7 @@ void DisAssembler::disAsmCode(BYTE* hotCodePtr, size_t hotCodeSize, BYTE* coldCo
 #endif // !DEBUG
 
 #ifdef DEBUG
-    const wchar_t* fileName = JitConfig.JitLateDisasmTo();
+    const WCHAR* fileName = JitConfig.JitLateDisasmTo();
     if (fileName != nullptr)
     {
         errno_t ec = _wfopen_s(&disAsmFile, fileName, W("a+"));
@@ -1566,16 +1566,13 @@ void DisAssembler::disOpenForLateDisAsm(const char* curMethodName, const char* c
 
 // Currently all loggers are the same
 #define LOGGER(L)                                                                                                      \
-    \
 static void __cdecl CorDisToolsLog##L(const char* msg, ...)                                                            \
-    \
-{                                                                                                               \
+{                                                                                                                      \
         va_list argList;                                                                                               \
         va_start(argList, msg);                                                                                        \
         vflogf(disAsmFileCorDisTools, msg, argList);                                                                   \
         va_end(argList);                                                                                               \
         fprintf(disAsmFileCorDisTools, "\n");                                                                          \
-    \
 }
 
 LOGGER(VERBOSE)

--- a/src/coreclr/jit/disasm.cpp
+++ b/src/coreclr/jit/disasm.cpp
@@ -1566,14 +1566,14 @@ void DisAssembler::disOpenForLateDisAsm(const char* curMethodName, const char* c
 
 // Currently all loggers are the same
 #define LOGGER(L)                                                                                                      \
-static void __cdecl CorDisToolsLog##L(const char* msg, ...)                                                            \
-{                                                                                                                      \
+    static void __cdecl CorDisToolsLog##L(const char* msg, ...)                                                        \
+    {                                                                                                                  \
         va_list argList;                                                                                               \
         va_start(argList, msg);                                                                                        \
         vflogf(disAsmFileCorDisTools, msg, argList);                                                                   \
         va_end(argList);                                                                                               \
         fprintf(disAsmFileCorDisTools, "\n");                                                                          \
-}
+    }
 
 LOGGER(VERBOSE)
 LOGGER(ERROR)

--- a/src/coreclr/jit/disasm.h
+++ b/src/coreclr/jit/disasm.h
@@ -236,6 +236,7 @@ private:
 #ifdef USE_COREDISTOOLS
 
     bool InitCoredistoolsDisasm();
+    bool disCoreDisToolsLibraryInitialized = false;
 
     CorDisasm* corDisasm;
 

--- a/src/coreclr/jit/disasm.h
+++ b/src/coreclr/jit/disasm.h
@@ -6,7 +6,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XX                                                                           XX
 XX                          DisAsm                                           XX
 XX                                                                           XX
-XX  The dis-assembler to display the native code generated                   XX
+XX  The "late disassembler" to display the native code generated             XX
 XX                                                                           XX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -17,6 +17,12 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #define _DIS_H_
 /*****************************************************************************/
 #ifdef LATE_DISASM
+
+#ifdef USE_COREDISTOOLS
+#include "coredistools.h"
+#endif // USE_COREDISTOOLS
+
+#ifdef USE_MSVCDIS
 
 // free() is deprecated (we should only allocate and free memory through CLR hosting interfaces)
 // and is redefined in clrhost.h to cause a compiler error.
@@ -54,6 +60,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #endif                          // CHECK_STRUCT_PADDING
 
 /*****************************************************************************/
+
+#endif // USE_MSVCDIS
 
 #ifdef HOST_64BIT
 template <typename T>
@@ -176,6 +184,8 @@ private:
 #pragma warning(pop)
     }
 
+#ifdef USE_MSVCDIS
+
     /* Callbacks from msdis */
 
     static size_t __stdcall disCchAddr(
@@ -220,6 +230,16 @@ private:
                          bool        printit       = false,
                          bool        dispOffs      = false,
                          bool        dispCodeBytes = false);
+
+#endif // USE_MSVCDIS
+
+#ifdef USE_COREDISTOOLS
+
+    bool InitCoredistoolsDisasm();
+
+    CorDisasm* corDisasm;
+
+#endif // USE_COREDISTOOLS
 };
 
 /*****************************************************************************/

--- a/src/coreclr/jit/disasm.h
+++ b/src/coreclr/jit/disasm.h
@@ -86,6 +86,9 @@ public:
     // Constructor
     void disInit(Compiler* pComp);
 
+    // Destructor
+    void disDone();
+
     // Initialize the class for the current method being generated.
     void disOpenForLateDisAsm(const char* curMethodName, const char* curClassName, PCCOR_SIGNATURE sig);
 
@@ -235,9 +238,16 @@ private:
 
 #ifdef USE_COREDISTOOLS
 
-    bool InitCoredistoolsDisasm();
-    bool disCoreDisToolsLibraryInitialized = false;
+    bool                      InitCoredistoolsLibrary();            // Load the coredistools library
+    static LONG               s_disCoreDisToolsLibraryInitializing; // 0 = not initializing; 1 = initializing
+    static bool               s_disCoreDisToolsLibraryInitialized;
+    static bool               s_disCoreDisToolsLibraryLoadSuccessful;
+    static NewDisasm_t*       s_PtrNewDisasm;
+    static DumpInstruction_t* s_PtrDumpInstruction;
+    static FinishDisasm_t*    s_PtrFinishDisasm;
 
+    bool       InitCoredistoolsDisasm(); // Prepare for disassembly
+    void       DoneCoredistoolsDisasm(); // Done with disassembly
     CorDisasm* corDisasm;
 
 #endif // USE_COREDISTOOLS

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -304,13 +304,16 @@ typedef ptrdiff_t ssize_t;
 #include "utils.h"
 #include "targetosarch.h"
 
-// Late disassembly is OFF by default. Can be turned ON by
-// adding /DLATE_DISASM=1 on the command line.
-// Always OFF in the non-debug version
+// The late disassembler is built in for certain platforms, for DEBUG builds. It is enabled by using
+// DOTNET_JitLateDisasm. It can be built in for non-DEBUG builds if desired.
+
+#if defined(TARGET_ARM64) || defined(TARGET_ARM) || defined(TARGET_X86) || defined(TARGET_AMD64)
 #ifdef DEBUG
 #define LATE_DISASM 1
 #define USE_COREDISTOOLS
 #endif // DEBUG
+#endif // platforms
+
 #if defined(LATE_DISASM) && (LATE_DISASM == 0)
 #undef LATE_DISASM
 #endif

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -304,6 +304,17 @@ typedef ptrdiff_t ssize_t;
 #include "utils.h"
 #include "targetosarch.h"
 
+// Late disassembly is OFF by default. Can be turned ON by
+// adding /DLATE_DISASM=1 on the command line.
+// Always OFF in the non-debug version
+#ifdef DEBUG
+#define LATE_DISASM 1
+#define USE_COREDISTOOLS
+#endif // DEBUG
+#if defined(LATE_DISASM) && (LATE_DISASM == 0)
+#undef LATE_DISASM
+#endif
+
 #ifdef DEBUG
 #define INDEBUG(x) x
 #define DEBUGARG(x) , x
@@ -454,14 +465,6 @@ public:
 #include "vartype.h"
 
 /*****************************************************************************/
-
-// Late disassembly is OFF by default. Can be turned ON by
-// adding /DLATE_DISASM=1 on the command line.
-// Always OFF in the non-debug version
-
-#if defined(LATE_DISASM) && (LATE_DISASM == 0)
-#undef LATE_DISASM
-#endif
 
 /*****************************************************************************/
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
@@ -704,12 +704,6 @@ struct allocGCInfoDetails
     void*  retval;
 };
 
-struct Agnostic_AddressMap
-{
-    DWORDLONG Address;
-    DWORD     size;
-};
-
 struct Agnostic_AllocGCInfo
 {
     DWORDLONG size;

--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.h
@@ -187,11 +187,6 @@ public:
     void dmpProcessName(DWORD key, DWORD value);
     const char* repProcessName();
 
-    void recAddressMap(void* original_address, void* replay_address, unsigned int size);
-    void dmpAddressMap(DWORDLONG key, const Agnostic_AddressMap& value);
-    void* repAddressMap(void* replay_address);
-    void* searchAddressMap(void* replay_address);
-
     void recReserveUnwindInfo(BOOL isFunclet, BOOL isColdCode, ULONG unwindSize);
     void dmpReserveUnwindInfo(DWORD key, const Agnostic_ReserveUnwindInfo& value);
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/crlwmlist.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/crlwmlist.h
@@ -16,7 +16,6 @@
 #define DENSELWM(map, value) LWM(map, this_is_an_error, value)
 #endif
 
-LWM(AddressMap, DWORDLONG, Agnostic_AddressMap)
 LWM(AllocGCInfo, DWORD, Agnostic_AllocGCInfo)
 LWM(AllocMem, DWORD, Agnostic_AllocMemDetails)
 DENSELWM(AllocUnwindInfo, Agnostic_AllocUnwindInfo)

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
@@ -1038,7 +1038,7 @@ enum mcPackets
     //Packet_SatisfiesClassConstraints = 110,
     Packet_SatisfiesMethodConstraints = 111,
     Packet_DoesFieldBelongToClass = 112,
-    PacketCR_AddressMap = 113,
+    //PacketCR_AddressMap = 113,
     PacketCR_AllocGCInfo = 114,
     PacketCR_AllocMem = 115,
     PacketCR_CallLog = 116,

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmiutil.h
@@ -85,8 +85,13 @@ void PutThumb2BlRel24(UINT16* p, INT32 imm24);
 
 bool GetArm64MovConstant(UINT32* p, unsigned* pReg, unsigned* pCon);
 bool GetArm64MovkConstant(UINT32* p, unsigned* pReg, unsigned* pCon, unsigned* pShift);
-
 void PutArm64MovkConstant(UINT32* p, unsigned con);
+
+bool GetArm32MovwConstant(UINT32* p, unsigned* pReg, unsigned* pCon);
+bool GetArm32MovtConstant(UINT32* p, unsigned* pReg, unsigned* pCon);
+bool Is32BitThumb2Instruction(UINT16* p);
+UINT32 ExtractArm32MovImm(UINT32 instr);
+void PutArm32MovtConstant(UINT32* p, unsigned con);
 
 template <typename T, int size>
 inline constexpr unsigned ArrLen(T (&)[size])

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -49,7 +49,7 @@ const PrintControl CorPrinter = {CorDisToolsLogERROR, CorDisToolsLogWARNING, Cor
 #endif // USE_COREDISTOOLS
 
 #ifdef USE_COREDISTOOLS
-NewDiffer_t*          g_PtrNewDiffer          = nullptr;
+NewDiffer2_t*         g_PtrNewDiffer2         = nullptr;
 FinishDiff_t*         g_PtrFinishDiff         = nullptr;
 NearDiffCodeBlocks_t* g_PtrNearDiffCodeBlocks = nullptr;
 DumpDiffBlocks_t*     g_PtrDumpDiffBlocks     = nullptr;
@@ -98,10 +98,10 @@ bool NearDiffer::InitAsmDiff()
             return false;
         }
 
-        g_PtrNewDiffer = (NewDiffer_t*)::GetProcAddress(hCoreDisToolsLib, "NewDiffer");
-        if (g_PtrNewDiffer == nullptr)
+        g_PtrNewDiffer2 = (NewDiffer2_t*)::GetProcAddress(hCoreDisToolsLib, "NewDiffer2");
+        if (g_PtrNewDiffer2 == nullptr)
         {
-            LogError("GetProcAddress 'NewDiffer' failed (0x%08x)", ::GetLastError());
+            LogError("GetProcAddress 'NewDiffer2' failed (0x%08x)", ::GetLastError());
             return false;
         }
         g_PtrFinishDiff = (FinishDiff_t*)::GetProcAddress(hCoreDisToolsLib, "FinishDiff");
@@ -124,6 +124,7 @@ bool NearDiffer::InitAsmDiff()
         }
 
         TargetArch coreDisTargetArchitecture = Target_Host;
+        OffsetMunger Munger = nullptr; // Only arm32 uses this feature currently
 
         if (TargetArchitecture != nullptr)
         {
@@ -138,6 +139,7 @@ bool NearDiffer::InitAsmDiff()
             else if ((0 == _stricmp(TargetArchitecture, "arm")) || (0 == _stricmp(TargetArchitecture, "arm32")))
             {
                 coreDisTargetArchitecture = Target_Thumb;
+                Munger = NearDiffer::CoreDisMungeOffsetsCallback;
             }
             else if (0 == _stricmp(TargetArchitecture, "arm64"))
             {
@@ -148,7 +150,8 @@ bool NearDiffer::InitAsmDiff()
                 LogError("Illegal target architecture '%s'", TargetArchitecture);
             }
         }
-        corAsmDiff = (*g_PtrNewDiffer)(coreDisTargetArchitecture, &CorPrinter, NearDiffer::CoreDisCompareOffsetsCallback);
+        corAsmDiff = (*g_PtrNewDiffer2)(coreDisTargetArchitecture, &CorPrinter,
+            NearDiffer::CoreDisCompareOffsetsCallback, Munger);
     }
 #endif // USE_COREDISTOOLS
 
@@ -161,6 +164,13 @@ bool __cdecl NearDiffer::CoreDisCompareOffsetsCallback(
     const void* payload, size_t blockOffset, size_t instrLen, uint64_t offset1, uint64_t offset2)
 {
     return compareOffsets(payload, blockOffset, instrLen, offset1, offset2);
+}
+
+// static
+bool __cdecl NearDiffer::CoreDisMungeOffsetsCallback(
+    const void* payload, size_t blockOffset, size_t instrLen, uint64_t* offset1, uint64_t* offset2, uint32_t* skip1, uint32_t* skip2)
+{
+    return mungeOffsets(payload, blockOffset, instrLen, offset1, offset2, skip1, skip2);
 }
 #endif // USE_COREDISTOOLS
 
@@ -318,6 +328,188 @@ struct DiffData
     size_t         otherCodeBlockSize2;
 };
 
+bool NearDiffer::mungeOffsets(
+    const void* payload, size_t blockOffset, size_t instrLen, uint64_t* offset1, uint64_t* offset2, uint32_t* skip1, uint32_t* skip2)
+{
+    const SPMI_TARGET_ARCHITECTURE targetArch = GetSpmiTargetArchitecture();
+    const DiffData*                data       = (const DiffData*)payload;
+
+    // On Thumb-2, we often have movw/movt pairs to generate a 32-bit address. Treat these pairs as
+    // a single instruction.
+    //
+    if (targetArch == SPMI_TARGET_ARCHITECTURE_ARM)
+    {
+        bool pair1 = false, pair2 = false;
+        unsigned reg1_w = 0, reg1_t;
+        unsigned reg2_w = 0, reg2_t;
+        unsigned con1_w, con1_t;
+        unsigned con2_w, con2_t;
+
+        UINT32* iaddr1    = (UINT32*)(data->block1 + blockOffset);
+        UINT32* iaddr2    = (UINT32*)(data->block2 + blockOffset);
+        UINT32* iaddr1end = (UINT32*)(data->block1 + data->blocksize1);
+        UINT32* iaddr2end = (UINT32*)(data->block2 + data->blocksize2);
+
+        uint64_t addr1 = 0;
+        uint64_t addr2 = 0;
+
+        // Look for a movw/movt address pattern in code stream 1.
+
+        if ((iaddr1 < iaddr1end) &&
+            GetArm32MovwConstant(iaddr1, &reg1_w, &con1_w))
+        {
+            if ((iaddr1 + 1 < iaddr1end) &&
+                GetArm32MovtConstant(iaddr1 + 1, &reg1_t, &con1_t) &&
+                (reg1_w == reg1_t))
+            {
+                addr1 = con1_w + (con1_t << 16);
+                pair1 = true;
+            }
+        }
+
+        // Look for a movw/movt address pattern in code stream 2.
+
+        if ((iaddr2 < iaddr2end) &&
+            GetArm32MovwConstant(iaddr2, &reg2_w, &con2_w))
+        {
+            if ((iaddr2 + 1 < iaddr2end) &&
+                GetArm32MovtConstant(iaddr2 + 1, &reg2_t, &con2_t) &&
+                (reg2_w == reg2_t))
+            {
+                addr2 = con2_w + (con2_t << 16);
+                pair2 = true;
+            }
+        }
+
+        if (pair1 && pair2 && (reg1_w == reg2_w))
+        {
+            // Use the constructed constant instead.
+            *offset1 = addr1;
+            *offset2 = addr2;
+            *skip1 = *skip2 = 1; // skip the `movt` instruction
+            return true;
+        }
+    }
+
+#if 0
+    // We might want to do something similar for mov/movk/movk/movk sequences on Arm64. The following code was
+    // previously used, but currently is not active.
+    //
+    // One difference is we might see a different number of movk on arm64 depending on the the data. Our "hack"
+    // of zeroing out the constant so they compare equal doesn't work well. In this case, we really do want
+    // a callback to the disassembler to skip the instructions.
+    //
+    // Another solution is to have the coredistools disassembler have this logic, but that seems like the wrong
+    // place for that logic, and it's hard to update coredistools.
+    // 
+    // The instruction sequence is something like this:
+    //     mov     x0, #63408
+    //     movk    x0, #23602, lsl #16
+    //     movk    x0, #606, lsl #32
+    //
+    // Since the mov/movk sequence is specific to the replay address constant, we don't assume the baseline
+    // and diff have the same number of instructions (e.g., it's possible to skip a `movk` if it is zero).
+    //
+    if (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64)
+    {
+        int numMovk_1 = 0, numMovk_2 = 0;
+
+        unsigned reg1_1 = 0, reg2_1, reg3_1, reg4_1;
+        unsigned reg1_2 = 0, reg2_2, reg3_2, reg4_2;
+        unsigned con1_1, con2_1, con3_1, con4_1;
+        unsigned con1_2, con2_2, con3_2, con4_2;
+        unsigned shift2_1, shift3_1, shift4_1;
+        unsigned shift2_2, shift3_2, shift4_2;
+
+        UINT32* iaddr1    = (UINT32*)(data->block1 + blockOffset);
+        UINT32* iaddr2    = (UINT32*)(data->block2 + blockOffset);
+        UINT32* iaddr1end = (UINT32*)(data->block1 + data->blocksize1);
+        UINT32* iaddr2end = (UINT32*)(data->block2 + data->blocksize2);
+
+        uint64_t addr1 = 0;
+        uint64_t addr2 = 0;
+
+        // Look for a mov/movk address pattern in code stream 1.
+
+        if ((iaddr1 < iaddr1end) &&
+            GetArm64MovConstant(iaddr1, &reg1_1, &con1_1))
+        {
+            // We assume the address requires at least 1 'movk' instruction.
+            if ((iaddr1 + 1 < iaddr1end) &&
+                GetArm64MovkConstant(iaddr1 + 1, &reg2_1, &con2_1, &shift2_1) &&
+                (reg1_1 == reg2_1))
+            {
+                ++numMovk_1;
+                addr1 = (uint64_t)con1_1 + ((uint64_t)con2_1 << shift2_1);
+
+                if ((iaddr1 + 2 < iaddr1end) &&
+                    GetArm64MovkConstant(iaddr1 + 2, &reg3_1, &con3_1, &shift3_1) &&
+                    (reg1_1 == reg3_1))
+                {
+                    ++numMovk_1;
+                    addr1 += (uint64_t)con3_1 << shift3_1;
+
+                    if ((iaddr1 + 3 < iaddr1end) &&
+                        GetArm64MovkConstant(iaddr1 + 3, &reg4_1, &con4_1, &shift4_1) &&
+                        (reg1_1 == reg4_1))
+                    {
+                        ++numMovk_1;
+                        addr1 += (uint64_t)con4_1 << shift4_1;
+                    }
+                }
+            }
+        }
+
+        // Look for a mov/movk address pattern in code stream 2.
+
+        if ((iaddr2 < iaddr2end) &&
+            GetArm64MovConstant(iaddr2, &reg1_2, &con1_2))
+        {
+            // We assume the address requires at least 1 'movk' instruction.
+            if ((iaddr2 + 1 < iaddr2end) &&
+                GetArm64MovkConstant(iaddr2 + 1, &reg2_2, &con2_2, &shift2_2) &&
+                (reg1_2 == reg2_2))
+            {
+                ++numMovk_2;
+                addr2 = (uint64_t)con1_2 + ((uint64_t)con2_2 << shift2_2);
+
+                if ((iaddr2 + 2 < iaddr2end) &&
+                    GetArm64MovkConstant(iaddr2 + 2, &reg3_2, &con3_2, &shift3_2) &&
+                    (reg1_2 == reg3_2))
+                {
+                    ++numMovk_2;
+                    addr2 += (uint64_t)con3_2 << shift3_2;
+
+                    if ((iaddr2 + 3 < iaddr2end) &&
+                        GetArm64MovkConstant(iaddr2 + 3, &reg4_2, &con4_2, &shift4_2) &&
+                        (reg1_2 == reg4_2))
+                    {
+                        ++numMovk_2;
+                        addr2 += (uint64_t)con4_2 << shift4_2;
+                    }
+                }
+            }
+        }
+
+        // Note: when replaying on a 32-bit platform, we must have
+        // numMovk_1 == numMovk_2 == 1
+
+        if ((addr1 != 0) && (addr2 != 0) && (reg1_1 == reg1_2))
+        {
+            offset1 = addr1;
+            offset2 = addr2;
+
+            *skip1 = numMovk_1;
+            *skip2 = numMovk_2;
+
+            return true;
+        }
+    }
+#endif // 0 
+
+    return false;
+}
+
 //
 // NearDiff Offset Comparator.
 // Determine whether two syntactically different constants are
@@ -332,7 +524,6 @@ bool NearDiffer::compareOffsets(
         return true;
     }
 
-    const SPMI_TARGET_ARCHITECTURE targetArch = GetSpmiTargetArchitecture();
     const DiffData* data         = (const DiffData*)payload;
     size_t          ip1          = data->originalBlock1 + blockOffset;
     size_t          ip2          = data->originalBlock2 + blockOffset;
@@ -353,22 +544,20 @@ bool NearDiffer::compareOffsets(
         (roOffset1a < data->datablockSize1)) // Confirm its an offset that fits inside our RoRegion
         return true;
 
-    // This case is written to catch IP-relative offsets to the RO data-section
-    // For example:
-    //
+    // Case for IP-relative offset to the RO data-section
     size_t roOffset1b = ipRelOffset1 - data->originalDataBlock1;
     size_t roOffset2b = ipRelOffset2 - data->originalDataBlock2;
     if ((roOffset1b == roOffset2b) &&
         (roOffset1b < data->datablockSize1)) // Confirm its an offset that fits inside our RoRegion
         return true;
 
-    // Case where we push an address to our own code section.
+    // Case where we have an address to our own code section.
     size_t gOffset1a = (size_t)offset1 - data->originalBlock1;
     size_t gOffset2a = (size_t)offset2 - data->originalBlock2;
     if ((gOffset1a == gOffset2a) && (gOffset1a < data->blocksize1)) // Confirm its in our code region
         return true;
 
-    // Case where we push an address in the other codeblock.
+    // Case where we have an address in the other codeblock.
     size_t gOffset1b = (size_t)offset1 - data->otherCodeBlock1;
     size_t gOffset2b = (size_t)offset2 - data->otherCodeBlock2;
     if ((gOffset1b == gOffset2b) && (gOffset1b < data->otherCodeBlockSize1)) // Confirm it's in the other code region
@@ -408,168 +597,6 @@ bool NearDiffer::compareOffsets(
         // This logging is too noisy, so disable it.
         // LogVerbose("Found VSD callsite, did softer compare than ideal");
         return true;
-    }
-
-    // Case might be a field address that we handed out to handle inlined values being loaded into
-    // a register as an immediate value (and where the address is encoded as an indirect immediate load)
-    size_t realTargetAddr = (size_t)data->cr2->searchAddressMap((void*)gOffset2);
-    if (realTargetAddr == gOffset1)
-        return true;
-
-    // Case might be a field address that we handed out to handle inlined values being loaded into
-    // a register as an immediate value (and where the address is encoded and loaded by immediate into a register)
-    realTargetAddr = (size_t)data->cr2->searchAddressMap((void*)offset2);
-    if (realTargetAddr == offset1)
-        return true;
-    if (realTargetAddr == 0x424242) // this offset matches what we got back from a getTailCallCopyArgsThunk
-        return true;
-
-    realTargetAddr = (size_t)data->cr2->searchAddressMap((void*)(gOffset2));
-    if (realTargetAddr != (size_t)-1) // we know this was passed out as a bbloc
-        return true;
-
-    // A new clause that tries to handle the case where neither cr1 or cr2 is the
-    // recorded CR (diff case with two jits, neither of which is the one used for
-    // collection)
-    //
-    size_t mapped1 = (size_t)data->cr1->searchAddressMap((void*)offset1);
-    size_t mapped2 = (size_t)data->cr2->searchAddressMap((void*)offset2);
-
-    if ((mapped1 == mapped2) && (mapped1 != (size_t)-1))
-        return true;
-
-    // There are some cases on arm64 where we generate multiple instruction register construction of addresses
-    // but we don't have a relocation for them (so they aren't handled by `applyRelocs`). One case is
-    // allocPgoInstrumentationBySchema(), which returns an address the JIT writes into the code stream
-    // (used to store dynamic PGO probe data).
-    //
-    // The instruction sequence is something like this:
-    //     mov     x0, #63408
-    //     movk    x0, #23602, lsl #16
-    //     movk    x0, #606, lsl #32
-    //
-    // Here, we try to match this sequence and look it up in the address map.
-    //
-    // Since the mov/movk sequence is specific to the replay address constant, we don't assume the baseline
-    // and diff have the same number of instructions (e.g., it's possible to skip a `movk` if it is zero).
-    //
-    // Some version of this logic might apply to ARM as well.
-    //
-    if (targetArch == SPMI_TARGET_ARCHITECTURE_ARM64)
-    {
-        bool movk2_1 = false, movk3_1 = false;
-        bool movk2_2 = false, movk3_2 = false;
-
-        unsigned reg1_1 = 0, reg2_1, reg3_1, reg4_1;
-        unsigned reg1_2 = 0, reg2_2, reg3_2, reg4_2;
-        unsigned con1_1, con2_1, con3_1, con4_1;
-        unsigned con1_2, con2_2, con3_2, con4_2;
-        unsigned shift2_1, shift3_1, shift4_1;
-        unsigned shift2_2, shift3_2, shift4_2;
-
-        UINT32* iaddr1    = (UINT32*)(data->block1 + blockOffset);
-        UINT32* iaddr2    = (UINT32*)(data->block2 + blockOffset);
-        UINT32* iaddr1end = (UINT32*)(data->block1 + data->blocksize1);
-        UINT32* iaddr2end = (UINT32*)(data->block2 + data->blocksize2);
-
-        DWORDLONG addr1 = 0;
-        DWORDLONG addr2 = 0;
-
-        // Look for a mov/movk address pattern in code stream 1.
-
-        if ((iaddr1 < iaddr1end) &&
-            GetArm64MovConstant(iaddr1, &reg1_1, &con1_1))
-        {
-            // We assume the address requires at least 1 'movk' instruction.
-            if ((iaddr1 + 1 < iaddr1end) &&
-                GetArm64MovkConstant(iaddr1 + 1, &reg2_1, &con2_1, &shift2_1) &&
-                (reg1_1 == reg2_1))
-            {
-                addr1 = (DWORDLONG)con1_1 + ((DWORDLONG)con2_1 << shift2_1);
-
-                if ((iaddr1 + 2 < iaddr1end) &&
-                    GetArm64MovkConstant(iaddr1 + 2, &reg3_1, &con3_1, &shift3_1) &&
-                    (reg1_1 == reg3_1))
-                {
-                    movk2_1 = true;
-                    addr1 += (DWORDLONG)con3_1 << shift3_1;
-
-                    if ((iaddr1 + 3 < iaddr1end) &&
-                        GetArm64MovkConstant(iaddr1 + 3, &reg4_1, &con4_1, &shift4_1) &&
-                        (reg1_1 == reg4_1))
-                    {
-                        movk3_1 = true;
-                        addr1 += (DWORDLONG)con4_1 << shift4_1;
-                    }
-                }
-            }
-        }
-
-        // Look for a mov/movk address pattern in code stream 2.
-
-        if ((iaddr2 < iaddr2end) &&
-            GetArm64MovConstant(iaddr2, &reg1_2, &con1_2))
-        {
-            // We assume the address requires at least 1 'movk' instruction.
-            if ((iaddr2 + 1 < iaddr2end) &&
-                GetArm64MovkConstant(iaddr2 + 1, &reg2_2, &con2_2, &shift2_2) &&
-                (reg1_2 == reg2_2))
-            {
-                addr2 = (DWORDLONG)con1_2 + ((DWORDLONG)con2_2 << shift2_2);
-
-                if ((iaddr2 + 2 < iaddr2end) &&
-                    GetArm64MovkConstant(iaddr2 + 2, &reg3_2, &con3_2, &shift3_2) &&
-                    (reg1_2 == reg3_2))
-                {
-                    movk2_2 = true;
-                    addr2 += (DWORDLONG)con3_2 << shift3_2;
-
-                    if ((iaddr2 + 3 < iaddr2end) &&
-                        GetArm64MovkConstant(iaddr2 + 3, &reg4_2, &con4_2, &shift4_2) &&
-                        (reg1_2 == reg4_2))
-                    {
-                        movk3_2 = true;
-                        addr2 += (DWORDLONG)con4_2 << shift4_2;
-                    }
-                }
-            }
-        }
-
-        // Check the constants. We don't need to check 'addr1 == addr2' because if that were
-        // true we wouldn't have gotten here.
-        //
-        // Note: when replaying on a 32-bit platform, we must have
-        // movk2_1 == movk2_2 == movk3_1 == movk3_2 == false
-
-        if ((addr1 != 0) && (addr2 != 0) && (reg1_1 == reg1_2))
-        {
-            DWORDLONG mapped1 = (DWORDLONG)data->cr1->searchAddressMap((void*)addr1);
-            DWORDLONG mapped2 = (DWORDLONG)data->cr2->searchAddressMap((void*)addr2);
-            if ((mapped1 == mapped2) && (mapped1 != (DWORDLONG)-1))
-            {
-                // Now, zero out the constants in the `movk` instructions so when the disassembler
-                // gets to them, they compare equal.
-                PutArm64MovkConstant(iaddr1 + 1, 0);
-                PutArm64MovkConstant(iaddr2 + 1, 0);
-                if (movk2_1)
-                {
-                    PutArm64MovkConstant(iaddr1 + 2, 0);
-                }
-                if (movk2_2)
-                {
-                    PutArm64MovkConstant(iaddr2 + 2, 0);
-                }
-                if (movk3_1)
-                {
-                    PutArm64MovkConstant(iaddr1 + 3, 0);
-                }
-                if (movk3_2)
-                {
-                    PutArm64MovkConstant(iaddr2 + 3, 0);
-                }
-                return true;
-            }
-        }
     }
 
     return false;

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -128,7 +128,7 @@ bool NearDiffer::InitAsmDiff()
         }
 
         TargetArch coreDisTargetArchitecture = Target_Host;
-        OffsetMunger Munger = nullptr; // Only arm32 uses this feature currently
+        OffsetMunger munger = nullptr; // Only arm32 uses this feature currently
 
         if (TargetArchitecture != nullptr)
         {
@@ -143,7 +143,7 @@ bool NearDiffer::InitAsmDiff()
             else if ((0 == _stricmp(TargetArchitecture, "arm")) || (0 == _stricmp(TargetArchitecture, "arm32")))
             {
                 coreDisTargetArchitecture = Target_Thumb;
-                Munger = NearDiffer::CoreDisMungeOffsetsCallback;
+                munger = NearDiffer::CoreDisMungeOffsetsCallback;
             }
             else if (0 == _stricmp(TargetArchitecture, "arm64"))
             {
@@ -163,7 +163,7 @@ bool NearDiffer::InitAsmDiff()
         else
         {
             corAsmDiff = (*g_PtrNewDiffer2)(coreDisTargetArchitecture, &CorPrinter,
-                NearDiffer::CoreDisCompareOffsetsCallback, Munger);
+                NearDiffer::CoreDisCompareOffsetsCallback, munger);
         }
     }
 #endif // USE_COREDISTOOLS

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.h
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.h
@@ -71,10 +71,16 @@ private:
     static bool compareOffsets(
         const void* payload, size_t blockOffset, size_t instrLen, uint64_t offset1, uint64_t offset2);
 
+    static bool mungeOffsets(
+        const void* payload, size_t blockOffset, size_t instrLen, uint64_t* offset1, uint64_t* offset2, uint32_t* skip1, uint32_t* skip2);
+
 #ifdef USE_COREDISTOOLS
 
     static bool __cdecl CoreDisCompareOffsetsCallback(
         const void* payload, size_t blockOffset, size_t instrLen, uint64_t offset1, uint64_t offset2);
+
+    static bool __cdecl CoreDisMungeOffsetsCallback(
+        const void* payload, size_t blockOffset, size_t instrLen, uint64_t* offset1, uint64_t* offset2, uint32_t* skip1, uint32_t* skip2);
 
     CorAsmDiff* corAsmDiff;
 


### PR DESCRIPTION
Update to the 1.4.0 version of the coredistools package.

Also, implement a basic late disassembler for RyuJIT based on
coredistools (previously, this depended on closed-source msvcdis).

Various changes:
1. Remove unused AddressMap in SPMI. Removed a bunch of cases in
the NearDiffer that were using it.
2. Change arm64 emitter unit tests to not require `verbose`
3. Always build in the late disassembler under DEBUG. It's only
used when `JitLateDisasm` is set.
4. Implement new arm32 callback mechanism for movw/movt handling
in the NearDiffer.
