### PR TITLE
Remove ActiveIssue for passing tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/EnumTests.cs
@@ -1599,7 +1599,6 @@ namespace System.Tests
         private class ClassWithEnumConstraint<T> where T : Enum { }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/94189", typeof(PlatformDetection), nameof(PlatformDetection.IsReadyToRunCompiled))]
         public void EnumConstraint_ThrowsArgumentException()
         {
             Type genericArgumentWithEnumConstraint = typeof(ClassWithEnumConstraint<>).GetGenericArguments()[0];

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.Get.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.Get.cs
@@ -55,7 +55,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetInterface_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/94189", typeof(PlatformDetection), nameof(PlatformDetection.IsReadyToRunCompiled))]
         public void GetInterface_Invoke_ReturnsExpected(Type type, string name, bool ignoreCase, Type expected)
         {
             if (!ignoreCase)


### PR DESCRIPTION
This was ~~likely~~ fixed in #96358.

Cc @dotnet/crossgen-contrib 