### PR TITLE
[release/8.0-staging] Skip address for x64 prefix parsing

### DIFF
--- a/src/coreclr/debug/ee/amd64/walker.cpp
+++ b/src/coreclr/debug/ee/amd64/walker.cpp
@@ -929,7 +929,6 @@ void NativeWalker::DecodeInstructionForPatchSkip(const BYTE *address, Instructio
         case 0x45:
         case 0x46:
         case 0x47:
-            done = true;
             break;
 
         // REX register extension prefixes with W
@@ -942,7 +941,6 @@ void NativeWalker::DecodeInstructionForPatchSkip(const BYTE *address, Instructio
         case 0x4e:
         case 0x4f:
             W = true;
-            done = true;
             break;
 
         default:


### PR DESCRIPTION
## Description

Fixes customer reported issue in #96322.  

As part of AVX-512 work in .NET 8 we changed the .NET debugger breakpoint patching code to support EVEX instruction sets.  As part of the change, we incidentally broke instruction relative breakpoint patching by treating instruction prefixes as opcodes.  A customer found the issue when stepping over a function call that happened to use one of these instructions to pass in function parameters.  

This backport of #96352 from main.

## Customer Impact 

Customer reported issue.  May cause AV debugged process when stepping over a function that takes multiple parameters.  For an example, please see #96322.

## Regression? 

Regression from .NET 7

## Risk 

Low, changes stepping code to match previous behavior.  Validated stepping on windows x64 on both AVX512 and non-AVX512 hardware, and tested `Vector512<T>` debugging to ensure that values were not being corrupted.