### PR TITLE
Move setting variables to HelixPreCommands

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -69,6 +69,13 @@
     <ArchiveTestsAfterTargets Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(TestSingleFile)' == 'true'" />
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
+                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                         $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
+    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
+    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
+  </ItemGroup>
+
   <!-- Archive test binaries. -->
   <Target Name="ArchiveTests"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true' and ('$(TargetsMobile)' != 'true' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(BuildTestsOnHelix)' == 'true')"

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -69,16 +69,6 @@
     <ArchiveTestsAfterTargets Condition="'$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(TestSingleFile)' == 'true'" />
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(IsXUnitLogCheckerSupported)' == 'true' and
-                        '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                         $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '$(NETCoreAppCurrentVersion)'))">
-    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __TestArchitecture=$(TargetArchitecture)" />
-    <SetScriptCommands Condition="'$(TargetOS)' == 'windows'" Include="set __IsXUnitLogCheckerSupported=1" />
-
-    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __TestArchitecture=$(TargetArchitecture)" />
-    <SetScriptCommands Condition="'$(TargetOS)' != 'windows'" Include="export __IsXUnitLogCheckerSupported=1" />
-  </ItemGroup>
-
   <!-- Archive test binaries. -->
   <Target Name="ArchiveTests"
           Condition="'$(ArchiveTests)' == 'true' and '$(IgnoreForCI)' != 'true' and ('$(TargetsMobile)' != 'true' or '$(TargetOS)' == 'browser' or '$(TargetOS)' == 'wasi' or '$(BuildTestsOnHelix)' == 'true')"

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -115,14 +115,6 @@
        setting up the per-scenario environment.
   -->
 
-  <ItemGroup Condition=" '$(TargetOS)' == 'windows' and '$(IsXUnitLogCheckerSupported)' == 'true' ">
-    <HelixPreCommand Include="set __IsXUnitLogCheckerSupported=1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetOS)' != 'windows' and '$(IsXUnitLogCheckerSupported)' == 'true' ">
-    <HelixPreCommand Include="export __IsXUnitLogCheckerSupported=1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetOS)' == 'windows' ">
     <HelixPreCommand Include="set __TestArchitecture=$(TargetArchitecture)" />
   </ItemGroup>

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -115,6 +115,22 @@
        setting up the per-scenario environment.
   -->
 
+  <ItemGroup Condition=" '$(TargetOS)' == 'windows' and '$(IsXUnitLogCheckerSupported)' == 'true' ">
+    <HelixPreCommand Include="set __IsXUnitLogCheckerSupported=1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetOS)' != 'windows' and '$(IsXUnitLogCheckerSupported)' == 'true' ">
+    <HelixPreCommand Include="export __IsXUnitLogCheckerSupported=1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetOS)' == 'windows' ">
+    <HelixPreCommand Include="set __TestArchitecture=$(TargetArchitecture)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetOS)' != 'windows' ">
+    <HelixPreCommand Include="export __TestArchitecture=$(TargetArchitecture)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TestEnvFileName)' != '' and '$(TargetOS)' == 'windows' ">
     <HelixPreCommand Include="set __TestEnv=%HELIX_CORRELATION_PAYLOAD%\$(TestEnvFileName)" />
     <HelixPreCommand Include="type %__TestEnv%" />

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -709,7 +709,7 @@
     <HelixPreCommand Include="export __TestCollectionTimeoutMins=$(TimeoutPerTestCollectionInMinutes)" Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' " />
     <HelixPreCommand Include="export __CollectDumps=1" />
     <HelixPreCommand Include="export __CrashDumpFolder=$HELIX_DUMP_FOLDER" />
-    <HelixPreCommand Include="set __TestArchitecture=$(TargetArchitecture)" />
+    <HelixPreCommand Include="export __TestArchitecture=$(TargetArchitecture)" />
     <HelixPreCommand Include="cat $__TestEnv" />
 
     <HelixPostCommand Include="find $HELIX_WORKITEM_PAYLOAD -name '*testResults.xml' -exec cp {} $HELIX_DUMP_FOLDER\; " />


### PR DESCRIPTION
Don't inject them in the generated RunTests.cmd script.

Namely, `__IsXUnitLogCheckerSupported=1` and `__TestArchitecture`.