### PR TITLE
Refactor exception trackers

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -161,12 +161,12 @@ class AsmOffsets
     public const int SIZEOF__EHEnum = 0x10;
     public const int OFFSETOF__StackFrameIterator__m_pRegDisplay = 0x218;
     public const int OFFSETOF__ExInfo__m_pPrevExInfo = 0;
-    public const int OFFSETOF__ExInfo__m_pExContext = 0x10;
-    public const int OFFSETOF__ExInfo__m_exception = 0x14;
-    public const int OFFSETOF__ExInfo__m_kind = 0x18;
-    public const int OFFSETOF__ExInfo__m_passNumber = 0x19;
-    public const int OFFSETOF__ExInfo__m_idxCurClause = 0x1C;
-    public const int OFFSETOF__ExInfo__m_frameIter = 0x24;
+    public const int OFFSETOF__ExInfo__m_pExContext = 0x70;
+    public const int OFFSETOF__ExInfo__m_exception = 0x74;
+    public const int OFFSETOF__ExInfo__m_kind = 0x78;
+    public const int OFFSETOF__ExInfo__m_passNumber = 0x79;
+    public const int OFFSETOF__ExInfo__m_idxCurClause = 0x7C;
+    public const int OFFSETOF__ExInfo__m_frameIter = 0x80;
     public const int OFFSETOF__ExInfo__m_notifyDebuggerSP = OFFSETOF__ExInfo__m_frameIter + SIZEOF__StackFrameIterator;
 #endif // TARGET_64BIT
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -150,23 +150,23 @@ class AsmOffsets
     public const int SIZEOF__EHEnum = 0x20;
     public const int OFFSETOF__StackFrameIterator__m_pRegDisplay = 0x228;
     public const int OFFSETOF__ExInfo__m_pPrevExInfo = 0;
-    public const int OFFSETOF__ExInfo__m_pExContext = 8;
-    public const int OFFSETOF__ExInfo__m_exception = 0x10;
-    public const int OFFSETOF__ExInfo__m_kind = 0x18;
-    public const int OFFSETOF__ExInfo__m_passNumber = 0x19;
-    public const int OFFSETOF__ExInfo__m_idxCurClause = 0x1c;
-    public const int OFFSETOF__ExInfo__m_frameIter = 0x20;
+    public const int OFFSETOF__ExInfo__m_pExContext = 0xc0;
+    public const int OFFSETOF__ExInfo__m_exception = 0xc8;
+    public const int OFFSETOF__ExInfo__m_kind = 0xd0;
+    public const int OFFSETOF__ExInfo__m_passNumber = 0xd1;
+    public const int OFFSETOF__ExInfo__m_idxCurClause = 0xd4;
+    public const int OFFSETOF__ExInfo__m_frameIter = 0xe0;
     public const int OFFSETOF__ExInfo__m_notifyDebuggerSP = OFFSETOF__ExInfo__m_frameIter + SIZEOF__StackFrameIterator;
 #else // TARGET_64BIT
     public const int SIZEOF__EHEnum = 0x10;
     public const int OFFSETOF__StackFrameIterator__m_pRegDisplay = 0x218;
     public const int OFFSETOF__ExInfo__m_pPrevExInfo = 0;
-    public const int OFFSETOF__ExInfo__m_pExContext = 4;
-    public const int OFFSETOF__ExInfo__m_exception = 8;
-    public const int OFFSETOF__ExInfo__m_kind = 0xC;
-    public const int OFFSETOF__ExInfo__m_passNumber = 0xD;
-    public const int OFFSETOF__ExInfo__m_idxCurClause = 0x10;
-    public const int OFFSETOF__ExInfo__m_frameIter = 0x18;
+    public const int OFFSETOF__ExInfo__m_pExContext = 0x10;
+    public const int OFFSETOF__ExInfo__m_exception = 0x14;
+    public const int OFFSETOF__ExInfo__m_kind = 0x18;
+    public const int OFFSETOF__ExInfo__m_passNumber = 0x19;
+    public const int OFFSETOF__ExInfo__m_idxCurClause = 0x1C;
+    public const int OFFSETOF__ExInfo__m_frameIter = 0x24;
     public const int OFFSETOF__ExInfo__m_notifyDebuggerSP = OFFSETOF__ExInfo__m_frameIter + SIZEOF__StackFrameIterator;
 #endif // TARGET_64BIT
 
@@ -200,7 +200,7 @@ class AsmOffsets
     static_assert_no_msg(offsetof(StackFrameIterator, m_isRuntimeWrappedExceptions) == OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions);
     static_assert_no_msg(offsetof(StackFrameIterator, m_AdjustedControlPC) == OFFSETOF__StackFrameIterator__m_AdjustedControlPC);
     static_assert_no_msg(sizeof(ExtendedEHClauseEnumerator) == AsmOffsets::SIZEOF__EHEnum);
-    static_assert_no_msg(offsetof(ExInfo, m_pPrevExInfo) == OFFSETOF__ExInfo__m_pPrevExInfo);
+    static_assert_no_msg(offsetof(ExInfo, m_pPrevNestedInfo) == OFFSETOF__ExInfo__m_pPrevExInfo);
     static_assert_no_msg(offsetof(ExInfo, m_pExContext) == OFFSETOF__ExInfo__m_pExContext);
     static_assert_no_msg(offsetof(ExInfo, m_exception) == OFFSETOF__ExInfo__m_exception);
     static_assert_no_msg(offsetof(ExInfo, m_kind) == OFFSETOF__ExInfo__m_kind);

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -3393,7 +3393,7 @@ private:
 //----------------------------------------------------------------------------
 
 #ifdef FEATURE_EH_FUNCLETS
-typedef ExceptionTracker ClrDataExStateType;
+typedef ExceptionTrackerBase ClrDataExStateType;
 #else // FEATURE_EH_FUNCLETS
 typedef ExInfo ClrDataExStateType;
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3148,7 +3148,7 @@ ClrDataAccess::GetNestedExceptionData(CLRDATA_ADDRESS exception, CLRDATA_ADDRESS
     SOSDacEnter();
 
 #ifdef FEATURE_EH_FUNCLETS
-    ExceptionTracker *pExData = PTR_ExceptionTracker(TO_TADDR(exception));
+    ExceptionTrackerBase *pExData = PTR_ExceptionTrackerBase(TO_TADDR(exception));
 #else
     ExInfo *pExData = PTR_ExInfo(TO_TADDR(exception));
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/clrex.cpp
+++ b/src/coreclr/vm/clrex.cpp
@@ -856,7 +856,7 @@ void CLRException::HandlerState::SetupCatch(INDEBUG_COMMA(_In_z_ const char * sz
     }
 
 #ifdef FEATURE_EH_FUNCLETS
-    if (!DidCatchCxx())
+    if (!DidCatchCxx() && !g_isNewExceptionHandlingEnabled)
     {
         // this must be done after the second pass has run, it does not
         // reference anything on the stack, so it is safe to run in an

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2764,7 +2764,7 @@ VOID ETW::ExceptionLog::ExceptionThrown(CrawlFrame  *pCf, BOOL bIsReThrownExcept
 #ifndef FEATURE_EH_FUNCLETS
         PTR_ExInfo pExInfo = NULL;
 #else
-        PTR_ExceptionTracker pExInfo = NULL;
+        PTR_ExceptionTrackerBase pExInfo = NULL;
 #endif //!FEATURE_EH_FUNCLETS
         pExInfo = pExState->GetCurrentExceptionTracker();
         _ASSERTE(pExInfo != NULL);

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -8659,11 +8659,7 @@ void SetupWatsonBucketsForUEF(BOOL fUseLastThrownObject)
     // But if the tracker exists, simply copy the bucket details to the UE Watson Bucket
     // tracker for use by the "WatsonLastChance" path.
     BOOL fDoWeHaveWatsonBuckets = FALSE;
-    if ((pExState->GetCurrentExceptionTracker() != NULL)
-#ifdef FEATURE_EH_FUNCLETS
-        || (pExState->GetCurrentExInfo() != NULL)
-#endif // FEATURE_EH_FUNCLETS
-    )
+    if (pExState->GetCurrentExceptionTracker() != NULL)
     {
         // Check the exception state if we have Watson bucket details
         fDoWeHaveWatsonBuckets = pExState->GetFlags()->GotWatsonBucketDetails();
@@ -9360,17 +9356,7 @@ void SetupInitialThrowBucketDetails(UINT_PTR adjustedIp)
     // being thrown, then get them.
     ThreadExceptionState *pExState = pThread->GetExceptionState();
 
-#ifdef FEATURE_EH_FUNCLETS
-    // Ensure that the exception tracker exists
-    if (g_isNewExceptionHandlingEnabled)
-    {
-        _ASSERTE(pExState->GetCurrentExInfo() != NULL);
-    }
-    else
-#endif // FEATURE_EH_FUNCLETS
-    {
-        _ASSERTE(pExState->GetCurrentExceptionTracker() != NULL);
-    }
+    _ASSERTE(pExState->GetCurrentExceptionTracker() != NULL);
 
     // Switch to COOP mode
     GCX_COOP();
@@ -9395,17 +9381,7 @@ void SetupInitialThrowBucketDetails(UINT_PTR adjustedIp)
 
     // Get the WatsonBucketTracker for the current exception
     PTR_EHWatsonBucketTracker pWatsonBucketTracker;
-#ifdef FEATURE_EH_FUNCLETS
-    if (g_isNewExceptionHandlingEnabled)
-    {
-        pWatsonBucketTracker = pExState->GetCurrentExInfo()->GetWatsonBucketTracker();
-
-    }
-    else
-#endif // FEATURE_EH_FUNCLETS
-    {
-        pWatsonBucketTracker = pExState->GetCurrentExceptionTracker()->GetWatsonBucketTracker();
-    }
+    pWatsonBucketTracker = pExState->GetCurrentExceptionTracker()->GetWatsonBucketTracker();
 
     // Get the innermost exception object (if any)
     gc.oInnerMostExceptionThrowable = ((EXCEPTIONREF)gc.oCurrentThrowable)->GetBaseException();
@@ -10864,18 +10840,8 @@ void ExceptionNotifications::DeliverFirstChanceNotification()
     // processing for subsequent frames on the stack since FirstChance notification
     // will be delivered only when the exception is first thrown/rethrown.
     ThreadExceptionState *pCurTES = GetThread()->GetExceptionState();
-#ifdef FEATURE_EH_FUNCLETS
-    if (g_isNewExceptionHandlingEnabled)
-    {
-        _ASSERTE(pCurTES->GetCurrentExInfo());
-        _ASSERTE(!(pCurTES->GetCurrentExInfo()->DeliveredFirstChanceNotification()));
-    }
-    else
-#endif // FEATURE_EH_FUNCLETS
-    {
-        _ASSERTE(pCurTES->GetCurrentExceptionTracker());
-        _ASSERTE(!(pCurTES->GetCurrentExceptionTracker()->DeliveredFirstChanceNotification()));
-    }
+    _ASSERTE(pCurTES->GetCurrentExceptionTracker());
+    _ASSERTE(!(pCurTES->GetCurrentExceptionTracker()->DeliveredFirstChanceNotification()));
     {
         GCX_COOP();
         if (ExceptionNotifications::CanDeliverNotificationToCurrentAppDomain(FirstChanceExceptionHandler))
@@ -10891,18 +10857,8 @@ void ExceptionNotifications::DeliverFirstChanceNotification()
 
         }
 
-#ifdef FEATURE_EH_FUNCLETS
-        if (g_isNewExceptionHandlingEnabled)
-        {
-            // Mark the exception info as having delivered the first chance notification
-            pCurTES->GetCurrentExInfo()->SetFirstChanceNotificationStatus(TRUE);
-        }
-        else
-#endif // FEATURE_EH_FUNCLETS
-        {
-            // Mark the exception tracker as having delivered the first chance notification
-            pCurTES->GetCurrentExceptionTracker()->SetFirstChanceNotificationStatus(TRUE);
-        }
+        // Mark the exception tracker as having delivered the first chance notification
+        pCurTES->GetCurrentExceptionTracker()->SetFirstChanceNotificationStatus(TRUE);
     }
 }
 

--- a/src/coreclr/vm/exceptionhandling.h
+++ b/src/coreclr/vm/exceptionhandling.h
@@ -55,8 +55,162 @@ enum class InlinedCallFrameMarker
     Mask = ExceptionHandlingHelper | SecondPassFuncletCaller
 };
 
+typedef DPTR(struct ExceptionTrackerBase) PTR_ExceptionTrackerBase;
+
+struct ExceptionTrackerBase
+{
+    struct DAC_EXCEPTION_POINTERS
+    {
+        PTR_EXCEPTION_RECORD    ExceptionRecord;
+        PTR_CONTEXT             ContextRecord;
+    };
+
+    class StackRange
+    {
+    public:
+        StackRange();
+        void Reset();
+        bool IsEmpty();
+        bool IsSupersededBy(StackFrame sf);
+        void CombineWith(StackFrame sfCurrent, StackRange* pPreviousRange);
+        bool Contains(StackFrame sf);
+        void ExtendUpperBound(StackFrame sf);
+        void ExtendLowerBound(StackFrame sf);
+        void TrimLowerBound(StackFrame sf);
+        StackFrame GetLowerBound();
+        StackFrame GetUpperBound();
+        void SetLowerBound(StackFrame sf);
+        void SetUpperBound(StackFrame sf);
+        INDEBUG(bool IsDisjointWithAndLowerThan(StackRange* pOtherRange));
+    private:
+        INDEBUG(bool IsConsistent());
+
+    private:
+        // <TODO> can we use a smaller encoding? </TODO>
+        StackFrame          m_sfLowBound;
+        StackFrame          m_sfHighBound;
+    };
+
+    // Previous ExInfo in the chain of exceptions rethrown from their catch / finally handlers
+    PTR_ExceptionTrackerBase m_pPrevNestedInfo;
+    // thrown exception object handle
+    OBJECTHANDLE    m_hThrowable;
+    // EXCEPTION_RECORD and CONTEXT_RECORD describing the exception and its location
+    DAC_EXCEPTION_POINTERS m_ptrs;
+    // Stack trace of the current exception
+    StackTraceInfo m_StackTraceInfo;
+    // Information for the funclet we are calling
+    EHClauseInfo   m_EHClauseInfo;
+    // Flags representing exception handling state (exception is rethrown, unwind has started, various debugger notifications sent etc)
+    ExceptionFlags m_ExceptionFlags;
+    // Set to TRUE when the first chance notification was delivered for the current exception
+    BOOL           m_fDeliveredFirstChanceNotification;
+    // Code of the current exception
+    DWORD          m_ExceptionCode;
+#ifdef DEBUGGING_SUPPORTED
+    // Stores information necessary to intercept an exception
+    DebuggerExState m_DebuggerExState;
+#endif // DEBUGGING_SUPPORTED
+    // Low and high bounds of the stack unwound by the exception.
+    // In the new EH implementation, they are updated during 2nd pass only.
+    StackRange      m_ScannedStackRange;
+
+#ifndef TARGET_UNIX
+protected:
+    EHWatsonBucketTracker m_WatsonBucketTracker;
+public:
+    inline PTR_EHWatsonBucketTracker GetWatsonBucketTracker()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return PTR_EHWatsonBucketTracker(PTR_HOST_MEMBER_TADDR(ExceptionTrackerBase, this, m_WatsonBucketTracker));
+    }
+#endif // !TARGET_UNIX
+
+    ExceptionTrackerBase() :
+        m_pPrevNestedInfo((ExceptionTrackerBase*)NULL),
+        m_hThrowable(NULL),
+        m_fDeliveredFirstChanceNotification(FALSE)
+    {
+        
+    }
+
+    // Returns the exception tracker previous to the current
+    inline PTR_ExceptionTrackerBase GetPreviousExceptionTracker()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pPrevNestedInfo;
+    }
+
+    inline OBJECTREF GetThrowable()
+    {
+        CONTRACTL
+        {
+            MODE_COOPERATIVE;
+            NOTHROW;
+            GC_NOTRIGGER;
+        }
+        CONTRACTL_END;
+
+        if (NULL != m_hThrowable)
+        {
+            return ObjectFromHandle(m_hThrowable);
+        }
+
+        return NULL;
+    }
+
+    inline BOOL DeliveredFirstChanceNotification()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_fDeliveredFirstChanceNotification;
+    }
+
+    inline void SetFirstChanceNotificationStatus(BOOL fDelivered)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        m_fDeliveredFirstChanceNotification = fDelivered;
+    }
+
+    DWORD GetExceptionCode()
+    {
+        return m_ExceptionCode;
+    }
+
+    StackRange GetScannedStackRange()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_ScannedStackRange;
+    }
+
+    bool IsInFirstPass()
+    {
+        return !m_ExceptionFlags.UnwindHasStarted();
+    }
+
+#ifndef DACCESS_COMPILE
+    void DestroyExceptionHandle()
+    {
+        // Never, ever destroy a preallocated exception handle.
+        if ((m_hThrowable != NULL) && !CLRException::IsPreallocatedExceptionHandle(m_hThrowable))
+        {
+            DestroyHandle(m_hThrowable);
+        }
+
+        m_hThrowable = NULL;
+    }
+#endif // !DACCESS_COMPILE
+
+#ifdef DACCESS_COMPILE
+    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
+#endif // DACCESS_COMPILE
+};
+
 typedef DPTR(class ExceptionTracker) PTR_ExceptionTracker;
-class ExceptionTracker
+class ExceptionTracker : public ExceptionTrackerBase
 {
     friend class TrackerAllocator;
     friend class ThreadExceptionState;
@@ -67,13 +221,10 @@ class ExceptionTracker
 
     friend void FreeTrackerMemory(ExceptionTracker* pTracker, TrackerMemoryType mem);
 
-private:
-    class StackRange;
 public:
 
     ExceptionTracker() :
-        m_pThread(NULL),
-        m_hThrowable(NULL)
+        m_pThread(NULL)
     {
 #ifndef DACCESS_COMPILE
         m_StackTraceInfo.Init();
@@ -112,18 +263,16 @@ public:
     ExceptionTracker(DWORD_PTR             dwExceptionPc,
                      PTR_EXCEPTION_RECORD  pExceptionRecord,
                      PTR_CONTEXT           pContextRecord) :
-        m_pPrevNestedInfo((ExceptionTracker*)NULL),
         m_pThread(GetThread()),
-        m_hThrowable(NULL),
         m_uCatchToCallPC(NULL),
         m_pSkipToParentFunctionMD(NULL),
 // these members were added for resume frame processing
-        m_pClauseForCatchToken(NULL),
+        m_pClauseForCatchToken(NULL)
 // end resume frame members
-        m_ExceptionCode(pExceptionRecord->ExceptionCode)
     {
         m_ptrs.ExceptionRecord  = pExceptionRecord;
         m_ptrs.ContextRecord    = pContextRecord;
+        m_ExceptionCode = pExceptionRecord->ExceptionCode;
 
         m_pLimitFrame = NULL;
 
@@ -231,35 +380,15 @@ public:
         BOOL bAsynchronousThreadStop
         );
 
-    DWORD                   GetExceptionCode()      { return m_ExceptionCode;       }
     INDEBUG(inline  bool    IsValid());
     INDEBUG(static UINT_PTR DebugComputeNestingLevel());
-
-    inline OBJECTREF GetThrowable()
-    {
-        CONTRACTL
-        {
-            MODE_COOPERATIVE;
-            NOTHROW;
-            GC_NOTRIGGER;
-        }
-        CONTRACTL_END;
-
-        if (NULL != m_hThrowable)
-        {
-            return ObjectFromHandle(m_hThrowable);
-        }
-
-        return NULL;
-    }
 
     // Return a StackFrame of the current frame for parent frame checking purposes.
     // Don't use this StackFrame in any way except to pass it back to the ExceptionTracker
     // via IsUnwoundToTargetParentFrame().
     static StackFrame GetStackFrameForParentCheck(CrawlFrame * pCF);
 
-    static bool IsInStackRegionUnwoundBySpecifiedException(CrawlFrame * pCF, PTR_ExceptionTracker pExceptionTracker);
-    static bool IsInStackRegionUnwoundBySpecifiedException(CrawlFrame * pCF, PTR_ExInfo pExInfo);
+    static bool IsInStackRegionUnwoundBySpecifiedException(CrawlFrame * pCF, PTR_ExceptionTrackerBase pExceptionTracker);
     static bool IsInStackRegionUnwoundByCurrentException(CrawlFrame * pCF);
 
     static bool HasFrameBeenUnwoundByAnyActiveException(CrawlFrame * pCF);
@@ -371,10 +500,6 @@ public:
 
     void ResetLimitFrame();
 
-#ifdef DACCESS_COMPILE
-    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
-#endif // DACCESS_COMPILE
-
     static void DebugLogTrackerRanges(_In_z_ const char *pszTag);
 
     bool IsStackOverflowException();
@@ -404,19 +529,6 @@ private:
 
     static bool
         IsFilterStartOffset(EE_ILEXCEPTION_CLAUSE* pEHClause, DWORD_PTR dwHandlerStartPC);
-
-#ifndef DACCESS_COMPILE
-    void DestroyExceptionHandle()
-    {
-        // Never, ever destroy a preallocated exception handle.
-        if ((m_hThrowable != NULL) && !CLRException::IsPreallocatedExceptionHandle(m_hThrowable))
-        {
-            DestroyHandle(m_hThrowable);
-        }
-
-        m_hThrowable = NULL;
-    }
-#endif // !DACCESS_COMPILE
 
     void SaveStackTrace();
 
@@ -492,13 +604,6 @@ public:
         return m_pLimitFrame;
     }
 
-    StackRange GetScannedStackRange()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_ScannedStackRange;
-    }
-
     UINT_PTR GetCatchToCallPC()
     {
         LIMITED_METHOD_CONTRACT;
@@ -570,42 +675,7 @@ public:
         return m_EnclosingClauseInfoOfCollapsedTracker.GetEnclosingClauseCallerSP();
     }
 
-#ifndef TARGET_UNIX
-private:
-    EHWatsonBucketTracker m_WatsonBucketTracker;
 public:
-    inline PTR_EHWatsonBucketTracker GetWatsonBucketTracker()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return PTR_EHWatsonBucketTracker(PTR_HOST_MEMBER_TADDR(ExceptionTracker, this, m_WatsonBucketTracker));
-    }
-#endif // !TARGET_UNIX
-
-private:
-    BOOL                    m_fDeliveredFirstChanceNotification;
-
-public:
-    inline BOOL DeliveredFirstChanceNotification()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_fDeliveredFirstChanceNotification;
-    }
-
-    inline void SetFirstChanceNotificationStatus(BOOL fDelivered)
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        m_fDeliveredFirstChanceNotification = fDelivered;
-    }
-
-    // Returns the exception tracker previous to the current
-    inline PTR_ExceptionTracker GetPreviousExceptionTracker()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_pPrevNestedInfo;
-    }
 
     // Returns the throwble associated with the tracker as handle
     inline OBJECTHANDLE GetThrowableAsHandle()
@@ -613,11 +683,6 @@ public:
         LIMITED_METHOD_CONTRACT;
 
         return m_hThrowable;
-    }
-
-    bool IsInFirstPass()
-    {
-        return !m_ExceptionFlags.UnwindHasStarted();
     }
 
     EHClauseInfo* GetEHClauseInfo()
@@ -632,30 +697,6 @@ private: ;
     void SetEnclosingClauseInfo(bool     fEnclosingClauseIsFunclet,
                                 DWORD    dwEnclosingClauseOffset,
                                 UINT_PTR uEnclosingClauseCallerSP);
-
-    class StackRange
-    {
-    public:
-        StackRange();
-        void Reset();
-        bool IsEmpty();
-        bool IsSupersededBy(StackFrame sf);
-        void CombineWith(StackFrame sfCurrent, StackRange* pPreviousRange);
-        bool Contains(StackFrame sf);
-        void ExtendUpperBound(StackFrame sf);
-        void ExtendLowerBound(StackFrame sf);
-        void TrimLowerBound(StackFrame sf);
-        StackFrame GetLowerBound();
-        StackFrame GetUpperBound();
-        INDEBUG(bool IsDisjointWithAndLowerThan(StackRange* pOtherRange));
-    private:
-        INDEBUG(bool IsConsistent());
-
-    private:
-        // <TODO> can we use a smaller encoding? </TODO>
-        StackFrame          m_sfLowBound;
-        StackFrame          m_sfHighBound;
-    };
 
     struct EnclosingClauseInfo
     {
@@ -676,17 +717,12 @@ private: ;
         bool     m_fEnclosingClauseIsFunclet;
     };
 
-    PTR_ExceptionTracker    m_pPrevNestedInfo;
     Thread*                 m_pThread;          // this is used as an IsValid/IsFree field -- if it's NULL, the allocator can
                                                 // reuse its memory, if it's non-NULL, it better be a valid thread pointer
 
-    StackRange              m_ScannedStackRange;
-    DAC_EXCEPTION_POINTERS  m_ptrs;
 #ifdef TARGET_UNIX
     BOOL                    m_fOwnsExceptionPointers;
 #endif
-    OBJECTHANDLE            m_hThrowable;
-    StackTraceInfo          m_StackTraceInfo;
     UINT_PTR                m_uCatchToCallPC;
     BOOL           m_fResetEnclosingClauseSPForCatchFunclet;
 
@@ -709,22 +745,7 @@ private: ;
     StackFrame              m_sfEstablisherOfActualHandlerFrame;
     StackFrame              m_sfCallerOfActualHandlerFrame;
 
-    ExceptionFlags          m_ExceptionFlags;
-    DWORD                   m_ExceptionCode;
-
     PTR_Frame               m_pLimitFrame;
-
-#ifdef DEBUGGING_SUPPORTED
-    //
-    // DEBUGGER STATE
-    //
-    DebuggerExState         m_DebuggerExState;
-#endif // DEBUGGING_SUPPORTED
-
-    //
-    // Information for the funclet we are calling
-    //
-    EHClauseInfo            m_EHClauseInfo;
 
     // This flag indicates whether the SP we pass to a funclet is for an enclosing funclet.
     EnclosingClauseInfo     m_EnclosingClauseInfo;

--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -319,25 +319,24 @@ ExInfo::ExInfo(Thread *pThread, EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pEx
     m_notifyDebuggerSP(NULL),
     m_pFrame(pThread->GetFrame()),
     m_ClauseForCatch({}),
-    m_ptrs({pExceptionRecord, pExceptionContext}),
 #ifdef HOST_UNIX
     m_fOwnsExceptionPointers(FALSE),
     m_propagateExceptionCallback(NULL),
     m_propagateExceptionContext(NULL),
 #endif // HOST_UNIX
-    m_hThrowable(NULL),
     m_CurrentClause({}),
-    m_ExceptionCode(pExceptionRecord->ExceptionCode),
     m_pMDToReportFunctionLeave(NULL),
-    m_fDeliveredFirstChanceNotification(FALSE),
     m_exContext({})
 {
-    m_pPrevExInfo = pThread->GetExceptionState()->GetCurrentExInfo();
-    m_stackTraceInfo.Init();
-    m_stackTraceInfo.AllocateStackTrace();
-    m_sfLowBound.SetMaxVal();
+    m_pPrevNestedInfo = pThread->GetExceptionState()->GetCurrentExInfo();
+    m_StackTraceInfo.Init();
+    m_StackTraceInfo.AllocateStackTrace();
+    m_ScannedStackRange.Reset();
     pThread->GetExceptionState()->SetCurrentExInfo(this);
     m_exContext.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER;
+    m_ptrs.ExceptionRecord = pExceptionRecord;
+    m_ptrs.ContextRecord = pExceptionContext;
+    m_ExceptionCode = pExceptionRecord->ExceptionCode;
 }
 
 #if defined(TARGET_UNIX)
@@ -360,7 +359,7 @@ void ExInfo::ReleaseResources()
         }
         m_hThrowable = NULL;
     }
-    m_stackTraceInfo.FreeStackTrace();
+    m_StackTraceInfo.FreeStackTrace();
 
 #ifndef TARGET_UNIX
     // Clear any held Watson Bucketing details
@@ -401,12 +400,12 @@ void ExInfo::MakeCallbacksRelatedToHandler(
     {
         m_EHClauseInfo.SetManagedCodeEntered(TRUE);
         StackFrame sfToStore = sf;
-        if ((m_pPrevExInfo != NULL) &&
-            (m_pPrevExInfo->m_csfEnclosingClause == m_csfEnclosingClause))
+        if ((m_pPrevNestedInfo != NULL) &&
+            (((PTR_ExInfo)m_pPrevNestedInfo)->m_csfEnclosingClause == m_csfEnclosingClause))
         {
             // If this is a nested exception which has the same enclosing clause as the previous exception,
             // we should just propagate the clause info from the previous exception.
-            sfToStore = m_pPrevExInfo->m_EHClauseInfo.GetStackFrameForEHClause();
+            sfToStore = m_pPrevNestedInfo->m_EHClauseInfo.GetStackFrameForEHClause();
         }
         m_EHClauseInfo.SetInfo(COR_PRF_CLAUSE_NONE, (UINT_PTR)dwHandlerStartPC, sfToStore);
 
@@ -476,14 +475,6 @@ void ExInfo::MakeCallbacksRelatedToHandler(
 #endif // DEBUGGING_SUPPORTED
 }
 
-#else // DACCESS_COMPILE
-void ExInfo::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
-{
-    // ExInfo is embedded so don't enum 'this'.
-    OBJECTHANDLE_EnumMemoryRegions(m_hThrowable);
-    m_ptrs.ExceptionRecord.EnumMem();
-    m_ptrs.ContextRecord.EnumMem();
-}
 #endif // DACCESS_COMPILE
 
 #endif // !FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/exinfo.h
+++ b/src/coreclr/vm/exinfo.h
@@ -214,6 +214,20 @@ struct ExInfo : public ExceptionTrackerBase
         DWORD_PTR              dwHandlerStartPC,
         StackFrame             sf);
 
+    static void PopExInfos(Thread *pThread, void *targetSp);
+
+    // Padding to make the ExInfo offsets that the managed EH code needs to access
+    // the same for debug / release and Unix / Windows.
+#ifdef TARGET_UNIX
+    // sizeof(EHWatsonBucketTracker)
+    BYTE m_padding[2 * sizeof(void*) + sizeof(DWORD)];
+#else // TARGET_UNIX
+#ifndef _DEBUG
+    //  sizeof(EHWatsonBucketTracker::m_DebugFlags)
+    BYTE m_padding[sizeof(DWORD)];
+#endif // _DEBUG
+#endif // TARGET_UNIX
+
     // Context used by the stack frame iterator
     CONTEXT* m_pExContext;
     // actual exception object reference

--- a/src/coreclr/vm/exinfo.h
+++ b/src/coreclr/vm/exinfo.h
@@ -161,6 +161,8 @@ PTR_ExInfo GetEHTrackerForPreallocatedException(OBJECTREF oPreAllocThrowable, PT
 
 #else // !FEATURE_EH_FUNCLETS
 
+#include "exceptionhandling.h"
+
 enum RhEHClauseKind
 {
     RH_EH_CLAUSE_TYPED = 0,
@@ -196,14 +198,8 @@ enum class ExKind : uint8_t
 
 struct PAL_SEHException;
 
-struct ExInfo
+struct ExInfo : public ExceptionTrackerBase
 {
-    struct DAC_EXCEPTION_POINTERS
-    {
-        PTR_EXCEPTION_RECORD    ExceptionRecord;
-        PTR_CONTEXT             ContextRecord;
-    };
-
     ExInfo(Thread *pThread, EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pExceptionContext, ExKind exceptionKind);
 
     // Releases all the resources owned by the ExInfo
@@ -218,8 +214,6 @@ struct ExInfo
         DWORD_PTR              dwHandlerStartPC,
         StackFrame             sf);
 
-    // Previous ExInfo in the chain of exceptions rethrown from their catch / finally handlers
-    PTR_ExInfo m_pPrevExInfo;
     // Context used by the stack frame iterator
     CONTEXT* m_pExContext;
     // actual exception object reference
@@ -233,14 +227,9 @@ struct ExInfo
     // Stack frame iterator used to walk stack frames while handling the exception
     StackFrameIterator m_frameIter;
     volatile size_t m_notifyDebuggerSP;
-    // Stack trace of the current exception
-    StackTraceInfo m_stackTraceInfo;
     // Initial explicit frame
     Frame* m_pFrame;
 
-    // Low and high bounds of the stack unwound by the exception. They are updated during 2nd pass only.
-    StackFrame          m_sfLowBound;
-    StackFrame          m_sfHighBound;
     // Stack frame of the caller of the currently running exception handling clause (catch, finally, filter)
     CallerStackFrame    m_csfEHClause;
     // Stack frame of the caller of the code that encloses the currently running exception handling clause
@@ -249,8 +238,6 @@ struct ExInfo
     StackFrame          m_sfCallerOfActualHandlerFrame;
     // The exception handling clause for the catch handler that was identified during pass 1
     EE_ILEXCEPTION_CLAUSE m_ClauseForCatch;
-    // EXCEPTION_RECORD and CONTEXT_RECORD describing the exception and its location
-    DAC_EXCEPTION_POINTERS m_ptrs;
 
 #ifdef TARGET_UNIX
     // Set to TRUE to take ownership of the EXCEPTION_RECORD and CONTEXT_RECORD in the m_ptrs. When set, the
@@ -261,59 +248,17 @@ struct ExInfo
     void *m_propagateExceptionContext;
 #endif // TARGET_UNIX
 
-    // thrown exception object handle
-    OBJECTHANDLE    m_hThrowable;
-
     // The following fields are for profiler / debugger use only
     EE_ILEXCEPTION_CLAUSE m_CurrentClause;
-    // Stores information necessary to intercept an exception
-    DebuggerExState m_DebuggerExState;
-    // Information for the funclet we are calling
-    EHClauseInfo   m_EHClauseInfo;
-    // Flags representing exception handling state (exception is rethrown, unwind has started, various debugger notifications sent etc)
-    ExceptionFlags m_ExceptionFlags;
-    // Code of the current exception
-    DWORD          m_ExceptionCode;
     // Method to report to the debugger / profiler when stack frame iterator leaves a frame
     MethodDesc    *m_pMDToReportFunctionLeave;
-    // Set to TRUE when the first chance notification was delivered for the current exception
-    BOOL           m_fDeliveredFirstChanceNotification;
     // CONTEXT and REGDISPLAY used by the StackFrameIterator for stack walking
     CONTEXT        m_exContext;
     REGDISPLAY     m_regDisplay;
 
-    inline BOOL DeliveredFirstChanceNotification()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        return m_fDeliveredFirstChanceNotification;
-    }
-
-    inline void SetFirstChanceNotificationStatus(BOOL fDelivered)
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        m_fDeliveredFirstChanceNotification = fDelivered;
-    }
-
-#ifndef TARGET_UNIX
-    // Used to track Watson bucketing information for an exception.
-    EHWatsonBucketTracker m_WatsonBucketTracker;
-
-    inline PTR_EHWatsonBucketTracker GetWatsonBucketTracker()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return PTR_EHWatsonBucketTracker(PTR_HOST_MEMBER_TADDR(ExInfo, this, m_WatsonBucketTracker));
-    }
-#endif // !TARGET_UNIX
-
 #if defined(TARGET_UNIX)
     void TakeExceptionPointersOwnership(PAL_SEHException* ex);
 #endif // TARGET_UNIX
-
-#ifdef DACCESS_COMPILE
-    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags);
-#endif // DACCESS_COMPILE
 
 };
 

--- a/src/coreclr/vm/exstate.cpp
+++ b/src/coreclr/vm/exstate.cpp
@@ -22,10 +22,6 @@ OBJECTHANDLE ThreadExceptionState::GetThrowableAsHandle()
     {
         return m_pCurrentTracker->m_hThrowable;
     }
-    else if (m_pExInfo)
-    {
-        return m_pExInfo->m_hThrowable;
-    }
 
     return NULL;
 #else // FEATURE_EH_FUNCLETS
@@ -38,7 +34,6 @@ ThreadExceptionState::ThreadExceptionState()
 {
 #ifdef FEATURE_EH_FUNCLETS
     m_pCurrentTracker = NULL;
-    m_pExInfo = NULL;
 #endif // FEATURE_EH_FUNCLETS
 
     m_flag = TEF_None;
@@ -114,10 +109,6 @@ OBJECTREF ThreadExceptionState::GetThrowable()
     {
         return ObjectFromHandle(m_pCurrentTracker->m_hThrowable);
     }
-    if (m_pExInfo && m_pExInfo->m_exception != NULL)
-    {
-        return m_pExInfo->m_exception;
-    }
 #else // FEATURE_EH_FUNCLETS
     if (m_currentExInfo.m_hThrowable)
     {
@@ -184,18 +175,13 @@ void ThreadExceptionState::SetThrowable(OBJECTREF throwable DEBUG_ARG(SetThrowab
 #endif // FEATURE_INTERPRETER
             )
         {
-            CONSISTENCY_CHECK(CheckPointer(m_pCurrentTracker, NULL_OK) || CheckPointer(m_pExInfo));
+            CONSISTENCY_CHECK(CheckPointer(m_pCurrentTracker));
         }
 #endif
 
         if (m_pCurrentTracker != NULL)
         {
             m_pCurrentTracker->m_hThrowable = hNewThrowable;
-        }
-        if (m_pExInfo != NULL)
-        {
-            _ASSERTE(m_pExInfo->m_hThrowable == NULL);
-            m_pExInfo->m_hThrowable = hNewThrowable;
         }
 #else // FEATURE_EH_FUNCLETS
         m_currentExInfo.m_hThrowable = hNewThrowable;
@@ -208,14 +194,8 @@ DWORD ThreadExceptionState::GetExceptionCode()
     LIMITED_METHOD_CONTRACT;
 
 #ifdef FEATURE_EH_FUNCLETS
-    if (m_pCurrentTracker)
-    {
-        return m_pCurrentTracker->m_ExceptionCode;
-    }
-    _ASSERTE(m_pExInfo);
-    {   
-        return m_pExInfo->m_ExceptionCode;
-    }
+    _ASSERTE(m_pCurrentTracker);
+    return m_pCurrentTracker->m_ExceptionCode;
 #else // FEATURE_EH_FUNCLETS
     return m_currentExInfo.m_ExceptionCode;
 #endif // FEATURE_EH_FUNCLETS
@@ -247,7 +227,7 @@ BOOL ThreadExceptionState::IsExceptionInProgress()
     LIMITED_METHOD_DAC_CONTRACT;
 
 #ifdef FEATURE_EH_FUNCLETS
-    return (m_pCurrentTracker != NULL) || (m_pExInfo != NULL);
+    return (m_pCurrentTracker != NULL);
 #else // FEATURE_EH_FUNCLETS
     return (m_currentExInfo.m_pBottomMostHandler != NULL);
 #endif // FEATURE_EH_FUNCLETS
@@ -263,10 +243,6 @@ EXCEPTION_POINTERS* ThreadExceptionState::GetExceptionPointers()
     if (m_pCurrentTracker)
     {
         return (EXCEPTION_POINTERS*)&(m_pCurrentTracker->m_ptrs);
-    }
-    else if (m_pExInfo)
-    {
-        return (EXCEPTION_POINTERS*)&(m_pExInfo->m_ptrs);
     }
     else
     {
@@ -302,10 +278,6 @@ PTR_EXCEPTION_RECORD ThreadExceptionState::GetExceptionRecord()
     {
         return m_pCurrentTracker->m_ptrs.ExceptionRecord;
     }
-    else if (m_pExInfo)
-    {
-        return m_pExInfo->m_ptrs.ExceptionRecord;
-    }
     else
     {
         return NULL;
@@ -324,10 +296,6 @@ PTR_CONTEXT ThreadExceptionState::GetContextRecord()
     {
         return m_pCurrentTracker->m_ptrs.ContextRecord;
     }
-    else if (m_pExInfo)
-    {
-        return dac_cast<PTR_CONTEXT>(m_pExInfo->m_pExContext);
-    }
     else
     {
         return NULL;
@@ -344,10 +312,6 @@ ExceptionFlags* ThreadExceptionState::GetFlags()
     if (m_pCurrentTracker)
     {
         return &(m_pCurrentTracker->m_ExceptionFlags);
-    }
-    else if (m_pExInfo)
-    {
-        return &(m_pExInfo->m_ExceptionFlags);
     }
     else
     {
@@ -371,10 +335,6 @@ DebuggerExState*    ThreadExceptionState::GetDebuggerState()
     if (m_pCurrentTracker)
     {
         return &(m_pCurrentTracker->m_DebuggerExState);
-    }
-    else if (m_pExInfo)
-    {
-        return &(m_pExInfo->m_DebuggerExState);
     }
     else
     {
@@ -516,10 +476,6 @@ EHClauseInfo* ThreadExceptionState::GetCurrentEHClauseInfo()
     {
         return &(m_pCurrentTracker->m_EHClauseInfo);
     }
-    else if (m_pExInfo)
-    {
-        return &(m_pExInfo->m_EHClauseInfo);
-    }
     else
     {
         _ASSERTE(!"unexpected use of GetCurrentEHClauseInfo() when no exception in flight");
@@ -586,7 +542,7 @@ void
 ThreadExceptionState::EnumChainMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
 #ifdef FEATURE_EH_FUNCLETS
-    ExceptionTrackerBase* head = g_isNewExceptionHandlingEnabled ? (PTR_ExceptionTrackerBase)m_pExInfo : m_pCurrentTracker;
+    ExceptionTrackerBase* head = m_pCurrentTracker;
 #else // FEATURE_EH_FUNCLETS
     ExInfo*           head = &m_currentExInfo;
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/exstate.cpp
+++ b/src/coreclr/vm/exstate.cpp
@@ -86,7 +86,7 @@ void ThreadExceptionState::FreeAllStackTraces()
     WRAPPER_NO_CONTRACT;
 
 #ifdef FEATURE_EH_FUNCLETS
-    ExceptionTracker* pNode = m_pCurrentTracker;
+    ExceptionTrackerBase* pNode = m_pCurrentTracker;
 #else // FEATURE_EH_FUNCLETS
     ExInfo*           pNode = &m_currentExInfo;
 #endif // FEATURE_EH_FUNCLETS
@@ -586,21 +586,7 @@ void
 ThreadExceptionState::EnumChainMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
 #ifdef FEATURE_EH_FUNCLETS
-    ExceptionTracker* head = m_pCurrentTracker;
-
-    if (head == NULL)
-    {
-        PTR_ExInfo exInfo = m_pExInfo;
-        while (exInfo != NULL)
-        {
-            exInfo->EnumMemoryRegions(flags);
-            exInfo.EnumMem();
-            exInfo = exInfo->m_pPrevExInfo;
-        }
-
-        return;
-    }
-
+    ExceptionTrackerBase* head = g_isNewExceptionHandlingEnabled ? (PTR_ExceptionTrackerBase)m_pExInfo : m_pCurrentTracker;
 #else // FEATURE_EH_FUNCLETS
     ExInfo*           head = &m_currentExInfo;
 #endif // FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/exstate.h
+++ b/src/coreclr/vm/exstate.h
@@ -147,11 +147,11 @@ private:
     Thread* GetMyThread();
 
 #ifdef FEATURE_EH_FUNCLETS
-    PTR_ExceptionTracker    m_pCurrentTracker;
+    PTR_ExceptionTrackerBase m_pCurrentTracker;
     ExceptionTracker        m_OOMTracker;
     PTR_ExInfo m_pExInfo;
 public:
-    PTR_ExceptionTracker    GetCurrentExceptionTracker()
+    PTR_ExceptionTrackerBase GetCurrentExceptionTracker()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pCurrentTracker;

--- a/src/coreclr/vm/exstate.h
+++ b/src/coreclr/vm/exstate.h
@@ -52,6 +52,7 @@ class ThreadExceptionState
 
 #ifdef FEATURE_EH_FUNCLETS
     friend class ExceptionTracker;
+    friend struct ExInfo;
 #else
     friend class ExInfo;
 #endif // FEATURE_EH_FUNCLETS
@@ -149,24 +150,21 @@ private:
 #ifdef FEATURE_EH_FUNCLETS
     PTR_ExceptionTrackerBase m_pCurrentTracker;
     ExceptionTracker        m_OOMTracker;
-    PTR_ExInfo m_pExInfo;
 public:
     PTR_ExceptionTrackerBase GetCurrentExceptionTracker()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pCurrentTracker;
     }
-    PTR_ExInfo    GetCurrentExInfo()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_pExInfo;
-    }
 
-    void SetCurrentExInfo(PTR_ExInfo pExInfo)
+#ifndef DACCESS_COMPILE
+    void SetCurrentExceptionTracker(ExceptionTrackerBase* pTracker)
     {
         LIMITED_METHOD_CONTRACT;
-        m_pExInfo = pExInfo;
+        m_pCurrentTracker = pTracker;
     }
+#endif // DACCESS_COMPILE
+
 #else
     ExInfo                  m_currentExInfo;
 public:

--- a/src/coreclr/vm/exstatecommon.h
+++ b/src/coreclr/vm/exstatecommon.h
@@ -305,7 +305,6 @@ public:
         if (fReadOnly)
         {
             m_flags |= Ex_FlagsAreReadOnly;
-            m_debugFlags |= Ex_FlagsAreReadOnly;
         }
 #endif // _DEBUG
     }
@@ -316,7 +315,7 @@ public:
         SUPPORTS_DAC;
 
 #if defined(FEATURE_EH_FUNCLETS) && defined(_DEBUG)
-        if ((m_flags & Ex_FlagsAreReadOnly) || (m_debugFlags & Ex_FlagsAreReadOnly))
+        if (m_flags & Ex_FlagsAreReadOnly)
         {
             _ASSERTE(!"Tried to update read-only flags!");
         }
@@ -326,9 +325,6 @@ public:
     void Init()
     {
         m_flags = 0;
-#ifdef _DEBUG
-        m_debugFlags = 0;
-#endif // _DEBUG
     }
 
     BOOL IsRethrown()      { LIMITED_METHOD_CONTRACT; return m_flags & Ex_IsRethrown; }
@@ -348,9 +344,9 @@ public:
     void ResetUseExInfoForStackwalk() { LIMITED_METHOD_DAC_CONTRACT; AssertIfReadOnly(); m_flags &= ~Ex_UseExInfoForStackwalk; }
 
 #ifdef _DEBUG
-    BOOL ReversePInvokeEscapingException()      { LIMITED_METHOD_DAC_CONTRACT; return m_debugFlags & Ex_RPInvokeEscapingException; }
-    void SetReversePInvokeEscapingException()   { LIMITED_METHOD_DAC_CONTRACT; AssertIfReadOnly(); m_debugFlags |= Ex_RPInvokeEscapingException; }
-    void ResetReversePInvokeEscapingException() { LIMITED_METHOD_DAC_CONTRACT; AssertIfReadOnly(); m_debugFlags &= ~Ex_RPInvokeEscapingException; }
+    BOOL ReversePInvokeEscapingException()      { LIMITED_METHOD_DAC_CONTRACT; return m_flags & Ex_RPInvokeEscapingException; }
+    void SetReversePInvokeEscapingException()   { LIMITED_METHOD_DAC_CONTRACT; AssertIfReadOnly(); m_flags |= Ex_RPInvokeEscapingException; }
+    void ResetReversePInvokeEscapingException() { LIMITED_METHOD_DAC_CONTRACT; AssertIfReadOnly(); m_flags &= ~Ex_RPInvokeEscapingException; }
 #endif // _DEBUG
 
 #ifdef DEBUGGING_SUPPORTED
@@ -411,6 +407,10 @@ private:
 
         Ex_GotWatsonBucketInfo          = 0x00004000,
 
+#ifdef _DEBUG
+        Ex_RPInvokeEscapingException    = 0x40000000,
+#endif // _DEBUG
+
 #if defined(FEATURE_EH_FUNCLETS) && defined(_DEBUG)
         Ex_FlagsAreReadOnly             = 0x80000000
 #endif // defined(FEATURE_EH_FUNCLETS) && defined(_DEBUG)
@@ -418,14 +418,6 @@ private:
     };
 
     UINT32 m_flags;
-
-#ifdef _DEBUG
-    enum
-    {
-        Ex_RPInvokeEscapingException    = 0x40000000
-    };
-    UINT32 m_debugFlags;
-#endif // _DEBUG
 };
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -4303,7 +4303,7 @@ void RethrowNew()
 {
     Thread *pThread = GetThread();
 
-    ExInfo *pActiveExInfo = pThread->GetExceptionState()->GetCurrentExInfo();
+    ExInfo *pActiveExInfo = (ExInfo*)pThread->GetExceptionState()->GetCurrentExceptionTracker();
 
     ExInfo exInfo(pThread, pActiveExInfo->m_ptrs.ExceptionRecord, pActiveExInfo->m_ptrs.ContextRecord, ExKind::None);
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1216,7 +1216,7 @@ BOOL StackFrameIterator::Init(Thread *    pThread,
 #ifdef FEATURE_EH_FUNCLETS
     if (g_isNewExceptionHandlingEnabled)
     {
-        m_pNextExInfo = pThread->GetExceptionState()->GetCurrentExInfo();
+        m_pNextExInfo = (PTR_ExInfo)pThread->GetExceptionState()->GetCurrentExceptionTracker();
     }
 #endif // FEATURE_EH_FUNCLETS
 
@@ -1623,8 +1623,17 @@ StackWalkAction StackFrameIterator::Filter(void)
         fSkippingFunclet = false;
 
 #if defined(FEATURE_EH_FUNCLETS)
-        ExceptionTracker* pTracker = (PTR_ExceptionTracker)m_crawl.pThread->GetExceptionState()->GetCurrentExceptionTracker();
-        ExInfo* pExInfo = m_crawl.pThread->GetExceptionState()->GetCurrentExInfo();
+        ExceptionTracker* pTracker = NULL;
+        ExInfo* pExInfo = NULL;
+        if (g_isNewExceptionHandlingEnabled)
+        {
+            pExInfo = (PTR_ExInfo)m_crawl.pThread->GetExceptionState()->GetCurrentExceptionTracker();
+        }
+        else
+        {
+            pTracker = (PTR_ExceptionTracker)m_crawl.pThread->GetExceptionState()->GetCurrentExceptionTracker();
+        }
+
         fRecheckCurrentFrame = false;
         fSkipFuncletCallback = true;
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1623,7 +1623,7 @@ StackWalkAction StackFrameIterator::Filter(void)
         fSkippingFunclet = false;
 
 #if defined(FEATURE_EH_FUNCLETS)
-        ExceptionTracker* pTracker = m_crawl.pThread->GetExceptionState()->GetCurrentExceptionTracker();
+        ExceptionTracker* pTracker = (PTR_ExceptionTracker)m_crawl.pThread->GetExceptionState()->GetCurrentExceptionTracker();
         ExInfo* pExInfo = m_crawl.pThread->GetExceptionState()->GetCurrentExInfo();
         fRecheckCurrentFrame = false;
         fSkipFuncletCallback = true;
@@ -1780,7 +1780,7 @@ ProcessFuncletsForGCReporting:
                                 // since the current tracker was created due to an exception in the funclet belonging to
                                 // the previous tracker.
                                 hasFuncletStarted = true;
-                                pCurrTracker = pCurrTracker->GetPreviousExceptionTracker();
+                                pCurrTracker = (PTR_ExceptionTracker)pCurrTracker->GetPreviousExceptionTracker();
                             }
 
                             if (pCurrTracker != NULL)
@@ -3357,7 +3357,7 @@ void StackFrameIterator::ResetNextExInfoForSP(TADDR SP)
 {
     while (m_pNextExInfo && (SP > (TADDR)(m_pNextExInfo)))
     {
-        m_pNextExInfo = m_pNextExInfo->m_pPrevExInfo;
+        m_pNextExInfo = (PTR_ExInfo)m_pNextExInfo->m_pPrevNestedInfo;
     }
 }
 #endif // FEATURE_EH_FUNCLETS


### PR DESCRIPTION
While fixing few loose ends related to debug code and the new exception
handling, I have found that they were mostly caused by missing
conditional code for the new EH `ExInfo` where only the `ExceptionTracker`
was handled.
So, I have decided to refactor the code a bit by extracting a base
struct containing the members that are common to `ExInfo` and
`ExceptionTracker` and that are used by the debugging related code.
There was also a bit of unused code that I have found while making this
change, so I have removed it.
I obviously had to update the offsets that the managed code references
in the `ExInfo`. Due to some debug only members of some of the structures
used as `ExInfo` members, the offsets were initially different for
Windows/Unix and Release/Debug builds. To prevent having to have
separate offset values, I have added a little conditional padding to
the `ExInfo` and modified the `ExceptionFlags` structure by removing the
`m_debugFlags` that were holding only a single flag that can easily fit
into the `m_flags` member and there is no reason for having it separate.