### PR TITLE
Recover from failed OCSP download.

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -257,6 +257,14 @@ namespace System.Net.Security
                 GC.KeepAlive(caCert);
 
                 _pendingDownload = null;
+                if (ret == null)
+                {
+                    // all download attempts failed, don't try again for 5 seconds.
+                    // Note that if server does not send OCSP staples, clients may still
+                    // contact OCSP responders directly.
+                    _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
+                    _ocspExpiration = _nextDownload;
+                }
                 return ret;
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -247,7 +247,6 @@ namespace System.Net.Security
                         _ocspResponse = ret;
                         _ocspExpiration = expiration;
                         _nextDownload = nextCheckA < nextCheckB ? nextCheckA : nextCheckB;
-                        _pendingDownload = null;
                         break;
                     }
                 }
@@ -256,6 +255,8 @@ namespace System.Net.Security
                 ArrayPool<char>.Shared.Return(rentedChars.Array!);
                 GC.KeepAlive(TargetCertificate);
                 GC.KeepAlive(caCert);
+
+                _pendingDownload = null;
                 return ret;
             }
         }


### PR DESCRIPTION
Fixes #96770

When performing OCSP stapling by server and we get invalid response from the OCSP server (either because we don't get any data back or parsing the OCSP response fails), the server will never try to fetch OCSP again because the `SslStreamCertificateContext._pendingDownload` field still contains the previous task. As a consequence, the server will stop sending OCSP staples after the failure.

This PR moves the `_pendingDownload = null` assignment to a place where it is guaranteed to execute.

This has a potential pitfall when the given OCSP server is unhealthy (and consistently returning bad response), then we would potentially issue many requests to it. But I understand that if server does not send OCSP staple then clients may fetch the staple themselves, so I am not 100% sure if mitigation from our side changes much. @bartonjs, @vcsjones, what do you think? If we should mitigate it, what mechanism do you suggest? exponential back-off, or maybe even a simple rate-limiting of max 1 request per x minutes?