### PR TITLE
Slightly improve profiled casts

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5366,7 +5366,7 @@ public:
     Statement* fgNewStmtFromTree(GenTree* tree, BasicBlock* block);
     Statement* fgNewStmtFromTree(GenTree* tree, const DebugInfo& di);
 
-    GenTree* fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst = nullptr);
+    GenTreeQmark* fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst = nullptr);
     bool fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt);
     bool fgExpandQmarkStmt(BasicBlock* block, Statement* stmt);
     void fgExpandQmarkNodes();

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9380,7 +9380,8 @@ GenTree* Compiler::gtCloneExpr(
 
             case GT_QMARK:
                 copy = new (this, GT_QMARK)
-                    GenTreeQmark(tree->TypeGet(), tree->AsOp()->gtGetOp1(), tree->AsOp()->gtGetOp2()->AsColon());
+                    GenTreeQmark(tree->TypeGet(), tree->AsOp()->gtGetOp1(), tree->AsOp()->gtGetOp2()->AsColon(),
+                                 tree->AsQmark()->ThenNodeLikelihood());
                 break;
 
             case GT_BLK:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5801,21 +5801,42 @@ struct GenTreeFptrVal : public GenTree
 /* gtQmark */
 struct GenTreeQmark : public GenTreeOp
 {
-    GenTreeQmark(var_types type, GenTree* cond, GenTreeColon* colon) : GenTreeOp(GT_QMARK, type, cond, colon)
+    unsigned gtThenLikelihood;
+
+    GenTreeQmark(var_types type, GenTree* cond, GenTreeColon* colon, unsigned thenLikelihood = 50)
+        : GenTreeOp(GT_QMARK, type, cond, colon), gtThenLikelihood(thenLikelihood)
     {
         // These must follow a specific form.
         assert((cond != nullptr) && cond->TypeIs(TYP_INT));
         assert((colon != nullptr) && colon->OperIs(GT_COLON));
     }
 
-    GenTree* ThenNode()
+    GenTree* ThenNode() const
     {
         return gtOp2->AsColon()->ThenNode();
     }
 
-    GenTree* ElseNode()
+    GenTree* ElseNode() const
     {
         return gtOp2->AsColon()->ElseNode();
+    }
+
+    unsigned ThenNodeLikelihood() const
+    {
+        assert(gtThenLikelihood <= 100);
+        return gtThenLikelihood;
+    }
+
+    unsigned ElseNodeLikelihood() const
+    {
+        assert(gtThenLikelihood <= 100);
+        return 100 - gtThenLikelihood;
+    }
+
+    void SetThenNodeLikelihood(unsigned thenLikelihood)
+    {
+        assert(thenLikelihood <= 100);
+        gtThenLikelihood = thenLikelihood;
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5514,7 +5514,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                 {
                     const char* className = eeGetClassName((CORINFO_CLASS_HANDLE)likelyClasses[i].handle);
                     JITDUMP("  %u) %p (%s) [likelihood:%u%%]\n", i + 1, likelyClasses[i].handle, className,
-                           likelyClasses[i].likelihood);
+                            likelyClasses[i].likelihood);
                 }
 
                 // Optional stress mode to pick a random known class, rather than

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5513,7 +5513,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                 for (UINT32 i = 0; i < likelyClassCount; i++)
                 {
                     const char* className = eeGetClassName((CORINFO_CLASS_HANDLE)likelyClasses[i].handle);
-                    printf("  %u) %p (%s) [likelihood:%u%%]\n", i + 1, likelyClasses[i].handle, className,
+                    JITDUMP("  %u) %p (%s) [likelihood:%u%%]\n", i + 1, likelyClasses[i].handle, className,
                            likelyClasses[i].likelihood);
                 }
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5514,7 +5514,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                 {
                     const char* className = eeGetClassName((CORINFO_CLASS_HANDLE)likelyClasses[i].handle);
                     printf("  %u) %p (%s) [likelihood:%u%%]\n", i + 1, likelyClasses[i].handle, className,
-                        likelyClasses[i].likelihood);
+                           likelyClasses[i].likelihood);
                 }
 
                 // Optional stress mode to pick a random known class, rather than
@@ -5559,11 +5559,11 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
                             JITDUMP("Adding \"is %s (%X)\" check as a fast path for %s using PGO data.\n",
                                     eeGetClassName(likelyCls), likelyCls, isCastClass ? "castclass" : "isinst");
 
-                            reversedMTCheck = castResult == TypeCompareState::MustNot;
-                            canExpandInline = true;
-                            partialExpand   = true;
-                            exactCls        = likelyCls;
-                            fastPathLikelihood= likelyClass.likelihood;
+                            reversedMTCheck    = castResult == TypeCompareState::MustNot;
+                            canExpandInline    = true;
+                            partialExpand      = true;
+                            exactCls           = likelyCls;
+                            fastPathLikelihood = likelyClass.likelihood;
                         }
                     }
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14517,22 +14517,22 @@ void Compiler::fgPostExpandQmarkChecks()
 // Returns:
 //    The GT_QMARK node, or nullptr if there is no top level qmark.
 //
-GenTree* Compiler::fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst /* = NULL */)
+GenTreeQmark* Compiler::fgGetTopLevelQmark(GenTree* expr, GenTree** ppDst /* = NULL */)
 {
     if (ppDst != nullptr)
     {
         *ppDst = nullptr;
     }
 
-    GenTree* topQmark = nullptr;
+    GenTreeQmark* topQmark = nullptr;
 
     if (expr->gtOper == GT_QMARK)
     {
-        topQmark = expr;
+        topQmark = expr->AsQmark();
     }
     else if (expr->OperIsLocalStore() && expr->AsLclVarCommon()->Data()->OperIs(GT_QMARK))
     {
-        topQmark = expr->AsLclVarCommon()->Data();
+        topQmark = expr->AsLclVarCommon()->Data()->AsQmark();
 
         if (ppDst != nullptr)
         {
@@ -14595,8 +14595,8 @@ bool Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
     bool     introducedThrow = false;
     GenTree* expr            = stmt->GetRootNode();
 
-    GenTree* dst   = nullptr;
-    GenTree* qmark = fgGetTopLevelQmark(expr, &dst);
+    GenTree*      dst   = nullptr;
+    GenTreeQmark* qmark = fgGetTopLevelQmark(expr, &dst);
 
     noway_assert(dst != nullptr);
     assert(dst->OperIsLocalStore());
@@ -14613,11 +14613,13 @@ bool Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
     GenTree* true2Expr;
     GenTree* false2Expr;
 
+    unsigned nestedQmarkElseLikelihood = 50;
     if (nestedQmark->gtOper == GT_QMARK)
     {
-        cond2Expr  = nestedQmark->gtGetOp1();
-        true2Expr  = nestedQmark->gtGetOp2()->AsColon()->ThenNode();
-        false2Expr = nestedQmark->gtGetOp2()->AsColon()->ElseNode();
+        cond2Expr                 = nestedQmark->gtGetOp1();
+        true2Expr                 = nestedQmark->gtGetOp2()->AsColon()->ThenNode();
+        false2Expr                = nestedQmark->gtGetOp2()->AsColon()->ElseNode();
+        nestedQmarkElseLikelihood = nestedQmark->AsQmark()->ElseNodeLikelihood();
     }
     else
     {
@@ -14688,8 +14690,26 @@ bool Compiler::fgExpandQmarkForCastInstOf(BasicBlock* block, Statement* stmt)
     // Set the weights; some are guesses.
     asgBlock->inheritWeight(block);
     cond1Block->inheritWeight(block);
+
+    // We only have likelihood for the fast path (and fallback), but we don't know
+    // how often we have null in the root QMARK (although, we might be able to guess it too)
+    // so leave 50/50 for now. Thus, we have:
+    //
+    //   [weight 1.0]
+    //   if (obj != null)
+    //   {
+    //       [weight 0.5]
+    //       if (obj.GetType() == typeof(FastType))
+    //       {
+    //           [weight 0.5 * <likelihood of FastType>]
+    //       }
+    //       else
+    //       {
+    //           [weight 0.5 * <100 - likelihood of FastType>]
+    //       }
+    //
     cond2Block->inheritWeightPercentage(cond1Block, 50);
-    helperBlock->inheritWeightPercentage(cond2Block, 50);
+    helperBlock->inheritWeightPercentage(cond2Block, nestedQmarkElseLikelihood);
 
     // Append cond1 as JTRUE to cond1Block
     GenTree*   jmpTree = gtNewOperNode(GT_JTRUE, TYP_VOID, condExpr);
@@ -14812,8 +14832,8 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     GenTree* expr            = stmt->GetRootNode();
 
     // Retrieve the Qmark node to be expanded.
-    GenTree* dst   = nullptr;
-    GenTree* qmark = fgGetTopLevelQmark(expr, &dst);
+    GenTree*      dst   = nullptr;
+    GenTreeQmark* qmark = fgGetTopLevelQmark(expr, &dst);
     if (qmark == nullptr)
     {
         return false;
@@ -14874,6 +14894,9 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
 
     condBlock->inheritWeight(block);
 
+    // Make sure remainderBlock gets exactly the same weight as block after split
+    assert(condBlock->bbWeight == remainderBlock->bbWeight);
+
     assert(block->KindIs(BBJ_ALWAYS));
     block->SetTarget(condBlock);
     condBlock->SetTarget(elseBlock);
@@ -14913,8 +14936,8 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         fgAddRefPred(thenBlock, condBlock);
         fgAddRefPred(remainderBlock, thenBlock);
 
-        thenBlock->inheritWeightPercentage(condBlock, 50);
-        elseBlock->inheritWeightPercentage(condBlock, 50);
+        thenBlock->inheritWeightPercentage(condBlock, qmark->ThenNodeLikelihood());
+        elseBlock->inheritWeightPercentage(condBlock, qmark->ElseNodeLikelihood());
     }
     else if (hasTrueExpr)
     {
@@ -14931,7 +14954,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         thenBlock = elseBlock;
         elseBlock = nullptr;
 
-        thenBlock->inheritWeightPercentage(condBlock, 50);
+        thenBlock->inheritWeightPercentage(condBlock, qmark->ThenNodeLikelihood());
     }
     else if (hasFalseExpr)
     {
@@ -14944,7 +14967,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
         condBlock->SetCond(remainderBlock, elseBlock);
         fgAddRefPred(remainderBlock, condBlock);
 
-        elseBlock->inheritWeightPercentage(condBlock, 50);
+        elseBlock->inheritWeightPercentage(condBlock, qmark->ElseNodeLikelihood());
     }
 
     assert(condBlock->KindIs(BBJ_COND));


### PR DESCRIPTION
This PR:
1) Changes the likelihood threshold, it used to be `(UINT32)JitConfig.JitGuardedDevirtualizationChainLikelihood()` (makes no sense) which is `75` and I changed it to `40` because any cast with two likelily classes won't be handed otherwise (50/50). It's based on our threshold for GDV for calls which is `20-30`, I just made it a bit more conservative since the benefit is smaller.

2) Adds ability to save weights (likelihoods) inside a Qmark.

Example:
```cs
for (int i = 0; i < 200; i++)
{
    Test(new Program());
    Thread.Sleep(10);
}


static void Test(object o)
{
    if (o is Program)
        Console.WriteLine();
}
```

```asm
; Assembly listing for method Program:Test(System.Object) (Tier1)
G_M3485_IG01:
       sub      rsp, 40
						;; size=4 bbWeight=1 PerfScore 0.25
G_M3485_IG02:
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M3485_IG04
						;; size=8 bbWeight=1 PerfScore 1.50
G_M3485_IG03:
       mov      rdx, 0xD1FFAB1E      ; Program
       cmp      qword ptr [rax], rdx
       jne      SHORT G_M3485_IG07
						;; size=15 bbWeight=0.50 PerfScore 2.12
G_M3485_IG04:
       test     rax, rax
       je       SHORT G_M3485_IG05
       call     [System.Console:WriteLine()]
						;; size=11 bbWeight=1 PerfScore 4.25
G_M3485_IG05:
       nop      
						;; size=1 bbWeight=1 PerfScore 0.25
G_M3485_IG06:
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25
G_M3485_IG07:
       mov      rdx, rcx
       mov      rcx, 0xD1FFAB1E      ; Program
       call     CORINFO_HELP_ISINSTANCEOFCLASS
       jmp      SHORT G_M3485_IG04
						;; size=20 bbWeight=0 PerfScore 0.00

; Total bytes of code 64
```
`CORINFO_HELP_ISINSTANCEOFCLASS` is now a cold block (because our profile is monomorphic)