### PR TITLE
JIT: Skip `BBJ_CALLFINALLYRET` in `BasicBlock::VisitEHSuccs`

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -572,6 +572,13 @@ static BasicBlockVisit VisitEHSuccs(Compiler* comp, BasicBlock* block, TFunc fun
 template <typename TFunc>
 BasicBlockVisit BasicBlock::VisitEHSuccs(Compiler* comp, TFunc func)
 {
+    // These are "pseudo-blocks" and control never actually flows into them
+    // (codegen directly jumps to its successor after finally calls).
+    if (KindIs(BBJ_CALLFINALLYRET))
+    {
+        return BasicBlockVisit::Continue;
+    }
+
     return ::VisitEHSuccs</* skipJumpDest */ false, TFunc>(comp, this, func);
 }
 
@@ -608,7 +615,8 @@ BasicBlockVisit BasicBlock::VisitAllSuccs(Compiler* comp, TFunc func)
             return ::VisitEHSuccs</* skipJumpDest */ true, TFunc>(comp, this, func);
 
         case BBJ_CALLFINALLYRET:
-            // No exceptions can occur in this paired block; skip its normal EH successors.
+            // These are "pseudo-blocks" and control never actually flows into them
+            // (codegen directly jumps to its successor after finally calls).
             return func(bbTarget);
 
         case BBJ_EHCATCHRET:


### PR DESCRIPTION
We currently skip yielding EH successors of BBJ_CALLFINALLYRET nodes in `BasicBlock::VisitAllSuccs`. `BasicBlock::VisitEHSuccs` should be consistent with this.

Minor diffs from differences in PHI placement expected.