### PR TITLE
[mono] Fix a crash in mono_jit_info_table_foreach_internal ().

### DIFF
--- a/src/mono/mono/metadata/jit-info.c
+++ b/src/mono/mono/metadata/jit-info.c
@@ -62,6 +62,7 @@ static mono_mutex_t jit_info_mutex;
 
 #define JIT_INFO_TABLE_HAZARD_INDEX		0
 #define JIT_INFO_HAZARD_INDEX			1
+#define FOREACH_TABLE_HAZARD_INDEX		2
 
 static inline void
 jit_info_lock (void)
@@ -343,10 +344,15 @@ mono_jit_info_table_foreach_internal (MonoJitInfoFunc func, gpointer user_data)
 	MonoJitInfo *ji;
 	MonoThreadHazardPointers *hp = mono_hazard_pointer_get ();
 
-	table = (MonoJitInfoTable *)mono_get_hazardous_pointer ((gpointer volatile*)&jit_info_table, hp, JIT_INFO_TABLE_HAZARD_INDEX);
+	/*
+	 * The callback could end up calling code which use the same hazard table indexes as JIT_INFO_TABLE_HAZARD_INDEX, so use
+	 * a different one as a workaround.
+	 */
+	table = (MonoJitInfoTable *)mono_get_hazardous_pointer ((gpointer volatile*)&jit_info_table, hp, FOREACH_TABLE_HAZARD_INDEX);
 	if (table) {
 		for (int chunk_index = 0; chunk_index < table->num_chunks; ++chunk_index) {
 			MonoJitInfoTableChunk *chunk = table->chunks [chunk_index];
+			g_assert (chunk);
 			for (int jit_info_index = 0; jit_info_index < chunk->num_elements; ++jit_info_index) {
 
 				ji = (MonoJitInfo *)mono_get_hazardous_pointer ((gpointer volatile*)&chunk->data [jit_info_index], hp, JIT_INFO_HAZARD_INDEX);
@@ -360,7 +366,7 @@ mono_jit_info_table_foreach_internal (MonoJitInfoFunc func, gpointer user_data)
 	}
 
 	if (hp)
-		mono_hazard_pointer_clear (hp, JIT_INFO_TABLE_HAZARD_INDEX);
+		mono_hazard_pointer_clear (hp, FOREACH_TABLE_HAZARD_INDEX);
 }
 
 static G_GNUC_UNUSED void


### PR DESCRIPTION
The crash can happen if another thread was resizing the jit info table while the eventpipe thread was iterating it. The hazard pointer used to keep the table alive was also used by some runtime code which was called from the foreach callback i.e. from fire_method_events ().

As a workaround, use a different hazard pointer index which is not used by other runtime code right now.