### PR TITLE
Augment the backport PR description template to prompt for more info

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -38,11 +38,11 @@ jobs:
 
         ## Testing
 
-        [How was the fix verified? How was the issue missed previously?]
+        [How was the fix verified? How was the issue missed previously? What tests were added?]
 
         ## Risk
 
-        [High/Medium/Low. Justify the indication by mentioning how risks were measured and minimized.]
+        [High/Medium/Low. Justify the indication by mentioning how risks were measured and addressed.]
 
         **IMPORTANT**: If this backport is for a servicing release, please verify that:
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,13 +24,28 @@ jobs:
 
         ## Customer Impact
 
+        - [ ] Customer reported
+        - [ ] Found internally
+
+        [Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]
+
+        ## Regression
+
+        - [ ] Yes
+        - [ ] No
+
+        [If yes, specify when the regression was introduced. Provide the PR or commit if known.]
+
         ## Testing
 
+        [How was the fix verified? How was the issue missed previously?]
+
         ## Risk
+
+        [High/Medium/Low. Justify the indication by mentioning how risks were measured and minimized.]
 
         **IMPORTANT**: If this backport is for a servicing release, please verify that:
 
         - The PR target branch is `release/X.0-staging`, not `release/X.0`.
 
         - If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
-


### PR DESCRIPTION
Taking inspiration from [dotnet/aspnetcore's backport template](https://github.com/dotnet/aspnetcore/blob/main/.github/workflows/backport.yml), this augments ours to prompt for:

1. Customer reported, or found internally
2. Regression (if so, when was it introduced)
3. How the issue escaped testing
4. Justifying the declared risk
