### PR TITLE
Build Windows NativeAOT runtime packs

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -315,6 +315,8 @@ extends:
           - linux_musl_arm64
           - linux_bionic_x64
           - linux_bionic_arm64
+          - win_x64
+          - win_arm64
           jobParameters:
             buildArgs: -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c $(_BuildConfig) /p:BuildNativeAOTRuntimePack=true /p:SkipLibrariesNativeRuntimePackages=true
             nameSuffix: NativeAOT

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -132,7 +132,7 @@
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.amd64.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.arm.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />
     <PlatformManifestFileEntry Include="Microsoft.DiaSymReader.Native.arm64.dll" IsNative="true" FallbackFileVersion="$(MicrosoftDiaSymReaderNativeFileVersion)" />
-    <!-- NativeAOT specific files -->
+    <!-- NativeAOT/Unix specific files -->
     <PlatformManifestFileEntry Include="libbootstrapper.a" IsNative="true" /> <!-- The bootstrapper lib used to be a static library, now it's an object file. -->
     <PlatformManifestFileEntry Include="libbootstrapperdll.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libbootstrapper.o" IsNative="true" />
@@ -141,9 +141,33 @@
     <PlatformManifestFileEntry Include="libeventpipe-enabled.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libRuntime.ServerGC.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libRuntime.WorkstationGC.a" IsNative="true" />
-    <PlatformManifestFileEntry Include="libstandalonegc-disabled.a " IsNative="true" />
-    <PlatformManifestFileEntry Include="libstandalonegc-enabled.a " IsNative="true" />
+    <PlatformManifestFileEntry Include="libstandalonegc-disabled.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libstandalonegc-enabled.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libstdc++compat.a" IsNative="true" />
+    <!-- NativeAOT/Windows specific files -->
+    <PlatformManifestFileEntry Include="bootstrapper.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="bootstrapper.GuardCF.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="bootstrapperdll.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="bootstrapperdll.GuardCF.obj" IsNative="true" />
+    <PlatformManifestFileEntry Include="eventpipe-disabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="eventpipe-disabled.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="eventpipe-enabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="eventpipe-enabled.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.ServerGC.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.ServerGC.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.WorkstationGC.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.VxsortEnabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.VxsortEnabled.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="Runtime.VxsortDisabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="standalonegc-disabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="standalonegc-disabled.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="standalonegc-enabled.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="standalonegc-enabled.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="System.Globalization.Native.Aot.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="System.Globalization.Native.Aot.GuardCF.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="System.IO.Compression.Native.Aot.lib" IsNative="true" />
+    <PlatformManifestFileEntry Include="System.IO.Compression.Native.Aot.GuardCF.lib" IsNative="true" />
+    <!-- NativeAOT managed specific files -->
     <PlatformManifestFileEntry Include="System.Private.DisabledReflection.dll" />
     <PlatformManifestFileEntry Include="System.Private.Reflection.Execution.dll" />
     <PlatformManifestFileEntry Include="System.Private.StackTraceMetadata.dll" />


### PR DESCRIPTION
Contributes to #87060. These are the last missing runtime packs. We can update the list in dotnet/installer next, and switch to using `PublishAotUsingRuntimePack` unconditionally for .NET 9 in SDK. Then we can remove the duplicate files from ILCompiler packages.

I locally tested that it's possible to build and use win-x64 runtime pack (after it's added to [the list](https://github.com/dotnet/installer/blob/e08874da5814f7bca5b86c6bd41ac2d5def22634/src/redist/targets/GenerateBundledVersions.targets#L347C8-L361)).