### PR TITLE
Disable EventSource manifest gen tests on stress runs.

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestGeneration.Etw.cs
@@ -30,7 +30,7 @@ namespace BasicEventSourceTests
 
         /// ETW only works with elevated process
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798")]
+        [SkipOnCoreClr("Test should only be run in non-stress modes", ~RuntimeTestModes.RegularRun)]
         public void Test_EventSource_EtwManifestGeneration()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions { TimeOut = 300_000 /* ms */ };
@@ -77,7 +77,7 @@ namespace BasicEventSourceTests
         }
 
         [ConditionalFact(nameof(IsProcessElevatedAndNotWindowsNanoServerAndRemoteExecutorSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/48798")]
+        [SkipOnCoreClr("Test should only be run in non-stress modes", ~RuntimeTestModes.RegularRun)]
         public void Test_EventSource_EtwManifestGenerationRollover()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/tests/Interop/Directory.Build.targets
+++ b/src/tests/Interop/Directory.Build.targets
@@ -11,7 +11,7 @@
   <Target Name="CopyInteropNativeRuntimeDependencies"
     BeforeTargets="CopyAllNativeProjectReferenceBinaries"
     Condition="'$(TargetsWindows)' == 'true' And ('$(Configuration)' == 'Debug' Or '$(Configuration)' == 'Checked') And '$(CopyDebugCRTDllsToOutputDirectory)' == 'true'" >
-    <Warning Message="Building C++/CLI tests requires a Visual Studio Dev Command Prompt" Condition="'$(VCToolsRedistDir)' == '' or '$(ExtensionSdkDir)' == ''" />
+    <Warning Text="Building C++/CLI tests requires a Visual Studio Dev Command Prompt" Condition="'$(VCToolsRedistDir)' == '' or '$(ExtensionSdkDir)' == ''" />
     <!-- Required debug vcruntime and UCRT dlls -->
     <ItemGroup Condition="'$(VCToolsRedistDir)' != '' and '$(ExtensionSdkDir)' != ''">
       <InteropNativeRuntimeDependencies Include="$(VCToolsRedistDir)onecore/debug_nonredist/$(TargetArchitecture)/Microsoft.VC*.DebugCRT/vcruntime*d.dll" />


### PR DESCRIPTION
Fixes #48798 

The tests in question will no longer run under any stress mode.