### PR TITLE
[Mono]: Add "driver" support to Mono AOT cross compiler.

### DIFF
--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -974,6 +974,11 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_open open
 #endif
 #ifdef G_OS_WIN32
+#define g_close _close
+#else
+#define g_close close
+#endif
+#ifdef G_OS_WIN32
 #define g_unlink _unlink
 #else
 #define g_unlink unlink
@@ -987,6 +992,11 @@ gboolean   g_file_test (const gchar *filename, GFileTest test);
 #define g_read(fd, buffer, buffer_size) _read(fd, buffer, (unsigned)buffer_size)
 #else
 #define g_read(fd, buffer, buffer_size) (int)read(fd, buffer, buffer_size)
+#endif
+#ifdef G_OS_WIN32
+#define g_dup _dup
+#else
+#define g_dup dup
 #endif
 
 gchar *g_mkdtemp (gchar *tmpl);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -9110,7 +9110,7 @@ mono_aot_parse_options (const char *aot_options, MonoAotOptions *opts)
 			printf ("    direct-pinvoke-lists=<string>        - Files containing specific direct pinvokes to generate direct calls for an entire 'module' or specific 'module!entrypoint' on separate lines. Incompatible with 'direct-pinvoke' option.\n");
 			printf ("    direct-pinvoke                       - Generate direct calls for all direct pinvokes encountered in the managed assembly.\n");
 			printf ("    driver                               - Run AOT compiler in driver mode. Runs cross compiler and tools as child processes.\n");
-			printf ("    driver-logfile                       - Pass by driver parent process when executin AOT cross compiler as a child process. Executed commands will be logged into file instead of executed by child process. Path to file or 'stdout'.\n");
+			printf ("    driver-logfile                       - Pass by driver parent process when executing AOT cross compiler as a child process. Executed commands will be logged into file instead of executed by child process. Path to file or 'stdout'.\n");
 			printf ("    dwarfdebug                           - \n");
 			printf ("    full                                 - \n");
 			printf ("    hybrid                               - \n");

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -10979,7 +10979,7 @@ execute_compiler_command (const char *command, GString *compiler_execute_command
 	if (line && stream) {
 		size_t read = 0;
 		while ((read = fread (buffer, sizeof (buffer [0]), G_N_ELEMENTS (buffer), stream)) > 0) {
-			for (int i = 0; i < read; i++) {
+			for (size_t i = 0; i < read; i++) {
 				g_string_append_c (line, buffer [i]);
 				if (buffer [i] == '\n') {
 					if (compiler_execute_command_log && get_execute_command (line->str, NULL)) {
@@ -11059,7 +11059,7 @@ create_tool_path (const char *base_path, const char *binary_name)
 {
 	GString *path = g_string_sized_new (strlen (base_path) + strlen (binary_name) + 1 + 2);
 	gboolean needs_wrap = strstr (base_path, " ") || strstr (binary_name, " ");
-	gboolean needs_dir_sep = !g_str_has_suffix (base_path, G_DIR_SEPARATOR_S);
+	gboolean needs_dir_sep = (base_path [0] != '\0' && !g_str_has_suffix (base_path, G_DIR_SEPARATOR_S));
 
 	if (needs_wrap)
 		g_string_append_c (path, '\"');

--- a/src/mono/mono/mini/aot-compiler.h
+++ b/src/mono/mono/mini/aot-compiler.h
@@ -7,7 +7,7 @@
 
 #include "mini.h"
 
-int mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 opts, const char *aot_options);
+int mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 opts, const char *aot_options, int orig_argc, const char * const *orig_argv);
 void* mono_aot_readonly_field_override (MonoClassField *field);
 gboolean mono_aot_direct_icalls_enabled_for_method (MonoCompile *cfg, MonoMethod *method);
 gboolean mono_aot_is_shared_got_offset (int offset);

--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -133,6 +133,9 @@ static const gint16 opt_names [] = {
 
 #define EXCLUDED_FROM_ALL (MONO_OPT_PRECOMP | MONO_OPT_UNSAFE | MONO_OPT_GSHAREDVT)
 
+static int mono_main_argc;
+static const char * const *mono_main_argv;
+
 static char *mono_parse_options (const char *options, int *ref_argc, char **ref_argv [], gboolean prepend);
 static char *mono_parse_response_options (const char *options, int *ref_argc, char **ref_argv [], gboolean prepend);
 
@@ -1421,7 +1424,7 @@ main_thread_handler (gpointer user_data)
 			assemblies [i] = assembly;
 		}
 
-		res = mono_aot_assemblies (assemblies, main_args->argc, main_args->opts, main_args->aot_options);
+		res = mono_aot_assemblies (assemblies, main_args->argc, main_args->opts, main_args->aot_options, mono_main_argc, mono_main_argv);
 		if (res)
 			exit (1);
 		return;
@@ -2071,6 +2074,11 @@ mono_main (int argc, char* argv[])
 	int test_jit_info_table = FALSE;
 #endif
 	ERROR_DECL (error);
+
+	if (!mono_main_argc && !mono_main_argv) {
+		mono_main_argc = argc;
+		mono_main_argv = (const char * const *)argv;
+	}
 
 #ifdef MOONLIGHT
 #ifndef HOST_WIN32
@@ -3100,6 +3108,9 @@ mono_parse_options (const char *options, int *ref_argc, char **ref_argv [], gboo
 	if (buffer->len != 0)
 		g_ptr_array_add (array, g_strdup (buffer->str));
 	g_string_free (buffer, TRUE);
+
+	mono_main_argc = *ref_argc;
+	mono_main_argv = (const char * const *)*ref_argv;
 
 	merge_parsed_options (array, ref_argc, ref_argv, prepend);
 	g_ptr_array_free (array, TRUE);


### PR DESCRIPTION
Running Mono AOT cross compiler will keep the process alive while running external tools like opt and llc. When building a large assembly using LLVM the memory footprint of Mono AOT cross compiler can fall in the gigabytes and then running LLVM tools like opt and llc as child processes tends to take up additional memory in the gigabyte space for large assemblies meaning that the total memory needed to compile one large assembly will be max Mono AOT cross compiler memory usage + (opt|llc) memory usage, meaning that it can consume gigabytes of memory. Adding parallel compiles into the mix means machine memory will drain pretty fast.

This PR adds a "driver" mode to AOT compiler. Its integrated into the execute system command infrastructure of the Mono AOT cross compiler, meaning that a Mono AOT compiler process doing the compile work will write the exact commands (opt, llc, clang, ld etc) that it would have executed into a file or stdout and the AOT compiler instance acting as the driver will record them and execute them once the original child process exited (and released all its memory). Doing it like this won't keep memory around and the Mono AOT cross compiler instance acting as the "driver" will only consume a couple of MB's of memory. The benefit of recording the commands into a file/stdout will make sure we are always up to date with the correct set of arguments for each command and it is even possible to write a custom driver and it will be able to run the exact same commands as the AOT cross compiler would have done when not executed as a driver child process.

By default, driver mode in Mono AOT cross compiler is disabled. To enable it add aot=driver argument to the list of all arguments passed to Mono AOT cross compiler. That will run a different instance of the Mono AOT cross compiler with the same set of arguments, but adding aot=driver-logfile=stdout that makes sure child process runs the compile of the assembly, but record selected executed commands into the supplied file, by default that is stdout to only communicate between the pipe setup between parent and child process. Once all commands have been recorded and the child process terminates, the driver instance will execute each command in sequence (after doing validation of the binary used in each command).

Here is an example of how the child process of a driver instance logs into stdout:

```
Mono Ahead of Time compiler - compiling assembly System.Private.CoreLib.dll
AOTID 41E59EEC-D030-B60E-4C98-5ABE667E0B63
[LLVM_OPT_COMMAND] opt.exe -f -disable-tail-calls -passes="default<O2>,place-safepoints" -spp-all-backedges -o "temp.opt.bc" "temp.bc"
[LLVM_LLC_COMMAND] llc.exe  -march=x86-64 -mcpu=generic -enable-implicit-null-checks -disable-fault-maps -asm-verbose=false -mtriple=x86_64-pc-windows-msvc -disable-gnu-eh-frame -enable-mono-eh-frame -mono-eh-frame-symbol=mono_aot_corlib_eh_frame -disable-tail-calls -no-x86-call-frame-opt -relocation-model=pic -filetype=obj -o "System.Private.CoreLib.dll-llvm.obj.tmp" "temp.opt.bc"
Compiled: 40119/40643
[ASM_COMMAND] "clang.exe" --target=x86_64-pc-windows-msvc -c -x assembler  -o System.Private.CoreLib.dll.obj.tmp temp.s
Output file: System.Private.CoreLib.dll.obj.tmp.
Linking symbol: 'mono_aot_module_System_Private_CoreLib_info'.
JIT time: 11254 ms, Generation time: 8502 ms, Assembly+Link time: 0 ms.
```

so each of the [XX_COMMAND] are just logged into stdout by child process as it would have been executed, driver parent process reads stdout and extract commands into a command log, the rest is written to its stdout making sure all the output (except the commands) are still visible to the user. It will then execute the list of commands in sequence as recorded by the child process after the child process has terminated and the system has been able to reclaim its memory.

Since the driver currently don't support the unlink, rename and rm commands used by AOT compiler in some scenarios, it currently only works with the outfile || llvm_outfile and temp_path aot options. It is simple to add them in the driver, but in the use case where the complete driver option was implemented  didn't have the need since things where always executed with outfile and temp_path. The same applies to assemblies compiled through the MonoAOTCompiler msbuild task.