### PR TITLE
[perf] Use HybridGlobalization as default and only option for Apple mobile platforms

### DIFF
--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -72,6 +72,8 @@ jobs:
 
   # Build and run iOS Mono and NativeAOT scenarios
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
+    parameters:
+      hybridGlobalization: True
 
   # run android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -4,301 +4,301 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        testGroup: perf
+  # # build coreclr and libraries
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+  #     buildConfig: release
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
-        nameSuffix: AOT
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: AOT Mono Artifacts
-              artifactName: LinuxMonoAOTx64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+  # # build mono for AOT
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
+  #       nameSuffix: AOT
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/common/upload-artifact-step.yml
+  #           parameters:
+  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #             includeRootFolder: true
+  #             displayName: AOT Mono Artifacts
+  #             artifactName: LinuxMonoAOTx64
+  #             archiveExtension: '.tar.gz'
+  #             archiveType: tar
+  #             tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Android Mono Artifacts
-              artifactName: AndroidMonoarm64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+  # # build mono Android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: AndroidMono
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #           parameters:
+  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #             includeRootFolder: true
+  #             displayName: Android Mono Artifacts
+  #             artifactName: AndroidMonoarm64
+  #             archiveExtension: '.tar.gz'
+  #             archiveType: tar
+  #             tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - linux_x64
+  # # build mono
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #     runtimeFlavor: mono
+  #     buildConfig: release
+  #     platforms:
+  #     - linux_x64
 
   # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
     parameters:
       hybridGlobalization: True
 
-  # run android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+  # # run android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: AndroidMono
+  #       projectFile: android_scenarios.proj
+  #       runKind: android_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfpixel4a'
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono interpreter perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'Interpreter'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono aot microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr perftiger microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoDynamicPGO
+  # # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -NoDynamicPGO
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: --nodynamicpgo
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: --nodynamicpgo
 
-  # run coreclr perftiger microbenchmarks no R2R perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        r2rRunType: -NoR2R
+  # # run coreclr perftiger microbenchmarks no R2R perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       r2rRunType: -NoR2R
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        r2rRunType: --nor2r
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       r2rRunType: --nor2r
 
-  # run coreclr perftiger microbenchmarks memory randomization jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        experimentName: 'memoryRandomization'
+  # # run coreclr perftiger microbenchmarks memory randomization jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       experimentName: 'memoryRandomization'
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  # # run coreclr perfowl microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger_crossgen'
+  # # run coreclr crossgen perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: crossgen_perf.proj
+  #       runKind: crossgen_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perftiger_crossgen'
 
-  # build mono runtime packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Mono_Packs
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
+  # # build mono runtime packs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: Mono_Packs
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #           parameters:
+  #             name: MonoRuntimePacks
 
   # Disabled due to: https://github.com/dotnet/performance/issues/3655
   # # build PerfBDN app

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -2,301 +2,301 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # build coreclr and libraries
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-      buildConfig: release
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        testGroup: perf
+  # # build coreclr and libraries
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+  #     buildConfig: release
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
 
-  # build mono for AOT
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
-        nameSuffix: AOT
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-artifact-step.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: AOT Mono Artifacts
-              artifactName: LinuxMonoAOTx64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+  # # build mono for AOT
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
+  #       nameSuffix: AOT
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/common/upload-artifact-step.yml
+  #           parameters:
+  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #             includeRootFolder: true
+  #             displayName: AOT Mono Artifacts
+  #             artifactName: LinuxMonoAOTx64
+  #             archiveExtension: '.tar.gz'
+  #             archiveType: tar
+  #             tarCompression: gz
 
-  # build mono Android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: AndroidMono
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-            parameters:
-              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-              includeRootFolder: true
-              displayName: Android Mono Artifacts
-              artifactName: AndroidMonoarm64
-              archiveExtension: '.tar.gz'
-              archiveType: tar
-              tarCompression: gz
+  # # build mono Android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: AndroidMono
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+  #           parameters:
+  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+  #             includeRootFolder: true
+  #             displayName: Android Mono Artifacts
+  #             artifactName: AndroidMonoarm64
+  #             archiveExtension: '.tar.gz'
+  #             archiveType: tar
+  #             tarCompression: gz
 
-  # build mono
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - linux_x64
+  # # build mono
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+  #     runtimeFlavor: mono
+  #     buildConfig: release
+  #     platforms:
+  #     - linux_x64
 
   # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
     parameters:
       hybridGlobalization: True
 
-  # run android scenarios
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - windows_x64
-      jobParameters:
-        testGroup: perf
-        runtimeType: AndroidMono
-        projectFile: android_scenarios.proj
-        runKind: android_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perfpixel4a'
+  # # run android scenarios
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #       - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       runtimeType: AndroidMono
+  #       projectFile: android_scenarios.proj
+  #       runKind: android_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perfpixel4a'
 
-  # run mono microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono interpreter perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'Interpreter'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono interpreter perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'Interpreter'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run mono aot microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-      buildConfig: release
-      runtimeFlavor: aot
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        runtimeType: mono
-        codeGenType: 'AOT'
-        projectFile: microbenchmarks.proj
-        runKind: micro_mono
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run mono aot microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+  #     buildConfig: release
+  #     runtimeFlavor: aot
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       runtimeType: mono
+  #       codeGenType: 'AOT'
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro_mono
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      - linux_musl_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
+  # # run coreclr perftiger microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     - linux_musl_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
 
-  # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: -NoDynamicPGO
+  # # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: -NoDynamicPGO
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        pgoRunType: --nodynamicpgo
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       pgoRunType: --nodynamicpgo
 
-  # run coreclr perftiger microbenchmarks no R2R perf jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        r2rRunType: -NoR2R
+  # # run coreclr perftiger microbenchmarks no R2R perf jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       r2rRunType: -NoR2R
 
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        r2rRunType: --nor2r
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       r2rRunType: --nor2r
 
-  # run coreclr perftiger microbenchmarks memory randomization jobs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perftiger'
-        experimentName: 'memoryRandomization'
+  # # run coreclr perftiger microbenchmarks memory randomization jobs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perftiger'
+  #       experimentName: 'memoryRandomization'
 
-  # run coreclr perfowl microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: microbenchmarks.proj
-        runKind: micro
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-        logicalmachine: 'perfowl'
+  # # run coreclr perfowl microbenchmarks perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: microbenchmarks.proj
+  #       runKind: micro
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+  #       logicalmachine: 'perfowl'
 
-  # run coreclr crossgen perf job
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      - windows_x64
-      - windows_x86
-      jobParameters:
-        testGroup: perf
-        liveLibrariesBuildConfig: Release
-        projectFile: crossgen_perf.proj
-        runKind: crossgen_scenarios
-        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-        logicalmachine: 'perftiger_crossgen'
+  # # run coreclr crossgen perf job
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: coreclr
+  #     platforms:
+  #     - linux_x64
+  #     - windows_x64
+  #     - windows_x86
+  #     jobParameters:
+  #       testGroup: perf
+  #       liveLibrariesBuildConfig: Release
+  #       projectFile: crossgen_perf.proj
+  #       runKind: crossgen_scenarios
+  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+  #       logicalmachine: 'perftiger_crossgen'
 
-  # build mono runtime packs
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/common/global-build-job.yml
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-      - android_arm64
-      jobParameters:
-        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-        nameSuffix: Mono_Packs
-        isOfficialBuild: false
-        postBuildSteps:
-          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-            parameters:
-              name: MonoRuntimePacks
+  # # build mono runtime packs
+  # - template: /eng/pipelines/common/platform-matrix.yml
+  #   parameters:
+  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
+  #     buildConfig: release
+  #     runtimeFlavor: mono
+  #     platforms:
+  #     - android_arm64
+  #     jobParameters:
+  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+  #       nameSuffix: Mono_Packs
+  #       isOfficialBuild: false
+  #       postBuildSteps:
+  #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+  #           parameters:
+  #             name: MonoRuntimePacks
 
   # Disabled due to: https://github.com/dotnet/performance/issues/3655
   # # build PerfBDN app

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -2,301 +2,299 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # # build coreclr and libraries
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-  #     buildConfig: release
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        testGroup: perf
 
-  # # build mono for AOT
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
-  #       nameSuffix: AOT
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/common/upload-artifact-step.yml
-  #           parameters:
-  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #             includeRootFolder: true
-  #             displayName: AOT Mono Artifacts
-  #             artifactName: LinuxMonoAOTx64
-  #             archiveExtension: '.tar.gz'
-  #             archiveType: tar
-  #             tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
+        nameSuffix: AOT
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/common/upload-artifact-step.yml
+            parameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: AOT Mono Artifacts
+              artifactName: LinuxMonoAOTx64
+              archiveExtension: '.tar.gz'
+              archiveType: tar
+              tarCompression: gz
 
-  # # build mono Android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: AndroidMono
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #           parameters:
-  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #             includeRootFolder: true
-  #             displayName: Android Mono Artifacts
-  #             artifactName: AndroidMonoarm64
-  #             archiveExtension: '.tar.gz'
-  #             archiveType: tar
-  #             tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+            parameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: Android Mono Artifacts
+              artifactName: AndroidMonoarm64
+              archiveExtension: '.tar.gz'
+              archiveType: tar
+              tarCompression: gz
 
-  # # build mono
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #     runtimeFlavor: mono
-  #     buildConfig: release
-  #     platforms:
-  #     - linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - linux_x64
 
   # Build and run iOS Mono and NativeAOT scenarios
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
+
+  # run android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
-      hybridGlobalization: True
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
 
-  # # run android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #       - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       runtimeType: AndroidMono
-  #       projectFile: android_scenarios.proj
-  #       runKind: android_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perfpixel4a'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono interpreter perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono aot microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run coreclr perftiger microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoDynamicPGO
 
-  # # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: -NoDynamicPGO
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: --nodynamicpgo
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: --nodynamicpgo
+  # run coreclr perftiger microbenchmarks no R2R perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        r2rRunType: -NoR2R
 
-  # # run coreclr perftiger microbenchmarks no R2R perf jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       r2rRunType: -NoR2R
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        r2rRunType: --nor2r
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       r2rRunType: --nor2r
+  # run coreclr perftiger microbenchmarks memory randomization jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        experimentName: 'memoryRandomization'
 
-  # # run coreclr perftiger microbenchmarks memory randomization jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       experimentName: 'memoryRandomization'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  # # run coreclr perfowl microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perfowl'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger_crossgen'
 
-  # # run coreclr crossgen perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: crossgen_perf.proj
-  #       runKind: crossgen_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perftiger_crossgen'
-
-  # # build mono runtime packs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: Mono_Packs
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #           parameters:
-  #             name: MonoRuntimePacks
+  # build mono runtime packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Mono_Packs
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+            parameters:
+              name: MonoRuntimePacks
 
   # Disabled due to: https://github.com/dotnet/performance/issues/3655
   # # build PerfBDN app

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -70,7 +70,7 @@ jobs:
       platforms:
       - linux_x64
 
-  # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
+  # Build and run iOS Mono and NativeAOT scenarios
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
     parameters:
       hybridGlobalization: True

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -1,304 +1,302 @@
 jobs:
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
-  # # build coreclr and libraries
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
-  #     buildConfig: release
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       testGroup: perf
+  # build coreclr and libraries
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+      buildConfig: release
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        testGroup: perf
 
-  # # build mono for AOT
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
-  #       nameSuffix: AOT
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/common/upload-artifact-step.yml
-  #           parameters:
-  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #             includeRootFolder: true
-  #             displayName: AOT Mono Artifacts
-  #             artifactName: LinuxMonoAOTx64
-  #             archiveExtension: '.tar.gz'
-  #             archiveType: tar
-  #             tarCompression: gz
+  # build mono for AOT
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=x64 /p:AotHostOS=linux
+        nameSuffix: AOT
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/common/upload-artifact-step.yml
+            parameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: AOT Mono Artifacts
+              artifactName: LinuxMonoAOTx64
+              archiveExtension: '.tar.gz'
+              archiveType: tar
+              tarCompression: gz
 
-  # # build mono Android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: AndroidMono
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
-  #           parameters:
-  #             rootFolder: '$(Build.SourcesDirectory)/artifacts/'
-  #             includeRootFolder: true
-  #             displayName: Android Mono Artifacts
-  #             artifactName: AndroidMonoarm64
-  #             archiveExtension: '.tar.gz'
-  #             archiveType: tar
-  #             tarCompression: gz
+  # build mono Android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: AndroidMono
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/coreclr/templates/build-perf-sample-apps.yml
+            parameters:
+              rootFolder: '$(Build.SourcesDirectory)/artifacts/'
+              includeRootFolder: true
+              displayName: Android Mono Artifacts
+              artifactName: AndroidMonoarm64
+              archiveExtension: '.tar.gz'
+              archiveType: tar
+              tarCompression: gz
 
-  # # build mono
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-  #     runtimeFlavor: mono
-  #     buildConfig: release
-  #     platforms:
-  #     - linux_x64
+  # build mono
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+      runtimeFlavor: mono
+      buildConfig: release
+      platforms:
+      - linux_x64
 
   # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
     parameters:
       hybridGlobalization: True
 
-  # # run android scenarios
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #       - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       runtimeType: AndroidMono
-  #       projectFile: android_scenarios.proj
-  #       runKind: android_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perfpixel4a'
+  # run android scenarios
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+        - windows_x64
+      jobParameters:
+        testGroup: perf
+        runtimeType: AndroidMono
+        projectFile: android_scenarios.proj
+        runKind: android_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perfpixel4a'
 
-  # # run mono microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono interpreter perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'Interpreter'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono interpreter perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'Interpreter'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run mono aot microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
-  #     buildConfig: release
-  #     runtimeFlavor: aot
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       runtimeType: mono
-  #       codeGenType: 'AOT'
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro_mono
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run mono aot microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml # NOTE: should we move this file out of coreclr tempelates because it contains mono jobs?
+      buildConfig: release
+      runtimeFlavor: aot
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        runtimeType: mono
+        codeGenType: 'AOT'
+        projectFile: microbenchmarks.proj
+        runKind: micro_mono
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run coreclr perftiger microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     - linux_musl_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
+  # run coreclr perftiger microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      - linux_musl_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
 
-  # # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: -NoDynamicPGO
+  # run coreclr perftiger microbenchmarks no dynamic pgo perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: -NoDynamicPGO
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       pgoRunType: --nodynamicpgo
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        pgoRunType: --nodynamicpgo
 
-  # # run coreclr perftiger microbenchmarks no R2R perf jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       r2rRunType: -NoR2R
+  # run coreclr perftiger microbenchmarks no R2R perf jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        r2rRunType: -NoR2R
 
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       r2rRunType: --nor2r
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        r2rRunType: --nor2r
 
-  # # run coreclr perftiger microbenchmarks memory randomization jobs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perftiger'
-  #       experimentName: 'memoryRandomization'
+  # run coreclr perftiger microbenchmarks memory randomization jobs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perftiger'
+        experimentName: 'memoryRandomization'
 
-  # # run coreclr perfowl microbenchmarks perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: microbenchmarks.proj
-  #       runKind: micro
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
-  #       logicalmachine: 'perfowl'
+  # run coreclr perfowl microbenchmarks perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: microbenchmarks.proj
+        runKind: micro
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
+        logicalmachine: 'perfowl'
 
-  # # run coreclr crossgen perf job
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: coreclr
-  #     platforms:
-  #     - linux_x64
-  #     - windows_x64
-  #     - windows_x86
-  #     jobParameters:
-  #       testGroup: perf
-  #       liveLibrariesBuildConfig: Release
-  #       projectFile: crossgen_perf.proj
-  #       runKind: crossgen_scenarios
-  #       runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
-  #       logicalmachine: 'perftiger_crossgen'
+  # run coreclr crossgen perf job
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+      - linux_x64
+      - windows_x64
+      - windows_x86
+      jobParameters:
+        testGroup: perf
+        liveLibrariesBuildConfig: Release
+        projectFile: crossgen_perf.proj
+        runKind: crossgen_scenarios
+        runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
+        logicalmachine: 'perftiger_crossgen'
 
-  # # build mono runtime packs
-  # - template: /eng/pipelines/common/platform-matrix.yml
-  #   parameters:
-  #     jobTemplate: /eng/pipelines/common/global-build-job.yml
-  #     buildConfig: release
-  #     runtimeFlavor: mono
-  #     platforms:
-  #     - android_arm64
-  #     jobParameters:
-  #       buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
-  #       nameSuffix: Mono_Packs
-  #       isOfficialBuild: false
-  #       postBuildSteps:
-  #         - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-  #           parameters:
-  #             name: MonoRuntimePacks
+  # build mono runtime packs
+  - template: /eng/pipelines/common/platform-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
+      buildConfig: release
+      runtimeFlavor: mono
+      platforms:
+      - android_arm64
+      jobParameters:
+        buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
+        nameSuffix: Mono_Packs
+        isOfficialBuild: false
+        postBuildSteps:
+          - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+            parameters:
+              name: MonoRuntimePacks
 
   # Disabled due to: https://github.com/dotnet/performance/issues/3655
   # # build PerfBDN app

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -2,11 +2,6 @@ jobs:
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
 
-  # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
-  - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
-    parameters:
-      hybridGlobalization: True
-
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
 
   # build coreclr and libraries
@@ -77,10 +72,10 @@ jobs:
       platforms:
       - linux_x64
 
-  # Build and run iOS Mono and NativeAOT scenarios without HybridGlobalization
+  # Build and run iOS Mono and NativeAOT scenarios with HybridGlobalization
   - template: /eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
     parameters:
-      hybridGlobalization: False
+      hybridGlobalization: True
 
   # run android scenarios
   - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -42,12 +42,12 @@ extends:
     - stage: Build
       jobs:
 
-      - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
-        parameters:
-          collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
-          #${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-          #  runProfile: 'non-v8'
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            runProfile: 'v8'
+      # - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
+      #   parameters:
+      #     collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
+      #     #${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+      #     #  runProfile: 'non-v8'
+      #     ${{ if ne(variables['System.TeamProject'], 'public') }}:
+      #       runProfile: 'v8'
 
       - template: /eng/pipelines/coreclr/perf-non-wasm-jobs.yml

--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -42,12 +42,12 @@ extends:
     - stage: Build
       jobs:
 
-      # - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
-      #   parameters:
-      #     collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
-      #     #${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
-      #     #  runProfile: 'non-v8'
-      #     ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      #       runProfile: 'v8'
+      - template: /eng/pipelines/coreclr/perf-wasm-jobs.yml
+        parameters:
+          collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
+          #${{ and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+          #  runProfile: 'non-v8'
+          ${{ if ne(variables['System.TeamProject'], 'public') }}:
+            runProfile: 'v8'
 
       - template: /eng/pipelines/coreclr/perf-non-wasm-jobs.yml

--- a/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
+++ b/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
@@ -1,5 +1,5 @@
 parameters:
-  hybridGlobalization: False
+  hybridGlobalization: True
 
 jobs:
   # build mono iOS scenarios HybridGlobalization

--- a/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
+++ b/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
@@ -1,8 +1,5 @@
-parameters:
-  hybridGlobalization: True
-
 jobs:
-  # build mono iOS scenarios HybridGlobalization
+  # build mono iOS scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -24,9 +21,9 @@ jobs:
               archiveExtension: '.tar.gz'
               archiveType: tar
               tarCompression: gz
-              hybridGlobalization: ${{ parameters.hybridGlobalization }}
+              hybridGlobalization: True
 
-  # build NativeAOT iOS scenarios HybridGlobalization
+  # build NativeAOT iOS scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -48,7 +45,7 @@ jobs:
               archiveExtension: '.tar.gz'
               archiveType: tar
               tarCompression: gz
-              hybridGlobalization: ${{ parameters.hybridGlobalization }}
+              hybridGlobalization: True
 
   # run mono iOS scenarios scenarios HybridGlobalization
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -85,7 +82,7 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: False
         iOSStripSymbols: True
-        hybridGlobalization: ${{ parameters.hybridGlobalization }}
+        hybridGlobalization: True
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -103,7 +100,7 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: True
         iOSStripSymbols: False
-        hybridGlobalization: ${{ parameters.hybridGlobalization }}
+        hybridGlobalization: True
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -121,9 +118,9 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: True
         iOSStripSymbols: True
-        hybridGlobalization: ${{ parameters.hybridGlobalization }}
+        hybridGlobalization: True
 
-  # run NativeAOT iOS scenarios HybridGlobalization
+  # run NativeAOT iOS scenarios
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
@@ -139,7 +136,7 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
         logicalmachine: 'perfiphone12mini'
         iOSStripSymbols: False
-        hybridGlobalization: ${{ parameters.hybridGlobalization }}
+        hybridGlobalization: True
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -156,4 +153,4 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
         logicalmachine: 'perfiphone12mini'
         iOSStripSymbols: True
-        hybridGlobalization: ${{ parameters.hybridGlobalization }}
+        hybridGlobalization: True

--- a/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
+++ b/eng/pipelines/coreclr/templates/build-and-run-perf-ios-scenarios.yml
@@ -1,5 +1,8 @@
+parameters:
+  hybridGlobalization: True
+
 jobs:
-  # build mono iOS scenarios
+  # build mono iOS scenarios HybridGlobalization
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -21,9 +24,9 @@ jobs:
               archiveExtension: '.tar.gz'
               archiveType: tar
               tarCompression: gz
-              hybridGlobalization: True
+              hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
-  # build NativeAOT iOS scenarios
+  # build NativeAOT iOS scenarios HybridGlobalization
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -45,7 +48,7 @@ jobs:
               archiveExtension: '.tar.gz'
               archiveType: tar
               tarCompression: gz
-              hybridGlobalization: True
+              hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   # run mono iOS scenarios scenarios HybridGlobalization
   - template: /eng/pipelines/common/platform-matrix.yml
@@ -82,7 +85,7 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: False
         iOSStripSymbols: True
-        hybridGlobalization: True
+        hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -100,7 +103,7 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: True
         iOSStripSymbols: False
-        hybridGlobalization: True
+        hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -118,9 +121,9 @@ jobs:
         logicalmachine: 'perfiphone12mini'
         iOSLlvmBuild: True
         iOSStripSymbols: True
-        hybridGlobalization: True
+        hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
-  # run NativeAOT iOS scenarios
+  # run NativeAOT iOS scenarios HybridGlobalization
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
@@ -136,7 +139,7 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
         logicalmachine: 'perfiphone12mini'
         iOSStripSymbols: False
-        hybridGlobalization: True
+        hybridGlobalization: ${{ parameters.hybridGlobalization }}
 
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -153,4 +156,4 @@ jobs:
         runJobTemplate: /eng/pipelines/coreclr/templates/run-scenarios-job.yml
         logicalmachine: 'perfiphone12mini'
         iOSStripSymbols: True
-        hybridGlobalization: True
+        hybridGlobalization: ${{ parameters.hybridGlobalization }}


### PR DESCRIPTION
## Description

This PR updates the CI to runs iOS jobs using hybrid globalization exclusively. The Apple mobile platforms rely on the system ICU provided by the Apple SDK. Following the changes introduced in https://github.com/dotnet/runtime/pull/93220, the HybridGlobalization is the default and only option for Apple mobile platforms.

Fixes https://github.com/dotnet/runtime/issues/96868