### PR TITLE
Fix XUnitLogChecker detection for local test runs

### DIFF
--- a/eng/testing/RunnerTemplate.cmd
+++ b/eng/testing/RunnerTemplate.cmd
@@ -98,6 +98,9 @@ if %_exit_code%==1 (
   )
 )
 
+if "%HELIX_CORRELATION_PAYLOAD%"=="" (
+  GOTO SKIP_XUNITLOGCHECKER
+)
 if NOT "%__IsXUnitLogCheckerSupported%"=="1" (
   echo XUnitLogChecker not supported for this test case. Skipping.
   GOTO SKIP_XUNITLOGCHECKER

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -233,7 +233,9 @@ if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
 
 fi
 
-if [[ -z "$__IsXUnitLogCheckerSupported" ]]; then
+if [[ -z "$HELIX_CORRELATION_PAYLOAD" ]]; then
+  : # Skip XUnitLogChecker execution
+elif [[ -z "$__IsXUnitLogCheckerSupported" ]]; then
   echo "The '__IsXUnitLogCheckerSupported' env var is not set."
 elif [[ "$__IsXUnitLogCheckerSupported" != "1" ]]; then
   echo "XUnitLogChecker not supported for this test case. Skipping."

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,7 +2035,6 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
-  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,6 +2035,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
+  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/95762

When attempting to run tests locally, XUnitLogChecker would cause a test failure because HELIX_CORRELATION_PAYLOAD is not defined in the local machine. If we skip the execution of XUnitLogChecker completely when HELIX_CORRELATION_PAYLOAD is not defined, we stop seeing the tests fail locally.

NOTE: I am adding a temporary crash to ensure XUnitLogChecker still works in the CI. Will remove before merging.