### PR TITLE
Add Avx512 support to ProbabilisticMap

### DIFF
--- a/src/libraries/System.Memory/tests/Span/SearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/SearchValues.cs
@@ -403,7 +403,7 @@ namespace System.SpanTests
         private static class SearchValuesTestHelper
         {
             private const int MaxNeedleLength = 10;
-            private const int MaxHaystackLength = 100;
+            private const int MaxHaystackLength = 200;
 
             private static readonly char[] s_randomAsciiChars;
             private static readonly char[] s_randomLatin1Chars;

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -371,7 +371,7 @@ namespace System.Buffers
         {
             if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && searchSpaceLength >= 16)
             {
-                return Avx512Vbmi.VL.IsSupported
+                return Vector512.IsHardwareAccelerated && Avx512Vbmi.VL.IsSupported
                     ? IndexOfAnyVectorizedAvx512(ref charMap, ref searchSpace, searchSpaceLength, values)
                     : IndexOfAnyVectorized(ref charMap, ref searchSpace, searchSpaceLength, values);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -472,7 +472,7 @@ namespace System.Buffers
             }
             else
             {
-                Debug.Assert(searchSpaceLength is >= 16 and < 32);
+                Debug.Assert(searchSpaceLength is >= 16 and <= 32);
 
                 // Process the first and last vector in the search space.
                 // They may overlap, but we'll handle that in the index calculation if we do get a match.

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -107,6 +106,76 @@ namespace System.Buffers
                 values.Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(Avx512Vbmi))]
+        private static Vector512<byte> ContainsMask64CharsAvx512(Vector512<byte> charMap, ref char searchSpace0, ref char searchSpace1)
+        {
+            Vector512<ushort> source0 = Vector512.LoadUnsafe(ref searchSpace0);
+            Vector512<ushort> source1 = Vector512.LoadUnsafe(ref searchSpace1);
+
+            Vector512<byte> sourceLower = Avx512BW.PackUnsignedSaturate(
+                (source0 & Vector512.Create((ushort)255)).AsInt16(),
+                (source1 & Vector512.Create((ushort)255)).AsInt16());
+
+            Vector512<byte> sourceUpper = Avx512BW.PackUnsignedSaturate(
+                (source0 >>> 8).AsInt16(),
+                (source1 >>> 8).AsInt16());
+
+            Vector512<byte> resultLower = IsCharBitNotSetAvx512(charMap, sourceLower);
+            Vector512<byte> resultUpper = IsCharBitNotSetAvx512(charMap, sourceUpper);
+
+            return ~(resultLower | resultUpper);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(Avx512Vbmi))]
+        private static Vector512<byte> IsCharBitNotSetAvx512(Vector512<byte> charMap, Vector512<byte> values)
+        {
+            Vector512<byte> shifted = values >>> VectorizedIndexShift;
+
+            Vector512<byte> bitPositions = Avx512BW.Shuffle(Vector512.Create(0x8040201008040201).AsByte(), shifted);
+
+            Vector512<byte> index = values & Vector512.Create((byte)VectorizedIndexMask);
+            Vector512<byte> bitMask = Avx512Vbmi.PermuteVar64x8(charMap, index);
+
+            return Vector512.Equals(bitMask & bitPositions, Vector512<byte>.Zero);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(Avx512Vbmi.VL))]
+        private static Vector256<byte> ContainsMask32CharsAvx512(Vector256<byte> charMap, ref char searchSpace0, ref char searchSpace1)
+        {
+            Vector256<ushort> source0 = Vector256.LoadUnsafe(ref searchSpace0);
+            Vector256<ushort> source1 = Vector256.LoadUnsafe(ref searchSpace1);
+
+            Vector256<byte> sourceLower = Avx2.PackUnsignedSaturate(
+                (source0 & Vector256.Create((ushort)255)).AsInt16(),
+                (source1 & Vector256.Create((ushort)255)).AsInt16());
+
+            Vector256<byte> sourceUpper = Avx2.PackUnsignedSaturate(
+                (source0 >>> 8).AsInt16(),
+                (source1 >>> 8).AsInt16());
+
+            Vector256<byte> resultLower = IsCharBitNotSetAvx512(charMap, sourceLower);
+            Vector256<byte> resultUpper = IsCharBitNotSetAvx512(charMap, sourceUpper);
+
+            return ~(resultLower | resultUpper);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(Avx512Vbmi.VL))]
+        private static Vector256<byte> IsCharBitNotSetAvx512(Vector256<byte> charMap, Vector256<byte> values)
+        {
+            Vector256<byte> shifted = values >>> VectorizedIndexShift;
+
+            Vector256<byte> bitPositions = Avx2.Shuffle(Vector256.Create(0x8040201008040201).AsByte(), shifted);
+
+            Vector256<byte> index = values & Vector256.Create((byte)VectorizedIndexMask);
+            Vector256<byte> bitMask = Avx512Vbmi.VL.PermuteVar32x8(charMap, index);
+
+            return Vector256.Equals(bitMask & bitPositions, Vector256<byte>.Zero);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx2))]
         private static Vector256<byte> ContainsMask32CharsAvx2(Vector256<byte> charMapLower, Vector256<byte> charMapUpper, ref char searchSpace)
         {
@@ -121,15 +190,15 @@ namespace System.Buffers
                 (source0 >>> 8).AsInt16(),
                 (source1 >>> 8).AsInt16());
 
-            Vector256<byte> resultLower = IsCharBitSetAvx2(charMapLower, charMapUpper, sourceLower);
-            Vector256<byte> resultUpper = IsCharBitSetAvx2(charMapLower, charMapUpper, sourceUpper);
+            Vector256<byte> resultLower = IsCharBitNotSetAvx2(charMapLower, charMapUpper, sourceLower);
+            Vector256<byte> resultUpper = IsCharBitNotSetAvx2(charMapLower, charMapUpper, sourceUpper);
 
-            return resultLower & resultUpper;
+            return ~(resultLower | resultUpper);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx2))]
-        private static Vector256<byte> IsCharBitSetAvx2(Vector256<byte> charMapLower, Vector256<byte> charMapUpper, Vector256<byte> values)
+        private static Vector256<byte> IsCharBitNotSetAvx2(Vector256<byte> charMapLower, Vector256<byte> charMapUpper, Vector256<byte> values)
         {
             Vector256<byte> shifted = values >>> VectorizedIndexShift;
 
@@ -141,7 +210,7 @@ namespace System.Buffers
             Vector256<byte> mask = Vector256.GreaterThan(index, Vector256.Create((byte)15));
             Vector256<byte> bitMask = Vector256.ConditionalSelect(mask, bitMaskUpper, bitMaskLower);
 
-            return ~Vector256.Equals(bitMask & bitPositions, Vector256<byte>.Zero);
+            return Vector256.Equals(bitMask & bitPositions, Vector256<byte>.Zero);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -160,10 +229,10 @@ namespace System.Buffers
                 ? Sse2.PackUnsignedSaturate((source0 >>> 8).AsInt16(), (source1 >>> 8).AsInt16())
                 : AdvSimd.Arm64.UnzipOdd(source0.AsByte(), source1.AsByte());
 
-            Vector128<byte> resultLower = IsCharBitSet(charMapLower, charMapUpper, sourceLower);
-            Vector128<byte> resultUpper = IsCharBitSet(charMapLower, charMapUpper, sourceUpper);
+            Vector128<byte> resultLower = IsCharBitNotSet(charMapLower, charMapUpper, sourceLower);
+            Vector128<byte> resultUpper = IsCharBitNotSet(charMapLower, charMapUpper, sourceUpper);
 
-            return resultLower & resultUpper;
+            return ~(resultLower | resultUpper);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -172,7 +241,7 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        private static Vector128<byte> IsCharBitSet(Vector128<byte> charMapLower, Vector128<byte> charMapUpper, Vector128<byte> values)
+        private static Vector128<byte> IsCharBitNotSet(Vector128<byte> charMapLower, Vector128<byte> charMapUpper, Vector128<byte> values)
         {
             Vector128<byte> shifted = values >>> VectorizedIndexShift;
 
@@ -193,7 +262,7 @@ namespace System.Buffers
                 bitMask = Vector128.ConditionalSelect(mask, bitMaskUpper, bitMaskLower);
             }
 
-            return ~Vector128.Equals(bitMask & bitPositions, Vector128<byte>.Zero);
+            return Vector128.Equals(bitMask & bitPositions, Vector128<byte>.Zero);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -302,7 +371,9 @@ namespace System.Buffers
         {
             if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && searchSpaceLength >= 16)
             {
-                return IndexOfAnyVectorized(ref charMap, ref searchSpace, searchSpaceLength, values);
+                return Avx512Vbmi.VL.IsSupported
+                    ? IndexOfAnyVectorizedAvx512(ref charMap, ref searchSpace, searchSpaceLength, values)
+                    : IndexOfAnyVectorized(ref charMap, ref searchSpace, searchSpaceLength, values);
             }
 
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
@@ -313,7 +384,7 @@ namespace System.Buffers
                 int ch = cur;
                 if (Contains(ref charMap, values, ch))
                 {
-                    return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    return MatchOffset(ref searchSpace, ref cur);
                 }
 
                 cur = ref Unsafe.Add(ref cur, 1);
@@ -331,6 +402,88 @@ namespace System.Buffers
                 if (Contains(ref charMap, values, ch))
                 {
                     return i;
+                }
+            }
+
+            return -1;
+        }
+
+        [CompExactlyDependsOn(typeof(Avx512Vbmi.VL))]
+        private static int IndexOfAnyVectorizedAvx512(ref uint charMap, ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
+        {
+            Debug.Assert(Avx512Vbmi.VL.IsSupported);
+            Debug.Assert(searchSpaceLength >= 16);
+
+            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+
+            Vector256<byte> charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<uint, byte>(ref charMap));
+
+            if (searchSpaceLength > 32)
+            {
+                Vector512<byte> charMap512 = Vector512.Create(charMap256, charMap256);
+
+                if (searchSpaceLength > 64)
+                {
+                    ref char cur = ref searchSpace;
+                    ref char lastStartVector = ref Unsafe.Subtract(ref searchSpaceEnd, 64);
+
+                    while (true)
+                    {
+                        Vector512<byte> result = ContainsMask64CharsAvx512(charMap512, ref cur, ref Unsafe.Add(ref cur, Vector512<ushort>.Count));
+
+                        if (result != Vector512<byte>.Zero)
+                        {
+                            if (TryFindMatch(ref cur, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), values, out int index))
+                            {
+                                return MatchOffset(ref searchSpace, ref cur) + index;
+                            }
+                        }
+
+                        cur = ref Unsafe.Add(ref cur, 64);
+
+                        if (Unsafe.IsAddressGreaterThan(ref cur, ref lastStartVector))
+                        {
+                            if (Unsafe.AreSame(ref cur, ref searchSpaceEnd))
+                            {
+                                break;
+                            }
+
+                            // Adjust the current vector and do one last iteration.
+                            cur = ref lastStartVector;
+                        }
+                    }
+                }
+                else
+                {
+                    Debug.Assert(searchSpaceLength is > 32 and <= 64);
+
+                    // Process the first and last vector in the search space.
+                    // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                    Vector512<byte> result = ContainsMask64CharsAvx512(charMap512, ref searchSpace, ref Unsafe.Subtract(ref searchSpaceEnd, Vector512<ushort>.Count));
+
+                    if (result != Vector512<byte>.Zero)
+                    {
+                        if (TryFindMatchOverlapped(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), values, out int index))
+                        {
+                            return index;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                Debug.Assert(searchSpaceLength is >= 16 and < 32);
+
+                // Process the first and last vector in the search space.
+                // They may overlap, but we'll handle that in the index calculation if we do get a match.
+                Vector256<byte> result = ContainsMask32CharsAvx512(charMap256, ref searchSpace, ref Unsafe.Subtract(ref searchSpaceEnd, Vector256<ushort>.Count));
+
+                if (result != Vector256<byte>.Zero)
+                {
+                    if (TryFindMatchOverlapped(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), values, out int index))
+                    {
+                        return index;
+                    }
                 }
             }
 
@@ -365,21 +518,10 @@ namespace System.Buffers
 
                     if (result != Vector256<byte>.Zero)
                     {
-                        result = PackedSpanHelpers.FixUpPackedVector256Result(result);
-
-                        uint mask = result.ExtractMostSignificantBits();
-                        do
+                        if (TryFindMatch(ref cur, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), values, out int index))
                         {
-                            ref char candidatePos = ref Unsafe.Add(ref cur, BitOperations.TrailingZeroCount(mask));
-
-                            if (Contains(values, candidatePos))
-                            {
-                                return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref candidatePos) / sizeof(char));
-                            }
-
-                            mask = BitOperations.ResetLowestSetBit(mask);
+                            return MatchOffset(ref searchSpace, ref cur) + index;
                         }
-                        while (mask != 0);
                     }
 
                     cur = ref Unsafe.Add(ref cur, 32);
@@ -416,19 +558,10 @@ namespace System.Buffers
 
                 if (result != Vector128<byte>.Zero)
                 {
-                    uint mask = result.ExtractMostSignificantBits();
-                    do
+                    if (TryFindMatch(ref cur, result.ExtractMostSignificantBits(), values, out int index))
                     {
-                        ref char candidatePos = ref Unsafe.Add(ref cur, BitOperations.TrailingZeroCount(mask));
-
-                        if (Contains(values, candidatePos))
-                        {
-                            return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref candidatePos) / sizeof(char));
-                        }
-
-                        mask = BitOperations.ResetLowestSetBit(mask);
+                        return MatchOffset(ref searchSpace, ref cur) + index;
                     }
-                    while (mask != 0);
                 }
 
                 cur = ref Unsafe.Add(ref cur, 16);
@@ -449,6 +582,104 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int MatchOffset(ref char searchSpace, ref char cur) =>
+            (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFindMatch(ref char cur, uint mask, ReadOnlySpan<char> values, out int index)
+        {
+            do
+            {
+                index = BitOperations.TrailingZeroCount(mask);
+
+                if (Contains(values, Unsafe.Add(ref cur, index)))
+                {
+                    return true;
+                }
+
+                mask = BitOperations.ResetLowestSetBit(mask);
+            }
+            while (mask != 0);
+
+            index = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFindMatchOverlapped(ref char cur, int searchSpaceLength, uint mask, ReadOnlySpan<char> values, out int index)
+        {
+            do
+            {
+                index = BitOperations.TrailingZeroCount(mask);
+
+                if (index >= Vector256<ushort>.Count)
+                {
+                    // The potential match is in the second vector.
+                    // Fixup the index to account for how we loaded the second overlapped vector.
+                    index += searchSpaceLength - (2 * Vector256<ushort>.Count);
+                }
+
+                if (Contains(values, Unsafe.Add(ref cur, index)))
+                {
+                    return true;
+                }
+
+                mask = BitOperations.ResetLowestSetBit(mask);
+            }
+            while (mask != 0);
+
+            index = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFindMatch(ref char cur, ulong mask, ReadOnlySpan<char> values, out int index)
+        {
+            do
+            {
+                index = BitOperations.TrailingZeroCount(mask);
+
+                if (Contains(values, Unsafe.Add(ref cur, index)))
+                {
+                    return true;
+                }
+
+                mask = BitOperations.ResetLowestSetBit(mask);
+            }
+            while (mask != 0);
+
+            index = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFindMatchOverlapped(ref char cur, int searchSpaceLength, ulong mask, ReadOnlySpan<char> values, out int index)
+        {
+            do
+            {
+                index = BitOperations.TrailingZeroCount(mask);
+
+                if (index >= Vector512<ushort>.Count)
+                {
+                    // The potential match is in the second vector.
+                    // Fixup the index to account for how we loaded the second overlapped vector.
+                    index += searchSpaceLength - (2 * Vector512<ushort>.Count);
+                }
+
+                if (Contains(values, Unsafe.Add(ref cur, index)))
+                {
+                    return true;
+                }
+
+                mask = BitOperations.ResetLowestSetBit(mask);
+            }
+            while (mask != 0);
+
+            index = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IndexOfAnySimpleLoop<TNegator>(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
             where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
         {
@@ -460,7 +691,7 @@ namespace System.Buffers
                 char c = cur;
                 if (TNegator.NegateIfNeeded(Contains(values, c)))
                 {
-                    return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    return MatchOffset(ref searchSpace, ref cur);
                 }
 
                 cur = ref Unsafe.Add(ref cur, 1);


### PR DESCRIPTION
```c#
public class ProbMap
{
    private static readonly SearchValues<char> s_values = SearchValues.Create("abcABC123ű");
    private string _text = "ő";

    [Params(16, 32, 64, 128, 256, 10_000)]
    public int Length;

    [GlobalSetup]
    public void Setup() => _text += new string('\n', Length - 1);

    [Benchmark]
    public int IndexOfAny() => _text.AsSpan().IndexOfAny(s_values);
}
```

| Method     | Toolchain | Length | Mean         | Error     | Ratio |
|----------- |---------- |------- |-------------:|----------:|------:|
| IndexOfAny |  main     | 16     |     8.471 ns | 0.0203 ns |  1.00 |
| IndexOfAny |  pr       | 16     |     7.466 ns | 0.0391 ns |  0.88 |
|            |           |        |              |           |       |
| IndexOfAny |  main     | 32     |     9.284 ns | 0.0215 ns |  1.00 |
| IndexOfAny |  pr       | 32     |     7.313 ns | 0.0242 ns |  0.79 |
|            |           |        |              |           |       |
| IndexOfAny |  main     | 64     |    12.980 ns | 0.0082 ns |  1.00 |
| IndexOfAny |  pr       | 64     |     8.339 ns | 0.0619 ns |  0.64 |
|            |           |        |              |           |       |
| IndexOfAny |  main     | 128    |    21.795 ns | 0.0089 ns |  1.00 |
| IndexOfAny |  pr       | 128    |    11.330 ns | 0.0359 ns |  0.52 |
|            |           |        |              |           |       |
| IndexOfAny |  main     | 256    |    38.733 ns | 0.0193 ns |  1.00 |
| IndexOfAny |  pr       | 256    |    18.775 ns | 0.0245 ns |  0.48 |
|            |           |        |              |           |       |
| IndexOfAny |  main     | 10000  | 1,347.139 ns | 0.7767 ns |  1.00 |
| IndexOfAny |  pr       | 10000  |   625.296 ns | 0.3626 ns |  0.46 |

Besides just doubling the vector width, `Avx512Vbmi.VL` gives us access to better permute instructions, allowing us to replace
```c#
Vector256<byte> bitMaskLower = Avx2.Shuffle(charMapLower, index);
Vector256<byte> bitMaskUpper = Avx2.Shuffle(charMapUpper, index - Vector256.Create((byte)16));
Vector256<byte> mask = Vector256.GreaterThan(index, Vector256.Create((byte)15));
Vector256<byte> bitMask = Vector256.ConditionalSelect(mask, bitMaskUpper, bitMaskLower);
```
with
```c#
Vector256<byte> bitMask = Avx512Vbmi.VL.PermuteVar32x8(charMap, index);
```


<details>
<summary>AVX2 vs AVX512 main loop</summary>

```asm
// AVX2 loop to process 32 characters   // AVX512 loop to process 64 characters
M02_L00:                                M02_L00:
       vmovups   ymm4,[r14]                    vmovups   zmm1,[rbx]
       vmovups   ymm5,[r14+20]                 vmovups   zmm2,[rbx+40]
       vmovups   ymm6,[7FC7B99432C0]           vmovups   zmm3,[7F3FF2744E40]
       vpand     ymm7,ymm4,ymm6                vpandd    zmm4,zmm1,zmm3
       vpand     ymm6,ymm5,ymm6                vpandd    zmm3,zmm2,zmm3
       vpackuswb ymm6,ymm7,ymm6                vpackuswb zmm3,zmm4,zmm3
       vpsrlw    ymm4,ymm4,8                   vpsrlw    zmm1,zmm1,8
       vpsrlw    ymm5,ymm5,8                   vpsrlw    zmm2,zmm2,8
       vpackuswb ymm4,ymm4,ymm5                vpackuswb zmm1,zmm1,zmm2
       vpsrld    ymm5,ymm6,5                   vmovups   zmm2,[7F3FF2744E80]
       vmovups   ymm7,[7FC7B99432E0]           vpandd    zmm4,zmm3,zmm2
       vpand     ymm5,ymm5,ymm7                vpermb    zmm4,zmm4,zmm0
       vmovups   ymm8,[7FC7B9943300]           vpsrld    zmm3,zmm3,5
       vpshufb   ymm5,ymm8,ymm5                vmovups   zmm5,[7F3FF2744EC0]
       vmovups   ymm8,[7FC7B9943320]           vpandd    zmm3,zmm3,zmm5
       vpand     ymm6,ymm6,ymm8                vmovups   zmm6,[7F3FF2744F00]
       vmovups   ymm9,[7FC7B9943340]           vpshufb   zmm3,zmm6,zmm3
       vpsubb    ymm10,ymm6,ymm9               vpandd    zmm3,zmm4,zmm3
       vpcmpgtb  ymm10,ymm10,[7FC7B9943360]    vptestnmb k1,zmm3,zmm3
       vmovups   ymm11,[7FC7B9943380]          vpandd    zmm2,zmm1,zmm2
       vpsubb    ymm12,ymm6,ymm11              vpermb    zmm2,zmm2,zmm0
       vpshufb   ymm12,ymm3,ymm12              vpsrld    zmm1,zmm1,5
       vpshufb   ymm6,ymm2,ymm6                vpandd    zmm1,zmm1,zmm5
       vpblendvb ymm6,ymm6,ymm12,ymm10         vpshufb   zmm1,zmm6,zmm1
       vpand     ymm5,ymm6,ymm5                vpandd    zmm1,zmm2,zmm1
       vxorps    ymm6,ymm6,ymm6                vptestnmb k2,zmm1,zmm1
       vpcmpeqb  ymm5,ymm5,ymm6                korq      k1,k1,k2
       vpsrld    ymm6,ymm4,5                   vpmovm2b  zmm1,k1
       vpand     ymm6,ymm6,ymm7                vpternlogd zmm2,zmm2,zmm2,0FF
       vmovups   ymm7,[7FC7B9943300]           vpxord    zmm1,zmm1,zmm2
       vpshufb   ymm6,ymm7,ymm6                vptestmb  k1,zmm1,zmm1
       vpand     ymm4,ymm4,ymm8                kortestq  k1,k1
       vpsubb    ymm7,ymm4,ymm9                jne       short M02_L03
       vpcmpgtb  ymm7,ymm7,[7FC7B9943360]
       vpsubb    ymm8,ymm4,ymm11
       vpshufb   ymm8,ymm3,ymm8
       vpshufb   ymm4,ymm2,ymm4
       vpblendvb ymm4,ymm4,ymm8,ymm7
       vpand     ymm4,ymm4,ymm6
       vxorps    ymm6,ymm6,ymm6
       vpcmpeqb  ymm4,ymm4,ymm6
       vpor      ymm4,ymm5,ymm4
       vpcmpeqd  ymm5,ymm5,ymm5
       vpxor     ymm4,ymm4,ymm5
       vptest    ymm4,ymm4
       jne       near ptr M02_L10
M02_L01:                                M02_L01:
       add       r14,40                        add       rbx,80
       cmp       r14,r13                       cmp       rbx,r13
       vmovups   ymm2,[rbp-70]                 vmovups   zmm0,[rbp-70]
       vmovups   ymm3,[rbp-90]                 jbe       near ptr M02_L00
       jbe       near ptr M02_L00
```

</details>