### PR TITLE
Code coverage for Server-side OCSP stapling

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -17,6 +17,10 @@ namespace System.Net.Security
 {
     public partial class SslStreamCertificateContext
     {
+        internal static TimeSpan DefaultOcspRefreshInterval => TimeSpan.FromHours(24);
+        internal static TimeSpan MinRefreshBeforeExpirationInterval => TimeSpan.FromMinutes(5);
+        internal static TimeSpan RefreshAfterFailureBackOffInterval => TimeSpan.FromSeconds(5);
+
         private const bool TrimRootCertificate = true;
         internal readonly ConcurrentDictionary<SslProtocols, SafeSslContextHandle> SslContexts;
         internal readonly SafeX509Handle CertificateHandle;
@@ -260,8 +264,8 @@ namespace System.Net.Security
                             _ocspUrls[i] = tmp;
                         }
 
-                        DateTimeOffset nextCheckA = DateTimeOffset.UtcNow.AddDays(1);
-                        DateTimeOffset nextCheckB = expiration.AddMinutes(-5);
+                        DateTimeOffset nextCheckA = DateTimeOffset.UtcNow.Add(DefaultOcspRefreshInterval);
+                        DateTimeOffset nextCheckB = expiration.Subtract(MinRefreshBeforeExpirationInterval);
 
                         _ocspResponse = ret;
                         _ocspExpiration = expiration;
@@ -285,7 +289,7 @@ namespace System.Net.Security
                     // All download attempts failed, don't try again for 5 seconds.
                     // This backoff will be applied only if the OCSP staple is not expired.
                     // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
-                    _nextDownload = DateTimeOffset.UtcNow.AddSeconds(5);
+                    _nextDownload = DateTimeOffset.UtcNow.Add(RefreshAfterFailureBackOffInterval);
                 }
                 return ret;
             }

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -121,7 +121,6 @@ public class SslStreamCertificateContextOcspLinuxTests
     }
 
     [Fact]
-    [OuterLoop("Takes about 3 seconds")]
     public async Task RefreshOcspResponse_AfterExpiration()
     {
         await SimpleTest(PkiOptions.OcspEverywhere, async (root, intermediate, endEntity, ctxFactory, responder) =>

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -67,7 +67,7 @@ public class SslStreamCertificateContextOcspLinuxTests
     {
         await SimpleTest(PkiOptions.OcspEverywhere, async (root, intermediate, endEntity, ctxFactory, responder) =>
         {
-            intermediate.RevocationExpiration = DateTimeOffset.UtcNow;
+            intermediate.RevocationExpiration = DateTimeOffset.UtcNow.AddMinutes(-5);
 
             SslStreamCertificateContext ctx = ctxFactory(false);
             byte[] ocsp = await ctx.GetOcspResponseAsync();

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO;
+using System.Net.Test.Common;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.X509Certificates.Tests.Common;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Net.Security;
+
+using Xunit;
+
+namespace System.Net.Security.Tests;
+
+// [OuterLoop("Tests tests run long time")]
+public class SslStreamCertificateContextOcspLinuxTests
+{
+    [Fact]
+    public async Task Runs()
+    {
+        var pkiOptions = PkiOptions.None;
+        await SimpleTest(pkiOptions, async (root, intermediate, endEntity, ctxFactory, responder) =>
+        {
+            var ctx = ctxFactory(false);
+            var ocsp = await ctx.GetOcspResponseAsync();
+        });
+    }
+
+    private delegate Task RunSimpleTest(
+        CertificateAuthority root,
+        CertificateAuthority intermediate,
+        X509Certificate2 endEntity,
+        Func<bool, SslStreamCertificateContext> ctxFactory,
+        RevocationResponder responder);
+
+    private static async Task SimpleTest(
+        PkiOptions pkiOptions,
+        RunSimpleTest callback,
+        [CallerMemberName] string callerName = null,
+        bool pkiOptionsInTestName = true)
+    {
+        BuildPrivatePki(
+            pkiOptions,
+            out RevocationResponder responder,
+            out CertificateAuthority root,
+            out CertificateAuthority intermediate,
+            out X509Certificate2 endEntity,
+            callerName,
+            pkiOptionsInSubject: pkiOptionsInTestName);
+
+        using (responder)
+        using (root)
+        using (intermediate)
+        using (endEntity)
+        using (X509Certificate2 rootCert = root.CloneIssuerCert())
+        using (X509Certificate2 intermediateCert = intermediate.CloneIssuerCert())
+        {
+            if (pkiOptions.HasFlag(PkiOptions.RootAuthorityHasDesignatedOcspResponder))
+            {
+                using (RSA tmpKey = RSA.Create())
+                using (X509Certificate2 tmp = root.CreateOcspSigner(
+                    BuildSubject("A Root Designated OCSP Responder", callerName, pkiOptions, true),
+                    tmpKey))
+                {
+                    root.DesignateOcspResponder(tmp.CopyWithPrivateKey(tmpKey));
+                }
+            }
+
+            if (pkiOptions.HasFlag(PkiOptions.IssuerAuthorityHasDesignatedOcspResponder))
+            {
+                using (RSA tmpKey = RSA.Create())
+                using (X509Certificate2 tmp = intermediate.CreateOcspSigner(
+                    BuildSubject("An Intermediate Designated OCSP Responder", callerName, pkiOptions, true),
+                    tmpKey))
+                {
+                    intermediate.DesignateOcspResponder(tmp.CopyWithPrivateKey(tmpKey));
+                }
+            }
+
+            X509Certificate2Collection additionalCerts = new();
+            additionalCerts.Add(intermediateCert);
+            additionalCerts.Add(rootCert);
+
+            Func<bool, SslStreamCertificateContext> factory = offline => SslStreamCertificateContext.Create(
+                endEntity,
+                additionalCerts,
+                offline,
+                trust: null);
+
+            await RetryHelper.ExecuteAsync(() =>
+            {
+                return callback(root, intermediate, endEntity, factory, responder);
+            });
+        }
+    }
+
+    internal static void BuildPrivatePki(
+        PkiOptions pkiOptions,
+        out RevocationResponder responder,
+        out CertificateAuthority rootAuthority,
+        out CertificateAuthority intermediateAuthority,
+        out X509Certificate2 endEntityCert,
+        [CallerMemberName] string testName = null,
+        bool registerAuthorities = true,
+        bool pkiOptionsInSubject = false)
+    {
+        bool issuerRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaCrl);
+        bool issuerRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaOcsp);
+        bool endEntityRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaCrl);
+        bool endEntityRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaOcsp);
+
+        Assert.True(
+            issuerRevocationViaCrl || issuerRevocationViaOcsp ||
+                endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
+            "At least one revocation mode is enabled");
+
+        CertificateAuthority.BuildPrivatePki(pkiOptions, out responder, out rootAuthority, out intermediateAuthority, out endEntityCert, testName, registerAuthorities, pkiOptionsInSubject);
+    }
+
+    private static string BuildSubject(
+        string cn,
+        string testName,
+        PkiOptions pkiOptions,
+        bool includePkiOptions)
+    {
+        if (includePkiOptions)
+        {
+            return $"CN=\"{cn}\", O=\"{testName}\", OU=\"{pkiOptions}\"";
+        }
+
+        return $"CN=\"{cn}\", O=\"{testName}\"";
+    }
+}

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -40,7 +40,97 @@
              Link="CommonTest\System\Net\SslProtocolSupport.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"
              Link="Common\System\HexConverter.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\CertificateAuthority.cs"
+             Link="CommonTest\System\Security\Cryptography\X509Certificates\CertificateAuthority.cs" />
+    <Compile Include="$(CommonTestPath)System\Security\Cryptography\X509Certificates\RevocationResponder.cs"
+             Link="CommonTest\System\Security\Cryptography\X509Certificates\RevocationResponder.cs" />
   </ItemGroup>
+
+  <!-- Linux specific files -->
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'unix'">
+    <!-- Linux specific tests -->
+    <Compile Include="SslStreamCertificateContextOcspLinuxTests.cs" />
+
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.Linux.cs" />
+    <Compile Include="..\..\src\System\Net\Security\Pal.Managed\SafeChannelBindingHandle.cs" />
+    <Compile Include="..\..\src\System\Net\Security\CipherSuitesPolicyPal.Linux.cs" />
+    <Compile Include="..\..\src\System\Net\Security\SslCertificateTrust.cs" />
+    <Compile Include="..\..\src\System\Net\Security\CipherSuitesPolicy.cs" />
+
+    <!-- these are not specific to linux, but they are not necessary for tests on other platforms -->
+    <Compile Include="$(CommonPath)System\Net\UriScheme.cs"
+             Link="Common\System\Net\UriScheme.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SecChannelBindings.cs"
+             Link="Common\System\Net\Security\Unix\SecChannelBindings.cs" />
+
+    <Compile Include="$(CommonPath)System\Net\Http\X509ResourceClient.cs"
+             Link="Common\System\Net\Http\X509ResourceClient.cs" />
+    <Compile Include="$(CommonPath)System\Text\UrlBase64Encoding.cs"
+             Link="Common\System\Text\UrlBase64Encoding.cs" />
+
+    <!-- Linux interop layer here -->
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs"
+             Link="Common\Interop\Unix\Interop.Errors.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteContext.cs"
+             Link="Common\System\Net\Security\Unix\SafeDeleteContext.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OCSP.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSsl.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSsl.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs"
+                 Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.OpenSslVersion.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SetProtocolOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs" />
+    <Compile Include="$(CommonPath)Microsoft\Win32\SafeHandles\SafeHandleCache.cs"
+             Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteSslContext.cs"
+             Link="Common\System\Net\Security\Unix\SafeDeleteSslContext.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios'">
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.OSX.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.Android.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'browser'">
     <!-- Production code references -->
     <Compile Include="$(CommonPath)System\Net\Security\MD4.cs"
@@ -51,6 +141,9 @@
              Link="Common\System\Net\Security\TlsAlertMessage.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs"
              Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
+
+    <Compile Include="..\..\src\System\Net\SecurityStatusPal.cs"
+             Link="ProductionCode\System\Net\SecurityStatusPal.cs" />
     <Compile Include="..\..\src\System\Net\Security\NetEventSource.Security.cs"
              Link="ProductionCode\System\Net\Security\NetEventSource.Security.cs" />
     <Compile Include="..\..\src\System\Net\Security\SslStream.cs"
@@ -67,8 +160,6 @@
              Link="ProductionCode\System\Net\Security\SslConnectionInfo.cs" />
     <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.cs"
              Link="ProductionCode\System\Net\Security\SslStreamCertificateContext.cs" />
-    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.Windows.cs"
-             Link="ProductionCode\System\Net\Security\SslStreamCertificateContext.Windows.cs" />
     <Compile Include="..\..\src\System\Net\Security\ReadWriteAdapter.cs"
              Link="ProductionCode\System\Net\Security\ReadWriteAdapter.cs" />
     <Compile Include="..\..\src\System\Net\SslStreamContext.cs"
@@ -130,6 +221,8 @@
 
   <!-- Windows specific files (NT Authentication) -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'windows'">
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.Windows.cs"
+             Link="ProductionCode\System\Net\Security\SslStreamCertificateContext.Windows.cs" />
     <Compile Include="$(CommonPath)System\Collections\Generic\BidirectionalDictionary.cs"
              Link="Common\System\Collections\Generic\BidirectionalDictionary.cs" />
     <Compile Include="$(CommonPath)System\NotImplemented.cs"


### PR DESCRIPTION
Adds tests for getting OCSP staple to send in TLS handshake, including testing staple refresh and correct handling of error responses.