### PR TITLE
[wasm][docs] Add information about AOT build

### DIFF
--- a/docs/workflow/testing/libraries/testing-wasm.md
+++ b/docs/workflow/testing/libraries/testing-wasm.md
@@ -146,6 +146,8 @@ By default, `chrome` browser is used.
 
 ## AOT library tests
 
+- Running AOT tests requires AOT runtime build. Add `/p:RunAOTCompilation=true` to your build command, e.g. `build.sh mono+libs -c release -os browser /p:RunAOTCompilation=true`.
+
 - Building library tests with AOT, and (even) with `EnableAggressiveTrimming` takes 3-9mins on CI, and that adds up for all the assemblies, causing
 a large build time. To circumvent that on CI, we build the test assemblies on the build machine, but skip the WasmApp build part of it, since
 that includes the expensive AOT step.


### PR DESCRIPTION
Nowhere in wasm docs we mention the need to build the runtime with AOT option switched on. There is only an info how to run tests when the runtime is already built.
E.g. android has this info:
https://github.com/dotnet/runtime/blob/a08d3fc730505edd0f29c20de76a01995de8cd36/docs/workflow/testing/libraries/testing-android.md?plain=1#L103
and apple as well:
https://github.com/dotnet/runtime/blob/a08d3fc730505edd0f29c20de76a01995de8cd36/docs/workflow/testing/libraries/testing-apple.md?plain=1#L121