### PR TITLE
JIT: Set false target for predecessor to first cold block

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3225,6 +3225,7 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                         BasicBlock* transitionBlock =
                             fgNewBBafter(BBJ_ALWAYS, prevToFirstColdBlock, true, firstColdBlock);
                         transitionBlock->inheritWeight(firstColdBlock);
+                        prevToFirstColdBlock->SetFalseTarget(transitionBlock);
 
                         // Update the predecessor list for firstColdBlock
                         fgReplacePred(firstColdBlock, prevToFirstColdBlock, transitionBlock);


### PR DESCRIPTION
Fixes #96391. In #96265, I neglected to set the false target for `BBJ_COND` blocks preceding the first cold block when inserting a fixup block between the two.