### PR TITLE
Forward minipal_get_length_utf16_to_utf8 and minipal_convert_utf16_to_utf8 from DAC

### DIFF
--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -69,6 +69,9 @@ nativeStringResourceTable_mscorrc
 #PAL__pread
 #PAL__close
 
+#minipal_get_length_utf16_to_utf8
+#minipal_convert_utf16_to_utf8
+
 #_wcsicmp
 #_stricmp
 #sprintf_s


### PR DESCRIPTION
Fixes #96747