### PR TITLE
Add capacity hint to OidCollection

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidCollection.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidCollection.cs
@@ -2,16 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using Internal.Cryptography;
+using System.Diagnostics;
 
 namespace System.Security.Cryptography
 {
     public sealed class OidCollection : ICollection
     {
-        private Oid[] _oids = Array.Empty<Oid>();
+        private Oid[] _oids;
         private int _count;
 
-        public OidCollection() { }
+        public OidCollection()
+        {
+            _oids = [];
+        }
+
+        internal OidCollection(int initialCapacity)
+        {
+            Debug.Assert(initialCapacity >= 0);
+            _oids = initialCapacity == 0 ? [] : new Oid[initialCapacity];
+        }
 
         public int Add(Oid oid)
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509Encoder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509Encoder.cs
@@ -235,13 +235,14 @@ namespace System.Security.Cryptography.X509Certificates
 
         public override void DecodeX509EnhancedKeyUsageExtension(byte[] encoded, out OidCollection usages)
         {
-            OidCollection oids = new OidCollection();
+            OidCollection oids;
 
             using (SafeEkuExtensionHandle eku = Interop.Crypto.DecodeExtendedKeyUsage(encoded, encoded.Length))
             {
                 Interop.Crypto.CheckValidOpenSslHandle(eku);
 
                 int count = Interop.Crypto.GetX509EkuFieldCount(eku);
+                oids = new OidCollection(count);
 
                 for (int i = 0; i < count; i++)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
@@ -31,9 +31,14 @@ namespace System.Security.Cryptography.X509Certificates
                     X509Pal.Instance.DecodeX509EnhancedKeyUsageExtension(RawData, out _enhancedKeyUsages);
                     _decoded = true;
                 }
-                OidCollection oids = new OidCollection();
-                foreach (Oid oid in _enhancedKeyUsages!)
+
+                OidCollection oids = new OidCollection(_enhancedKeyUsages!.Count);
+
+                foreach (Oid oid in _enhancedKeyUsages)
+                {
                     oids.Add(oid);
+                }
+
                 return oids;
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.CustomExtensions.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.CustomExtensions.cs
@@ -140,11 +140,11 @@ namespace System.Security.Cryptography.X509Certificates
                     CryptDecodeObjectStructType.X509_ENHANCED_KEY_USAGE,
                     static delegate (void* pvDecoded, int cbDecoded)
                     {
-                        var localUsages = new OidCollection();
 
                         Debug.Assert(cbDecoded >= sizeof(CERT_ENHKEY_USAGE));
                         CERT_ENHKEY_USAGE* pEnhKeyUsage = (CERT_ENHKEY_USAGE*)pvDecoded;
                         int count = pEnhKeyUsage->cUsageIdentifier;
+                        var localUsages = new OidCollection(count);
                         for (int i = 0; i < count; i++)
                         {
                             IntPtr oidValuePointer = pEnhKeyUsage->rgpszUsageIdentifier[i];


### PR DESCRIPTION
The `OidCollection` class starts off with an internal array size of zero, then adjusts to 4, then adjusts to growing by a factor of 2. However, In many cases, we know the size of the `OidCollection` prior to it being created. In this scenario, we waste two calls to `Array.Resize` if the collection size is greater than 4, or one call if it is less than or equal to 4.

This pull request adds an internal size hint to the `OidCollection` so the backing array is appropriately sized from the beginning, and uses it in places where it is suitable to do so.