### PR TITLE
Fix assertion at System.Numerics.BigInteger.Parse

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -602,6 +602,12 @@ namespace System
 
                 Debug.Assert(partialDigitCount == 0 && bufferPos == -1);
 
+                if (isNegative)
+                {
+                    NumericsHelpers.DangerousMakeTwosComplement(buffer);
+                }
+
+                // BigInteger requires leading zero blocks to be truncated.
                 buffer = buffer.TrimEnd(0u);
 
                 int sign;
@@ -612,26 +618,15 @@ namespace System
                     sign = 0;
                     bits = null;
                 }
-                else if (buffer.Length == 1)
+                else if (buffer.Length == 1 && buffer[0] <= int.MaxValue)
                 {
-                    sign = (int)buffer[0];
+                    sign = (int)buffer[0] * (isNegative ? -1 : 1);
                     bits = null;
-
-                    if ((!isNegative && sign < 0) || sign == int.MinValue)
-                    {
-                        bits = new[] { (uint)sign };
-                        sign = isNegative ? -1 : 1;
-                    }
                 }
                 else
                 {
                     sign = isNegative ? -1 : 1;
                     bits = buffer.ToArray();
-
-                    if (isNegative)
-                    {
-                        NumericsHelpers.DangerousMakeTwosComplement(bits);
-                    }
                 }
 
                 result = new BigInteger(sign, bits);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -680,6 +680,11 @@ namespace System.Numerics
 
         public static bool TryParse([NotNullWhen(true)] string? value, NumberStyles style, IFormatProvider? provider, out BigInteger result)
         {
+            if (value is null)
+            {
+                result = 0;
+                return false;
+            }
             return TryParse(value.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out result);
         }
 

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/parse.cs
@@ -129,6 +129,12 @@ namespace System.Numerics.Tests
         [Fact]
         public void Parse_Hex32Bits()
         {
+            // SimpleNumbers - 0xF
+            for (int i = 1; i < 2 * BigInteger.kcbitUint + 2; i++)
+            {
+                VerifyParseToString(new string('F', i), NumberStyles.HexNumber, true);
+            }
+
             // Regression test for: https://github.com/dotnet/runtime/issues/54251
             BigInteger result;
 
@@ -341,6 +347,18 @@ namespace System.Numerics.Tests
             VerifyParseToString("000", ns, true);
             VerifyParseToString("1", ns, true);
             VerifyParseToString("001", ns, true);
+
+            // SimpleNumbers - Zero
+            for (int i = 1; i < 2 * BigInteger.kcbitUint + 2; i++)
+            {
+                VerifyParseToString(new string('0', i), ns, true);
+            }
+
+            // SimpleNumbers - One
+            for (int i = 1; i < 2 * BigInteger.kcbitUint + 2; i++)
+            {
+                VerifyParseToString(new string('1', i), ns, true);
+            }
 
             // SimpleNumbers - Small
             for (int i = 0; i < s_samples; i++)


### PR DESCRIPTION
I fixed the following assertions.

- ~~`BigInteger.Parse(new string('1',33))`~~
  - ~~I changed buffer reading in `TryParseBigIntegerBinaryNumberStyle` to be the same as in `TryParseBigIntegerHexNumberStyle`.~~
- `BigInteger.TryParse(null, out _)`
  - null check