### PR TITLE
Fix source_file bug in mono_ppdb_lookup_location_internal

### DIFF
--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -406,7 +406,9 @@ mono_ppdb_lookup_location_internal (MonoImage *image, int idx, uint32_t offset, 
 	start_col = 0;
 	while (ptr < end) {
 		guint32 delta_il = mono_metadata_decode_value (ptr, &ptr);
-		if (!first && delta_il == 0) {
+		// check the current iloffset to ensure that we do not update docname after the target
+		// offset has been reached (the updated docname will be for the next sequence point)
+		if (!first && delta_il == 0 && iloffset < offset) {
 			/* document-record */
 			docidx = mono_metadata_decode_value (ptr, &ptr);
 			docname = get_docname (ppdb, image, docidx);


### PR DESCRIPTION
document-records affect sequence points that follow in the byte stream, not points previously read.

When reading the document-record we may already be at the target offset. Do not update docname local if we have reached the end target already otherwise the wrong source_file will be reported for the requested offset