### PR TITLE
Don't disable crossgen in crossbuild verticals

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -19,7 +19,6 @@
     <SysRoot Condition="'$(NativeAotSupported)' == 'true' and '$(CrossBuild)' == 'true' and '$(HostOS)' != 'windows'">$(ROOTFS_DIR)</SysRoot>
     <PublishReadyToRun Condition="'$(NativeAotSupported)' != 'true'">true</PublishReadyToRun>
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
-    <PublishReadyToRun Condition="'$(DotNetBuildVertical)' == 'true' AND '$(CrossBuild)' == 'true'">false</PublishReadyToRun>
     <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
     <!-- Compute host package name (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -28,7 +28,6 @@
     <PublishReadyToRun Condition="'$(TargetOS)' == 'netbsd' Or '$(TargetOS)' == 'illumos' Or '$(TargetOS)' == 'solaris' Or '$(TargetOS)' == 'haiku'">false</PublishReadyToRun>
     <!-- Disable crossgen on FreeBSD when cross building from Linux. -->
     <PublishReadyToRun Condition="'$(TargetOS)' == 'freebsd' and '$(CrossBuild)' == 'true'">false</PublishReadyToRun>
-    <PublishReadyToRun Condition="'$(DotnetBuildVertical)' == 'true' AND '$(CrossBuild)' == 'true'">false</PublishReadyToRun>
     <PublishReadyToRunComposite>$(PublishReadyToRun)</PublishReadyToRunComposite>
   </PropertyGroup>
 


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/96858, we can now use the live crossgen in vertical crossbuilds. This removes the conditions disabling it.