### PR TITLE
Simplify regex code gen for whitespace search

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1143,6 +1143,11 @@ namespace System.Text.RegularExpressions.Generator
                             (true, true) => $"{span}.IndexOfAnyExcept({Literal(primarySet.Range.Value.LowInclusive)})",
                         };
                     }
+                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated))
+                    {
+                        // We have a known set of characters, and we can use the supplied IndexOfAny{Except}(...).
+                        indexOf = $"{span}.{(negated ? "IndexOfAnyExcept" : "IndexOfAny")}({EmitSearchValues(setChars, requiredHelpers)})";
+                    }
                     else
                     {
                         // We have an arbitrary set of characters that's really large or otherwise not enumerable.

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -400,55 +400,57 @@ namespace System.Text.RegularExpressions.Generator
         }
 
         /// <summary>Adds a SearchValues instance declaration to the required helpers collection.</summary>
-        private static string EmitSearchValues(char[] chars, Dictionary<string, string[]> requiredHelpers)
+        private static string EmitSearchValues(char[] chars, Dictionary<string, string[]> requiredHelpers, string? fieldName = null)
         {
             Array.Sort(chars);
 
-            string fieldName;
-            if (RegexCharClass.IsAscii(chars))
+            if (fieldName is null)
             {
-                // The set of ASCII characters can be represented as a 128-bit bitmap. Use the 16-byte hex string as the key.
-                var bitmap = new byte[16];
-                foreach (char c in chars)
+                if (RegexCharClass.IsAscii(chars))
                 {
-                    bitmap[c >> 3] |= (byte)(1 << (c & 7));
+                    // The set of ASCII characters can be represented as a 128-bit bitmap. Use the 16-byte hex string as the key.
+                    var bitmap = new byte[16];
+                    foreach (char c in chars)
+                    {
+                        bitmap[c >> 3] |= (byte)(1 << (c & 7));
+                    }
+
+                    string hexBitmap = BitConverter.ToString(bitmap).Replace("-", string.Empty);
+
+                    fieldName = hexBitmap switch
+                    {
+                        "FFFFFFFF000000000000000000000080" => "s_asciiControl",
+                        "000000000000FF030000000000000000" => "s_asciiDigits",
+                        "0000000000000000FEFFFF07FEFFFF07" => "s_asciiLetters",
+                        "000000000000FF03FEFFFF07FEFFFF07" => "s_asciiLettersAndDigits",
+                        "000000000000FF037E0000007E000000" => "s_asciiHexDigits",
+                        "000000000000FF03000000007E000000" => "s_asciiHexDigitsLower",
+                        "000000000000FF037E00000000000000" => "s_asciiHexDigitsUpper",
+                        "00000000EEF7008C010000B800000028" => "s_asciiPunctuation",
+                        "00000000010000000000000000000000" => "s_asciiSeparators",
+                        "00000000100800700000004001000050" => "s_asciiSymbols",
+                        "003E0000010000000000000000000000" => "s_asciiWhiteSpace",
+                        "000000000000FF03FEFFFF87FEFFFF07" => "s_asciiWordChars",
+
+                        "00000000FFFFFFFFFFFFFFFFFFFFFF7F" => "s_asciiExceptControl",
+                        "FFFFFFFFFFFF00FCFFFFFFFFFFFFFFFF" => "s_asciiExceptDigits",
+                        "FFFFFFFFFFFFFFFF010000F8010000F8" => "s_asciiExceptLetters",
+                        "FFFFFFFFFFFF00FC010000F8010000F8" => "s_asciiExceptLettersAndDigits",
+                        "FFFFFFFFFFFFFFFFFFFFFFFF010000F8" => "s_asciiExceptLower",
+                        "FFFFFFFF1108FF73FEFFFF47FFFFFFD7" => "s_asciiExceptPunctuation",
+                        "FFFFFFFFFEFFFFFFFFFFFFFFFFFFFFFF" => "s_asciiExceptSeparators",
+                        "FFFFFFFFEFF7FF8FFFFFFFBFFEFFFFAF" => "s_asciiExceptSymbols",
+                        "FFFFFFFFFFFFFFFF010000F8FFFFFFFF" => "s_asciiExceptUpper",
+                        "FFC1FFFFFEFFFFFFFFFFFFFFFFFFFFFF" => "s_asciiExceptWhiteSpace",
+                        "FFFFFFFFFFFF00FC01000078010000F8" => "s_asciiExceptWordChars",
+
+                        _ => $"s_ascii_{hexBitmap.TrimStart('0')}"
+                    };
                 }
-
-                string hexBitmap = BitConverter.ToString(bitmap).Replace("-", string.Empty);
-
-                fieldName = hexBitmap switch
+                else
                 {
-                    "FFFFFFFF000000000000000000000080" => "s_asciiControl",
-                    "000000000000FF030000000000000000" => "s_asciiDigits",
-                    "0000000000000000FEFFFF07FEFFFF07" => "s_asciiLetters",
-                    "000000000000FF03FEFFFF07FEFFFF07" => "s_asciiLettersAndDigits",
-                    "000000000000FF037E0000007E000000" => "s_asciiHexDigits",
-                    "000000000000FF03000000007E000000" => "s_asciiHexDigitsLower",
-                    "000000000000FF037E00000000000000" => "s_asciiHexDigitsUpper",
-                    "00000000EEF7008C010000B800000028" => "s_asciiPunctuation",
-                    "00000000010000000000000000000000" => "s_asciiSeparators",
-                    "00000000100800700000004001000050" => "s_asciiSymbols",
-                    "003E0000010000000000000000000000" => "s_asciiWhiteSpace",
-                    "000000000000FF03FEFFFF87FEFFFF07" => "s_asciiWordChars",
-
-                    "00000000FFFFFFFFFFFFFFFFFFFFFF7F" => "s_asciiExceptControl",
-                    "FFFFFFFFFFFF00FCFFFFFFFFFFFFFFFF" => "s_asciiExceptDigits",
-                    "FFFFFFFFFFFFFFFF010000F8010000F8" => "s_asciiExceptLetters",
-                    "FFFFFFFFFFFF00FC010000F8010000F8" => "s_asciiExceptLettersAndDigits",
-                    "FFFFFFFFFFFFFFFFFFFFFFFF010000F8" => "s_asciiExceptLower",
-                    "FFFFFFFF1108FF73FEFFFF47FFFFFFD7" => "s_asciiExceptPunctuation",
-                    "FFFFFFFFFEFFFFFFFFFFFFFFFFFFFFFF" => "s_asciiExceptSeparators",
-                    "FFFFFFFFEFF7FF8FFFFFFFBFFEFFFFAF" => "s_asciiExceptSymbols",
-                    "FFFFFFFFFFFFFFFF010000F8FFFFFFFF" => "s_asciiExceptUpper",
-                    "FFC1FFFFFEFFFFFFFFFFFFFFFFFFFFFF" => "s_asciiExceptWhiteSpace",
-                    "FFFFFFFFFFFF00FC01000078010000F8" => "s_asciiExceptWordChars",
-
-                    _ => $"s_ascii_{hexBitmap.TrimStart('0')}"
-                };
-            }
-            else
-            {
-                fieldName = GetSHA256FieldName("s_nonAscii_", new string(chars));
+                    fieldName = GetSHA256FieldName("s_nonAscii_", new string(chars));
+                }
             }
 
             if (!requiredHelpers.ContainsKey(fieldName))
@@ -1143,10 +1145,10 @@ namespace System.Text.RegularExpressions.Generator
                             (true, true) => $"{span}.IndexOfAnyExcept({Literal(primarySet.Range.Value.LowInclusive)})",
                         };
                     }
-                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated))
+                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated, out string? description))
                     {
                         // We have a known set of characters, and we can use the supplied IndexOfAny{Except}(...).
-                        indexOf = $"{span}.{(negated ? "IndexOfAnyExcept" : "IndexOfAny")}({EmitSearchValues(setChars, requiredHelpers)})";
+                        indexOf = $"{span}.{(negated ? "IndexOfAnyExcept" : "IndexOfAny")}({EmitSearchValues(setChars, requiredHelpers, $"s_{description}")})";
                     }
                     else
                     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -962,7 +962,11 @@ namespace System.Text.RegularExpressions
         /// Gets whether the specified set is a named set with a reasonably small count
         /// of Unicode characters.
         /// </summary>
-        public static bool IsUnicodeCategoryOfSmallCharCount(string set, [NotNullWhen(true)] out char[]? chars, out bool negated)
+        /// <param name="set">The set description.</param>
+        /// <param name="chars">The chars that make up the known set.</param>
+        /// <param name="negated">Whether the <paramref name="chars"/> need to be negated.</param>
+        /// <param name="description">A description suitable for use in C# code as a variable name.</param>
+        public static bool IsUnicodeCategoryOfSmallCharCount(string set, [NotNullWhen(true)] out char[]? chars, out bool negated, [NotNullWhen(true)] out string? description)
         {
             switch (set)
             {
@@ -970,11 +974,13 @@ namespace System.Text.RegularExpressions
                 case NotSpaceClass:
                     chars = s_whitespaceChars;
                     negated = set == NotSpaceClass;
+                    description = "whitespace";
                     return true;
             }
 
             chars = default;
             negated = false;
+            description = null;
             return false;
         }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -304,6 +304,13 @@ namespace System.Text.RegularExpressions
                 +"\u3041\u3097\u3099\u30A0\u30A1\u30FB\u30FC\u3100\u3105\u312D\u3131\u318F\u3190\u31B8\u31F0\u321D\u3220\u3244\u3251\u327C\u327F\u32CC\u32D0\u32FF\u3300\u3377\u337B\u33DE\u33E0\u33FF\u3400\u4DB6\u4E00\u9FA6\uA000\uA48D\uA490\uA4C7\uAC00\uD7A4\uF900\uFA2E\uFA30\uFA6B\uFB00\uFB07\uFB13\uFB18\uFB1D\uFB37\uFB38\uFB3D\uFB3E\uFB3F\uFB40\uFB42\uFB43\uFB45\uFB46\uFBB2\uFBD3\uFD3E\uFD50\uFD90\uFD92\uFDC8\uFDF0\uFDFD\uFE00\uFE10\uFE20\uFE24\uFE62\uFE63\uFE64\uFE67\uFE69\uFE6A\uFE70\uFE75\uFE76\uFEFD\uFF04\uFF05\uFF0B\uFF0C\uFF10\uFF1A\uFF1C\uFF1F\uFF21\uFF3B\uFF3E\uFF3F\uFF40\uFF5B\uFF5C\uFF5D\uFF5E\uFF5F\uFF66\uFFBF\uFFC2\uFFC8\uFFCA\uFFD0\uFFD2\uFFD8\uFFDA\uFFDD\uFFE0\uFFE7\uFFE8\uFFEF\uFFFC\uFFFE"],
         ];
 
+        private static readonly char[] s_whitespaceChars =
+            ['\u0009', '\u000A', '\u000B', '\u000C', '\u000D',
+             '\u0020', '\u0085', '\u00A0', '\u1680', '\u2000',
+             '\u2001', '\u2002', '\u2003', '\u2004', '\u2005',
+             '\u2006', '\u2007', '\u2008', '\u2009', '\u200A',
+             '\u2028', '\u2029', '\u202F', '\u205F', '\u3000'];
+
         private List<(char First, char Last)>? _rangelist;
         private StringBuilder? _categories;
         private RegexCharClass? _subtractor;
@@ -323,6 +330,12 @@ namespace System.Text.RegularExpressions
             for (int i = 0; i < len - 1; i++)
                 Debug.Assert(string.Compare(s_propTable[i][0], s_propTable[i + 1][0], StringComparison.Ordinal) < 0, $"RegexCharClass s_propTable is out of order at ({s_propTable[i][0]}, {s_propTable[i + 1][0]})");
 
+            // Make sure character information is in sync with Unicode data.
+            var whitespaceSet = new HashSet<char>(s_whitespaceChars);
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                Debug.Assert(whitespaceSet.Contains((char)i) == char.IsWhiteSpace((char)i));
+            }
         }
 #endif
 
@@ -943,6 +956,26 @@ namespace System.Text.RegularExpressions
 
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Gets whether the specified set is a named set with a reasonably small count
+        /// of Unicode characters.
+        /// </summary>
+        public static bool IsUnicodeCategoryOfSmallCharCount(string set, [NotNullWhen(true)] out char[]? chars, out bool negated)
+        {
+            switch (set)
+            {
+                case SpaceClass:
+                case NotSpaceClass:
+                    chars = s_whitespaceChars;
+                    negated = set == NotSpaceClass;
+                    return true;
+            }
+
+            chars = default;
+            negated = false;
+            return false;
         }
 
         /// <summary>Gets whether the specified character participates in case conversion.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -953,7 +953,7 @@ namespace System.Text.RegularExpressions
                             Call(primarySet.Negated ? s_spanIndexOfAnyExceptInRange : s_spanIndexOfAnyInRange);
                         }
                     }
-                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated))
+                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated, out _))
                     {
                         // We have a known set of small number of characters; we can use IndexOfAny{Except}(searchValues).
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -953,6 +953,14 @@ namespace System.Text.RegularExpressions
                             Call(primarySet.Negated ? s_spanIndexOfAnyExceptInRange : s_spanIndexOfAnyInRange);
                         }
                     }
+                    else if (RegexCharClass.IsUnicodeCategoryOfSmallCharCount(primarySet.Set, out char[]? setChars, out bool negated))
+                    {
+                        // We have a known set of small number of characters; we can use IndexOfAny{Except}(searchValues).
+
+                        // tmp = ...IndexOfAny(s_searchValues);
+                        LoadSearchValues(setChars);
+                        Call(negated ? s_spanIndexOfAnyExceptSearchValues : s_spanIndexOfAnySearchValues);
+                    }
                     else
                     {
                         // In order to optimize the search for ASCII characters, we use SearchValues to vectorize a search


### PR DESCRIPTION
Rather than emitting a custom helper, we can just use IndexOfAny{Except} with a SearchValues for the whitespace characters.

Fixes https://github.com/dotnet/runtime/issues/93573