### PR TITLE
Support caching ILogger<T> on the ILoggerFactory.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILoggerFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.Logging
         /// <typeparam name="T">The type.</typeparam>
         /// <returns>The <see cref="ILogger"/> that was created.</returns>
         ILogger<T> CreateLogger<T>() => new Logger<T>(this);
-        
+
         /// <summary>
         /// Adds an <see cref="ILoggerProvider"/> to the logging system.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/ILoggerFactory.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Extensions.Logging
         ILogger CreateLogger(string categoryName);
 
         /// <summary>
+        /// Creates a new <see cref="ILogger"/> instance using the full name of the given type.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <returns>The <see cref="ILogger"/> that was created.</returns>
+        ILogger<T> CreateLogger<T>() => new Logger<T>(this);
+        
+        /// <summary>
         /// Adds an <see cref="ILoggerProvider"/> to the logging system.
         /// </summary>
         /// <param name="provider">The <see cref="ILoggerProvider"/>.</param>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LoggerFactoryExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Extensions.Logging
         {
             ThrowHelper.ThrowIfNull(factory);
 
-            return new Logger<T>(factory);
+            return factory.CreateLogger<T>();
         }
         /// <summary>
         /// Creates a new <see cref="ILogger"/> instance using the full name of the given <paramref name="type"/>.

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Logging
     public class LoggerFactory : ILoggerFactory
     {
         private readonly ConcurrentDictionary<string, Logger> _loggers = new ConcurrentDictionary<string, Logger>(StringComparer.Ordinal);
+        private readonly ConcurrentDictionary<Type, ILogger> _loggersOfT = new ConcurrentDictionary<Type, ILogger>();
         private readonly List<ProviderRegistration> _providerRegistrations = new List<ProviderRegistration>();
         private readonly object _sync = new object();
         private volatile bool _disposed;
@@ -159,6 +160,16 @@ namespace Microsoft.Extensions.Logging
             }
 
             return logger;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ILogger"/> instance using the full name of the given type.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <returns>The <see cref="ILogger"/> that was created.</returns>
+        public ILogger<T> CreateLogger<T>()
+        {
+            return (ILogger<T>)_loggersOfT.GetOrAdd(typeof(T), _ => new Lazy<ILogger<T>>(() => new Logger<T>(this)).Value);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs
@@ -180,7 +180,8 @@ namespace Microsoft.Extensions.Logging
                 {
                     if (!_loggersOfT.TryGetValue(typeof(T), out logger))
                     {
-                        _loggersOfT[typeof(T)] = new Logger<T>(this);
+                        logger = new Logger<T>(this);
+                        _loggersOfT[typeof(T)] = logger;
                     }
                 }
             }


### PR DESCRIPTION
The `LoggerFactoryExtensions.CreateLogger<T>()` method did not cache the created `Logger<T>` but the underlying `ILogger` is (depending on the `LoggerFactory`) usually cached. This PR aligns the behavior and enables caching for `ILogger<T>` on the current `LoggerFactory`.