### PR TITLE
[mono][debugger] Bump mono debugger protocol version

### DIFF
--- a/src/mono/mono/component/debugger-protocol.h
+++ b/src/mono/mono/component/debugger-protocol.h
@@ -11,7 +11,7 @@
  */
 
 #define MAJOR_VERSION 2
-#define MINOR_VERSION 65
+#define MINOR_VERSION 66
 
 typedef enum {
 	MDBGPROT_CMD_COMPOSITE = 100


### PR DESCRIPTION
Bump protocol version to check if we are in correct version that has all the things to make icordebug work.