### PR TITLE
JIT: Remove some early fgReorderBlocks calls

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -150,12 +150,11 @@ PhaseStatus Compiler::fgInsertGCPolls()
         block = curBasicBlock;
     }
 
-    // If we split a block to create a GC Poll, then rerun fgReorderBlocks to push the rarely run blocks out
-    // past the epilog.  We should never split blocks unless we're optimizing.
+    // If we split a block to create a GC Poll, call fgUpdateChangedFlowGraph.
+    // We should never split blocks unless we're optimizing.
     if (createdPollBlocks)
     {
         noway_assert(opts.OptimizationEnabled());
-        fgReorderBlocks(/* useProfileData */ false);
         fgUpdateChangedFlowGraph(FlowGraphUpdates::COMPUTE_BASICS);
     }
 

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -867,7 +867,6 @@ PhaseStatus Compiler::fgExpandHelper(bool skipRarelyRunBlocks)
 
     if ((result == PhaseStatus::MODIFIED_EVERYTHING) && opts.OptimizationEnabled())
     {
-        fgReorderBlocks(/* useProfileData */ false);
         fgUpdateChangedFlowGraph(FlowGraphUpdates::COMPUTE_BASICS);
     }
 


### PR DESCRIPTION
Before finalizing the block layout with `optOptimizeLayout`, we call `fgReorderBlocks` in a few optimization passes that modify the flowgraph (though without the intent to actually reorder any blocks, by passing `useProfile=false`). Removing all of these early calls -- except for the one in `optOptimizeFlow`, which can probably be replaced by moving `fgReorderBlocks`'s branch optimization logic to `fgUpdateFlowGraph` -- incurs relatively few diffs, and gets us closer to #93020's goal of deferring block reordering until late in the JIT's optimization phases.