### PR TITLE
NativeAOT implement warning as errors as a compiler feature

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -268,6 +268,9 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(_targetOS)' == 'win' and $(IlcMultiModule) != 'true' and '$(IlcGenerateWin32Resources)' != 'false' and '$(NativeLib)' != 'Static'" Include="--win32resourcemodule:%(ManagedBinary.Filename)" />
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
+      <IlcArg Condition="$(TreatWarningsAsErrors) == 'true'" Include="--warnaserror" />
+      <IlcArg Condition="$(WarningsAsErrors) != ''" Include='--enable-warnaserror:"$([MSBuild]::Escape($(WarningsAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
+      <IlcArg Condition="$(WarningsNotAsErrors) != ''" Include='--disable-warnaserror:"$([MSBuild]::Escape($(WarningsNotAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
       <IlcArg Condition="$(SuppressTrimAnalysisWarnings) == 'true'" Include="--notrimwarn" />
       <IlcArg Condition="$(SuppressAotAnalysisWarnings) == 'true'" Include="--noaotwarn" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -28,6 +28,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PublishTrimmed Condition="'$(PublishTrimmed)' == ''">true</PublishTrimmed>
     <IlcPgoOptimize Condition="'$(IlcPgoOptimize)' == '' and '$(OptimizationPreference)' == 'Speed'">true</IlcPgoOptimize>
     <RunILLink>false</RunILLink>
+    <IlcTreatWarningsAsErrors Condition="'$(IlcTreatWarningsAsErrors)' == ''">$(TreatWarningsAsErrors)</IlcTreatWarningsAsErrors>
     <_IsiOSLikePlatform Condition="'$(_targetOS)' == 'maccatalyst' or $(_targetOS.StartsWith('ios')) or $(_targetOS.StartsWith('tvos'))">true</_IsiOSLikePlatform>
     <_IsApplePlatform Condition="'$(_targetOS)' == 'osx' or '$(_IsiOSLikePlatform)' == 'true'">true</_IsApplePlatform>
   </PropertyGroup>
@@ -268,7 +269,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="'$(_targetOS)' == 'win' and $(IlcMultiModule) != 'true' and '$(IlcGenerateWin32Resources)' != 'false' and '$(NativeLib)' != 'Static'" Include="--win32resourcemodule:%(ManagedBinary.Filename)" />
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
-      <IlcArg Condition="$(TreatWarningsAsErrors) == 'true'" Include="--warnaserror" />
+      <IlcArg Condition="$(IlcTreatWarningsAsErrors) == 'true'" Include="--warnaserror" />
       <IlcArg Condition="$(WarningsAsErrors) != ''" Include='--warnaserr:"$([MSBuild]::Escape($(WarningsAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
       <IlcArg Condition="$(WarningsNotAsErrors) != ''" Include='--nowarnaserr:"$([MSBuild]::Escape($(WarningsNotAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -269,8 +269,8 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
       <IlcArg Condition="$(TreatWarningsAsErrors) == 'true'" Include="--warnaserror" />
-      <IlcArg Condition="$(WarningsAsErrors) != ''" Include='--enable-warnaserror:"$([MSBuild]::Escape($(WarningsAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
-      <IlcArg Condition="$(WarningsNotAsErrors) != ''" Include='--disable-warnaserror:"$([MSBuild]::Escape($(WarningsNotAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
+      <IlcArg Condition="$(WarningsAsErrors) != ''" Include='--warnaserr:"$([MSBuild]::Escape($(WarningsAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
+      <IlcArg Condition="$(WarningsNotAsErrors) != ''" Include='--nowarnaserr:"$([MSBuild]::Escape($(WarningsNotAsErrors)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />
       <IlcArg Condition="$(TrimmerSingleWarn) == 'true'" Include="--singlewarn" />
       <IlcArg Condition="$(SuppressTrimAnalysisWarnings) == 'true'" Include="--notrimwarn" />
       <IlcArg Condition="$(SuppressAotAnalysisWarnings) == 'true'" Include="--noaotwarn" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
@@ -72,11 +72,15 @@ namespace ILCompiler
                     _methodSubstitutions.Add(method, BodySubstitution.ThrowingBody);
                     break;
                 case "stub":
-                    BodySubstitution stubBody;
+                    BodySubstitution stubBody = null;
                     if (method.Signature.ReturnType.IsVoid)
                         stubBody = BodySubstitution.EmptyBody;
                     else
-                        stubBody = BodySubstitution.Create(TryCreateSubstitution(method.Signature.ReturnType, GetAttribute(methodNav, "value")));
+                    {
+                        object substitution = TryCreateSubstitution(method.Signature.ReturnType, GetAttribute(methodNav, "value"));
+                        if (substitution != null)
+                            stubBody = BodySubstitution.Create(substitution);
+                    }
 
                     if (stubBody != null)
                     {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Logging/MessageContainer.cs
@@ -131,7 +131,7 @@ namespace ILCompiler.Logging
             if (TryLogSingleWarning(context, code, origin, subcategory))
                 return null;
 
-            if (Logger.IsWarningAsError(code))
+            if (context.IsWarningAsError(code))
                 return new MessageContainer(MessageCategory.WarningAsError, text, code, subcategory, origin);
 
             return new MessageContainer(MessageCategory.Warning, text, code, subcategory, origin);
@@ -148,7 +148,7 @@ namespace ILCompiler.Logging
             if (TryLogSingleWarning(context, (int)id, origin, subcategory))
                 return null;
 
-            if (Logger.IsWarningAsError((int)id))
+            if (context.IsWarningAsError((int)id))
                 return new MessageContainer(MessageCategory.WarningAsError, id, subcategory, origin, args);
 
             return new MessageContainer(MessageCategory.Warning, id, subcategory, origin, args);

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
@@ -16,5 +16,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		public List<string> Descriptors = new List<string> ();
 		public bool FrameworkCompilation;
 		public bool SingleWarn;
+		public List<string> SubstitutionFiles = new List<string> ();
+		public bool TreatWarningsAsErrors;
+		public Dictionary<int, bool> WarningsAsErrors = new Dictionary<int, bool> ();
 	}
 }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Xml;
 using ILCompiler;
 using ILCompiler.Dataflow;
 using ILLink.Shared.TrimAnalysis;
@@ -84,15 +85,33 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				options.SingleWarn,
 				singleWarnEnabledModules: Enumerable.Empty<string> (),
 				singleWarnDisabledModules: Enumerable.Empty<string> (),
-				suppressedCategories: Enumerable.Empty<string> ());
+				suppressedCategories: Enumerable.Empty<string> (),
+				treatWarningsAsErrors: options.TreatWarningsAsErrors,
+				warningsAsErrors: options.WarningsAsErrors);
 
 			foreach (var descriptor in options.Descriptors) {
 				if (!File.Exists (descriptor))
 					throw new FileNotFoundException ($"'{descriptor}' doesn't exist");
 				compilationRoots.Add (new ILCompiler.DependencyAnalysis.TrimmingDescriptorNode (descriptor));
 			}
-			
-			ilProvider = new FeatureSwitchManager (ilProvider, logger, options.FeatureSwitches, default);
+
+			var featureSwitches = options.FeatureSwitches;
+			BodyAndFieldSubstitutions substitutions = default;
+			IReadOnlyDictionary<ModuleDesc, IReadOnlySet<string>>? resourceBlocks = default;
+			foreach (string substitutionFilePath in options.SubstitutionFiles)
+			{
+				using FileStream fs = File.OpenRead(substitutionFilePath);
+				substitutions.AppendFrom(BodySubstitutionsParser.GetSubstitutions(
+					logger, typeSystemContext, XmlReader.Create(fs), substitutionFilePath, featureSwitches));
+
+				fs.Seek(0, SeekOrigin.Begin);
+
+				resourceBlocks = ManifestResourceBlockingPolicy.UnionBlockings(resourceBlocks,
+					ManifestResourceBlockingPolicy.SubstitutionsReader.GetSubstitutions(
+						logger, typeSystemContext, XmlReader.Create(fs), substitutionFilePath, featureSwitches));
+			}
+
+			ilProvider = new FeatureSwitchManager(ilProvider, logger, featureSwitches, substitutions);
 
 			CompilerGeneratedState compilerGeneratedState = new CompilerGeneratedState (ilProvider, logger);
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -132,9 +132,9 @@ namespace ILCompiler
         public CliOption<bool> TreatWarningsAsErrors { get; } =
             new("--warnaserror") { Description = "Treat warnings as errors" };
         public CliOption<string[]> WarningsAsErrorsEnable { get; } =
-            new("--enable-warnaserror") { Description = "Enable treating specific warnings as errors" };
+            new("--warnaserr") { Description = "Enable treating specific warnings as errors" };
         public CliOption<string[]> WarningsAsErrorsDisable { get; } =
-            new("--disable-warnaserror") { Description = "Disable treating specific warnings as errors" };
+            new("--nowarnaserr") { Description = "Disable treating specific warnings as errors" };
         public CliOption<string[]> DirectPInvokes { get; } =
             new("--directpinvoke") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "PInvoke to call directly" };
         public CliOption<string[]> DirectPInvokeLists { get; } =

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -129,6 +129,12 @@ namespace ILCompiler
             new("--singlewarnassembly") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "Generate single AOT/trimming warning for given assembly" };
         public CliOption<string[]> SingleWarnDisabledAssemblies { get; } =
             new("--nosinglewarnassembly") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "Expand AOT/trimming warnings for given assembly" };
+        public CliOption<bool> TreatWarningsAsErrors { get; } =
+            new("--warnaserror") { Description = "Treat warnings as errors" };
+        public CliOption<string[]> WarningsAsErrorsEnable { get; } =
+            new("--enable-warnaserror") { Description = "Enable treating specific warnings as errors" };
+        public CliOption<string[]> WarningsAsErrorsDisable { get; } =
+            new("--disable-warnaserror") { Description = "Disable treating specific warnings as errors" };
         public CliOption<string[]> DirectPInvokes { get; } =
             new("--directpinvoke") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "PInvoke to call directly" };
         public CliOption<string[]> DirectPInvokeLists { get; } =
@@ -225,6 +231,9 @@ namespace ILCompiler
             Options.Add(NoAotWarn);
             Options.Add(SingleWarnEnabledAssemblies);
             Options.Add(SingleWarnDisabledAssemblies);
+            Options.Add(TreatWarningsAsErrors);
+            Options.Add(WarningsAsErrorsEnable);
+            Options.Add(WarningsAsErrorsDisable);
             Options.Add(DirectPInvokes);
             Options.Add(DirectPInvokeLists);
             Options.Add(MaxGenericCycleDepth);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -75,8 +75,18 @@ namespace ILCompiler
 
             ILProvider ilProvider = new NativeAotILProvider();
 
+            Dictionary<int, bool> warningsAsErrors = new Dictionary<int, bool>();
+            foreach (int warning in ProcessWarningCodes(Get(_command.WarningsAsErrorsEnable)))
+            {
+                warningsAsErrors[warning] = true;
+            }
+            foreach (int warning in ProcessWarningCodes(Get(_command.WarningsAsErrorsDisable)))
+            {
+                warningsAsErrors[warning] = false;
+            }
             var logger = new Logger(Console.Out, ilProvider, Get(_command.IsVerbose), ProcessWarningCodes(Get(_command.SuppressedWarnings)),
-                Get(_command.SingleWarn), Get(_command.SingleWarnEnabledAssemblies), Get(_command.SingleWarnDisabledAssemblies), suppressedWarningCategories);
+                Get(_command.SingleWarn), Get(_command.SingleWarnEnabledAssemblies), Get(_command.SingleWarnDisabledAssemblies), suppressedWarningCategories,
+                Get(_command.TreatWarningsAsErrors), warningsAsErrors);
 
             // NativeAOT is full AOT and its pre-compiled methods can not be
             // thrown away at runtime if they mismatch in required ISAs or

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -555,6 +555,8 @@
          so the default for the test tree is partial. -->
     <TrimMode Condition="'$(EnableAggressiveTrimming)' != 'true'">partial</TrimMode>
 
+    <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+
     <IlcToolsPath>$(CoreCLRILCompilerDir)</IlcToolsPath>
     <IlcToolsPath Condition="'$(TargetArchitecture)' != '$(BuildArchitecture)' or '$(TargetOS)' != '$(HostOS)' or '$(EnableNativeSanitizers)' != ''">$(CoreCLRCrossILCompilerDir)</IlcToolsPath>
     <IlcBuildTasksPath>$(CoreCLRILCompilerDir)netstandard/ILCompiler.Build.Tasks.dll</IlcBuildTasksPath>

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -625,6 +625,8 @@ class DeadCodeElimination
         }
     }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2072:UnrecognizedReflectionPattern",
+        Justification = "That's the point")]
     private static void ThrowIfPresentWithUsableMethodTable(Type testType, string typeName)
     {
         Type t = GetTypeSecretly(testType, typeName);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 
 class Devirtualization
 {
@@ -103,6 +104,7 @@ class Devirtualization
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void TestIntf2(IIntf2 o, int expected) => AssertEqual(expected, o.GetValue());
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             TestIntf1(new Intf1Impl(), 123);

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -5,7 +5,12 @@ using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Diagnostics.CodeAnalysis;
 
+[UnconditionalSuppressMessage("Trimming", "IL2055", Justification = "MakeGenericType - Intentional")]
+[UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "MakeGenericMethod - Intentional")]
+[UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType/MakeGenericMethod - Intentional")]
+[UnconditionalSuppressMessage("AOT", "IL3054", Justification = "Generic expansion aborted - Intentional")]
 class Generics
 {
     internal static int Run()

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Diagnostics.CodeAnalysis;
 
 public class Interfaces
 {
@@ -1225,6 +1226,7 @@ public class Interfaces
 
         static Type s_fooType = typeof(Foo);
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             Type t = typeof(FrobCaller<>).MakeGenericType(s_fooType);
@@ -1289,6 +1291,7 @@ public class Interfaces
 
         static Type s_atomType = typeof(Atom);
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             Type t = typeof(Wrapper<>).MakeGenericType(s_atomType);
@@ -1354,6 +1357,7 @@ public class Interfaces
         static Type s_atomType = typeof(Atom);
         static Type s_atomBaseType = typeof(AtomBase);
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             Type t = typeof(FrobCaller<,>).MakeGenericType(typeof(AbjectFail<AtomBase>), s_atomType);
@@ -1576,6 +1580,7 @@ public class Interfaces
             public static string GrabCookie() => T.ImHungryGiveMeCookie();
         }
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz)).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
@@ -1612,6 +1617,7 @@ public class Interfaces
             public static string GrabCookie() => T.ImHungryGiveMeCookie();
         }
 
+        [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
             Activator.CreateInstance(typeof(Baz<>).MakeGenericType(typeof(Atom1)));

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/WarningsTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/WarningsTests.g.cs
@@ -88,6 +88,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task CanWarnAsErrorGlobal ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task InvalidWarningVersion ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsErrorGlobal.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsErrorGlobal.cs
@@ -5,26 +5,27 @@ namespace Mono.Linker.Tests.Cases.Warnings
 {
 	[ExpectNonZeroExitCode (1)]
 	[SkipKeptItemsValidation]
+	[Define("IN_TEST_BUILD")]
 	[SetupLinkerSubstitutionFile ("CanWarnAsErrorSubstitutions.xml")]
 	[SetupLinkerArgument ("--verbose")]
-	[SetupLinkerArgument ("--warnaserror-")]
-	[SetupLinkerArgument ("--warnaserror+", "IL2011,IgnoreThis")]
-	[SetupLinkerArgument ("--warnaserror", "IL2012,CS4321,IgnoreThisToo")]
-	[SetupLinkerArgument ("--warnaserror", "IL2010")]
-	[SetupLinkerArgument ("--warnaserror-", "IL2010")]
-	[LogContains ("warning IL2007")]
-	[LogContains ("warning IL2008")]
-	[LogContains ("warning IL2009")]
-	[LogContains ("warning IL2010")]
+	[SetupLinkerArgument ("--warnaserror")]
+	[LogContains ("error IL2007")]
+	[LogContains ("error IL2008")]
+	[LogContains ("error IL2009")]
+	[LogContains ("error IL2010")]
 	[LogContains ("error IL2011")]
 	[LogContains ("error IL2012")]
 	[NoLinkedOutput]
-	public class CanWarnAsError
+	public class CanWarnAsErrorGlobal
 	{
 		public static void Main ()
 		{
 		}
+	}
 
+#if IN_TEST_BUILD
+	public class CanWarnAsError
+	{
 		class HelperClass
 		{
 			private int helperField = 0;
@@ -34,4 +35,5 @@ namespace Mono.Linker.Tests.Cases.Warnings
 			}
 		}
 	}
+#endif
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsErrorSubstitutions.xml
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Warnings/CanWarnAsErrorSubstitutions.xml
@@ -5,13 +5,13 @@
 		<!-- IL2008 -->
 		<type fullname="Mono.Linker.Tests.Cases.Warnings.CanWarnAsError.NonExistentType" />
 		<type fullname="Mono.Linker.Tests.Cases.Warnings.CanWarnAsError/HelperClass">
-			<!-- IL2009 -->
+			<!-- IL2012 -->
 			<field name="NonExistentField" />
 			<!-- IL2010 -->
 			<method signature="System.Int32 HelperMethod()" body="stub" value="InvalidValue" />
 			<!-- IL2011 -->
 			<method signature="System.Int32 HelperMethod()" body="UnknownBodyModification" value="InvalidValue" />
-			<!-- IL2012 -->
+			<!-- IL2009 -->
 			<method signature="NonExistentMethod" />
 		</type>
 	</assembly>


### PR DESCRIPTION
Both roslyn and trimmer implement "warn as error" as a compiler feature - specifically the `TreatWarningsAsErrors` property only affects tools which explicitly react to it. There's a related MSBuild command line option which will affect all warnings, but that's not the one VS sets from the UI and what most customers use. See the comments in https://github.com/dotnet/runtime/issues/94178.

This implements the same behavior as the trimmer. It adds 3 new command line options to `ilc` and enable "warn as error" globally and to enable/disable specific warning codes. Note that `illink` implements a more complex command line parsing where order of parameters matters and sometimes the later ones can override the earlier ones. This was trying to emulate `csc` behavior. For `ilc` I don't see a reason to emulate that because running `ilc` on its own is not supported, only going through the SDK, which will never pass the new parameters multiple times.

For testing this enables the existing trimmer tests for this functionality. This uncovered a small issue in substitution parser, which is also fixed here. For simplicity the test infra emulates the `illink` command line behavior over `ilc` (which is easy as they're very similar).

Open question:
Trimmer introduces `ILLinkTreatWarningsAsErrors` property which defaults to `TreatWarningsAsErrors` but can be overriden and it specifically applies on to `illink`. I didn't introduce a new one for `ilc` as I don't see much value in doing so, but I may be missing something. @sbomer - do you think we should add `IlcTreatWarningsAsErrors`?

Update:
We agreed to add `IlcTreatWarningsAsErrors`.