### PR TITLE
[iOS] Skip PublicPrivateKey_IndependentLifetimes_DSA test

### DIFF
--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -137,6 +137,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "DSA is not available")]
         public static void PublicPrivateKey_IndependentLifetimes_DSA()
         {
             X509Certificate2 loaded;


### PR DESCRIPTION
DSA is not supported

Fixes #96690