### PR TITLE
Fix native memory leak on OCSP_Response

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_ssl.c
@@ -577,7 +577,7 @@ X509* CryptoNative_SslGetPeerCertificate(SSL* ssl)
     long len = SSL_get_tlsext_status_ocsp_resp(ssl, &data);
     X509* cert = SSL_get1_peer_certificate(ssl);
 
-    if (len > 0 && cert != NULL)
+    if (len > 0 && cert != NULL && !X509_get_ex_data(cert, g_x509_ocsp_index))
     {
         OCSP_RESPONSE* ocspResp = d2i_OCSP_RESPONSE(NULL, &data, len);
 


### PR DESCRIPTION
Fixes #96616.

This PR makes sure we parse OCSP_Response only once per certificate. This fixes a leak when `CryptoNative_SslGetPeerCertificate` is called multiple times to retrieve the same certificate, as previously the already parsed OCSP_RESPONSE in X509 instance would be simply overwritten without freeing it.

We did not hit this before because the implementation generally retrieves the peer's certificate only once, but during renegotiation, we may ask for it multiple times.