### PR TITLE
[mono][amd64] Fix Vector128 relational comparison API's for nuint type

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -1411,7 +1411,6 @@ namespace System.Numerics.Tensors.Tests
             Assert.Throws<ArgumentException>(() => MaxMagnitude(ReadOnlySpan<T>.Empty));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MaxMagnitude_Tensor()
         {
@@ -1483,7 +1482,6 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(ConvertFromSingle(1), MaxMagnitude( [ConvertFromSingle(-0f), ConvertFromSingle(-0f), ConvertFromSingle(-0f), ConvertFromSingle(-0f), ConvertFromSingle(-1), ConvertFromSingle(-0f), ConvertFromSingle(0f), ConvertFromSingle(1)]));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MaxMagnitude_TwoTensors()
         {
@@ -1502,7 +1500,6 @@ namespace System.Numerics.Tensors.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MaxMagnitude_TwoTensors_InPlace()
         {
@@ -1531,7 +1528,6 @@ namespace System.Numerics.Tensors.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MaxMagnitude_TwoTensors_SpecialValues()
         {
@@ -1789,7 +1785,6 @@ namespace System.Numerics.Tensors.Tests
             Assert.Throws<ArgumentException>(() => MinMagnitude(ReadOnlySpan<T>.Empty));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MinMagnitude_Tensor()
         {
@@ -1859,7 +1854,6 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(ConvertFromSingle(0), MinMagnitude([ConvertFromSingle(-1), ConvertFromSingle(-0f), ConvertFromSingle(1)]));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MinMagnitude_TwoTensors()
         {
@@ -1878,7 +1872,6 @@ namespace System.Numerics.Tensors.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MinMagnitude_TwoTensors_InPlace()
         {
@@ -1907,7 +1900,6 @@ namespace System.Numerics.Tensors.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/96443", TestRuntimes.Mono)]
         [Fact]
         public void MinMagnitude_TwoTensors_SpecialValues()
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -4545,6 +4545,13 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Fact]
+        public void Vector128NuintGreaterThan_MaxValue()
+        {
+            Vector128<nuint> vector = Vector128.Create(nuint.MaxValue);
+            Assert.True(Vector128.EqualsAll(Vector128.GreaterThan(vector, Vector128<nuint>.Zero), vector));
+        }
+
+        [Fact]
         public void IsSupportedByte() => TestIsSupported<byte>();
 
         [Fact]

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3415,9 +3415,9 @@ simd_type_to_shl_op (int t)
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 #if TARGET_SIZEOF_VOID_P == 8
-		return OP_PSHLD;
-#else
 		return OP_PSHLQ;
+#else
+		return OP_PSHLD;
 #endif
 	default:
 		g_assert_not_reached ();


### PR DESCRIPTION
This PR fixes the following Vector128 API's, when the argument type is `nuint`:
- GreaterThan
- GreaterThanAll
- GreaterThanAny
- GreaterThanOrEqual
- GreaterThanOrEqualAll
- GreaterThanOrEqualAny
- LessThan
- LessThanAll
- LessThanAny
- LessThanOrEqual
- LessThanOrEqualAll
- LessThanOrEqualAny

Fixes #96443