### PR TITLE
Detect static default interface methods in illink

### DIFF
--- a/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
@@ -149,26 +149,26 @@ namespace Mono.Linker
 					// we shouldn't need to run the below logic. This results in ILLink potentially
 					// keeping more methods than needed.
 
-					// Static methods on interfaces must be implemented only via explicit method-impl record
-					// not by a signature match. So there's no point in running the logic below for static methods.
-
 					if (!resolvedInterfaceMethod.IsVirtual
-						|| resolvedInterfaceMethod.IsFinal
-						|| resolvedInterfaceMethod.IsStatic)
+						|| resolvedInterfaceMethod.IsFinal)
 						continue;
 
-					// Try to find an implementation with a name/sig match on the current type
-					MethodDefinition? exactMatchOnType = TryMatchMethod (type, interfaceMethod);
-					if (exactMatchOnType != null) {
-						AnnotateMethods (resolvedInterfaceMethod, exactMatchOnType);
-						continue;
-					}
+					// Static methods on interfaces must be implemented only via explicit method-impl record
+					// not by a signature match. So there's no point in running this logic for static methods.
+					if (!resolvedInterfaceMethod.IsStatic) {
+						// Try to find an implementation with a name/sig match on the current type
+						MethodDefinition? exactMatchOnType = TryMatchMethod (type, interfaceMethod);
+						if (exactMatchOnType != null) {
+							AnnotateMethods (resolvedInterfaceMethod, exactMatchOnType);
+							continue;
+						}
 
-					// Next try to find an implementation with a name/sig match in the base hierarchy
-					var @base = GetBaseMethodInTypeHierarchy (type, interfaceMethod);
-					if (@base != null) {
-						AnnotateMethods (resolvedInterfaceMethod, @base, interfaceImpl.OriginalImpl);
-						continue;
+						// Next try to find an implementation with a name/sig match in the base hierarchy
+						var @base = GetBaseMethodInTypeHierarchy (type, interfaceMethod);
+						if (@base != null) {
+							AnnotateMethods (resolvedInterfaceMethod, @base, interfaceImpl.OriginalImpl);
+							continue;
+						}
 					}
 
 					// Look for a default implementation last.

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDefaultInterfaceMethodOnStruct.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDefaultInterfaceMethodOnStruct.cs
@@ -8,22 +8,22 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		public static void Main ()
 		{
 #if SUPPORTS_DEFAULT_INTERFACE_METHODS
-			Foo<Derived> ();
+			CallStaticInterfaceMethod<Derived> ();
 #endif
 		}
 
 #if SUPPORTS_DEFAULT_INTERFACE_METHODS
 		[Kept]
-		static void Foo<T> () where T : IBase
+		static void CallStaticInterfaceMethod<T> () where T : IBase
 		{
-			T.Foo ();
+			T.StaticInterfaceMethod ();
 		}
 
 		[Kept]
 		interface IBase
 		{
 			[Kept]
-			static abstract void Foo ();
+			static abstract void StaticInterfaceMethod ();
 		}
 
 		[Kept]
@@ -31,7 +31,7 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 		interface IDerived : IBase
 		{
 			[Kept]
-			static void IBase.Foo () { }
+			static void IBase.StaticInterfaceMethod () { }
 		}
 
 		[Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDefaultInterfaceMethodOnStruct.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDefaultInterfaceMethodOnStruct.cs
@@ -1,0 +1,45 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
+{
+	[TestCaseRequirements (TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
+	class StaticDefaultInterfaceMethodOnStruct
+	{
+		public static void Main ()
+		{
+#if SUPPORTS_DEFAULT_INTERFACE_METHODS
+			Foo<Derived> ();
+#endif
+		}
+
+#if SUPPORTS_DEFAULT_INTERFACE_METHODS
+		[Kept]
+		static void Foo<T> () where T : IBase
+		{
+			T.Foo ();
+		}
+
+		[Kept]
+		interface IBase
+		{
+			[Kept]
+			static abstract void Foo ();
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IBase))]
+		interface IDerived : IBase
+		{
+			[Kept]
+			static void IBase.Foo () { }
+		}
+
+		[Kept]
+		[KeptInterface (typeof (IDerived))]
+		[KeptInterface (typeof (IBase))]
+		struct Derived : IDerived
+		{
+		}
+#endif
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/96516. The issue was that we were skipping the TypeMapInfo logic that would have been needed to discover static default interface implementations.

While investigating this I noticed more problems in this area (I will file bugs) that I plan to fix separately. For example, the current logic only works for instantiated types, so if you replace `struct Derived` in this testcase with a class, it fails.