### PR TITLE
Using HashSet instead of Dictionary multiple times

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/XmlCompatibilityReader.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/XmlCompatibilityReader.cs
@@ -1727,7 +1727,7 @@ namespace System.IO.Packaging
             private bool _all;
             private readonly string _namespaceName;
             private readonly XmlCompatibilityReader _reader;
-            private Dictionary<string, object?>? _names;
+            private HashSet<string>? _names;
 
             public ProcessContentSet(string namespaceName, XmlCompatibilityReader reader)
             {
@@ -1737,7 +1737,7 @@ namespace System.IO.Packaging
 
             public bool ShouldProcessContent(string elementName)
             {
-                return _all || (_names != null && _names.ContainsKey(elementName));
+                return _all || (_names != null && _names.Contains(elementName));
             }
 
             public void Add(string elementName)
@@ -1767,8 +1767,8 @@ namespace System.IO.Packaging
                 }
                 else
                 {
-                    _names ??= new Dictionary<string, object?>();
-                    _names[elementName] = null; // we don't care about value, just key
+                    _names ??= new HashSet<string>();
+                    _names.Add(elementName);
                 }
             }
         }
@@ -1778,7 +1778,7 @@ namespace System.IO.Packaging
             private bool _all;
             private readonly string _namespaceName;
             private readonly XmlCompatibilityReader _reader;
-            private Dictionary<string, string>? _names;
+            private HashSet<string>? _names;
 
             public PreserveItemSet(string namespaceName, XmlCompatibilityReader reader)
             {
@@ -1788,7 +1788,7 @@ namespace System.IO.Packaging
 
             public bool ShouldPreserveItem(string itemName)
             {
-                return _all || (_names != null && _names.ContainsKey(itemName));
+                return _all || (_names != null && _names.Contains(itemName));
             }
 
             public void Add(string itemName)
@@ -1818,8 +1818,8 @@ namespace System.IO.Packaging
                 }
                 else
                 {
-                    _names ??= new Dictionary<string, string>();
-                    _names.Add(itemName, itemName);
+                    _names ??= new HashSet<string>();
+                    _names.Add(itemName);
                 }
             }
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpEndPointListener.cs
@@ -42,7 +42,7 @@ namespace System.Net
         private readonly HttpListener _listener;
         private readonly IPEndPoint _endpoint;
         private readonly Socket _socket;
-        private readonly Dictionary<HttpConnection, HttpConnection> _unregisteredConnections;
+        private readonly HashSet<HttpConnection> _unregisteredConnections;
         private Dictionary<ListenerPrefix, HttpListener> _prefixes;
         private List<ListenerPrefix>? _unhandledPrefixes; // host = '*'
         private List<ListenerPrefix>? _allPrefixes;       // host = '+'
@@ -70,7 +70,7 @@ namespace System.Net
             Accept(args);
 
             _prefixes = new Dictionary<ListenerPrefix, HttpListener>();
-            _unregisteredConnections = new Dictionary<HttpConnection, HttpConnection>();
+            _unregisteredConnections = new HashSet<HttpConnection>();
         }
 
         internal HttpListener Listener
@@ -131,7 +131,7 @@ namespace System.Net
 
             lock (_unregisteredConnections)
             {
-                _unregisteredConnections[conn] = conn;
+                _unregisteredConnections.Add(conn);
             }
             conn.BeginReadRequest();
         }
@@ -309,7 +309,7 @@ namespace System.Net
             lock (_unregisteredConnections)
             {
                 // Clone the list because RemoveConnection can be called from Close
-                var connections = new List<HttpConnection>(_unregisteredConnections.Keys);
+                var connections = new List<HttpConnection>(_unregisteredConnections);
 
                 foreach (HttpConnection c in connections)
                     c.Close(true);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -260,7 +260,7 @@ namespace System.Xml
         private long _charactersFromEntities;
 
         // All entities that are currently being processed
-        private Dictionary<IDtdEntityInfo, IDtdEntityInfo>? _currentEntities;
+        private HashSet<IDtdEntityInfo>? _currentEntities;
 
         // DOM helpers
         private bool _disableUndeclaredEntityCheck;
@@ -8062,7 +8062,7 @@ namespace System.Xml
             // check entity recursion
             if (_currentEntities != null)
             {
-                if (_currentEntities.ContainsKey(entity))
+                if (_currentEntities.Contains(entity))
                 {
                     Throw(entity.IsParameterEntity ? SR.Xml_RecursiveParEntity : SR.Xml_RecursiveGenEntity, entity.Name,
                         _parsingStatesStack![_parsingStatesStackTop].LineNo, _parsingStatesStack[_parsingStatesStackTop].LinePos);
@@ -8076,9 +8076,9 @@ namespace System.Xml
             // register entity for recursion checkes
             if (entity != null)
             {
-                _currentEntities ??= new Dictionary<IDtdEntityInfo, IDtdEntityInfo>();
+                _currentEntities ??= new HashSet<IDtdEntityInfo>();
 
-                _currentEntities.Add(entity, entity);
+                _currentEntities.Add(entity);
             }
         }
 


### PR DESCRIPTION
Replaced occurrences of `Dictionary<TKey, TValue>` with `HashSet<T>`.

Inspired by [Performance improvements in .Net 8](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/) and #89030.