### PR TITLE
[mono] [tests] Set error for mono_fullaot runtime tests when no suitable tests are found

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -118,7 +118,12 @@
     <RemoveDuplicates Inputs="@(TestDirsWithDuplicates)">
       <Output TaskParameter="Filtered" ItemName="TestDirs" />
     </RemoveDuplicates>
-    <ItemGroup>
+    
+    <Error 
+      Text="No tests found for Mono AOT compilation."
+      Condition="!Exists(%(TestDirs.Identity))" />
+
+    <ItemGroup>  
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/**/*.dll" Exclude="@(NoMonoAotAssemblyPaths)" />
       <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll;$(CORE_ROOT)/Microsoft.CodeAnalysis.VisualBasic.dll" />
       <AllDlls Condition="'$(MonoFullAot)' == 'true'" Include="@(TestsAndAssociatedAssemblies);@(CoreRootDlls)" />

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -115,14 +115,14 @@
       <TestAssemblies Include="%(TestAssemblyPaths.Identity)" Condition="Exists(%(TestAssemblyPaths.Identity))" />
       <TestDirsWithDuplicates Include="$([System.IO.Path]::GetDirectoryName('%(TestAssemblies.Identity)'))" />
     </ItemGroup>
+      
+    <Error 
+      Text="No tests found for Mono AOT compilation. Make sure that the desired test cases are not excluded from AOT compilation."
+      Condition="!Exists(%(TestAssemblies.Identity))" />
+
     <RemoveDuplicates Inputs="@(TestDirsWithDuplicates)">
       <Output TaskParameter="Filtered" ItemName="TestDirs" />
     </RemoveDuplicates>
-    
-    <Error 
-      Text="No tests found for Mono AOT compilation."
-      Condition="!Exists(%(TestDirs.Identity))" />
-
     <ItemGroup>  
       <TestsAndAssociatedAssemblies Include="%(TestDirs.Identity)/**/*.dll" Exclude="@(NoMonoAotAssemblyPaths)" />
       <CoreRootDlls Include="$(CORE_ROOT)/*.dll" Exclude="$(CORE_ROOT)/xunit.performance.api.dll;$(CORE_ROOT)/Microsoft.CodeAnalysis.VisualBasic.dll" />


### PR DESCRIPTION
Report MSBuild error when compiling selected runtime tests with `mono_fullaot` and no suitable tests are found. 

# Motivation
This can happen when locally building selected tests that are disabled in `issues.targets`. This causes:
1. Because `TestExclusions` contain the selected tests, `TestScripts` won't be created. https://github.com/dotnet/runtime/blob/980491d21705ab491d8423f061c757836a62f162/src/tests/build.proj#L112
2. This subsequently causes `TestDirs` to no exists, leading to enumarating all dlls on the disk (`/**/*.dll`) in  https://github.com/dotnet/runtime/blob/980491d21705ab491d8423f061c757836a62f162/src/tests/build.proj#L127

## Previous behavior


Build doesn't get stopped and the following warning is reported:

`MSBUILD : warning MSB5029: The value "/**/*.dll" of the "Include" attribute in element <ItemGroup> in file "<RUNTIME_ROOT>runtime/src/tests/build.proj (122,37)" is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.`

## New behavior
Build gets canceled and error is reported: `error : No tests found for Mono AOT compilation.`


