### PR TITLE
[RISC-V] Adjust genRangeCheck for handling integer length stored in 6…

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5420,6 +5420,12 @@ void CodeGen::genRangeCheck(GenTree* oper)
     genConsumeRegs(index);
     genConsumeRegs(length);
 
+    if (genActualType(length) == TYP_INT)
+    {
+        regNumber tempReg = oper->ExtractTempReg();
+        GetEmitter()->emitIns_R_R_I(INS_addiw, EA_4BYTE, tempReg, lengthReg, 0); // sign-extend
+        lengthReg = tempReg;
+    }
     if (genActualType(index) == TYP_INT)
     {
         regNumber tempReg = oper->GetSingleTempReg();

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -605,11 +605,15 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_BOUNDS_CHECK:
         {
             GenTreeBoundsChk* node = tree->AsBoundsChk();
+            if (genActualType(node->GetArrayLength()) == TYP_INT)
+            {
+                buildInternalIntRegisterDefForNode(tree);
+            }
             if (genActualType(node->GetIndex()) == TYP_INT)
             {
                 buildInternalIntRegisterDefForNode(tree);
-                buildInternalRegisterUses();
             }
+            buildInternalRegisterUses();
             // Consumes arrLen & index - has no result
             assert(dstCount == 0);
             srcCount = BuildOperandUses(node->GetIndex());


### PR DESCRIPTION
…4 bit register

CodeGen::genRangeCheck already takes care of integer index. We need to handle integer length in similar way. This change fixes ArrBoundBinaryOp.sh test crash in JitStress mode:

```
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
	at Tests.Test231_cns(Int32)
	at Program.RunTest(System.Func`1<Byte>)
	at Program.CompareActions(Int32, System.Func`2<Int32,Byte>, System.Func`2<Int32,Byte>)
	at Program.TestEntryPoint()
	at __GeneratedMainWrapper.Main()
Aborted (core dumped)
```
Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @ashaurtaev @sirntar @tomeksowi @Bajtazar @viewizard