### PR TITLE
Fix nativeaot-outerloop

### DIFF
--- a/src/libraries/System.Linq/tests/default.rd.xml
+++ b/src/libraries/System.Linq/tests/default.rd.xml
@@ -153,6 +153,9 @@
           <GenericArgument Name="System.Int16,System.Runtime" />
         </Method>
         <Method Name="Max_AllTypes" Dynamic="Required All">
+          <GenericArgument Name="System.Char,System.Runtime" />
+        </Method>
+        <Method Name="Max_AllTypes" Dynamic="Required All">
           <GenericArgument Name="System.UInt32,System.Runtime" />
         </Method>
         <Method Name="Max_AllTypes" Dynamic="Required All">
@@ -178,6 +181,12 @@
         </Method>
         <Method Name="Max_AllTypes" Dynamic="Required All">
           <GenericArgument Name="System.UIntPtr,System.Runtime" />
+        </Method>
+        <Method Name="Max_AllTypes" Dynamic="Required All">
+          <GenericArgument Name="System.Int128,System.Runtime" />
+        </Method>
+        <Method Name="Max_AllTypes" Dynamic="Required All">
+          <GenericArgument Name="System.UInt128,System.Runtime" />
         </Method>
       </Type>
 


### PR DESCRIPTION
PR #96605 added new generic arguments to the unit tests which need to be preserved in the rd.xml since the test suite is not yet trim-compatible.