### PR TITLE
EventPipe: Don't clean up thread list on shutdown

### DIFF
--- a/src/native/eventpipe/ep-thread.c
+++ b/src/native/eventpipe/ep-thread.c
@@ -93,19 +93,6 @@ ep_thread_init (void)
 		EP_UNREACHABLE ("Failed to allocate threads list.");
 }
 
-void
-ep_thread_fini (void)
-{
-	// If threads are still included in list (depending on runtime shutdown order),
-	// don't clean up since TLS destructor migh callback freeing items, no new
-	// threads should however not be added to list at this stage.
-	if (dn_list_empty (_ep_threads)) {
-		dn_list_free (_ep_threads);
-		_ep_threads = NULL;
-		ep_rt_spin_lock_free (&_ep_threads_lock);
-	}
-}
-
 bool
 ep_thread_register (EventPipeThread *thread)
 {

--- a/src/native/eventpipe/ep-thread.h
+++ b/src/native/eventpipe/ep-thread.h
@@ -92,9 +92,6 @@ ep_thread_release (EventPipeThread *thread);
 void
 ep_thread_init (void);
 
-void
-ep_thread_fini (void);
-
 bool
 ep_thread_register (EventPipeThread *thread);
 

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -1499,21 +1499,6 @@ ep_shutdown (void)
 	dn_vector_free (_ep_deferred_disable_session_ids);
 	_ep_deferred_disable_session_ids = NULL;
 
-	ep_thread_fini ();
-
-	// dotnet/coreclr: issue 24850: EventPipe shutdown race conditions
-	// Deallocating providers/events here might cause AV if a WriteEvent
-	// was to occur. Thus, we are not doing this cleanup.
-
-	/*EP_LOCK_ENTER (section1)
-		ep_sample_profiler_shutdown ();
-	EP_LOCK_EXIT (section1)*/
-
-	// // Remove EventPipeEventSource first since it tries to use the data structures that we remove below.
-	// // We need to do this after disabling sessions since those try to write to EventPipeEventSource.
-	// ep_event_source_fini (ep_event_source_get ());
-	// ep_config_shutdown (ep_config_get ());
-
 ep_on_exit:
 	ep_requires_lock_not_held ();
 	ep_rt_shutdown ();


### PR DESCRIPTION
We had a report of a crash in EventPipe where the app was shutting down, and after `_ep_threads_lock` was freed a new thread was trying to fire an event and ran in to an AV trying to lock `_ep_threads_lock` to check if the thread was known.

This PR cleans up some dead code and makes `_ep_threads_lock` follow the approach we've been taking for some time now, to not clean up and let the OS deal with it after process exit.