### PR TITLE
Upstreaming typo from runtimelab

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -48,7 +48,7 @@ namespace Internal.Runtime
                 if (type->RequiresAlign8)
                 {
                     // Align8 objects are not supported yet
-                    return nullptr;
+                    return null;
                 }
 #endif
 


### PR DESCRIPTION
This PR changes `nullptr` to `null` - a typo in some unreachable code that is reachable in runtimelab.

cc @MichalStrehovsky 