### PR TITLE
[wasm] Fix a few more paths to in-tree emsdk

### DIFF
--- a/.devcontainer/wasm/devcontainer.json
+++ b/.devcontainer/wasm/devcontainer.json
@@ -49,7 +49,7 @@
 		"PATH": "${containerWorkspaceFolder}/.dotnet:${containerWorkspaceFolder}/.dotnet-tools-global:${containerEnv:PATH}",
 		"DOTNET_MULTILEVEL_LOOKUP": "0",
 		// Path to provisioned Emscripten SDK, for rebuilding the wasm runtime
-		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/wasm/emsdk",
+		"EMSDK_PATH": "${containerWorkspaceFolder}/src/mono/browser/emsdk",
 	},
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/docs/workflow/debugging/mono/wasm-debugging.md
+++ b/docs/workflow/debugging/mono/wasm-debugging.md
@@ -86,7 +86,7 @@ There is another random number generator in `upstream/emscripten/src/determinist
 which needs the same treatment.
 
 Running `make patch-deterministic` in `src/mono/wasm` will patch the
-emscripten installation in `src/mono/wasm/emsdk` with these changes.
+emscripten installation in `src/mono/browser/emsdk` with these changes.
 
 # Debugging signature mismatch errors
 

--- a/src/mono/browser/README.md
+++ b/src/mono/browser/README.md
@@ -1,12 +1,12 @@
 # Build WebAssembly
 
-If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Build_Requirements) to understand the build requirements for your operating system. If you are specifically interested in building libraries for WebAssembly, read [Libraries WebAssembly](../../../docs/workflow/building/libraries/webassembly-instructions.md). Emscripten that is needed to build the project will be provisioned automatically, unless `EMSDK_PATH` variable is set or emscripten is already present in `src\mono\wasm\emsdk` directory.
+If you haven't already done so, please read [this document](../../../docs/workflow/README.md#Build_Requirements) to understand the build requirements for your operating system. If you are specifically interested in building libraries for WebAssembly, read [Libraries WebAssembly](../../../docs/workflow/building/libraries/webassembly-instructions.md). Emscripten that is needed to build the project will be provisioned automatically, unless `EMSDK_PATH` variable is set or emscripten is already present in `src\mono\browser\emsdk` directory.
 
 ### Windows
 
 Windows build [requirements](../../../docs/workflow/requirements/windows-requirements.md)
 
-**Note:** The EMSDK has an implicit dependency on Python for it to be initialized. A consequence of this is that if the system doesn't have Python installed prior to attempting a build, the automatic provisioning will fail and be in an invalid state. Therefore, if Python needs to be installed after a build attempt the `$reporoot/src/mono/wasm/emsdk` directory should be manually deleted and then a rebuild attempted.
+**Note:** The EMSDK has an implicit dependency on Python for it to be initialized. A consequence of this is that if the system doesn't have Python installed prior to attempting a build, the automatic provisioning will fail and be in an invalid state. Therefore, if Python needs to be installed after a build attempt the `$reporoot/src/mono/browser/emsdk` directory should be manually deleted and then a rebuild attempted.
 
 ## Building
 

--- a/src/native/libs/build-native.sh
+++ b/src/native/libs/build-native.sh
@@ -55,7 +55,7 @@ source "$__RepoRootDir"/eng/native/build-commons.sh
 # Set cross build
 if [[ "$__TargetOS" == browser ]]; then
     if [[ -z "$EMSDK_PATH" ]]; then
-        if [[ -d "$__RepoRootDir"/src/mono/wasm/emsdk/ ]]; then
+        if [[ -d "$__RepoRootDir"/src/mono/browser/emsdk/ ]]; then
             export EMSDK_PATH="$__RepoRootDir"/src/mono/browser/emsdk/
         else
             echo "Error: You need to set the EMSDK_PATH environment variable pointing to the emscripten SDK root."


### PR DESCRIPTION
It was moved from src/mono/wasm to src/mono/browser in https://github.com/dotnet/runtime/pull/95940