### PR TITLE
Override DbConnection.DbProviderFactory for ODBC/OleDB

### DIFF
--- a/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
+++ b/src/libraries/System.Data.Odbc/src/System/Data/Odbc/OdbcConnection.cs
@@ -143,6 +143,14 @@ namespace System.Data.Odbc
             }
         }
 
+        protected override DbProviderFactory DbProviderFactory
+        {
+            get
+            {
+                return OdbcFactory.Instance;
+            }
+        }
+
         internal OdbcConnectionPoolGroupProviderInfo ProviderInfo
         {
             get

--- a/src/libraries/System.Data.Odbc/tests/ConnectionTests.cs
+++ b/src/libraries/System.Data.Odbc/tests/ConnectionTests.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Data.Common;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.Data.Odbc.Tests
+{
+    public class ConnectionTests : IntegrationTestBase
+    {
+        // Bug #96278 fixed only on .NET, not on .NET Framework
+        [ConditionalFact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void DbConnectionFactories_GetFactory_from_connection()
+        {
+            DbProviderFactory factory = DbProviderFactories.GetFactory(connection);
+            Assert.Same(OdbcFactory.Instance, factory);
+        }
+    }
+}

--- a/src/libraries/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
+++ b/src/libraries/System.Data.Odbc/tests/System.Data.Odbc.Tests.csproj
@@ -8,6 +8,7 @@
     <DefineConstants Condition="'$(TargetPlatformIdentifier)' == 'windows' or $([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">$(DefineConstants);TargetsWindows</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ConnectionTests.cs" />
     <Compile Include="DependencyCheckTest.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="IntegrationTestBase.cs" />

--- a/src/libraries/System.Data.OleDb/src/OleDbConnection.cs
+++ b/src/libraries/System.Data.OleDb/src/OleDbConnection.cs
@@ -210,6 +210,14 @@ namespace System.Data.OleDb
             }
         }
 
+        protected override DbProviderFactory DbProviderFactory
+        {
+            get
+            {
+                return OleDbFactory.Instance;
+            }
+        }
+
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public void ResetState()
         {

--- a/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
+++ b/src/libraries/System.Data.OleDb/tests/OleDbConnectionTests.cs
@@ -416,5 +416,14 @@ namespace System.Data.OleDb.Tests
             string connStr = builder.ConnectionString;
             Assert.Equal($"Provider={provider};Data Source=myDB.mdb", connStr);
         }
+
+        // Bug #96278 fixed only on .NET, not on .NET Framework
+        [ConditionalFact(Helpers.IsDriverAvailable)]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public void DbConnectionFactories_GetFactory_from_connection()
+        {
+            DbProviderFactory factory = DbProviderFactories.GetFactory(connection);
+            Assert.Same(OleDbFactory.Instance, factory);
+        }
     }
 }


### PR DESCRIPTION
Fixes #96278