### PR TITLE
JIT: Simplify `BasicBlock::CloneBlockState`

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -786,16 +786,10 @@ void* BasicBlock::MemoryPhiArg::operator new(size_t sz, Compiler* comp)
 //    varNum - lclVar uses with lclNum `varNum` will be replaced; can be ~0 to indicate no replacement.
 //    varVal - If replacing uses of `varNum`, replace them with int constants with value `varVal`.
 //
-// Return Value:
-//    Cloning may fail because this routine uses `gtCloneExpr` for cloning and it can't handle all
-//    IR nodes.  If cloning of any statement fails, `false` will be returned and block `to` may be
-//    partially populated.  If cloning of all statements succeeds, `true` will be returned and
-//    block `to` will be fully populated.
-//
 // Note:
 //    Leaves block ref count at zero, and pred edge list empty.
 //
-bool BasicBlock::CloneBlockState(
+void BasicBlock::CloneBlockState(
     Compiler* compiler, BasicBlock* to, const BasicBlock* from, unsigned varNum, int varVal)
 {
     assert(to->bbStmtList == nullptr);
@@ -817,16 +811,9 @@ bool BasicBlock::CloneBlockState(
     for (Statement* const fromStmt : from->Statements())
     {
         GenTree* newExpr = compiler->gtCloneExpr(fromStmt->GetRootNode(), GTF_EMPTY, varNum, varVal);
-        if (!newExpr)
-        {
-            // gtCloneExpr doesn't handle all opcodes, so may fail to clone a statement.
-            // When that happens, it returns nullptr; abandon the rest of this block and
-            // return `false` to the caller to indicate that cloning was unsuccessful.
-            return false;
-        }
+        assert(newExpr != nullptr);
         compiler->fgInsertStmtAtEnd(to, compiler->fgNewStmtFromTree(newExpr, fromStmt->GetDebugInfo()));
     }
-    return true;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1661,10 +1661,9 @@ public:
         return BBCompilerSuccList(comp, this);
     }
 
-    // Try to clone block state and statements from `from` block to `to` block (which must be new/empty),
-    // optionally replacing uses of local `varNum` with IntCns `varVal`.  Return true if all statements
-    // in the block are cloned successfully, false (with partially-populated `to` block) if one fails.
-    static bool CloneBlockState(
+    // Clone block state and statements from `from` block to `to` block (which must be new/empty),
+    // optionally replacing uses of local `varNum` with IntCns `varVal`.
+    static void CloneBlockState(
         Compiler* compiler, BasicBlock* to, const BasicBlock* from, unsigned varNum = (unsigned)-1, int varVal = 0);
 
     // Copy the block kind and targets. The `from` block is untouched.

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1008,7 +1008,6 @@ PhaseStatus Compiler::fgCloneFinally()
         const unsigned  finallyTryIndex = firstBlock->bbTryIndex;
         BasicBlock*     insertAfter     = nullptr;
         BlockToBlockMap blockMap(getAllocator());
-        bool            clonedOk       = true;
         unsigned        cloneBBCount   = 0;
         weight_t const  originalWeight = firstBlock->hasProfileWeight() ? firstBlock->bbWeight : BB_ZERO_WEIGHT;
 
@@ -1046,12 +1045,7 @@ PhaseStatus Compiler::fgCloneFinally()
             insertAfter = newBlock;
             blockMap.Set(block, newBlock);
 
-            clonedOk = BasicBlock::CloneBlockState(this, newBlock, block);
-
-            if (!clonedOk)
-            {
-                break;
-            }
+            BasicBlock::CloneBlockState(this, newBlock, block);
 
             // Update block flags. Note a block can be both first and last.
             if (block == firstBlock)
@@ -1075,13 +1069,6 @@ PhaseStatus Compiler::fgCloneFinally()
             // Jump dests are set in a post-pass; make sure CloneBlockState hasn't tried to set them.
             assert(newBlock->KindIs(BBJ_ALWAYS));
             assert(!newBlock->HasInitializedTarget());
-        }
-
-        if (!clonedOk)
-        {
-            // TODO: cleanup the partial clone?
-            JITDUMP("Unable to clone the finally; skipping.\n");
-            continue;
         }
 
         // We should have cloned all the finally region blocks.

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1399,7 +1399,6 @@ DONE_CALL:
                     // fatPointer candidates should be in statements of the form call() or var = call().
                     // Such form allows to find statements with fat calls without walking through whole trees
                     // and removes problems with cutting trees.
-                    assert(!bIntrinsicImported);
                     assert(IsTargetAbi(CORINFO_NATIVEAOT_ABI));
                     if (call->OperGet() != GT_LCL_VAR) // can be already converted by impFixupCallStructReturn.
                     {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2092,11 +2092,7 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
         BasicBlock* newBlk = fgNewBBafter(BBJ_ALWAYS, newPred, /*extendRegion*/ true);
         JITDUMP("Adding " FMT_BB " (copy of " FMT_BB ") after " FMT_BB "\n", newBlk->bbNum, blk->bbNum, newPred->bbNum);
 
-        // Call CloneBlockState to make a copy of the block's statements (and attributes), and assert that it
-        // has a return value indicating success, because optCanOptimizeByLoopCloningVisitor has already
-        // checked them to guarantee they are clonable.
-        bool cloneOk = BasicBlock::CloneBlockState(this, newBlk, blk);
-        noway_assert(cloneOk);
+        BasicBlock::CloneBlockState(this, newBlk, blk);
 
         // We're going to create the preds below, which will set the bbRefs properly,
         // so clear out the cloned bbRefs field.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4247,10 +4247,10 @@ RETRY_UNROLL:
 
             BlockToBlockMap blockMap(getAllocator(CMK_LoopUnroll));
 
-            BasicBlock*       bottom        = loop->GetLexicallyBottomMostBlock();
-            BasicBlock*       insertAfter   = bottom;
-            BasicBlock*       prevTestBlock = nullptr;
-            unsigned          iterToUnroll  = totalIter; // The number of iterations left to unroll
+            BasicBlock* bottom        = loop->GetLexicallyBottomMostBlock();
+            BasicBlock* insertAfter   = bottom;
+            BasicBlock* prevTestBlock = nullptr;
+            unsigned    iterToUnroll  = totalIter; // The number of iterations left to unroll
 
             // Find the exit block of the IV test first. We need to do that
             // here since it may have implicit fallthrough that we'll change

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3922,18 +3922,15 @@ bool Compiler::optComputeLoopRep(int        constInit,
 // Loops handled are fully unrolled; there is no partial unrolling.
 //
 // Limitations: only the following loop types are handled:
-// 1. "while" loops (top entry)
-// 2. constant initializer, constant bound
-// 3. The entire loop must be in the same EH region.
-// 4. The loop iteration variable can't be address exposed.
-// 5. The loop iteration variable can't be a promoted struct field.
-// 6. We must be able to calculate the total constant iteration count.
-// 7. On x86, there is a limit to the number of return blocks. So if there are return blocks in the loop that
-//    would be unrolled, the unrolled code can't exceed that limit.
+// 1. constant initializer, constant bound
+// 2. The entire loop must be in the same EH region.
+// 3. The loop iteration variable can't be address exposed.
+// 4. The loop iteration variable can't be a promoted struct field.
+// 5. We must be able to calculate the total constant iteration count.
 //
 // Cost heuristics:
 // 1. there are cost metrics for maximum number of allowed iterations, and maximum unroll size
-// 2. single-iteration loops are always allowed (to eliminate the loop structure).
+// 2. constant trip count loops are always allowed, up to a limit of 4
 // 3. otherwise, only loops where the limit is Vector<T>.Length are currently allowed
 //
 // In stress modes, these heuristic limits are expanded, and loops aren't required to have the
@@ -3967,8 +3964,7 @@ PhaseStatus Compiler::optUnrollLoops()
 
     bool change      = false;
     bool anyIRchange = false;
-    INDEBUG(int unrollCount = 0);    // count of loops unrolled
-    INDEBUG(int unrollFailures = 0); // count of loops attempted to be unrolled, but failed
+    INDEBUG(int unrollCount = 0); // count of loops unrolled
 
     static const unsigned ITER_LIMIT[COUNT_OPT_CODE + 1] = {
         10, // BLENDED_CODE
@@ -4253,7 +4249,6 @@ RETRY_UNROLL:
 
             BasicBlock*       bottom        = loop->GetLexicallyBottomMostBlock();
             BasicBlock*       insertAfter   = bottom;
-            BasicBlock* const tail          = bottom->Next();
             BasicBlock*       prevTestBlock = nullptr;
             unsigned          iterToUnroll  = totalIter; // The number of iterations left to unroll
 
@@ -4290,8 +4285,8 @@ RETRY_UNROLL:
 
             for (int lval = lbeg; iterToUnroll > 0; iterToUnroll--)
             {
-                BasicBlock*     testBlock = nullptr;
-                BasicBlockVisit result    = loop->VisitLoopBlocksLexical([&](BasicBlock* block) {
+                BasicBlock* testBlock = nullptr;
+                loop->VisitLoopBlocksLexical([&](BasicBlock* block) {
 
                     // Don't set a jump target for now.
                     // BasicBlock::CopyTarget() will fix the jump kind/target in the loop below.
@@ -4300,18 +4295,9 @@ RETRY_UNROLL:
 
                     blockMap.Set(block, newBlock, BlockToBlockMap::Overwrite);
 
-                    if (!BasicBlock::CloneBlockState(this, newBlock, block, lvar, lval))
-                    {
-                        // CloneBlockState (specifically, gtCloneExpr) doesn't handle everything. If it fails
-                        // to clone a block in the loop, splice out and forget all the blocks we cloned so far:
-                        // put the loop blocks back to how they were before we started cloning blocks,
-                        // and abort unrolling the loop.
-                        bottom->SetNext(tail);
-                        INDEBUG(++unrollFailures);
-                        JITDUMP("Failed to unroll loop " FMT_LP ": block cloning failed on " FMT_BB "\n",
-                                loop->GetIndex(), block->bbNum);
-                        return BasicBlockVisit::Abort;
-                    }
+                    // Now clone block state and statements from `from` block to `to` block.
+                    //
+                    BasicBlock::CloneBlockState(this, newBlock, block, lvar, lval);
 
                     // Block weight should no longer have the loop multiplier
                     //
@@ -4371,11 +4357,6 @@ RETRY_UNROLL:
 
                     return BasicBlockVisit::Continue;
                 });
-
-                if (result == BasicBlockVisit::Abort)
-                {
-                    goto DONE_LOOP;
-                }
 
                 assert(testBlock != nullptr);
 
@@ -4550,10 +4531,6 @@ RETRY_UNROLL:
         if (verbose)
         {
             printf("\nFinished unrolling %d loops", unrollCount);
-            if (unrollFailures > 0)
-            {
-                printf(", %d failures due to block cloning", unrollFailures);
-            }
             printf("\n");
         }
 #endif // DEBUG
@@ -4570,14 +4547,7 @@ RETRY_UNROLL:
     }
     else
     {
-#ifdef DEBUG
         assert(unrollCount == 0);
-
-        if (unrollFailures > 0)
-        {
-            printf("\nFinished loop unrolling, %d failures due to block cloning\n", unrollFailures);
-        }
-#endif // DEBUG
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
In particular, make it return void. `gtCloneExpr` cannot fail today which is checked by the `STRESS_CLONE_EXPR` stress mode during morph.

Also update some comments and remove an unnecessary assert in `impImportCall` (feedback from a previous PR).