### PR TITLE
Replace call to GetFalseTarget method with GetTarget inside fgRemoveConditionalJump

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2586,7 +2586,7 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
     {
         printf("Block " FMT_BB " becoming a BBJ_ALWAYS to " FMT_BB " (jump target is the same whether the condition"
                " is true or false)\n",
-               block->bbNum, block->GetFalseTarget()->bbNum);
+               block->bbNum, block->GetTarget()->bbNum);
     }
 #endif
 


### PR DESCRIPTION
As I mentioned [here](https://github.com/dotnet/runtime/pull/96558#issuecomment-1878889414), this is a small fix for #95773

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @tomeksowi @yurai007 @Bajtazar