### PR TITLE
Fix generic signature issue when calling non generic method of closed generic type

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -535,8 +535,9 @@ namespace System.Reflection.Emit
             return memberHandle;
         }
 
-        private EntityHandle GetMethodReference(MethodInfo method, Type[] optionalParameterTypes)
+        private EntityHandle GetMethodReference(MethodInfo methodInfo, Type[] optionalParameterTypes)
         {
+            MethodInfo method = (MethodInfo)GetOriginalMemberIfConstructedType(methodInfo);
             BlobBuilder signature = GetMethodSignature(method, optionalParameterTypes);
             KeyValuePair<MethodInfo, BlobBuilder> pair = new(method, signature);
             if (!_memberReferences.TryGetValue(pair, out var memberHandle))
@@ -549,16 +550,28 @@ namespace System.Reflection.Emit
             return memberHandle;
         }
 
-        private BlobBuilder GetMethodSignature(MethodInfo method, Type[] optionalParameterTypes) =>
+        private BlobBuilder GetMethodSignature(MethodInfo method, Type[]? optionalParameterTypes) =>
             MetadataSignatureHelper.GetMethodSignature(this, ParameterTypes(method.GetParameters()), method.ReturnType,
                 MethodBuilderImpl.GetSignatureConvention(method.CallingConvention), method.GetGenericArguments().Length, !method.IsStatic, optionalParameterTypes);
 
-        private BlobBuilder GetMemberSignature(MemberInfo member)
+        private static MemberInfo GetOriginalMemberIfConstructedType(MemberInfo memberInfo)
         {
+            Type declaringType = memberInfo.DeclaringType!;
+            if (declaringType.IsConstructedGenericType && declaringType.GetGenericTypeDefinition() is not TypeBuilderImpl)
+            {
+                return declaringType.GetGenericTypeDefinition().GetMemberWithSameMetadataDefinitionAs(memberInfo);
+            }
+
+            return memberInfo;
+        }
+
+        private BlobBuilder GetMemberSignature(MemberInfo memberInfo)
+        {
+            MemberInfo member = GetOriginalMemberIfConstructedType(memberInfo);
+
             if (member is MethodInfo method)
             {
-                return MetadataSignatureHelper.GetMethodSignature(this, ParameterTypes(method.GetParameters()), method.ReturnType,
-                    MethodBuilderImpl.GetSignatureConvention(method.CallingConvention), method.GetGenericArguments().Length, !method.IsStatic);
+                return GetMethodSignature(method, optionalParameterTypes: null);
             }
 
             if (member is FieldInfo field)

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Reflection.Emit.Tests
@@ -1591,67 +1592,75 @@ internal class Dummy
 
         private static int Int32Sum(int a, int b) => a + b;
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void EmitCalliBlittable()
         {
-            int a = 1, b = 1, result = 2;
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliBlittable"), out MethodInfo saveMethod);
-                TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
-                Type returnType = typeof(int);
-                MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(int), typeof(int)]);
-                methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
-                ILGenerator il = methodBuilder.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldarg_2);
-                il.Emit(OpCodes.Ldarg_0);
-                il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, [typeof(int), typeof(int)]);
-                il.Emit(OpCodes.Ret);
-                tb.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                int a = 1, b = 1, result = 2;
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliBlittable"), out MethodInfo saveMethod);
+                    TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+                    Type returnType = typeof(int);
+                    MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(int), typeof(int)]);
+                    methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
+                    ILGenerator il = methodBuilder.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_2);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.EmitCalli(OpCodes.Calli, CallingConvention.StdCall, returnType, [typeof(int), typeof(int)]);
+                    il.Emit(OpCodes.Ret);
+                    tb.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
-                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
-                var del = new Int32SumStdCall(Int32Sum);
-                IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(del);
-                object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, a, b]);
-                GC.KeepAlive(del);
+                    Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                    var del = new Int32SumStdCall(Int32Sum);
+                    IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(del);
+                    object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, a, b]);
+                    GC.KeepAlive(del);
 
-                Assert.IsType(returnType, resultValue);
-                Assert.Equal(result, resultValue);
-            }
+                    Assert.IsType(returnType, resultValue);
+                    Assert.Equal(result, resultValue);
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void EmitCalliManagedBlittable()
         {
-            int a = 1, b = 1, result = 2;
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliManagedBlittable"), out MethodInfo saveMethod);
-                TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
-                Type returnType = typeof(int);
-                MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(int), typeof(int)]);
-                methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
-                MethodInfo method = typeof(AssemblySaveILGeneratorTests).GetMethod(nameof(Int32Sum), BindingFlags.NonPublic | BindingFlags.Static)!;
-                IntPtr funcPtr = method.MethodHandle.GetFunctionPointer();
-                ILGenerator il = methodBuilder.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldarg_2);
-                il.Emit(OpCodes.Ldarg_0);
-                il.EmitCalli(OpCodes.Calli, CallingConventions.Standard, returnType, [typeof(int), typeof(int)], null);
-                il.Emit(OpCodes.Ret);
-                tb.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                int a = 1, b = 1, result = 2;
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliManagedBlittable"), out MethodInfo saveMethod);
+                    TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+                    Type returnType = typeof(int);
+                    MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(int), typeof(int)]);
+                    methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
+                    MethodInfo method = typeof(AssemblySaveILGeneratorTests).GetMethod(nameof(Int32Sum), BindingFlags.NonPublic | BindingFlags.Static)!;
+                    IntPtr funcPtr = method.MethodHandle.GetFunctionPointer();
+                    ILGenerator il = methodBuilder.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_2);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.EmitCalli(OpCodes.Calli, CallingConventions.Standard, returnType, [typeof(int), typeof(int)], null);
+                    il.Emit(OpCodes.Ret);
+                    tb.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
-                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
-                object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, a, b]);
+                    Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                    object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, a, b]);
 
-                Assert.IsType(returnType, resultValue);
-                Assert.Equal(result, resultValue);
-            }
+                    Assert.IsType(returnType, resultValue);
+                    Assert.Equal(result, resultValue);
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -1659,35 +1668,39 @@ internal class Dummy
 
         private static string StringReverse(string a) => string.Join("", a.Reverse());
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void EmitCalliNonBlittable()
         {
-            string input = "Test string!", result = "!gnirts tseT";
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliNonBlittable"), out MethodInfo saveMethod);
-                TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
-                Type returnType = typeof(string);
-                MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(string)]);
-                methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
-                ILGenerator il = methodBuilder.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Ldarg_0);
-                il.EmitCalli(OpCodes.Calli, CallingConvention.Cdecl, returnType, [typeof(string)]);
-                il.Emit(OpCodes.Ret);
-                tb.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                string input = "Test string!", result = "!gnirts tseT";
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("EmitCalliNonBlittable"), out MethodInfo saveMethod);
+                    TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+                    Type returnType = typeof(string);
+                    MethodBuilder methodBuilder = tb.DefineMethod("F", MethodAttributes.Public | MethodAttributes.Static, returnType, [typeof(IntPtr), typeof(string)]);
+                    methodBuilder.SetImplementationFlags(MethodImplAttributes.NoInlining);
+                    ILGenerator il = methodBuilder.GetILGenerator();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.EmitCalli(OpCodes.Calli, CallingConvention.Cdecl, returnType, [typeof(string)]);
+                    il.Emit(OpCodes.Ret);
+                    tb.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
-                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
-                var del = new StringReverseCdecl(StringReverse);
-                IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(del);
-                object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, input]);
-                GC.KeepAlive(del);
+                    Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                    var del = new StringReverseCdecl(StringReverse);
+                    IntPtr funcPtr = Marshal.GetFunctionPointerForDelegate(del);
+                    object resultValue = typeFromDisk.GetMethod("F", BindingFlags.Public | BindingFlags.Static).Invoke(null, [funcPtr, input]);
+                    GC.KeepAlive(del);
 
-                Assert.IsType(returnType, resultValue);
-                Assert.Equal(result, resultValue);
-            }
+                    Assert.IsType(returnType, resultValue);
+                    Assert.Equal(result, resultValue);
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
 
         [Fact]
@@ -2093,120 +2106,131 @@ internal class Dummy
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void SimpleForLoopTest()
         {
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder tb, out MethodInfo saveMethod);
-                MethodBuilder mb2 = tb.DefineMethod("SumMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int)]);
-                ILGenerator il = mb2.GetILGenerator();
-                LocalBuilder sum = il.DeclareLocal(typeof(int));
-                LocalBuilder i = il.DeclareLocal(typeof(int));
-                Label loopEnd = il.DefineLabel();
-                Label loopStart = il.DefineLabel();
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Stloc_0);
-                il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Stloc_1);
-                il.MarkLabel(loopStart);
-                il.Emit(OpCodes.Ldloc_1);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Bgt, loopEnd);
-                il.Emit(OpCodes.Ldloc_0);
-                il.Emit(OpCodes.Ldloc_1);
-                il.Emit(OpCodes.Add);
-                il.Emit(OpCodes.Stloc_0);
-                il.Emit(OpCodes.Ldloc_1);
-                il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Add);
-                il.Emit(OpCodes.Stloc_1);
-                il.Emit(OpCodes.Br, loopStart);
-                il.MarkLabel(loopEnd);
-                il.Emit(OpCodes.Ldloc_0);
-                il.Emit(OpCodes.Ret);
-                tb.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder tb, out MethodInfo saveMethod);
+                    MethodBuilder mb2 = tb.DefineMethod("SumMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int)]);
+                    ILGenerator il = mb2.GetILGenerator();
+                    LocalBuilder sum = il.DeclareLocal(typeof(int));
+                    LocalBuilder i = il.DeclareLocal(typeof(int));
+                    Label loopEnd = il.DefineLabel();
+                    Label loopStart = il.DefineLabel();
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Stloc_0);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Stloc_1);
+                    il.MarkLabel(loopStart);
+                    il.Emit(OpCodes.Ldloc_1);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Bgt, loopEnd);
+                    il.Emit(OpCodes.Ldloc_0);
+                    il.Emit(OpCodes.Ldloc_1);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc_0);
+                    il.Emit(OpCodes.Ldloc_1);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Stloc_1);
+                    il.Emit(OpCodes.Br, loopStart);
+                    il.MarkLabel(loopEnd);
+                    il.Emit(OpCodes.Ldloc_0);
+                    il.Emit(OpCodes.Ret);
+                    tb.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                MethodInfo getMaxStackMethod = GetMaxStackMethod();
-                Assert.Equal(2, getMaxStackMethod.Invoke(il, null));
+                    MethodInfo getMaxStackMethod = GetMaxStackMethod();
+                    Assert.Equal(2, getMaxStackMethod.Invoke(il, null));
 
-                Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
-                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
-                MethodInfo sumMethodFromDisk = typeFromDisk.GetMethod("SumMethod");
-                Assert.Equal(55, sumMethodFromDisk.Invoke(null, [10]));
-            }
+                    Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                    MethodInfo sumMethodFromDisk = typeFromDisk.GetMethod("SumMethod");
+                    Assert.Equal(55, sumMethodFromDisk.Invoke(null, [10]));
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void RecursiveSumTest()
         {
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("RecursiveSumTest"), out MethodInfo saveMethod);
-                TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
-                MethodBuilder mb2 = tb.DefineMethod("RecursiveMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int)]);
-                ILGenerator il = mb2.GetILGenerator();
-                Label loopEnd = il.DefineLabel();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ble, loopEnd); // if (value1 <= value2)
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Sub);
-                il.Emit(OpCodes.Call, mb2);
-                il.Emit(OpCodes.Add);
-                il.Emit(OpCodes.Ret);
-                il.MarkLabel(loopEnd);
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Ret);
-                tb.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndSaveMethod(new AssemblyName("RecursiveSumTest"), out MethodInfo saveMethod);
+                    TypeBuilder tb = ab.DefineDynamicModule("MyModule").DefineType("MyType", TypeAttributes.Public | TypeAttributes.Class);
+                    MethodBuilder mb2 = tb.DefineMethod("RecursiveMethod", MethodAttributes.Public | MethodAttributes.Static, typeof(int), [typeof(int)]);
+                    ILGenerator il = mb2.GetILGenerator();
+                    Label loopEnd = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Ble, loopEnd); // if (value1 <= value2)
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Sub);
+                    il.Emit(OpCodes.Call, mb2);
+                    il.Emit(OpCodes.Add);
+                    il.Emit(OpCodes.Ret);
+                    il.MarkLabel(loopEnd);
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Ret);
+                    tb.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                MethodInfo getMaxStackMethod = GetMaxStackMethod();
-                Assert.Equal(3, getMaxStackMethod.Invoke(il, null));
+                    MethodInfo getMaxStackMethod = GetMaxStackMethod();
+                    Assert.Equal(3, getMaxStackMethod.Invoke(il, null));
 
-                Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
-                Type typeFromDisk = assemblyFromDisk.GetType("MyType");
-                MethodInfo recursiveMethodFromDisk = typeFromDisk.GetMethod("RecursiveMethod");
-                Assert.NotNull(recursiveMethodFromDisk);
-                Assert.Equal(55, recursiveMethodFromDisk.Invoke(null, [10]));
-            }
+                    Assembly assemblyFromDisk = Assembly.LoadFrom(file.Path);
+                    Type typeFromDisk = assemblyFromDisk.GetType("MyType");
+                    MethodInfo recursiveMethodFromDisk = typeFromDisk.GetMethod("RecursiveMethod");
+                    Assert.NotNull(recursiveMethodFromDisk);
+                    Assert.Equal(55, recursiveMethodFromDisk.Invoke(null, [10]));
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void CallOpenGenericMembersFromConstructedGenericType()
         {
-            using (TempFile file = TempFile.Create())
+            RemoteExecutor.Invoke(() =>
             {
-                AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
-                MethodBuilder method = type.DefineMethod("M1", MethodAttributes.Public, null, null);
+                using (TempFile file = TempFile.Create())
+                {
+                    AssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderTypeBuilderAndSaveMethod(out TypeBuilder type, out MethodInfo saveMethod);
+                    MethodBuilder method = type.DefineMethod("M1", MethodAttributes.Public, typeof(string), null);
 
-                ILGenerator ilGenerator = method.GetILGenerator();
-                LocalBuilder span = ilGenerator.DeclareLocal(typeof(ReadOnlySpan<char>));
-                LocalBuilder str = ilGenerator.DeclareLocal(typeof(string));
+                    ILGenerator ilGenerator = method.GetILGenerator();
+                    LocalBuilder span = ilGenerator.DeclareLocal(typeof(ReadOnlySpan<char>));
+                    LocalBuilder str = ilGenerator.DeclareLocal(typeof(string));
 
-                ilGenerator.Emit(OpCodes.Ldstr, "hello");
-                ilGenerator.Emit(OpCodes.Call, typeof(MemoryExtensions).GetMethod("AsSpan", [typeof(string)])!);
-                ilGenerator.Emit(OpCodes.Stloc, span);
-                ilGenerator.Emit(OpCodes.Ldloca_S, span);
-                ilGenerator.Emit(OpCodes.Ldc_I4_1);
-                ilGenerator.Emit(OpCodes.Call, typeof(ReadOnlySpan<char>).GetMethod("Slice", [typeof(int)])!);
-                ilGenerator.Emit(OpCodes.Stloc, span);
-                ilGenerator.Emit(OpCodes.Ldloca_S, span);
-                ilGenerator.Emit(OpCodes.Constrained, typeof(ReadOnlySpan<char>));
-                ilGenerator.Emit(OpCodes.Callvirt, typeof(object).GetMethod("ToString"));
-                ilGenerator.Emit(OpCodes.Stloc, str);
-                ilGenerator.EmitWriteLine(str);
-                ilGenerator.Emit(OpCodes.Ret);
+                    ilGenerator.Emit(OpCodes.Ldstr, "hello");
+                    ilGenerator.Emit(OpCodes.Call, typeof(MemoryExtensions).GetMethod("AsSpan", [typeof(string)])!);
+                    ilGenerator.Emit(OpCodes.Stloc, span);
+                    ilGenerator.Emit(OpCodes.Ldloca_S, span);
+                    ilGenerator.Emit(OpCodes.Ldc_I4_1);
+                    ilGenerator.Emit(OpCodes.Call, typeof(ReadOnlySpan<char>).GetMethod("Slice", [typeof(int)])!);
+                    ilGenerator.Emit(OpCodes.Stloc, span);
+                    ilGenerator.Emit(OpCodes.Ldloca_S, span);
+                    ilGenerator.Emit(OpCodes.Constrained, typeof(ReadOnlySpan<char>));
+                    ilGenerator.Emit(OpCodes.Callvirt, typeof(object).GetMethod("ToString"));
+                    ilGenerator.Emit(OpCodes.Ret);
 
-                type.CreateType();
-                saveMethod.Invoke(ab, [file.Path]);
+                    type.CreateType();
+                    saveMethod.Invoke(ab, [file.Path]);
 
-                Type typeFromDisk = Assembly.LoadFile(file.Path).GetType("MyType");
-                typeFromDisk.GetMethod("M1").Invoke(Activator.CreateInstance(typeFromDisk), null);
-            }
+                    Type typeFromDisk = Assembly.LoadFile(file.Path).GetType("MyType");
+                    string result = (string)typeFromDisk.GetMethod("M1").Invoke(Activator.CreateInstance(typeFromDisk), null);
+                    Assert.Equal("ello", result);
+                }
+                return RemoteExecutor.SuccessExitCode;
+            }).Dispose();
         }
     }
 }


### PR DESCRIPTION
The method signature populated incorrectly for non generic method that declared within generic type and uses the generic parameters as return type or parameter.

For example, return type of `ReadonlySpan<T>.Slice(int)` method of an `ReadonlySpan<char>` instance should be closed generic `ReadonlySpan<T>` not `ReadonlySpan<char>`: 

Fixes https://github.com/dotnet/runtime/issues/96469