### PR TITLE
Fix processing `--substitutions`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/FeatureSwitchManager.cs
@@ -925,6 +925,8 @@ namespace ILCompiler
 
                 PEMemoryBlock resourceDirectory = module.PEReader.GetSectionData(module.PEReader.PEHeaders.CorHeader.ResourcesDirectory.RelativeVirtualAddress);
 
+                BodyAndFieldSubstitutions substitutions = default;
+
                 foreach (var resourceHandle in module.MetadataReader.ManifestResources)
                 {
                     ManifestResource resource = module.MetadataReader.GetManifestResource(resourceHandle);
@@ -947,13 +949,7 @@ namespace ILCompiler
                             ms = new UnmanagedMemoryStream(reader.CurrentPointer, length);
                         }
 
-                        BodyAndFieldSubstitutions substitutions = BodySubstitutionsParser.GetSubstitutions(logger, module.Context, ms, resource, module, "name", featureSwitchValues);
-
-                        // Also apply any global substitutions
-                        // Note we allow these to overwrite substitutions in the assembly
-                        substitutions.AppendFrom(globalSubstitutions);
-
-                        (BodySubstitutions, FieldSubstitutions) = (substitutions.BodySubstitutions, substitutions.FieldSubstitutions);
+                        substitutions = BodySubstitutionsParser.GetSubstitutions(logger, module.Context, ms, resource, module, "name", featureSwitchValues);
                     }
                     else if (InlineableStringsResourceNode.IsInlineableStringsResource(module, resourceName))
                     {
@@ -977,6 +973,12 @@ namespace ILCompiler
                         }
                     }
                 }
+
+                // Also apply any global substitutions
+                // Note we allow these to overwrite substitutions in the assembly
+                substitutions.AppendFrom(globalSubstitutions);
+
+                (BodySubstitutions, FieldSubstitutions) = (substitutions.BodySubstitutions, substitutions.FieldSubstitutions);
             }
         }
     }


### PR DESCRIPTION
The global substitutions passed on the command line only work if the assembly itself has ILLink.Substitutions.xml in its resources due to the placement of the line that appends global substitutions (facepalm).