### PR TITLE
[release/6.0] Disable CI job: Android x64 Release AllSubsets_Mono_RuntimeTests

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -492,40 +492,40 @@ jobs:
 #
 # Build the whole product using Mono for Android and run runtime tests with Android emulator
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-    - Android_x64
-    variables:
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: pr/dotnet/runtime/$(Build.SourceBranch)
-      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
-        - name: _HelixSource
-          value: ci/dotnet/runtime/$(Build.SourceBranch)
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_RuntimeTests
-      buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
-          eq(variables['isFullMatrix'], true))
-      # extra steps, run tests
-      extraStepsTemplate: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
-      extraStepsParameters:
-        creator: dotnet-bot
-        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+#- template: /eng/pipelines/common/platform-matrix.yml
+#  parameters:
+#    jobTemplate: /eng/pipelines/common/global-build-job.yml
+#    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#    buildConfig: Release
+#    runtimeFlavor: mono
+#    platforms:
+#    - Android_x64
+#    variables:
+#      - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+#        - name: _HelixSource
+#          value: pr/dotnet/runtime/$(Build.SourceBranch)
+#      - ${{ if and(eq(variables['System.TeamProject'], 'public'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+#        - name: _HelixSource
+#          value: ci/dotnet/runtime/$(Build.SourceBranch)
+#      - name: timeoutPerTestInMinutes
+#        value: 60
+#      - name: timeoutPerTestCollectionInMinutes
+#        value: 180
+#    jobParameters:
+#      testGroup: innerloop
+#      nameSuffix: AllSubsets_Mono_RuntimeTests
+#      buildArgs: -s mono+libs -c $(_BuildConfig)
+#      timeoutInMinutes: 240
+#      condition: >-
+#        or(
+#          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono.containsChange'], true),
+#          eq(variables['isFullMatrix'], true))
+#      # extra steps, run tests
+#      extraStepsTemplate: /eng/pipelines/common/templates/runtimes/android-runtime-and-send-to-helix.yml
+#      extraStepsParameters:
+#        creator: dotnet-bot
+#        testRunNamePrefixSuffix: Mono_$(_BuildConfig)
 
 #
 # Build Mono and Installer on LLVMJIT mode


### PR DESCRIPTION
It is causing a lot of flaky failures: https://github.com/dotnet/runtime/issues/83422

.NET MAUI is already EOL on 6.0 so disabling the tests is fine.

Fixes https://github.com/dotnet/runtime/issues/83422

## Customer Impact

None, this is an infrastructure change.

## Testing

CI testing.

## Risk

Low.