### PR TITLE
riscv64 is now upstream Debian architecture

### DIFF
--- a/eng/common/cross/build-rootfs.sh
+++ b/eng/common/cross/build-rootfs.sh
@@ -182,12 +182,12 @@ while :; do
             __AlpinePackages="${__AlpinePackages// lldb-dev/}"
             __QEMUArch=riscv64
             __UbuntuArch=riscv64
-            __UbuntuRepo="http://deb.debian.org/debian-ports"
+            __UbuntuRepo="http://deb.debian.org/debian"
             __UbuntuPackages="${__UbuntuPackages// libunwind8-dev/}"
             unset __LLDB_Package
 
-            if [[ -e "/usr/share/keyrings/debian-ports-archive-keyring.gpg" ]]; then
-                __Keyring="--keyring /usr/share/keyrings/debian-ports-archive-keyring.gpg --include=debian-ports-archive-keyring"
+            if [[ -e "/usr/share/keyrings/debian-archive-keyring.gpg" ]]; then
+                __Keyring="--keyring /usr/share/keyrings/debian-archive-keyring.gpg --include=debian-archive-keyring"
             fi
             ;;
         ppc64le)

--- a/eng/common/cross/riscv64/sources.list.sid
+++ b/eng/common/cross/riscv64/sources.list.sid
@@ -1,1 +1,1 @@
-deb http://deb.debian.org/debian-ports sid main
+deb http://deb.debian.org/debian sid main


### PR DESCRIPTION
https://wiki.debian.org/RISC-V#Package_repository

```
sudo ./eng/common/cross/build-rootfs.sh riscv64 sid --rootfsdir ./riscv64-rootfs
```