### PR TITLE
Fix fast-path support for ignoring nullable value types

### DIFF
--- a/src/libraries/Common/src/SourceGenerators/TypeRef.cs
+++ b/src/libraries/Common/src/SourceGenerators/TypeRef.cs
@@ -19,7 +19,7 @@ namespace SourceGenerators
             FullyQualifiedName = type.GetFullyQualifiedName();
             IsValueType = type.IsValueType;
             TypeKind = type.TypeKind;
-            SpecialType = type.SpecialType;
+            SpecialType = type.OriginalDefinition.SpecialType;
         }
 
         public string Name { get; }

--- a/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/PropertyVisibilityTests.cs
@@ -1322,10 +1322,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Needs support for more collections.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53393")]
-#endif
         public async Task JsonIgnoreAttribute_UnsupportedCollection()
         {
             string json =
@@ -1771,10 +1767,6 @@ namespace System.Text.Json.Serialization.Tests
         [Theory]
         [InlineData(typeof(ClassWithProperty_IgnoreConditionAlways))]
         [InlineData(typeof(ClassWithProperty_IgnoreConditionAlways_Ctor))]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreConditionSetToAlwaysWorks(Type type)
         {
             string json = @"{""MyString"":""Random"",""MyDateTime"":""2020-03-23"",""MyInt"":4}";
@@ -1798,7 +1790,7 @@ namespace System.Text.Json.Serialization.Tests
             public int MyInt { get; set; }
         }
 
-        private class ClassWithProperty_IgnoreConditionAlways_Ctor
+        public class ClassWithProperty_IgnoreConditionAlways_Ctor
         {
             public string MyString { get; set; }
             [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
@@ -1814,10 +1806,6 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_ClassProperty_TestData))]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreConditionWhenWritingDefault_ClassProperty(Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
@@ -1868,7 +1856,7 @@ namespace System.Text.Json.Serialization.Tests
             public int Int2 { get; set; }
         }
 
-        private class ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor
+        public class ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor
         {
             public int Int1 { get; set; }
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -1892,10 +1880,6 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_StructProperty_TestData))]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreConditionWhenWritingDefault_StructProperty(Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
@@ -1924,7 +1908,7 @@ namespace System.Text.Json.Serialization.Tests
             public int Int2 { get; set; }
         }
 
-        private struct StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor
+        public struct StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor
         {
             public int Int1 { get; set; }
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
@@ -1948,10 +1932,6 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionNever_TestData))]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreConditionNever(Type type)
         {
             // Property should always be (de)serialized, even when null.
@@ -1983,10 +1963,6 @@ namespace System.Text.Json.Serialization.Tests
 
         [Theory]
         [MemberData(nameof(JsonIgnoreConditionNever_TestData))]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreConditionNever_IgnoreNullValues_True(Type type)
         {
             // Property should always be (de)serialized.
@@ -2060,9 +2036,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53393")]
-#endif
         public async Task ClassWithComplexObjectsUsingIgnoreWhenWritingDefaultAttribute()
         {
             string json = @"{""Class"":{""MyInt16"":18}, ""Dictionary"":null}";
@@ -2091,9 +2064,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/53393")]
-#endif
         public async Task ClassWithComplexObjectUsingIgnoreNeverAttribute()
         {
             string json = @"{""Class"":null, ""Dictionary"":null}";
@@ -2375,10 +2345,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task ValueType_Properties_NotIgnoredWhen_IgnoreNullValues_Active_LargeStructTest()
         {
             var options = new JsonSerializerOptions { IgnoreNullValues = true };
@@ -2412,10 +2378,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task ValueType_Properties_NotIgnoredWhen_IgnoreNullValues_Active_SmallStructTest()
         {
             var options = new JsonSerializerOptions { IgnoreNullValues = true };
@@ -2478,7 +2440,7 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        private struct SmallStructWithValueAndReferenceTypes
+        public struct SmallStructWithValueAndReferenceTypes
         {
             public string MyString { get; }
             public int MyInt { get; set; }
@@ -2502,10 +2464,6 @@ namespace System.Text.Json.Serialization.Tests
         public class PointClass { }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task Ignore_WhenWritingNull_Globally()
         {
             var options = new JsonSerializerOptions
@@ -2579,17 +2537,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Need support for parameterized ctors.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task Ignore_WhenWritingNull_PerProperty()
         {
-            var options = new JsonSerializerOptions
-            {
-                IncludeFields = true
-            };
-
             string json = @"{
 ""MyPointClass2_IgnoredWhenWritingNull"":{},
 ""MyString1_IgnoredWhenWritingNull"":""Default"",
@@ -2604,7 +2553,7 @@ namespace System.Text.Json.Serialization.Tests
 }";
 
             // All members should correspond to JSON contents, as ignore doesn't apply to deserialization.
-            ClassWithThingsToIgnore_PerProperty obj = await Serializer.DeserializeWrapper<ClassWithThingsToIgnore_PerProperty>(json, options);
+            ClassWithThingsToIgnore_PerProperty obj = await Serializer.DeserializeWrapper<ClassWithThingsToIgnore_PerProperty>(json);
             Assert.NotNull(obj.MyPointClass2_IgnoredWhenWritingNull);
             Assert.Equal("Default", obj.MyString1_IgnoredWhenWritingNull);
             Assert.Null(obj.MyNullableBool1_IgnoredWhenWritingNull);
@@ -2628,7 +2577,7 @@ namespace System.Text.Json.Serialization.Tests
 ""MyNullableBool2_IgnoredWhenWritingNull"":true,
 ""MyPointStruct1"":{""X"":0,""Y"":0}
 }";
-            JsonTestHelper.AssertJsonEqual(expectedJson, await Serializer.SerializeWrapper(obj, options));
+            JsonTestHelper.AssertJsonEqual(expectedJson, await Serializer.SerializeWrapper(obj));
         }
 
         public class ClassWithThingsToIgnore_PerProperty
@@ -2639,6 +2588,7 @@ namespace System.Text.Json.Serialization.Tests
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public string MyString2_IgnoredWhenWritingNull;
 
+            [JsonInclude]
             public int MyInt1;
 
             public int MyInt2 { get; set; }
@@ -2646,15 +2596,16 @@ namespace System.Text.Json.Serialization.Tests
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public bool? MyNullableBool1_IgnoredWhenWritingNull { get; set; }
 
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+            [JsonInclude, JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public bool? MyNullableBool2_IgnoredWhenWritingNull;
 
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+            [JsonInclude, JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public PointClass MyPointClass1_IgnoredWhenWritingNull;
 
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public PointClass MyPointClass2_IgnoredWhenWritingNull { get; set; }
 
+            [JsonInclude]
             public Point_2D_Struct_WithAttribute MyPointStruct1;
 
             public Point_2D_Struct_WithAttribute MyPointStruct2 { get; set; }
@@ -2748,10 +2699,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Needs bug fixes to custom converter handling.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreCondition_WhenWritingDefault_OnValueTypeWithCustomConverter()
         {
             var obj = new MyClassWithValueType();
@@ -2799,10 +2746,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-#if BUILDING_SOURCE_GENERATOR_TESTS
-        // Needs bug fixes to custom converter handling.
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45448")]
-#endif
         public async Task JsonIgnoreCondition_WhenWritingNull_OnValueTypeWithCustomConverter()
         {
             string json;

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/PropertyVisibilityTests.cs
@@ -334,6 +334,14 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(DictionaryWithPrivateKeyAndValueType))][JsonSerializable(typeof(ClassWithIgnoredAndPrivateMembers))]
         [JsonSerializable(typeof(ClassWithInternalJsonIncludeProperties))]
         [JsonSerializable(typeof(ClassWithIgnoredAndPrivateMembers))]
+        [JsonSerializable(typeof(ClassUsingIgnoreWhenWritingDefaultAttribute))]
+        [JsonSerializable(typeof(ClassUsingIgnoreNeverAttribute))]
+        [JsonSerializable(typeof(ClassWithIgnoredUnsupportedDictionary))]
+        [JsonSerializable(typeof(ClassWithProperty_IgnoreConditionAlways_Ctor))]
+        [JsonSerializable(typeof(ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor))]
+        [JsonSerializable(typeof(StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor))]
+        [JsonSerializable(typeof(SmallStructWithValueAndReferenceTypes))]
+        [JsonSerializable(typeof(WrapperForClassWithIgnoredUnsupportedDictionary))]
         [JsonSerializable(typeof(Class1))]
         [JsonSerializable(typeof(Class2))]
         [JsonSerializable(typeof(NamespaceBase.Class1), TypeInfoPropertyName = "Class1FromNamespaceBase")]
@@ -426,6 +434,27 @@ namespace System.Text.Json.SourceGeneration.Tests
             Assert.Equal(obj.IgnoreReadOnlyFields, deserialized.IgnoreReadOnlyFields);
             Assert.Equal(obj.MaxDepth, deserialized.MaxDepth);
         }
+
+        [Fact]
+        public void PocoWithNullableProperties_IgnoresNullValuesWithGlobalSetting()
+        {
+            // Regression test for https://github.com/dotnet/runtime/issues/96404
+            var value = new PocoWithNullableProperties();
+            string json = JsonSerializer.Serialize(value, DefaultContextWithGlobalIgnoreSetting.Default.PocoWithNullableProperties);
+            Assert.Equal("{}", json);
+        }
+
+        class PocoWithNullableProperties
+        {
+            public string? NullableRefType { get; set; }
+            public int? NullableValueType { get; set; }
+        }
+
+        [JsonSourceGenerationOptions(
+            GenerationMode = JsonSourceGenerationMode.Default,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonSerializable(typeof(PocoWithNullableProperties))]
+        partial class DefaultContextWithGlobalIgnoreSetting : JsonSerializerContext;
 
         [JsonSerializable(typeof(ClassWithNewSlotField))]
         [JsonSerializable(typeof(int))]
@@ -578,6 +607,14 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(DictionaryWithPrivateKeyAndValueType))]
         [JsonSerializable(typeof(ClassWithInternalJsonIncludeProperties))]
         [JsonSerializable(typeof(ClassWithIgnoredAndPrivateMembers))]
+        [JsonSerializable(typeof(ClassUsingIgnoreWhenWritingDefaultAttribute))]
+        [JsonSerializable(typeof(ClassUsingIgnoreNeverAttribute))]
+        [JsonSerializable(typeof(ClassWithIgnoredUnsupportedDictionary))]
+        [JsonSerializable(typeof(ClassWithProperty_IgnoreConditionAlways_Ctor))]
+        [JsonSerializable(typeof(ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor))]
+        [JsonSerializable(typeof(StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor))]
+        [JsonSerializable(typeof(SmallStructWithValueAndReferenceTypes))]
+        [JsonSerializable(typeof(WrapperForClassWithIgnoredUnsupportedDictionary))]
         [JsonSerializable(typeof(Class1))]
         [JsonSerializable(typeof(Class2))]
         [JsonSerializable(typeof(NamespaceBase.Class1), TypeInfoPropertyName = "Class1FromNamespaceBase")]


### PR DESCRIPTION
Fix #96404. Should be backported to .NET 8.