### PR TITLE
[coreclr] Block test that should not be run

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
@@ -121,7 +121,7 @@ namespace System.Globalization.Tests
             yield return new object[] { '\u2029', thaiCmpInfo }; // ParagraphSeparator: PARAGRAPH SEPARATOR
         }
 
-        [ConditionalTheory(PlatformDetection.IsIcuGlobalization)]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         [MemberData(nameof(CheckHashingOfSkippedChars_TestData))]
         public void CheckHashingOfSkippedChars(char character, CompareInfo cmpInfo)
         {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
@@ -121,7 +121,7 @@ namespace System.Globalization.Tests
             yield return new object[] { '\u2029', thaiCmpInfo }; // ParagraphSeparator: PARAGRAPH SEPARATOR
         }
 
-        [Theory]
+        [ConditionalTheory(PlatformDetection.IsIcuGlobalization)]
         [MemberData(nameof(CheckHashingOfSkippedChars_TestData))]
         public void CheckHashingOfSkippedChars(char character, CompareInfo cmpInfo)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/97241.
This test was not supposed to be run on coreclr.