### PR TITLE
Optimize BigInteger.CompareTo()

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -1183,16 +1183,12 @@ namespace System.Numerics
                     return _sign < other._sign ? -1 : _sign > other._sign ? +1 : 0;
                 return -other._sign;
             }
-            int cuThis, cuOther;
-            if (other._bits == null || (cuThis = _bits.Length) > (cuOther = other._bits.Length))
-                return _sign;
-            if (cuThis < cuOther)
-                return -_sign;
 
-            int cuDiff = GetDiffLength(_bits, other._bits, cuThis);
-            if (cuDiff == 0)
-                return 0;
-            return _bits[cuDiff - 1] < other._bits[cuDiff - 1] ? -_sign : _sign;
+            if (other._bits == null)
+                return _sign;
+
+            int bitsResult = BigIntegerCalculator.Compare(_bits, other._bits);
+            return _sign < 0 ? -bitsResult : bitsResult;
         }
 
         public int CompareTo(object? obj)
@@ -3115,16 +3111,6 @@ namespace System.Numerics
                 _bits.CopyTo(xd);
             }
             return _sign < 0;
-        }
-
-        internal static int GetDiffLength(uint[] rgu1, uint[] rgu2, int cu)
-        {
-            for (int iv = cu; --iv >= 0;)
-            {
-                if (rgu1[iv] != rgu2[iv])
-                    return iv + 1;
-            }
-            return 0;
         }
 
         [Conditional("DEBUG")]

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
@@ -17,18 +17,14 @@ namespace System.Numerics
 
         public static int Compare(ReadOnlySpan<uint> left, ReadOnlySpan<uint> right)
         {
-            Debug.Assert(left.Length == 0 || left[^1] > 0);
-            Debug.Assert(right.Length == 0 || right[^1] > 0);
+            Debug.Assert(left.Length <= right.Length || left.Slice(right.Length).ContainsAnyExcept(0u));
+            Debug.Assert(left.Length >= right.Length || right.Slice(left.Length).ContainsAnyExcept(0u));
 
             if (left.Length != right.Length)
                 return left.Length < right.Length ? -1 : 1;
 
             int iv = left.Length;
-            while (--iv >= 0)
-            {
-                if (left[iv] != right[iv])
-                    break;
-            }
+            while (--iv >= 0 && left[iv] == right[iv]) ;
 
             if (iv < 0)
                 return 0;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace System.Numerics
 {
     internal static partial class BigIntegerCalculator
@@ -15,19 +19,20 @@ namespace System.Numerics
 
         public static int Compare(ReadOnlySpan<uint> left, ReadOnlySpan<uint> right)
         {
-            if (left.Length < right.Length)
-                return -1;
-            if (left.Length > right.Length)
-                return 1;
+            Debug.Assert(left.Length == 0 || left[^1] > 0);
+            Debug.Assert(right.Length == 0 || right[^1] > 0);
+
+            if (left.Length != right.Length)
+                return left.Length < right.Length ? -1 : 1;
+
+            ref uint rightPtr = ref MemoryMarshal.GetReference(right);
 
             for (int i = left.Length - 1; i >= 0; i--)
             {
                 uint leftElement = left[i];
-                uint rightElement = right[i];
-                if (leftElement < rightElement)
-                    return -1;
-                if (leftElement > rightElement)
-                    return 1;
+                uint rightElement = Unsafe.Add(ref rightPtr, i);
+                if (leftElement != rightElement)
+                    return leftElement < rightElement ? -1 : 1;
             }
 
             return 0;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace System.Numerics
 {

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.Utils.cs
@@ -25,17 +25,16 @@ namespace System.Numerics
             if (left.Length != right.Length)
                 return left.Length < right.Length ? -1 : 1;
 
-            ref uint rightPtr = ref MemoryMarshal.GetReference(right);
-
-            for (int i = left.Length - 1; i >= 0; i--)
+            int iv = left.Length;
+            while (--iv >= 0)
             {
-                uint leftElement = left[i];
-                uint rightElement = Unsafe.Add(ref rightPtr, i);
-                if (leftElement != rightElement)
-                    return leftElement < rightElement ? -1 : 1;
+                if (left[iv] != right[iv])
+                    break;
             }
 
-            return 0;
+            if (iv < 0)
+                return 0;
+            return left[iv] < right[iv] ? -1 : 1;
         }
 
         private static int ActualLength(ReadOnlySpan<uint> value)

--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/Comparison.cs
@@ -344,6 +344,40 @@ namespace System.Numerics.Tests
 
             BigInteger b1 = new BigInteger(byteArray);
             VerifyComparison(BigInteger.One, false, b1 / b1, false, 0);
+
+            // BigIntegers constructed with a byte[]
+            {
+                int byteLength = 17;
+                var byteArray1 = new byte[byteLength];
+                var byteArray2 = new byte[byteLength];
+
+                byteArray1.AsSpan().Fill(1);
+                byteArray2.AsSpan().Fill(1);
+
+                // Equals
+                byteArray1[0] = 2;
+                byteArray2[0] = 2;
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), false, 0);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), true, 0);
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), true, 1);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), false, -1);
+
+                // Smaller
+                byteArray1[0] = 2;
+                byteArray2[0] = 3;
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), false, -1);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), true, 1);
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), true, 1);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), false, -1);
+
+                // Larger
+                byteArray1[0] = 3;
+                byteArray2[0] = 2;
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), false, 1);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), true, -1);
+                VerifyComparison(new BigInteger(byteArray1), false, new BigInteger(byteArray2), true, 1);
+                VerifyComparison(new BigInteger(byteArray1), true, new BigInteger(byteArray2), false, -1);
+            }
         }
 
         private static void RunNegativeTests(Random random)
@@ -636,7 +670,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expectedGreaterThan || expectedEquals, x >= y);
             Assert.Equal(expectedLessThan || expectedEquals, y >= x);
         }
-        
+
         private static void VerifyCompareResult(int expected, int actual)
         {
             if (0 == expected)


### PR DESCRIPTION
I optimized `CompareTo()` as follows.

- Reduced number of comparison operation calls
- Removal of bound checks 
- Shared implementation of `BigInteger.CompareTo` and `BigIntegerCalculator.Compare` 

https://github.com/kzrnm/performance/commit/b3d58195b4739b28d87f144496d28d43e23215da

```

BenchmarkDotNet v0.13.11-nightly.20231126.107, Windows 11 (10.0.22631.2861/23H2/2023Update/SunValley3)
13th Gen Intel Core i5-13500, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.100-alpha.1.24055.2
  [Host]     : .NET 9.0.0 (9.0.24.5410), X64 RyuJIT AVX2
  Job-TFLKKT : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-RQNTME : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
| Method  | Job        | Toolchain                                                                                                        | arguments                 | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Allocated | Alloc Ratio |
|-------- |----------- |----------------------------------------------------------------------------------------------------------------- |-------------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **259 bytes, DiffFirstByte**  | **35.574 ns** | **0.1296 ns** | **0.1212 ns** | **35.565 ns** | **35.376 ns** | **35.776 ns** |  **0.77** |    **0.00** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 259 bytes, DiffFirstByte  | 46.289 ns | 0.1244 ns | 0.1102 ns | 46.276 ns | 46.154 ns | 46.535 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **259 bytes, DiffLastByte**   |  **2.023 ns** | **0.0112 ns** | **0.0093 ns** |  **2.022 ns** |  **2.007 ns** |  **2.044 ns** |  **0.88** |    **0.01** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 259 bytes, DiffLastByte   |  2.285 ns | 0.0137 ns | 0.0122 ns |  2.285 ns |  2.262 ns |  2.303 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **259 bytes, DiffMiddleByte** | **14.943 ns** | **0.0859 ns** | **0.0761 ns** | **14.937 ns** | **14.853 ns** | **15.106 ns** |  **0.69** |    **0.01** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 259 bytes, DiffMiddleByte | 21.642 ns | 0.1474 ns | 0.1307 ns | 21.616 ns | 21.410 ns | 21.916 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **259 bytes, Same**           | **30.253 ns** | **0.1889 ns** | **0.1577 ns** | **30.253 ns** | **29.968 ns** | **30.548 ns** |  **0.83** |    **0.02** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 259 bytes, Same           | 36.486 ns | 0.6951 ns | 0.6502 ns | 36.725 ns | 35.299 ns | 37.722 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **67 bytes, DiffFirstByte**   |  **7.920 ns** | **0.0364 ns** | **0.0341 ns** |  **7.919 ns** |  **7.864 ns** |  **7.978 ns** |  **0.72** |    **0.01** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 67 bytes, DiffFirstByte   | 11.046 ns | 0.2108 ns | 0.1972 ns | 10.970 ns | 10.824 ns | 11.488 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **67 bytes, DiffLastByte**    |  **2.311 ns** | **0.0692 ns** | **0.0578 ns** |  **2.297 ns** |  **2.254 ns** |  **2.455 ns** |  **1.11** |    **0.40** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 67 bytes, DiffLastByte    |  3.786 ns | 1.8665 ns | 2.1494 ns |  2.934 ns |  1.729 ns |  6.698 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **67 bytes, DiffMiddleByte**  |  **5.747 ns** | **0.0471 ns** | **0.0418 ns** |  **5.751 ns** |  **5.682 ns** |  **5.805 ns** |  **0.87** |    **0.01** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 67 bytes, DiffMiddleByte  |  6.631 ns | 0.0667 ns | 0.0624 ns |  6.611 ns |  6.564 ns |  6.760 ns |  1.00 |    0.00 |         - |          NA |
|         |            |                                                                                                                  |                           |           |           |           |           |           |           |       |         |           |             |
| **Compare** | **Job-TFLKKT** | **\new\corerun.exe** | **67 bytes, Same**            |  **6.220 ns** | **0.0496 ns** | **0.0464 ns** |  **6.216 ns** |  **6.169 ns** |  **6.308 ns** |  **0.75** |    **0.01** |         **-** |          **NA** |
| Compare | Job-RQNTME | \old\corerun.exe   | 67 bytes, Same            |  8.307 ns | 0.0794 ns | 0.0743 ns |  8.284 ns |  8.184 ns |  8.418 ns |  1.00 |    0.00 |         - |          NA |
