### PR TITLE
Add non-portable RID to list of known runtime packs instead of overwriting

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,12 +22,14 @@
   for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))">
-      <RuntimePackRuntimeIdentifiers>$(PackageRID)</RuntimePackRuntimeIdentifiers>
-    </KnownFrameworkReference>
-    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))">
-      <Crossgen2RuntimeIdentifiers>$(PackageRID)</Crossgen2RuntimeIdentifiers>
-    </KnownCrossgen2Pack>
+    <KnownFrameworkReference Update="@(KnownFrameworkReference
+                                       ->WithMetadataValue('Identity', 'Microsoft.NETCore.App')
+                                       ->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
+      RuntimePackRuntimeIdentifiers="%(RuntimePackRuntimeIdentifiers);$(PackageRID)" />
+    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack
+                                  ->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')
+                                  ->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
+      Crossgen2RuntimeIdentifiers="%(Crossgen2RuntimeIdentifiers);$(PackageRID)"/>
     <!-- Avoid references to Microsoft.AspNetCore.App.Runtime.<rid> -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,10 +22,14 @@
   for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
-      RuntimePackRuntimeIdentifiers="%(RuntimePackRuntimeIdentifiers);$(PackageRID)" />
-    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
-      Crossgen2RuntimeIdentifiers="%(Crossgen2RuntimeIdentifiers);$(PackageRID)"/>
+    <KnownFrameworkReference Update="Microsoft.NETCore.App">
+      <RuntimePackRuntimeIdentifiers
+        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'">%(RuntimePackRuntimeIdentifiers);$(PackageRID)</RuntimePackRuntimeIdentifiers>
+    </KnownFrameworkReference>
+    <KnownCrossgen2Pack Update="Microsoft.NETCore.App.Crossgen2">
+      <Crossgen2RuntimeIdentifiers
+        Condition="'%(TargetFramework)' == '$(NetCoreAppCurrent)'" >%(Crossgen2RuntimeIdentifiers);$(PackageRID)</Crossgen2RuntimeIdentifiers>
+    </KnownCrossgen2Pack>
     <!-- Avoid references to Microsoft.AspNetCore.App.Runtime.<rid> -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,13 +22,9 @@
   for Microsoft.NETCore.App.Runtime.<rid> and Microsoft.NETCore.App.Crossgen2.<rid>.
   -->
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <KnownFrameworkReference Update="@(KnownFrameworkReference
-                                       ->WithMetadataValue('Identity', 'Microsoft.NETCore.App')
-                                       ->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
+    <KnownFrameworkReference Update="@(KnownFrameworkReference->WithMetadataValue('Identity', 'Microsoft.NETCore.App')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
       RuntimePackRuntimeIdentifiers="%(RuntimePackRuntimeIdentifiers);$(PackageRID)" />
-    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack
-                                  ->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')
-                                  ->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
+    <KnownCrossgen2Pack Update="@(KnownCrossgen2Pack->WithMetadataValue('Identity', 'Microsoft.NETCore.App.Crossgen2')->WithMetadataValue('TargetFramework', '$(NetCoreAppCurrent)'))"
       Crossgen2RuntimeIdentifiers="%(Crossgen2RuntimeIdentifiers);$(PackageRID)"/>
     <!-- Avoid references to Microsoft.AspNetCore.App.Runtime.<rid> -->
     <KnownFrameworkReference Remove="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/75597, for source-build we replace all the RIDs with only the `PackageRID` in the `KnownFrameworkReference` for `NetCurrent` when we should have only added an additional RID.

This was causing issues in crossbuilds of vertical builds. The crossgen and ilc projects that run within the build require a runtime for the build machine's RID, but it wasn't found in `KnownFrameworkReference` and the build failed during restore.

Part of reenabling Crossgen and ILC in arm64 crossbuild verticals https://github.com/dotnet/source-build/issues/3698