### PR TITLE
Create directory for Binding Tools For Swift

### DIFF
--- a/src/tools/bindingtools/swift/README.md
+++ b/src/tools/bindingtools/swift/README.md
@@ -1,0 +1,7 @@
+# Binding Tools For Swift
+
+This is a collection of tools designed to consume a compiled Apple Swift library and generate bindings and wrappers that enable it to be used as a .NET library.
+
+## Current Status
+
+The components are currently undergoing iterative reviews and will be moved from https://github.com/xamarin/binding-tools-for-swift.


### PR DESCRIPTION
## Description

This PR creates a directory for the Swift projection tooling. The components are currently undergoing iterative reviews and will be moved from https://github.com/xamarin/binding-tools-for-swift.

Discussion: https://github.com/dotnet/designs/pull/312#discussion_r1450378326