### PR TITLE
Define installer-owned directories in dotnet-runtime RPM package

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -62,6 +62,7 @@
       <LinuxPackageDependency Include="dotnet-hostfxr-$(MajorVersion).$(MinorVersion);dotnet-runtime-deps-$(MajorVersion).$(MinorVersion)" Version="$(InstallerPackageVersion)" />
       <!-- We build on an image with LTTNGv0, but we package on distros that have v1. Ignore inspecting dependencies on our LLTNG provider to ensure we can package. -->
       <DebJsonProperty Include="debian_ignored_libraries" Object="[&quot;libcoreclrtraceptprovider.so&quot;]" />
+      <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet/shared/$(MicrosoftNetCoreAppFrameworkName)&quot; ]" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
`dotner-runtime` RPM package does not define any directories it owns. This causes versioned directory to be left on the machine after uninstall or package upgrade.

Support for installer-owned directories already exists in shared infra and is currently used by `dotnet-hostfxr` package: https://github.com/dotnet/runtime/blob/2f63046c28f2f57f2c8666845f1c1de8696b1626/src/installer/pkg/sfx/installers/dotnet-hostfxr.proj#L48

Similarly, `aspnetcore-runtime` package has this correct: https://github.com/dotnet/aspnetcore/blob/29a9c90edf6dbd773296723e8f82605d0364d9f2/src/Installers/Rpm/Rpm.Runtime.Common.targets#L28
