### PR TITLE
SPMI: Unindent jit-analysis header output

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2590,12 +2590,12 @@ class SuperPMIReplayAsmDiffs:
                         with open(jit_analyze_summary_file, "r") as read_fh:
                             with DetailsSection(write_fh, mch_file):
                                 write_fh.write("""\
-    To reproduce these diffs on Windows {0}:
-    ```
-    superpmi.py asmdiffs -target_os {1} -target_arch {2} -arch {0}
-    ```
+To reproduce these diffs on Windows {0}:
+```
+superpmi.py asmdiffs -target_os {1} -target_arch {2} -arch {0}
+```
 
-    """.format(self.coreclr_args.arch, self.coreclr_args.target_os, self.coreclr_args.target_arch))
+""".format(self.coreclr_args.arch, self.coreclr_args.target_os, self.coreclr_args.target_arch))
 
                                 shutil.copyfileobj(read_fh, write_fh)
 

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2589,13 +2589,10 @@ class SuperPMIReplayAsmDiffs:
 
                         with open(jit_analyze_summary_file, "r") as read_fh:
                             with DetailsSection(write_fh, mch_file):
-                                write_fh.write("""\
-To reproduce these diffs on Windows {0}:
-```
-superpmi.py asmdiffs -target_os {1} -target_arch {2} -arch {0}
-```
-
-""".format(self.coreclr_args.arch, self.coreclr_args.target_os, self.coreclr_args.target_arch))
+                                write_fh.write("To reproduce these diffs on Windows {0}:\n".format(self.coreclr_args.arch))
+                                write_fh.write("```\n")
+                                write_fh.write("superpmi.py asmdiffs -target_os {0} -target_arch {1} -arch {2}\n".format(self.coreclr_args.target_os, self.coreclr_args.target_arch, self.coreclr_args.arch))
+                                write_fh.write("```\n\n")
 
                                 shutil.copyfileobj(read_fh, write_fh)
 


### PR DESCRIPTION
Accidental change in #96637. The indentation makes it render as

<details>
<summary>Image</summary>

![image](https://github.com/dotnet/runtime/assets/7887810/e0bac57d-b2d8-4cc1-a9d2-10e9026e701b)

</details>