### PR TITLE
Add test for GetInterfaces() array type

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
@@ -945,6 +945,13 @@ namespace System.Reflection.Tests
             Assert.Equal(expected.OrderBy(t => t.Name), type.GetTypeInfo().GetInterfaces().OrderBy(t => t.Name));
         }
 
+        [Fact]
+        public void GetInterfaces_InvariantArrayType()
+        {
+            Assert.Equal(typeof(Type[]), typeof(int[]).GetInterfaces().GetType());
+            Assert.Equal(typeof(Type[]), typeof(int[]).GetTypeInfo().GetInterfaces().GetType());
+        }
+
         [Theory]
         [InlineData(typeof(List<>), new string[] { "T" })]
         [InlineData(typeof(Dictionary<,>), new string[] { "TKey", "TValue" })]

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/TypeInfoTests.cs
@@ -945,6 +945,7 @@ namespace System.Reflection.Tests
             Assert.Equal(expected.OrderBy(t => t.Name), type.GetTypeInfo().GetInterfaces().OrderBy(t => t.Name));
         }
 
+        [SkipOnMono("Mono returns a RuntimeType[] rather than a Type[]. https://github.com/dotnet/runtime/pull/96589")]
         [Fact]
         public void GetInterfaces_InvariantArrayType()
         {


### PR DESCRIPTION
Confirming suspicion that this fails on mono. Technically it's not wrong, so we could choose to not care, but I noticed it when I created a `Span<Type>` with the resulting array and it failed.