### PR TITLE
Disable dump creation for ParallelCrashTester child

### DIFF
--- a/src/tests/baseservices/exceptions/simple/ParallelCrashTester.cs
+++ b/src/tests/baseservices/exceptions/simple/ParallelCrashTester.cs
@@ -35,6 +35,8 @@ public class ParallelCrashTester
         testProcess.StartInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
         testProcess.StartInfo.Arguments = $"ParallelCrash.dll {arg}";
         testProcess.StartInfo.UseShellExecute = false;
+        // Disable creating dump since the target process is expected to crash
+        testProcess.StartInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
         testProcess.Start();
         testProcess.WaitForExit();
 


### PR DESCRIPTION
The child process is intentionally crashing, so creating a dump for it is a waste of time and disk space and it also seems to be causing random failures of the test in the CI.

This change disables the dump creation for it.

Close #94652