### PR TITLE
Fix mscordac exports

### DIFF
--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -18,6 +18,8 @@ IID_ICLRDataTarget
 IID_ICorDebugDataTarget4
 IID_ICLRDataEnumMemoryRegionsCallback
 nativeStringResourceTable_mscorrc
+minipal_get_length_utf16_to_utf8
+minipal_convert_utf16_to_utf8
 
 ; All the # exports are prefixed with DAC_
 #PAL_CatchHardwareExceptionHolderEnter

--- a/src/native/minipal/utf8.c
+++ b/src/native/minipal/utf8.c
@@ -2074,6 +2074,9 @@ size_t minipal_get_length_utf8_to_utf16(const char* source, size_t sourceLength,
     return GetCharCount(&enc, (unsigned char*)source, sourceLength);
 }
 
+#ifdef HOST_UNIX
+__attribute__ ((visibility ("default")))
+#endif
 size_t minipal_get_length_utf16_to_utf8(const CHAR16_T* source, size_t sourceLength, unsigned int flags)
 {
     errno = 0;
@@ -2121,6 +2124,9 @@ size_t minipal_convert_utf8_to_utf16(const char* source, size_t sourceLength, CH
     return ret;
 }
 
+#ifdef HOST_UNIX
+__attribute__ ((visibility ("default")))
+#endif
 size_t minipal_convert_utf16_to_utf8(const CHAR16_T* source, size_t sourceLength, char* destination, size_t destinationLength, unsigned int flags)
 {
     size_t ret;


### PR DESCRIPTION
The mscordbi depends on the PAL in mscordac and so it requires that all functions it uses from coreclr PAL are exported by the libmscordac. This got broken recently by a change in a header consumed by the mscordbi that pulled in usage of two functions for UTF16 to UTF8 conversion into the mscordbi (#96099).

This issue prevents debuggers using libmscordbi to initiate debugging.

This change fixes it by exporting those two functions from libmscordac.