### PR TITLE
FIX ConfigurationBinder resets sub objects stored in dictionaries

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -428,8 +428,9 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
-                if (isParentCollection)
+                if (isParentCollection && bindingPoint.Value is null)
                 {
+                    // If we don't have an instance, try to create one
                     bindingPoint.TrySetValue(CreateInstance(type, config, options));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -724,6 +724,40 @@ namespace Microsoft.Extensions
         }
 
         [Fact]
+        public void ObjectDictionaryWithHarcodedElements()
+        {
+            var input = new Dictionary<string, string>
+            {
+                {"ObjectDictionary:abc:Integer", "1"},
+                {"ObjectDictionary:def", "null"},
+                {"ObjectDictionary:ghi", "null"}
+            };
+
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(input);
+            var config = configurationBuilder.Build();
+
+            var options = new OptionsWithDictionary();
+            options.ObjectDictionary = new()
+            {
+                {"abc", new(){ Integer = 42}},
+                {"def", new(){ Integer = 42}},
+            };
+
+            Assert.Equal(2, options.ObjectDictionary.Count);
+            Assert.Equal(42, options.ObjectDictionary["abc"].Integer);
+            Assert.Equal(42, options.ObjectDictionary["def"].Integer);
+
+            config.Bind(options);
+
+            Assert.Equal(3, options.ObjectDictionary.Count);
+
+            Assert.Equal(1, options.ObjectDictionary["abc"].Integer);
+            Assert.Equal(42, options.ObjectDictionary["def"].Integer);
+            Assert.Equal(0, options.ObjectDictionary["ghi"].Integer);
+        }
+
+        [Fact]
         public void ListDictionary()
         {
             var input = new Dictionary<string, string>


### PR DESCRIPTION
fixes #96682
