### PR TITLE
[riscv64] fix linq MixedScope test

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5420,13 +5420,6 @@ void CodeGen::genRangeCheck(GenTree* oper)
     genConsumeRegs(index);
     genConsumeRegs(length);
 
-    if (genActualType(index) == TYP_INT)
-    {
-        regNumber tempReg = oper->GetSingleTempReg();
-        GetEmitter()->emitIns_R_R_I(INS_addiw, EA_4BYTE, tempReg, indexReg, 0); // sign-extend
-        indexReg = tempReg;
-    }
-
 #ifdef DEBUG
     var_types lengthType = genActualType(length);
     var_types indexType  = genActualType(index);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9908,6 +9908,10 @@ GenTree* Compiler::fgOptimizeCast(GenTreeCast* cast)
             return src;
         }
 
+#if defined(TARGET_RISCV64)
+        // TODO On RISC-V widening casts are NOPs and can be discarded, except for uint to long or ulong,
+        // which require zero-extension because all 32 bit values are kept sign-extended.
+#else // everything except RISC-V where narrowing is never a NOP
         // Try to narrow the operand of the cast and discard the cast.
         if (opts.OptEnabled(CLFLG_TREETRANS) && (genTypeSize(src) > genTypeSize(castToType)) &&
             optNarrowTree(src, src->TypeGet(), castToType, cast->gtVNPair, false))
@@ -9922,6 +9926,7 @@ GenTree* Compiler::fgOptimizeCast(GenTreeCast* cast)
 
             return src;
         }
+#endif
 
         // Check for two consecutive casts, we may be able to discard the intermediate one.
         if (opts.OptimizationEnabled() && src->OperIs(GT_CAST) && !src->gtOverflow())


### PR DESCRIPTION
Fixes RISC-V failure on System.Linq.Expressions.Tests.RuntimeVariablesTests.MixedScope

On amd64 and arm64 narrow operands are widened by each operation using them e.g. on arm64 instructions can sign or zero extend the 2nd operand from byte or half "for free". Narrowing casts can be optimised away.

On riscv64 all values are kept in canonical form at all times i.e. byte and half values are sign or zero extended to word, as appropriate, then the word is (always) sign extended to double. Operations assume that their operands are already in canonical form, and ensure that their result is.

Among other things, this allows the ISA to have only 64 bit compare-and-branch and set-less-than{-unsigned} operations, and they operate correctly on values of all sizes, whether signed or unsigned. Also, explicit 32 bit operations (which look at only the 32 LSBs and sign-extend the 32 bit result) are only necessary for add/sub/mul/div and shifts. Boolean operations automatically maintain the canonical form if their operands are already in canonical form.

Compiler::fgOptimizeCast() deletes narrowing (unchecked) casts. This is correct on amd64 and arm64, but never valid on riscv64 which must always sign/zero extend the narrowed value.

This patch simply #ifdef's out this optimisation on riscv64. There is no change on other ISAs.

A future patch will add a new riscv64-only optimisation to remove widening casts, which are NOPs in all cases except widening uint to a 64 bit type, which (always) requires zero-extension.

Note that the RISC-V Zba extension (which we don't use yet, but is implemented on the VisionFive 2) provides `add.uw`, `sh1add.uw`, `sh2add.uw`, `sh3add.uw`, and `slli.uw` instructions, all of which zero-extend their first argument (rs1) from 32 to 64 bits before shifting and/or adding it. These instructions make the widening cast needed when e.g. a uint is used to index an array "free". Widening int or any 8 or 16 bit value is always free (unnecessary).

Minimised example triggering the code generation bug, which crashes if the accessed element in the supplied `vars` is from a nested scope:

    using System.Runtime.CompilerServices;
    
    public static object bug(IRuntimeVariables vars)
    {
        return vars[0];
    }
