### PR TITLE
Do not generate reflectable `sealed` methods as virtual

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedMethodNode.cs
@@ -68,7 +68,7 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     else
                     {
-                        if (!factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
+                        if (ReflectionVirtualInvokeMapNode.NeedsVirtualInvokeInfo(slotDefiningMethod) && !factory.VTable(slotDefiningMethod.OwningType).HasFixedSlots)
                             dependencies.Add(factory.VirtualMethodUse(slotDefiningMethod), "Virtually callable reflectable method");
                     }
                 }


### PR DESCRIPTION
Noticed this while working on #96672. There are two ways how virtual method can be referred to: as a direct reference to the method body (i.e. non-virtually), or as a reference to a particular slot number (virtually). When we mark a virtual method as visible by reflection, it typically means “virtually visible to reflection” (one can invoke the method with a random derived `this` so the invoke happens through the slot).

But we still try to optimize this into a direct reference if possible so that we don’t waste an extra slot. This is possible for final methods, or methods on sealed classes for example. The marking in dependency graph didn’t take into account this optimization – it was creating an unnecessary virtual slot for reflection-visible final methods that then went unused. With this half of the diff in #96672 is technically not necessary (we no longer end up with the new virtual method in the vtable), but that fix is still a correct fix.

Cc @dotnet/ilc-contrib 