### PR TITLE
[NativeAOT] ObjWriter: Clear only necessary memory in SectionWriter.EmitSymbolReference

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/SectionWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/SectionWriter.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.ObjectWriter
             IBufferWriter<byte> bufferWriter = _sectionData.BufferWriter;
             int size = relocType == RelocType.IMAGE_REL_BASED_DIR64 ? sizeof(ulong) : sizeof(uint);
             Span<byte> buffer = bufferWriter.GetSpan(size);
-            buffer.Clear();
+            buffer.Slice(0, size).Clear();
             _objectWriter.EmitRelocation(
                 SectionIndex,
                 Position,


### PR DESCRIPTION
Contributes to #96884