### PR TITLE
Use OriginalDefinition to get members of generic types

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/ReflectionAccessAnalyzer.cs
@@ -16,6 +16,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 #pragma warning disable CA1822 // Mark members as static - the other partial implementations might need to be instance methods
 		internal void GetReflectionAccessDiagnostics (in DiagnosticContext diagnosticContext, ITypeSymbol typeSymbol, DynamicallyAccessedMemberTypes requiredMemberTypes, bool declaredOnly = false)
 		{
+			typeSymbol = typeSymbol.OriginalDefinition;
 			foreach (var member in typeSymbol.GetDynamicallyAccessedMembers (requiredMemberTypes, declaredOnly)) {
 				switch (member) {
 				case IMethodSymbol method:

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/RequiresCapability/RequiresOnClass.cs
@@ -809,8 +809,7 @@ namespace Mono.Linker.Tests.Cases.RequiresCapability
 				public static int NonGenericField;
 			}
 
-			// https://github.com/dotnet/runtime/issues/86633 - analyzer doesn't report this warning
-			[ExpectedWarning ("IL2026", "NonGenericField", "--GenericTypeWithRequires--", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[ExpectedWarning ("IL2026", "NonGenericField", "--GenericTypeWithRequires--")]
 			[ExpectedWarning ("IL3050", "NonGenericField", "--GenericTypeWithRequires--", ProducedBy = Tool.NativeAot)]
 			static void TestDAMAccessOnOpenGeneric ()
 			{


### PR DESCRIPTION
From https://github.com/dotnet/runtime/issues/86633#issuecomment-1559101776
> The open generic type is represented to us as NonErrorNamedTypeSymbol, but that reports to have 0 members. It seems we need to use the OriginalDefinition to get to the generic type definition which will report all members correctly.

Fixes https://github.com/dotnet/runtime/issues/86633