### PR TITLE
[QUIC] Call silent shutdown in case `CloseAsync` failed.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs
@@ -105,9 +105,7 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
                 _state = State.Awaiting;
             }
             // None, Ready, Completed: return the current task.
-            if (state == State.None ||
-                state == State.Ready ||
-                state == State.Completed)
+            if (state is State.None or State.Ready or State.Completed)
             {
                 // Remember that the value task with the current version is being given out.
                 _hasWaiter = true;
@@ -167,8 +165,7 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
 
                 // If the _valueTaskSource has already been set, we don't want to lose the result by overwriting it.
                 // So keep it as is and store the result in _finalTaskSource.
-                if (state == State.None ||
-                    state == State.Awaiting)
+                if (state is State.None or State.Awaiting)
                 {
                     _state = final ? State.Completed : State.Ready;
                 }
@@ -178,16 +175,14 @@ internal sealed class ResettableValueTaskSource : IValueTaskSource
                 {
                     // Set up the exception stack trace for the caller.
                     exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
-                    if (state == State.None ||
-                        state == State.Awaiting)
+                    if (state is State.None or State.Awaiting)
                     {
                         _valueTaskSource.SetException(exception);
                     }
                 }
                 else
                 {
-                    if (state == State.None ||
-                        state == State.Awaiting)
+                    if (state is State.None or State.Awaiting)
                     {
                         _valueTaskSource.SetResult(final);
                     }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
@@ -25,6 +25,7 @@ internal sealed class ValueTaskSource : IValueTaskSource
     private State _state;
     private ManualResetValueTaskSourceCore<bool> _valueTaskSource;
     private CancellationTokenRegistration _cancellationRegistration;
+    private Exception? _exception;
     private GCHandle _keepAlive;
 
     public ValueTaskSource()
@@ -32,6 +33,7 @@ internal sealed class ValueTaskSource : IValueTaskSource
         _state = State.None;
         _valueTaskSource = new ManualResetValueTaskSourceCore<bool>() { RunContinuationsAsynchronously = true };
         _cancellationRegistration = default;
+        _exception = default;
         _keepAlive = default;
     }
 
@@ -75,7 +77,7 @@ internal sealed class ValueTaskSource : IValueTaskSource
             State state = _state;
 
             // If we're the first here, we will return true.
-            if (state == State.None)
+            if (state == State.None && _valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
             {
                 // Keep alive the caller object until the result is read from the task.
                 // Used for keeping caller alive during async interop calls.
@@ -104,30 +106,42 @@ internal sealed class ValueTaskSource : IValueTaskSource
                 {
                     State state = _state;
 
-                    if (state != State.Completed)
+                    // Completed: nothing to do.
+                    if (state == State.Completed)
                     {
-                        _state = State.Completed;
+                        return false;
+                    }
 
-                        // Swap the cancellation registration so the one that's been registered gets eventually Disposed.
-                        // Ideally, we would dispose it here, but if the callbacks kicks in, it tries to take the lock held by this thread leading to deadlock.
-                        cancellationRegistration = _cancellationRegistration;
-                        _cancellationRegistration = default;
+                    // With cancellation, keep the state as-is so it can be restored after the OCE is consumed.
+                    _state = exception is OperationCanceledException ? state : State.Completed;
 
-                        if (exception is not null)
+                    // Swap the cancellation registration so the one that's been registered gets eventually Disposed.
+                    // Ideally, we would dispose it here, but if the callbacks kicks in, it tries to take the lock held by this thread leading to deadlock.
+                    cancellationRegistration = _cancellationRegistration;
+                    _cancellationRegistration = default;
+
+                    if (exception is not null)
+                    {
+                        // Set up the exception stack trace for the caller.
+                        exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
+                        if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
                         {
-                            // Set up the exception stack trace for the caller.
-                            exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
                             _valueTaskSource.SetException(exception);
                         }
-                        else
+                        else if (exception is not OperationCanceledException)
+                        {
+                            _exception = exception;
+                        }
+                    }
+                    else
+                    {
+                        if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
                         {
                             _valueTaskSource.SetResult(true);
                         }
-
-                        return true;
                     }
 
-                    return false;
+                    return true;
                 }
                 finally
                 {
@@ -173,5 +187,34 @@ internal sealed class ValueTaskSource : IValueTaskSource
         => _valueTaskSource.OnCompleted(continuation, state, token, flags);
 
     void IValueTaskSource.GetResult(short token)
-        => _valueTaskSource.GetResult(token);
+    {
+        try
+        {
+            _valueTaskSource.GetResult(token);
+        }
+        finally
+        {
+            lock (this)
+            {
+                State state = _state;
+
+                // In case of a cancellation, reset the task and set the stored results if necessary.
+                if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Canceled)
+                {
+                    _valueTaskSource.Reset();
+                    if (state == State.Completed)
+                    {
+                        if (_exception is not null)
+                        {
+                            _valueTaskSource.SetException(_exception);
+                        }
+                        else
+                        {
+                            _valueTaskSource.SetResult(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ValueTaskSource.cs
@@ -25,7 +25,6 @@ internal sealed class ValueTaskSource : IValueTaskSource
     private State _state;
     private ManualResetValueTaskSourceCore<bool> _valueTaskSource;
     private CancellationTokenRegistration _cancellationRegistration;
-    private Exception? _exception;
     private GCHandle _keepAlive;
 
     public ValueTaskSource()
@@ -33,7 +32,6 @@ internal sealed class ValueTaskSource : IValueTaskSource
         _state = State.None;
         _valueTaskSource = new ManualResetValueTaskSourceCore<bool>() { RunContinuationsAsynchronously = true };
         _cancellationRegistration = default;
-        _exception = default;
         _keepAlive = default;
     }
 
@@ -77,7 +75,7 @@ internal sealed class ValueTaskSource : IValueTaskSource
             State state = _state;
 
             // If we're the first here, we will return true.
-            if (state == State.None && _valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
+            if (state == State.None)
             {
                 // Keep alive the caller object until the result is read from the task.
                 // Used for keeping caller alive during async interop calls.
@@ -106,42 +104,30 @@ internal sealed class ValueTaskSource : IValueTaskSource
                 {
                     State state = _state;
 
-                    // Completed: nothing to do.
-                    if (state == State.Completed)
+                    if (state != State.Completed)
                     {
-                        return false;
-                    }
+                        _state = State.Completed;
 
-                    // With cancellation, keep the state as-is so it can be restored after the OCE is consumed.
-                    _state = exception is OperationCanceledException ? state : State.Completed;
+                        // Swap the cancellation registration so the one that's been registered gets eventually Disposed.
+                        // Ideally, we would dispose it here, but if the callbacks kicks in, it tries to take the lock held by this thread leading to deadlock.
+                        cancellationRegistration = _cancellationRegistration;
+                        _cancellationRegistration = default;
 
-                    // Swap the cancellation registration so the one that's been registered gets eventually Disposed.
-                    // Ideally, we would dispose it here, but if the callbacks kicks in, it tries to take the lock held by this thread leading to deadlock.
-                    cancellationRegistration = _cancellationRegistration;
-                    _cancellationRegistration = default;
-
-                    if (exception is not null)
-                    {
-                        // Set up the exception stack trace for the caller.
-                        exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
-                        if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
+                        if (exception is not null)
                         {
+                            // Set up the exception stack trace for the caller.
+                            exception = exception.StackTrace is null ? ExceptionDispatchInfo.SetCurrentStackTrace(exception) : exception;
                             _valueTaskSource.SetException(exception);
                         }
-                        else if (exception is not OperationCanceledException)
-                        {
-                            _exception = exception;
-                        }
-                    }
-                    else
-                    {
-                        if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Pending)
+                        else
                         {
                             _valueTaskSource.SetResult(true);
                         }
+
+                        return true;
                     }
 
-                    return true;
+                    return false;
                 }
                 finally
                 {
@@ -187,34 +173,5 @@ internal sealed class ValueTaskSource : IValueTaskSource
         => _valueTaskSource.OnCompleted(continuation, state, token, flags);
 
     void IValueTaskSource.GetResult(short token)
-    {
-        try
-        {
-            _valueTaskSource.GetResult(token);
-        }
-        finally
-        {
-            lock (this)
-            {
-                State state = _state;
-
-                // In case of a cancellation, reset the task and set the stored results if necessary.
-                if (_valueTaskSource.GetStatus(_valueTaskSource.Version) == ValueTaskSourceStatus.Canceled)
-                {
-                    _valueTaskSource.Reset();
-                    if (state == State.Completed)
-                    {
-                        if (_exception is not null)
-                        {
-                            _valueTaskSource.SetException(_exception);
-                        }
-                        else
-                        {
-                            _valueTaskSource.SetResult(true);
-                        }
-                    }
-                }
-            }
-        }
-    }
+        => _valueTaskSource.GetResult(token);
 }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -539,7 +539,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _acceptQueue.Writer.TryComplete(exception);
         _connectedTcs.TrySetException(exception);
         _shutdownTokenSource.Cancel();
-        _shutdownTcs.TrySetResult();
+        _shutdownTcs.TrySetResult(final: true);
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventLocalAddressChanged(ref LOCAL_ADDRESS_CHANGED_DATA data)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -636,6 +636,16 @@ public sealed partial class QuicConnection : IAsyncDisposable
                     (ulong)_defaultCloseErrorCode);
             }
         }
+        else if (!valueTask.IsCompletedSuccessfully)
+        {
+            unsafe
+            {
+                MsQuicApi.Api.ConnectionShutdown(
+                    _handle,
+                    QUIC_CONNECTION_SHUTDOWN_FLAGS.SILENT,
+                    (ulong)_defaultCloseErrorCode);
+            }
+        }
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
         await valueTask.ConfigureAwait(false);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -109,21 +109,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     private int _disposed;
 
     private readonly ValueTaskSource _connectedTcs = new ValueTaskSource();
-
     private TaskCompletionSource? _shutdownTcs;
-
-    private bool InitializeShutdownTcs(out TaskCompletionSource shutdownTcs)
-    {
-        if (_shutdownTcs is not null)
-        {
-            shutdownTcs = _shutdownTcs;
-            return false;
-        }
-
-        TaskCompletionSource? original = Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
-        shutdownTcs = _shutdownTcs;
-        return original is null;
-    }
 
     private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 
@@ -481,7 +467,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
-        if (InitializeShutdownTcs(out TaskCompletionSource shutdownTcs))
+        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
         {
             unsafe
             {
@@ -492,7 +478,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             }
         }
 
-        return new ValueTask(shutdownTcs.Task.WaitAsync(cancellationToken));
+        return new ValueTask(_shutdownTcs.Task.WaitAsync(cancellationToken));
     }
 
     private unsafe int HandleEventConnected(ref CONNECTED_DATA data)
@@ -534,8 +520,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _acceptQueue.Writer.TryComplete(exception);
         _connectedTcs.TrySetException(exception);
         _shutdownTokenSource.Cancel();
-        InitializeShutdownTcs(out TaskCompletionSource shutdownTcs);
-        shutdownTcs.TrySetResult();
+        Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
+        _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventLocalAddressChanged(ref LOCAL_ADDRESS_CHANGED_DATA data)
@@ -641,7 +627,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Check if the connection has been shut down and if not, shut it down.
-        if (InitializeShutdownTcs(out TaskCompletionSource shutdownTcs))
+        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
         {
             unsafe
             {
@@ -651,7 +637,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
                     (ulong)_defaultCloseErrorCode);
             }
         }
-        else if (!shutdownTcs.Task.IsCompletedSuccessfully)
+        else if (!_shutdownTcs.Task.IsCompletedSuccessfully)
         {
             unsafe
             {
@@ -663,7 +649,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
-        await shutdownTcs.Task.ConfigureAwait(false);
+        await _shutdownTcs.Task.ConfigureAwait(false);
         Debug.Assert(_connectedTcs.IsCompleted);
         _handle.Dispose();
         _shutdownTokenSource.Dispose();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -109,7 +109,26 @@ public sealed partial class QuicConnection : IAsyncDisposable
     private int _disposed;
 
     private readonly ValueTaskSource _connectedTcs = new ValueTaskSource();
-    private readonly ValueTaskSource _shutdownTcs = new ValueTaskSource();
+    private readonly ResettableValueTaskSource _shutdownTcs = new ResettableValueTaskSource()
+    {
+        CancellationAction = target =>
+        {
+            try
+            {
+                if (target is QuicConnection connection)
+                {
+                    // The OCE will be propagated through stored CancellationToken in ResettableValueTaskSource.
+                    connection._shutdownTcs.TrySetResult();
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // We collided with a Dispose in another thread. This can happen
+                // when using CancellationTokenSource.CancelAfter.
+                // Ignore the exception
+            }
+        }
+    };
 
     private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 
@@ -467,7 +486,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
-        if (_shutdownTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken))
+        if (_shutdownTcs.TryGetValueTask(out ValueTask valueTask, this, cancellationToken))
         {
             unsafe
             {
@@ -626,7 +645,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Check if the connection has been shut down and if not, shut it down.
-        if (_shutdownTcs.TryInitialize(out ValueTask valueTask, this))
+        if (_shutdownTcs.TryGetValueTask(out ValueTask valueTask, this))
         {
             unsafe
             {
@@ -648,7 +667,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
-        await valueTask.ConfigureAwait(false);
+        await _shutdownTcs.GetFinalTask(this).ConfigureAwait(false);
         Debug.Assert(_connectedTcs.IsCompleted);
         _handle.Dispose();
         _shutdownTokenSource.Dispose();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -109,7 +109,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     private int _disposed;
 
     private readonly ValueTaskSource _connectedTcs = new ValueTaskSource();
-    private TaskCompletionSource? _shutdownTcs;
+    private readonly ValueTaskSource _shutdownTcs = new ValueTaskSource();
 
     private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 
@@ -467,7 +467,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
-        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
+        if (_shutdownTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken))
         {
             unsafe
             {
@@ -478,7 +478,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             }
         }
 
-        return new ValueTask(_shutdownTcs.Task.WaitAsync(cancellationToken));
+        return valueTask;
     }
 
     private unsafe int HandleEventConnected(ref CONNECTED_DATA data)
@@ -520,7 +520,6 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _acceptQueue.Writer.TryComplete(exception);
         _connectedTcs.TrySetException(exception);
         _shutdownTokenSource.Cancel();
-        Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
         _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }
@@ -627,7 +626,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Check if the connection has been shut down and if not, shut it down.
-        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
+        if (_shutdownTcs.TryInitialize(out ValueTask valueTask, this))
         {
             unsafe
             {
@@ -637,7 +636,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
                     (ulong)_defaultCloseErrorCode);
             }
         }
-        else if (!_shutdownTcs.Task.IsCompletedSuccessfully)
+        else if (!valueTask.IsCompletedSuccessfully)
         {
             unsafe
             {
@@ -649,7 +648,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
-        await _shutdownTcs.Task.ConfigureAwait(false);
+        await valueTask.ConfigureAwait(false);
         Debug.Assert(_connectedTcs.IsCompleted);
         _handle.Dispose();
         _shutdownTokenSource.Dispose();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -109,7 +109,21 @@ public sealed partial class QuicConnection : IAsyncDisposable
     private int _disposed;
 
     private readonly ValueTaskSource _connectedTcs = new ValueTaskSource();
+
     private TaskCompletionSource? _shutdownTcs;
+
+    private bool InitializeShutdownTcs(out TaskCompletionSource shutdownTcs)
+    {
+        if (_shutdownTcs is not null)
+        {
+            shutdownTcs = _shutdownTcs;
+            return false;
+        }
+
+        TaskCompletionSource? original = Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
+        shutdownTcs = _shutdownTcs;
+        return original is null;
+    }
 
     private readonly CancellationTokenSource _shutdownTokenSource = new CancellationTokenSource();
 
@@ -467,7 +481,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed == 1, this);
 
-        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
+        if (InitializeShutdownTcs(out TaskCompletionSource shutdownTcs))
         {
             unsafe
             {
@@ -478,7 +492,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             }
         }
 
-        return new ValueTask(_shutdownTcs.Task.WaitAsync(cancellationToken));
+        return new ValueTask(shutdownTcs.Task.WaitAsync(cancellationToken));
     }
 
     private unsafe int HandleEventConnected(ref CONNECTED_DATA data)
@@ -520,8 +534,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
         _acceptQueue.Writer.TryComplete(exception);
         _connectedTcs.TrySetException(exception);
         _shutdownTokenSource.Cancel();
-        Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null);
-        _shutdownTcs.TrySetResult();
+        InitializeShutdownTcs(out TaskCompletionSource shutdownTcs);
+        shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }
     private unsafe int HandleEventLocalAddressChanged(ref LOCAL_ADDRESS_CHANGED_DATA data)
@@ -627,7 +641,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Check if the connection has been shut down and if not, shut it down.
-        if (Interlocked.CompareExchange(ref _shutdownTcs, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously), null) == null)
+        if (InitializeShutdownTcs(out TaskCompletionSource shutdownTcs))
         {
             unsafe
             {
@@ -637,7 +651,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
                     (ulong)_defaultCloseErrorCode);
             }
         }
-        else if (!_shutdownTcs.Task.IsCompletedSuccessfully)
+        else if (!shutdownTcs.Task.IsCompletedSuccessfully)
         {
             unsafe
             {
@@ -649,7 +663,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         }
 
         // Wait for SHUTDOWN_COMPLETE, the last event, so that all resources can be safely released.
-        await _shutdownTcs.Task.ConfigureAwait(false);
+        await shutdownTcs.Task.ConfigureAwait(false);
         Debug.Assert(_connectedTcs.IsCompleted);
         _handle.Dispose();
         _shutdownTokenSource.Dispose();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -220,7 +220,7 @@ public sealed partial class QuicListener : IAsyncDisposable
         {
             using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_disposeCts.Token, connection.ConnectionShutdownToken);
             cancellationToken = linkedCts.Token;
-            // initial timeout for retrieving connection options
+            // Initial timeout for retrieving connection options.
             linkedCts.CancelAfter(handshakeTimeout);
 
             wrapException = true;
@@ -229,7 +229,7 @@ public sealed partial class QuicListener : IAsyncDisposable
 
             options.Validate(nameof(options));
 
-            // update handshake timetout based on the returned value
+            // Update handshake timeout based on the returned value.
             handshakeTimeout = options.HandshakeTimeout;
             linkedCts.CancelAfter(handshakeTimeout);
 
@@ -248,12 +248,12 @@ public sealed partial class QuicListener : IAsyncDisposable
                 NetEventSource.Info(connection, $"{connection} Connection closed by remote peer");
             }
 
-            // retrieve the exception which failed the handshake, the parameters are not going to be
-            // validated because the inner _connectedTcs is already transitioned to faulted state
+            // Retrieve the exception which failed the handshake, the parameters are not going to be
+            // validated because the inner _connectedTcs is already transitioned to faulted state.
             ValueTask task = connection.FinishHandshakeAsync(null!, null!, default);
             Debug.Assert(task.IsFaulted);
 
-            // unwrap AggregateException and propagate it to the accept queue
+            // Unwrap AggregateException and propagate it to the accept queue.
             Exception ex = task.AsTask().Exception!.InnerException!;
 
             await connection.DisposeAsync().ConfigureAwait(false);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -613,6 +613,7 @@ public sealed partial class QuicStream
             _receiveTcs.TrySetException(exception, final: true);
             _sendTcs.TrySetException(exception, final: true);
         }
+        _startedTcs.TrySetResult();
         _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -134,27 +134,7 @@ namespace System.Net.Quic.Tests
                 {
                     var cts = new CancellationTokenSource();
                     cts.Cancel();
-                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await clientConnection.CloseAsync(ExpectedErrorCode, cts.Token));
-                    await clientConnection.DisposeAsync();
-                    sync.Release();
-                },
-                async serverConnection =>
-                {
-                    await sync.WaitAsync();
-                    await serverConnection.DisposeAsync();
-                });
-        }
-
-        [Fact]
-        public async Task DisposeAfterCloseTaskStored()
-        {
-            using var sync = new SemaphoreSlim(0);
-
-            await RunClientServer(
-                async clientConnection =>
-                {
-                    var cts = new CancellationTokenSource();
-                    var task = clientConnection.CloseAsync(0).AsTask();
+                    await Assert.ThrowsAsync<OperationCanceledException>(async () => await clientConnection.CloseAsync(ExpectedErrorCode, cts.Token));
                     await clientConnection.DisposeAsync();
                     sync.Release();
                 },

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -134,7 +134,27 @@ namespace System.Net.Quic.Tests
                 {
                     var cts = new CancellationTokenSource();
                     cts.Cancel();
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () => await clientConnection.CloseAsync(ExpectedErrorCode, cts.Token));
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await clientConnection.CloseAsync(ExpectedErrorCode, cts.Token));
+                    await clientConnection.DisposeAsync();
+                    sync.Release();
+                },
+                async serverConnection =>
+                {
+                    await sync.WaitAsync();
+                    await serverConnection.DisposeAsync();
+                });
+        }
+
+        [Fact]
+        public async Task DisposeAfterCloseTaskStored()
+        {
+            using var sync = new SemaphoreSlim(0);
+
+            await RunClientServer(
+                async clientConnection =>
+                {
+                    var cts = new CancellationTokenSource();
+                    var task = clientConnection.CloseAsync(0).AsTask();
                     await clientConnection.DisposeAsync();
                     sync.Release();
                 },

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -125,6 +125,27 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        public async Task DisposeAfterCloseCanceled()
+        {
+            using var sync = new SemaphoreSlim(0);
+
+            await RunClientServer(
+                async clientConnection =>
+                {
+                    var cts = new CancellationTokenSource();
+                    cts.Cancel();
+                    await Assert.ThrowsAsync<OperationCanceledException>(async () => await clientConnection.CloseAsync(ExpectedErrorCode, cts.Token));
+                    await clientConnection.DisposeAsync();
+                    sync.Release();
+                },
+                async serverConnection =>
+                {
+                    await sync.WaitAsync();
+                    await serverConnection.DisposeAsync();
+                });
+        }
+
+        [Fact]
         public async Task ConnectionClosedByPeer_WithPendingAcceptAndConnect_PendingAndSubsequentThrowConnectionAbortedException()
         {
             using var sync = new SemaphoreSlim(0);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -146,6 +146,26 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        public async Task DisposeAfterCloseTaskStored()
+        {
+            using var sync = new SemaphoreSlim(0);
+
+            await RunClientServer(
+                async clientConnection =>
+                {
+                    var cts = new CancellationTokenSource();
+                    var task = clientConnection.CloseAsync(0).AsTask();
+                    await clientConnection.DisposeAsync();
+                    sync.Release();
+                },
+                async serverConnection =>
+                {
+                    await sync.WaitAsync();
+                    await serverConnection.DisposeAsync();
+                });
+        }
+
+        [Fact]
         public async Task ConnectionClosedByPeer_WithPendingAcceptAndConnect_PendingAndSubsequentThrowConnectionAbortedException()
         {
             using var sync = new SemaphoreSlim(0);


### PR DESCRIPTION
1. Makes cancellation in `ValueTaskSource` temporary, which enables receiving the expected MsQuic signal even after `cancellationToken` fired. In this case `SHUTDOWN_COMPLETE`.
2. If `ValueTaskSource` is cancelled, remember what happened to it before the caller read the OCE so that it can be restored to the task afterwards.
3. When the OCE is delivered, restore `ValueTaskSource` to the remembered state (awaiting or completed with the result).
4. Lastly, examine the state of `_shutdownTcs` in `Dispose` and decide whether the silent shutdown needs to be called.

Changes are in ValueTaskSource and QuicConnection. Other changes are cosmetic, not functional (comments, code formatting).

Fixes https://github.com/dotnet/runtime/issues/78641

I also did a manual testing with cancellation between CloseAsync --> connection.Shutdown and SHUTDOWN_COMPLETED by inserting delay to the event handler, but this as this is timing sensitive it's impossible to do reliably in a test.