### PR TITLE
Don't shorten OCSP expriation on failed server OCSP fetch

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -282,19 +282,10 @@ namespace System.Net.Security
                 _pendingDownload = null;
                 if (ret == null)
                 {
-                    // all download attempts failed, don't try again for 5 seconds.
-                    // Note that if server does not send OCSP staples, clients may still
-                    // contact OCSP responders directly.
+                    // All download attempts failed, don't try again for 5 seconds.
+                    // This backoff will be applied only if the OCSP staple is not expired.
+                    // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
                     _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
-
-                    if (_ocspExpiration < _nextDownload)
-                    {
-                        // this prevent forced download on next call if called before _nextDownload.
-                        _ocspExpiration = _nextDownload;
-
-                        // Drop the cached OCSP response, it expires in next few seconds anyway.
-                        _ocspResponse = null;
-                    }
                 }
                 return ret;
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -286,7 +286,15 @@ namespace System.Net.Security
                     // Note that if server does not send OCSP staples, clients may still
                     // contact OCSP responders directly.
                     _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
-                    _ocspExpiration = _nextDownload;
+
+                    if (_ocspExpiration < _nextDownload)
+                    {
+                        // this prevent forced download on next call if called before _nextDownload.
+                        _ocspExpiration = _nextDownload;
+
+                        // Drop the cached OCSP response, it expires in next few seconds anyway.
+                        _ocspResponse = null;
+                    }
                 }
                 return ret;
             }


### PR DESCRIPTION
Follow up on #96448.

Minor bug in the original implementation could potentially drop a still valid OCSP staple if we fail to refresh. The failing scenario is as follows:

- Server fetches OCSP staple which is valid for, say 7 days
- After 24 hours, server attempts to fetch a new staple
- fetch fails, `_nextDownload` and `_ocspExpiration` get set to 5 seconds into the future to facilitate retry with a 5s backoff
- if OCSP responder server is still unavailable, then after % seconds, `_ocspExpiration` is in the past and we stop sending the original staple.

The original intent of setting `_ocspExpiration` was to avoid immediate refetch if we fail on the very first OCSP fetch.

This PR makes sure we don't shorten the `_ocspExpiration`