### PR TITLE
JIT: Remove IV analysis quirk in loop cloning

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -3078,14 +3078,9 @@ bool Compiler::optObtainLoopCloningOpts(LoopCloneContext* context)
 
         JITDUMP("Considering loop " FMT_LP " to clone for optimizations.\n", loop->GetIndex());
         NaturalLoopIterInfo iterInfo;
-        // TODO-Quirk: Remove
-        if ((m_newToOldLoop[loop->GetIndex()]->lpFlags & LPFLG_ITER) != 0)
+        if (loop->AnalyzeIteration(&iterInfo))
         {
-            if (loop->AnalyzeIteration(&iterInfo))
-            {
-                INDEBUG(optCrossCheckIterInfo(iterInfo, *m_newToOldLoop[loop->GetIndex()]));
-                context->SetLoopIterInfo(loop->GetIndex(), new (this, CMK_LoopClone) NaturalLoopIterInfo(iterInfo));
-            }
+            context->SetLoopIterInfo(loop->GetIndex(), new (this, CMK_LoopClone) NaturalLoopIterInfo(iterInfo));
         }
 
         if (optIsLoopClonable(loop, context) && optIdentifyLoopOptInfo(loop, context))


### PR DESCRIPTION
Fix a bug in `FlowGraphNaturalLoop::MatchLimit`; it did not properly check limit locals for address exposure when evaluating their invariance (the old logic does that). Also support promoted struct fields (like the old logic).

No diffs expected -- the diffs of the quirk here were coming from this bug in `FlowGraphNaturalLoop::MatchLimit`.