### PR TITLE
Ensuring XUnitLogChecker is included in libraries outerloop

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -762,7 +762,7 @@
                       BuildInParallel="$(Samples_BuildInParallel)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)' and '$(IsXUnitLogCheckerSupported)' == 'true'">
+  <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(IsXUnitLogCheckerSupported)' == 'true'">
     <ProjectReference
       Include="$(RepoRoot)src\tests\Common\XUnitLogChecker\XUnitLogChecker.csproj"
       AdditionalProperties="%(AdditionalProperties);Configuration=Release;OutDir=$(XUnitLogCheckerLibrariesOutDir)" />

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,7 +2035,6 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
-  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;

--- a/src/native/external/brotli/dec/decode.c
+++ b/src/native/external/brotli/dec/decode.c
@@ -2035,6 +2035,7 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
 BrotliDecoderResult BrotliDecoderDecompress(
     size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
     uint8_t* decoded_buffer) {
+  *(int*)4242424 = 42;
   BrotliDecoderState s;
   BrotliDecoderResult result;
   size_t total_out = 0;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/96035

To decide whether to include the XUnitLogChecker.csproj among the projects to build to include in the helix payloads, check for TargetFrameworkIdentifier==.NETCoreApp instead of BuildTargetFramework==NetCoreAppCurrent.

**TODO**: Revert the temporary crash commit before merging.