### PR TITLE
Reduce defensive copying in PublicKey

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -15,10 +15,24 @@ namespace System.Security.Cryptography.X509Certificates
         private AsymmetricAlgorithm? _key;
 
         public PublicKey(Oid oid, AsnEncodedData parameters, AsnEncodedData keyValue)
+            : this(oid, parameters, keyValue, skipCopy: false)
+        {
+        }
+
+        internal PublicKey(Oid oid, AsnEncodedData parameters, AsnEncodedData keyValue, bool skipCopy)
         {
             _oid = oid;
-            EncodedParameters = new AsnEncodedData(parameters);
-            EncodedKeyValue = new AsnEncodedData(keyValue);
+
+            if (skipCopy)
+            {
+                EncodedParameters = parameters;
+                EncodedKeyValue = keyValue;
+            }
+            else
+            {
+                EncodedParameters = new AsnEncodedData(parameters);
+                EncodedKeyValue = new AsnEncodedData(keyValue);
+            }
         }
 
         /// <summary>
@@ -136,7 +150,7 @@ namespace System.Security.Cryptography.X509Certificates
                 out AsnEncodedData localKeyValue);
 
             bytesRead = read;
-            return new PublicKey(localOid, localParameters, localKeyValue);
+            return new PublicKey(localOid, localParameters, localKeyValue, skipCopy: true);
         }
 
         /// <summary>
@@ -312,7 +326,7 @@ namespace System.Security.Cryptography.X509Certificates
                 out AsnEncodedData parameters,
                 out AsnEncodedData keyValue);
 
-            return new PublicKey(oid, parameters, keyValue);
+            return new PublicKey(oid, parameters, keyValue, skipCopy: true);
         }
 
         private static void DecodeSubjectPublicKeyInfo(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -310,7 +310,8 @@ namespace System.Security.Cryptography.X509Certificates
                     byte[] parameters = Pal.KeyAlgorithmParameters;
                     byte[] keyValue = Pal.PublicKeyValue;
                     Oid oid = new Oid(keyAlgorithmOid);
-                    publicKey = _lazyPublicKey = new PublicKey(oid, new AsnEncodedData(oid, parameters), new AsnEncodedData(oid, keyValue));
+                    // PublicKey can use skipCopy because AsnEncodedData creates a defensive copy of the values.
+                    publicKey = _lazyPublicKey = new PublicKey(oid, new AsnEncodedData(oid, parameters), new AsnEncodedData(oid, keyValue), skipCopy: true);
                 }
 
                 return publicKey;


### PR DESCRIPTION
The bypasses a few more defensive copies in `PublicKey`.

`AsnEncodedData(AsnEncodedData)` makes a defensive copy of the data for itself, which the constructor of `PublicKey` uses. However, there are a few factory methods in `PublicKey` that create an `AsnEncodedData` solely for the purpose of transferring to `PublicKey`. In that circumstance, we can bypass the copy since the creation of the `AsnEncodedData` already made the defensive copy.

Likewise for `X509Certificate2.PublicKey`. This shaves several hundred bytes in allocation, scaling with the key size.