### PR TITLE
JIT: Clone newly recognized loops

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -3010,12 +3010,6 @@ bool Compiler::optObtainLoopCloningOpts(LoopCloneContext* context)
     bool result = false;
     for (FlowGraphNaturalLoop* loop : m_loops->InReversePostOrder())
     {
-        // TODO-Quirk: Remove
-        if (!loop->GetHeader()->HasFlag(BBF_OLD_LOOP_HEADER_QUIRK))
-        {
-            continue;
-        }
-
         JITDUMP("Considering loop " FMT_LP " to clone for optimizations.\n", loop->GetIndex());
         NaturalLoopIterInfo iterInfo;
         if (loop->AnalyzeIteration(&iterInfo))


### PR DESCRIPTION
On our win-x64 collections this leads to around 800 more cloned loops (base: 24925, diff: 25775).