### PR TITLE
[release/6.0] Use NuGetAuthenticate@1 instead of @0 (#96651)

### DIFF
--- a/eng/pipelines/common/restore-internal-tools.yml
+++ b/eng/pipelines/common/restore-internal-tools.yml
@@ -1,5 +1,5 @@
 steps:
-  - task: NuGetAuthenticate@0
+  - task: NuGetAuthenticate@1
     inputs:
       nuGetServiceConnections: 'devdiv/dotnet-core-internal-tooling'
       forceReinstallCredentialProvider: true

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -344,7 +344,7 @@ jobs:
       displayName: Clean up old artifacts owned by root
 
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
 
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
     fetchDepth: 20
 
   - ${{ if eq(parameters.isOfficialBuild, true) }}:
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/96651 to release/6.0-staging

## Customer Impact

None, this is an infrastructure-only change.

## Testing

CI testing.

## Risk

Low.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
