### PR TITLE
JitDump and other minor improvements

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1783,7 +1783,7 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
     }
 #endif // DEBUG
 
-    // Track the shortcircuit criterias
+    // Track the short-circuit criteria
     optCanPropLclVar |= newAssertion->CanPropLclVar();
     optCanPropEqual |= newAssertion->CanPropEqualOrNotEqual();
     optCanPropNonNull |= newAssertion->CanPropNonNull();

--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -524,11 +524,17 @@ void BasicBlock::dspFlags() const
         {BBF_OLD_LOOP_HEADER_QUIRK, "loopheader"},
     };
 
+    bool first = true;
     for (unsigned i = 0; i < ArrLen(bbFlagDisplay); i++)
     {
         if (HasFlag(bbFlagDisplay[i].flag))
         {
-            printf("%s ", bbFlagDisplay[i].displayString);
+            if (!first)
+            {
+                printf(" ");
+            }
+            printf("%s", bbFlagDisplay[i].displayString);
+            first = false;
         }
     }
 }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2637,6 +2637,32 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
 #ifdef DEBUG
 
+    // Setup assembly name list for disassembly and dump, if not already set up.
+    if (!s_pJitDisasmIncludeAssembliesListInitialized)
+    {
+        const WCHAR* assemblyNameList = JitConfig.JitDisasmAssemblies();
+        if (assemblyNameList != nullptr)
+        {
+            s_pJitDisasmIncludeAssembliesList = new (HostAllocator::getHostAllocator())
+                AssemblyNamesList2(assemblyNameList, HostAllocator::getHostAllocator());
+        }
+        s_pJitDisasmIncludeAssembliesListInitialized = true;
+    }
+
+    // Check for a specific set of assemblies to dump.
+    // If we have an assembly name list for disassembly, also check this method's assembly.
+    bool assemblyInIncludeList = true; // assume we'll dump, if there's not an include list (or it's empty).
+    if (s_pJitDisasmIncludeAssembliesList != nullptr && !s_pJitDisasmIncludeAssembliesList->IsEmpty())
+    {
+        const char* assemblyName = info.compCompHnd->getAssemblyName(
+            info.compCompHnd->getModuleAssembly(info.compCompHnd->getClassModule(info.compClassHnd)));
+        if (!s_pJitDisasmIncludeAssembliesList->IsInList(assemblyName))
+        {
+            // We have a list, and the current assembly is not in it, so we won't dump.
+            assemblyInIncludeList = false;
+        }
+    }
+
     bool altJitConfig = !pfAltJit->isEmpty();
 
     bool verboseDump = false;
@@ -2658,6 +2684,13 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
                 verboseDump = true;
             }
         }
+    }
+
+    // Optionally suppress dumping if not in specified list of included assemblies.
+    //
+    if (verboseDump && !assemblyInIncludeList)
+    {
+        verboseDump = false;
     }
 
     // Optionally suppress dumping Tier0 jit requests.
@@ -2801,7 +2834,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         {
             assert(fgPgoSchema == nullptr);
         }
-#endif
+#endif // DEBUG
     }
 
     if (compIsForInlining())
@@ -2838,6 +2871,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.dspDiffable  = false;
     opts.disAlignment = false;
     opts.disCodeBytes = false;
+
 #ifdef DEBUG
     opts.dspInstrs       = false;
     opts.dspLines        = false;
@@ -2866,28 +2900,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     {
         bool disEnabled = true;
 
-        // Setup assembly name list for disassembly, if not already set up.
-        if (!s_pJitDisasmIncludeAssembliesListInitialized)
+        // Optionally suppress dumping if not in specified list of included assemblies.
+        //
+        if (!assemblyInIncludeList)
         {
-            const WCHAR* assemblyNameList = JitConfig.JitDisasmAssemblies();
-            if (assemblyNameList != nullptr)
-            {
-                s_pJitDisasmIncludeAssembliesList = new (HostAllocator::getHostAllocator())
-                    AssemblyNamesList2(assemblyNameList, HostAllocator::getHostAllocator());
-            }
-            s_pJitDisasmIncludeAssembliesListInitialized = true;
-        }
-
-        // If we have an assembly name list for disassembly, also check this method's assembly.
-        if (s_pJitDisasmIncludeAssembliesList != nullptr && !s_pJitDisasmIncludeAssembliesList->IsEmpty())
-        {
-            const char* assemblyName = info.compCompHnd->getAssemblyName(
-                info.compCompHnd->getModuleAssembly(info.compCompHnd->getClassModule(info.compClassHnd)));
-
-            if (!s_pJitDisasmIncludeAssembliesList->IsInList(assemblyName))
-            {
-                disEnabled = false;
-            }
+            disEnabled = false;
         }
 
         if (disEnabled)
@@ -2927,6 +2944,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
                 opts.dspDebugInfo = true;
             }
         }
+
         if (opts.disAsm && JitConfig.JitDisasmWithGC())
         {
             opts.disasmWithGC = true;
@@ -2934,14 +2952,16 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
 #ifdef LATE_DISASM
         if (JitConfig.JitLateDisasm().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args))
+        {
             opts.doLateDisasm = true;
+        }
 #endif // LATE_DISASM
 
-        // This one applies to both Ngen/Jit Disasm output: DOTNET_JitDasmWithAddress=1
         if (JitConfig.JitDasmWithAddress() != 0)
         {
             opts.disAddr = true;
         }
+
         if (JitConfig.JitLongAddress() != 0)
         {
             opts.compLongAddress = true;

--- a/src/coreclr/jit/gschecks.cpp
+++ b/src/coreclr/jit/gschecks.cpp
@@ -518,6 +518,7 @@ void Compiler::gsParamsToShadows()
         GenTree* store = gtNewStoreLclVarNode(shadowVarNum, src);
 
         fgEnsureFirstBBisScratch();
+        compCurBB = fgFirstBB; // Needed by some morphing
         (void)fgNewStmtAtBeg(fgFirstBB, fgMorphTree(store));
     }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4184,7 +4184,7 @@ void Lowering::LowerJmpMethod(GenTree* jmp)
 
     JITDUMP("lowering GT_JMP\n");
     DISPNODE(jmp);
-    JITDUMP("============");
+    JITDUMP("============\n");
 
     // If PInvokes are in-lined, we have to remember to execute PInvoke method epilog anywhere that
     // a method returns.
@@ -4201,7 +4201,7 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
 
     JITDUMP("lowering GT_RETURN\n");
     DISPNODE(ret);
-    JITDUMP("============");
+    JITDUMP("============\n");
 
     GenTree* retVal = ret->gtGetOp1();
     // There are two kinds of retyping:
@@ -4279,7 +4279,7 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
 }
 
 //----------------------------------------------------------------------------------------------
-// LowerStoreLocCommon: platform idependent part of local var or field store lowering.
+// LowerStoreLocCommon: platform independent part of local var or field store lowering.
 //
 // Arguments:
 //     lclStore - The store lcl node to lower.
@@ -7129,7 +7129,7 @@ void Lowering::WidenSIMD12IfNecessary(GenTreeLclVarCommon* node)
         {
             JITDUMP("Mapping TYP_SIMD12 lclvar node to TYP_SIMD16:\n");
             DISPNODE(node);
-            JITDUMP("============");
+            JITDUMP("============\n");
 
             node->gtType = TYP_SIMD16;
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12974,7 +12974,7 @@ void Compiler::fgAssertionGen(GenTree* tree)
     const bool makeCondAssertions =
         tree->OperIs(GT_JTRUE) && compCurBB->KindIs(BBJ_COND) && (compCurBB->NumSucc() == 2);
 
-    // Intialize apLocalIfTrue if we might look for it later,
+    // Initialize apLocalIfTrue if we might look for it later,
     // even if it ends up identical to apLocal.
     //
     if (makeCondAssertions)
@@ -13012,14 +13012,14 @@ void Compiler::fgAssertionGen(GenTree* tree)
 
         if (ifTrueAssertionIndex != NO_ASSERTION_INDEX)
         {
-            announce(ifTrueAssertionIndex, " [if true]");
+            announce(ifTrueAssertionIndex, "[if true] ");
             unsigned const bvIndex = ifTrueAssertionIndex - 1;
             BitVecOps::AddElemD(apTraits, apLocalIfTrue, bvIndex);
         }
 
         if (ifFalseAssertionIndex != NO_ASSERTION_INDEX)
         {
-            announce(ifFalseAssertionIndex, " [if false]");
+            announce(ifFalseAssertionIndex, "[if false] ");
             unsigned const bvIndex = ifFalseAssertionIndex - 1;
             BitVecOps::AddElemD(apTraits, apLocal, ifFalseAssertionIndex - 1);
         }
@@ -13479,7 +13479,7 @@ Compiler::FoldResult Compiler::fgFoldConditional(BasicBlock* block)
 //
 // Returns:
 //    true if 'stmt' was removed from the block.
-//  s false if 'stmt' is still in the block (even if other statements were removed).
+//    false if 'stmt' is still in the block (even if other statements were removed).
 //
 // Notes:
 //   Can be called anytime, unlike fgMorphStmts() which should only be called once.
@@ -13851,8 +13851,6 @@ void Compiler::fgMorphStmts(BasicBlock* block)
 //
 // Arguments:
 //    block - block in question
-//    highestReachablePostorder - maximum postorder number for a
-//     reachable block.
 //
 void Compiler::fgMorphBlock(BasicBlock* block)
 {
@@ -14006,7 +14004,7 @@ void Compiler::fgMorphBlock(BasicBlock* block)
 //
 // Note:
 //   Morph almost always changes IR, so we don't actually bother to
-//   track if it made any changees.
+//   track if it made any changes.
 //
 PhaseStatus Compiler::fgMorphBlocks()
 {

--- a/src/coreclr/jit/morphblock.cpp
+++ b/src/coreclr/jit/morphblock.cpp
@@ -71,7 +71,7 @@ protected:
 //    tree - A store tree that performs block initialization.
 //
 // Return Value:
-//    A possibly modified tree to perform the initializetion.
+//    A possibly modified tree to perform the initialization.
 //
 // static
 GenTree* MorphInitBlockHelper::MorphInitBlock(Compiler* comp, GenTree* tree)


### PR DESCRIPTION
1. Make `DOTNET_JitDisasmAssemblies` apply to `JitDump` as well.
2. Fix JitDump of `gsParamsToShadows`: it calls `fgMorphTree` which requires `compCurBB` to be set, but apparently only for JitDump.
3. Various typos and formatting nits