### PR TITLE
Add an internal mode to `Lock` to have it use non-alertable waits

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
@@ -9,7 +9,7 @@ namespace System.Threading
     public abstract partial class WaitHandle
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout, bool alertable);
+        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout, bool useTrivialWaits);
 
         private static unsafe int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
@@ -9,7 +9,7 @@ namespace System.Threading
     public abstract partial class WaitHandle
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout);
+        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout, bool alertable);
 
         private static unsafe int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
         {

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifier()
         {
-            _lock = new Lock();
+            _lock = new Lock(useAlertableWaits: false);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifier()
         {
-            _lock = new Lock(useAlertableWaits: false);
+            _lock = new Lock(useTrivialWaits: true);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
@@ -75,7 +75,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierW()
         {
-            _lock = new Lock();
+            _lock = new Lock(useAlertableWaits: false);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
@@ -75,7 +75,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierW()
         {
-            _lock = new Lock(useAlertableWaits: false);
+            _lock = new Lock(useTrivialWaits: true);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
@@ -84,7 +84,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierWKeyed()
         {
-            _lock = new Lock();
+            _lock = new Lock(useAlertableWaits: false);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
@@ -84,7 +84,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierWKeyed()
         {
-            _lock = new Lock(useAlertableWaits: false);
+            _lock = new Lock(useTrivialWaits: true);
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -914,6 +914,10 @@
     <Target>M:System.Reflection.MethodBase.GetParametersAsSpan</Target>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Threading.Lock.#ctor(System.Boolean)</Target>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0015</DiagnosticId>
     <Target>M:System.Diagnostics.Tracing.EventSource.Write``1(System.String,``0):[T:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute]</Target>
   </Suppression>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
     {
         public static readonly FrozenObjectHeapManager Instance = new FrozenObjectHeapManager();
 
-        private readonly Lock m_Crst = new Lock(useAlertableWaits: false);
+        private readonly Lock m_Crst = new Lock(useTrivialWaits: true);
         private FrozenObjectSegment m_CurrentSegment;
 
         // Default size to reserve for a frozen segment

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
     {
         public static readonly FrozenObjectHeapManager Instance = new FrozenObjectHeapManager();
 
-        private readonly LowLevelLock m_Crst = new LowLevelLock();
+        private readonly Lock m_Crst = new Lock(useAlertableWaits: false);
         private FrozenObjectSegment m_CurrentSegment;
 
         // Default size to reserve for a frozen segment
@@ -34,9 +34,7 @@ namespace Internal.Runtime
         {
             HalfBakedObject* obj = null;
 
-            m_Crst.Acquire();
-
-            try
+            using (m_Crst.EnterScope())
             {
                 Debug.Assert(type != null);
                 // _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
@@ -84,10 +82,6 @@ namespace Internal.Runtime
                     Debug.Assert(obj != null);
                 }
             } // end of m_Crst lock
-            finally
-            {
-                m_Crst.Release();
-            }
 
             IntPtr result = (IntPtr)obj;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -275,7 +275,7 @@ namespace System.Runtime.CompilerServices
 #if TARGET_WASM
                 if (s_cctorGlobalLock == null)
                 {
-                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(useAlertableWaits: false), null);
+                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(useTrivialWaits: true), null);
                 }
                 if (s_cctorArrays == null)
                 {
@@ -342,7 +342,7 @@ namespace System.Runtime.CompilerServices
 
                         Debug.Assert(resultArray[resultIndex]._pContext == default(StaticClassConstructionContext*));
                         resultArray[resultIndex]._pContext = pContext;
-                        resultArray[resultIndex].Lock = new Lock(useAlertableWaits: false);
+                        resultArray[resultIndex].Lock = new Lock(useTrivialWaits: true);
                         s_count++;
                     }
 
@@ -489,7 +489,7 @@ namespace System.Runtime.CompilerServices
         internal static void Initialize()
         {
             s_cctorArrays = new Cctor[10][];
-            s_cctorGlobalLock = new Lock(useAlertableWaits: false);
+            s_cctorGlobalLock = new Lock(useTrivialWaits: true);
         }
 
         [Conditional("ENABLE_NOISY_CCTOR_LOG")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -275,7 +275,7 @@ namespace System.Runtime.CompilerServices
 #if TARGET_WASM
                 if (s_cctorGlobalLock == null)
                 {
-                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(), null);
+                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(useAlertableWaits: false), null);
                 }
                 if (s_cctorArrays == null)
                 {
@@ -342,7 +342,7 @@ namespace System.Runtime.CompilerServices
 
                         Debug.Assert(resultArray[resultIndex]._pContext == default(StaticClassConstructionContext*));
                         resultArray[resultIndex]._pContext = pContext;
-                        resultArray[resultIndex].Lock = new Lock();
+                        resultArray[resultIndex].Lock = new Lock(useAlertableWaits: false);
                         s_count++;
                     }
 
@@ -489,7 +489,7 @@ namespace System.Runtime.CompilerServices
         internal static void Initialize()
         {
             s_cctorArrays = new Cctor[10][];
-            s_cctorGlobalLock = new Lock();
+            s_cctorGlobalLock = new Lock(useAlertableWaits: false);
         }
 
         [Conditional("ENABLE_NOISY_CCTOR_LOG")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.InteropServices
         private static readonly List<GCHandle> s_referenceTrackerNativeObjectWrapperCache = new List<GCHandle>();
 
         private readonly ConditionalWeakTable<object, ManagedObjectWrapperHolder> _ccwTable = new ConditionalWeakTable<object, ManagedObjectWrapperHolder>();
-        private readonly Lock _lock = new Lock(useAlertableWaits: false);
+        private readonly Lock _lock = new Lock(useTrivialWaits: true);
         private readonly Dictionary<IntPtr, GCHandle> _rcwCache = new Dictionary<IntPtr, GCHandle>();
 
         internal static bool TryGetComInstanceForIID(object obj, Guid iid, out IntPtr unknown, out long wrapperId)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.InteropServices
         private static readonly List<GCHandle> s_referenceTrackerNativeObjectWrapperCache = new List<GCHandle>();
 
         private readonly ConditionalWeakTable<object, ManagedObjectWrapperHolder> _ccwTable = new ConditionalWeakTable<object, ManagedObjectWrapperHolder>();
-        private readonly Lock _lock = new Lock();
+        private readonly Lock _lock = new Lock(useAlertableWaits: false);
         private readonly Dictionary<IntPtr, GCHandle> _rcwCache = new Dictionary<IntPtr, GCHandle>();
 
         internal static bool TryGetComInstanceForIID(object obj, Guid iid, out IntPtr unknown, out long wrapperId)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -114,7 +114,7 @@ namespace System.Threading
                 success =
                     waiter.ev.WaitOneNoCheck(
                         millisecondsTimeout,
-                        true, // alertable
+                        false, // useTrivialWaits
                         associatedObjectForMonitorWait,
                         associatedObjectForMonitorWait != null
                             ? NativeRuntimeEventSource.WaitHandleWaitSourceMap.MonitorWait

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -114,6 +114,7 @@ namespace System.Threading
                 success =
                     waiter.ev.WaitOneNoCheck(
                         millisecondsTimeout,
+                        true, // alertable
                         associatedObjectForMonitorWait,
                         associatedObjectForMonitorWait != null
                             ? NativeRuntimeEventSource.WaitHandleWaitSourceMap.MonitorWait

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -92,6 +92,18 @@ namespace System.Threading
             _recursionCount = previousRecursionCount;
         }
 
+        private static bool IsFullyInitialized
+        {
+            get
+            {
+                // If NativeRuntimeEventSource is already being class-constructed by this thread earlier in the stack, Log can
+                // be null. This property is used to avoid going down the wait path in that case to avoid null checks in several
+                // other places.
+                Debug.Assert((StaticsInitializationStage)s_staticsInitializationStage == StaticsInitializationStage.Complete);
+                return NativeRuntimeEventSource.Log != null;
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private TryLockResult LazyInitializeOrEnter()
         {
@@ -101,6 +113,10 @@ namespace System.Threading
                 case StaticsInitializationStage.Complete:
                     if (_spinCount == SpinCountNotInitialized)
                     {
+                        if (!IsFullyInitialized)
+                        {
+                            goto case StaticsInitializationStage.Started;
+                        }
                         _spinCount = s_maxSpinCount;
                     }
                     return TryLockResult.Spin;
@@ -121,7 +137,7 @@ namespace System.Threading
                         }
 
                         stage = (StaticsInitializationStage)Volatile.Read(ref s_staticsInitializationStage);
-                        if (stage == StaticsInitializationStage.Complete)
+                        if (stage == StaticsInitializationStage.Complete && IsFullyInitialized)
                         {
                             goto case StaticsInitializationStage.Complete;
                         }
@@ -166,14 +182,17 @@ namespace System.Threading
                     return true;
             }
 
+            bool isFullyInitialized;
             try
             {
                 s_isSingleProcessor = Environment.IsSingleProcessor;
                 s_maxSpinCount = DetermineMaxSpinCount();
                 s_minSpinCount = DetermineMinSpinCount();
 
-                // Also initialize some types that are used later to prevent potential class construction cycles
-                _ = NativeRuntimeEventSource.Log;
+                // Also initialize some types that are used later to prevent potential class construction cycles. If
+                // NativeRuntimeEventSource is already being class-constructed by this thread earlier in the stack, Log can be
+                // null. Avoid going down the wait path in that case to avoid null checks in several other places.
+                isFullyInitialized = NativeRuntimeEventSource.Log != null;
             }
             catch
             {
@@ -182,7 +201,7 @@ namespace System.Threading
             }
 
             Volatile.Write(ref s_staticsInitializationStage, (int)StaticsInitializationStage.Complete);
-            return true;
+            return isFullyInitialized;
         }
 
         // Returns false until the static variable is lazy-initialized

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
@@ -65,7 +65,7 @@ namespace System.Threading
         /// <summary>
         /// Protects all mutable operations on s_entries, s_freeEntryList, s_unusedEntryIndex. Also protects growing the table.
         /// </summary>
-        internal static readonly Lock s_lock = new Lock();
+        internal static readonly Lock s_lock = new Lock(useAlertableWaits: false);
 
         /// <summary>
         /// The dynamically growing array of sync entries.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
@@ -65,7 +65,7 @@ namespace System.Threading
         /// <summary>
         /// Protects all mutable operations on s_entries, s_freeEntryList, s_unusedEntryIndex. Also protects growing the table.
         /// </summary>
-        internal static readonly Lock s_lock = new Lock(useAlertableWaits: false);
+        internal static readonly Lock s_lock = new Lock(useTrivialWaits: true);
 
         /// <summary>
         /// The dynamically growing array of sync entries.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -167,7 +167,7 @@ namespace System.Threading
                 }
                 else
                 {
-                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout, alertable: true);
+                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout, useTrivialWaits: false);
                 }
 
                 return result == (int)Interop.Kernel32.WAIT_OBJECT_0;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -167,7 +167,7 @@ namespace System.Threading
                 }
                 else
                 {
-                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout);
+                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout, alertable: true);
                 }
 
                 return result == (int)Interop.Kernel32.WAIT_OBJECT_0;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -31,7 +31,7 @@ namespace System.Threading
         private Exception? _startException;
 
         // Protects starting the thread and setting its priority
-        private Lock _lock = new Lock(useAlertableWaits: false);
+        private Lock _lock = new Lock(useTrivialWaits: true);
 
         // This is used for a quick check on thread pool threads after running a work item to determine if the name, background
         // state, or priority were changed by the work item, and if so to reset it. Other threads may also change some of those,

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -31,7 +31,7 @@ namespace System.Threading
         private Exception? _startException;
 
         // Protects starting the thread and setting its priority
-        private Lock _lock = new Lock();
+        private Lock _lock = new Lock(useAlertableWaits: false);
 
         // This is used for a quick check on thread pool threads after running a work item to determine if the name, background
         // state, or priority were changed by the work item, and if so to reset it. Other threads may also change some of those,

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
@@ -42,15 +42,14 @@ namespace System
 
         private static class AllocationLockHolder
         {
-            public static LowLevelLock AllocationLock = new LowLevelLock();
+            public static Lock AllocationLock = new Lock(useAlertableWaits: false);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static unsafe RuntimeType GetTypeFromMethodTableSlow(MethodTable* pMT)
         {
             // Allocate and set the RuntimeType under a lock - there's no way to free it if there is a race.
-            AllocationLockHolder.AllocationLock.Acquire();
-            try
+            using (AllocationLockHolder.AllocationLock.EnterScope())
             {
                 ref RuntimeType? runtimeTypeCache = ref Unsafe.AsRef<RuntimeType?>(pMT->WritableData);
                 if (runtimeTypeCache != null)
@@ -65,10 +64,6 @@ namespace System
                 runtimeTypeCache = type;
 
                 return type;
-            }
-            finally
-            {
-                AllocationLockHolder.AllocationLock.Release();
             }
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
@@ -42,7 +42,7 @@ namespace System
 
         private static class AllocationLockHolder
         {
-            public static Lock AllocationLock = new Lock(useAlertableWaits: false);
+            public static Lock AllocationLock = new Lock(useTrivialWaits: true);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
@@ -24,7 +24,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all dynamic generic type registration/lookups under a global lock
-        private Lock _dynamicGenericsLock = new Lock();
+        private Lock _dynamicGenericsLock = new Lock(useAlertableWaits: false);
 
         internal void RegisterDynamicGenericTypesAndMethods(DynamicGenericsRegistrationData registrationData)
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
@@ -24,7 +24,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all dynamic generic type registration/lookups under a global lock
-        private Lock _dynamicGenericsLock = new Lock(useAlertableWaits: false);
+        private Lock _dynamicGenericsLock = new Lock(useTrivialWaits: true);
 
         internal void RegisterDynamicGenericTypesAndMethods(DynamicGenericsRegistrationData registrationData)
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime.TypeLoader
     public sealed partial class TypeLoaderEnvironment
     {
         // To keep the synchronization simple, we execute all TLS registration/lookups under a global lock
-        private Lock _threadStaticsLock = new Lock();
+        private Lock _threadStaticsLock = new Lock(useAlertableWaits: false);
 
         // Counter to keep track of generated offsets for TLS cells of dynamic types;
         private LowLevelDictionary<IntPtr, uint> _maxThreadLocalIndex = new LowLevelDictionary<IntPtr, uint>();

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime.TypeLoader
     public sealed partial class TypeLoaderEnvironment
     {
         // To keep the synchronization simple, we execute all TLS registration/lookups under a global lock
-        private Lock _threadStaticsLock = new Lock(useAlertableWaits: false);
+        private Lock _threadStaticsLock = new Lock(useTrivialWaits: true);
 
         // Counter to keep track of generated offsets for TLS cells of dynamic types;
         private LowLevelDictionary<IntPtr, uint> _maxThreadLocalIndex = new LowLevelDictionary<IntPtr, uint>();

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -145,7 +145,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all type loading under a global lock
-        private Lock _typeLoaderLock = new Lock();
+        private Lock _typeLoaderLock = new Lock(useAlertableWaits: false);
 
         public void VerifyTypeLoaderLockHeld()
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -145,7 +145,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all type loading under a global lock
-        private Lock _typeLoaderLock = new Lock(useAlertableWaits: false);
+        private Lock _typeLoaderLock = new Lock(useTrivialWaits: true);
 
         public void VerifyTypeLoaderLockHeld()
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime.TypeLoader
         // This allows us to avoid recreating the type resolution context again and again, but still allows it to go away once the types are no longer being built
         private static GCHandle s_cachedContext = GCHandle.Alloc(null, GCHandleType.Weak);
 
-        private static Lock s_lock = new Lock();
+        private static Lock s_lock = new Lock(useAlertableWaits: false);
 
         public static TypeSystemContext Create()
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime.TypeLoader
         // This allows us to avoid recreating the type resolution context again and again, but still allows it to go away once the types are no longer being built
         private static GCHandle s_cachedContext = GCHandle.Alloc(null, GCHandleType.Weak);
 
-        private static Lock s_lock = new Lock(useAlertableWaits: false);
+        private static Lock s_lock = new Lock(useTrivialWaits: true);
 
         public static TypeSystemContext Create()
         {

--- a/src/coreclr/vm/comwaithandle.cpp
+++ b/src/coreclr/vm/comwaithandle.cpp
@@ -16,7 +16,7 @@
 #include "excep.h"
 #include "comwaithandle.h"
 
-FCIMPL2(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout)
+FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL alertable)
 {
     FCALL_CONTRACT;
 
@@ -28,7 +28,8 @@ FCIMPL2(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout)
 
     Thread* pThread = GET_THREAD();
 
-    retVal = pThread->DoAppropriateWait(1, &handle, TRUE, timeout, (WaitMode)(WaitMode_Alertable | WaitMode_IgnoreSyncCtx));
+    WaitMode waitMode = (WaitMode)((alertable ? WaitMode_Alertable : WaitMode_None) | WaitMode_IgnoreSyncCtx);
+    retVal = pThread->DoAppropriateWait(1, &handle, TRUE, timeout, waitMode);
 
     HELPER_METHOD_FRAME_END();
     return retVal;

--- a/src/coreclr/vm/comwaithandle.cpp
+++ b/src/coreclr/vm/comwaithandle.cpp
@@ -16,7 +16,7 @@
 #include "excep.h"
 #include "comwaithandle.h"
 
-FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL alertable)
+FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL useTrivialWaits)
 {
     FCALL_CONTRACT;
 
@@ -28,7 +28,7 @@ FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout,
 
     Thread* pThread = GET_THREAD();
 
-    WaitMode waitMode = (WaitMode)((alertable ? WaitMode_Alertable : WaitMode_None) | WaitMode_IgnoreSyncCtx);
+    WaitMode waitMode = (WaitMode)((!useTrivialWaits ? WaitMode_Alertable : WaitMode_None) | WaitMode_IgnoreSyncCtx);
     retVal = pThread->DoAppropriateWait(1, &handle, TRUE, timeout, waitMode);
 
     HELPER_METHOD_FRAME_END();

--- a/src/coreclr/vm/comwaithandle.h
+++ b/src/coreclr/vm/comwaithandle.h
@@ -18,7 +18,7 @@
 class WaitHandleNative
 {
 public:
-    static FCDECL2(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout);
+    static FCDECL3(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL alertable);
     static FCDECL4(INT32, CorWaitMultipleNative, HANDLE *handleArray, INT32 numHandles, CLR_BOOL waitForAll, INT32 timeout);
     static FCDECL3(INT32, CorSignalAndWaitOneNative, HANDLE waitHandleSignalUNSAFE, HANDLE waitHandleWaitUNSAFE, INT32 timeout);
 };

--- a/src/coreclr/vm/comwaithandle.h
+++ b/src/coreclr/vm/comwaithandle.h
@@ -18,7 +18,7 @@
 class WaitHandleNative
 {
 public:
-    static FCDECL3(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL alertable);
+    static FCDECL3(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL useTrivialWaits);
     static FCDECL4(INT32, CorWaitMultipleNative, HANDLE *handleArray, INT32 numHandles, CLR_BOOL waitForAll, INT32 timeout);
     static FCDECL3(INT32, CorSignalAndWaitOneNative, HANDLE waitHandleSignalUNSAFE, HANDLE waitHandleWaitUNSAFE, INT32 timeout);
 };

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
@@ -7,8 +7,8 @@ namespace System.Threading
 {
     public abstract partial class WaitHandle
     {
-        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout) =>
-            WaitSubsystem.Wait(handle, millisecondsTimeout, true);
+        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool alertable) =>
+            WaitSubsystem.Wait(handle, millisecondsTimeout, alertable);
 
         private static int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> handles, bool waitAll, int millisecondsTimeout) =>
             WaitSubsystem.Wait(handles, waitAll, millisecondsTimeout);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
@@ -7,8 +7,8 @@ namespace System.Threading
 {
     public abstract partial class WaitHandle
     {
-        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool alertable) =>
-            WaitSubsystem.Wait(handle, millisecondsTimeout, alertable);
+        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits) =>
+            WaitSubsystem.Wait(handle, millisecondsTimeout, interruptible: !useTrivialWaits);
 
         private static int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> handles, bool waitAll, int millisecondsTimeout) =>
             WaitSubsystem.Wait(handles, waitAll, millisecondsTimeout);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
@@ -14,11 +14,11 @@ namespace System.Threading
         {
             fixed (IntPtr* pHandles = &MemoryMarshal.GetReference(handles))
             {
-                return WaitForMultipleObjectsIgnoringSyncContext(pHandles, handles.Length, waitAll, millisecondsTimeout, alertable: true);
+                return WaitForMultipleObjectsIgnoringSyncContext(pHandles, handles.Length, waitAll, millisecondsTimeout, useTrivialWaits: false);
             }
         }
 
-        private static unsafe int WaitForMultipleObjectsIgnoringSyncContext(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout, bool alertable)
+        private static unsafe int WaitForMultipleObjectsIgnoringSyncContext(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout, bool useTrivialWaits)
         {
             Debug.Assert(millisecondsTimeout >= -1);
 
@@ -27,8 +27,8 @@ namespace System.Threading
                 waitAll = false;
 
 #if NATIVEAOT // TODO: reentrant wait support https://github.com/dotnet/runtime/issues/49518
-            // Non-alertable waits don't allow reentrance
-            bool reentrantWait = alertable && Thread.ReentrantWaitsEnabled;
+            // Trivial waits don't allow reentrance
+            bool reentrantWait = !useTrivialWaits && Thread.ReentrantWaitsEnabled;
 
             if (reentrantWait)
             {
@@ -93,9 +93,9 @@ namespace System.Threading
             return result;
         }
 
-        internal static unsafe int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool alertable)
+        internal static unsafe int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits)
         {
-            return WaitForMultipleObjectsIgnoringSyncContext(&handle, 1, false, millisecondsTimeout, alertable);
+            return WaitForMultipleObjectsIgnoringSyncContext(&handle, 1, false, millisecondsTimeout, useTrivialWaits);
         }
 
         private static int SignalAndWaitCore(IntPtr handleToSignal, IntPtr handleToWaitOn, int millisecondsTimeout)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.cs
@@ -106,6 +106,7 @@ namespace System.Threading
 
         internal bool WaitOneNoCheck(
             int millisecondsTimeout,
+            bool alertable = true,
             object? associatedObject = null,
             NativeRuntimeEventSource.WaitHandleWaitSourceMap waitSource = NativeRuntimeEventSource.WaitHandleWaitSourceMap.Unknown)
         {
@@ -122,22 +123,26 @@ namespace System.Threading
                 waitHandle.DangerousAddRef(ref success);
 
                 int waitResult = WaitFailed;
-                SynchronizationContext? context = SynchronizationContext.Current;
-                if (context != null && context.IsWaitNotificationRequired())
+
+                // Check if the wait should be forwarded to a SynchronizationContext wait override. Non-alertable waits don't
+                // allow reentrance or interruption, and are not forwarded.
+                bool usedSyncContextWait = false;
+                if (alertable)
                 {
-                    waitResult = context.Wait(new[] { waitHandle.DangerousGetHandle() }, false, millisecondsTimeout);
+                    SynchronizationContext? context = SynchronizationContext.Current;
+                    if (context != null && context.IsWaitNotificationRequired())
+                    {
+                        usedSyncContextWait = true;
+                        waitResult = context.Wait(new[] { waitHandle.DangerousGetHandle() }, false, millisecondsTimeout);
+                    }
                 }
-                else
+
+                if (!usedSyncContextWait)
                 {
 #if !CORECLR // CoreCLR sends the wait events from the native side
                     bool sendWaitEvents =
                         millisecondsTimeout != 0 &&
-#if NATIVEAOT
-                        // A null check is necessary in NativeAOT due to the possibility of reentrance during class
-                        // construction, as this path can be reached through Lock. See
-                        // https://github.com/dotnet/runtime/issues/94728 for a call stack.
-                        NativeRuntimeEventSource.Log != null &&
-#endif
+                        alertable &&
                         NativeRuntimeEventSource.Log.IsEnabled(
                             EventLevel.Verbose,
                             NativeRuntimeEventSource.Keywords.WaitHandleKeyword);
@@ -149,7 +154,7 @@ namespace System.Threading
                         waitSource != NativeRuntimeEventSource.WaitHandleWaitSourceMap.MonitorWait;
                     if (tryNonblockingWaitFirst)
                     {
-                        waitResult = WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout: 0);
+                        waitResult = WaitOneCore(waitHandle.DangerousGetHandle(), 0 /* millisecondsTimeout */, alertable);
                         if (waitResult == WaitTimeout)
                         {
                             // Do a full wait and send the wait events
@@ -171,7 +176,7 @@ namespace System.Threading
                     if (!tryNonblockingWaitFirst)
 #endif
                     {
-                        waitResult = WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout);
+                        waitResult = WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout, alertable);
                     }
 
 #if !CORECLR // CoreCLR sends the wait events from the native side


### PR DESCRIPTION
- Added an internal constructor that enables the lock to use non-alertable waits
- Non-alertable waits are not forwarded to `SynchronizationContext` wait overrides, are non-message-pumping waits, and are not interruptible
- Updated most of the uses of `Lock` in NativeAOT to use non-alertable waits
- Also simplified the fix in https://github.com/dotnet/runtime/pull/94873 to avoid having to do the relevant null checks in various places along the wait path, by limiting the scope of the null checks to the initialization phase

Fixes https://github.com/dotnet/runtime/issues/97105