### PR TITLE
[PERF] Remove HybridGlobalization test name extension from iOS tests

### DIFF
--- a/eng/testing/performance/ios_scenarios.proj
+++ b/eng/testing/performance/ios_scenarios.proj
@@ -21,9 +21,7 @@
     <SymbolsPath Condition="'$(iOSStripSymbols)' == 'True'"> nosymbols</SymbolsPath>
     <!-- For non-default configurations, add the configuration to the name of the test (in the matching format), otherwise don't add anything.
     This will ensure that PowerBI's using the test name rather than the run configuration for the data continue to work properly and defaults are connected -->
-    <HybridGlobalizationPath></HybridGlobalizationPath>
-    <HybridGlobalizationPath Condition="'$(hybridGlobalization)' == 'True'"> HybridGlobalization</HybridGlobalizationPath>
-    <RunConfigsString>$(LlvmPath)$(SymbolsPath)$(HybridGlobalizationPath)</RunConfigsString>
+    <RunConfigsString>$(LlvmPath)$(SymbolsPath)</RunConfigsString>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AGENT_OS)' == 'Windows_NT'">


### PR DESCRIPTION
Remove HybridGlobalization test name extension from iOS tests as HG is now the default and only way to run. Another part of https://github.com/dotnet/runtime/pull/96918 that was initially missed.