### PR TITLE
[Mono] Add amd64 intrinsics for Vector128 Abs

### DIFF
--- a/src/mono/mono/arch/amd64/amd64-codegen.h
+++ b/src/mono/mono/arch/amd64/amd64-codegen.h
@@ -1195,9 +1195,9 @@ typedef union {
 #define amd64_sse_phaddd_reg_reg(inst, dreg, sreg) emit_sse_reg_reg_op4((inst), (dreg), (sreg), 0x66, 0x0f, 0x38, 0x02)
 #define amd64_sse_blendpd_reg_reg(inst,dreg,sreg,imm) emit_sse_reg_reg_op4_imm((inst), (dreg), (sreg), 0x66, 0x0f, 0x3a, 0x0d, (imm))
 
-#define amd64_sse_pabsb_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1c)
-#define amd64_sse_pabsw_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1d)
-#define amd64_sse_pabsd_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1e)
+#define amd64_ssse3_pabsb_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1c)
+#define amd64_ssse3_pabsw_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1d)
+#define amd64_ssse3_pabsd_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1e)
 
 #define amd64_movq_reg_reg(inst,dreg,sreg) emit_sse_reg_reg ((inst), (dreg), (sreg), 0xf3, 0x0f, 0x7e)
 

--- a/src/mono/mono/arch/amd64/amd64-codegen.h
+++ b/src/mono/mono/arch/amd64/amd64-codegen.h
@@ -1194,6 +1194,11 @@ typedef union {
 #define amd64_sse_phaddw_reg_reg(inst, dreg, sreg) emit_sse_reg_reg_op4((inst), (dreg), (sreg), 0x66, 0x0f, 0x38, 0x01)
 #define amd64_sse_phaddd_reg_reg(inst, dreg, sreg) emit_sse_reg_reg_op4((inst), (dreg), (sreg), 0x66, 0x0f, 0x38, 0x02)
 #define amd64_sse_blendpd_reg_reg(inst,dreg,sreg,imm) emit_sse_reg_reg_op4_imm((inst), (dreg), (sreg), 0x66, 0x0f, 0x3a, 0x0d, (imm))
+
+#define amd64_sse_pabsb_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1c)
+#define amd64_sse_pabsw_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1d)
+#define amd64_sse_pabsd_reg_reg(inst, dreg, reg) emit_sse_reg_reg_op4((inst), (dreg), (reg), 0x66, 0x0f, 0x38, 0x1e)
+
 #define amd64_movq_reg_reg(inst,dreg,sreg) emit_sse_reg_reg ((inst), (dreg), (sreg), 0xf3, 0x0f, 0x7e)
 
 /* Generated from x86-codegen.h */

--- a/src/mono/mono/mini/cpu-amd64.mdesc
+++ b/src/mono/mono/mini/cpu-amd64.mdesc
@@ -843,7 +843,7 @@ ssse3_shuffle: dest:x src1:x src2:x len:6 clob:1
 sse41_dpps_imm: dest:x src1:x src2:x len:7 clob:1
 sse41_dppd_imm: dest:x src1:x src2:x len:7 clob:1
 vector_andnot: dest:x src1:x src2:x len:7 clob:1
-vector_integer_abs: dest:x src1:x len:16
+vector_integer_abs: dest:x src1:x len:6
 
 roundp: dest:x src1:x len:10
 

--- a/src/mono/mono/mini/cpu-amd64.mdesc
+++ b/src/mono/mono/mini/cpu-amd64.mdesc
@@ -843,6 +843,7 @@ ssse3_shuffle: dest:x src1:x src2:x len:6 clob:1
 sse41_dpps_imm: dest:x src1:x src2:x len:7 clob:1
 sse41_dppd_imm: dest:x src1:x src2:x len:7 clob:1
 vector_andnot: dest:x src1:x src2:x len:7 clob:1
+vector_integer_abs: dest:x src1:x len:16
 
 roundp: dest:x src1:x len:10
 

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -7607,6 +7607,22 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_SSSE3_SHUFFLE:
 			amd64_sse_pshufb_reg_reg (code, ins->dreg, ins->sreg2);
 			break;
+		case OP_VECTOR_IABS:
+			switch (ins->inst_c1) {
+			case MONO_TYPE_I1:
+				amd64_sse_pabsb_reg_reg(code, ins->dreg, ins->sreg1);
+				break;
+			case MONO_TYPE_I2:
+				amd64_sse_pabsw_reg_reg(code, ins->dreg, ins->sreg1);
+				break;
+			case MONO_TYPE_I4:
+				amd64_sse_pabsd_reg_reg(code, ins->dreg, ins->sreg1);
+				break;
+			default:
+				g_assert_not_reached ();
+				break;
+			}
+			break;
 		case OP_SSE41_ROUNDP: {
 			if (ins->inst_c1 == MONO_TYPE_R8)
 				amd64_sse_roundpd_reg_reg_imm (code, ins->dreg, ins->sreg1, ins->inst_c0);

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -7610,14 +7610,16 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 		case OP_VECTOR_IABS:
 			switch (ins->inst_c1) {
 			case MONO_TYPE_I1:
-				amd64_sse_pabsb_reg_reg(code, ins->dreg, ins->sreg1);
+				amd64_ssse3_pabsb_reg_reg(code, ins->dreg, ins->sreg1);
 				break;
 			case MONO_TYPE_I2:
-				amd64_sse_pabsw_reg_reg(code, ins->dreg, ins->sreg1);
+				amd64_ssse3_pabsw_reg_reg(code, ins->dreg, ins->sreg1);
 				break;
 			case MONO_TYPE_I4:
+#if TARGET_SIZEOF_VOID_P == 4
 			case MONO_TYPE_I:
-				amd64_sse_pabsd_reg_reg(code, ins->dreg, ins->sreg1);
+#endif
+				amd64_ssse3_pabsd_reg_reg(code, ins->dreg, ins->sreg1);
 				break;
 			default:
 				g_assert_not_reached ();

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -7616,6 +7616,7 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 				amd64_sse_pabsw_reg_reg(code, ins->dreg, ins->sreg1);
 				break;
 			case MONO_TYPE_I4:
+			case MONO_TYPE_I:
 				amd64_sse_pabsd_reg_reg(code, ins->dreg, ins->sreg1);
 				break;
 			default:

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1479,7 +1479,7 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 				return emit_simd_ins_for_sig (cfg, klass, OP_VECTOR_IABS, -1, arg0_type, fsig, args);
 
 			// SSSE3 does not support i64
-			if (arg0_type == MONO_TYPE_I8) {
+			if (arg0_type == MONO_TYPE_I8 || (TARGET_SIZEOF_VOID_P == 8 && arg0_type == MONO_TYPE_I)) {
 				MonoInst *zero = emit_xzero (cfg, klass);
 				MonoInst *neg = emit_simd_ins (cfg, klass, OP_XBINOP, zero->dreg, args [0]->dreg);
 				neg->inst_c0 = OP_ISUB;

--- a/src/mono/mono/mini/simd-intrinsics.c
+++ b/src/mono/mono/mini/simd-intrinsics.c
@@ -1486,10 +1486,11 @@ emit_sri_vector (MonoCompile *cfg, MonoMethod *cmethod, MonoMethodSignature *fsi
 			MonoInst *zero = emit_xzero (cfg, klass);
 			MonoInst *neg = emit_simd_ins (cfg, klass, OP_XBINOP, zero->dreg, args [0]->dreg);
 			neg->inst_c0 = OP_ISUB;
-			neg->inst_c1 = MONO_TYPE_I8;
+			neg->inst_c1 = arg0_type;
+			
 			MonoInst *ins = emit_simd_ins (cfg, klass, OP_XBINOP, args [0]->dreg, neg->dreg);
 			ins->inst_c0 = OP_IMAX;
-			ins->inst_c1 = MONO_TYPE_I8;
+			ins->inst_c1 = arg0_type;
 			return ins;
 		}
 #elif defined(TARGET_WASM)


### PR DESCRIPTION
Should fix https://github.com/dotnet/perf-autofiling-issues/issues/25809. 