### PR TITLE
[NativeAOT] ObjWriter: Fix over-alignment of .eh_frame entries

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfEhFrame.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfEhFrame.cs
@@ -82,7 +82,8 @@ namespace ILCompiler.ObjectWriter
                 DwarfHelper.SizeOfULEB128(cie.ReturnAddressRegister) +
                 (uint)(augmentationLength > 0 ? DwarfHelper.SizeOfULEB128(augmentationLength) + augmentationLength : 0) +
                 (uint)cie.Instructions.Length;
-            uint padding = ((length + 7u) & ~7u) - length;
+            uint pointerEncodingSize = AddressSize(cie.PointerEncoding);
+            uint padding = ((length + pointerEncodingSize - 1u) & ~(pointerEncodingSize - 1u)) - length;
 
             _sectionWriter.WriteLittleEndian<uint>(length + padding - 4u);
             _sectionWriter.WriteLittleEndian<uint>(0);
@@ -122,14 +123,16 @@ namespace ILCompiler.ObjectWriter
                     (fde.Cie.PersonalityEncoding != 0 ? AddressSize(fde.Cie.PersonalityEncoding) : 0) +
                     (fde.Cie.LsdaEncoding != 0 ? AddressSize(fde.Cie.LsdaEncoding) : 0) : 0;
 
+            uint pointerEncodingSize = AddressSize(fde.Cie.PointerEncoding);
+
             uint length =
                 4u + // Length
                 4u + // CIE offset
-                AddressSize(fde.Cie.PointerEncoding) + // PC start
-                AddressSize(fde.Cie.PointerEncoding) + // PC end
+                pointerEncodingSize + // PC start
+                pointerEncodingSize + // PC end
                 augmentationLength +
                 (uint)fde.Instructions.Length;
-            uint padding = ((length + 7u) & ~7u) - length;
+            uint padding = ((length + pointerEncodingSize - 1u) & ~(pointerEncodingSize - 1u)) - length;
 
             _sectionWriter.WriteLittleEndian<uint>(length + padding - 4u);
             _sectionWriter.WriteLittleEndian<uint>((uint)(_sectionWriter.Position - cieOffset));


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/pull/95876#issuecomment-1885764564
Ref: https://github.com/dotnet/llvm-project/blob/d8bacb4031b1d1e290ab2792e8378560419ee0de/llvm/lib/MC/MCDwarf.cpp#L1759-L1764

The DWARF specification requires the CIE/FDE entries in the `.eh_frame` sections to be aligned to pointer size. However, I incorrectly implemented it as the platform target pointer size, while it's supposed to be the DWARF pointer size specified in the `pointer encoding` field. Since we use 4-byte relative pointers on all platforms this means the alignment is supposed to be on the 4-byte boundary, not on the 8-byte boundary. 

Tested on https://github.com/aspnet/Benchmarks/tree/main/src/BenchmarksApps/BasicMinimalApi where we now produce the same size of `.eh_frame` section as the legacy ObjWriter. Prior to the fix the additional alignment contributed 53,736 bytes to the section size (out of roughly ~1MiB).