### PR TITLE
Optimize threshold of BigInteger.Parse

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -662,6 +662,10 @@ namespace System
         // algorithm with a running time of O(N^2). And if it is greater than the threshold, use
         // a divide-and-conquer algorithm with a running time of O(NlogN).
         //
+        // `1233`, which is approx the upper bound of most RSA key lengths, covers the majority
+        // of most common inputs and allows for the less naive algorithm to be used for
+        // large/uncommon inputs.
+        //
 #if DEBUG
         // Mutable for unit testing...
         internal static

--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -668,7 +668,7 @@ namespace System
 #else
         internal const
 #endif
-        int s_naiveThreshold = 20000;
+        int s_naiveThreshold = 3200;
         private static ParsingStatus NumberToBigInteger(ref NumberBuffer number, out BigInteger result)
         {
             int currentBufferSize = 0;

--- a/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Number.BigInteger.cs
@@ -668,7 +668,7 @@ namespace System
 #else
         internal const
 #endif
-        int s_naiveThreshold = 3200;
+        int s_naiveThreshold = 1233;
         private static ParsingStatus NumberToBigInteger(ref NumberBuffer number, out BigInteger result)
         {
             int currentBufferSize = 0;


### PR DESCRIPTION
`BigInteger.Parse(new string('9', n))` is slow when n is less than or equal to 20000. I have adjusted the value of `Number.s_naiveThreshold`. It seems optimal to set `s_naiveThreshold` to ~3200.

![parse-large](https://github.com/dotnet/runtime/assets/32071278/f250e333-4a81-4d7a-88bf-fbfb0ba65312)
![parse-medium](https://github.com/dotnet/runtime/assets/32071278/914a13b3-14bf-4183-b563-766ab07984a8)
![parse-small](https://github.com/dotnet/runtime/assets/32071278/4285dfb8-6182-4076-a698-615ea34926db)


<details><summary>Benchmark result</summary>
<p>

```

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3007/23H2/2023Update/SunValley3)
13th Gen Intel Core i5-13500, 1 CPU, 20 logical and 14 physical cores
.NET SDK 9.0.100-alpha.1.24055.2
  [Host]     : .NET 9.0.0 (9.0.24.5410), X64 RyuJIT AVX2
  Job-GGYJPI : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-WWRJET : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-WGTAFG : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2


```
| Method | Job        | Toolchain                    | data   | Mean             | Error         | StdDev        | Ratio | RatioSD | Code Size |
|------- |----------- |----------------------------- |------- |-----------------:|--------------:|--------------:|------:|--------:|----------:|
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **10**     |         **45.60 ns** |      **0.738 ns** |      **0.690 ns** |  **1.00** |    **0.00** |   **1,301 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 10     |         44.64 ns |      0.181 ns |      0.169 ns |  0.98 |    0.02 |   1,301 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 10     |         46.52 ns |      0.754 ns |      0.706 ns |  1.02 |    0.02 |   1,301 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **1000**   |      **5,795.24 ns** |    **102.845 ns** |     **96.201 ns** |  **1.00** |    **0.00** |   **2,034 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 1000   |      6,977.25 ns |     91.240 ns |     85.346 ns |  1.20 |    0.03 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 1000   |      5,693.01 ns |     41.608 ns |     38.920 ns |  0.98 |    0.02 |   2,037 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **10000**  |    **421,049.09 ns** |  **2,501.488 ns** |  **2,339.893 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 10000  |    300,605.59 ns |  1,202.674 ns |  1,124.982 ns |  0.71 |    0.01 |   1,912 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 10000  |    302,896.96 ns |  1,347.163 ns |  1,194.225 ns |  0.72 |    0.00 |   1,912 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **100000** | **11,021,006.47 ns** | **43,855.362 ns** | **38,876.636 ns** |  **1.00** |    **0.00** |   **1,910 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 100000 | 10,987,397.43 ns | 46,058.556 ns | 40,829.710 ns |  1.00 |    0.01 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 100000 | 11,019,705.73 ns | 37,853.168 ns | 35,407.877 ns |  1.00 |    0.01 |   1,910 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **15000**  |    **923,114.03 ns** |  **1,927.688 ns** |  **1,708.845 ns** |  **1.00** |    **0.00** |   **2,034 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 15000  |    506,987.02 ns |  2,112.473 ns |  1,976.009 ns |  0.55 |    0.00 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 15000  |    512,487.95 ns |  4,214.187 ns |  3,735.767 ns |  0.56 |    0.00 |   1,907 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **200**    |        **546.25 ns** |      **3.662 ns** |      **3.425 ns** |  **1.00** |    **0.00** |   **1,323 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 200    |        542.25 ns |      3.999 ns |      3.741 ns |  0.99 |    0.01 |   1,301 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 200    |        594.30 ns |      9.087 ns |      8.500 ns |  1.09 |    0.02 |   1,323 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **2000**   |     **18,861.05 ns** |    **244.683 ns** |    **216.905 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 2000   |     20,262.46 ns |     55.018 ns |     45.943 ns |  1.07 |    0.01 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 2000   |     19,282.80 ns |    358.565 ns |    335.401 ns |  1.02 |    0.02 |   2,034 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **20000**  |  **1,642,039.23 ns** | **26,908.019 ns** | **23,853.258 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 20000  |    918,541.43 ns |  6,649.921 ns |  5,894.982 ns |  0.56 |    0.01 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 20000  |    913,176.52 ns |  5,379.492 ns |  5,031.980 ns |  0.56 |    0.01 |   1,907 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **21000**  |    **990,613.79 ns** |  **4,270.432 ns** |  **3,994.565 ns** |  **1.00** |    **0.00** |   **1,907 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 21000  |    972,333.43 ns |  3,308.060 ns |  2,762.380 ns |  0.98 |    0.00 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 21000  |    976,396.97 ns |  2,629.997 ns |  2,460.101 ns |  0.99 |    0.01 |   1,907 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **25000**  |  **1,220,008.70 ns** |  **5,987.507 ns** |  **5,600.718 ns** |  **1.00** |    **0.00** |   **1,907 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 25000  |  1,209,837.99 ns |  5,421.557 ns |  5,071.327 ns |  0.99 |    0.01 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 25000  |  1,217,052.27 ns |  4,808.584 ns |  4,497.952 ns |  1.00 |    0.01 |   1,907 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3000**   |     **41,862.51 ns** |    **800.256 ns** |    **748.560 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3000   |     43,036.34 ns |    826.021 ns |    918.121 ns |  1.03 |    0.02 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3000   |     40,108.01 ns |    166.842 ns |    156.064 ns |  0.96 |    0.02 |   2,037 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3100**   |     **43,062.93 ns** |    **187.372 ns** |    **175.267 ns** |  **1.00** |    **0.00** |   **2,034 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3100   |     43,495.98 ns |    151.154 ns |    133.995 ns |  1.01 |    0.01 |   1,906 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3100   |     42,428.54 ns |    172.682 ns |    144.197 ns |  0.98 |    0.00 |   2,034 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3190**   |     **44,815.35 ns** |    **115.218 ns** |     **96.212 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3190   |     45,054.97 ns |    271.193 ns |    253.674 ns |  1.00 |    0.01 |   1,906 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3190   |     45,502.33 ns |    691.214 ns |    646.562 ns |  1.01 |    0.02 |   2,034 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3200**   |     **44,732.35 ns** |    **128.450 ns** |    **120.152 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3200   |     45,064.43 ns |    176.626 ns |    156.574 ns |  1.01 |    0.00 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3200   |     45,516.23 ns |    381.866 ns |    338.514 ns |  1.02 |    0.01 |   2,037 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3210**   |     **46,742.76 ns** |    **654.699 ns** |    **612.406 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3210   |     46,056.45 ns |    222.297 ns |    197.060 ns |  0.98 |    0.01 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3210   |     45,319.98 ns |    233.934 ns |    207.376 ns |  0.97 |    0.01 |   1,910 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **3300**   |     **48,172.70 ns** |    **254.882 ns** |    **225.946 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 3300   |     46,151.79 ns |    156.535 ns |    138.764 ns |  0.96 |    0.00 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 3300   |     46,575.74 ns |    337.154 ns |    315.374 ns |  0.97 |    0.01 |   1,910 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **4000**   |     **70,018.87 ns** |    **190.796 ns** |    **169.135 ns** |  **1.00** |    **0.00** |   **2,034 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 4000   |     59,450.45 ns |    284.232 ns |    265.871 ns |  0.85 |    0.00 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 4000   |     59,727.96 ns |    258.895 ns |    242.171 ns |  0.85 |    0.00 |   1,906 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **500**    |      **1,929.92 ns** |     **10.069 ns** |      **8.926 ns** |  **1.00** |    **0.00** |   **2,034 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 500    |      2,437.91 ns |     12.908 ns |     12.074 ns |  1.26 |    0.01 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 500    |      2,062.71 ns |      9.490 ns |      8.877 ns |  1.07 |    0.01 |   2,037 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **5000**   |    **106,056.19 ns** |    **524.458 ns** |    **464.918 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 5000   |     99,107.96 ns |    370.876 ns |    346.918 ns |  0.93 |    0.01 |   1,910 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 5000   |     98,501.99 ns |    326.673 ns |    305.570 ns |  0.93 |    0.00 |   1,907 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **50000**  |  **3,637,431.90 ns** | **12,147.589 ns** | **11,362.863 ns** |  **1.00** |    **0.00** |   **1,912 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 50000  |  3,658,643.39 ns | 26,188.345 ns | 23,215.286 ns |  1.01 |    0.01 |   1,912 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 50000  |  3,634,539.97 ns | 31,264.624 ns | 29,244.949 ns |  1.00 |    0.01 |   1,912 B |
|        |            |                              |        |                  |               |               |       |         |           |
| **Parse**  | **Job-GGYJPI** | **\threshold-20000\corerun.exe** | **7500**   |    **236,146.59 ns** |    **930.672 ns** |    **870.551 ns** |  **1.00** |    **0.00** |   **2,037 B** |
| Parse  | Job-WWRJET | \threshold-200\corerun.exe   | 7500   |    167,152.52 ns |    973.603 ns |    813.002 ns |  0.71 |    0.00 |   1,907 B |
| Parse  | Job-WGTAFG | \threshold-3200\corerun.exe  | 7500   |    167,245.00 ns |    625.042 ns |    584.665 ns |  0.71 |    0.00 |   1,910 B |


</p>
</details> 

<details><summary>Benchmark code</summary>
<p>

```csharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Numerics;
using System.Runtime.InteropServices;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[DisassemblyDiagnoser]
public class Tests
{
    public record Data(int Length)
    {
        public string Text = new string('9', Length);
        public override string ToString() => $"{Length}";
    }
    public IEnumerable<object> NumberStrings()
    {
        yield return new Data(10);
        yield return new Data(200);
        yield return new Data(500);
        yield return new Data(1000);
        yield return new Data(2000);
        yield return new Data(3000);
        yield return new Data(3100);
        yield return new Data(3190);
        yield return new Data(3200);
        yield return new Data(3210);
        yield return new Data(3300);
        yield return new Data(4000);
        yield return new Data(5000);
        yield return new Data(7500);
        yield return new Data(10000);
        yield return new Data(15000);
        yield return new Data(20000);
        yield return new Data(21000);
        yield return new Data(25000);
        yield return new Data(50000);
        yield return new Data(100000);
    }


    [Benchmark]
    [ArgumentsSource(nameof(NumberStrings))]
    public BigInteger Parse(Data data) => BigInteger.Parse(data.Text);
}
```

</p>
</details> 

**Related**

#55121 https://github.com/dotnet/runtime/pull/55121/commits/e93dde530bba27636636e2c83d1bd8a56bd12ba6