### PR TITLE
Intrinsify typeof(T).IsGenericType

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1368,6 +1368,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                             case NI_System_Type_get_IsValueType:
                             case NI_System_Type_get_IsPrimitive:
                             case NI_System_Type_get_IsByRefLike:
+                            case NI_System_Type_get_IsGenericType:
                             case NI_System_Type_GetTypeFromHandle:
                             case NI_System_String_get_Length:
                             case NI_System_Buffers_Binary_BinaryPrimitives_ReverseEndianness:

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3375,6 +3375,13 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                             {
                                 retNode = gtNewTrue();
                             }
+                            else if ((info.compCompHnd->getClassAttribs(hClass) & CORINFO_FLG_SHAREDINST) != 0)
+                            {
+                                // if we have no type arguments, check that the type itself is not __Canon, and
+                                // simply skip expanding the intrinsic in that case, rather than incorrectly
+                                // hardcoding 'false' as the resulting expression.
+                                retNode = nullptr;
+                            }
                             else
                             {
                                 retNode = gtNewFalse();

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2726,6 +2726,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_Type_get_IsByRefLike:
             case NI_System_Type_IsAssignableFrom:
             case NI_System_Type_IsAssignableTo:
+            case NI_System_Type_get_IsGenericType:
 
             // Lightweight intrinsics
             case NI_System_String_get_Chars:
@@ -3318,6 +3319,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
             case NI_System_Type_get_IsValueType:
             case NI_System_Type_get_IsPrimitive:
             case NI_System_Type_get_IsByRefLike:
+            case NI_System_Type_get_IsGenericType:
             {
                 // Optimize
                 //
@@ -3356,6 +3358,20 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                             // because enums are not primitive types.
                             if ((info.compCompHnd->isEnum(hClass, nullptr) == TypeCompareState::MustNot) &&
                                 info.compCompHnd->getTypeForPrimitiveValueClass(hClass) != CORINFO_TYPE_UNDEF)
+                            {
+                                retNode = gtNewTrue();
+                            }
+                            else
+                            {
+                                retNode = gtNewFalse();
+                            }
+                            break;
+                        case NI_System_Type_get_IsGenericType:
+                            // a type is a generic type if there is at least one type argument that is
+                            // some valid type, so we can always just check the one at index 0 for this.
+                            // This will work on open generic types as well, and the returned type handle
+                            // will be some handle that represents the (non constructed) type parameter.
+                            if (info.compCompHnd->getTypeInstantiationArgument(hClass, 0) != NO_CLASS_HANDLE)
                             {
                                 retNode = gtNewTrue();
                             }
@@ -9005,6 +9021,10 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         else if (strcmp(methodName, "get_IsPrimitive") == 0)
                         {
                             result = NI_System_Type_get_IsPrimitive;
+                        }
+                        else if (strcmp(methodName, "get_IsGenericType") == 0)
+                        {
+                            result = NI_System_Type_get_IsGenericType;
                         }
                         else if (strcmp(methodName, "get_IsByRefLike") == 0)
                         {

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -79,6 +79,7 @@ enum NamedIntrinsic : unsigned short
     NI_System_Type_get_IsPrimitive,
     NI_System_Type_get_IsByRefLike,
     NI_System_Type_get_TypeHandle,
+    NI_System_Type_get_IsGenericType,
     NI_System_Type_IsAssignableFrom,
     NI_System_Type_IsAssignableTo,
     NI_System_Type_op_Equality,

--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -57,7 +57,7 @@ namespace System
         public virtual bool IsGenericParameter => false;
         public virtual bool IsGenericTypeParameter => IsGenericParameter && DeclaringMethod is null;
         public virtual bool IsGenericMethodParameter => IsGenericParameter && DeclaringMethod != null;
-        public virtual bool IsGenericType => false;
+        public virtual bool IsGenericType { [Intrinsic] get => false; }
         public virtual bool IsGenericTypeDefinition => false;
 
         public virtual bool IsSZArray => throw NotImplemented.ByDesign;

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
@@ -133,6 +133,7 @@ public partial class Program
         GetEnumUnderlyingType.TestGetEnumUnderlyingType();
 
         IsPrimitiveTests();
+        IsGenericTypeTests();
 
         return 100 + _errors;
     }
@@ -184,6 +185,71 @@ public partial class Program
         IsFalse(typeof(delegate*<int>).IsPrimitive);
         IsFalse(typeof(Nullable<>).IsPrimitive);
         IsFalse(typeof(Dictionary<,>).IsPrimitive);
+    }
+
+    private static void IsGenericTypeTests()
+    {
+        IsFalse(typeof(bool).IsGenericType);
+        IsFalse(typeof(char).IsGenericType);
+        IsFalse(typeof(sbyte).IsGenericType);
+        IsFalse(typeof(byte).IsGenericType);
+        IsFalse(typeof(short).IsGenericType);
+        IsFalse(typeof(ushort).IsGenericType);
+        IsFalse(typeof(int).IsGenericType);
+        IsFalse(typeof(uint).IsGenericType);
+        IsFalse(typeof(long).IsGenericType);
+        IsFalse(typeof(ulong).IsGenericType);
+        IsFalse(typeof(float).IsGenericType);
+        IsFalse(typeof(double).IsGenericType);
+        IsFalse(typeof(nint).IsGenericType);
+        IsFalse(typeof(nuint).IsGenericType);
+        IsFalse(typeof(IntPtr).IsGenericType);
+        IsFalse(typeof(UIntPtr).IsGenericType);
+        IsFalse(typeof(Enum).IsGenericType);
+        IsFalse(typeof(ValueType).IsGenericType);
+        IsFalse(typeof(SimpleEnum).IsGenericType);
+        IsFalse(typeof(IntPtrEnum).IsGenericType);
+        IsFalse(typeof(FloatEnum).IsGenericType);
+        IsFalse(typeof(decimal).IsGenericType);
+        IsFalse(typeof(TimeSpan).IsGenericType);
+        IsFalse(typeof(DateTime).IsGenericType);
+        IsFalse(typeof(DateTimeOffset).IsGenericType);
+        IsFalse(typeof(Guid).IsGenericType);
+        IsFalse(typeof(Half).IsGenericType);
+        IsFalse(typeof(DateOnly).IsGenericType);
+        IsFalse(typeof(TimeOnly).IsGenericType);
+        IsFalse(typeof(Int128).IsGenericType);
+        IsFalse(typeof(UInt128).IsGenericType);
+        IsFalse(typeof(string).IsGenericType);
+        IsFalse(typeof(object).IsGenericType);
+        IsFalse(typeof(RuntimeArgumentHandle).IsGenericType);
+        IsFalse(typeof(DerivedGenericSimpleClass).IsGenericType);
+        IsFalse(typeof(int[]).IsGenericType);
+        IsFalse(typeof(int[,]).IsGenericType);
+        IsFalse(typeof(int*).IsGenericType);
+        IsFalse(typeof(void*).IsGenericType);
+        IsFalse(typeof(delegate*<int>).IsGenericType);
+
+        IsTrue(typeof(GenericSimpleClass<int>).IsGenericType);
+        IsTrue(typeof(GenericSimpleClass<>).IsGenericType);
+        IsTrue(typeof(GenericEnumClass<SimpleEnum>).IsGenericType);
+        IsTrue(typeof(GenericEnumClass<>).IsGenericType);
+        IsTrue(typeof(IGenericInterface<string>).IsGenericType);
+        IsTrue(typeof(IGenericInterface<>).IsGenericType);
+        IsTrue(typeof(GenericStruct<string>).IsGenericType);
+        IsTrue(typeof(GenericStruct<>).IsGenericType);
+        IsTrue(typeof(SimpleEnum?).IsGenericType);
+        IsTrue(typeof(int?).IsGenericType);
+        IsTrue(typeof(IntPtr?).IsGenericType);
+        IsTrue(typeof(Nullable<>).IsGenericType);
+        IsTrue(typeof(Dictionary<int,string>).IsGenericType);
+        IsTrue(typeof(Dictionary<,>).IsGenericType);
+        IsTrue(typeof(List<string>).IsGenericType);
+        IsTrue(typeof(List<>).IsGenericType);
+        IsTrue(typeof(Action<>).IsGenericType);
+        IsTrue(typeof(Action<string>).IsGenericType);
+        IsTrue(typeof(Func<string, int>).IsGenericType);
+        IsTrue(typeof(Func<,>).IsGenericType);
     }
 
     private static int _varInt = 42;
@@ -256,6 +322,14 @@ public partial class Program
         Console.WriteLine($"Line {line}: test failed (expected: NullReferenceException)");
         _errors++;
     }
+}
+
+public class GenericSimpleClass<T>
+{    
+}
+
+public class DerivedGenericSimpleClass : GenericSimpleClass<string>
+{    
 }
 
 public class GenericEnumClass<T> where T : Enum

--- a/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
+++ b/src/tests/JIT/Intrinsics/TypeIntrinsics.cs
@@ -232,6 +232,8 @@ public partial class Program
 
         IsTrue(typeof(GenericSimpleClass<int>).IsGenericType);
         IsTrue(typeof(GenericSimpleClass<>).IsGenericType);
+        IsTrue(typeof(GenericSimpleClass<int>.Nested).IsGenericType);
+        IsTrue(typeof(GenericSimpleClass<>.Nested).IsGenericType);
         IsTrue(typeof(GenericEnumClass<SimpleEnum>).IsGenericType);
         IsTrue(typeof(GenericEnumClass<>).IsGenericType);
         IsTrue(typeof(IGenericInterface<string>).IsGenericType);
@@ -325,7 +327,10 @@ public partial class Program
 }
 
 public class GenericSimpleClass<T>
-{    
+{
+    public class Nested
+    {       
+    }  
 }
 
 public class DerivedGenericSimpleClass : GenericSimpleClass<string>


### PR DESCRIPTION
Contributes to #96898

```csharp
public static bool Test<T>() => typeof(T).IsGenericType;
```

Codegen diffs:

```diff
; Assembly listing for method Methods:Test[int]():ubyte (FullOpts)
-   sub      rsp, 40
-   mov      rcx, 0x1D980105580      ; 'System.Int32'
-   call     [System.RuntimeType:get_IsGenericType():ubyte:this]
-   add      rsp, 40
+   xor      eax, eax
    ret

; Assembly listing for method Methods:Test[System.Nullable`1[int]]():ubyte (FullOpts)
-   sub      rsp, 40
-   mov      rcx, 0x1D980109298 
-   call     [System.RuntimeType:get_IsGenericType():ubyte:this]
-   nop 
-   add      rsp, 40
+   mov      eax, 1
    ret      

; Assembly listing for method Methods:Test[System.Collections.Generic.KeyValuePair`2[System.__Canon,System.__Canon]]():ubyte (FullOpts)
-   sub      rsp, 40
-   mov      qword ptr [rsp+0x20], rcx
-   mov      rcx, qword ptr [rcx+0x38]
-   mov      rcx, qword ptr [rcx]
-   call     CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE
-   mov      rcx, rax
-   call     [System.RuntimeType:get_IsGenericType():ubyte:this]
-   nop      
-   add      rsp, 40
+   mov      eax, 1
    ret
```
Added tests but not entirely sure how to get diffs too 😅