### PR TITLE
Clear less memory in object writer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
@@ -140,7 +140,7 @@ namespace ILCompiler.ObjectWriter
 
         public DwarfExpressionBuilder GetExpressionBuilder()
         {
-            _expressionBufferWriter.Clear();
+            _expressionBufferWriter.ResetWrittenCount();
             return new DwarfExpressionBuilder(TargetArchitecture, TargetPointerSize, _expressionBufferWriter);
         }
 


### PR DESCRIPTION
Contributes to #96884. I can see it helping somewhat.

Ref: https://github.com/dotnet/runtime/issues/96884#issuecomment-1888633080

Cc @dotnet/ilc-contrib @filipnavara 