### PR TITLE
Do not limit InlineArrays on Native AOT

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -498,6 +498,11 @@ namespace Internal.TypeSystem
                 long size = instanceByteSizeAndAlignment.Size.AsInt;
                 size *= repeat;
 
+                if (size != (int)size)
+                {
+                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, type);
+                }
+
                 instanceByteSizeAndAlignment.Size = new LayoutInt((int)size);
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -498,13 +498,6 @@ namespace Internal.TypeSystem
                 long size = instanceByteSizeAndAlignment.Size.AsInt;
                 size *= repeat;
 
-                // limit the max size of array instance to 1MiB
-                const int maxSize = 1024 * 1024;
-                if (size > maxSize)
-                {
-                    ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, type);
-                }
-
                 instanceByteSizeAndAlignment.Size = new LayoutInt((int)size);
             }
 


### PR DESCRIPTION
Following program works fine with JIT, but throws a `TypeLoadException` with AOT:

```csharp
using System.Runtime.CompilerServices;

unsafe
{
    fixed (Inline* pInline = &Inline.s_inst)
        *(byte*)pInline = 123;
}

[InlineArray(640 * 480 * 4)]
struct Inline
{
    internal static Inline s_inst;
    private byte _bytes;
}
```

CoreCLR/JIT seems to have a similar block in place but only if the layout of the InlineArray is Auto. Native AOT is typically more permissive. It's not clear why there is such limit on CoreCLR/JIT in the first place; we don't limit `fixed` arrays in C# this way.

Cc @dotnet/ilc-contrib 