### PR TITLE
[mono] Fix class initialization spurious wakeups

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -457,21 +457,24 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 	 * on this cond var.
 	 */
 
+	HANDLE_FUNCTION_ENTER ();
+
 retry_top:
+	(void)0; // appease C compiler; label must preceed a statement not a var declaration
+
+	gboolean ret = FALSE;
+
 	mono_type_initialization_lock ();
 	/* double check... */
 	if (vtable->initialized) {
 		mono_type_initialization_unlock ();
-		return TRUE;
+		goto return_true;
 	}
 
 	gboolean do_initialization = FALSE;
 	TypeInitializationLock *lock = NULL;
 	gboolean pending_tae = FALSE;
 
-	gboolean ret = FALSE;
-
-	HANDLE_FUNCTION_ENTER ();
 
 	if (vtable->init_failed) {
 		/* The type initialization already failed once, rethrow the same exception */

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -614,8 +614,8 @@ retry_top:
 		if (!lock->done) {
 			int timeout_ms = 500;
 			int wait_result = mono_coop_cond_timedwait (&lock->cond, &lock->mutex, timeout_ms);
-			if (wait_result == -1) {
-				/* timed out - go around again from the beginning.  If we got here
+			if (wait_result == -1 || (wait_result == 0 && !lock->done)) {
+				/* timed out or spurious wakeup - go around again from the beginning.  If we got here
 				 * from the "is_blocked = FALSE" case, above (another thread was
 				 * blocked on the current thread, but on a lock that was already
 				 * done but it didn't get to wake up yet), then it might still be
@@ -646,7 +646,7 @@ retry_top:
 					g_hash_table_remove (type_initialization_hash, vtable);
 				mono_type_initialization_unlock ();
 				goto retry_top;
-			} else if (wait_result == 0) {
+			} else if (wait_result == 0 && lock->done) {
 				/* Success: we were signaled that the other thread is done.  Proceed */
 			} else {
 				g_assert_not_reached ();


### PR DESCRIPTION
1. `mono_runtime_class_init_full`: handle spurious wakeups.
   the condition variable may be signaled even if the initialization by the other thread is not done yet.  Handle spurious wakeups the same way as timeouts: go around once more from the beginning.

   Fixes https://github.com/dotnet/runtime/issues/96872 and https://github.com/dotnet/runtime/issues/96804

2. fix unbalanced handle frames.
   if we goto retry_top, don't set up a new handle frame that lacks a matching HANDLE_FUNCTION_RETURN_VAL.

   Instead setup the handle frame once upfront