### PR TITLE
Use NuGetAuthenticate@1 instead of @0

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     inputs:
       nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true

--- a/eng/pipelines/installer/jobs/steps/build-linux-package.yml
+++ b/eng/pipelines/installer/jobs/steps/build-linux-package.yml
@@ -9,7 +9,7 @@ parameters:
 steps:
 ## Run NuGet Authentication for each of the side containers
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     target: ${{ parameters.target }}
 - script: |
     $(Build.SourcesDirectory)/build.sh \

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
     fetchDepth: 20
 
   - ${{ if eq(parameters.isOfficialBuild, true) }}:
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
There is a build warning about the old version now. eng/common usages are handled by https://github.com/dotnet/arcade/pull/14314