### PR TITLE
JIT: Validate loop invariant base case as part of IV analysis

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2006,13 +2006,15 @@ struct NaturalLoopIterInfo
     // The local that is the induction variable.
     unsigned IterVar = BAD_VAR_NUM;
 
+#ifdef DEBUG
+    // Tree that initializes induction varaible outside the loop.
+    // Only valid if HasConstInit is true.
+    GenTree* InitTree = nullptr;
+#endif
+
     // Constant value that the induction variable is initialized with, outside
     // the loop. Only valid if HasConstInit is true.
     int ConstInitValue = 0;
-
-    // Block outside the loop that initializes the induction variable. Only
-    // valid if HasConstInit is true.
-    BasicBlock* InitBlock = nullptr;
 
     // Tree that has the loop test for the induction variable.
     GenTree* TestTree = nullptr;
@@ -2022,6 +2024,9 @@ struct NaturalLoopIterInfo
 
     // Tree that mutates the induction variable.
     GenTree* IterTree = nullptr;
+
+    // Is the loop exited when TestTree is true?
+    bool ExitedOnTrue : 1;
 
     // Whether or not we found an initialization of the induction variable.
     bool HasConstInit : 1;
@@ -2042,7 +2047,8 @@ struct NaturalLoopIterInfo
     bool HasArrayLengthLimit : 1;
 
     NaturalLoopIterInfo()
-        : HasConstInit(false)
+        : ExitedOnTrue(false)
+        , HasConstInit(false)
         , HasConstLimit(false)
         , HasSimdLimit(false)
         , HasInvariantLocalLimit(false)
@@ -2053,7 +2059,6 @@ struct NaturalLoopIterInfo
     int IterConst();
     genTreeOps IterOper();
     var_types IterOperType();
-    bool IsReversed();
     genTreeOps TestOper();
     bool IsIncreasingLoop();
     bool IsDecreasingLoop();
@@ -2062,6 +2067,9 @@ struct NaturalLoopIterInfo
     int ConstLimit();
     unsigned VarLimit();
     bool ArrLenLimit(Compiler* comp, ArrIndex* index);
+
+private:
+    bool IsReversed();
 };
 
 // Represents a natural loop in the flow graph. Natural loops are characterized
@@ -2136,7 +2144,9 @@ class FlowGraphNaturalLoop
 
     void MatchInit(NaturalLoopIterInfo* info, BasicBlock* initBlock, GenTree* init);
     bool MatchLimit(NaturalLoopIterInfo* info, GenTree* test);
-
+    bool CheckLoopConditionBaseCase(BasicBlock* initBlock, NaturalLoopIterInfo* info);
+    template<typename T>
+    static bool EvaluateRelop(T op1, T op2, genTreeOps oper);
 public:
     BasicBlock* GetHeader() const
     {
@@ -7190,7 +7200,6 @@ private:
                            var_types  iterType,
                            genTreeOps testOper,
                            bool       unsignedTest,
-                           bool       dupCond,
                            unsigned*  iterCount);
 
 protected:

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4933,15 +4933,31 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 //   otherwise false.
 //
 // Remarks:
-//   The function guarantees that at all definitions of the iteration local,
-//   the loop condition is reestablished before iteration continues. In other
-//   words, if this function returns true the loop invariant is guaranteed to
-//   be upheld in all blocks in the loop (but see below for establishing the
-//   base case).
+//   On a true return, the function guarantees that the loop invariant is true
+//   and maintained at all points within the loop, except possibly right after
+//   the update of the iterator variable (NaturalLoopIterInfo::IterTree). The
+//   function guarantees that the test (NaturalLoopIterInfo::TestTree) occurs
+//   immediately after the update, so no IR in the loop is executed without the
+//   loop invariant being true, except for the test.
 //
-//   Currently we do not validate that there is a zero-trip test ensuring the
-//   condition is true, so it is up to the user to validate that. This is
-//   normally done via GTF_RELOP_ZTT set by loop inversion.
+//   The loop invariant is defined as the expression obtained by
+//   [info->IterVar] [info->TestOper()] [info->Limit()]. Note that
+//   [info->TestTree()] may not be of this form; it could for instance have the
+//   iterator variable as the second operand. However,
+//   [NaturalLoopIterInfo::TestOper()] will automatically normalize the test
+//   oper so that the invariant is equivalent to the returned form that has the
+//   iteration variable as op1 and the limit as op2.
+//
+//   The limit can be further decomposed via NaturalLoopIterInfo::ConstLimit,
+//   ::VarLimit and ::ArrLenLimit.
+//
+//   As an example, if info->IterVar == V02, info->TestOper() == GT_LT and
+//   info->ConstLimit() == 10, then the function guarantees that the value of
+//   the local V02 is less than 10 everywhere within the loop (except possibly
+//   at the test).
+//
+//   In some cases we also know the initial value on entry to the loop; see
+//   ::HasConstInit and ::ConstInitValue.
 //
 bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info)
 {
@@ -4972,8 +4988,15 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info)
         return false;
     }
 
-    info->TestBlock = cond;
-    info->IterVar   = comp->optIsLoopIncrTree(info->IterTree);
+    assert(ContainsBlock(cond->GetTrueTarget()) != ContainsBlock(cond->GetFalseTarget()));
+
+    info->TestBlock    = cond;
+    info->IterVar      = comp->optIsLoopIncrTree(info->IterTree);
+    info->ExitedOnTrue = !ContainsBlock(cond->GetTrueTarget());
+
+    // TODO-CQ: Currently, since we only look at the lexically bottom most block all loops have
+    // ExitedOnTrue == false. Once we recognize more structures this can be true.
+    assert(!info->ExitedOnTrue);
 
     assert(info->IterVar != BAD_VAR_NUM);
     LclVarDsc* const iterVarDsc = comp->lvaGetDesc(info->IterVar);
@@ -5027,13 +5050,20 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info)
         return false;
     }
 
+    if (!CheckLoopConditionBaseCase(initBlock, info))
+    {
+        JITDUMP("  Loop condition is not always true\n");
+        return false;
+    }
+
 #ifdef DEBUG
     if (comp->verbose)
     {
         printf("  IterVar = V%02u\n", info->IterVar);
 
         if (info->HasConstInit)
-            printf("  Const init with value %d in " FMT_BB "\n", info->ConstInitValue, info->InitBlock->bbNum);
+            printf("  Const init with value %d (at [%06u])\n", info->ConstInitValue,
+                   Compiler::dspTreeID(info->InitTree));
 
         printf("  Test is [%06u] (", Compiler::dspTreeID(info->TestTree));
         if (info->HasConstLimit)
@@ -5075,7 +5105,7 @@ void FlowGraphNaturalLoop::MatchInit(NaturalLoopIterInfo* info, BasicBlock* init
 
     info->HasConstInit   = true;
     info->ConstInitValue = (int)initValue->AsIntCon()->IconValue();
-    info->InitBlock      = initBlock;
+    INDEBUG(info->InitTree = init);
 }
 
 //------------------------------------------------------------------------
@@ -5118,12 +5148,12 @@ bool FlowGraphNaturalLoop::MatchLimit(NaturalLoopIterInfo* info, GenTree* test)
     GenTree* limitOp;
 
     // Make sure op1 or op2 is the iterVar.
-    if (opr1->gtOper == GT_LCL_VAR && opr1->AsLclVarCommon()->GetLclNum() == info->IterVar)
+    if (opr1->OperIsScalarLocal() && (opr1->AsLclVarCommon()->GetLclNum() == info->IterVar))
     {
         iterOp  = opr1;
         limitOp = opr2;
     }
-    else if (opr2->gtOper == GT_LCL_VAR && opr2->AsLclVarCommon()->GetLclNum() == info->IterVar)
+    else if (opr2->OperIsScalarLocal() && (opr2->AsLclVarCommon()->GetLclNum() == info->IterVar))
     {
         iterOp  = opr2;
         limitOp = opr1;
@@ -5138,11 +5168,8 @@ bool FlowGraphNaturalLoop::MatchLimit(NaturalLoopIterInfo* info, GenTree* test)
         return false;
     }
 
-    // Mark the iterator node.
-    iterOp->gtFlags |= GTF_VAR_ITERATOR;
-
     // Check what type of limit we have - constant, variable or arr-len.
-    if (limitOp->gtOper == GT_CNS_INT)
+    if (limitOp->IsCnsIntOrI())
     {
         info->HasConstLimit = true;
         if ((limitOp->gtFlags & GTF_ICON_SIMD_COUNT) != 0)
@@ -5210,6 +5237,105 @@ bool FlowGraphNaturalLoop::MatchLimit(NaturalLoopIterInfo* info, GenTree* test)
 
     info->TestTree = relop;
     return true;
+}
+
+//------------------------------------------------------------------------
+// EvaluateRelop: Evaluate a relational operator with constant arguments.
+//
+// Parameters:
+//   op1  - First operand
+//   op2  - Second operand
+//   oper - Operator
+//
+// Returns:
+//   Result.
+//
+template<typename T>
+bool FlowGraphNaturalLoop::EvaluateRelop(T op1, T op2, genTreeOps oper)
+{
+    switch (oper)
+    {
+        case GT_EQ:
+            return op1 == op2;
+
+        case GT_NE:
+            return op1 != op2;
+
+        case GT_LT:
+            return op1 < op2;
+
+        case GT_LE:
+            return op1 <= op2;
+
+        case GT_GT:
+            return op1 > op2;
+
+        case GT_GE:
+            return op1 >= op2;
+
+        default:
+            unreached();
+    }
+}
+
+//------------------------------------------------------------------------
+// CheckLoopConditionBaseCase: Verify that the loop condition is true when the
+// loop is entered (or validated immediately on entry).
+//
+// Returns:
+//   True if we could prove that the condition is true at all interesting
+//   points in the loop.
+//
+// Remarks:
+//   Currently handles the following cases:
+//     * The condition being trivially true in the first iteration (e.g. for (int i = 0; i < 3; i++))
+//     * The condition is checked before entry (often due to loop inversion)
+//
+bool FlowGraphNaturalLoop::CheckLoopConditionBaseCase(BasicBlock* initBlock, NaturalLoopIterInfo* info)
+{
+    // TODO: A common loop idiom is to enter the loop at the test, with the
+    // unique in-loop predecessor of the header block being the increment. We
+    // currently do not handle these patterns in `optExtractInitTestIncr`.
+    // Instead we depend on loop inversion to put them into an
+    //   if (x) { do { ... } while (x) }
+    // form. Once we handle the pattern in `optExtractInitTestIncr` we can
+    // handle it here by checking for whether the test is the header and first
+    // thing in the header.
+
+    // Is it trivially true?
+    if (info->HasConstInit && info->HasConstLimit)
+    {
+        int initVal  = info->ConstInitValue;
+        int limitVal = info->ConstLimit();
+
+        assert(genActualType(info->TestTree->gtGetOp1()) == TYP_INT);
+
+        bool isTriviallyTrue = info->TestTree->IsUnsigned()
+                                   ? EvaluateRelop<uint32_t>((uint32_t)initVal, (uint32_t)limitVal, info->TestOper())
+                                   : EvaluateRelop<int32_t>(initVal, limitVal, info->TestOper());
+
+        if (isTriviallyTrue)
+        {
+            JITDUMP("  Condition is trivially true on entry (%d %s%s %d)\n", initVal,
+                    info->TestTree->IsUnsigned() ? "(uns)" : "", GenTree::OpName(info->TestOper()), limitVal);
+            return true;
+        }
+    }
+
+    // Do we have a zero-trip test?
+    if (initBlock->KindIs(BBJ_COND))
+    {
+        GenTree* enteringJTrue = initBlock->lastStmt()->GetRootNode();
+        assert(enteringJTrue->OperIs(GT_JTRUE));
+        if (enteringJTrue->gtGetOp1()->OperIsCompare() && ((enteringJTrue->gtGetOp1()->gtFlags & GTF_RELOP_ZTT) != 0))
+        {
+            JITDUMP("  Condition is established before entry at [%06u]\n",
+                    Compiler::dspTreeID(enteringJTrue->gtGetOp1()));
+            return true;
+        }
+    }
+
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -5340,7 +5466,7 @@ var_types NaturalLoopIterInfo::IterOperType()
 //
 bool NaturalLoopIterInfo::IsReversed()
 {
-    return TestTree->gtGetOp2()->OperIs(GT_LCL_VAR) && ((TestTree->gtGetOp2()->gtFlags & GTF_VAR_ITERATOR) != 0);
+    return TestTree->gtGetOp2()->OperIsScalarLocal() && (TestTree->gtGetOp2()->AsLclVar()->GetLclNum() == IterVar);
 }
 
 //------------------------------------------------------------------------
@@ -5353,7 +5479,15 @@ bool NaturalLoopIterInfo::IsReversed()
 genTreeOps NaturalLoopIterInfo::TestOper()
 {
     genTreeOps op = TestTree->OperGet();
-    return IsReversed() ? GenTree::SwapRelop(op) : op;
+    if (IsReversed())
+    {
+        op = GenTree::SwapRelop(op);
+    }
+    if (ExitedOnTrue)
+    {
+        op = GenTree::ReverseRelop(op);
+    }
+    return op;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5250,7 +5250,7 @@ bool FlowGraphNaturalLoop::MatchLimit(NaturalLoopIterInfo* info, GenTree* test)
 // Returns:
 //   Result.
 //
-template<typename T>
+template <typename T>
 bool FlowGraphNaturalLoop::EvaluateRelop(T op1, T op2, genTreeOps oper)
 {
     switch (oper)

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1819,6 +1819,9 @@ bool Compiler::optIsLoopClonable(FlowGraphNaturalLoop* loop, LoopCloneContext* c
 
     // Is the entry block a handler or filter start?  If so, then if we cloned, we could create a jump
     // into the middle of a handler (to go to the cloned copy.)  Reject.
+    // TODO: This seems like it can be deleted. If the header is the beginning
+    // of a handler then the loop should be fully contained within the handler,
+    // and the cloned loop will also be in the handler.
     if (bbIsHandlerBeg(loop->GetHeader()))
     {
         JITDUMP("Loop cloning: rejecting loop " FMT_LP ". Header block is a handler start.\n", loop->GetIndex());
@@ -1873,6 +1876,8 @@ bool Compiler::optIsLoopClonable(FlowGraphNaturalLoop* loop, LoopCloneContext* c
             return false;
         }
 
+        // TODO-Quirk: Can be removed, loop invariant is validated by
+        // `FlowGraphNaturalLoop::AnalyzeIteration`.
         if (!iterInfo->TestTree->OperIsCompare() || ((iterInfo->TestTree->gtFlags & GTF_RELOP_ZTT) == 0))
         {
             JITDUMP("Loop cloning: rejecting loop " FMT_LP

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2964,19 +2964,18 @@ bool Compiler::optIterSmallUnderflow(int iterAtExit, var_types decrType)
 }
 
 //-----------------------------------------------------------------------------
-// optComputeLoopRep: Helper for loop unrolling. Computes the number of repetitions
-// in a constant loop.
+// optComputeLoopRep: Helper for loop unrolling. Computes the number of times
+// the test block of a loop is executed.
 //
 // Arguments:
-//    constInit    - loop constant initial value
-//    constLimit   - loop constant limit
-//    iterInc      - loop iteration increment
-//    iterOper     - loop iteration increment operator (ADD, SUB, etc.)
-//    iterOperType - iteration operator type
-//    testOper     - type of loop test (i.e. GT_LE, GT_GE, etc.)
-//    unsTest      - true if test is unsigned
-//    dupCond      - true if the loop head contains a test which skips this loop
-//    iterCount    - *iterCount is set to the iteration count, if the function returns `true`
+//    constInit     - loop constant initial value
+//    constLimit    - loop constant limit
+//    iterInc       - loop iteration increment
+//    iterOper      - loop iteration increment operator (ADD, SUB, etc.)
+//    iterOperType  - iteration operator type
+//    testOper      - type of loop test (i.e. GT_LE, GT_GE, etc.)
+//    unsTest       - true if test is unsigned
+//    iterCount     - *iterCount is set to the iteration count, if the function returns `true`
 //
 // Returns:
 //   true if the loop has a constant repetition count, false if that cannot be proven
@@ -2988,7 +2987,6 @@ bool Compiler::optComputeLoopRep(int        constInit,
                                  var_types  iterOperType,
                                  genTreeOps testOper,
                                  bool       unsTest,
-                                 bool       dupCond,
                                  unsigned*  iterCount)
 {
     noway_assert(genActualType(iterOperType) == TYP_INT);
@@ -3054,22 +3052,8 @@ bool Compiler::optComputeLoopRep(int        constInit,
         return false;
     }
 
-    // Set iterSign to +1 for positive iterInc and -1 for negative iterInc.
-    iterSign = (iterInc > 0) ? +1 : -1;
-
-    // Initialize loopCount to zero.
+    iterSign  = (iterInc > 0) ? +1 : -1;
     loopCount = 0;
-
-    // If dupCond is true then the loop initialization block contains a test which skips
-    // this loop, if the constInit does not pass the loop test.
-    // Such a loop can execute zero times.
-    // If dupCond is false then we have a true do-while loop where we
-    // always execute the loop once before performing the loop test.
-    if (!dupCond)
-    {
-        loopCount += 1;
-        constInitX += iterInc;
-    }
 
     // bail if count is based on wrap-around math
     if (iterInc > 0)
@@ -3114,7 +3098,6 @@ bool Compiler::optComputeLoopRep(int        constInit,
             }
             else
             {
-                noway_assert(iterInc < 0);
                 // Stepping by -1, i.e. Mod with 1 is always zero.
                 if (iterInc != -1)
                 {
@@ -3560,40 +3543,30 @@ bool Compiler::optTryUnrollLoop(FlowGraphNaturalLoop* loop, bool* changedIR)
     //  - increment operation type (i.e. ADD, SUB, etc...)
     //  - loop test type (i.e. GT_GE, GT_LT, etc...)
 
-    BasicBlock* initBlock    = iterInfo.InitBlock;
-    int         lbeg         = iterInfo.ConstInitValue;
-    int         llim         = iterInfo.ConstLimit();
-    genTreeOps  testOper     = iterInfo.TestOper();
-    unsigned    lvar         = iterInfo.IterVar;
-    int         iterInc      = iterInfo.IterConst();
-    genTreeOps  iterOper     = iterInfo.IterOper();
-    var_types   iterOperType = iterInfo.IterOperType();
-    bool        unsTest      = (iterInfo.TestTree->gtFlags & GTF_UNSIGNED) != 0;
+    int        lbeg         = iterInfo.ConstInitValue;
+    int        llim         = iterInfo.ConstLimit();
+    genTreeOps testOper     = iterInfo.TestOper();
+    unsigned   lvar         = iterInfo.IterVar;
+    int        iterInc      = iterInfo.IterConst();
+    genTreeOps iterOper     = iterInfo.IterOper();
+    var_types  iterOperType = iterInfo.IterOperType();
+    bool       unsTest      = (iterInfo.TestTree->gtFlags & GTF_UNSIGNED) != 0;
 
     assert(!lvaGetDesc(lvar)->IsAddressExposed());
     assert(!lvaGetDesc(lvar)->lvIsStructField);
 
-    // Locate/initialize the increment/test statements.
-    Statement* initStmt = initBlock->lastStmt();
-    noway_assert((initStmt != nullptr) && (initStmt->GetNextStmt() == nullptr));
-
-    bool dupCond = false;
-    if (initStmt->GetRootNode()->OperIs(GT_JTRUE))
-    {
-        // Must be a duplicated loop condition.
-
-        dupCond  = true;
-        initStmt = initStmt->GetPrevStmt();
-        noway_assert(initStmt != nullptr);
-    }
+    JITDUMP("Analyzing candidate for loop unrolling:\n");
+    DBEXEC(verbose, FlowGraphNaturalLoop::Dump(loop));
 
     // Find the number of iterations - the function returns false if not a constant number.
     unsigned totalIter;
-    if (!optComputeLoopRep(lbeg, llim, iterInc, iterOper, iterOperType, testOper, unsTest, dupCond, &totalIter))
+    if (!optComputeLoopRep(lbeg, llim, iterInc, iterOper, iterOperType, testOper, unsTest, &totalIter))
     {
         JITDUMP("Failed to unroll loop " FMT_LP ": not a constant iteration count\n", loop->GetIndex());
         return false;
     }
+
+    JITDUMP("Computed loop repetition count (number of test block executions) to be %u\n", totalIter);
 
     // Forget it if there are too many repetitions or not a constant loop.
 
@@ -3643,21 +3616,14 @@ bool Compiler::optTryUnrollLoop(FlowGraphNaturalLoop* loop, bool* changedIR)
     }
     incr = incr->AsLclVar()->Data();
 
-    GenTree* init = initStmt->GetRootNode();
-
     // Make sure everything looks ok.
     assert((iterInfo.TestBlock != nullptr) && iterInfo.TestBlock->KindIs(BBJ_COND));
 
     // clang-format off
-    if (!init->OperIs(GT_STORE_LCL_VAR) ||
-        (init->AsLclVar()->GetLclNum() != lvar) ||
-        !init->AsLclVar()->Data()->IsCnsIntOrI() ||
-        (init->AsLclVar()->Data()->AsIntCon()->gtIconVal != lbeg) ||
-
-        !((incr->gtOper == GT_ADD) || (incr->gtOper == GT_SUB)) ||
-        (incr->AsOp()->gtOp1->gtOper != GT_LCL_VAR) ||
+    if (!incr->OperIs(GT_ADD, GT_SUB) ||
+        !incr->AsOp()->gtOp1->OperIs(GT_LCL_VAR) ||
         (incr->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum() != lvar) ||
-        (incr->AsOp()->gtOp2->gtOper != GT_CNS_INT) ||
+        !incr->AsOp()->gtOp2->OperIs(GT_CNS_INT) ||
         (incr->AsOp()->gtOp2->AsIntCon()->gtIconVal != iterInc) ||
 
         (iterInfo.TestBlock->lastStmt()->GetRootNode()->gtGetOp1() != iterInfo.TestTree))
@@ -3939,10 +3905,15 @@ bool Compiler::optTryUnrollLoop(FlowGraphNaturalLoop* loop, bool* changedIR)
         }
     }
 
-    // If we get here, we successfully cloned all the blocks in the unrolled loop.
-    // Note we may not have done any cloning at all, if the loop iteration count was zero.
-    // Now redirect the last iteration to the real exit of the loop (or
-    // the entry to the exit if we unrolled 0 iterations).
+    // If we get here, we successfully cloned all the blocks in the
+    // unrolled loop. Note we may not have done any cloning at all if
+    // the loop iteration count was computed to be zero. Such loops are
+    // guaranteed to be unreachable since if the repetition count is
+    // zero the loop invariant is false on the first iteration, yet
+    // FlowGraphNaturalLoop::AnalyzeIteration only returns true if the
+    // loop invariant is true on every iteration. That means we have a
+    // guarding check before we enter the loop that will always be
+    // false.
     if (prevTestBlock != nullptr)
     {
         assert(prevTestBlock->KindIs(BBJ_ALWAYS));
@@ -3959,49 +3930,21 @@ bool Compiler::optTryUnrollLoop(FlowGraphNaturalLoop* loop, bool* changedIR)
             BasicBlock* entering = entryEdge->getSourceBlock();
             assert(!entering->KindIs(BBJ_COND)); // Ensured by canonicalization
             optRedirectBlock(entering, &blockMap, Compiler::RedirectBlockOption::UpdatePredLists);
-
             JITDUMP("Redirecting original entry " FMT_BB " -> " FMT_BB " to " FMT_BB " -> " FMT_BB "\n",
                     entering->bbNum, loop->GetHeader()->bbNum, entering->bbNum, exit->bbNum);
         }
     }
 
-    // The old loop body is unreachable now.
-
-    // Control will fall through from the initBlock to its successor, which is either
-    // the preheader HEAD (if it exists), or the now empty TOP (if totalIter == 0),
-    // or the first cloned top.
-    //
-    // If the initBlock is a BBJ_COND drop the condition (and make initBlock a BBJ_ALWAYS block).
-    //
-    // TODO: Isn't this missing validity checks? This seems dangerous.
-    //
-    if (initBlock->KindIs(BBJ_COND))
-    {
-        assert(dupCond);
-        Statement* initBlockBranchStmt = initBlock->lastStmt();
-        noway_assert(initBlockBranchStmt->GetRootNode()->OperIs(GT_JTRUE));
-        fgRemoveStmt(initBlock, initBlockBranchStmt);
-        fgRemoveRefPred(initBlock->GetTrueTarget(), initBlock);
-        initBlock->SetKindAndTarget(BBJ_ALWAYS, initBlock->GetFalseTarget());
-
-        // TODO-NoFallThrough: If bbFalseTarget can diverge from bbNext, it may not make sense to set
-        // BBF_NONE_QUIRK
-        initBlock->SetFlags(BBF_NONE_QUIRK);
-    }
-    else
-    {
-        // the loop must execute
-        assert(!dupCond);
-        assert(totalIter > 0);
-        noway_assert(initBlock->KindIs(BBJ_ALWAYS));
-    }
+    // The old loop body is unreachable now, but we will remove those
+    // blocks after we finish unrolling.
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef DEBUG
     if (verbose)
     {
         printf("Whole unrolled loop:\n");
 
-        gtDispTree(initStmt->GetRootNode());
+        gtDispTree(iterInfo.InitTree);
         printf("\n");
         fgDumpTrees(bottom->Next(), insertAfter);
     }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_95315/Runtime_95315.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_95315/Runtime_95315.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Xunit;
+
+public class Runtime_95315
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 200; j++)
+            {
+                Assert.Throws<IndexOutOfRangeException>(() => Bar(new int[10], new C()));
+            }
+
+            Thread.Sleep(100);
+        }
+
+        Assert.Throws<IndexOutOfRangeException>(() => Bar(new int[1], new C()));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Bar(int[] arr, I iface)
+    {
+        if (arr == null)
+        {
+            return;
+        }
+
+        iface.Foo();
+
+        int i = 10000000;
+        do
+        {
+            Console.WriteLine(arr[i]);
+            i++;
+        } while (i < arr.Length);
+    }
+}
+
+internal interface I
+{
+    void Foo();
+}
+
+internal class C : I
+{
+    public void Foo()
+    {
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_95315/Runtime_95315.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_95315/Runtime_95315.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredCompilation" Value="1" />
+    <CLRTestEnvironmentVariable Include="DOTNET_TieredPGO" Value="1" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_96591
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return 100 - Foo(0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Foo(int y)
+    {
+        int x = 0;
+        if (y != 0)
+        {
+            do
+            {
+                x++;
+            }
+            while (x < 4);
+        }
+        return x;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591_2.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591_2.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_96591_2
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return 99 + Foo(1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Foo(int y)
+    {
+        int x = 0;
+        if (y != 0)
+        {
+            do
+            {
+                x++;
+            }
+            while (x < 0);
+        }
+        return x;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96591/Runtime_96591_2.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+    <DebugType>None</DebugType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96623/Runtime_96623.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96623/Runtime_96623.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_96623
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<IndexOutOfRangeException>(() => Foo(new int[15]));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Foo(int[] arr)
+    {
+        int limit = GetLimit();
+        int sum = 0;
+        int i = 0;
+        int j = 0;
+
+        int x;
+
+        if (Environment.TickCount < 0)
+            x = 42;
+        else
+            x = 42;
+
+        if (x == 42)
+        {
+            i = int.MaxValue;
+            goto TestInner;
+        }
+
+        Console.WriteLine("Unreachable");
+        goto TestOuter;
+
+OuterStart:;
+        Console.WriteLine("Outer");
+        goto TestInner;
+
+InnerStart:;
+        sum += arr[i];
+
+TestInner:;
+        j++;
+        if (j < 30)
+            goto InnerStart;
+
+TestOuter:;
+        i++;
+        if (i < limit)
+            goto OuterStart;
+
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int GetLimit() => 10;
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_96623/Runtime_96623.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_96623/Runtime_96623.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Move the validation of the base case of the IV analysis into `FlowGraphNaturalLoop::AnalyzeIteration`. Previously the validation for the base case was left up to the users:

- Loop cloning tried to accomplish this by checking whether loop inversion had run, but this is not sufficient (#96623) as nothing guarantees the loop is dominated by the inverted test. Loop cloning also skipped the check entirely for GDV, leading to #95315.

- Unrolling completely neglected to check the condition leading to #96591. Furthermore, unrolling made implicit assumptions that any `BBJ_COND` init block was an inverted test and downright removed the condition without any checks. This also led to another issue #97040 where unrolling could uncover new natural loops that had not been canonicalized.

This change makes `FlowGraphNaturalLoop::AnalyzeIteration` try to prove that the loop invariant it returns is true in the base case as well as being maintained by the loop. If it cannot prove this then it fails. This fixes all the issues, but sadly uncovers that we were doing a lot of cloning in OSR methods without actually proving legality, and where it is actually illegal. We no longer clone in these cases, but we can look into what to do about them separately.

In addition, loop unrolling no longer removes the init block condition. We leave that up to RBO which is able to remove the trivial checks that loop inversion sometimes creates in generality. This does lead to a few diffs from removing the check later in the JIT pipeline.

Diffs expected from less cloning in OSR and from leaving the trivial inverted tests around until RBO.

Fix #95315
Fix #96591
Fix #96623
Fix #97040