### PR TITLE
Prevent access violation in ThreadExceptionState::EnumChainMemoryRegions

### DIFF
--- a/src/coreclr/vm/exstate.cpp
+++ b/src/coreclr/vm/exstate.cpp
@@ -547,6 +547,11 @@ ThreadExceptionState::EnumChainMemoryRegions(CLRDataEnumMemoryFlags flags)
     ExInfo*           head = &m_currentExInfo;
 #endif // FEATURE_EH_FUNCLETS
 
+    if (head == NULL)
+    {
+        return;
+    }
+
     for (;;)
     {
         head->EnumMemoryRegions(flags);

--- a/src/coreclr/vm/exstate.cpp
+++ b/src/coreclr/vm/exstate.cpp
@@ -543,14 +543,15 @@ ThreadExceptionState::EnumChainMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
 #ifdef FEATURE_EH_FUNCLETS
     ExceptionTrackerBase* head = m_pCurrentTracker;
-#else // FEATURE_EH_FUNCLETS
-    ExInfo*           head = &m_currentExInfo;
-#endif // FEATURE_EH_FUNCLETS
 
     if (head == NULL)
     {
         return;
     }
+
+#else // FEATURE_EH_FUNCLETS
+    ExInfo*           head = &m_currentExInfo;
+#endif // FEATURE_EH_FUNCLETS
 
     for (;;)
     {


### PR DESCRIPTION
Not checking for null here seems to cause access violation in heap dump creation using `createdump --withheap`