### PR TITLE
Move PendingTypeLoadTable from the ClassLoader object to a global structure

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -162,6 +162,7 @@
 #include "disassembler.h"
 #include "jithost.h"
 #include "pgo.h"
+#include "pendingload.h"
 
 #ifndef TARGET_UNIX
 #include "dwreport.h"
@@ -622,6 +623,8 @@ void EEStartupHelper()
         // Initialize global configuration settings based on startup flags
         // This needs to be done before the EE has started
         InitializeStartupFlags();
+
+        PendingTypeLoadTable::Init();
 
         IfFailGo(ExecutableAllocator::StaticInitialize(FatalErrorHandler));
 

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -216,7 +216,7 @@ Module * ClassLoader::ComputeLoaderModule(MethodTable * pMT,
                                methodInst);
 }
 /*static*/
-Module *ClassLoader::ComputeLoaderModule(TypeKey *typeKey)
+Module *ClassLoader::ComputeLoaderModule(const TypeKey *typeKey)
 {
     CONTRACTL
     {
@@ -729,7 +729,7 @@ void ClassLoader::LazyPopulateCaseInsensitiveHashTables()
 }
 
 /*static*/
-void DECLSPEC_NORETURN ClassLoader::ThrowTypeLoadException(TypeKey *pKey,
+void DECLSPEC_NORETURN ClassLoader::ThrowTypeLoadException(const TypeKey *pKey,
                                                            UINT resIDWhy)
 {
     STATIC_CONTRACT_THROWS;
@@ -743,7 +743,7 @@ void DECLSPEC_NORETURN ClassLoader::ThrowTypeLoadException(TypeKey *pKey,
 
 #endif
 
-TypeHandle ClassLoader::LoadConstructedTypeThrowing(TypeKey *pKey,
+TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
                                                     LoadTypesFlag fLoadTypes /*= LoadTypes*/,
                                                     ClassLoadLevel level /*=CLASS_LOADED*/,
                                                     const InstantiationContext *pInstContext /*=NULL*/)
@@ -873,7 +873,7 @@ void ClassLoader::TryEnsureLoaded(TypeHandle typeHnd, ClassLoadLevel level)
 }
 
 /* static */
-TypeHandle ClassLoader::LookupTypeKey(TypeKey *pKey, EETypeHashTable *pTable)
+TypeHandle ClassLoader::LookupTypeKey(const TypeKey *pKey, EETypeHashTable *pTable)
 {
     CONTRACTL {
         NOTHROW;
@@ -890,7 +890,7 @@ TypeHandle ClassLoader::LookupTypeKey(TypeKey *pKey, EETypeHashTable *pTable)
 }
 
 /* static */
-TypeHandle ClassLoader::LookupInLoaderModule(TypeKey *pKey)
+TypeHandle ClassLoader::LookupInLoaderModule(const TypeKey *pKey)
 {
     CONTRACTL {
         NOTHROW;
@@ -910,7 +910,7 @@ TypeHandle ClassLoader::LookupInLoaderModule(TypeKey *pKey)
 
 
 /* static */
-TypeHandle ClassLoader::LookupTypeHandleForTypeKey(TypeKey *pKey)
+TypeHandle ClassLoader::LookupTypeHandleForTypeKey(const TypeKey *pKey)
 {
     CONTRACTL
     {
@@ -2606,7 +2606,7 @@ ClassLoader::LoadApproxParentThrowing(
 // Perform a single phase of class loading
 // It is the caller's responsibility to lock
 /*static*/
-TypeHandle ClassLoader::DoIncrementalLoad(TypeKey *pTypeKey, TypeHandle typeHnd, ClassLoadLevel currentLevel)
+TypeHandle ClassLoader::DoIncrementalLoad(const TypeKey *pTypeKey, TypeHandle typeHnd, ClassLoadLevel currentLevel)
 {
     CONTRACTL
     {
@@ -2680,7 +2680,7 @@ TypeHandle ClassLoader::DoIncrementalLoad(TypeKey *pTypeKey, TypeHandle typeHnd,
 // For canonical instantiations of generic types, create a brand new method table
 // For other constructed types, create a type desc and template method table if necessary
 // For all other types, create a method table
-TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracker* pamTracker)
+TypeHandle ClassLoader::CreateTypeHandleForTypeKey(const TypeKey* pKey, AllocMemTracker* pamTracker)
 {
     CONTRACT(TypeHandle)
     {
@@ -2795,7 +2795,7 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracke
 // particular, exact parent info (base class and interfaces) is loaded
 // in a later phase
 /*static*/
-TypeHandle ClassLoader::PublishType(TypeKey *pTypeKey, TypeHandle typeHnd)
+TypeHandle ClassLoader::PublishType(const TypeKey *pTypeKey, TypeHandle typeHnd)
 {
     CONTRACTL
     {
@@ -2995,7 +2995,7 @@ static void PushFinalLevels(TypeHandle typeHnd, ClassLoadLevel targetLevel, cons
 
 
 //
-TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
+TypeHandle ClassLoader::LoadTypeHandleForTypeKey(const TypeKey *pTypeKey,
                                                  TypeHandle typeHnd,
                                                  ClassLoadLevel targetLevel/*=CLASS_LOADED*/,
                                                  const InstantiationContext *pInstContext/*=NULL*/)
@@ -3051,7 +3051,7 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
 }
 
 //
-TypeHandle ClassLoader::LoadTypeHandleForTypeKeyNoLock(TypeKey *pTypeKey,
+TypeHandle ClassLoader::LoadTypeHandleForTypeKeyNoLock(const TypeKey *pTypeKey,
                                                        ClassLoadLevel targetLevel/*=CLASS_LOADED*/,
                                                        const InstantiationContext *pInstContext/*=NULL*/)
 {
@@ -3136,7 +3136,7 @@ public:
 //
 TypeHandle
 ClassLoader::LoadTypeHandleForTypeKey_Body(
-    TypeKey *                         pTypeKey,
+    const TypeKey *                         pTypeKey,
     TypeHandle                        typeHnd,
     ClassLoadLevel                    targetLevel)
 {
@@ -3222,7 +3222,7 @@ retry:
         }
 
         // Result of other thread loading the class
-        HRESULT hr = pLoadingEntry->DelayForProgress();
+        HRESULT hr = pLoadingEntry->DelayForProgress(&typeHnd);
 
         if (FAILED(hr)) {
 
@@ -3256,9 +3256,6 @@ retry:
 
             pLoadingEntry->ThrowException();
         }
-
-        // Get a pointer to the EEClass being loaded
-        typeHnd = pLoadingEntry->GetTypeHandle();
 
         if (!typeHnd.IsNull())
         {

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -1675,12 +1675,6 @@ ClassLoader::~ClassLoader()
     CONTRACTL_END
 
 #ifdef _DEBUG
-    // Do not walk m_pUnresolvedClassHash at destruct time as it is loaderheap allocated memory
-    // and may already have been deallocated via an AllocMemTracker.
-    m_pUnresolvedClassHash = (PendingTypeLoadTable*)(UINT_PTR)0xcccccccc;
-#endif
-
-#ifdef _DEBUG
 //     LOG((
 //         LF_CLASSLOADER,
 //         INFO3,
@@ -1719,7 +1713,6 @@ ClassLoader::~ClassLoader()
 
     FreeModules();
 
-    m_UnresolvedClassLock.Destroy();
     m_AvailableClassLock.Destroy();
     m_AvailableTypesLock.Destroy();
 }
@@ -1744,7 +1737,6 @@ ClassLoader::ClassLoader(Assembly *pAssembly)
 
     m_pAssembly = pAssembly;
 
-    m_pUnresolvedClassHash          = NULL;
     m_cUnhashedModules              = 0;
 
 #ifdef _DEBUG
@@ -1774,12 +1766,6 @@ ClassLoader::ClassLoader(Assembly *pAssembly)
 VOID ClassLoader::Init(AllocMemTracker *pamTracker)
 {
     STANDARD_VM_CONTRACT;
-
-    m_pUnresolvedClassHash = PendingTypeLoadTable::Create(GetAssembly()->GetLowFrequencyHeap(),
-                                                          UNRESOLVED_CLASS_HASH_BUCKETS,
-                                                          pamTracker);
-
-    m_UnresolvedClassLock.Init(CrstUnresolvedClassLock);
 
     // This lock is taken within the classloader whenever we have to enter a
     // type in one of the modules governed by the loader.
@@ -3033,8 +3019,7 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
         SString name;
         TypeString::AppendTypeKeyDebug(name, pTypeKey);
         LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: LoadTypeHandleForTypeKey for type %s to level %s\n", name.GetUTF8(), classLoadLevelName[targetLevel]));
-        CrstHolder unresolvedClassLockHolder(&m_UnresolvedClassLock);
-        m_pUnresolvedClassHash->Dump();
+        PendingTypeLoadTable::GetTable()->Dump();
     }
 #endif
 
@@ -3106,11 +3091,11 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKeyNoLock(TypeKey *pTypeKey,
 class PendingTypeLoadHolder
 {
     Thread * m_pThread;
-    PendingTypeLoadEntry * m_pEntry;
+    PendingTypeLoadTable::Entry * m_pEntry;
     PendingTypeLoadHolder * m_pPrevious;
 
 public:
-    PendingTypeLoadHolder(PendingTypeLoadEntry * pEntry)
+    PendingTypeLoadHolder(PendingTypeLoadTable::Entry * pEntry)
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -3129,7 +3114,7 @@ public:
         m_pThread->SetPendingTypeLoad(m_pPrevious);
     }
 
-    static bool CheckForDeadLockOnCurrentThread(PendingTypeLoadEntry * pEntry)
+    static bool CheckForDeadLockOnCurrentThread(PendingTypeLoadTable::Entry * pEntry)
     {
         LIMITED_METHOD_CONTRACT;
 
@@ -3182,14 +3167,16 @@ ClassLoader::LoadTypeHandleForTypeKey_Body(
 #endif
     }
 
-    ReleaseHolder<PendingTypeLoadEntry> pLoadingEntry;
-    CrstHolderWithState unresolvedClassLockHolder(&m_UnresolvedClassLock, false);
+    ReleaseHolder<PendingTypeLoadTable::Entry> pLoadingEntry;
+    DWORD dwHashedTypeKey;
+    PendingTypeLoadTable::Shard *pPendingTypeLoadShard = PendingTypeLoadTable::GetTable()->GetShard(*pTypeKey, this, &dwHashedTypeKey);
+    CrstHolderWithState unresolvedClassLockHolder(pPendingTypeLoadShard->GetCrst(), false);
 
 retry:
     unresolvedClassLockHolder.Acquire();
 
     // Is it in the hash of classes currently being loaded?
-    pLoadingEntry = m_pUnresolvedClassHash->GetValue(pTypeKey);
+    pLoadingEntry = pPendingTypeLoadShard->FindPendingTypeLoadEntry(dwHashedTypeKey, *pTypeKey);
     if (pLoadingEntry)
     {
         pLoadingEntry->AddRef();
@@ -3234,15 +3221,8 @@ retry:
             goto retry;
         }
 
-        {
-            // Wait for class to be loaded by another thread.  This is where we start tracking the
-            // entry, so there is an implicit Acquire in our use of Assign here.
-            CrstHolder loadingEntryLockHolder(&pLoadingEntry->m_Crst);
-            _ASSERTE(pLoadingEntry->HasLock());
-        }
-
         // Result of other thread loading the class
-        HRESULT hr = pLoadingEntry->m_hrResult;
+        HRESULT hr = pLoadingEntry->DelayForProgress();
 
         if (FAILED(hr)) {
 
@@ -3278,7 +3258,7 @@ retry:
         }
 
         // Get a pointer to the EEClass being loaded
-        typeHnd = pLoadingEntry->m_typeHandle;
+        typeHnd = pLoadingEntry->GetTypeHandle();
 
         if (!typeHnd.IsNull())
         {
@@ -3309,12 +3289,7 @@ retry:
 
     // It was not loaded, and it is not being loaded, so we must load it.  Create a new LoadingEntry
     // and acquire it immediately so that other threads will block.
-    pLoadingEntry = new PendingTypeLoadEntry(*pTypeKey, typeHnd);  // this atomically creates a crst and acquires it
-
-    if (!(m_pUnresolvedClassHash->InsertValue(pLoadingEntry)))
-    {
-        COMPlusThrowOM();
-    }
+    pLoadingEntry = pPendingTypeLoadShard->InsertPendingTypeLoadEntry(dwHashedTypeKey, *pTypeKey, typeHnd);  // this atomically creates a crst and acquires it
 
     // Leave the global lock, so that other threads may now start waiting on our class's lock
     unresolvedClassLockHolder.Release();
@@ -3352,7 +3327,7 @@ retry:
 
         // Unlink this class from the unresolved class list.
         unresolvedClassLockHolder.Acquire();
-        m_pUnresolvedClassHash->DeleteValue(pTypeKey);
+        pPendingTypeLoadShard->RemovePendingTypeLoadEntry(pLoadingEntry);
 
         // Release the lock before proceeding. The unhandled exception filters take number of locks that
         // have ordering violations with this lock.
@@ -3365,13 +3340,13 @@ retry:
 
     // Unlink this class from the unresolved class list.
     unresolvedClassLockHolder.Acquire();
-    m_pUnresolvedClassHash->DeleteValue(pTypeKey);
+    pPendingTypeLoadShard->RemovePendingTypeLoadEntry(pLoadingEntry);
     unresolvedClassLockHolder.Release();
 
     // Unblock any thread waiting to load same type as in TypeLoadEntry. This should be done
-    // after pLoadingEntry is removed from m_pUnresolvedClassHash. Otherwise the other thread
+    // after pLoadingEntry is removed from the PendingTypeLoadTable. Otherwise the other thread
     // (which was waiting) will keep spinning for a while after waking up, till the current thread removes
-    //  pLoadingEntry from m_pUnresolvedClassHash. This can cause hang in situation when the current
+    //  pLoadingEntry from the PendingTypeLoadTable. This can cause hang in situation when the current
     // thread is a background thread and so will get very less processor cycle to perform subsequent
     // operations to remove the entry from hash later.
     pLoadingEntry->UnblockWaiters();

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -544,7 +544,7 @@ public:
     static Module * ComputeLoaderModule(MethodTable * pMT,
                                        mdToken        token,        // the token of the method
                                        Instantiation  methodInst);  // the type arguments to the method (if any)
-    static Module * ComputeLoaderModule(TypeKey * typeKey);
+    static Module * ComputeLoaderModule(const TypeKey * typeKey);
     inline static PTR_Module ComputeLoaderModuleForFunctionPointer(TypeHandle * pRetAndArgTypes, DWORD NumArgsPlusRetType);
     inline static PTR_Module ComputeLoaderModuleForParamType(TypeHandle paramType);
 
@@ -793,7 +793,7 @@ public:
 
     // Load canonical shared instantiation for type key (each instantiation argument is
     // substituted by CanonicalizeGenericArg)
-    static TypeHandle LoadCanonicalGenericInstantiation(TypeKey *pTypeKey,
+    static TypeHandle LoadCanonicalGenericInstantiation(const TypeKey *pTypeKey,
                                                         LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                         ClassLoadLevel level/*=CLASS_LOADED*/);
 
@@ -875,20 +875,20 @@ public:
     friend class AvailableClasses_LockHolder;
 
 private:
-    static TypeHandle LoadConstructedTypeThrowing(TypeKey *pKey,
+    static TypeHandle LoadConstructedTypeThrowing(const TypeKey *pKey,
                                                   LoadTypesFlag fLoadTypes = LoadTypes,
                                                   ClassLoadLevel level = CLASS_LOADED,
                                                   const InstantiationContext *pInstContext = NULL);
 
-    static TypeHandle LookupTypeKey(TypeKey *pKey, EETypeHashTable *pTable);
+    static TypeHandle LookupTypeKey(const TypeKey *pKey, EETypeHashTable *pTable);
 
-    static TypeHandle LookupInLoaderModule(TypeKey* pKey);
+    static TypeHandle LookupInLoaderModule(const TypeKey* pKey);
 
     // Lookup a handle in the appropriate table
     // (declaring module for TypeDef or loader-module for constructed types)
-    static TypeHandle LookupTypeHandleForTypeKey(TypeKey *pTypeKey);
+    static TypeHandle LookupTypeHandleForTypeKey(const TypeKey *pTypeKey);
 
-    static void DECLSPEC_NORETURN  ThrowTypeLoadException(TypeKey *pKey, UINT resIDWhy);
+    static void DECLSPEC_NORETURN  ThrowTypeLoadException(const TypeKey *pKey, UINT resIDWhy);
 
 
     BOOL IsNested(const NameHandle* pName, mdToken *mdEncloser);
@@ -921,16 +921,16 @@ private:
 #ifndef DACCESS_COMPILE
     // Perform a single phase of class loading
     // If no type handle has yet been created, typeHnd is null.
-    static TypeHandle DoIncrementalLoad(TypeKey *pTypeKey,
+    static TypeHandle DoIncrementalLoad(const TypeKey *pTypeKey,
                                         TypeHandle typeHnd,
                                         ClassLoadLevel workLevel);
 
     // Phase CLASS_LOAD_CREATE of class loading
-    static TypeHandle CreateTypeHandleForTypeKey(TypeKey *pTypeKey,
+    static TypeHandle CreateTypeHandleForTypeKey(const TypeKey *pTypeKey,
                                                  AllocMemTracker *pamTracker);
 
     // Publish the type in the loader's tables
-    static TypeHandle PublishType(TypeKey *pTypeKey, TypeHandle typeHnd);
+    static TypeHandle PublishType(const TypeKey *pTypeKey, TypeHandle typeHnd);
 
     // Notify profiler and debugger that a type load has completed
     // Also update perf counters
@@ -952,7 +952,7 @@ private:
 
     // Create a non-canonical instantiation of a generic type based off the canonical instantiation
     // (For example, MethodTable for List<string> is based on the MethodTable for List<__Canon>)
-    static TypeHandle CreateTypeHandleForNonCanonicalGenericInstantiation(TypeKey *pTypeKey,
+    static TypeHandle CreateTypeHandleForNonCanonicalGenericInstantiation(const TypeKey *pTypeKey,
                                                                           AllocMemTracker *pamTracker);
 
     // Loads a class. This is the inner call from the multi-threaded load. This load must
@@ -966,12 +966,12 @@ private:
 
     // The token must be a type def.  GC must be enabled.
     // If we're attempting to load a fresh instantiated type then genericArgs should be filled in
-    TypeHandle LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
+    TypeHandle LoadTypeHandleForTypeKey(const TypeKey *pTypeKey,
                                         TypeHandle typeHnd,
                                         ClassLoadLevel level = CLASS_LOADED,
                                         const InstantiationContext *pInstContext = NULL);
 
-    TypeHandle LoadTypeHandleForTypeKeyNoLock(TypeKey *pTypeKey,
+    TypeHandle LoadTypeHandleForTypeKeyNoLock(const TypeKey *pTypeKey,
                                               ClassLoadLevel level = CLASS_LOADED,
                                               const InstantiationContext *pInstContext = NULL);
 
@@ -1015,7 +1015,7 @@ private:
                                     AllocMemTracker *pamTracker);
 
     // don't call this directly.
-    TypeHandle LoadTypeHandleForTypeKey_Body(TypeKey *pTypeKey,
+    TypeHandle LoadTypeHandleForTypeKey_Body(const TypeKey *pTypeKey,
                                              TypeHandle typeHnd,
                                              ClassLoadLevel targetLevel);
 #endif //!DACCESS_COMPILE

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -30,7 +30,6 @@ class SystemDomain;
 class Assembly;
 class ClassLoader;
 class TypeKey;
-class PendingTypeLoadEntry;
 class PendingTypeLoadTable;
 class EEClass;
 class Thread;
@@ -466,7 +465,7 @@ void DECLSPEC_NORETURN ThrowTypeAccessException(AccessCheckContext* pContext,
 //
 class ClassLoader
 {
-    friend class PendingTypeLoadEntry;
+    friend class PendingTypeLoadTable;
     friend class MethodTableBuilder;
     friend class AppDomain;
     friend class Assembly;
@@ -478,10 +477,6 @@ class ClassLoader
     friend class COMModule;
 
 private:
-    // Classes for which load is in progress
-    PendingTypeLoadTable  * m_pUnresolvedClassHash;
-    CrstExplicitInit        m_UnresolvedClassLock;
-
     // Protects addition of elements to module's m_pAvailableClasses.
     // (indeed thus protects addition of elements to any m_pAvailableClasses in any
     // of the modules managed by this loader)

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -105,8 +105,6 @@ extern DWORD g_fEEShutDown;
 extern Volatile<LONG> g_ShutdownCrstUsageCount;
 extern Volatile<LONG> g_fForbidEnterEE;
 
-class PendingTypeLoadTable;
-
 // The CRST.
 class CrstBase
 {

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -105,6 +105,8 @@ extern DWORD g_fEEShutDown;
 extern Volatile<LONG> g_ShutdownCrstUsageCount;
 extern Volatile<LONG> g_fForbidEnterEE;
 
+class PendingTypeLoadTable;
+
 // The CRST.
 class CrstBase
 {
@@ -134,9 +136,9 @@ friend class Crst;
     friend class DbgTransportLock;
 #endif // FEATURE_DBGIPC_TRANSPORT_VM
 
-    // PendingTypeLoadEntry acquires the lock during construction before anybody has a chance to see it to avoid
+    // PendingTypeLoadTable::Entry acquires the lock during construction before anybody has a chance to see it to avoid
     // level violations.
-    friend class PendingTypeLoadEntry;
+    friend class PendingTypeLoadTable;
 
 public:
 #ifdef _DEBUG

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -114,7 +114,7 @@ TypeHandle ClassLoader::CanonicalizeGenericArg(TypeHandle thGenericArg)
 
 #ifndef DACCESS_COMPILE
 
-TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(TypeKey *pTypeKey,
+TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(const TypeKey *pTypeKey,
                                                           LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                           ClassLoadLevel level/*=CLASS_LOADED*/)
 {
@@ -157,7 +157,7 @@ TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(TypeKey *pTypeKey,
 /* static */
 TypeHandle
 ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
-    TypeKey         *pTypeKey,
+    const TypeKey         *pTypeKey,
     AllocMemTracker *pamTracker)
 {
     CONTRACT(TypeHandle)

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -12,194 +12,26 @@
 
 #ifndef DACCESS_COMPILE
 
+#ifdef PENDING_TYPE_LOAD_TABLE_STATS
 
-// ============================================================================
-// Pending type load hash table methods
-// ============================================================================
-/*static */ PendingTypeLoadTable* PendingTypeLoadTable::Create(LoaderHeap *pHeap,
-                                                               DWORD dwNumBuckets,
-                                                               AllocMemTracker *pamTracker)
+LONG pendingTypeLoadEntryDynamicAllocations = 0;
+void PendingTypeLoadEntryDynamicAlloc()
 {
-    CONTRACTL
-    {
-        STANDARD_VM_CHECK;
-        PRECONDITION(CheckPointer(pHeap));
-    }
-    CONTRACTL_END;
+    InterlockedIncrement(&pendingTypeLoadEntryDynamicAllocations);
+}
+#endif // PENDING_TYPE_LOAD_TABLE_STATS
 
-    size_t                  size = sizeof(PendingTypeLoadTable);
-    BYTE *                  pMem;
-    PendingTypeLoadTable * pThis;
+static BYTE s_PendingTypeLoadTable[sizeof(PendingTypeLoadTable)];
 
-    _ASSERT( dwNumBuckets >= 0 );
-    S_SIZE_T allocSize = S_SIZE_T( dwNumBuckets )
-                                        * S_SIZE_T( sizeof(PendingTypeLoadTable::TableEntry*) )
-                                        + S_SIZE_T( size );
-    if( allocSize.IsOverflow() )
-    {
-        ThrowHR(E_INVALIDARG);
-    }
-    pMem = (BYTE *) pamTracker->Track(pHeap->AllocMem( allocSize ));
-
-    pThis = (PendingTypeLoadTable *) pMem;
+/*static*/
+PendingTypeLoadTable* PendingTypeLoadTable::GetTable()
+{
+    LIMITED_METHOD_CONTRACT;
+    return reinterpret_cast<PendingTypeLoadTable*>(&s_PendingTypeLoadTable);
+}
 
 #ifdef _DEBUG
-    pThis->m_dwDebugMemory = (DWORD)(size + dwNumBuckets*sizeof(PendingTypeLoadTable::TableEntry*));
-#endif
-
-    pThis->m_dwNumBuckets = dwNumBuckets;
-    pThis->m_pBuckets = (PendingTypeLoadTable::TableEntry**) (pMem + size);
-
-    // Don't need to memset() since this was ClrVirtualAlloc()'d memory
-    // memset(pThis->m_pBuckets, 0, dwNumBuckets*sizeof(PendingTypeLoadTable::TableEntry*));
-
-    return pThis;
-}
-
-
-
-PendingTypeLoadTable::TableEntry *PendingTypeLoadTable::AllocNewEntry()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        INJECT_FAULT( return NULL; );
-    }
-    CONTRACTL_END
-
-#ifdef _DEBUG
-    m_dwDebugMemory += (DWORD) (sizeof(PendingTypeLoadTable::TableEntry));
-#endif
-
-    return (PendingTypeLoadTable::TableEntry *) new (nothrow) BYTE[sizeof(PendingTypeLoadTable::TableEntry)];
-}
-
-
-void PendingTypeLoadTable::FreeEntry(PendingTypeLoadTable::TableEntry * pEntry)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END
-
-    // keep in sync with the allocator used in AllocNewEntry
-    delete[] ((BYTE*)pEntry);
-
-#ifdef _DEBUG
-    m_dwDebugMemory -= (DWORD) (sizeof(PendingTypeLoadTable::TableEntry));
-#endif
-}
-
-
-//
-// Does not handle duplicates!
-//
-BOOL PendingTypeLoadTable::InsertValue(PendingTypeLoadEntry *pData)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        INJECT_FAULT( return FALSE; );
-        PRECONDITION(CheckPointer(pData));
-        PRECONDITION(FindItem(&pData->GetTypeKey()) == NULL);
-    }
-    CONTRACTL_END
-
-    _ASSERTE(m_dwNumBuckets != 0);
-
-    DWORD           dwHash = HashTypeKey(&pData->GetTypeKey());
-    DWORD           dwBucket = dwHash % m_dwNumBuckets;
-    PendingTypeLoadTable::TableEntry * pNewEntry = AllocNewEntry();
-    if (pNewEntry == NULL)
-        return FALSE;
-
-    // Insert at head of bucket
-    pNewEntry->pNext        = m_pBuckets[dwBucket];
-    pNewEntry->pData        = pData;
-    pNewEntry->dwHashValue  = dwHash;
-
-    m_pBuckets[dwBucket] = pNewEntry;
-
-    return TRUE;
-}
-
-BOOL PendingTypeLoadTable::DeleteValue(TypeKey *pKey)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        FORBID_FAULT;
-        PRECONDITION(CheckPointer(pKey));
-    }
-    CONTRACTL_END
-
-    _ASSERTE(m_dwNumBuckets != 0);
-
-    DWORD           dwHash = HashTypeKey(pKey);
-    DWORD           dwBucket = dwHash % m_dwNumBuckets;
-    PendingTypeLoadTable::TableEntry * pSearch;
-    PendingTypeLoadTable::TableEntry **ppPrev = &m_pBuckets[dwBucket];
-
-    for (pSearch = m_pBuckets[dwBucket]; pSearch; pSearch = pSearch->pNext)
-    {
-        TypeKey entryTypeKey = pSearch->pData->GetTypeKey();
-        if (pSearch->dwHashValue == dwHash && TypeKey::Equals(pKey, &entryTypeKey))
-        {
-            *ppPrev = pSearch->pNext;
-            FreeEntry(pSearch);
-            return TRUE;
-        }
-
-        ppPrev = &pSearch->pNext;
-    }
-
-    return FALSE;
-}
-
-
-PendingTypeLoadTable::TableEntry *PendingTypeLoadTable::FindItem(TypeKey *pKey)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        FORBID_FAULT;
-        PRECONDITION(CheckPointer(pKey));
-    }
-    CONTRACTL_END
-
-    _ASSERTE(m_dwNumBuckets != 0);
-
-
-    DWORD           dwHash = HashTypeKey(pKey);
-    DWORD           dwBucket = dwHash % m_dwNumBuckets;
-    PendingTypeLoadTable::TableEntry * pSearch;
-
-    for (pSearch = m_pBuckets[dwBucket]; pSearch; pSearch = pSearch->pNext)
-    {
-        TypeKey entryTypeKey = pSearch->pData->GetTypeKey();
-        if (pSearch->dwHashValue == dwHash && TypeKey::Equals(pKey, &entryTypeKey))
-        {
-            return pSearch;
-        }
-    }
-
-    return NULL;
-}
-
-
-#ifdef _DEBUG
-void PendingTypeLoadTable::Dump()
+void PendingTypeLoadTable::Shard::Dump()
 {
     CONTRACTL
     {
@@ -209,44 +41,17 @@ void PendingTypeLoadTable::Dump()
     }
     CONTRACTL_END
 
-    LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: table contains:\n"));
-    for (DWORD i = 0; i < m_dwNumBuckets; i++)
+    LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: shard contains:\n"));
+    for (Entry *pSearch = this->m_pLinkedListOfActiveEntries; pSearch; pSearch = pSearch->m_pNext)
     {
-        for (TableEntry *pSearch = m_pBuckets[i]; pSearch; pSearch = pSearch->pNext)
-        {
-            SString name;
-            TypeKey entryTypeKey = pSearch->pData->GetTypeKey();
-            TypeString::AppendTypeKeyDebug(name, &entryTypeKey);
-            LOG((LF_CLASSLOADER, LL_INFO10000, "  Entry %s with handle %p at level %s\n", name.GetUTF8(), pSearch->pData->m_typeHandle.AsPtr(),
-                 pSearch->pData->m_typeHandle.IsNull() ? "not-applicable" : classLoadLevelName[pSearch->pData->m_typeHandle.GetLoadLevel()]));
-        }
+        SString name;
+        TypeKey entryTypeKey = pSearch->GetTypeKey();
+        TypeString::AppendTypeKeyDebug(name, &entryTypeKey);
+        LOG((LF_CLASSLOADER, LL_INFO10000, "  Entry %s with handle %p at level %s\n", name.GetUTF8(), pSearch->m_typeHandle.AsPtr(),
+                pSearch->m_typeHandle.IsNull() ? "not-applicable" : classLoadLevelName[pSearch->m_typeHandle.GetLoadLevel()]));
     }
 }
 #endif
-
-PendingTypeLoadEntry* PendingTypeLoadTable::GetValue(TypeKey *pKey)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-        FORBID_FAULT;
-        PRECONDITION(CheckPointer(pKey));
-    }
-    CONTRACTL_END
-
-    PendingTypeLoadTable::TableEntry *pItem = FindItem(pKey);
-
-    if (pItem != NULL)
-    {
-        return pItem->pData;
-    }
-    else
-    {
-        return NULL;
-    }
-}
 
 #endif // #ifndef DACCESS_COMPILE
 

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -14,21 +14,14 @@
 
 #ifdef PENDING_TYPE_LOAD_TABLE_STATS
 
-LONG pendingTypeLoadEntryDynamicAllocations = 0;
+static LONG pendingTypeLoadEntryDynamicAllocations = 0;
 void PendingTypeLoadEntryDynamicAlloc()
 {
     InterlockedIncrement(&pendingTypeLoadEntryDynamicAllocations);
 }
 #endif // PENDING_TYPE_LOAD_TABLE_STATS
 
-static BYTE s_PendingTypeLoadTable[sizeof(PendingTypeLoadTable)];
-
-/*static*/
-PendingTypeLoadTable* PendingTypeLoadTable::GetTable()
-{
-    LIMITED_METHOD_CONTRACT;
-    return reinterpret_cast<PendingTypeLoadTable*>(&s_PendingTypeLoadTable);
-}
+PendingTypeLoadTable PendingTypeLoadTable::s_table;
 
 #ifdef _DEBUG
 void PendingTypeLoadTable::Shard::Dump()

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -13,6 +13,7 @@
 #ifndef DACCESS_COMPILE
 
 #ifdef PENDING_TYPE_LOAD_TABLE_STATS
+// Enable PENDING_TYPE_LOAD_TABLE_STATS to gather counts of Entry structures which are allocated
 
 static LONG pendingTypeLoadEntryDynamicAllocations = 0;
 void PendingTypeLoadEntryDynamicAlloc()
@@ -23,7 +24,333 @@ void PendingTypeLoadEntryDynamicAlloc()
 
 PendingTypeLoadTable PendingTypeLoadTable::s_table;
 
+PendingTypeLoadTable::Entry::Entry()
+    : m_typeKey(TypeKey::InvalidTypeKey()),
+        m_fIsPreallocated(true)
+{
+}
+
+PendingTypeLoadTable::Entry::Entry(const TypeKey& typeKey)
+    : m_typeKey(typeKey),
+        m_fIsPreallocated(false)
+{
+#ifdef PENDING_TYPE_LOAD_TABLE_STATS
+    PendingTypeLoadEntryDynamicAlloc();
+#endif // PENDING_TYPE_LOAD_TABLE_STATS
+}
+
+void PendingTypeLoadTable::Entry::SetTypeKey(const TypeKey& typeKey)
+{
+    m_typeKey = typeKey;
+}
+
+void PendingTypeLoadTable::Entry::InitCrst()
+{
+    WRAPPER_NO_CONTRACT;
+    m_Crst.Init(CrstPendingTypeLoadEntry,
+                CrstFlags(CRST_HOST_BREAKABLE|CRST_UNSAFE_SAMELEVEL));
+}
+
+void PendingTypeLoadTable::Entry::Init(Entry *pNext, DWORD hash, TypeHandle typeHnd)
+{
+    WRAPPER_NO_CONTRACT;
+
+    _ASSERTE(m_fIsUnused);
+    m_dwHash = hash;
+    m_pNext = pNext;
+    m_typeHandle = typeHnd;
+    m_dwWaitCount = 1;
+    m_hrResult = S_OK;
+    m_pException = NULL;
 #ifdef _DEBUG
+    if (LoggingOn(LF_CLASSLOADER, LL_INFO10000))
+    {
+        SString name;
+        TypeString::AppendTypeKeyDebug(name, &m_typeKey);
+        LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: Creating loading entry for type %s\n", name.GetUTF8()));
+    }
+#endif
+
+    m_fIsUnused = false;
+    m_fLockAcquired = TRUE;
+
+    //---------------------------------------------------------------------------
+    // The PendingTypeLoadEntry() lock has a higher level than UnresolvedClassLock.
+    // But whenever we create one, we have to acquire it while holding the UnresolvedClassLock.
+    // This is safe since we're the ones that created the lock and are guaranteed to acquire
+    // it without blocking. But to prevent the crstlevel system from asserting, we
+    // must acquire using a special method.
+    //---------------------------------------------------------------------------
+    m_Crst.Enter(INDEBUG(Crst::CRST_NO_LEVEL_CHECK));
+}
+
+void PendingTypeLoadTable::Entry::Reset()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    if (m_fLockAcquired)
+    {
+        m_Crst.Leave();
+        m_fLockAcquired = false;
+    }
+
+    if (m_pException && !m_pException->IsPreallocatedException()) {
+        delete m_pException;
+        m_pException = NULL;
+    }
+}
+
+bool PendingTypeLoadTable::Entry::IsUnused()
+{
+    // This VolatileLoad synchrnonizes with the Release()
+    return (m_fIsUnused && VolatileLoad(&m_fIsUnused));
+}
+
+#ifdef _DEBUG
+bool PendingTypeLoadTable::Entry::HasLock()
+{
+    LIMITED_METHOD_CONTRACT;
+    return !!m_Crst.OwnedByCurrentThread();
+}
+#endif
+
+VOID DECLSPEC_NORETURN PendingTypeLoadTable::Entry::ThrowException()
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        INJECT_FAULT(COMPlusThrowOM(););
+    }
+    CONTRACTL_END;
+
+    if (m_pException)
+        PAL_CPP_THROW(Exception *, m_pException->Clone());
+
+    _ASSERTE(FAILED(m_hrResult));
+
+    if (m_hrResult == COR_E_TYPELOAD)
+    {
+        ClassLoader::ThrowTypeLoadException(GetTypeKey(),
+                                            IDS_CLASSLOAD_GENERAL);
+
+    }
+    else
+        EX_THROW(EEMessageException, (m_hrResult));
+}
+
+void PendingTypeLoadTable::Entry::SetException(Exception *pException)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        PRECONDITION(HasLock());
+        PRECONDITION(m_pException == NULL);
+        PRECONDITION(m_dwWaitCount > 0);
+    }
+    CONTRACTL_END;
+
+    m_typeHandle = TypeHandle();
+    m_hrResult = COR_E_TYPELOAD;
+
+    // we don't care if this fails
+    // we already know the HRESULT so if we can't store
+    // the details - so be it
+    EX_TRY
+    {
+        FAULT_NOT_FATAL();
+        m_pException = pException->Clone();
+    }
+    EX_CATCH
+    {
+        m_pException=NULL;
+    }
+    EX_END_CATCH(SwallowAllExceptions);
+}
+
+void PendingTypeLoadTable::Entry::SetResult(TypeHandle typeHnd)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        PRECONDITION(HasLock());
+        PRECONDITION(m_pException == NULL);
+        PRECONDITION(m_dwWaitCount > 0);
+    }
+    CONTRACTL_END;
+
+    m_typeHandle = typeHnd;
+}
+
+void PendingTypeLoadTable::Entry::UnblockWaiters()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        PRECONDITION(HasLock());
+        PRECONDITION(m_dwWaitCount > 0);
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(m_fLockAcquired);
+    m_Crst.Leave();
+    m_fLockAcquired = FALSE;
+}
+
+const TypeKey* PendingTypeLoadTable::Entry::GetTypeKey()
+{
+    LIMITED_METHOD_CONTRACT;
+    return &m_typeKey;
+}
+
+void PendingTypeLoadTable::Entry::AddRef()
+{
+    LIMITED_METHOD_CONTRACT;
+    InterlockedIncrement(&m_dwWaitCount);
+}
+
+void PendingTypeLoadTable::Entry::Release()
+{
+    LIMITED_METHOD_CONTRACT;
+    if (InterlockedDecrement(&m_dwWaitCount) == 0)
+    {
+        Reset();
+
+        if (this->m_fIsPreallocated)
+        {
+            // We won't be holding the lock while Releasing, so use a VolatileStore to ensure all writes during Reset are complete.
+            VolatileStore(&m_fIsUnused, true);
+        }
+        else
+        {
+            // Call the derived type with a destructor
+            delete static_cast<DynamicallyAllocatedEntry*>(this);
+        }
+    }
+}
+
+bool PendingTypeLoadTable::Entry::HasWaiters()
+{
+    LIMITED_METHOD_CONTRACT;
+    return m_dwWaitCount > 1;
+}
+
+HRESULT PendingTypeLoadTable::Entry::DelayForProgress(TypeHandle* typeHndWithProgress)
+{
+    STANDARD_VM_CONTRACT;
+    HRESULT hr = S_OK;
+    {
+        CrstHolder crstHolder(&m_Crst);
+        _ASSERTE(HasLock());
+        hr = m_hrResult;
+
+        if (SUCCEEDED(hr))
+        {
+            *typeHndWithProgress = m_typeHandle;
+        }
+    }
+
+    return m_hrResult;
+}
+
+void PendingTypeLoadTable::Shard::Init()
+{
+    m_shardCrst.Init(CrstUnresolvedClassLock);
+    for (int i = 0; i < PreallocatedEntryCount; i++)
+    {
+        m_preAllocatedEntries[i].InitCrst();
+    }
+}
+
+PendingTypeLoadTable::Entry* PendingTypeLoadTable::Shard::FindPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey)
+{
+    WRAPPER_NO_CONTRACT;
+    for (PendingTypeLoadTable::Entry *current = m_pLinkedListOfActiveEntries; current != NULL; current = current->m_pNext)
+    {
+        if (current->m_dwHash != hash)
+            continue;
+        if (TypeKey::Equals(&typeKey, current->GetTypeKey()))
+        {
+            return current;
+        }
+    }
+
+    return NULL;
+}
+
+void PendingTypeLoadTable::Shard::RemovePendingTypeLoadEntry(Entry* pEntry)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    Entry **pCurrent = &m_pLinkedListOfActiveEntries;
+
+    while (*pCurrent != pEntry)
+    {
+        pCurrent = &((*pCurrent)->m_pNext);
+    }
+    *pCurrent = (*pCurrent)->m_pNext;
+}
+
+PendingTypeLoadTable::Entry* PendingTypeLoadTable::Shard::InsertPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey, TypeHandle typeHnd)
+{
+    STANDARD_VM_CONTRACT;
+    Entry* result = NULL;
+
+    for (int iEntry = 0; iEntry < PreallocatedEntryCount; iEntry++)
+    {
+        if (m_preAllocatedEntries[iEntry].IsUnused())
+        {
+            result = &m_preAllocatedEntries[iEntry];
+            result->SetTypeKey(typeKey);
+            result->Init(m_pLinkedListOfActiveEntries, hash, typeHnd);
+            break;
+        }
+    }
+    if (result == NULL)
+    {
+        NewHolder<DynamicallyAllocatedEntry> dynamicResult(new DynamicallyAllocatedEntry(typeKey));
+        dynamicResult->Init(m_pLinkedListOfActiveEntries, hash, typeHnd);
+        result = dynamicResult.Extract();
+    }
+    
+    m_pLinkedListOfActiveEntries = result;
+    return result;
+}
+
+/*static*/
+PendingTypeLoadTable* PendingTypeLoadTable::GetTable()
+{
+    LIMITED_METHOD_CONTRACT;
+    return &s_table;
+}
+
+/*static*/
+void PendingTypeLoadTable::Init()
+{
+    STANDARD_VM_CONTRACT;
+    for (int i = 0; i < PendingTypeLoadTableShardCount; i++)
+        GetTable()->m_shards[i].Init();
+}
+
+PendingTypeLoadTable::Shard* PendingTypeLoadTable::GetShard(const TypeKey &typeKey, ClassLoader* pClassLoader, DWORD *pHashCodeForType)
+{
+    STANDARD_VM_CONTRACT;
+    DWORD hash = HashTypeKey(&typeKey) ^ (DWORD)(size_t)pClassLoader; // Mix in some entropy about which classloader is in use
+    *pHashCodeForType = hash;
+    return &m_shards[hash % PendingTypeLoadTableShardCount];
+}
+
+#ifdef _DEBUG
+void PendingTypeLoadTable::Dump()
+{
+    STANDARD_VM_CONTRACT;
+    for (int iShard = 0; iShard < PendingTypeLoadTableShardCount; iShard++)
+    {
+        CrstHolder unresolvedClassLockHolder(m_shards[iShard].GetCrst());
+        m_shards[iShard].Dump();
+    }
+}
+
 void PendingTypeLoadTable::Shard::Dump()
 {
     CONTRACTL
@@ -38,8 +365,7 @@ void PendingTypeLoadTable::Shard::Dump()
     for (Entry *pSearch = this->m_pLinkedListOfActiveEntries; pSearch; pSearch = pSearch->m_pNext)
     {
         SString name;
-        TypeKey entryTypeKey = pSearch->GetTypeKey();
-        TypeString::AppendTypeKeyDebug(name, &entryTypeKey);
+        TypeString::AppendTypeKeyDebug(name, pSearch->GetTypeKey());
         LOG((LF_CLASSLOADER, LL_INFO10000, "  Entry %s with handle %p at level %s\n", name.GetUTF8(), pSearch->m_typeHandle.AsPtr(),
                 pSearch->m_typeHandle.IsNull() ? "not-applicable" : classLoadLevelName[pSearch->m_typeHandle.GetLoadLevel()]));
     }

--- a/src/coreclr/vm/pendingload.cpp
+++ b/src/coreclr/vm/pendingload.cpp
@@ -39,7 +39,7 @@ PendingTypeLoadTable::Entry::Entry(const TypeKey& typeKey)
 #endif // PENDING_TYPE_LOAD_TABLE_STATS
 }
 
-void PendingTypeLoadTable::Entry::SetTypeKey(const TypeKey& typeKey)
+void PendingTypeLoadTable::Entry::SetTypeKey(TypeKey typeKey)
 {
     m_typeKey = typeKey;
 }
@@ -250,7 +250,7 @@ HRESULT PendingTypeLoadTable::Entry::DelayForProgress(TypeHandle* typeHndWithPro
         }
     }
 
-    return m_hrResult;
+    return hr;
 }
 
 void PendingTypeLoadTable::Shard::Init()

--- a/src/coreclr/vm/pendingload.h
+++ b/src/coreclr/vm/pendingload.h
@@ -17,11 +17,6 @@
 #include "shash.h"
 #include "typestring.h"
 
-#ifdef PENDING_TYPE_LOAD_TABLE_STATS
-// Enable PENDING_TYPE_LOAD_TABLE_STATS to gather counts of Entry structures which are allocated
-void PendingTypeLoadEntryDynamicAlloc();
-#endif // PENDING_TYPE_LOAD_TABLE_STATS
-
 //
 // A temporary structure used when loading and resolving classes
 //
@@ -31,250 +26,40 @@ void PendingTypeLoadEntryDynamicAlloc();
 // This is a singleton
 class PendingTypeLoadTable
 {
-    static void CallCrstEnter(CrstBase* pCrst)
-    {
-        pCrst->Enter(INDEBUG(Crst::CRST_NO_LEVEL_CHECK));
-    }
-
 public:
-    struct Shard;
     class Entry
     {
         friend class PendingTypeLoadTable;
-    protected:
-        Entry()
-            : m_typeKey(TypeKey::InvalidTypeKey()),
-              m_fIsPreallocated(true)
-        {
-        }
-
-        Entry(const TypeKey& typeKey)
-            : m_typeKey(typeKey),
-              m_fIsPreallocated(false)
-        {
-#ifdef PENDING_TYPE_LOAD_TABLE_STATS
-            PendingTypeLoadEntryDynamicAlloc();
-#endif // PENDING_TYPE_LOAD_TABLE_STATS
-        }
+    private:
+        Entry();
+        Entry(const TypeKey& typeKey);
 
     protected:
 
-        void SetTypeKey(const TypeKey& typeKey)
-        {
-            m_typeKey = typeKey;
-        }
-
-        void InitCrst()
-        {
-            WRAPPER_NO_CONTRACT;
-            m_Crst.Init(CrstPendingTypeLoadEntry,
-                        CrstFlags(CRST_HOST_BREAKABLE|CRST_UNSAFE_SAMELEVEL));
-        }
-
-        void Init(Entry *pNext, DWORD hash, TypeHandle typeHnd)
-        {
-            WRAPPER_NO_CONTRACT;
-
-            _ASSERTE(m_fIsUnused);
-            m_dwHash = hash;
-            m_pNext = pNext;
-            m_typeHandle = typeHnd;
-            m_dwWaitCount = 1;
-            m_hrResult = S_OK;
-            m_pException = NULL;
-    #ifdef _DEBUG
-            if (LoggingOn(LF_CLASSLOADER, LL_INFO10000))
-            {
-                SString name;
-                TypeString::AppendTypeKeyDebug(name, &m_typeKey);
-                LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: Creating loading entry for type %s\n", name.GetUTF8()));
-            }
-    #endif
-
-            m_fIsUnused = false;
-            m_fLockAcquired = TRUE;
-
-            //---------------------------------------------------------------------------
-            // The PendingTypeLoadEntry() lock has a higher level than UnresolvedClassLock.
-            // But whenever we create one, we have to acquire it while holding the UnresolvedClassLock.
-            // This is safe since we're the ones that created the lock and are guaranteed to acquire
-            // it without blocking. But to prevent the crstlevel system from asserting, we
-            // must acquire using a special method.
-            //---------------------------------------------------------------------------
-            PendingTypeLoadTable::CallCrstEnter(&m_Crst);
-        }
-
-        void Reset()
-        {
-            LIMITED_METHOD_CONTRACT;
-
-            if (m_fLockAcquired)
-            {
-                m_Crst.Leave();
-                m_fLockAcquired = false;
-            }
-
-            if (m_pException && !m_pException->IsPreallocatedException()) {
-                delete m_pException;
-                m_pException = NULL;
-            }
-        }
-        bool IsUnused()
-        {
-            // This VolatileLoad synchrnonizes with the Release()
-            return (m_fIsUnused && VolatileLoad(&m_fIsUnused));
-        }
+        void SetTypeKey(const TypeKey& typeKey);
+        void InitCrst();
+        void Init(Entry *pNext, DWORD hash, TypeHandle typeHnd);
+        void Reset();
+        bool IsUnused();
 
     public:
 
     #ifdef _DEBUG
-        BOOL HasLock()
-        {
-            LIMITED_METHOD_CONTRACT;
-            return m_Crst.OwnedByCurrentThread();
-        }
+        bool HasLock();
     #endif
 
-    #ifndef DACCESS_COMPILE
-        VOID DECLSPEC_NORETURN ThrowException()
-        {
-            CONTRACTL
-            {
-                THROWS;
-                GC_TRIGGERS;
-                INJECT_FAULT(COMPlusThrowOM(););
-            }
-            CONTRACTL_END;
+        VOID DECLSPEC_NORETURN ThrowException();
+        void SetException(Exception *pException);
+        void SetResult(TypeHandle typeHnd);
+        void UnblockWaiters();
+        const TypeKey* GetTypeKey();
 
-            if (m_pException)
-                PAL_CPP_THROW(Exception *, m_pException->Clone());
-
-            _ASSERTE(FAILED(m_hrResult));
-
-            if (m_hrResult == COR_E_TYPELOAD)
-            {
-                TypeKey typeKey = GetTypeKey();
-                ClassLoader::ThrowTypeLoadException(&typeKey,
-                                                    IDS_CLASSLOAD_GENERAL);
-
-            }
-            else
-                EX_THROW(EEMessageException, (m_hrResult));
-        }
-
-        void SetException(Exception *pException)
-        {
-            CONTRACTL
-            {
-                NOTHROW;
-                PRECONDITION(HasLock());
-                PRECONDITION(m_pException == NULL);
-                PRECONDITION(m_dwWaitCount > 0);
-            }
-            CONTRACTL_END;
-
-            m_typeHandle = TypeHandle();
-            m_hrResult = COR_E_TYPELOAD;
-
-            // we don't care if this fails
-            // we already know the HRESULT so if we can't store
-            // the details - so be it
-            EX_TRY
-            {
-                FAULT_NOT_FATAL();
-                m_pException = pException->Clone();
-            }
-            EX_CATCH
-            {
-                m_pException=NULL;
-            }
-            EX_END_CATCH(SwallowAllExceptions);
-        }
-
-        void SetResult(TypeHandle typeHnd)
-        {
-            CONTRACTL
-            {
-                NOTHROW;
-                PRECONDITION(HasLock());
-                PRECONDITION(m_pException == NULL);
-                PRECONDITION(m_dwWaitCount > 0);
-            }
-            CONTRACTL_END;
-
-            m_typeHandle = typeHnd;
-        }
-
-        void UnblockWaiters()
-        {
-            CONTRACTL
-            {
-                NOTHROW;
-                PRECONDITION(HasLock());
-                PRECONDITION(m_dwWaitCount > 0);
-            }
-            CONTRACTL_END;
-
-            _ASSERTE(m_fLockAcquired);
-            m_Crst.Leave();
-            m_fLockAcquired = FALSE;
-        }
-    #endif //DACCESS_COMPILE
-
-        TypeKey& GetTypeKey()
-        {
-            LIMITED_METHOD_CONTRACT;
-            return m_typeKey;
-        }
-
-        // This is only safe to call on an AddRef'd PendingTypeLoadEntry which has had DelayForProgress() called on it
-        TypeHandle GetTypeHandle()
-        {
-            LIMITED_METHOD_CONTRACT;
-            return m_typeHandle;
-        }
-
-        void AddRef()
-        {
-            LIMITED_METHOD_CONTRACT;
-            InterlockedIncrement(&m_dwWaitCount);
-        }
-
-        void Release()
-        {
-            LIMITED_METHOD_CONTRACT;
-            if (InterlockedDecrement(&m_dwWaitCount) == 0)
-            {
-                Reset();
-
-                if (this->m_fIsPreallocated)
-                {
-                    // We won't be holding the lock while Releasing, so use a VolatileStore to ensure all writes during Reset are complete.
-                    VolatileStore(&m_fIsUnused, true);
-                }
-                else
-                {
-                    // Call the derived type with a destructor
-                    delete static_cast<DynamicallyAllocatedEntry*>(this);
-                }
-            }
-        }
-
-        BOOL HasWaiters()
-        {
-            LIMITED_METHOD_CONTRACT;
-            return m_dwWaitCount > 1;
-        }
-
+        void AddRef();
+        void Release();
+        bool HasWaiters();
         // Call this when After calling AddRef to see what the next amount of progress to wait for the load in progress to complete
-        // and to find out if that load in progress succeeded
-        HRESULT DelayForProgress()
-        {
-            STANDARD_VM_CONTRACT;
-            CrstHolder crstHolder(&m_Crst);
-            _ASSERTE(HasLock());
-            return m_hrResult;
-        }
+        // and to find the TypeHandle if progress was successful.
+        HRESULT DelayForProgress(TypeHandle* typeHndWithProgress);
 
     protected:
         Entry*              m_pNext;
@@ -296,17 +81,15 @@ public:
 
         // Exception object to throw
         Exception          *m_pException;
-
         DWORD               m_dwHash;
 
         // m_Crst was acquired
         bool                m_fLockAcquired;
-
         bool                m_fIsPreallocated;
-
         bool                m_fIsUnused = true;
     };
 
+private:
     class DynamicallyAllocatedEntry : public Entry
     {
     public:
@@ -332,6 +115,7 @@ public:
     {
     };
 
+public:
     struct Shard
     {
         friend class PendingTypeLoadTable;
@@ -347,15 +131,7 @@ private:
         CrstStatic m_shardCrst;
         Entry  m_preAllocatedEntries[PreallocatedEntryCount];
 
-        void Init()
-        {
-            m_shardCrst.Init(CrstUnresolvedClassLock);
-            for (int i = 0; i < PreallocatedEntryCount; i++)
-            {
-                m_preAllocatedEntries[i].InitCrst();
-            }
-        }
-
+        void Init();
 public:
         CrstBase* GetCrst()
         {
@@ -363,105 +139,30 @@ public:
             return &m_shardCrst;
         }
 
-        Entry* FindPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey)
-        {
-            WRAPPER_NO_CONTRACT;
-            for (PendingTypeLoadTable::Entry *current = m_pLinkedListOfActiveEntries; current != NULL; current = current->m_pNext)
-            {
-                if (current->m_dwHash != hash)
-                    continue;
-                TypeKey entryTypeKey = current->GetTypeKey();
-                if (TypeKey::Equals(&typeKey, &entryTypeKey))
-                {
-                    return current;
-                }
-            }
-
-            return NULL;
-        }
-
-        void RemovePendingTypeLoadEntry(Entry* pEntry)
-        {
-            LIMITED_METHOD_CONTRACT;
-
-            Entry **pCurrent = &m_pLinkedListOfActiveEntries;
-
-            while (*pCurrent != pEntry)
-            {
-                pCurrent = &((*pCurrent)->m_pNext);
-            }
-            *pCurrent = (*pCurrent)->m_pNext;
-        }
-
-        Entry* InsertPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey, TypeHandle typeHnd)
-        {
-            STANDARD_VM_CONTRACT;
-            Entry* result = NULL;
-
-            for (int iEntry = 0; iEntry < PreallocatedEntryCount; iEntry++)
-            {
-                if (m_preAllocatedEntries[iEntry].IsUnused())
-                {
-                    result = &m_preAllocatedEntries[iEntry];
-                    result->SetTypeKey(typeKey);
-                    result->Init(m_pLinkedListOfActiveEntries, hash, typeHnd);
-                    break;
-                }
-            }
-            if (result == NULL)
-            {
-                NewHolder<DynamicallyAllocatedEntry> dynamicResult(new DynamicallyAllocatedEntry(typeKey));
-                dynamicResult->Init(m_pLinkedListOfActiveEntries, hash, typeHnd);
-                result = dynamicResult.Extract();
-            }
-            
-            m_pLinkedListOfActiveEntries = result;
-            return result;
-        }
+        Entry* FindPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey);
+        void RemovePendingTypeLoadEntry(Entry* pEntry);
+        Entry* InsertPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey, TypeHandle typeHnd);
 
 #ifdef _DEBUG
         void Dump();
 #endif
     };
 
-    // This number chosen by experimentation with a fairly complex ASP.NET application that would naturally use about 40,000 Entry structures on startup.
-    // Entry allocations were shifted to about 11 during that startup phase.
+    // This number chosen by experimentation with a fairly complex ASP.NET application that would naturally allocate
+    // about 40,000 Entry structures on startup. With PendingTypeLoadTableShardCount(31) number of shards and 
+    // PreallocatedEntryCount(2) number of pre-allocated entries in each shard, the number of dynamic allocations of
+    // Entry structures was reduced to 11.
     static constexpr int PendingTypeLoadTableShardCount = 31;
     Shard     m_shards[PendingTypeLoadTableShardCount];
 
     static PendingTypeLoadTable s_table;
+    static PendingTypeLoadTable* GetTable();
 
 public:
-    static PendingTypeLoadTable* GetTable()
-    {
-        return &s_table;
-    }
-
-    static void Init()
-    {
-        STANDARD_VM_CONTRACT;
-        for (int i = 0; i < PendingTypeLoadTableShardCount; i++)
-            GetTable()->m_shards[i].Init();
-    }
-
-    Shard* GetShard(const TypeKey &typeKey, ClassLoader* pClassLoader, DWORD *pHashCodeForType)
-    {
-        STANDARD_VM_CONTRACT;
-        DWORD hash = HashTypeKey(&typeKey) ^ (DWORD)(size_t)pClassLoader; // Mix in some entropy about which classloader is in use
-        *pHashCodeForType = hash;
-        return &m_shards[hash % PendingTypeLoadTableShardCount];
-    }
-
+    static void Init();
+    Shard* GetShard(const TypeKey &typeKey, ClassLoader* pClassLoader, DWORD *pHashCodeForType);
 #ifdef _DEBUG
-    void Dump()
-    {
-        STANDARD_VM_CONTRACT;
-        for (int iShard = 0; iShard < PendingTypeLoadTableShardCount; iShard++)
-        {
-            CrstHolder unresolvedClassLockHolder(m_shards[iShard].GetCrst());
-            m_shards[iShard].Dump();
-        }
-    }
+    void Dump();
 #endif
 };
 

--- a/src/coreclr/vm/pendingload.h
+++ b/src/coreclr/vm/pendingload.h
@@ -124,8 +124,7 @@ public:
         static constexpr int PreallocatedEntryCount = 2;
 
 private:
-        Shard()
-        {}
+        Shard() = default;
 
         Entry *m_pLinkedListOfActiveEntries = NULL;
         CrstStatic m_shardCrst;

--- a/src/coreclr/vm/pendingload.h
+++ b/src/coreclr/vm/pendingload.h
@@ -17,248 +17,404 @@
 #include "shash.h"
 #include "typestring.h"
 
+#ifdef PENDING_TYPE_LOAD_TABLE_STATS
+// Enable PENDING_TYPE_LOAD_TABLE_STATS to gather counts of Entry structures which are allocated
+void PendingTypeLoadEntryDynamicAlloc();
+#endif // PENDING_TYPE_LOAD_TABLE_STATS
+
 //
 // A temporary structure used when loading and resolving classes
 //
-class PendingTypeLoadEntry
-{
-    friend class ClassLoader;       // workaround really need to beef up the API below
-
-public:
-    PendingTypeLoadEntry(TypeKey typeKey, TypeHandle typeHnd)
-        : m_Crst(
-                 CrstPendingTypeLoadEntry,
-                 CrstFlags(CRST_HOST_BREAKABLE|CRST_UNSAFE_SAMELEVEL)
-                 ),
-        m_typeKey(typeKey)
-
-    {
-        WRAPPER_NO_CONTRACT;
-
-        m_typeHandle = typeHnd;
-        m_dwWaitCount = 1;
-        m_hrResult = S_OK;
-        m_pException = NULL;
-#ifdef _DEBUG
-        if (LoggingOn(LF_CLASSLOADER, LL_INFO10000))
-        {
-            SString name;
-            TypeString::AppendTypeKeyDebug(name, &m_typeKey);
-            LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: Creating loading entry for type %s\n", name.GetUTF8()));
-        }
-#endif
-
-        m_fLockAcquired = TRUE;
-
-        //---------------------------------------------------------------------------
-        // The PendingTypeLoadEntry() lock has a higher level than UnresolvedClassLock.
-        // But whenever we create one, we have to acquire it while holding the UnresolvedClassLock.
-        // This is safe since we're the ones that created the lock and are guaranteed to acquire
-        // it without blocking. But to prevent the crstlevel system from asserting, we
-        // must acquire using a special method.
-        //---------------------------------------------------------------------------
-        m_Crst.Enter(INDEBUG(Crst::CRST_NO_LEVEL_CHECK));
-    }
-
-    ~PendingTypeLoadEntry()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        if (m_fLockAcquired)
-            m_Crst.Leave();
-
-        if (m_pException && !m_pException->IsPreallocatedException()) {
-            delete m_pException;
-        }
-    }
-
-#ifdef _DEBUG
-    BOOL HasLock()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_Crst.OwnedByCurrentThread();
-    }
-#endif
-
-#ifndef DACCESS_COMPILE
-    VOID DECLSPEC_NORETURN ThrowException()
-    {
-        CONTRACTL
-        {
-            THROWS;
-            GC_TRIGGERS;
-            INJECT_FAULT(COMPlusThrowOM(););
-        }
-        CONTRACTL_END;
-
-        if (m_pException)
-            PAL_CPP_THROW(Exception *, m_pException->Clone());
-
-        _ASSERTE(FAILED(m_hrResult));
-
-        if (m_hrResult == COR_E_TYPELOAD)
-        {
-            TypeKey typeKey = GetTypeKey();
-            ClassLoader::ThrowTypeLoadException(&typeKey,
-                                                IDS_CLASSLOAD_GENERAL);
-
-        }
-        else
-            EX_THROW(EEMessageException, (m_hrResult));
-    }
-
-    void SetException(Exception *pException)
-    {
-        CONTRACTL
-        {
-              NOTHROW;
-              PRECONDITION(HasLock());
-              PRECONDITION(m_pException == NULL);
-              PRECONDITION(m_dwWaitCount > 0);
-        }
-        CONTRACTL_END;
-
-        m_typeHandle = TypeHandle();
-        m_hrResult = COR_E_TYPELOAD;
-
-        // we don't care if this fails
-        // we already know the HRESULT so if we can't store
-        // the details - so be it
-        EX_TRY
-        {
-            FAULT_NOT_FATAL();
-            m_pException = pException->Clone();
-        }
-        EX_CATCH
-        {
-            m_pException=NULL;
-        }
-        EX_END_CATCH(SwallowAllExceptions);
-    }
-
-    void SetResult(TypeHandle typeHnd)
-    {
-        CONTRACTL
-        {
-              NOTHROW;
-              PRECONDITION(HasLock());
-              PRECONDITION(m_pException == NULL);
-              PRECONDITION(m_dwWaitCount > 0);
-        }
-        CONTRACTL_END;
-
-        m_typeHandle = typeHnd;
-    }
-
-    void UnblockWaiters()
-    {
-        CONTRACTL
-        {
-              NOTHROW;
-              PRECONDITION(HasLock());
-              PRECONDITION(m_dwWaitCount > 0);
-        }
-        CONTRACTL_END;
-
-        _ASSERTE(m_fLockAcquired);
-        m_Crst.Leave();
-        m_fLockAcquired = FALSE;
-    }
-#endif //DACCESS_COMPILE
-
-    TypeKey& GetTypeKey()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_typeKey;
-    }
-
-    void AddRef()
-    {
-        LIMITED_METHOD_CONTRACT;
-        InterlockedIncrement(&m_dwWaitCount);
-    }
-
-    void Release()
-    {
-        LIMITED_METHOD_CONTRACT;
-        if (InterlockedDecrement(&m_dwWaitCount) == 0)
-            delete this;
-    }
-
-    BOOL HasWaiters()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_dwWaitCount > 1;
-    }
-
- private:
-    Crst                m_Crst;
-
- public:
-    // Result of loading; this is first created in the CREATE stage of class loading
-    TypeHandle          m_typeHandle;
-
- private:
-    // Type that we're loading
-    TypeKey             m_typeKey;
-
-    // Number of threads waiting for this type
-    LONG                m_dwWaitCount;
-
-    // Error result, propagated to all threads loading this class
-    HRESULT             m_hrResult;
-
-    // Exception object to throw
-    Exception          *m_pException;
-
-    // m_Crst was acquired
-    BOOL                m_fLockAcquired;
-};
 
 // Hash table used to hold pending type loads
-// @todo : use shash.h when it supports LoaderHeap/Alloc\MemTracker
+// This is a sharded fixed bucket count hashtable, with locking per shard
+// This is a singleton
 class PendingTypeLoadTable
 {
-protected:
-    struct TableEntry
+    static void CallCrstEnter(Crst* pCrst)
     {
-        TableEntry* pNext;
-        DWORD                 dwHashValue;
-        PendingTypeLoadEntry* pData;
+        pCrst->Enter(INDEBUG(Crst::CRST_NO_LEVEL_CHECK));
+    }
+
+public:
+    struct Shard;
+    class Entry
+    {
+        friend class PendingTypeLoadTable;
+    private:
+        Entry()
+            : m_Crst(
+                    CrstPendingTypeLoadEntry,
+                    CrstFlags(CRST_HOST_BREAKABLE|CRST_UNSAFE_SAMELEVEL)
+                    ),
+              m_typeKey(TypeKey::InvalidTypeKey()),
+              m_fIsPreallocated(true)
+        {
+        }
+
+        Entry(Entry *pNext, DWORD hash, const TypeKey& typeKey, TypeHandle typeHnd)
+            : m_Crst(
+                    CrstPendingTypeLoadEntry,
+                    CrstFlags(CRST_HOST_BREAKABLE|CRST_UNSAFE_SAMELEVEL)
+                    ),
+              m_typeKey(typeKey),
+              m_fIsPreallocated(false)
+        {
+#ifdef PENDING_TYPE_LOAD_TABLE_STATS
+            PendingTypeLoadEntryDynamicAlloc();
+#endif // PENDING_TYPE_LOAD_TABLE_STATS
+            Init(pNext, hash, typeHnd);
+        }
+
+        void SetTypeKey(const TypeKey& typeKey)
+        {
+            m_typeKey = typeKey;
+        }
+
+        void Init(Entry *pNext, DWORD hash, TypeHandle typeHnd)
+        {
+            WRAPPER_NO_CONTRACT;
+
+            _ASSERTE(m_fIsUnused);
+            m_dwHash = hash;
+            m_pNext = pNext;
+            m_typeHandle = typeHnd;
+            m_dwWaitCount = 1;
+            m_hrResult = S_OK;
+            m_pException = NULL;
+    #ifdef _DEBUG
+            if (LoggingOn(LF_CLASSLOADER, LL_INFO10000))
+            {
+                SString name;
+                TypeString::AppendTypeKeyDebug(name, &m_typeKey);
+                LOG((LF_CLASSLOADER, LL_INFO10000, "PHASEDLOAD: Creating loading entry for type %s\n", name.GetUTF8()));
+            }
+    #endif
+
+            m_fIsUnused = false;
+            m_fLockAcquired = TRUE;
+
+            //---------------------------------------------------------------------------
+            // The PendingTypeLoadEntry() lock has a higher level than UnresolvedClassLock.
+            // But whenever we create one, we have to acquire it while holding the UnresolvedClassLock.
+            // This is safe since we're the ones that created the lock and are guaranteed to acquire
+            // it without blocking. But to prevent the crstlevel system from asserting, we
+            // must acquire using a special method.
+            //---------------------------------------------------------------------------
+            PendingTypeLoadTable::CallCrstEnter(&m_Crst);
+        }
+
+        void Reset()
+        {
+            LIMITED_METHOD_CONTRACT;
+
+            if (m_fLockAcquired)
+            {
+                m_Crst.Leave();
+                m_fLockAcquired = false;
+            }
+
+            if (m_pException && !m_pException->IsPreallocatedException()) {
+                delete m_pException;
+                m_pException = NULL;
+            }
+        }
+        bool IsUnused()
+        {
+            // This VolatileLoad synchrnonizes with the Release()
+            return (m_fIsUnused && VolatileLoad(&m_fIsUnused));
+        }
+
+    public:
+    #ifdef _DEBUG
+        BOOL HasLock()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return m_Crst.OwnedByCurrentThread();
+        }
+    #endif
+
+    #ifndef DACCESS_COMPILE
+        VOID DECLSPEC_NORETURN ThrowException()
+        {
+            CONTRACTL
+            {
+                THROWS;
+                GC_TRIGGERS;
+                INJECT_FAULT(COMPlusThrowOM(););
+            }
+            CONTRACTL_END;
+
+            if (m_pException)
+                PAL_CPP_THROW(Exception *, m_pException->Clone());
+
+            _ASSERTE(FAILED(m_hrResult));
+
+            if (m_hrResult == COR_E_TYPELOAD)
+            {
+                TypeKey typeKey = GetTypeKey();
+                ClassLoader::ThrowTypeLoadException(&typeKey,
+                                                    IDS_CLASSLOAD_GENERAL);
+
+            }
+            else
+                EX_THROW(EEMessageException, (m_hrResult));
+        }
+
+        void SetException(Exception *pException)
+        {
+            CONTRACTL
+            {
+                NOTHROW;
+                PRECONDITION(HasLock());
+                PRECONDITION(m_pException == NULL);
+                PRECONDITION(m_dwWaitCount > 0);
+            }
+            CONTRACTL_END;
+
+            m_typeHandle = TypeHandle();
+            m_hrResult = COR_E_TYPELOAD;
+
+            // we don't care if this fails
+            // we already know the HRESULT so if we can't store
+            // the details - so be it
+            EX_TRY
+            {
+                FAULT_NOT_FATAL();
+                m_pException = pException->Clone();
+            }
+            EX_CATCH
+            {
+                m_pException=NULL;
+            }
+            EX_END_CATCH(SwallowAllExceptions);
+        }
+
+        void SetResult(TypeHandle typeHnd)
+        {
+            CONTRACTL
+            {
+                NOTHROW;
+                PRECONDITION(HasLock());
+                PRECONDITION(m_pException == NULL);
+                PRECONDITION(m_dwWaitCount > 0);
+            }
+            CONTRACTL_END;
+
+            m_typeHandle = typeHnd;
+        }
+
+        void UnblockWaiters()
+        {
+            CONTRACTL
+            {
+                NOTHROW;
+                PRECONDITION(HasLock());
+                PRECONDITION(m_dwWaitCount > 0);
+            }
+            CONTRACTL_END;
+
+            _ASSERTE(m_fLockAcquired);
+            m_Crst.Leave();
+            m_fLockAcquired = FALSE;
+        }
+    #endif //DACCESS_COMPILE
+
+        TypeKey& GetTypeKey()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return m_typeKey;
+        }
+
+        // This is only safe to call on an AddRef'd PendingTypeLoadEntry which has had DelayForProgress() called on it
+        TypeHandle GetTypeHandle()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return m_typeHandle;
+        }
+
+        void AddRef()
+        {
+            LIMITED_METHOD_CONTRACT;
+            InterlockedIncrement(&m_dwWaitCount);
+        }
+
+        void Release()
+        {
+            LIMITED_METHOD_CONTRACT;
+            if (InterlockedDecrement(&m_dwWaitCount) == 0)
+            {
+                Reset();
+
+                if (this->m_fIsPreallocated)
+                {
+                    // We won't be holding the lock while Releasing, so use a VolatileStore to ensure all writes during Reset are complete.
+                    VolatileStore(&m_fIsUnused, true);
+                }
+                else
+                    delete this;
+            }
+        }
+
+        BOOL HasWaiters()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return m_dwWaitCount > 1;
+        }
+
+        // Call this when After calling AddRef to see what the next amount of progress to wait for the load in progress to complete
+        // and to find out if that load in progress succeeded
+        HRESULT DelayForProgress()
+        {
+            STANDARD_VM_CONTRACT;
+            CrstHolder crstHolder(&m_Crst);
+            _ASSERTE(HasLock());
+            return m_hrResult;
+        }
+
+    private:
+        Entry*              m_pNext;
+        Crst                m_Crst;
+
+    public:
+        // Result of loading; this is first created in the CREATE stage of class loading
+        TypeHandle          m_typeHandle;
+
+    private:
+        // Type that we're loading
+        TypeKey             m_typeKey;
+
+        // Number of threads waiting for this type
+        LONG                m_dwWaitCount;
+
+        // Error result, propagated to all threads loading this class
+        HRESULT             m_hrResult;
+
+        // Exception object to throw
+        Exception          *m_pException;
+
+        DWORD               m_dwHash;
+
+        // m_Crst was acquired
+        bool                m_fLockAcquired;
+
+        bool                m_fIsPreallocated;
+
+        bool                m_fIsUnused = true;
     };
 
-    TableEntry     **m_pBuckets;    // Pointer to first entry for each bucket
-    DWORD           m_dwNumBuckets;
-
-public:
-
-#ifdef _DEBUG
-    DWORD           m_dwDebugMemory;
-#endif
-
-    static PendingTypeLoadTable *Create(LoaderHeap *pHeap, DWORD dwNumBuckets, AllocMemTracker *pamTracker);
+    struct Shard
+    {
+        friend class PendingTypeLoadTable;
+        // This number chosen by experimentation with a fairly complex ASP.NET application that would naturally use about 40,000 Entry structures on startup.
+        // Entry allocations were shifted to about 11 during that startup phase.
+        static constexpr int PreallocatedEntryCount = 2;
 
 private:
-    // These functions don't actually exist - declared private to prevent bypassing PendingTypeLoadTable::Create
-    void *          operator new(size_t size);
-    void            operator delete(void *p);
+        Shard() : m_shardCrst(CrstUnresolvedClassLock)
+        {}
 
-    PendingTypeLoadTable();
-    ~PendingTypeLoadTable();
+        Entry *m_pLinkedListOfActiveEntries = NULL;
+        Crst                  m_shardCrst;
+        Entry  m_preAllocatedEntries[PreallocatedEntryCount];
 
 public:
-    BOOL            InsertValue(PendingTypeLoadEntry* pEntry);
-    BOOL            DeleteValue(TypeKey *pKey);
-    PendingTypeLoadEntry* GetValue(TypeKey *pKey);
-    TableEntry* AllocNewEntry();
-    void FreeEntry(TableEntry* pEntry);
-#ifdef _DEBUG
-    void            Dump();
-#endif
+        Crst* GetCrst()
+        {
+            LIMITED_METHOD_CONTRACT;
+            return &m_shardCrst;
+        }
 
-private:
-    TableEntry* FindItem(TypeKey *pKey);
+        Entry* FindPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey)
+        {
+            WRAPPER_NO_CONTRACT;
+            for (PendingTypeLoadTable::Entry *current = m_pLinkedListOfActiveEntries; current != NULL; current = current->m_pNext)
+            {
+                if (current->m_dwHash != hash)
+                    continue;
+                TypeKey entryTypeKey = current->GetTypeKey();
+                if (TypeKey::Equals(&typeKey, &entryTypeKey))
+                {
+                    return current;
+                }
+            }
+
+            return NULL;
+        }
+
+        void RemovePendingTypeLoadEntry(Entry* pEntry)
+        {
+            LIMITED_METHOD_CONTRACT;
+
+            Entry **pCurrent = &m_pLinkedListOfActiveEntries;
+
+            while (*pCurrent != pEntry)
+            {
+                pCurrent = &((*pCurrent)->m_pNext);
+            }
+            *pCurrent = (*pCurrent)->m_pNext;
+        }
+
+        Entry* InsertPendingTypeLoadEntry(DWORD hash, const TypeKey& typeKey, TypeHandle typeHnd)
+        {
+            STANDARD_VM_CONTRACT;
+            Entry* result = NULL;
+
+            for (int iEntry = 0; iEntry < PreallocatedEntryCount; iEntry++)
+            {
+                if (m_preAllocatedEntries[iEntry].IsUnused())
+                {
+                    result = &m_preAllocatedEntries[iEntry];
+                    result->SetTypeKey(typeKey);
+                    result->Init(m_pLinkedListOfActiveEntries, hash, typeHnd);
+                    break;
+                }
+            }
+            if (result == NULL)
+                result = new Entry(m_pLinkedListOfActiveEntries, hash, typeKey, typeHnd);
+            
+            m_pLinkedListOfActiveEntries = result;
+            return result;
+        }
+
+#ifdef _DEBUG
+        void Dump();
+#endif
+    };
+
+    // This number chosen by experimentation with a fairly complex ASP.NET application that would naturally use about 40,000 Entry structures on startup.
+    // Entry allocations were shifted to about 11 during that startup phase.
+    static constexpr int PendingTypeLoadTableShardCount = 31;
+    Shard     m_shards[PendingTypeLoadTableShardCount]; 
+
+public:
+    static PendingTypeLoadTable* GetTable();
+
+    static void Init()
+    {
+        STANDARD_VM_CONTRACT;
+        new(GetTable())PendingTypeLoadTable();
+    }
+
+    Shard* GetShard(const TypeKey &typeKey, ClassLoader* pClassLoader, DWORD *pHashCodeForType)
+    {
+        STANDARD_VM_CONTRACT;
+        DWORD hash = HashTypeKey(&typeKey) ^ (DWORD)(size_t)pClassLoader; // Mix in some entropy about which classloader is in use
+        *pHashCodeForType = hash;
+        return &m_shards[hash % PendingTypeLoadTableShardCount];
+    }
+
+#ifdef _DEBUG
+    void Dump()
+    {
+        STANDARD_VM_CONTRACT;
+        for (int iShard = 0; iShard < PendingTypeLoadTableShardCount; iShard++)
+        {
+            CrstHolder unresolvedClassLockHolder(m_shards[iShard].GetCrst());
+            m_shards[iShard].Dump();
+        }
+    }
+#endif
 };
-
 
 #endif // _H_PENDINGLOAD

--- a/src/coreclr/vm/pendingload.h
+++ b/src/coreclr/vm/pendingload.h
@@ -36,7 +36,7 @@ public:
 
     protected:
 
-        void SetTypeKey(const TypeKey& typeKey);
+        void SetTypeKey(TypeKey typeKey);
         void InitCrst();
         void Init(Entry *pNext, DWORD hash, TypeHandle typeHnd);
         void Reset();

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -1516,7 +1516,7 @@ TypeKey TypeHandle::GetTypeKey() const
 
 #ifdef _DEBUG
 // Check that a type handle matches the key provided
-CHECK TypeHandle::CheckMatchesKey(TypeKey *pKey) const
+CHECK TypeHandle::CheckMatchesKey(const TypeKey *pKey) const
 {
     WRAPPER_NO_CONTRACT;
     CONTRACT_VIOLATION(TakesLockViolation);        // this is debug-only code

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -385,7 +385,7 @@ public:
 #ifdef _DEBUG
     // Check that this type matches the key given
     // i.e. that all aspects (element type, module/token, rank for arrays, instantiation for generic types) match up
-    CHECK CheckMatchesKey(TypeKey *pKey) const;
+    CHECK CheckMatchesKey(const TypeKey *pKey) const;
 
     // Check that this type is loaded up to the level indicated
     // Also check that it is non-null

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -239,7 +239,7 @@ static DWORD HashTypeHandle(TypeHandle t)
 }
 
 // Calculate hash value from key
-DWORD HashTypeKey(TypeKey* pKey)
+DWORD HashTypeKey(const TypeKey* pKey)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/typehash.cpp
+++ b/src/coreclr/vm/typehash.cpp
@@ -275,7 +275,7 @@ DWORD HashTypeKey(const TypeKey* pKey)
 // We avoid restoring types during search by cracking the signature
 // encoding used by the zapper for out-of-module types e.g. in the
 // instantiation of an instantiated type.
-EETypeHashEntry_t *EETypeHashTable::FindItem(TypeKey* pKey)
+EETypeHashEntry_t *EETypeHashTable::FindItem(const TypeKey* pKey)
 {
     CONTRACTL
     {
@@ -478,7 +478,7 @@ BOOL EETypeHashTable::CompareFnPtrType(TypeHandle t, BYTE callConv, DWORD numArg
 #endif // #ifndef DACCESS_COMPILE
 }
 
-TypeHandle EETypeHashTable::GetValue(TypeKey *pKey)
+TypeHandle EETypeHashTable::GetValue(const TypeKey *pKey)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/typehash.h
+++ b/src/coreclr/vm/typehash.h
@@ -100,7 +100,7 @@ public:
 
     // Look up a value in the hash table, key explicit in pKey
     // Return a null type handle if not found
-    TypeHandle GetValue(TypeKey* pKey);
+    TypeHandle GetValue(const TypeKey* pKey);
 
     BOOL ContainsValue(TypeHandle th);
 
@@ -134,7 +134,7 @@ public:
 #endif
 
 private:
-    EETypeHashEntry_t * FindItem(TypeKey* pKey);
+    EETypeHashEntry_t * FindItem(const TypeKey* pKey);
     BOOL CompareInstantiatedType(TypeHandle t, Module *pModule, mdTypeDef token, Instantiation inst);
     BOOL CompareFnPtrType(TypeHandle t, BYTE callConv, DWORD numArgs, TypeHandle *retAndArgTypes);
     BOOL GrowHashTable();

--- a/src/coreclr/vm/typehash.h
+++ b/src/coreclr/vm/typehash.h
@@ -26,7 +26,7 @@
 //
 //========================================================================================
 
-DWORD HashTypeKey(TypeKey* pKey);
+DWORD HashTypeKey(const TypeKey* pKey);
 
 // One of these is present for each element in the table
 // It simply chains together (hash,data) pairs

--- a/src/coreclr/vm/typekey.h
+++ b/src/coreclr/vm/typekey.h
@@ -217,7 +217,7 @@ public:
         return u.asFnPtr.m_pRetAndArgTypes;
     }
 
-    BOOL Equals(TypeKey *pKey) const
+    BOOL Equals(const TypeKey *pKey) const
     {
         WRAPPER_NO_CONTRACT;
         return TypeKey::Equals(this, pKey);

--- a/src/coreclr/vm/typekey.h
+++ b/src/coreclr/vm/typekey.h
@@ -9,7 +9,7 @@
 // Support for type lookups based on components of the type (as opposed to string)
 // Used in
 // * Table of constructed types (Module::m_pAvailableParamTypes)
-// * Types currently being loaded (ClassLoader::m_pUnresolvedClassHash)
+// * Types currently being loaded (PendingTypeLoadTable)
 //
 // Type handles are in one-to-one correspondence with TypeKeys
 // In particular, note that tokens in the key are resolved TypeDefs
@@ -59,6 +59,11 @@ class TypeKey
         } asFnPtr;
     } u;
 
+    TypeKey()
+    {
+        // Used to construct InvalidTypeKey
+        m_kind = (CorElementType)0;
+    }
 public:
 
     // Constructor for BYREF/PTR/ARRAY/SZARRAY types
@@ -98,6 +103,11 @@ public:
         u.asFnPtr.m_callConv = callConv;
         u.asFnPtr.m_numArgs = numArgs;
         u.asFnPtr.m_pRetAndArgTypes = retAndArgTypes;
+    }
+
+    static TypeKey InvalidTypeKey()
+    {
+        return TypeKey();
     }
 
     CorElementType GetKind() const

--- a/src/coreclr/vm/typestring.cpp
+++ b/src/coreclr/vm/typestring.cpp
@@ -1078,7 +1078,7 @@ void TypeString::AppendTypeDebug(SString& ss, TypeHandle t)
 #endif
 }
 
-void TypeString::AppendTypeKeyDebug(SString& ss, TypeKey *pTypeKey)
+void TypeString::AppendTypeKeyDebug(SString& ss, const TypeKey *pTypeKey)
 {
     CONTRACTL
     {
@@ -1110,7 +1110,7 @@ void TypeString::AppendTypeKeyDebug(SString& ss, TypeKey *pTypeKey)
 #endif // _DEBUG
 
 
-void TypeString::AppendTypeKey(TypeNameBuilder& tnb, TypeKey *pTypeKey, DWORD format)
+void TypeString::AppendTypeKey(TypeNameBuilder& tnb, const TypeKey *pTypeKey, DWORD format)
 {
     CONTRACT_VOID
     {
@@ -1194,7 +1194,7 @@ void TypeString::AppendTypeKey(TypeNameBuilder& tnb, TypeKey *pTypeKey, DWORD fo
     RETURN;
 }
 
-void TypeString::AppendTypeKey(SString& ss, TypeKey *pTypeKey, DWORD format)
+void TypeString::AppendTypeKey(SString& ss, const TypeKey *pTypeKey, DWORD format)
 {
     CONTRACT_VOID
     {

--- a/src/coreclr/vm/typestring.h
+++ b/src/coreclr/vm/typestring.h
@@ -176,7 +176,7 @@ public:
     // instantiation info provided, instead of the instantiation in the TypeHandle.
     static void AppendType(SString& s, TypeHandle t, Instantiation typeInstantiation, DWORD format = FormatNamespace);
 
-    static void AppendTypeKey(SString& s, TypeKey *pTypeKey, DWORD format = FormatNamespace);
+    static void AppendTypeKey(SString& s, const TypeKey *pTypeKey, DWORD format = FormatNamespace);
 
     // Appends the method name and generic instantiation info.  This might
     // look like "Namespace.ClassName[T].Foo[U, V]()"
@@ -193,7 +193,7 @@ public:
     // as they may leave "s" in a bad state if there are any problems/exceptions.
     static void AppendMethodDebug(SString& s, MethodDesc *pMD);
     static void AppendTypeDebug(SString& s, TypeHandle t);
-    static void AppendTypeKeyDebug(SString& s, TypeKey* pTypeKey);
+    static void AppendTypeKeyDebug(SString& s, const TypeKey* pTypeKey);
 #endif
 
 private:
@@ -203,7 +203,7 @@ private:
     static void AppendNestedTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pImport, mdTypeDef td, DWORD format = FormatNamespace);
     static void AppendInst(TypeNameBuilder& tnb, Instantiation inst, DWORD format = FormatNamespace);
     static void AppendType(TypeNameBuilder& tnb, TypeHandle t, Instantiation typeInstantiation, DWORD format = FormatNamespace); // ????
-    static void AppendTypeKey(TypeNameBuilder& tnb, TypeKey *pTypeKey, DWORD format = FormatNamespace);
+    static void AppendTypeKey(TypeNameBuilder& tnb, const TypeKey *pTypeKey, DWORD format = FormatNamespace);
     static void AppendParamTypeQualifier(TypeNameBuilder& tnb, CorElementType kind, DWORD rank);
     static void EscapeSimpleTypeName(SString* ssTypeName, SString* ssEscapedTypeName);
     static bool ContainsReservedChar(LPCWSTR pTypeName);


### PR DESCRIPTION
- Shard the hashtable so that it will rarely have lock contention
- Pre-allocate the PendingTypeLoad Entries. This reduces allocator pressure on startup substantially, especially in the presence of multithreaded loading where the struct is allocated on 1 thread and often freed on another.

The effectiveness of the pre-allocation and sharding heuristics was measured on a complex ASP.NET scenario tweaked to perform extremely high numbers of multithreaded loads and produced startup wins of about 10%.