### PR TITLE
runtime: minor bugs fixed in coreclr and libraries

### DIFF
--- a/src/coreclr/pal/src/file/filetime.cpp
+++ b/src/coreclr/pal/src/file/filetime.cpp
@@ -263,6 +263,7 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
 #else   /* HAVE_GMTIME_R */
         UnixSystemTime = gmtime( &UnixFileTime );
 #endif  /* HAVE_GMTIME_R */
+        if (!UnixSystemTime) return FALSE;
 
         /* Convert unix system time to Windows system time. */
         lpSystemTime->wDay      = (WORD)UnixSystemTime->tm_mday;

--- a/src/coreclr/pal/src/file/filetime.cpp
+++ b/src/coreclr/pal/src/file/filetime.cpp
@@ -263,8 +263,13 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
 #else   /* HAVE_GMTIME_R */
         UnixSystemTime = gmtime( &UnixFileTime );
 #endif  /* HAVE_GMTIME_R */
-        if (!UnixSystemTime) return FALSE;
-
+        if (!UnixSystemTime)
+        {
+	       ERROR( "gmtime failed.\n" );
+	       SetLastError(ERROR_INVALID_PARAMETER);
+	       return FALSE;
+	    }
+        
         /* Convert unix system time to Windows system time. */
         lpSystemTime->wDay      = (WORD)UnixSystemTime->tm_mday;
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2821,6 +2821,7 @@ CorUnix::InitializeProcessCommandLine(
     if (lpwstrFullPath)
     {
         LPWSTR lpwstr = PAL_wcsrchr(lpwstrFullPath, '/');
+        if (!lpwstr) {palError = ERROR_INTERNAL_ERROR; goto exit;}
         lpwstr[0] = '\0';
         size_t n = PAL_wcslen(lpwstrFullPath) + 1;
 

--- a/src/coreclr/pal/src/thread/process.cpp
+++ b/src/coreclr/pal/src/thread/process.cpp
@@ -2821,7 +2821,12 @@ CorUnix::InitializeProcessCommandLine(
     if (lpwstrFullPath)
     {
         LPWSTR lpwstr = PAL_wcsrchr(lpwstrFullPath, '/');
-        if (!lpwstr) {palError = ERROR_INTERNAL_ERROR; goto exit;}
+        if (!lpwstr)
+        {
+            ERROR("Invalid full path\n");
+            palError = ERROR_INTERNAL_ERROR;
+            goto exit;
+        }    
         lpwstr[0] = '\0';
         size_t n = PAL_wcslen(lpwstrFullPath) + 1;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -414,7 +414,7 @@ namespace ILCompiler.IBC
                 if (method.Name == methodName)
                 {
                     EcmaMethod ecmaCandidateMethod = method as EcmaMethod;
-                    if (method == null)
+                    if (ecmaCandidateMethod == null)
                         continue;
 
                     MetadataReader metadataReader = ecmaCandidateMethod.MetadataReader;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -343,7 +343,7 @@ namespace System.Configuration
             }
             else
             {
-                if (sectionRecord.HasIndirectLocationInputs)
+                if ((sectionRecord != null) && sectionRecord.HasIndirectLocationInputs)
                 {
                     Debug.Assert(IsLocationConfig, "Indirect location inputs exist only in location config record");
                     SectionInput input = sectionRecord.LastIndirectLocationInput;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -335,7 +335,8 @@ namespace System.Configuration
 
             string configKey = section.SectionInformation.SectionName;
             SectionRecord sectionRecord = GetSectionRecord(configKey, false);
-            if ((sectionRecord != null) && sectionRecord.HasLocationInputs)
+            Debug.Assert(sectionRecord != null);
+            if (sectionRecord.HasLocationInputs)
             {
                 SectionInput input = sectionRecord.LastLocationInput;
                 Debug.Assert(input.HasResult, "input.HasResult");

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -344,7 +344,7 @@ namespace System.Configuration
             }
             else
             {
-                if ((sectionRecord != null) && sectionRecord.HasIndirectLocationInputs)
+                if (sectionRecord.HasIndirectLocationInputs)
                 {
                     Debug.Assert(IsLocationConfig, "Indirect location inputs exist only in location config record");
                     SectionInput input = sectionRecord.LastIndirectLocationInput;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/MgmtConfigurationRecord.cs
@@ -335,7 +335,7 @@ namespace System.Configuration
 
             string configKey = section.SectionInformation.SectionName;
             SectionRecord sectionRecord = GetSectionRecord(configKey, false);
-            if (sectionRecord.HasLocationInputs)
+            if ((sectionRecord != null) && sectionRecord.HasLocationInputs)
             {
                 SectionInput input = sectionRecord.LastLocationInput;
                 Debug.Assert(input.HasResult, "input.HasResult");


### PR DESCRIPTION
The bugs fixed are related to:
-situations where a pointer is dereferenced, but can only have NULL value, and so the operation of dereference can never be run without causing a runtime error;
-after some value is retrieved by as operator, the original value is checked for null instead of the new one.

Found by Linux Verification Center (linuxtesting.org) with SVACE.