### PR TITLE
[mono] Do not throw in AssemblyExtensions.TryGetRawMetadata.

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using System.Reflection.Metadata;
+using System.Reflection;
+
+namespace System.Runtime.Loader.Tests
+{
+    public unsafe class AssemblyExtensionsTest
+    {
+        [Fact]
+        public void TryGetRawMetadata()
+        {
+            bool supportsRawMetadata = PlatformDetection.IsNotMonoRuntime && PlatformDetection.IsNotNativeAot;
+
+            Assembly assembly = typeof(AssemblyExtensionsTest).Assembly;
+            bool hasMetadata = assembly.TryGetRawMetadata(out byte* blob, out int length);
+
+            Assert.Equal(supportsRawMetadata, hasMetadata);
+            Assert.Equal(supportsRawMetadata, blob != null);
+            Assert.Equal(supportsRawMetadata, length > 0);
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyExtensionsTest.cs
@@ -20,6 +20,13 @@ namespace System.Runtime.Loader.Tests
             Assert.Equal(supportsRawMetadata, hasMetadata);
             Assert.Equal(supportsRawMetadata, blob != null);
             Assert.Equal(supportsRawMetadata, length > 0);
+
+            if (supportsRawMetadata)
+            {
+                var metadataReader = new MetadataReader(blob, length);
+                string assemblyName = metadataReader.GetString(metadataReader.GetAssemblyDefinition().Name);
+                Assert.Equal(assembly.GetName().Name, assemblyName);
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <RootNamespace>System.Runtime.Loader.Tests</RootNamespace>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <!-- Some tests rely on no deps.json file being present. -->
@@ -16,6 +17,7 @@
   <ItemGroup>
     <Compile Include="ApplyUpdateTest.cs" />
     <Compile Include="ApplyUpdateUtil.cs" />
+    <Compile Include="AssemblyExtensionsTest.cs" />
     <Compile Include="AssemblyLoadContextTest.cs" />
     <Compile Include="CollectibleAssemblyLoadContextTest.cs" />
     <Compile Include="ContextualReflection.cs" />

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -8,6 +8,13 @@ namespace System.Reflection.Metadata
     public static class AssemblyExtensions
     {
         [CLSCompliant(false)]
-        public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length) => throw new NotImplementedException();
+        public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+
+            blob = null;
+            length = 0;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
A `Try***` method should not throw. This PR changes the method to return false, [just like Native AOT](https://github.com/dotnet/runtime/blob/2de9facc8668bac0d8b9d53f9e2bd654a1f49e9b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs).