### PR TITLE
Enable CMake Flag `-W3` as New CMP0092 no Longer Does it Implicitly

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -767,9 +767,6 @@ if (MSVC)
   # Compile options for targeting windows
 
   add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/nologo>) # Suppress Startup Banner
-  # /W3 is added by default by CMake, so remove it
-  string(REPLACE "/W3" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  string(REPLACE "/W3" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
   # [[! Microsoft.Security.SystemsADM.10086 !]] - SDL required warnings
   # set default warning level to 4 but allow targets to override it.

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -35,8 +35,6 @@ endif()
 
 OPTION(CLR_CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 
-add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-W3>)
-
 #----------------------------------------------------
 # Cross target Component build specific configuration
 #----------------------------------------------------

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -35,6 +35,8 @@ endif()
 
 OPTION(CLR_CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 
+add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-W3>)
+
 #----------------------------------------------------
 # Cross target Component build specific configuration
 #----------------------------------------------------


### PR DESCRIPTION
Resolves #96815. Starting on CMake 3.15, the warning flag `-W3` is no longer added by default. We now have a minimum version of 3.20, and we would like to keep this warning enabled, so this PR addresses this.