### PR TITLE
JIT: Fix double handling of call operands when importing intrinsic

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1303,11 +1303,10 @@ DONE_CALL:
             eeGetCallSiteSig(pResolvedToken->token, pResolvedToken->tokenScope, pResolvedToken->tokenContext, sig);
         }
 
-        typeInfo tiRetVal = verMakeTypeInfo(sig->retType, sig->retTypeClass);
-
-        if (call->IsCall())
+        // Sometimes "call" is not a GT_CALL (if we imported an intrinsic that didn't turn into a call)
+        if (!bIntrinsicImported)
         {
-            // Sometimes "call" is not a GT_CALL (if we imported an intrinsic that didn't turn into a call)
+            assert(call->IsCall());
 
             GenTreeCall* origCall = call->AsCall();
 
@@ -1423,10 +1422,7 @@ DONE_CALL:
                     impSpillSideEffects(true, CHECK_SPILL_ALL DEBUGARG("non-inline candidate call"));
                 }
             }
-        }
 
-        if (!bIntrinsicImported)
-        {
             //-------------------------------------------------------------------------
             //
             /* If the call is of a small type and the callee is managed, the callee will normalize the result
@@ -1441,13 +1437,9 @@ DONE_CALL:
             }
         }
 
+        typeInfo tiRetVal = verMakeTypeInfo(sig->retType, sig->retTypeClass);
         impPushOnStack(call, tiRetVal);
     }
-
-    // VSD functions get a new call target each time we getCallInfo, so clear the cache.
-    // Also, the call info cache for CALLI instructions is largely incomplete, so clear it out.
-    // if ( (opcode == CEE_CALLI) || (callInfoCache.fetchCallInfo().kind == CORINFO_VIRTUALCALL_STUB))
-    //  callInfoCache.uncacheCallInfo();
 
     return callRetTyp;
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96461/Runtime_96461.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96461/Runtime_96461.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public class Runtime_96461
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        Vector128<int> result = Unsafe.BitCast<Vector128<int>, Vector128<int>>(V());
+        return result[0];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<int> V() => Vector128.Create(100);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96461/Runtime_96461.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96461/Runtime_96461.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Some intrinsics can be a noop when they are imported. For example,
`Unsafe.BitCast<T, T>(X)` just returns its operand when importing. If
that operand is a call then we will run the tail logic of call
importation for that call node twice, since that logic tries to filter
out intrinsic importation with an `IsCall()` check. Switch the check to
be based on `!bIntrinsicImported` instead.

Fix #96461