### PR TITLE
Fix AggregateBy with seed to use correct helper

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AggregateBy.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AggregateBy.cs
@@ -28,7 +28,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.func);
             }
 
-            return AggregateByIterator(source, keySelector, _ => seed, func, keyComparer);
+            return AggregateByIterator(source, keySelector, seed, func, keyComparer);
         }
 
         public static IEnumerable<KeyValuePair<TKey, TAccumulate>> AggregateBy<TSource, TKey, TAccumulate>(


### PR DESCRIPTION
Either the dedicate helper should be deleted or used. Since it exists, I changed the code to use it and avoid the closure allocation. If we instead want to reuse the same helper, the method can instead be changed to just call the other overload, and the unused helper can be deleted.