### PR TITLE
Fix OperIsSimple assert in lower

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -500,8 +500,8 @@ GenTree* Lowering::LowerNode(GenTree* node)
         case GT_NEG:
 #ifdef TARGET_ARM64
         {
-            GenTree* next = TryLowerNegToMulLongOp(node->AsOp());
-            if (next != nullptr)
+            GenTree* next;
+            if (TryLowerNegToMulLongOp(node->AsOp(), &next))
             {
                 return next;
             }
@@ -6384,14 +6384,13 @@ GenTree* Lowering::LowerAdd(GenTreeOp* node)
 #ifdef TARGET_ARM64
     if (node->OperIs(GT_ADD))
     {
-        GenTree* next = LowerAddForPossibleContainment(node);
-        if (next != nullptr)
+        GenTree* next;
+        if (TryLowerAddForPossibleContainment(node, &next))
         {
             return next;
         }
 
-        next = TryLowerAddSubToMulLongOp(node);
-        if (next != nullptr)
+        if (TryLowerAddSubToMulLongOp(node, &next))
         {
             return next;
         }

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -88,14 +88,14 @@ private:
     void ContainCheckLclHeap(GenTreeOp* node);
     void ContainCheckRet(GenTreeUnOp* ret);
 #ifdef TARGET_ARM64
-    GenTree* TryLowerAndOrToCCMP(GenTreeOp* tree);
+    bool TryLowerAndOrToCCMP(GenTreeOp* tree, GenTree** next);
     insCflags TruthifyingFlags(GenCondition cond);
     void ContainCheckConditionalCompare(GenTreeCCMP* ccmp);
     void ContainCheckNeg(GenTreeOp* neg);
     void TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond);
     void TryLowerCselToCSOp(GenTreeOp* select, GenTree* cond);
-    GenTree* TryLowerAddSubToMulLongOp(GenTreeOp* op);
-    GenTree* TryLowerNegToMulLongOp(GenTreeOp* op);
+    bool TryLowerAddSubToMulLongOp(GenTreeOp* op, GenTree** next);
+    bool TryLowerNegToMulLongOp(GenTreeOp* op, GenTree** next);
 #endif
     void ContainCheckSelect(GenTreeOp* select);
     void ContainCheckBitCast(GenTree* node);
@@ -386,7 +386,7 @@ private:
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);
     void LowerModPow2(GenTree* node);
-    GenTree* LowerAddForPossibleContainment(GenTreeOp* node);
+    bool TryLowerAddForPossibleContainment(GenTreeOp* node, GenTree** next);
 #endif // !TARGET_XARCH && !TARGET_ARM64
     GenTree* InsertNewSimdCreateScalarUnsafeNode(var_types   type,
                                                  GenTree*    op1,

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2444,9 +2444,9 @@ bool Lowering::TryLowerAndOrToCCMP(GenTreeOp* tree, GenTree** next)
     tree->SetOper(GT_SETCC);
     tree->AsCC()->gtCondition = cond2;
 
-    JITDUMP("Conversion was legal. Result:\n")
-    DISPTREERANGE(BlockRange(), tree)
-    JITDUMP("\n")
+    JITDUMP("Conversion was legal. Result:\n");
+    DISPTREERANGE(BlockRange(), tree);
+    JITDUMP("\n");
 
     *next = tree->gtNext;
     return true;
@@ -2883,10 +2883,10 @@ bool Lowering::TryLowerAddSubToMulLongOp(GenTreeOp* op, GenTree** next)
     BlockRange().Remove(mul);
     BlockRange().Remove(op);
 
-    JITDUMP("Converted to HW_INTRINSIC 'NI_ArmBase_Arm64_MultiplyLong[Add/Sub]'.\n")
-    JITDUMP(":\n")
-    DISPTREERANGE(BlockRange(), outOp)
-    JITDUMP("\n")
+    JITDUMP("Converted to HW_INTRINSIC 'NI_ArmBase_Arm64_MultiplyLong[Add/Sub]'.\n");
+    JITDUMP(":\n");
+    DISPTREERANGE(BlockRange(), outOp);
+    JITDUMP("\n");
 
     *next = outOp;
     return true;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/96612

@dotnet/jit-contrib It seems that in lower we have a worrisome pattern to handle nodes like this:

```c
// Returns:
//     A pointer to the next node to evaluate. On no operation, returns nullptr.
//
GenTree* LowerFoo(GenTree* tree)
{
    if (!someValidation)
        return nullptr;

    return newNode->gtNext;
}
```

and then caller assumes that `nullptr` means nothing was handled. Which is not true - it could be handled and it's just that `gtNext` is nullptr.

This is exactly what happens with https://github.com/dotnet/runtime/issues/96612
`TryLowerAndOrToCCMP` converts a binary op to `GT_SECC` and returns nullptr and then `ContainBinaryNode` fails because node is no longer a simple op.

The correct pattern should be
```c
bool TryLowerFoo(GenTree* node, GenTree** next)
{
    if (!someValidation)
        return false;

    *next = newNode->gtNext;
    return true;
}
```

I'll inspect more functions for this pattern separately.