### PR TITLE
Set `s_naiveThreshold` to `const` in the release build.

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -657,7 +657,13 @@ namespace System
         // algorithm with a running time of O(N^2). And if it is greater than the threshold, use
         // a divide-and-conquer algorithm with a running time of O(NlogN).
         //
-        private static int s_naiveThreshold = 20000; // non-readonly for testing
+#if DEBUG
+        // Mutable for unit testing...
+        private static
+#else
+        private const
+#endif
+        int s_naiveThreshold = 20000;
         private static ParsingStatus NumberToBigInteger(ref NumberBuffer number, out BigInteger result)
         {
             int currentBufferSize = 0;


### PR DESCRIPTION
Another source uses the following idiom. I have adapted it.

```csharp
#if DEBUG
        // Mutable for unit testing...
        private static
#else
        private const
#endif
```

https://github.com/dotnet/runtime/blob/9e31c21bcbb661fc4fa235839a66442a65ef447c/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs#L8-L14

https://github.com/dotnet/runtime/blob/9e31c21bcbb661fc4fa235839a66442a65ef447c/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.SquMul.cs#L13-L19