### PR TITLE
Make RandomAccess.Read*|Write* methods work with non-seekable files

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadV.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadV.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadV", SetLastError = true)]
+        internal static unsafe partial long ReadV(SafeHandle fd, IOVector* vectors, int vectorCount);
+    }
+}

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.WriteV.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.WriteV.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_WriteV", SetLastError = true)]
+        internal static unsafe partial long WriteV(SafeHandle fd, IOVector* vectors, int vectorCount);
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2378,6 +2378,9 @@
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.PRead.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.PRead.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ReadV.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.ReadV.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.PReadV.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.PReadV.cs</Link>
     </Compile>
@@ -2389,6 +2392,9 @@
     </Compile>
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Read.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.Read.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.WriteV.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.WriteV.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.ReadDir.cs">
       <Link>Common\Interop\Unix\System.Native\Interop.ReadDir.cs</Link>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/RandomAccess.cs
@@ -22,7 +22,7 @@ namespace System.IO
         /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         public static long GetLength(SafeFileHandle handle)
         {
-            ValidateInput(handle, fileOffset: 0);
+            ValidateInput(handle, fileOffset: 0, allowUnseekableHandles: false);
 
             return handle.GetFileLength();
         }
@@ -39,7 +39,7 @@ namespace System.IO
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="length" /> is negative.</exception>
         public static void SetLength(SafeFileHandle handle, long length)
         {
-            ValidateInput(handle, fileOffset: 0);
+            ValidateInput(handle, fileOffset: 0, allowUnseekableHandles: false);
 
             if (length < 0)
             {
@@ -54,12 +54,11 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffer">A region of memory. When this method returns, the contents of this region are replaced by the bytes read from the file.</param>
-        /// <param name="fileOffset">The file position to read from.</param>
+        /// <param name="fileOffset">The file position to read from. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes allocated in the buffer if that many bytes are not currently available, or zero (0) if the end of the file has been reached.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for reading.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -76,12 +75,11 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffers">A list of memory buffers. When this method returns, the contents of the buffers are replaced by the bytes read from the file.</param>
-        /// <param name="fileOffset">The file position to read from.</param>
+        /// <param name="fileOffset">The file position to read from. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <returns>The total number of bytes read into the buffers. This can be less than the number of bytes allocated in the buffers if that many bytes are not currently available, or zero (0) if the end of the file has been reached.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for reading.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -99,13 +97,12 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffer">A region of memory. When this method returns, the contents of this region are replaced by the bytes read from the file.</param>
-        /// <param name="fileOffset">The file position to read from.</param>
+        /// <param name="fileOffset">The file position to read from. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
         /// <returns>The total number of bytes read into the buffer. This can be less than the number of bytes allocated in the buffer if that many bytes are not currently available, or zero (0) if the end of the file has been reached.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for reading.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -127,13 +124,12 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffers">A list of memory buffers. When this method returns, the contents of these buffers are replaced by the bytes read from the file.</param>
-        /// <param name="fileOffset">The file position to read from.</param>
+        /// <param name="fileOffset">The file position to read from. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
         /// <returns>The total number of bytes read into the buffers. This can be less than the number of bytes allocated in the buffers if that many bytes are not currently available, or zero (0) if the end of the file has been reached.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for reading.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -156,11 +152,10 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffer">A region of memory. This method copies the contents of this region to the file.</param>
-        /// <param name="fileOffset">The file position to write to.</param>
+        /// <param name="fileOffset">The file position to write to. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -177,11 +172,10 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffers">A list of memory buffers. This method copies the contents of these buffers to the file.</param>
-        /// <param name="fileOffset">The file position to write to.</param>
+        /// <param name="fileOffset">The file position to write to. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -199,13 +193,12 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffer">A region of memory. This method copies the contents of this region to the file.</param>
-        /// <param name="fileOffset">The file position to write to.</param>
+        /// <param name="fileOffset">The file position to write to. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task representing the asynchronous completion of the write operation.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -227,13 +220,12 @@ namespace System.IO
         /// </summary>
         /// <param name="handle">The file handle.</param>
         /// <param name="buffers">A list of memory buffers. This method copies the contents of these buffers to the file.</param>
-        /// <param name="fileOffset">The file position to write to.</param>
+        /// <param name="fileOffset">The file position to write to. For a file that does not support seeking (pipe or socket), it's ignored.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="P:System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task representing the asynchronous completion of the write operation.</returns>
         /// <exception cref="T:System.ArgumentNullException"><paramref name="handle" /> or <paramref name="buffers"/> is <see langword="null" />.</exception>
         /// <exception cref="T:System.ArgumentException"><paramref name="handle" /> is invalid.</exception>
         /// <exception cref="T:System.ObjectDisposedException">The file is closed.</exception>
-        /// <exception cref="T:System.NotSupportedException">The file does not support seeking (pipe or socket).</exception>
         /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="fileOffset" /> is negative.</exception>
         /// <exception cref="T:System.UnauthorizedAccessException"><paramref name="handle" /> was not opened for writing.</exception>
         /// <exception cref="T:System.IO.IOException">An I/O error occurred.</exception>
@@ -276,12 +268,12 @@ namespace System.IO
             // Unix does NOT support unseekable handles however, the code that ultimately runs on Unix when we
             // call FileStreamHelpers.FlushToDisk() later below, will silently ignore those errors, effectively
             // making FlushToDisk() a no-op on Unix when used with unseekable handles.
-            ValidateInput(handle, fileOffset: 0, allowUnseekableHandles: true);
+            ValidateInput(handle, fileOffset: 0);
 
             FileStreamHelpers.FlushToDisk(handle);
         }
 
-        private static void ValidateInput(SafeFileHandle handle, long fileOffset, bool allowUnseekableHandles = false)
+        private static void ValidateInput(SafeFileHandle handle, long fileOffset, bool allowUnseekableHandles = true)
         {
             if (handle is null)
             {
@@ -291,18 +283,13 @@ namespace System.IO
             {
                 ThrowHelper.ThrowArgumentException_InvalidHandle(nameof(handle));
             }
-            else if (!handle.CanSeek)
+            else if (handle.IsClosed)
             {
-                // CanSeek calls IsClosed, we don't want to call it twice for valid handles
-                if (handle.IsClosed)
-                {
-                    ThrowHelper.ThrowObjectDisposedException_FileClosed();
-                }
-
-                if (!allowUnseekableHandles)
-                {
-                    ThrowHelper.ThrowNotSupportedException_UnseekableStream();
-                }
+                ThrowHelper.ThrowObjectDisposedException_FileClosed();
+            }
+            else if (!allowUnseekableHandles && !handle.CanSeek)
+            {
+                ThrowHelper.ThrowNotSupportedException_UnseekableStream();
             }
             else if (fileOffset < 0)
             {

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/Base.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/Base.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.IO.Pipes;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 using Xunit;
@@ -14,8 +13,6 @@ namespace System.IO.Tests
         protected abstract T MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset);
 
         protected virtual bool UsesOffsets => true;
-
-        protected virtual bool ThrowsForUnseekableFile => true;
 
         public static IEnumerable<object[]> GetSyncAsyncOptions()
         {
@@ -50,20 +47,6 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => MethodUnderTest(handle, Array.Empty<byte>(), 0));
         }
 
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "System.IO.Pipes aren't supported on browser")]
-        public void ThrowsNotSupportedExceptionForUnseekableFile()
-        {
-            if (ThrowsForUnseekableFile)
-            {
-                using (var server = new AnonymousPipeServerStream(PipeDirection.Out))
-                using (SafeFileHandle handle = new SafeFileHandle(server.SafePipeHandle.DangerousGetHandle(), ownsHandle: false))
-                {
-                    Assert.Throws<NotSupportedException>(() => MethodUnderTest(handle, Array.Empty<byte>(), 0));
-                }
-            }
-        }
-
         [Theory]
         [MemberData(nameof(GetSyncAsyncOptions))]
         public void ThrowsArgumentOutOfRangeExceptionForNegativeFileOffset(FileOptions options)
@@ -77,7 +60,7 @@ namespace System.IO.Tests
             }
         }
 
-        protected static CancellationTokenSource GetCancelledTokenSource()
+        internal static CancellationTokenSource GetCancelledTokenSource()
         {
             CancellationTokenSource source = new CancellationTokenSource();
             source.Cancel();

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/FlushToDisk.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/FlushToDisk.cs
@@ -24,8 +24,6 @@ namespace System.IO.Tests
 
         protected override bool UsesOffsets => false;
 
-        protected override bool ThrowsForUnseekableFile => false;
-
         protected override long MethodUnderTest(SafeFileHandle handle, byte[] bytes, long fileOffset)
         {
             RandomAccess.FlushToDisk(handle);

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/NonSeekable.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/NonSeekable.cs
@@ -1,0 +1,395 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipes;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    [SkipOnPlatform(TestPlatforms.Browser, "async file IO is not supported on browser")]
+    public class RandomAccess_NonSeekable : FileSystemTest
+    {
+        private const int VectorCount = 10;
+        private const int BufferSize = 3;
+        private const int VectorsByteCount = VectorCount * BufferSize;
+
+        protected virtual PipeOptions PipeOptions => PipeOptions.None;
+
+        private async Task<(SafeFileHandle readHandle, SafeFileHandle writeHandle)> GetNamedPipeHandlesAsync()
+        {
+            string name = GetNamedPipeServerStreamName();
+
+            var server = new NamedPipeServerStream(name, PipeDirection.In, -1, PipeTransmissionMode.Byte, PipeOptions);
+            var client = new NamedPipeClientStream(".", name, PipeDirection.Out, PipeOptions);
+
+            await Task.WhenAll(server.WaitForConnectionAsync(), client.ConnectAsync());
+
+            bool isAsync = (PipeOptions & PipeOptions.Asynchronous) != 0;
+            return (GetFileHandle(server, isAsync), GetFileHandle(client, isAsync));
+        }
+
+        [Fact]
+        [SkipOnPlatform(TestPlatforms.AnyUnix, "named pipe implementation used by this test is using Sockets on Unix, which allow for both reading and writing")]
+        public async Task ThrowsUnauthorizedAccessExceptionWhenOperationIsNotAllowed()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                Assert.Throws<UnauthorizedAccessException>(() => RandomAccess.Read(writeHandle, new byte[1], 0));
+                Assert.Throws<UnauthorizedAccessException>(() => RandomAccess.Write(readHandle, new byte[1], 0));
+
+                Assert.Throws<UnauthorizedAccessException>(() => RandomAccess.Read(writeHandle, GenerateVectors(1, 1), 0));
+                Assert.Throws<UnauthorizedAccessException>(() => RandomAccess.Write(readHandle, GenerateReadOnlyVectors(1, 1), 0));
+
+                await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RandomAccess.ReadAsync(writeHandle, new byte[1], 0));
+                await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RandomAccess.WriteAsync(readHandle, new byte[1], 0));
+
+                await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RandomAccess.ReadAsync(writeHandle, GenerateVectors(1, 1), 0));
+                await Assert.ThrowsAsync<UnauthorizedAccessException>(async () => await RandomAccess.WriteAsync(readHandle, GenerateReadOnlyVectors(1, 1), 0));
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsTaskAlreadyCanceledForCancelledTokenAsync()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                CancellationTokenSource cts = RandomAccess_Base<byte>.GetCancelledTokenSource();
+                CancellationToken token = cts.Token;
+
+                Assert.True(RandomAccess.ReadAsync(readHandle, new byte[1], 0, token).IsCanceled);
+                Assert.True(RandomAccess.WriteAsync(writeHandle, new byte[1], 0, token).IsCanceled);
+                Assert.True(RandomAccess.ReadAsync(readHandle, GenerateVectors(1, 1), 0, token).IsCanceled);
+                Assert.True(RandomAccess.WriteAsync(writeHandle, GenerateReadOnlyVectors(1, 1), 0, token).IsCanceled);
+
+                TaskCanceledException ex = await Assert.ThrowsAsync<TaskCanceledException>(() => RandomAccess.ReadAsync(readHandle, new byte[1], 0, token).AsTask());
+                Assert.Equal(token, ex.CancellationToken);
+                ex = await Assert.ThrowsAsync<TaskCanceledException>(() => RandomAccess.WriteAsync(writeHandle, new byte[1], 0, token).AsTask());
+                Assert.Equal(token, ex.CancellationToken);
+                ex = await Assert.ThrowsAsync<TaskCanceledException>(() => RandomAccess.ReadAsync(writeHandle, GenerateVectors(1, 1), 0, token).AsTask());
+                Assert.Equal(token, ex.CancellationToken);
+                ex = await Assert.ThrowsAsync<TaskCanceledException>(() => RandomAccess.WriteAsync(writeHandle, GenerateReadOnlyVectors(1, 1), 0, token).AsTask());
+                Assert.Equal(token, ex.CancellationToken);
+            }
+        }
+
+        [Fact]
+        public async Task ReadToAnEmptyBufferReturnsZeroWhenDataIsAvailable()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                ValueTask write = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 0);
+
+                Assert.Equal(0, RandomAccess.Read(readHandle, Array.Empty<byte>(), fileOffset: 0)); // what we test
+                byte[] buffer = new byte[content.Length * 2];
+                Assert.Equal(content.Length, RandomAccess.Read(readHandle, buffer, fileOffset: 0)); // what is required for the above write to succeed
+                Assert.Equal(content, buffer.AsSpan(0, content.Length).ToArray());
+
+                await write;
+            }
+        }
+
+        [Fact]
+        public async Task ReadToAnEmptyBufferReturnsZeroWhenDataIsAvailableAsync()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                Task write = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 0).AsTask();
+                Task<int> readToEmpty = RandomAccess.ReadAsync(readHandle, Array.Empty<byte>(), fileOffset: 0).AsTask(); // what we test
+
+                Assert.Equal(0, await readToEmpty);
+
+                byte[] buffer = new byte[content.Length * 2];
+                Task<int> readToNonEmpty = RandomAccess.ReadAsync(readHandle, buffer, fileOffset: 0).AsTask(); // what is required for the above write to succeed
+
+                await Task.WhenAll(readToNonEmpty, write);
+
+                Assert.Equal(content.Length, readToNonEmpty.Result);
+                Assert.Equal(content, buffer.AsSpan(0, readToNonEmpty.Result).ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task CanReadToStackAllocatedMemory()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                Task write = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 0).AsTask();
+
+                ReadToStackAllocatedBuffer(readHandle, content);
+
+                await write;
+            }
+
+            void ReadToStackAllocatedBuffer(SafeFileHandle handle, byte[] array)
+            {
+                Span<byte> buffer = stackalloc byte[array.Length * 2];
+                Assert.Equal(array.Length, RandomAccess.Read(handle, buffer, fileOffset: 0));
+                Assert.Equal(array, buffer.Slice(0, array.Length).ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task CanWriteFromStackAllocatedMemory()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                byte[] buffer = new byte[content.Length * 2];
+                Task<int> read = RandomAccess.ReadAsync(readHandle, buffer, fileOffset: 0).AsTask();
+
+                WriteFromStackAllocatedBuffer(writeHandle, content);
+
+                Assert.Equal(content.Length, await read);
+                Assert.Equal(content, buffer.AsSpan(0, content.Length).ToArray());
+            }
+
+            void WriteFromStackAllocatedBuffer(SafeFileHandle handle, byte[] array)
+            {
+                Span<byte> buffer = stackalloc byte[array.Length];
+                array.CopyTo(buffer);
+                RandomAccess.Write(handle, buffer, fileOffset: 0);
+            }
+        }
+
+        [Fact]
+        public async Task FileOffsetsAreIgnored_AsyncWrite_SyncRead()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                Task writeToOffset123 = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 123).AsTask();
+                byte[] buffer = new byte[content.Length * 2];
+                int readFromOffset456 = RandomAccess.Read(readHandle, buffer, fileOffset: 456);
+
+                Assert.Equal(content.Length, readFromOffset456);
+                Assert.Equal(content, buffer.AsSpan(0, readFromOffset456).ToArray());
+
+                await writeToOffset123;
+            }
+        }
+
+        [Fact]
+        public async Task FileOffsetsAreIgnored_AsyncRead_SyncWrite()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                byte[] buffer = new byte[content.Length * 2];
+                Task<int> readFromOffset456 = RandomAccess.ReadAsync(readHandle, buffer, fileOffset: 456).AsTask();
+
+                RandomAccess.Write(writeHandle, content, fileOffset: 123);
+
+                Assert.Equal(content.Length, readFromOffset456.Result);
+                Assert.Equal(content, buffer.AsSpan(0, readFromOffset456.Result).ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task FileOffsetsAreIgnoredAsync()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                Task writeToOffset123 = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 123).AsTask();
+                byte[] buffer = new byte[content.Length * 2];
+                Task<int> readFromOffset456 = RandomAccess.ReadAsync(readHandle, buffer, fileOffset: 456).AsTask();
+
+                await Task.WhenAll(readFromOffset456, writeToOffset123);
+
+                Assert.Equal(content.Length, readFromOffset456.Result);
+                Assert.Equal(content, buffer.AsSpan(0, readFromOffset456.Result).ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task PartialReadsAreSupported()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                ValueTask write = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 0);
+
+                byte[] buffer = new byte[content.Length * 2];
+
+                for (int i = 0; i < content.Length; i++)
+                {
+                    Assert.Equal(1, RandomAccess.Read(readHandle, buffer.AsSpan(i, 1), fileOffset: 0));
+                }
+                Assert.Equal(content, buffer.AsSpan(0, content.Length).ToArray());
+
+                await write;
+            }
+        }
+
+        [Fact]
+        public async Task PartialReadsAreSupportedAsync()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                byte[] content = RandomNumberGenerator.GetBytes(BufferSize);
+                ValueTask write = RandomAccess.WriteAsync(writeHandle, content, fileOffset: 0);
+
+                byte[] buffer = new byte[content.Length * 2];
+                Assert.Equal(1, await RandomAccess.ReadAsync(readHandle, buffer.AsMemory(0, 1), fileOffset: 0));
+                Assert.Equal(2, await RandomAccess.ReadAsync(readHandle, buffer.AsMemory(1), fileOffset: 0));
+                Assert.Equal(content, buffer.AsSpan(0, 3).ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task MultipleBuffersAreSupported_AsyncWrite_SyncReads()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                ReadOnlyMemory<byte>[] vectors = GenerateReadOnlyVectors(VectorCount, BufferSize);
+                Task write = RandomAccess.WriteAsync(writeHandle, vectors, fileOffset: 123).AsTask();
+                byte[] buffer = new byte[VectorsByteCount * 2];
+
+                int read = 0;
+
+                do
+                {
+                    read += RandomAccess.Read(readHandle, buffer.AsSpan(read), fileOffset: 456);
+                } while (read != VectorsByteCount);
+
+                Assert.Equal(vectors.SelectMany(vector => vector.ToArray()), buffer.AsSpan(0, read).ToArray());
+
+                await write;
+            }
+        }
+
+        [Fact]
+        public async Task MultipleBuffersAreSupported_AsyncWrite_SyncRead()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                ReadOnlyMemory<byte>[] readOnlyVectors = GenerateReadOnlyVectors(VectorCount, BufferSize);
+                Task write = RandomAccess.WriteAsync(writeHandle, readOnlyVectors, fileOffset: 123).AsTask();
+                byte[] buffer = new byte[VectorsByteCount * 2];
+
+                Memory<byte>[] writableVectors = GenerateVectors(VectorCount, BufferSize);
+                long read = RandomAccess.Read(readHandle, writableVectors, fileOffset: 456);
+
+                Assert.Equal(VectorsByteCount, read);
+                Assert.Equal(readOnlyVectors.SelectMany(vector => vector.ToArray()), writableVectors.SelectMany(vector => vector.ToArray()));
+
+                await write;
+            }
+        }
+
+        [Fact]
+        public async Task MultipleBuffersAreSupported_AsyncWrite_AsyncRead()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                ReadOnlyMemory<byte>[] readOnlyVectors = GenerateReadOnlyVectors(VectorCount, BufferSize);
+                Task write = RandomAccess.WriteAsync(writeHandle, readOnlyVectors, fileOffset: 123).AsTask();
+                byte[] buffer = new byte[VectorsByteCount * 2];
+
+                Memory<byte>[] writableVectors = GenerateVectors(VectorCount, BufferSize);
+
+                Assert.Equal(VectorsByteCount, await RandomAccess.ReadAsync(readHandle, writableVectors, fileOffset: 456));
+                Assert.Equal(readOnlyVectors.SelectMany(vector => vector.ToArray()), writableVectors.SelectMany(vector => vector.ToArray()));
+
+                await write;
+            }
+        }
+
+        [Fact]
+        public async Task MultipleBuffersAreSupported_AsyncRead_SyncWrite()
+        {
+            (SafeFileHandle readHandle, SafeFileHandle writeHandle) = await GetNamedPipeHandlesAsync();
+
+            using (readHandle)
+            using (writeHandle)
+            {
+                Memory<byte>[] writableVectors = GenerateVectors(VectorCount, BufferSize);
+                ValueTask<long> read = RandomAccess.ReadAsync(readHandle, writableVectors, fileOffset: 456);
+
+                byte[] content = RandomNumberGenerator.GetBytes(VectorsByteCount);
+                RandomAccess.Write(writeHandle, content, fileOffset: 123);
+
+                Assert.Equal(VectorsByteCount, await read);
+                Assert.Equal(content, writableVectors.SelectMany(vector => vector.ToArray()));
+            }
+        }
+
+        private static ReadOnlyMemory<byte>[] GenerateReadOnlyVectors(int vectorCount, int bufferSize)
+            => Enumerable.Range(0, vectorCount).Select(_ => new ReadOnlyMemory<byte>(RandomNumberGenerator.GetBytes(bufferSize))).ToArray();
+
+        private static Memory<byte>[] GenerateVectors(int vectorCount, int bufferSize)
+            => Enumerable.Range(0, vectorCount).Select(_ => new Memory<byte>(RandomNumberGenerator.GetBytes(bufferSize))).ToArray();
+
+        private static SafeFileHandle GetFileHandle(PipeStream pipeStream, bool isAsync)
+        {
+            var serverHandle = new SafeFileHandle(pipeStream.SafePipeHandle.DangerousGetHandle(), ownsHandle: true);
+
+            try
+            {
+                if (OperatingSystem.IsWindows() && isAsync)
+                {
+                    // Currently it's impossible to duplicate an async safe handle that has already been bound to Thread Pool: https://github.com/dotnet/runtime/issues/28585
+                    // I am opened for ideas on how we could solve it without an ugly reflection hack..
+                    ThreadPoolBoundHandle threadPoolBinding = (ThreadPoolBoundHandle)typeof(PipeStream).GetField("_threadPoolBinding", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance).GetValue(pipeStream);
+                    typeof(SafeFileHandle).GetProperty("ThreadPoolBinding", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance).GetSetMethod(true).Invoke(serverHandle, new object[] { threadPoolBinding });
+                }
+
+                return serverHandle;
+            }
+            finally
+            {
+                pipeStream.SafePipeHandle.SetHandleAsInvalid();
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/NonSeekable_AsyncHandles.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/RandomAccess/NonSeekable_AsyncHandles.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Pipes;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class RandomAccess_NonSeekable_AsyncHandles : RandomAccess_NonSeekable
+    {
+        protected override PipeOptions PipeOptions => PipeOptions.Asynchronous;
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows))] // cancellable file IO is supported only on Windows
+        [InlineData(FileAccess.Read)]
+        [InlineData(FileAccess.Write)]
+        public async Task CancellationIsSupported(FileAccess access)
+        {
+            string pipeName = FileSystemTest.GetNamedPipeServerStreamName();
+            string pipePath = Path.GetFullPath($@"\\.\pipe\{pipeName}");
+
+            using (var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut))
+            using (SafeFileHandle clientHandle = File.OpenHandle(pipePath, FileMode.Open, access, FileShare.None, FileOptions.Asynchronous))
+            {
+                await server.WaitForConnectionAsync();
+
+                Assert.True(clientHandle.IsAsync);
+
+                CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(250));
+                CancellationToken token = cts.Token;
+                byte[] buffer = new byte[1];
+
+                OperationCanceledException ex = await Assert.ThrowsAsync<OperationCanceledException>(
+                    () => access == FileAccess.Write
+                        ? RandomAccess.WriteAsync(clientHandle, buffer, 0, token).AsTask()
+                        : RandomAccess.ReadAsync(clientHandle, buffer, 0, token).AsTask());
+
+                Assert.Equal(token, ex.CancellationToken);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/System.IO.FileSystem.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/System.IO.FileSystem.Tests.csproj
@@ -74,6 +74,8 @@
     <Compile Include="RandomAccess\Base.cs" />
     <Compile Include="RandomAccess\FlushToDisk.cs" />
     <Compile Include="RandomAccess\GetLength.cs" />
+    <Compile Include="RandomAccess\NonSeekable.cs" />
+    <Compile Include="RandomAccess\NonSeekable_AsyncHandles.cs" />
     <Compile Include="RandomAccess\Read.cs" />
     <Compile Include="RandomAccess\ReadAsync.cs" />
     <Compile Include="RandomAccess\ReadScatter.cs" />

--- a/src/native/libs/System.Native/entrypoints.c
+++ b/src/native/libs/System.Native/entrypoints.c
@@ -265,6 +265,8 @@ static const Entry s_sysNative[] =
     DllImportEntry(SystemNative_PWrite)
     DllImportEntry(SystemNative_PReadV)
     DllImportEntry(SystemNative_PWriteV)
+    DllImportEntry(SystemNative_ReadV)
+    DllImportEntry(SystemNative_WriteV)
     DllImportEntry(SystemNative_CreateThread)
     DllImportEntry(SystemNative_EnablePosixSignalHandling)
     DllImportEntry(SystemNative_DisablePosixSignalHandling)

--- a/src/native/libs/System.Native/pal_io.c
+++ b/src/native/libs/System.Native/pal_io.c
@@ -1868,6 +1868,20 @@ int32_t SystemNative_PWrite(intptr_t fd, void* buffer, int32_t bufferSize, int64
     return (int32_t)count;
 }
 
+int64_t SystemNative_ReadV(intptr_t fd, IOVector* vectors, int32_t vectorCount)
+{
+    assert(vectors != NULL);
+    assert(vectorCount >= 0);
+
+    int64_t count = 0;
+    int fileDescriptor = ToFileDescriptor(fd);
+
+    while ((count = readv(fileDescriptor, (struct iovec*)vectors, (int)vectorCount)) < 0 && errno == EINTR);
+
+    assert(count >= -1);
+    return count;
+}
+
 int64_t SystemNative_PReadV(intptr_t fd, IOVector* vectors, int32_t vectorCount, int64_t fileOffset)
 {
     assert(vectors != NULL);
@@ -1903,6 +1917,20 @@ int64_t SystemNative_PReadV(intptr_t fd, IOVector* vectors, int32_t vectorCount,
         }
     }
 #endif
+
+    assert(count >= -1);
+    return count;
+}
+
+int64_t SystemNative_WriteV(intptr_t fd, IOVector* vectors, int32_t vectorCount)
+{
+    assert(vectors != NULL);
+    assert(vectorCount >= 0);
+
+    int64_t count = 0;
+    int fileDescriptor = ToFileDescriptor(fd);
+
+    while ((count = writev(fileDescriptor, (struct iovec*)vectors, (int)vectorCount)) < 0 && errno == EINTR);
 
     assert(count >= -1);
     return count;

--- a/src/native/libs/System.Native/pal_io.h
+++ b/src/native/libs/System.Native/pal_io.h
@@ -829,3 +829,17 @@ PALEXPORT int64_t SystemNative_PReadV(intptr_t fd, IOVector* vectors, int32_t ve
  * Returns the number of bytes written on success; otherwise, -1 is returned an errno is set.
  */
 PALEXPORT int64_t SystemNative_PWriteV(intptr_t fd, IOVector* vectors, int32_t vectorCount, int64_t fileOffset);
+
+/**
+ * Reads the number of bytes specified into the provided buffers from the specified, opened file descriptor.
+ *
+ * Returns the number of bytes read on success; otherwise, -1 is returned an errno is set.
+ */
+PALEXPORT int64_t SystemNative_ReadV(intptr_t fd, IOVector* vectors, int32_t vectorCount);
+
+/**
+ * Writes the number of bytes specified in the buffers into the specified, opened file descriptor
+ *
+ * Returns the number of bytes written on success; otherwise, -1 is returned an errno is set.
+ */
+PALEXPORT int64_t SystemNative_WriteV(intptr_t fd, IOVector* vectors, int32_t vectorCount);


### PR DESCRIPTION
fixes #58381 