### PR TITLE
Make startup hooks kind of work with native AOT

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
@@ -8,8 +8,5 @@
       <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
       <method signature="System.Boolean get_IsDynamicCodeSupported()" body="stub" value="false" />
     </type>
-    <type fullname="System.StartupHookProvider" feature="System.StartupHookProvider.IsSupported" featurevalue="false">
-      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
-    </type>
   </assembly>
 </linker>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System.Private.CoreLib.csproj
@@ -221,6 +221,7 @@
     <Compile Include="System\String.Intern.cs" />
     <Compile Include="System\Array.NativeAot.cs" />
     <Compile Include="System\Delegate.cs" />
+    <Compile Include="System\StartupHookProvider.NativeAot.cs" />
     <Compile Include="System\RuntimeTypeHandle.cs" />
     <Compile Include="System\Exception.NativeAot.cs" />
     <Compile Include="System\RuntimeExceptionHelpers.cs" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/StartupHookProvider.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/StartupHookProvider.NativeAot.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static partial class StartupHookProvider
+    {
+#pragma warning disable CA2255
+        [ModuleInitializer]
+#pragma warning restore CA2255
+        internal static void Initialize()
+        {
+            if (IsSupported)
+                ProcessStartupHooks(Environment.GetEnvironmentVariable("DOTNET_STARTUP_HOOKS"));
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/repro/repro.csproj
@@ -41,6 +41,7 @@
       <ReproResponseLines Include="--feature:System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported=false" />
       <ReproResponseLines Include="--feature:System.Globalization.Invariant=true" />
       <ReproResponseLines Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
+      <ReproResponseLines Include="--feature:System.StartupHookProvider.IsSupported=false" />
     </ItemGroup>
 
     <WriteLinesToFile File="$(OutputPath)\compile-with-$(LibrariesConfiguration)-libs.rsp"

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -37,5 +37,8 @@
     <type fullname="Internal.Runtime.InteropServices.ComponentActivator" feature="System.Runtime.InteropServices.EnableConsumingManagedCodeFromNativeHosting" featurevalue="false">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.StartupHookProvider" feature="System.StartupHookProvider.IsSupported" featurevalue="false">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
   </assembly>
 </linker>

--- a/src/tests/nativeaot/StartupHook/StartupHook.cs
+++ b/src/tests/nativeaot/StartupHook/StartupHook.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+class Program
+{
+    internal static int s_return;
+
+    [DynamicDependency(nameof(StartupHook.Initialize), typeof(StartupHook))]
+    static int Main() => s_return;
+}
+
+class StartupHook
+{
+    public static void Initialize()
+    {
+        Console.WriteLine("Running startup hook");
+        Program.s_return = 100;
+    }
+}

--- a/src/tests/nativeaot/StartupHook/StartupHook.csproj
+++ b/src/tests/nativeaot/StartupHook/StartupHook.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <StartupHookSupport>true</StartupHookSupport>
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="StartupHook.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_STARTUP_HOOKS" Value="StartupHook" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #96052.

Since we compile startup hooks anyway, just add a call to it. It will be deadcoded by default. Can be enabled and then it will at least work for hooks that were part of the app. It will throw PNSE for random file paths.

Cc @dotnet/ilc-contrib 