### PR TITLE
Don't copy runner to test output during regular builds

### DIFF
--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -93,6 +93,6 @@
       <None Remove="@(_xunitAbstractionsRemove)" />
     </ItemGroup>
     <Error Condition="'$(Pkgxunit_runner_visualstudio)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '@(_xunitAbstractionsRemove)' == ''"
-           Text="Remove workaround above and GeneratePathProperty from the xunit.runner.visualstudio PackageReference as they are no longer needed"/>
+           Text="Remove workaround above and GeneratePathProperty from the xunit.runner.visualstudio PackageReference as they are no longer needed." />
   </Target>
 </Project>

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -85,14 +85,5 @@
             CopyToOutputDirectory="PreserveNewest"
             Visible="false" />
     </ItemGroup>
-
-    <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
-    <ItemGroup Condition="'$(Pkgxunit_runner_visualstudio)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework'">
-      <!-- Remove `xunit.abstractions.dll` that was added to @(None) by xunit.runner.visualstudio -->
-      <_xunitAbstractionsRemove Include="@(None->WithMetadataValue('Filename', 'xunit.abstractions'))" />
-      <None Remove="@(_xunitAbstractionsRemove)" />
-    </ItemGroup>
-    <Error Condition="'$(Pkgxunit_runner_visualstudio)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '@(_xunitAbstractionsRemove)' == ''"
-           Text="Remove workaround above and GeneratePathProperty from the xunit.runner.visualstudio PackageReference as they are no longer needed." />
   </Target>
 </Project>

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -68,8 +68,8 @@
 
   <!-- ResolveAssemblyReferences is the target that populates ReferenceCopyLocalPaths which is what is copied to output directory. -->
   <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="ResolveAssemblyReferences" Condition="'$(TargetsMobile)' != 'true' or '$(BundleXunitRunner)' == 'true'">
-    <ItemGroup>
-      <!-- Copy test runner to output directory -->
+    <ItemGroup Condition="'$(ArchiveTests)' == 'true'">
+      <!-- When ArchiveTests is set, copy xunit.runner.console to output directory -->
       <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
             Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;
                      $([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe;
@@ -87,11 +87,9 @@
     </ItemGroup>
 
     <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
-    <ItemGroup Condition="'$(ArchiveTests)' != 'true'">
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.utility.net452.dll" />
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.reporters.net452.dll" />
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll" />
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll" />
+    <ItemGroup>
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net462\xunit.abstractions.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net6.0\xunit.abstractions.dll" />
     </ItemGroup>
   </Target>
 </Project>

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -87,9 +87,12 @@
     </ItemGroup>
 
     <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
-    <ItemGroup>
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net462\xunit.abstractions.dll" />
-      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net6.0\xunit.abstractions.dll" />
+    <ItemGroup Condition="'$(Pkgxunit_runner_visualstudio)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework'">
+      <!-- Remove `xunit.abstractions.dll` that was added to @(None) by xunit.runner.visualstudio -->
+      <_xunitAbstractionsRemove Include="@(None->WithMetadataValue('Filename', 'xunit.abstractions'))" />
+      <None Remove="@(_xunitAbstractionsRemove)" />
     </ItemGroup>
+    <Error Condition="'$(Pkgxunit_runner_visualstudio)' != '' AND '$(TargetFrameworkIdentifier)' == '.NETFramework' AND '@(_xunitAbstractionsRemove)' == ''"
+           Text="Remove workaround above and GeneratePathProperty from the xunit.runner.visualstudio PackageReference as they are no longer needed"/>
   </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94183

The test runner is not required for local test execution, but is needed for helix (today).  In the future we should try to change helix to not expect the runner in the output directory, but instead as a correlation payload.