### PR TITLE
Use `SearchValues<string>` for prefix searching in RegexCompiler / source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunner.cs
@@ -1,8 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Globalization;
+
+#pragma warning disable CA1823, CS0169, IDE0044 // Fields used via reflection
 
 namespace System.Text.RegularExpressions
 {
@@ -10,18 +11,19 @@ namespace System.Text.RegularExpressions
     {
         private readonly ScanDelegate _scanMethod;
 
-        private readonly SearchValues<char>[]? _searchValues;
+        /// <summary>Set if the regex uses any SearchValues instances. Accessed via reflection.</summary>
+        /// <remarks>If the array is non-null, this contains instances of SearchValues{char} or SearchValues{string}.</remarks>
+        private readonly object[]? _searchValues;
 
-        /// <summary>This field will only be set if the pattern contains backreferences and has RegexOptions.IgnoreCase</summary>
+        /// <summary>Set if the pattern contains backreferences and has RegexOptions.IgnoreCase. Accessed via reflection.</summary>
         private readonly CultureInfo? _culture;
 
-#pragma warning disable CA1823, CS0169, IDE0044 // Used via reflection to cache the Case behavior if needed.
+        /// <summary>Caches a RegexCaseBehavior. Accessed via reflection.</summary>
         private RegexCaseBehavior _caseBehavior;
-#pragma warning restore CA1823, CS0169, IDE0044
 
         internal delegate void ScanDelegate(RegexRunner runner, ReadOnlySpan<char> text);
 
-        public CompiledRegexRunner(ScanDelegate scan, SearchValues<char>[]? searchValues, CultureInfo? culture)
+        public CompiledRegexRunner(ScanDelegate scan, object[]? searchValues, CultureInfo? culture)
         {
             _scanMethod = scan;
             _searchValues = searchValues;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CompiledRegexRunnerFactory.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers;
 using System.Globalization;
 using System.Reflection.Emit;
 
@@ -10,14 +9,14 @@ namespace System.Text.RegularExpressions
     internal sealed class CompiledRegexRunnerFactory : RegexRunnerFactory
     {
         private readonly DynamicMethod _scanMethod;
-        private readonly SearchValues<char>[]? _searchValues;
+        private readonly object[]? _searchValues;
         /// <summary>This field will only be set if the pattern has backreferences and uses RegexOptions.IgnoreCase</summary>
         private readonly CultureInfo? _culture;
 
         // Delegate is lazily created to avoid forcing JIT'ing until the regex is actually executed.
         private CompiledRegexRunner.ScanDelegate? _scan;
 
-        public CompiledRegexRunnerFactory(DynamicMethod scanMethod, SearchValues<char>[]? searchValues, CultureInfo? culture)
+        public CompiledRegexRunnerFactory(DynamicMethod scanMethod, object[]? searchValues, CultureInfo? culture)
         {
             _scanMethod = scanMethod;
             _searchValues = searchValues;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -519,7 +519,7 @@ namespace System.Text.RegularExpressions.Tests
                                     {
                                         // The pattern has the literal "href" at the beginning of the pattern. Find the next occurrence.
                                         // If it can't be found, there's no match.
-                                        int i = inputSpan.Slice(pos).IndexOf("href");
+                                        int i = inputSpan.Slice(pos).IndexOfAny(Utilities.s_indexOfString_href_Ordinal);
                                         if (i >= 0)
                                         {
                                             base.runtextpos = pos + i;
@@ -706,6 +706,13 @@ namespace System.Text.RegularExpressions.Tests
 
                     }
 
+                    /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
+                    [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "42.42.42.42")]
+                    file static class Utilities
+                    {
+                        /// <summary>Supports searching for the string "href".</summary>
+                        internal static readonly SearchValues<string> s_indexOfString_href_Ordinal = SearchValues.Create(["href"], StringComparison.Ordinal);
+                    }
                 }
                 """
             };


### PR DESCRIPTION
We currently use IndexOf(literal), but every call to that incurs a little overhead to determine how best to do the search. Now that we have `SearchValues<string>`, even though it's bread-and-butter is searching for multiple substrings, we can use it to search for a single substring, in which case it's effectively the same as IndexOf(literal) but caching the result of that examination in order to only do it once rather than on every call.

This also introduces some of the infrastructure necessary to subsequently enable multi-substring search.

Contributes to https://github.com/dotnet/runtime/issues/85693

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[HideColumns("Error", "StdDev", "Median", "RatioSD")]
[MemoryDiagnoser(false)]
public partial class Tests
{
    private Regex _regex;
    private string _haystack;

    [Params(true, false)]
    public bool IgnoreCase { get; set; }

    [Params("hello", "hithere")]
    public string Haystack { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _regex = new Regex(@"hello\d", RegexOptions.Compiled | (IgnoreCase ? RegexOptions.IgnoreCase : RegexOptions.None));
        _haystack = string.Concat(Enumerable.Repeat(Haystack, 1000));
    }

    [Benchmark]
    public int Count() => _regex.Count(_haystack);
}
```

| Method | Toolchain         | IgnoreCase | Haystack | Mean        | Ratio |
|-------  |------------------ |----------- |--------- |------------:|------:|
| Count  | \main\corerun.exe | False      | hello    | 13,957.2 ns |  1.00 |
| Count  | \pr\corerun.exe   | False      | hello    | 12,158.0 ns |  0.87 |
|        |                   |            |          |             |       |
| Count   | \main\corerun.exe | False      | hithere  |    556.9 ns |  1.00 |
| Count   | \pr\corerun.exe   | False      | hithere  |    370.6 ns |  0.67 |
|        |                   |            |          |             |       |
| Count   | \main\corerun.exe | True       | hello    | 15,978.6 ns |  1.00 |
| Count   | \pr\corerun.exe   | True       | hello    | 12,183.9 ns |  0.76 |
|        |                   |            |          |             |       |
| Count  | \main\corerun.exe | True       | hithere  |    485.9 ns |  1.00 |
| Count  | \pr\corerun.exe   | True       | hithere  |    499.3 ns |  1.03 |