### PR TITLE
Add osx RPATH in corehost

### DIFF
--- a/src/native/corehost/apphost/standalone/CMakeLists.txt
+++ b/src/native/corehost/apphost/standalone/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CLR_CMAKE_TARGET_OSX)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
 endif()
 
-# Add executable directory in rpath
+# Add executable directory in RPATH
 if (CLR_CMAKE_TARGET_APPLE)
     set(CMAKE_INSTALL_RPATH "@executable_path")
 else ()

--- a/src/native/corehost/apphost/standalone/CMakeLists.txt
+++ b/src/native/corehost/apphost/standalone/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 if (CLR_CMAKE_TARGET_APPLE)
     set(CMAKE_INSTALL_RPATH "@executable_path")
 else ()
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};\$ORIGIN")
 endif()
 
 set(SKIP_VERSIONING 1)

--- a/src/native/corehost/apphost/standalone/CMakeLists.txt
+++ b/src/native/corehost/apphost/standalone/CMakeLists.txt
@@ -4,14 +4,22 @@
 project(apphost)
 set(DOTNET_PROJECT_NAME "apphost")
 
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
 # Add RPATH to the apphost binary that allows using local copies of shared libraries
 # dotnet core depends on for special scenarios when system wide installation of such
 # dependencies is not possible for some reason.
 # This cannot be enabled for MacOS (Darwin) since its RPATH works in a different way,
 # doesn't apply to libraries loaded via dlopen and most importantly, it is not transitive.
 if (NOT CLR_CMAKE_TARGET_OSX)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
+endif()
+
+# Add executable directory in rpath
+if (CLR_CMAKE_TARGET_APPLE)
+    set(CMAKE_INSTALL_RPATH "@executable_path")
+else ()
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 endif()
 
 set(SKIP_VERSIONING 1)

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -4,14 +4,22 @@
 project(singlefilehost)
 set(DOTNET_PROJECT_NAME "singlefilehost")
 
+set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+
 # Add RPATH to the apphost binary that allows using local copies of shared libraries
 # dotnet core depends on for special scenarios when system wide installation of such
 # dependencies is not possible for some reason.
 # This cannot be enabled for MacOS (Darwin) since its RPATH works in a different way,
 # doesn't apply to libraries loaded via dlopen and most importantly, it is not transitive.
 if (NOT CLR_CMAKE_TARGET_APPLE)
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
+endif()
+
+# Add executable directory in rpath
+if (CLR_CMAKE_TARGET_APPLE)
+    set(CMAKE_INSTALL_RPATH "@executable_path")
+else ()
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 endif()
 
 set(SKIP_VERSIONING 1)

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 if (CLR_CMAKE_TARGET_APPLE)
     set(CMAKE_INSTALL_RPATH "@executable_path")
 else ()
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};\$ORIGIN")
 endif()
 
 set(SKIP_VERSIONING 1)

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CLR_CMAKE_TARGET_APPLE)
     set(CMAKE_INSTALL_RPATH "\$ORIGIN/netcoredeps")
 endif()
 
-# Add executable directory in rpath
+# Add executable directory in RPATH
 if (CLR_CMAKE_TARGET_APPLE)
     set(CMAKE_INSTALL_RPATH "@executable_path")
 else ()


### PR DESCRIPTION
Fix #96337.

i.e. .NET interop does check the "executable directory" while loading a lib on Unix, but if the requested lib itself requires another lib from its own directory, the OS library loader then depends on RPATH which we were missing. This PR adds explicit RPATH so OS library loader gets the same hint path used by .NET library loading fallback implementation.

Tested on osx-arm64.