### PR TITLE
STJ/JsonPropertyDictionary: eagerly initialize _propertyDictionary if known capacity

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -35,7 +35,7 @@ namespace System.Text.Json
                 _propertyDictionary = new(capacity, _stringComparer);
             }
 
-            _propertyList = new (capacity);
+            _propertyList = new(capacity);
         }
 
         // Enable direct access to the List for performance reasons.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonPropertyDictionary.cs
@@ -29,7 +29,13 @@ namespace System.Text.Json
         public JsonPropertyDictionary(bool caseInsensitive, int capacity)
         {
             _stringComparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-            _propertyList = new List<KeyValuePair<string, T>>(capacity);
+
+            if (capacity > ListToDictionaryThreshold)
+            {
+                _propertyDictionary = new(capacity, _stringComparer);
+            }
+
+            _propertyList = new (capacity);
         }
 
         // Enable direct access to the List for performance reasons.


### PR DESCRIPTION
In cases where the caller knows the desired capacity, and that capacity is greater than the `ListToDictionaryThreshold`, we can avoid paying the penalty of having to instantiate the `_propertyList` _and then_ having to initialize  `_propertyDictionary` _as well_. 

Because that operation (`CreateDictionaryIfThresholdMet`) is using `CreateDictionaryFromCollection`, in .NET Core and later, it will be initialized with a capacity equivalent to the collection length passed into it (I believe), which will always be `ListToDictionaryThreshold + 1`. Which means, if the known desired capacity is larger than that, we would then likely undergo an immediate resize operation (or multiple consecutive resize operations if the desired number of elements is large enough, say 50 or something like that) as all the elements are added to `JsonPropertyDictionary`. The case is even worse for targets lower than .NET  Core (e.g. net462) because the dictionary is always initialized as empty, which result in (potentially) more resize operations.