### PR TITLE
JIT: Canonicalize newly recognized loops

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5981,7 +5981,7 @@ public:
 
     PhaseStatus fgCanonicalizeFirstBB();
 
-    void fgSetEHRegionForNewLoopHead(BasicBlock* newHead, BasicBlock* top);
+    void fgSetEHRegionForNewPreheader(BasicBlock* preheader);
 
     void fgUnreachableBlock(BasicBlock* block);
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4787,12 +4787,6 @@ void Compiler::fgDebugCheckLoopTable()
     {
         for (FlowGraphNaturalLoop* loop : m_loops->InReversePostOrder())
         {
-            // TODO-Quirk: Remove
-            if (!loop->GetHeader()->HasFlag(BBF_OLD_LOOP_HEADER_QUIRK))
-            {
-                continue;
-            }
-
             assert(loop->EntryEdges().size() == 1);
             assert(loop->EntryEdge(0)->getSourceBlock()->KindIs(BBJ_ALWAYS));
         }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4927,12 +4927,6 @@ bool Compiler::optCanonicalizeLoops(FlowGraphNaturalLoops* loops)
     bool changed = false;
     for (FlowGraphNaturalLoop* loop : loops->InReversePostOrder())
     {
-        // TODO-Quirk: Remove
-        if (!loop->GetHeader()->HasFlag(BBF_OLD_LOOP_HEADER_QUIRK))
-        {
-            continue;
-        }
-
         changed |= optCreatePreheader(loop);
     }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -7421,8 +7421,8 @@ bool Compiler::optVNIsLoopInvariant(ValueNum vn, FlowGraphNaturalLoop* loop, VNS
 }
 
 //------------------------------------------------------------------------------
-// fgSetPreheaderEHRegionForTryBeginLoopHeader: Set the EH region correctly for a
-// preheader inserted before a header that is the start of a try-region.
+// fgSetEHRegionForNewPreheader: Set the EH region for a newly inserted
+// preheader.
 //
 // In which EH region should the header live?
 //
@@ -7432,7 +7432,7 @@ bool Compiler::optVNIsLoopInvariant(ValueNum vn, FlowGraphNaturalLoop* loop, VNS
 // header itself.
 //
 // If the `next` block is NOT the first block of a `try` region, the preheader
-// can simply extend the header's block region.
+// can simply extend the header block's EH region.
 //
 // If the `next` block IS the first block of a `try`, we find its parent region
 // and use that. For mutual-protect regions, we need to find the actual parent,


### PR DESCRIPTION
Create preheaders for all loops, not just loops recognized by old loop finding. Requires adding support for creating preheaders when the loop header is the beginning of a handler block, which requires updating the EH table (so we switch to `fgExtendEHRegionBefore`).