### PR TITLE
JIT: Compact newly recognized loops

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4466,11 +4466,6 @@ bool Compiler::optCompactLoops()
     bool changed = false;
     for (FlowGraphNaturalLoop* loop : m_loops->InReversePostOrder())
     {
-        if (!loop->GetHeader()->HasFlag(BBF_OLD_LOOP_HEADER_QUIRK))
-        {
-            continue;
-        }
-
         changed |= optCompactLoop(loop);
     }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4499,6 +4499,16 @@ bool Compiler::optCompactLoop(FlowGraphNaturalLoop* loop)
             continue;
         }
 
+        // If this is a CALLFINALLYRET that is not in the loop, but the
+        // CALLFINALLY was, then we have to leave it in place. For compaction
+        // purposes this doesn't really make any difference, since no codegen
+        // is associated with the CALLFINALLYRET anyway.
+        if (cur->isBBCallFinallyPairTail())
+        {
+            cur = cur->Next();
+            continue;
+        }
+
         BasicBlock* lastNonLoopBlock = cur;
         while (true)
         {


### PR DESCRIPTION
Large diffs expected. Sadly that's just churn until we get a new block layout in the backend, but I do not see an easy way to avoid it if we want to be able to remove old loop finding.