### PR TITLE
[mono] Enable Interop/UnmanagedCallersOnlyBasic on mini-arm64

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2531,9 +2531,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/ICustomMarshaler/ConflictingNames/SameNameDifferentAssembly/**">
             <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/UnmanagedCallersOnlyBasic/UnmanagedCallersOnlyBasicTest/**">
-            <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Primitives/Pointer/NonBlittablePointer/**">
             <Issue>https://github.com/dotnet/runtime/issues/82859</Issue>
         </ExcludeList>


### PR DESCRIPTION
Enable Interop/UnmanagedCallersOnlyBasic on mini-arm64 for Mono.

Contributes to https://github.com/dotnet/runtime/issues/82859.