### PR TITLE
JIT: Fix last block removal during layout optimization

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5145,17 +5145,15 @@ void Compiler::fgUnlinkBlock(BasicBlock* block)
             fgFirstBBScratch = nullptr;
         }
     }
+    else if (block->IsLast())
+    {
+        assert(fgLastBB == block);
+        fgLastBB = block->Prev();
+        fgLastBB->SetNextToNull();
+    }
     else
     {
-        if (block == fgLastBB)
-        {
-            fgLastBB = block->Prev();
-            fgLastBB->SetNextToNull();
-        }
-        else
-        {
-            block->Prev()->SetNext(block->Next());
-        }
+        block->Prev()->SetNext(block->Next());
     }
 }
 
@@ -5301,9 +5299,6 @@ BasicBlock* Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
         // The block cannot follow a non-retless BBJ_CALLFINALLY (because we don't know who may jump to it).
         noway_assert(!block->isBBCallFinallyPairTail());
-
-        /* This cannot be the last basic block */
-        noway_assert(block != fgLastBB);
 
 #ifdef DEBUG
         if (verbose)

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -2932,14 +2932,13 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
                 }
             }
 
-            /* special case if this is the last BB */
-            if (block == fgLastBB)
+            /* special case if this is the only BB */
+            if (block->IsFirst() && block->IsLast())
             {
-                if (!bPrev)
-                {
-                    break;
-                }
-                fgLastBB = bPrev;
+                assert(block == fgFirstBB);
+                assert(block == fgLastBB);
+                assert(bPrev == nullptr);
+                break;
             }
 
             // When using profile weights, fgComputeEdgeWeights expects the first non-internal block to have profile


### PR DESCRIPTION
Fixes #96642, though the issue doesn't seem limited to hot/cold splitting scenarios. In `Compiler::fgOptimizeEmptyBlock`, if removing the last block, we previously updated `fgLastBB` to point to its previous block before calling `Compiler::fgRemoveBlock` to avoid triggering an overzealous assert. By updating `fgLastBB` prematurely, we'd execute the wrong path for updating the removed block's next/previous pointers in `Compiler::fgUnlinkBlock`, hence the `next != nullptr` assert in `BasicBlock::SetNext`. This change updates `fgOptimizeEmptyBlock` to not prematurely update `fgLastBB`, instead allowing `fgUnlinkBlock` to update `fgLastBB` if unlinking the last block; to make this work, it also removes the overzealous assert in `fgRemoveBlock`.