### PR TITLE
[release/8.0] Fix server-side OCSP stapling on Linux

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OCSP.cs
@@ -29,27 +29,30 @@ internal static partial class Interop
             int len,
             SafeOcspRequestHandle req,
             IntPtr subject,
-            IntPtr issuer,
+            IntPtr* issuers,
+            int issuersLen,
             ref long expiration);
 
         internal static unsafe bool X509DecodeOcspToExpiration(
             ReadOnlySpan<byte> buf,
             SafeOcspRequestHandle request,
             IntPtr x509Subject,
-            IntPtr x509Issuer,
+            ReadOnlySpan<IntPtr> x509Issuers,
             out DateTimeOffset expiration)
         {
             long timeT = 0;
             int ret;
 
             fixed (byte* pBuf = buf)
+            fixed (IntPtr* pIssuers = x509Issuers)
             {
                 ret = CryptoNative_X509DecodeOcspToExpiration(
                     pBuf,
                     buf.Length,
                     request,
                     x509Subject,
-                    x509Issuer,
+                    pIssuers,
+                    x509Issuers.Length,
                     ref timeT);
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -282,11 +282,10 @@ namespace System.Net.Security
                 _pendingDownload = null;
                 if (ret == null)
                 {
-                    // all download attempts failed, don't try again for 5 seconds.
-                    // Note that if server does not send OCSP staples, clients may still
-                    // contact OCSP responders directly.
+                    // All download attempts failed, don't try again for 5 seconds.
+                    // This backoff will be applied only if the OCSP staple is not expired.
+                    // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
                     _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
-                    _ocspExpiration = _nextDownload;
                 }
                 return ret;
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -266,7 +266,6 @@ namespace System.Net.Security
                         _ocspResponse = ret;
                         _ocspExpiration = expiration;
                         _nextDownload = nextCheckA < nextCheckB ? nextCheckA : nextCheckB;
-                        _pendingDownload = null;
                         break;
                     }
                 }
@@ -279,6 +278,16 @@ namespace System.Net.Security
                 GC.KeepAlive(_privateIntermediateCertificates);
                 GC.KeepAlive(_rootCertificate);
                 GC.KeepAlive(caCert);
+
+                _pendingDownload = null;
+                if (ret == null)
+                {
+                    // all download attempts failed, don't try again for 5 seconds.
+                    // Note that if server does not send OCSP staples, clients may still
+                    // contact OCSP responders directly.
+                    _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
+                    _ocspExpiration = _nextDownload;
+                }
                 return ret;
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -26,13 +26,30 @@ namespace System.Net.Security
         private byte[]? _ocspResponse;
         private DateTimeOffset _ocspExpiration;
         private DateTimeOffset _nextDownload;
+        // Private copy of the intermediate certificates, in case the user decides to dispose the
+        // instances reachable through IntermediateCertificates property.
+        private X509Certificate2[] _privateIntermediateCertificates;
+        private X509Certificate2? _rootCertificate;
         private Task<byte[]?>? _pendingDownload;
         private List<string>? _ocspUrls;
-        private X509Certificate2? _ca;
 
         private SslStreamCertificateContext(X509Certificate2 target, ReadOnlyCollection<X509Certificate2> intermediates, SslCertificateTrust? trust)
         {
             IntermediateCertificates = intermediates;
+            if (intermediates.Count > 0)
+            {
+                _privateIntermediateCertificates = new X509Certificate2[intermediates.Count];
+
+                for (int i = 0; i < intermediates.Count; i++)
+                {
+                    _privateIntermediateCertificates[i] = new X509Certificate2(intermediates[i]);
+                }
+            }
+            else
+            {
+                _privateIntermediateCertificates = Array.Empty<X509Certificate2>();
+            }
+
             TargetCertificate = target;
             Trust = trust;
             SslContexts = new ConcurrentDictionary<SslProtocols, SafeSslContextHandle>();
@@ -76,15 +93,8 @@ namespace System.Net.Security
 
         partial void AddRootCertificate(X509Certificate2? rootCertificate, ref bool transferredOwnership)
         {
-            if (IntermediateCertificates.Count == 0)
-            {
-                _ca = rootCertificate;
-                transferredOwnership = true;
-            }
-            else
-            {
-                _ca = IntermediateCertificates[0];
-            }
+            _rootCertificate = rootCertificate;
+            transferredOwnership = rootCertificate != null;
 
             if (!_staplingForbidden)
             {
@@ -149,7 +159,7 @@ namespace System.Net.Security
                 return new ValueTask<byte[]?>(pending);
             }
 
-            if (_ocspUrls is null && _ca is not null)
+            if (_ocspUrls is null && _rootCertificate is not null)
             {
                 foreach (X509Extension ext in TargetCertificate.Extensions)
                 {
@@ -192,7 +202,9 @@ namespace System.Net.Security
 
         private async Task<byte[]?> FetchOcspAsync()
         {
-            X509Certificate2? caCert = _ca;
+            Debug.Assert(_rootCertificate != null);
+            X509Certificate2? caCert = _privateIntermediateCertificates.Length > 0 ? _privateIntermediateCertificates[0] : _rootCertificate;
+
             Debug.Assert(_ocspUrls is not null);
             Debug.Assert(_ocspUrls.Count > 0);
             Debug.Assert(caCert is not null);
@@ -211,6 +223,13 @@ namespace System.Net.Security
                 return null;
             }
 
+            IntPtr[] issuerHandles = ArrayPool<IntPtr>.Shared.Rent(_privateIntermediateCertificates.Length + 1);
+            for (int i = 0; i < _privateIntermediateCertificates.Length; i++)
+            {
+                issuerHandles[i] = _privateIntermediateCertificates[i].Handle;
+            }
+            issuerHandles[_privateIntermediateCertificates.Length] = _rootCertificate.Handle;
+
             using (SafeOcspRequestHandle ocspRequest = Interop.Crypto.X509BuildOcspRequest(subject, issuer))
             {
                 byte[] rentedBytes = ArrayPool<byte>.Shared.Rent(Interop.Crypto.GetOcspRequestDerSize(ocspRequest));
@@ -227,7 +246,7 @@ namespace System.Net.Security
 
                     if (ret is not null)
                     {
-                        if (!Interop.Crypto.X509DecodeOcspToExpiration(ret, ocspRequest, subject, issuer, out DateTimeOffset expiration))
+                        if (!Interop.Crypto.X509DecodeOcspToExpiration(ret, ocspRequest, subject, issuerHandles.AsSpan(0, _privateIntermediateCertificates.Length + 1), out DateTimeOffset expiration))
                         {
                             ret = null;
                             continue;
@@ -252,9 +271,13 @@ namespace System.Net.Security
                     }
                 }
 
+                issuerHandles.AsSpan().Clear();
+                ArrayPool<IntPtr>.Shared.Return(issuerHandles);
                 ArrayPool<byte>.Shared.Return(rentedBytes);
                 ArrayPool<char>.Shared.Return(rentedChars.Array!);
                 GC.KeepAlive(TargetCertificate);
+                GC.KeepAlive(_privateIntermediateCertificates);
+                GC.KeepAlive(_rootCertificate);
                 GC.KeepAlive(caCert);
                 return ret;
             }

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.h
@@ -412,4 +412,4 @@ PALEXPORT int32_t CryptoNative_X509ChainVerifyOcsp(X509_STORE_CTX* storeCtx,
 Decode len bytes of buf into an OCSP response, process it against the OCSP request, and return if the bytes were valid.
 If the bytes were valid, and the OCSP response had a nextUpdate value, assign it to expiration.
 */
-PALEXPORT int32_t CryptoNative_X509DecodeOcspToExpiration(const uint8_t* buf, int32_t len, OCSP_REQUEST* req, X509* subject, X509* issuer, int64_t* expiration);
+PALEXPORT int32_t CryptoNative_X509DecodeOcspToExpiration(const uint8_t* buf, int32_t len, OCSP_REQUEST* req, X509* subject, X509** issuers, int issuersLen, int64_t* expiration);


### PR DESCRIPTION
Backport of PR #96792, PR #96448, PR #90200 and PR #96972.

Fixes #96770, #96659 and #89907

# Description

Regression: No, .NET 6 didn't have OCSP staple feature.
Customer: Internal partner team - blocking migration from Windows to Linux.

OCSP (Online Certificate Status Protocol) stapling is an optimization where instead of clients individually retrieving revocation status of the server certificate, server will fetch the OCSP response itself and send it to clients during connection handshake. The authenticity of the response is assured by a digital signature.

First bug in .NET 7.0+ ... An invalid response can get cached and the server would fail to refresh it. The server would then keep sending the old, cached and potentially malformed OCSP response. This bug is triggered when either:
- The OCSP response could not be parsed (e.g. due to OCSP server sending an error page due to outage)
- .NET fails to validate the authenticity of the OCSP response
This has been partially fixed in main by PR #90200 and completely fixed in main by PR #96448

Second bug in .NET 7.0+ ... Validation of OCSP response always fails when the method of "delegated signing" is used (delegated signing means that the OCSP response is signed by a special certificate delegated by the server certificate issuer).
- Note that validation when receiving OCSP response on client-side is not affected by this bug and is extensively tested, only the server part is affected by the bug.
- Server validating the OCSP response before sending it out is only to play nice and not send invalid OCSP responses out. This bug DOES NOT create security vulnerability because clients are expected to independently validate the OCSP response themselves.
Fixed in main by PR #96792

The two issues mentioned above may lead to following undesired behaviors:
- Server caches an invalid OCSP staple (e.g. error page due to OCSP server outage), and keeps sending it out.
- Server stops refreshing the OCSP staple and keeps sending the old one even after its validity expired.
- Server sends out OCSP staple which it does not consider valid

# Customer Impact

Android clients cannot connect to .NET 7+ servers affected by this bug because the OCSP information may get outdated (and not refreshed) and Android 9+'s application default security restrictions don't allow HTTP connections by default.

# Regression

No, sending OCSP staples from .NET servers is a new feature in .NET 7.

# Testing

Locally reproduced affected scenario and extensively tested manually.

Customer validated private 7.0 bits.

There is extensive existing test coverage on client-side OCSP usage/validation. Missing E2E server-side automated test coverage is planned for upcoming weeks.

# Risk

Small to medium. Code touched by this PR is not used in other code paths than OCSP, so only "Sending OCSP staples from a server" scenario is affected.