### PR TITLE
Small cleanup in the cctor interpreter

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1860,9 +1860,7 @@ namespace ILCompiler
                         return spanRef.TryAccessElement(spanIndex.AsInt32(), out retVal);
                     }
                     return false;
-                case "GetTypeFromHandle" when method.OwningType is MetadataType typeType
-                        && typeType.Name == "Type" && typeType.Namespace == "System"
-                        && typeType.Module == typeType.Context.SystemModule
+                case "GetTypeFromHandle" when IsSystemType(method.OwningType)
                         && parameters[0] is RuntimeTypeHandleValue typeHandle:
                     {
                         if (!_internedTypes.TryGetValue(typeHandle.Type, out RuntimeTypeValue runtimeType))
@@ -1872,23 +1870,24 @@ namespace ILCompiler
                         retVal = runtimeType;
                         return true;
                     }
-                case "get_IsValueType" when method.OwningType is MetadataType typeType
-                        && typeType.Name == "Type" && typeType.Namespace == "System"
-                        && typeType.Module == typeType.Context.SystemModule
+                case "get_IsValueType" when IsSystemType(method.OwningType)
                         && parameters[0] is RuntimeTypeValue typeToCheckForValueType:
                     {
                         retVal = ValueTypeValue.FromSByte(typeToCheckForValueType.TypeRepresented.IsValueType ? (sbyte)1 : (sbyte)0);
                         return true;
                     }
-                case "op_Equality" when method.OwningType is MetadataType typeType
-                        && typeType.Name == "Type" && typeType.Namespace == "System"
-                        && typeType.Module == typeType.Context.SystemModule
+                case "op_Equality" when IsSystemType(method.OwningType)
                         && (parameters[0] is RuntimeTypeValue || parameters[1] is RuntimeTypeValue):
                     {
                         retVal = ValueTypeValue.FromSByte(parameters[0] == parameters[1] ? (sbyte)1 : (sbyte)0);
                         return true;
                     }
             }
+
+            static bool IsSystemType(TypeDesc type)
+                => type is MetadataType typeType
+                        && typeType.Name == "Type" && typeType.Namespace == "System"
+                        && typeType.Module == typeType.Context.SystemModule;
 
             return false;
         }


### PR DESCRIPTION
I was looking at the IsValueType handling here and decided to clean it up.

Cc @dotnet/ilc-contrib 