### PR TITLE
[NativeAOT] Creation of non-suspendable threads does not need to synchronize with the caller.

### DIFF
--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -573,7 +573,7 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
     UNREFERENCED_PARAMETER(name);
 
     if (!is_suspendable)
-        return CreateUnsuspendableThread(threadStart, arg, name);
+        return CreateNonSuspendableThread(threadStart, arg, name);
 
     ThreadStubArguments threadStubArgs;
     threadStubArgs.m_pRealStartRoutine = threadStart;

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -536,7 +536,7 @@ struct ThreadStubArguments
     CLREventStatic m_ThreadStartedEvent;
 };
 
-static bool CreateUnsuspendableThread(void (*threadStart)(void*), void* arg, const char* name)
+static bool CreateNonSuspendableThread(void (*threadStart)(void*), void* arg, const char* name)
 {
     UNREFERENCED_PARAMETER(name);
 

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -565,7 +565,13 @@ static bool CreateNonSuspendableThread(void (*threadStart)(void*), void* arg, co
             return 0;
         };
 
-    return PalStartBackgroundGCThread(threadStub, threadStubArgs);
+    if (!PalStartBackgroundGCThread(threadStub, threadStubArgs))
+    {
+        delete threadStubArgs;
+        return false;
+    }
+
+    return true;
 }
 
 bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -533,19 +533,51 @@ struct ThreadStubArguments
 {
     void (*m_pRealStartRoutine)(void*);
     void* m_pRealContext;
-    bool m_isSuspendable;
     CLREventStatic m_ThreadStartedEvent;
 };
+
+static bool CreateUnsuspendableThread(void (*threadStart)(void*), void* arg, const char* name)
+{
+    UNREFERENCED_PARAMETER(name);
+
+    ThreadStubArguments* threadStubArgs = new (nothrow) ThreadStubArguments();
+    if (!threadStubArgs)
+        return false;
+
+    threadStubArgs->m_pRealStartRoutine = threadStart;
+    threadStubArgs->m_pRealContext = arg;
+
+    // Helper used to wrap the start routine of GC threads so we can do things like initialize the
+    // thread state which requires running in the new thread's context.
+    auto threadStub = [](void* argument) -> DWORD
+        {
+            ThreadStore::RawGetCurrentThread()->SetGCSpecial();
+
+            ThreadStubArguments* pStartContext = (ThreadStubArguments*)argument;
+            auto realStartRoutine = pStartContext->m_pRealStartRoutine;
+            void* realContext = pStartContext->m_pRealContext;
+            delete pStartContext;
+
+            STRESS_LOG_RESERVE_MEM(GC_STRESSLOG_MULTIPLY);
+
+            realStartRoutine(realContext);
+
+            return 0;
+        };
+
+    return PalStartBackgroundGCThread(threadStub, threadStubArgs);
+}
 
 bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool is_suspendable, const char* name)
 {
     UNREFERENCED_PARAMETER(name);
 
-    ThreadStubArguments threadStubArgs;
+    if (!is_suspendable)
+        return CreateUnsuspendableThread(threadStart, arg, name);
 
+    ThreadStubArguments threadStubArgs;
     threadStubArgs.m_pRealStartRoutine = threadStart;
     threadStubArgs.m_pRealContext = arg;
-    threadStubArgs.m_isSuspendable = is_suspendable;
 
     if (!threadStubArgs.m_ThreadStartedEvent.CreateAutoEventNoThrow(false))
     {
@@ -553,34 +585,32 @@ bool GCToEEInterface::CreateThread(void (*threadStart)(void*), void* arg, bool i
     }
 
     // Helper used to wrap the start routine of background GC threads so we can do things like initialize the
-    // Redhawk thread state which requires running in the new thread's context.
+    // thread state which requires running in the new thread's context.
     auto threadStub = [](void* argument) -> DWORD
-    {
-        ThreadStubArguments* pStartContext = (ThreadStubArguments*)argument;
-
-        if (pStartContext->m_isSuspendable)
         {
+            ThreadStubArguments* pStartContext = (ThreadStubArguments*)argument;
+
             // Initialize the Thread for this thread. The false being passed indicates that the thread store lock
             // should not be acquired as part of this operation. This is necessary because this thread is created in
             // the context of a garbage collection and the lock is already held by the GC.
+            // This also implies that creation and initialization must proceed sequentially, one thread after another.
+            // GCToEEInterface::CreateThread will not return until the thread is done attaching itself.
             ASSERT(GCHeapUtilities::IsGCInProgress());
-
             ThreadStore::AttachCurrentThread(false);
-        }
 
-        ThreadStore::RawGetCurrentThread()->SetGCSpecial();
+            ThreadStore::RawGetCurrentThread()->SetGCSpecial();
 
-        auto realStartRoutine = pStartContext->m_pRealStartRoutine;
-        void* realContext = pStartContext->m_pRealContext;
+            auto realStartRoutine = pStartContext->m_pRealStartRoutine;
+            void* realContext = pStartContext->m_pRealContext;
 
-        pStartContext->m_ThreadStartedEvent.Set();
+            pStartContext->m_ThreadStartedEvent.Set();
 
-        STRESS_LOG_RESERVE_MEM(GC_STRESSLOG_MULTIPLY);
+            STRESS_LOG_RESERVE_MEM(GC_STRESSLOG_MULTIPLY);
 
-        realStartRoutine(realContext);
+            realStartRoutine(realContext);
 
-        return 0;
-    };
+            return 0;
+        };
 
     if (!PalStartBackgroundGCThread(threadStub, &threadStubArgs))
     {


### PR DESCRIPTION
Unlike suspendable threads that attach themselves to the threadstore without taking locks (and thus must be initialized sequentially one-by-one), unsuspendable threads have very trivial self-contained initialization and can be created in a shoot-and-forget way. 

On server GC we create #procs of GC threads early in startup and waiting for each of them to become runnable and able to communicate that to the caller before we start creating another is an unnecessary delay. 

On my machine (Windows10, AMD 5950X, 16 cores, 32 logical) this adds ~20% (1.1 msec.) to the time spent in `InitializeRuntime`.