### PR TITLE
Limit PNSE by using default comparer in `HybridGlobalization`

### DIFF
--- a/docs/design/features/globalization-hybrid-mode.md
+++ b/docs/design/features/globalization-hybrid-mode.md
@@ -19,31 +19,36 @@ Hybrid has higher priority than sharding or custom modes, described in globaliza
 
 **SortKey**
 
+SortKey equivalent is not available in JS. Following APIs will throw `PlatformNotSupportedException`:
+
 Affected public APIs:
 - System.Globalization.CompareInfo.GetSortKey
 - System.Globalization.CompareInfo.GetSortKeyLength
 - System.Globalization.CompareInfo.GetHashCode
-Indirectly affected APIs (the list might not be complete):
-- Microsoft.VisualBasic.Collection.Add
-- System.Collections.Hashtable.Add
-- System.Collections.Hashtable.GetHash
-- System.Collections.CaseInsensitiveHashCodeProvider.GetHashCode
-- System.Collections.Specialized.NameObjectCollectionBase.BaseAdd
-- System.Collections.Specialized.NameValueCollection.Add
-- System.Collections.Specialized.NameObjectCollectionBase.BaseGet
-- System.Collections.Specialized.NameValueCollection.Get
-- System.Collections.Specialized.NameObjectCollectionBase.BaseRemove
-- System.Collections.Specialized.NameValueCollection.Remove
-- System.Collections.Specialized.OrderedDictionary.Add
-- System.Collections.Specialized.NameObjectCollectionBase.BaseSet
-- System.Collections.Specialized.NameValueCollection.Set
-- System.Data.DataColumnCollection.Add
-- System.Collections.Generic.HashSet
-- System.Collections.Generic.Dictionary
+
+Some classes use these functions internally. We were able to maintain support for most of them, with changed behavior.
+
+Indirectly affected APIs that throw `PlatformNotSupportedException`:
+- System.Collections.CaseInsensitiveHashCodeProvider.GetHashCode (deprecated)
+- Microsoft.VisualBasic.Collection.Add (string-keyed collections only)
+- System.Data.DataColumnCollection.Add (string-keyed collections only)
 - System.Net.Mail.MailAddress.GetHashCode
 - System.Xml.Xsl.XslCompiledTransform.Transform
 
-Web API does not have an equivalent, so they throw `PlatformNotSupportedException`.
+Indirectly affected APIs with changed behavior (string-keyed collections):
+
+In `Hybrid Globalization` these collections use `StringComparer.Ordinal` as a default comparer:
+- System.Collections.Generic.Dictionary
+- System.Collections.Generic.HashSet
+- System.Collections.Hashtable
+You can overwrite this comparer by using constructor with parameter, e.g. [Dictionary<TKey,TValue>(IEqualityComparer<TKey>)](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.-ctor#system-collections-generic-dictionary-2-ctor(system-collections-generic-iequalitycomparer((-0)))). The only supported options for string-keys are: `StringComparer.Ordinal` and `StringComparer.OrdinalIgnoreCase`, other options throw `PlatformNotSupportedException`.
+
+`Hashtable` is non-generic collection that defines the types of keys in the runtime. `Hybrid Globalization` does not support using `string` keys together with `non-string` keys in the same collection.
+
+These collections will throw `PlatformNotSupportedException` if they were constructed without `StringComparer.Ordinal` or `StringComparer.OrdinalIgnoreCase` but use string keys.
+- System.Collections.Specialized.NameValueCollection
+- System.Collections.Specialized.NameObjectCollectionBase
+- System.Collections.Specialized.OrderedDictionary
 
 **Case change**
 

--- a/src/libraries/System.Collections.Specialized/tests/Helpers.cs
+++ b/src/libraries/System.Collections.Specialized/tests/Helpers.cs
@@ -7,7 +7,9 @@ namespace System.Collections.Specialized.Tests
     {
         public static MyNameObjectCollection CreateNameObjectCollection(int count)
         {
-            MyNameObjectCollection nameObjectCollection = new MyNameObjectCollection();
+            MyNameObjectCollection nameObjectCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new MyNameObjectCollection(StringComparer.OrdinalIgnoreCase) :
+                new MyNameObjectCollection();
 
             for (int i = 0; i < count; i++)
             {
@@ -19,7 +21,9 @@ namespace System.Collections.Specialized.Tests
 
         public static NameValueCollection CreateNameValueCollection(int count, int start = 0)
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
 
             for (int i = start; i < start + count; i++)
             {

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/MyNameObjectCollection.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/MyNameObjectCollection.cs
@@ -22,7 +22,7 @@ namespace System.Collections.Specialized.Tests
 
         public bool HasKeys() => BaseHasKeys();
 
-        public void Add(string name, Foo value) =>  BaseAdd(name, value);
+        public void Add(string name, Foo value) => BaseAdd(name, value);
 
         public void Remove(string name) => BaseRemove(name);
 

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.ConstructorTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.ConstructorTests.cs
@@ -20,11 +20,13 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(0, coll.Count);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Constructor_Int_Provider_Comparer()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            MyNameObjectCollection coll = new MyNameObjectCollection(5, CaseInsensitiveHashCodeProvider.DefaultInvariant, CaseInsensitiveComparer.DefaultInvariant);
+            MyNameObjectCollection coll = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new MyNameObjectCollection(5, StringComparer.OrdinalIgnoreCase) :
+                new MyNameObjectCollection(5, CaseInsensitiveHashCodeProvider.DefaultInvariant, CaseInsensitiveComparer.DefaultInvariant);
 #pragma warning restore CS0618 // Type or member is obsolete
             coll.Add("a", new Foo("1"));
             int i = 0;

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.CopyToTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.CopyToTests.cs
@@ -7,14 +7,14 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseCopyToTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0, 0)]
         [InlineData(0, 5)]
         [InlineData(10, 0)]
         [InlineData(10, 5)]
         public void CopyTo(int count, int index)
         {
-            MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(count);
+             MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(count);
             ICollection collection = nameObjectCollection;
 
             string[] copyArray = new string[index + collection.Count + index];
@@ -39,7 +39,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(previousCount, copyArray.Length);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void CopyTo_Invalid(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.GetAllValuesTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.GetAllValuesTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class GetAllValuesTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0, typeof(object))]
         [InlineData(0, typeof(Foo))]
         [InlineData(10, typeof(object))]
@@ -33,10 +33,12 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public static void GetAllValues_Invalid()
         {
-            MyNameObjectCollection nameObjectCollection = new MyNameObjectCollection();
+            MyNameObjectCollection nameObjectCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new MyNameObjectCollection(StringComparer.OrdinalIgnoreCase) :
+                new MyNameObjectCollection();
             AssertExtensions.Throws<ArgumentNullException>("type", () => nameObjectCollection.GetAllValues(null));
 
             nameObjectCollection.Add("name", new Foo("value"));

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.GetEnumeratorTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.GetEnumeratorTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseGetEnumeratorTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void GetEnumerator(int count)
@@ -29,7 +29,7 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void GetEnumerator_Invalid(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.KeysTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.KeysTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseKeysTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Keys_PreservesInstance(int count)
@@ -16,7 +16,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Same(nameObjectCollection.Keys, nameObjectCollection.Keys);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Keys_GetEnumerator(int count)
@@ -40,7 +40,7 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Keys_GetEnumerator_Invalid(int count)
@@ -85,7 +85,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Keys_Properties(int count)
@@ -97,7 +97,7 @@ namespace System.Collections.Specialized.Tests
             Assert.False(keysCollection.IsSynchronized);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0, 0)]
         [InlineData(0, 5)]
         [InlineData(10, 0)]
@@ -145,7 +145,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(previousCount, keysArray.Length);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Keys_CopyTo_Invalid(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.ReadOnlyTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.ReadOnlyTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseReadOnlyTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void IsReadOnly_Set()
         {
             MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(10);

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.RemoveAtTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.RemoveAtTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseRemoveAtTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void RemoveAt()
         {
             MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(10);
@@ -59,7 +59,7 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void RemoveAt_InvalidIndex_ThrowsArgumentOutOfRangeException(int count)
@@ -69,7 +69,7 @@ namespace System.Collections.Specialized.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => nameObjectCollection.RemoveAt(count));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void RemoveAt_ReadOnly_ThrowsNotSupportedException()
         {
             MyNameObjectCollection nameObjectCollection = Helpers.CreateNameObjectCollection(1);

--- a/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.SetItemTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameObjectCollectionBase/NameObjectCollectionBase.SetItemTests.cs
@@ -7,10 +7,12 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameObjectCollectionBaseSetItemTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Set_ObjectAtIndex_ModifiesCollection()
         {
-            var noc = new MyNameObjectCollection();
+            var noc = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new MyNameObjectCollection(StringComparer.OrdinalIgnoreCase) :
+                new MyNameObjectCollection();
             for (int i = 0; i < 10; i++)
             {
                 var foo1 = new Foo("Value_1");

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.AddNVCTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.AddNVCTests.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionAddNameValueCollectionTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0, 0)]
         [InlineData(0, 5)]
         [InlineData(5, 0)]
@@ -43,11 +43,15 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add_ExistingKeys()
         {
-            NameValueCollection nameValueCollection1 = new NameValueCollection();
-            NameValueCollection nameValueCollection2 = new NameValueCollection();
+            NameValueCollection nameValueCollection1 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            NameValueCollection nameValueCollection2 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
 
             string name = "name";
             string value1 = "value1";
@@ -61,11 +65,15 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(new string[] { value2, value1 }, nameValueCollection2.GetValues(name));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add_MultipleValues()
         {
-            NameValueCollection nameValueCollection1 = new NameValueCollection();
-            NameValueCollection nameValueCollection2 = new NameValueCollection();
+            NameValueCollection nameValueCollection1 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            NameValueCollection nameValueCollection2 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
 
             string name = "name";
             string value1 = "value1";
@@ -83,9 +91,15 @@ namespace System.Collections.Specialized.Tests
         [Fact]
         public void Add_NameValueCollection_WithNullKeys()
         {
-            NameValueCollection nameValueCollection1 = new NameValueCollection();
-            NameValueCollection nameValueCollection2 = new NameValueCollection();
-            NameValueCollection nameValueCollection3 = new NameValueCollection();
+            NameValueCollection nameValueCollection1 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            NameValueCollection nameValueCollection2 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            NameValueCollection nameValueCollection3 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
 
 
             string nullKeyValue1 = "value";
@@ -104,11 +118,15 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(nullKeyValue1 + "," + nullKeyValue2, nameValueCollection3[null]);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add_NameValueCollection_WithNullValues()
         {
-            NameValueCollection nameValueCollection1 = new NameValueCollection();
-            NameValueCollection nameValueCollection2 = new NameValueCollection();
+            NameValueCollection nameValueCollection1 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            NameValueCollection nameValueCollection2 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
 
             string nullValueName = "name";
             nameValueCollection1.Add(nullValueName, null);
@@ -122,7 +140,10 @@ namespace System.Collections.Specialized.Tests
         [Fact]
         public void Add_NullNameValueCollection_ThrowsArgumentNullException()
         {
-            AssertExtensions.Throws<ArgumentNullException>("c", () => new NameValueCollection().Add(null));
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
+            AssertExtensions.Throws<ArgumentNullException>("c", () => nameValueCollection.Add(null));
         }
     }
 }

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.AddStringStringTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.AddStringStringTests.cs
@@ -8,10 +8,12 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionAddStringStringTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             Assert.False(nameValueCollection.HasKeys());
             for (int i = 0; i < 10; i++)
             {
@@ -82,10 +84,12 @@ namespace System.Collections.Specialized.Tests
             Assert.False(nameValueCollection.HasKeys());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add_NullValue()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             nameValueCollection.Add(name, null);
             Assert.Equal(1, nameValueCollection.Count);
@@ -108,10 +112,12 @@ namespace System.Collections.Specialized.Tests
             Assert.True(nameValueCollection.HasKeys());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Add_AddingValueToExistingName_AppendsValueToOriginalValue()
         {
-            var nameValueCollection = new NameValueCollection();
+            var nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             nameValueCollection.Add(name, "value1");
             nameValueCollection.Add(name, "value2");

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.ClearTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.ClearTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionClearTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(10)]
         public void Clear(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CopyToTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionCopyToTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0, 0)]
         [InlineData(0, 1)]
         [InlineData(5, 0)]
@@ -37,10 +37,12 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void CopyTo_MultipleValues_SameName()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             nameValueCollection.Add(name, "value1");
             nameValueCollection.Add(name, "value2");
@@ -51,7 +53,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(nameValueCollection[0], dest[0]);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void CopyTo_Invalid(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CtorTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.CtorTests.cs
@@ -46,12 +46,14 @@ namespace System.Collections.Specialized.Tests
             Assert.False(((ICollection)nameValueCollection).IsSynchronized);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Ctor_Int(int capacity)
         {
-            NameValueCollection nameValueCollection = new NameValueCollection(capacity);
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(capacity, StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection(capacity);
             Assert.Equal(0, nameValueCollection.Count);
             Assert.Equal(0, nameValueCollection.Keys.Count);
             Assert.Equal(0, nameValueCollection.AllKeys.Length);
@@ -80,12 +82,20 @@ namespace System.Collections.Specialized.Tests
 
         public static IEnumerable<object[]> Ctor_NameValueCollection_TestData()
         {
-            yield return new object[] { new NameValueCollection(10) };
-            yield return new object[] { new NameValueCollection() };
+            yield return new object[] {
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(10, StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection(10)
+                };
+            yield return new object[] {
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection()
+                };
             yield return new object[] { Helpers.CreateNameValueCollection(10) };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [MemberData(nameof(Ctor_NameValueCollection_TestData))]
         public void Ctor_NameValueCollection(NameValueCollection nameValueCollection1)
         {
@@ -115,18 +125,32 @@ namespace System.Collections.Specialized.Tests
 
         public static IEnumerable<object[]> Ctor_Int_NameValueCollection_TestData()
         {
-            yield return new object[] { 0, new NameValueCollection() };
-
-            yield return new object[] { 10, new NameValueCollection(10) };
-            yield return new object[] { 5, new NameValueCollection(10) };
-            yield return new object[] { 15, new NameValueCollection(10) };
-
+            yield return new object[] { 0, 
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection()
+            };
+            yield return new object[] { 10,
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(10, StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection(10)
+            };
+            yield return new object[] { 5,
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(10, StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection(10)
+            };
+            yield return new object[] { 15,
+                PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                    new NameValueCollection(10, StringComparer.OrdinalIgnoreCase) :
+                    new NameValueCollection(10)
+            };
             yield return new object[] { 10, Helpers.CreateNameValueCollection(10) };
             yield return new object[] { 5, Helpers.CreateNameValueCollection(10) };
             yield return new object[] { 15, Helpers.CreateNameValueCollection(10) };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [MemberData(nameof(Ctor_Int_NameValueCollection_TestData))]
         public void Ctor_Int_NameValueCollection(int capacity, NameValueCollection nameValueCollection1)
         {
@@ -152,11 +176,14 @@ namespace System.Collections.Specialized.Tests
             yield return new object[] { 0, new IdiotComparer() };
             yield return new object[] { 10, new IdiotComparer() };
             yield return new object[] { 1000, new IdiotComparer() };
-            yield return new object[] { 0, null };
-            yield return new object[] { 10, null };
+            if (PlatformDetection.IsNotHybridGlobalizationOnBrowser)
+            {
+                yield return new object[] { 0, null };
+                yield return new object[] { 10, null };
+            }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [MemberData(nameof(Ctor_Int_IEqualityComparer_TestData))]
         public void Ctor_Int_IEqualityComparer(int capacity, IEqualityComparer equalityComparer)
         {
@@ -167,10 +194,11 @@ namespace System.Collections.Specialized.Tests
         public static IEnumerable<object[]> Ctor_IEqualityComparer_TestData()
         {
             yield return new object[] { new IdiotComparer() };
-            yield return new object[] { null };
+            if (PlatformDetection.IsNotHybridGlobalizationOnBrowser)
+                yield return new object[] { null };
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [MemberData(nameof(Ctor_IEqualityComparer_TestData))]
         public void Ctor_IEqualityComparer(IEqualityComparer equalityComparer)
         {

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetIntTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetIntTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetIntTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Get_InvalidIndex_ThrowsArgumentOutOfRangeException(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetItemTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetItemTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetItemTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Item_Get_InvalidIndex_ThrowsArgumentOutOfRangeException(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetKeyTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetKeyTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetKeyTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Get_InvalidIndex_ThrowsArgumentOutOfRangeException(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetStringTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetStringTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetStringTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Get_NoSuchName_ReturnsNull(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetValuesIntTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetValuesIntTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetValuesIntTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void GetValues_InvalidIndex_ThrowsArgumentOutOfRangeException(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetValuesStringTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.GetValuesStringTests.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionGetValuesStringTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void GetValues_NoSuchName_ReturnsNull(int count)

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.RemoveTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.RemoveTests.cs
@@ -8,7 +8,7 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionRemoveTests
     {
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Remove(int count)
@@ -46,10 +46,12 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Remove_MultipleValues_SameName()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             nameValueCollection.Add(name, "value1");
             nameValueCollection.Add(name, "value2");

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.SetItemTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.SetItemTests.cs
@@ -7,10 +7,12 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionSetItemTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Item_Set()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             for (int i = 0; i < 10; i++)
             {
                 string newName = "Name_" + i;
@@ -22,10 +24,12 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Item_Set_OvewriteExistingValue()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             string value = "value";
             nameValueCollection.Add(name, "old-value");
@@ -35,7 +39,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(new string[] { value }, nameValueCollection.GetValues(name));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Item_Set_NullName(int count)
@@ -53,7 +57,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(newNullNameValue, nameValueCollection[null]);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Item_Set_NullValue(int count)
@@ -74,10 +78,12 @@ namespace System.Collections.Specialized.Tests
             Assert.Null(nameValueCollection[nullValueName]);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Item_Set_IsCaseSensitive()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             nameValueCollection["name"] = "value1";
             nameValueCollection["Name"] = "value2";
             nameValueCollection["NAME"] = "value3";

--- a/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.SetTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/NameValueCollection/NameValueCollection.SetTests.cs
@@ -7,10 +7,12 @@ namespace System.Collections.Specialized.Tests
 {
     public class NameValueCollectionSetTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Set()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             int newCount = 10;
             for (int i = 0; i < newCount; i++)
             {
@@ -23,10 +25,12 @@ namespace System.Collections.Specialized.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Set_OvewriteExistingValue()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             string name = "name";
             string value = "value";
             nameValueCollection.Add(name, "old-value");
@@ -36,7 +40,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(new string[] { value }, nameValueCollection.GetValues(name));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Set_NullName(int count)
@@ -54,7 +58,7 @@ namespace System.Collections.Specialized.Tests
             Assert.Equal(newNullNameValue, nameValueCollection.Get(null));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Theory]
         [InlineData(0)]
         [InlineData(5)]
         public void Set_NullValue(int count)
@@ -75,10 +79,12 @@ namespace System.Collections.Specialized.Tests
             Assert.Null(nameValueCollection.Get(nullValueName));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void Set_IsCaseSensitive()
         {
-            NameValueCollection nameValueCollection = new NameValueCollection();
+            NameValueCollection nameValueCollection = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new NameValueCollection(StringComparer.OrdinalIgnoreCase) :
+                new NameValueCollection();
             nameValueCollection.Set("name", "value1");
             nameValueCollection.Set("Name", "value2");
             nameValueCollection.Set("NAME", "value3");

--- a/src/libraries/System.Collections.Specialized/tests/OrderedDictionary/OrderedDictionaryTests.cs
+++ b/src/libraries/System.Collections.Specialized/tests/OrderedDictionary/OrderedDictionaryTests.cs
@@ -35,10 +35,12 @@ namespace System.Collections.Specialized.Tests
         }
 
         // public OrderedDictionary(IEqualityComparer comparer);
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void PassingEqualityComparers()
         {
-            var d1 = new OrderedDictionary(StringComparer.InvariantCultureIgnoreCase);
+            var d1 = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new OrderedDictionary(StringComparer.OrdinalIgnoreCase) :
+                new OrderedDictionary(StringComparer.InvariantCultureIgnoreCase);
             d1.Add("foo", "bar");
             AssertExtensions.Throws<ArgumentException>(null, () => d1.Add("FOO", "bar"));
 
@@ -55,14 +57,17 @@ namespace System.Collections.Specialized.Tests
         }
 
         // public OrderedDictionary(int capacity, IEqualityComparer comparer);
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void PassingCapacityAndIEqualityComparer()
         {
-            var d1 = new OrderedDictionary(-1000, StringComparer.InvariantCultureIgnoreCase);
-            var d2 = new OrderedDictionary(-1, StringComparer.InvariantCultureIgnoreCase);
-            var d3 = new OrderedDictionary(0, StringComparer.InvariantCultureIgnoreCase);
-            var d4 = new OrderedDictionary(1, StringComparer.InvariantCultureIgnoreCase);
-            var d5 = new OrderedDictionary(1000, StringComparer.InvariantCultureIgnoreCase);
+            var comparer = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                StringComparer.OrdinalIgnoreCase :
+                StringComparer.InvariantCultureIgnoreCase;
+            var d1 = new OrderedDictionary(-1000, comparer);
+            var d2 = new OrderedDictionary(-1, comparer);
+            var d3 = new OrderedDictionary(0, comparer);
+            var d4 = new OrderedDictionary(1, comparer);
+            var d5 = new OrderedDictionary(1000, comparer);
             Assert.Throws<ArgumentOutOfRangeException>(() => d1.Add("foo", "bar"));
             Assert.Throws<ArgumentOutOfRangeException>(() => d2.Add("foo", "bar"));
             d3.Add("foo", "bar");
@@ -626,10 +631,12 @@ namespace System.Collections.Specialized.Tests
             Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public void IListedKeysPropertyCanUseCustomEqualityComparer()
         {
-            var orderedDictionary = new OrderedDictionary(StringComparer.InvariantCultureIgnoreCase);
+            var orderedDictionary = PlatformDetection.IsHybridGlobalizationOnBrowser ?
+                new OrderedDictionary(StringComparer.OrdinalIgnoreCase) :
+                new OrderedDictionary(StringComparer.InvariantCultureIgnoreCase);
             orderedDictionary.Add("KeY", null);
 
             IList list = (IList)orderedDictionary.Keys;

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -163,7 +163,7 @@ namespace System.Collections.Tests
             if (PlatformDetection.IsNotHybridGlobalizationOnBrowser)
             {
                 // linguistic comparer (not optimized)
-                RunDictionaryTest(
+                RunHashSetTest(
                     equalityComparer: StringComparer.InvariantCulture,
                     expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
                     expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,

--- a/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
+++ b/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs
@@ -42,7 +42,7 @@ namespace System.Collections.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public static void ComparerImplementations_Dictionary_WithWellKnownStringComparers()
         {
             Type nonRandomizedOrdinalComparerType = typeof(object).Assembly.GetType("System.Collections.Generic.NonRandomizedStringEqualityComparer+OrdinalComparer", throwOnError: true);
@@ -82,13 +82,15 @@ namespace System.Collections.Tests
                 expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase,
                 expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
 
-            // linguistic comparer (not optimized)
-
-            RunDictionaryTest(
-                equalityComparer: StringComparer.InvariantCulture,
-                expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
-                expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+            if (PlatformDetection.IsNotHybridGlobalizationOnBrowser)
+            {
+                // linguistic comparer (not optimized)
+                RunDictionaryTest(
+                    equalityComparer: StringComparer.InvariantCulture,
+                    expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
+                    expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
+                    expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+            }
 
             // CollectionsMarshal.GetValueRefOrAddDefault
 
@@ -118,7 +120,7 @@ namespace System.Collections.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotHybridGlobalizationOnBrowser))]
+        [Fact]
         public static void ComparerImplementations_HashSet_WithWellKnownStringComparers()
         {
             Type nonRandomizedOrdinalComparerType = typeof(object).Assembly.GetType("System.Collections.Generic.NonRandomizedStringEqualityComparer+OrdinalComparer", throwOnError: true);
@@ -158,13 +160,15 @@ namespace System.Collections.Tests
                 expectedPublicComparerBeforeCollisionThreshold: StringComparer.OrdinalIgnoreCase,
                 expectedInternalComparerTypeAfterCollisionThreshold: randomizedOrdinalIgnoreCaseComparerType);
 
-            // linguistic comparer (not optimized)
-
-            RunHashSetTest(
-                equalityComparer: StringComparer.InvariantCulture,
-                expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
-                expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
-                expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+            if (PlatformDetection.IsNotHybridGlobalizationOnBrowser)
+            {
+                // linguistic comparer (not optimized)
+                RunDictionaryTest(
+                    equalityComparer: StringComparer.InvariantCulture,
+                    expectedInternalComparerTypeBeforeCollisionThreshold: StringComparer.InvariantCulture.GetType(),
+                    expectedPublicComparerBeforeCollisionThreshold: StringComparer.InvariantCulture,
+                    expectedInternalComparerTypeAfterCollisionThreshold: StringComparer.InvariantCulture.GetType());
+            }
 
             static void RunHashSetTest(
                 IEqualityComparer<string> equalityComparer,

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4100,6 +4100,9 @@
   <data name="PlatformNotSupported_HybridGlobalization" xml:space="preserve">
     <value>{0} is not supported when HybridGlobalization=true. Disable it to load larger ICU bundle, then use this option.</value>
   </data>
+  <data name="PlatformNotSupported_HybridGlobalizationHashCode" xml:space="preserve">
+    <value>{0} is not supported when HybridGlobalization=true. If possible, use collection cctr(IEqualityComparer) with value StringComparer.Ordinal or StringComparer.OrdinalIgnoreCase instead. Otherwise, disable Hybrid Globalization to increase application size by loading ICU data.</value>
+  </data>
   <data name="NotSupported_BodyRemoved" xml:space="preserve">
     <value>The body of this method was removed by the AOT compiler because it's not callable.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+using System.Globalization;
 
 namespace System.Collections.Generic
 {
@@ -72,7 +73,18 @@ namespace System.Collections.Generic
                 if (typeof(TKey) == typeof(string) &&
                     NonRandomizedStringEqualityComparer.GetStringComparer(_comparer!) is IEqualityComparer<string> stringComparer)
                 {
+#if TARGET_BROWSER
+                    if (GlobalizationMode.Hybrid)
+                    {
+                        _comparer = comparer ?? (IEqualityComparer<TKey>)(IEqualityComparer<string>)StringComparer.Ordinal;
+                    }
+                    else
+                    {
+                        _comparer = (IEqualityComparer<TKey>)stringComparer;
+                    }
+#else
                     _comparer = (IEqualityComparer<TKey>)stringComparer;
+#endif
                 }
             }
             else if (comparer is not null && // first check for null to avoid forcing default comparer instantiation unnecessarily

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Globalization;
 
 namespace System.Collections.Generic
 {
@@ -70,7 +71,18 @@ namespace System.Collections.Generic
                 if (typeof(T) == typeof(string) &&
                     NonRandomizedStringEqualityComparer.GetStringComparer(_comparer!) is IEqualityComparer<string> stringComparer)
                 {
+#if TARGET_BROWSER
+                    if (GlobalizationMode.Hybrid)
+                    {
+                        _comparer = comparer ?? (IEqualityComparer<T>)(IEqualityComparer<string>)StringComparer.Ordinal;
+                    }
+                    else
+                    {
+                        _comparer = (IEqualityComparer<T>)stringComparer;
+                    }
+#else
                     _comparer = (IEqualityComparer<T>)stringComparer;
+#endif
                 }
             }
             else if (comparer is not null && // first check for null to avoid forcing default comparer instantiation unnecessarily

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Hashtable.cs
@@ -17,6 +17,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
+using System.Globalization;
 
 namespace System.Collections
 {
@@ -415,6 +416,17 @@ namespace System.Collections
         //
         public virtual void Add(object key, object? value)
         {
+#if TARGET_BROWSER
+            if (_keycomparer == null)
+            {
+                // for non-generic collections type of keys is defined in the runtime
+                // adding keys of different types later will throw an exception
+                if (GlobalizationMode.Hybrid && key is string)
+                {
+                    _keycomparer = StringComparer.Ordinal;
+                }
+            }
+#endif
             Insert(key, value, true);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -1609,7 +1609,7 @@ namespace System.Globalization
                 NlsGetHashCodeOfString(source, options) :
 #if TARGET_BROWSER
             GlobalizationMode.Hybrid ?
-                throw new PlatformNotSupportedException(GetPNSEText("HashCode")) :
+                throw new PlatformNotSupportedException(GetPNSETextHashCode("HashCode")) :
 #endif
                 IcuGetHashCodeOfString(source, options);
 
@@ -1649,6 +1649,7 @@ namespace System.Globalization
 
 #if TARGET_BROWSER || TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
         private static string GetPNSEText(string funcName) => SR.Format(SR.PlatformNotSupported_HybridGlobalization, funcName);
+        private static string GetPNSETextHashCode(string funcName) => SR.Format(SR.PlatformNotSupported_HybridGlobalizationHashCode, funcName);
 #endif
     }
 }


### PR DESCRIPTION
Improved version of https://github.com/dotnet/runtime/pull/96354. Fixes https://github.com/dotnet/runtime/issues/96400.
Changes:
- Sets default `comparer=StringComparer.Ordinal` for string-keyed collections that have access to `GlobalizationMode` (= are in `System.Private.CoreLib`):
`System.Collections.Generic.Dictionary`, `System.Collections.Generic.HashSet`, `System.Collections.Hashtable`
`Dictionary` and `HashSet` are generic collections and we know their key type in the compile time. We can decide if the collection requires the default comparer (has keys of string type) or not, in collection constructor.
`Hashtable` is non-generic, types of keys are not known in the compile time. Because of this, logic of comparer initialization was moved to `Add()` function. If the first element is string, we assume all the other will be strings. `Hashtable` does not prevent users from adding keys of different types and it's only a good practice to keep them in the same type. In `HybridGlobalization` keys of different types are not supported, adding non-string key to collection that has `comparer=StringComparer` will throw `ArgumentException(Arg_MustBeString)`.
- For collections that do not belong to `System.Private.CoreLib` assembly (that is:
`System.Collections.Specialized.OrderedDictionary`, `System.Collections.Specialized.NameValueCollection`, `System.Collections.Specialized.NameValueCollection`, `System.Collections.Specialized.NameObjectCollectionBase`) we cannot detect if they are run in `Hybrid Globalization` mode. It is still possible to use these collections if `StringComparer.Ordinal` or `StringComparer.OrdinalIgnoreCase` will be passed to their constructors. We change the tests to use the constructor with parameter for HG.
- Changed the PNSE message to point into using the cctr with `StringComparer.Ordinal` or `StringComparer.OrdinalIgnoreCase` parameter.
- Classes: `System.Data.DataColumnCollection`, `Microsoft.VisualBasic.Collection`, `System.Net.Mail.MailAddress`, `System.Collections.CaseInsensitiveHashCodeProvider` (deprecated) have no constructor with parameter and are not in `System.Private.CoreLib`, so none of above apply to them. They will stay unsupported.