### PR TITLE
JIT: Remove Compiler::fgIsBetterFallThrough

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5926,8 +5926,6 @@ public:
 
     void fgFindBasicBlocks();
 
-    bool fgIsBetterFallThrough(BasicBlock* bCur, BasicBlock* bAlt);
-
     bool fgCheckEHCanInsertAfterBlock(BasicBlock* blk, unsigned regionIndex, bool putInTryRegion);
 
     BasicBlock* fgFindInsertPoint(unsigned    regionIndex,

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6606,9 +6606,7 @@ BasicBlock* Compiler::fgFindInsertPoint(unsigned    regionIndex,
             }
         }
 
-        // Look for an insert location:
-        // 1. We want blocks that don't end with a fall through,
-        // 2. Also, when blk equals nearBlk we may want to insert here.
+        // Look for an insert location. We want blocks that don't end with a fall through.
         // Quirk: Manually check for BBJ_COND fallthrough behavior
         const bool blkFallsThrough =
             blk->bbFallsThrough() && (!blk->KindIs(BBJ_COND) || blk->NextIs(blk->GetFalseTarget()));


### PR DESCRIPTION
Next step for #93020. This removal didn't have any diffs locally, so I thought I'd open this now.