### PR TITLE
[libs] Skip AdvSimdEncode on Mono

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -84,7 +84,7 @@ namespace System.Buffers.Text
                         if (src == srcEnd)
                             goto DoneExit;
                     }
-#if !MONO
+
                     end = srcMax - 48;
                     if (AdvSimd.Arm64.IsSupported && (end >= src))
                     {
@@ -93,7 +93,7 @@ namespace System.Buffers.Text
                         if (src == srcEnd)
                             goto DoneExit;
                     }
-#endif
+
                     end = srcMax - 16;
                     if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
                     {
@@ -493,9 +493,9 @@ namespace System.Buffers.Text
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static unsafe void AdvSimdEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
-#if MONO
+#if MONO // https://github.com/dotnet/runtime/issues/96828
             return;
-#else
+#endif
             // C# implementatino of https://github.com/aklomp/base64/blob/3a5add8652076612a8407627a42c768736a4263f/lib/arch/neon64/enc_loop.c
             Vector128<byte> str1;
             Vector128<byte> str2;
@@ -548,7 +548,6 @@ namespace System.Buffers.Text
 
             srcBytes = src;
             destBytes = dest;
-#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -85,7 +85,7 @@ namespace System.Buffers.Text
                             goto DoneExit;
                     }
 
-#if !MONO // https://github.com/dotnet/runtime/issues/96828
+#if !MONO // https://github.com/dotnet/runtime/issues/93081
                     end = srcMax - 48;
                     if (AdvSimd.Arm64.IsSupported && (end >= src))
                     {
@@ -491,7 +491,7 @@ namespace System.Buffers.Text
             destBytes = dest;
         }
 
-#if !MONO // https://github.com/dotnet/runtime/issues/96828
+#if !MONO // https://github.com/dotnet/runtime/issues/93081
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static unsafe void AdvSimdEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -493,9 +493,7 @@ namespace System.Buffers.Text
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static unsafe void AdvSimdEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
-#if MONO // https://github.com/dotnet/runtime/issues/96828
-            return;
-#endif
+#if !MONO // https://github.com/dotnet/runtime/issues/96828
             // C# implementatino of https://github.com/aklomp/base64/blob/3a5add8652076612a8407627a42c768736a4263f/lib/arch/neon64/enc_loop.c
             Vector128<byte> str1;
             Vector128<byte> str2;
@@ -548,6 +546,7 @@ namespace System.Buffers.Text
 
             srcBytes = src;
             destBytes = dest;
+#endif // !MONO
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -84,7 +84,7 @@ namespace System.Buffers.Text
                         if (src == srcEnd)
                             goto DoneExit;
                     }
-
+#if !MONO
                     end = srcMax - 48;
                     if (AdvSimd.Arm64.IsSupported && (end >= src))
                     {
@@ -93,7 +93,7 @@ namespace System.Buffers.Text
                         if (src == srcEnd)
                             goto DoneExit;
                     }
-
+#endif
                     end = srcMax - 16;
                     if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -85,6 +85,7 @@ namespace System.Buffers.Text
                             goto DoneExit;
                     }
 
+#if !MONO // https://github.com/dotnet/runtime/issues/96828
                     end = srcMax - 48;
                     if (AdvSimd.Arm64.IsSupported && (end >= src))
                     {
@@ -93,6 +94,7 @@ namespace System.Buffers.Text
                         if (src == srcEnd)
                             goto DoneExit;
                     }
+#endif
 
                     end = srcMax - 16;
                     if ((Ssse3.IsSupported || AdvSimd.Arm64.IsSupported) && BitConverter.IsLittleEndian && (end >= src))
@@ -489,11 +491,11 @@ namespace System.Buffers.Text
             destBytes = dest;
         }
 
+#if !MONO // https://github.com/dotnet/runtime/issues/96828
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static unsafe void AdvSimdEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
-#if !MONO // https://github.com/dotnet/runtime/issues/96828
             // C# implementatino of https://github.com/aklomp/base64/blob/3a5add8652076612a8407627a42c768736a4263f/lib/arch/neon64/enc_loop.c
             Vector128<byte> str1;
             Vector128<byte> str2;
@@ -546,8 +548,8 @@ namespace System.Buffers.Text
 
             srcBytes = src;
             destBytes = dest;
-#endif // !MONO
         }
+#endif // !MONO
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Encoder.cs
@@ -493,6 +493,9 @@ namespace System.Buffers.Text
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         private static unsafe void AdvSimdEncode(ref byte* srcBytes, ref byte* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, byte* destStart)
         {
+#if MONO
+            return;
+#else
             // C# implementatino of https://github.com/aklomp/base64/blob/3a5add8652076612a8407627a42c768736a4263f/lib/arch/neon64/enc_loop.c
             Vector128<byte> str1;
             Vector128<byte> str2;
@@ -545,6 +548,7 @@ namespace System.Buffers.Text
 
             srcBytes = src;
             destBytes = dest;
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Works around https://github.com/dotnet/runtime/issues/96828

Not sure if the problematic code affects all of mono arm64 configurations or just ios/tvos arm64.