### PR TITLE
Warn when building C++/CLI tests not in a command prompt and don't try copying the files if we aren't in one

### DIFF
--- a/src/tests/Interop/Directory.Build.targets
+++ b/src/tests/Interop/Directory.Build.targets
@@ -11,8 +11,9 @@
   <Target Name="CopyInteropNativeRuntimeDependencies"
     BeforeTargets="CopyAllNativeProjectReferenceBinaries"
     Condition="'$(TargetsWindows)' == 'true' And ('$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Checked') And '$(CopyDebugCRTDllsToOutputDirectory)' == 'true'" >
+    <Warning Message="Building C++/CLI tests requires a Visual Studio Dev Command Prompt" Condition="'$(VCToolsRedistDir)' == '' or '$(ExtensionSdkDir)' == ''" />
     <!-- Required debug vcruntime and UCRT dlls -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(VCToolsRedistDir)' != '' and '$(ExtensionSdkDir)' != ''">
       <InteropNativeRuntimeDependencies Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(TargetArchitecture)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" />
       <InteropNativeRuntimeDependencies Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(TargetArchitecture)/Microsoft.VC*.DebugCRT/msvcp*d.dll" />
       <InteropNativeRuntimeDependencies Include="$(ExtensionSdkDir)/Microsoft.UniversalCRT.Debug/$(UCRTVersion)/Redist/Debug/$(TargetArchitecture)/ucrtbased.dll" />


### PR DESCRIPTION
This will allow devs to use dotnet build to build the Interop test suite and still run non C++/CLI tests while using `dotnet build`.