### PR TITLE
Rewind the BIO before attempting to re-process as DER

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -231,9 +232,7 @@ namespace System.Security.Cryptography.X509Certificates
                     // The additional data contains the appropriate usage (e.g. emailProtection, serverAuth, ...).
                     // Because we don't validate for a specific usage, derived certificates are rejected.
                     // For now, we skip the certificates with AUX data and use the regular certificates.
-                    ICertificatePal? pal;
-                    while (OpenSslX509CertificateReader.TryReadX509PemNoAux(fileBio, out pal) ||
-                        OpenSslX509CertificateReader.TryReadX509Der(fileBio, out pal))
+                    while (TryReadPemOrDer(fileBio, out ICertificatePal? pal))
                     {
                         readData = true;
                         X509Certificate2 cert = new X509Certificate2(pal);
@@ -283,6 +282,35 @@ namespace System.Security.Cryptography.X509Certificates
                 }
 
                 return readData;
+
+                static bool TryReadPemOrDer(SafeBioHandle fileBio, [NotNullWhen(true)] out ICertificatePal? pal)
+                {
+                    int currentPosition = Interop.Crypto.BioTell(fileBio);
+
+                    if (OpenSslX509CertificateReader.TryReadX509PemNoAux(fileBio, out pal))
+                    {
+                        return true;
+                    }
+
+                    // If BIO_tell was not able to tell us the position, then the BIO cannot be rewound. Treat this the
+                    // same as not being able to read the contents as DER.
+                    if (currentPosition < 0)
+                    {
+                        pal = null;
+                        return false;
+                    }
+
+                    int seek = Interop.Crypto.BioSeek(fileBio, currentPosition);
+
+                    // If the BIO_seek failed, treat this the same as not being able to read the contents as DER.
+                    if (seek < 0)
+                    {
+                        pal = null;
+                        return false;
+                    }
+
+                    return OpenSslX509CertificateReader.TryReadX509Der(fileBio, out pal);
+                }
             }
 
             foreach (X509Certificate2 cert in uniqueRootCerts)

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509StoreTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509StoreTests.Unix.cs
@@ -90,6 +90,33 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [PlatformSpecific(TestPlatforms.Linux)] // Windows/OSX doesn't use SSL_CERT_{DIR,FILE}.
+        private void X509Store_MachineStoreSupportsDer()
+        {
+            // We create a folder for our machine store and use it by setting SSL_CERT_DIR.
+            string sslCertDir = GetTestFilePath();
+            Directory.CreateDirectory(sslCertDir);
+
+            using X509Certificate2 cert = new(TestData.SelfSigned1PemBytes);
+
+            // Add a DER file.
+            File.WriteAllBytes(Path.Combine(sslCertDir, "1.der"), cert.RawData);
+
+            var psi = new ProcessStartInfo();
+            psi.Environment.Add("SSL_CERT_DIR", sslCertDir);
+            // Set SSL_CERT_FILE to avoid loading the default bundle file.
+            psi.Environment.Add("SSL_CERT_FILE", "/nonexisting");
+            RemoteExecutor.Invoke(static () =>
+            {
+                using (var store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
+                {
+                    store.Open(OpenFlags.OpenExistingOnly);
+                    Assert.Equal(1, store.Certificates.Count);
+                }
+            }, new RemoteInvokeOptions { StartInfo = psi }).Dispose();
+        }
+
         public static bool NotRunningAsRootAndRemoteExecutorSupported => !Environment.IsPrivilegedProcess && RemoteExecutor.IsSupported;
     }
 }


### PR DESCRIPTION
This fixes loading machine certificates in DER format because the BIO was not rewound between the PEM and DER attempts.

An alternative option is to simply remove the DER attempt completely. It didn't work and no one noticed, and the machine certificates are expected to be provided in PEM format.

Fixes #97001