### PR TITLE
Enhance OSX's ProcessManager to extract process names from their paths

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -25,58 +25,44 @@ namespace System.Diagnostics
             // Negative PIDs aren't valid
             ArgumentOutOfRangeException.ThrowIfNegative(pid);
 
-            ProcessInfo procInfo;
+            string? processName = null;
+
+            try
+            {
+                // Extract the process name from its path, because other alternatives such as
+                // reading proc_taskallinfo.pbsd.pbi_comm are limited in length
+                string processPath = GetProcPath(pid);
+                processName = Path.GetFileName(processPath);
+            }
+            catch
+            {
+                // Ignored
+            }
+
+            // Fallback to empty string if the process name could not be retrieved
+            processName ??= "";
+
+            if (!string.IsNullOrEmpty(processNameFilter) && !string.Equals(processName, processNameFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var procInfo = new ProcessInfo()
+            {
+                ProcessId = pid,
+                ProcessName = processName,
+            };
 
             // Try to get the task info. This can fail if the user permissions don't permit
             // this user context to query the specified process
             Interop.libproc.proc_taskallinfo? info = Interop.libproc.GetProcessInfoById(pid);
             if (info.HasValue)
             {
-                string? processName = null;
-
-                try
-                {
-                    // Extract the process name from its path, because other alternatives such as
-                    // reading proc_taskallinfo.pbsd.pbi_comm are limited in length
-                    string processPath = GetProcPath(pid);
-                    processName = Path.GetFileName(processPath);
-                }
-                catch
-                {
-                    // Ignored
-                }
-
-                // Fallback to empty string if the process name could not be retrieved
-                processName ??= "";
-
-                if (!string.IsNullOrEmpty(processNameFilter) && !string.Equals(processName, processNameFilter, StringComparison.OrdinalIgnoreCase))
-                {
-                    return null;
-                }
-
                 // Set the values we have; all the other values don't have meaning or don't exist on OSX
                 Interop.libproc.proc_taskallinfo temp = info.Value;
-                procInfo = new ProcessInfo()
-                {
-                    ProcessId = pid,
-                    ProcessName = processName,
-                    BasePriority = temp.pbsd.pbi_nice,
-                    VirtualBytes = (long)temp.ptinfo.pti_virtual_size,
-                    WorkingSet = (long)temp.ptinfo.pti_resident_size,
-                };
-            }
-            else if (string.IsNullOrEmpty(processNameFilter))
-            {
-                procInfo = new ProcessInfo()
-                {
-                    ProcessId = pid,
-                };
-            }
-            else
-            {
-                // We couldn't get process information but we only want to return a process that
-                // matches the specified name, so consider this process not a match.
-                return null;
+                procInfo.BasePriority = temp.pbsd.pbi_nice;
+                procInfo.VirtualBytes = (long)temp.ptinfo.pti_virtual_size;
+                procInfo.WorkingSet = (long)temp.ptinfo.pti_resident_size;
             }
 
             // Get the sessionId for the given pid, getsid returns -1 on error

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.OSX.cs
@@ -32,15 +32,30 @@ namespace System.Diagnostics
             Interop.libproc.proc_taskallinfo? info = Interop.libproc.GetProcessInfoById(pid);
             if (info.HasValue)
             {
-                // Set the values we have; all the other values don't have meaning or don't exist on OSX
-                Interop.libproc.proc_taskallinfo temp = info.Value;
-                string processName;
-                unsafe { processName = Marshal.PtrToStringUTF8(new IntPtr(temp.pbsd.pbi_comm))!; }
+                string? processName = null;
+
+                try
+                {
+                    // Extract the process name from its path, because other alternatives such as
+                    // reading proc_taskallinfo.pbsd.pbi_comm are limited in length
+                    string processPath = GetProcPath(pid);
+                    processName = Path.GetFileName(processPath);
+                }
+                catch
+                {
+                    // Ignored
+                }
+
+                // Fallback to empty string if the process name could not be retrieved
+                processName ??= "";
+
                 if (!string.IsNullOrEmpty(processNameFilter) && !string.Equals(processName, processNameFilter, StringComparison.OrdinalIgnoreCase))
                 {
                     return null;
                 }
 
+                // Set the values we have; all the other values don't have meaning or don't exist on OSX
+                Interop.libproc.proc_taskallinfo temp = info.Value;
                 procInfo = new ProcessInfo()
                 {
                     ProcessId = pid,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/52860.

The OSX `ProcessManager` has been updated to extract the process name from its path, rather than relying on the 15-character-limited pbi_comm.

This change improves `GetProcessByName`, allowing the specification of the full process name for lookup. Additionally, `Process.ProcessName` now returns the full process name, aligning with the behavior of OSX's Activity Monitor.

Moreover, this update enables the retrieval of process names for which we lack privileges. For example, we can now obtain the pid and other basic information of the launchd process without elevation.