### PR TITLE
For RuntimeTypeValue make it dependent on SupportsFrozenRuntimeTypeInstances

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -325,6 +325,8 @@ namespace ILCompiler
                                 Value value = stack.PopIntoLocation(field.FieldType);
                                 if (value is IInternalModelingOnlyValue)
                                     return Status.Fail(methodIL.OwningMethod, opcode, "Value with no external representation");
+                                if (value is { TargetSupportsWritingFieldData: false })
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Value cannot be written to target as it does not support writing field data and hence FrozenRuntimeTypeNode");
                                 _fieldValues[field] = value;
                             }
                         }
@@ -2217,6 +2219,8 @@ namespace ILCompiler
             public virtual float AsSingle() => ThrowInvalidProgram<float>();
             public virtual double AsDouble() => ThrowInvalidProgram<double>();
             public virtual Value Clone() => ThrowInvalidProgram<Value>();
+
+            public virtual bool TargetSupportsWritingFieldData => true;
         }
 
         private abstract class BaseValueTypeValue : Value
@@ -2399,8 +2403,14 @@ namespace ILCompiler
 
             public override bool GetRawData(NodeFactory factory, out object data)
             {
-                data = factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented);
-                return true;
+                if (TargetSupportsWritingFieldData)
+                {
+                    data = factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented);
+                    return true;
+                }
+
+                data = null;
+                return false;
             }
             public override ReferenceTypeValue ToForeignInstance(int baseInstructionCounter, TypePreinit preinitContext)
             {
@@ -2414,6 +2424,8 @@ namespace ILCompiler
             {
                 builder.EmitPointerReloc(factory.SerializedMaximallyConstructableRuntimeTypeObject(TypeRepresented));
             }
+
+            public override bool TargetSupportsWritingFieldData => EETypeNode.SupportsFrozenRuntimeTypeInstances(Type.Context.Target);
         }
 
         private sealed class ReadOnlySpanValue : BaseValueTypeValue, IInternalModelingOnlyValue


### PR DESCRIPTION
This PR allows targets to not support preinit in NativeAOT for `RuntimeTypeValue`s.  This is based on a new virtual property `TargetSupportsWritingFieldData` which is based on `EETypeNode.SupportsFrozenRuntimeTypeInstances(Type.Context.Target)`

Follows https://github.com/dotnet/runtimelab/pull/2473#pullrequestreview-1801396853 from NativeAOT-LLVM.

cc @MichalStrehovsky 
