### PR TITLE
Various createdump fixes and cleanup

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -138,7 +138,8 @@ CrashInfo::EnumMemoryRegion(
     /* [in] */ CLRDATA_ADDRESS address,
     /* [in] */ ULONG32 size)
 {
-    m_enumMemoryPagesAdded += InsertMemoryRegion((ULONG_PTR)address, size);
+    address = CONVERT_FROM_SIGN_EXTENDED(address);
+    m_enumMemoryPagesAdded += InsertMemoryRegion(address, size);
     return S_OK;
 }
 
@@ -449,10 +450,12 @@ CrashInfo::EnumerateManagedModules()
             DacpGetModuleData moduleData;
             if (SUCCEEDED(hr = moduleData.Request(pClrDataModule.GetPtr())))
             {
-                TRACE("MODULE: %" PRIA PRIx64 " dyn %d inmem %d file %d pe %" PRIA PRIx64 " pdb %" PRIA PRIx64, (uint64_t)moduleData.LoadedPEAddress, moduleData.IsDynamic,
+                uint64_t loadedPEAddress = CONVERT_FROM_SIGN_EXTENDED(moduleData.LoadedPEAddress);
+
+                TRACE("MODULE: %" PRIA PRIx64 " dyn %d inmem %d file %d pe %" PRIA PRIx64 " pdb %" PRIA PRIx64, loadedPEAddress, moduleData.IsDynamic,
                     moduleData.IsInMemory, moduleData.IsFileLayout, (uint64_t)moduleData.PEAssembly, (uint64_t)moduleData.InMemoryPdbAddress);
 
-                if (!moduleData.IsDynamic && moduleData.LoadedPEAddress != 0)
+                if (!moduleData.IsDynamic && loadedPEAddress != 0)
                 {
                     ArrayHolder<WCHAR> wszUnicodeName = new WCHAR[MAX_LONGPATH + 1];
                     if (SUCCEEDED(hr = pClrDataModule->GetFileName(MAX_LONGPATH, nullptr, wszUnicodeName)))
@@ -460,10 +463,10 @@ CrashInfo::EnumerateManagedModules()
                         std::string moduleName = ConvertString(wszUnicodeName.GetPtr());
 
                         // Change the module mapping name
-                        AddOrReplaceModuleMapping(moduleData.LoadedPEAddress, moduleData.LoadedPESize, moduleName);
+                        AddOrReplaceModuleMapping(loadedPEAddress, moduleData.LoadedPESize, moduleName);
 
                         // Add managed module info
-                        AddModuleInfo(true, moduleData.LoadedPEAddress, pClrDataModule, moduleName);
+                        AddModuleInfo(true, loadedPEAddress, pClrDataModule, moduleName);
                     }
                     else {
                         TRACE("\nModule.GetFileName FAILED %08x\n", hr);
@@ -517,17 +520,17 @@ CrashInfo::UnwindAllThreads()
 // Replace an existing module mapping with one with a different name.
 //
 void
-CrashInfo::AddOrReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& name)
+CrashInfo::AddOrReplaceModuleMapping(uint64_t baseAddress, uint64_t size, const std::string& name)
 {
     // Round to page boundary (single-file managed assemblies are not page aligned)
-    ULONG_PTR start = ((ULONG_PTR)baseAddress) & PAGE_MASK;
+    uint64_t start = baseAddress & PAGE_MASK;
     assert(start > 0);
 
     // Round up to page boundary
-    ULONG_PTR end = ((baseAddress + size) + (PAGE_SIZE - 1)) & PAGE_MASK;
+    uint64_t end = ((baseAddress + size) + (PAGE_SIZE - 1)) & PAGE_MASK;
     assert(end > 0);
 
-    uint32_t flags = GetMemoryRegionFlags((ULONG_PTR)baseAddress);
+    uint32_t flags = GetMemoryRegionFlags(baseAddress);
 
     // Make sure that the page containing the PE header for the managed assemblies is in the dump
     // especially on MacOS where they are added artificially.
@@ -648,15 +651,15 @@ CrashInfo::AddModuleInfo(bool isManaged, uint64_t baseAddress, IXCLRDataModule* 
         if (isManaged)
         {
             IMAGE_DOS_HEADER dosHeader;
-            if (ReadMemory((void*)baseAddress, &dosHeader, sizeof(dosHeader)))
+            if (ReadMemory(baseAddress, &dosHeader, sizeof(dosHeader)))
             {
                 WORD magic;
-                if (ReadMemory((void*)(baseAddress + dosHeader.e_lfanew + offsetof(IMAGE_NT_HEADERS, OptionalHeader.Magic)), &magic, sizeof(magic)))
+                if (ReadMemory(baseAddress + dosHeader.e_lfanew + offsetof(IMAGE_NT_HEADERS, OptionalHeader.Magic), &magic, sizeof(magic)))
                 {
                     if (magic == IMAGE_NT_OPTIONAL_HDR32_MAGIC)
                     {
                         IMAGE_NT_HEADERS32 header;
-                        if (ReadMemory((void*)(baseAddress + dosHeader.e_lfanew), &header, sizeof(header)))
+                        if (ReadMemory(baseAddress + dosHeader.e_lfanew, &header, sizeof(header)))
                         {
                             imageSize = header.OptionalHeader.SizeOfImage;
                             timeStamp = header.FileHeader.TimeDateStamp;
@@ -665,7 +668,7 @@ CrashInfo::AddModuleInfo(bool isManaged, uint64_t baseAddress, IXCLRDataModule* 
                     else if (magic == IMAGE_NT_OPTIONAL_HDR64_MAGIC)
                     {
                         IMAGE_NT_HEADERS64 header;
-                        if (ReadMemory((void*)(baseAddress + dosHeader.e_lfanew), &header, sizeof(header)))
+                        if (ReadMemory(baseAddress + dosHeader.e_lfanew, &header, sizeof(header)))
                         {
                             imageSize = header.OptionalHeader.SizeOfImage;
                             timeStamp = header.FileHeader.TimeDateStamp;
@@ -694,7 +697,7 @@ CrashInfo::AddModuleInfo(bool isManaged, uint64_t baseAddress, IXCLRDataModule* 
 // ReadMemory from target and add to memory regions list
 //
 bool
-CrashInfo::ReadMemory(void* address, void* buffer, size_t size)
+CrashInfo::ReadMemory(uint64_t address, void* buffer, size_t size)
 {
     size_t read = 0;
     if (!ReadProcessMemory(address, buffer, size, &read))
@@ -702,7 +705,7 @@ CrashInfo::ReadMemory(void* address, void* buffer, size_t size)
         return false;
     }
     assert(read == size);
-    InsertMemoryRegion(reinterpret_cast<uint64_t>(address), read);
+    InsertMemoryRegion(address, read);
     return true;
 }
 
@@ -712,6 +715,7 @@ CrashInfo::ReadMemory(void* address, void* buffer, size_t size)
 int
 CrashInfo::InsertMemoryRegion(uint64_t address, size_t size)
 {
+    assert(address == CONVERT_FROM_SIGN_EXTENDED(address));
     assert(size < UINT_MAX);
 
     // Round to page boundary
@@ -831,7 +835,7 @@ CrashInfo::PageCanBeRead(uint64_t start)
 {
     BYTE buffer[1];
     size_t read;
-    return ReadProcessMemory((void*)start, buffer, 1, &read);
+    return ReadProcessMemory(start, buffer, 1, &read);
 }
 
 //

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -71,7 +71,7 @@ private:
     std::vector<elf_aux_entry> m_auxvEntries;       // full auxv entries
 #endif
     std::vector<ThreadInfo*> m_threads;             // threads found and suspended
-    std::set<MemoryRegion> m_moduleMappings;        // module memory mappings
+    std::set<ModuleRegion> m_moduleMappings;        // module memory mappings
     std::set<MemoryRegion> m_otherMappings;         // other memory mappings
     std::set<MemoryRegion> m_memoryRegions;         // memory regions from DAC, etc.
     std::set<MemoryRegion> m_moduleAddresses;       // memory region to module base address
@@ -105,6 +105,7 @@ public:
     void AddModuleAddressRange(uint64_t startAddress, uint64_t endAddress, uint64_t baseAddress);
     void AddModuleInfo(bool isManaged, uint64_t baseAddress, IXCLRDataModule* pClrDataModule, const std::string& moduleName);
     int InsertMemoryRegion(uint64_t address, size_t size);
+    const ModuleRegion* SearchModuleRegions(const ModuleRegion& search);
     static const MemoryRegion* SearchMemoryRegions(const std::set<MemoryRegion>& regions, const MemoryRegion& search);
 
     inline pid_t Pid() const { return m_pid; }
@@ -122,7 +123,7 @@ public:
     inline const uint64_t RuntimeBaseAddress() const { return m_runtimeBaseAddress; }
 
     inline const std::vector<ThreadInfo*>& Threads() const { return m_threads; }
-    inline const std::set<MemoryRegion>& ModuleMappings() const { return m_moduleMappings; }
+    inline const std::set<ModuleRegion>& ModuleMappings() const { return m_moduleMappings; }
     inline const std::set<MemoryRegion>& OtherMappings() const { return m_otherMappings; }
     inline const std::set<MemoryRegion>& MemoryRegions() const { return m_memoryRegions; }
     inline const siginfo_t* SigInfo() const { return &m_siginfo; }

--- a/src/coreclr/debug/createdump/crashinfo.h
+++ b/src/coreclr/debug/createdump/crashinfo.h
@@ -97,8 +97,8 @@ public:
     bool GatherCrashInfo(DumpType dumpType);
     void CombineMemoryRegions();
     bool EnumerateMemoryRegionsWithDAC(DumpType dumpType);
-    bool ReadMemory(void* address, void* buffer, size_t size);                          // read memory and add to dump
-    bool ReadProcessMemory(void* address, void* buffer, size_t size, size_t* read);     // read raw memory
+    bool ReadMemory(uint64_t address, void* buffer, size_t size);                       // read memory and add to dump
+    bool ReadProcessMemory(uint64_t address, void* buffer, size_t size, size_t* read);  // read raw memory
     uint64_t GetBaseAddressFromAddress(uint64_t address);
     uint64_t GetBaseAddressFromName(const char* moduleName);
     ModuleInfo* GetModuleInfoFromBaseAddress(uint64_t baseAddress);
@@ -131,6 +131,7 @@ public:
     inline const std::vector<elf_aux_entry>& AuxvEntries() const { return m_auxvEntries; }
     inline size_t GetAuxvSize() const { return m_auxvEntries.size() * sizeof(elf_aux_entry); }
 #endif
+    bool ReadMemory(void* address, void* buffer, size_t size) { return ReadMemory((uint64_t)address, buffer, size); }
 
     // IUnknown
     STDMETHOD(QueryInterface)(___in REFIID InterfaceId, ___out PVOID* Interface);
@@ -160,7 +161,7 @@ private:
     bool InitializeDAC(DumpType dumpType);
     bool EnumerateManagedModules();
     bool UnwindAllThreads();
-    void AddOrReplaceModuleMapping(CLRDATA_ADDRESS baseAddress, ULONG64 size, const std::string& pszName);
+    void AddOrReplaceModuleMapping(uint64_t baseAddress, uint64_t size, const std::string& pszName);
     int InsertMemoryRegion(const MemoryRegion& region);
     uint32_t GetMemoryRegionFlags(uint64_t start);
     bool PageCanBeRead(uint64_t start);

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -256,7 +256,7 @@ void CrashInfo::VisitModule(MachOModule& module)
                 m_runtimeBaseAddress = module.BaseAddress();
 
                 RuntimeInfo runtimeInfo { };
-                if (ReadMemory((void*)(module.BaseAddress() + symbolOffset), &runtimeInfo, sizeof(RuntimeInfo)))
+                if (ReadMemory(module.BaseAddress() + symbolOffset, &runtimeInfo, sizeof(RuntimeInfo)))
                 {
                     if (strcmp(runtimeInfo.Signature, RUNTIME_INFO_SIGNATURE) == 0)
                     {
@@ -274,7 +274,7 @@ void CrashInfo::VisitModule(MachOModule& module)
                 m_runtimeBaseAddress = module.BaseAddress();
 
                 uint8_t cookie[sizeof(g_debugHeaderCookie)];
-                if (ReadMemory((void*)(module.BaseAddress() + symbolOffset), cookie, sizeof(cookie)))
+                if (ReadMemory(module.BaseAddress() + symbolOffset, cookie, sizeof(cookie)))
                 {
                     if (memcmp(cookie, g_debugHeaderCookie, sizeof(g_debugHeaderCookie)) == 0)
                     {
@@ -375,12 +375,14 @@ CrashInfo::VisitSection(MachOModule& module, const section_64& section)
 uint32_t
 CrashInfo::GetMemoryRegionFlags(uint64_t start)
 {
+    assert(start == CONVERT_FROM_SIGN_EXTENDED(start));
+
     MemoryRegion search(0, start, start + PAGE_SIZE, 0);
     const MemoryRegion* region = SearchMemoryRegions(m_allMemoryRegions, search);
     if (region != nullptr) {
         return region->Flags();
     }
-    TRACE("GetMemoryRegionFlags: %016llx FAILED\n", start);
+    TRACE_VERBOSE("GetMemoryRegionFlags: %016llx FAILED\n", start);
     return PF_R | PF_W | PF_X;
 }
 
@@ -388,7 +390,7 @@ CrashInfo::GetMemoryRegionFlags(uint64_t start)
 // Read raw memory
 //
 bool
-CrashInfo::ReadProcessMemory(void* address, void* buffer, size_t size, size_t* read)
+CrashInfo::ReadProcessMemory(uint64_t address, void* buffer, size_t size, size_t* read)
 {
     assert(buffer != nullptr);
     assert(read != nullptr);
@@ -411,7 +413,7 @@ CrashInfo::ReadProcessMemory(void* address, void* buffer, size_t size, size_t* r
         {
             g_readProcessMemoryResult = result;
             TRACE_VERBOSE("ReadProcessMemory(%p %d): vm_read_overwrite failed bytesLeft %d bytesRead %d from %p: %s (%x)\n",
-                address, size, bytesLeft, bytesRead, (void*)addressAligned, mach_error_string(result), result);
+                (void*)address, size, bytesLeft, bytesRead, (void*)addressAligned, mach_error_string(result), result);
             break;
         }
         ssize_t bytesToCopy = PAGE_SIZE - offset;

--- a/src/coreclr/debug/createdump/crashinfomac.cpp
+++ b/src/coreclr/debug/createdump/crashinfomac.cpp
@@ -179,7 +179,7 @@ CrashInfo::InitializeOtherMappings()
     // to include all the native and managed module regions.
     for (const MemoryRegion& region : m_allMemoryRegions)
     {
-        std::set<MemoryRegion>::iterator found = m_moduleMappings.find(region);
+        std::set<ModuleRegion>::iterator found = m_moduleMappings.find(ModuleRegion(region));
         if (found == m_moduleMappings.end())
         {
             m_otherMappings.insert(region);
@@ -315,8 +315,8 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
             assert(end > 0);
 
             // Add module memory region if not already on the list
-            MemoryRegion newModule(regionFlags, start, end, offset, module.Name());
-            std::set<MemoryRegion>::iterator existingModule = m_moduleMappings.find(newModule);
+            ModuleRegion newModule(regionFlags, start, end, offset, module.Name());
+            std::set<ModuleRegion>::iterator existingModule = m_moduleMappings.find(newModule);
             if (existingModule == m_moduleMappings.end())
             {
                 if (g_diagnosticsVerbose)
@@ -340,7 +340,7 @@ void CrashInfo::VisitSegment(MachOModule& module, const segment_command_64& segm
                     uint64_t numberPages = newModule.SizeInPages();
                     for (size_t p = 0; p < numberPages; p++, start += PAGE_SIZE, offset += PAGE_SIZE)
                     {
-                        MemoryRegion gap(newModule.Flags(), start, start + PAGE_SIZE, offset, newModule.FileName());
+                        ModuleRegion gap(newModule.Flags(), start, start + PAGE_SIZE, offset, newModule.FileName());
 
                         const auto& found = m_moduleMappings.find(gap);
                         if (found != m_moduleMappings.end())

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -278,6 +278,10 @@ CrashInfo::EnumerateMemoryRegions()
                     m_moduleMappings.insert(moduleRegion);
                     m_cbModuleMappings += moduleRegion.Size();
                 }
+                else
+                {
+                    m_otherMappings.insert(moduleRegion);
+                }
             }
             else
             {

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -271,8 +271,14 @@ CrashInfo::EnumerateMemoryRegions()
 
             if (moduleName != nullptr && *moduleName == '/')
             {
-                m_moduleMappings.insert(moduleRegion);
-                m_cbModuleMappings += moduleRegion.Size();
+                // Don't add files that don't exists anymore especially /memfd:doublemapper.
+                std::string name(moduleName);
+                size_t last = name.rfind(" (deleted)");
+                if (last == std::string::npos)
+                {
+                    m_moduleMappings.insert(moduleRegion);
+                    m_cbModuleMappings += moduleRegion.Size();
+                }
             }
             else
             {

--- a/src/coreclr/debug/createdump/crashinfounix.cpp
+++ b/src/coreclr/debug/createdump/crashinfounix.cpp
@@ -267,13 +267,12 @@ CrashInfo::EnumerateMemoryRegions()
             if (strchr(permissions, 'p')) {
                 regionFlags |= MEMORY_REGION_FLAG_PRIVATE;
             }
-            ModuleRegion moduleRegion(regionFlags, start, end, offset, std::string(moduleName != nullptr ? moduleName : ""));
+            ModuleRegion moduleRegion(regionFlags, start, end, offset, moduleName);
 
             if (moduleName != nullptr && *moduleName == '/')
             {
                 // Don't add files that don't exists anymore especially /memfd:doublemapper.
-                std::string name(moduleName);
-                size_t last = name.rfind(" (deleted)");
+                size_t last = moduleRegion.FileName().rfind(" (deleted)");
                 if (last == std::string::npos)
                 {
                     m_moduleMappings.insert(moduleRegion);

--- a/src/coreclr/debug/createdump/datatarget.cpp
+++ b/src/coreclr/debug/createdump/datatarget.cpp
@@ -118,8 +118,9 @@ DumpDataTarget::ReadVirtual(
     /* [in] */ ULONG32 size,
     /* [optional][out] */ ULONG32 *done)
 {
+    address = CONVERT_FROM_SIGN_EXTENDED(address);
     size_t read = 0;
-    if (!m_crashInfo.ReadProcessMemory((void*)(ULONG_PTR)address, buffer, size, &read))
+    if (!m_crashInfo.ReadProcessMemory(address, buffer, size, &read))
     {
         TRACE("DumpDataTarget::ReadVirtual %p %d FAILED\n", (void*)address, size);
         *done = 0;

--- a/src/coreclr/debug/createdump/dumpwriterelf.cpp
+++ b/src/coreclr/debug/createdump/dumpwriterelf.cpp
@@ -189,7 +189,7 @@ DumpWriter::WriteDump()
                 size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
                 size_t read = 0;
 
-                if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
+                if (!m_crashInfo.ReadProcessMemory(address, m_tempBuffer, bytesToRead, &read)) {
                     printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx FAILED %s (%d)\n", address, bytesToRead, strerror(g_readProcessMemoryErrno), g_readProcessMemoryErrno);
                     return false;
                 }

--- a/src/coreclr/debug/createdump/dumpwriterelf.cpp
+++ b/src/coreclr/debug/createdump/dumpwriterelf.cpp
@@ -290,7 +290,7 @@ DumpWriter::GetNTFileInfoSize(size_t* alignmentBytes)
     size += count;
 
     // File name storage needed
-    for (const MemoryRegion& image : m_crashInfo.ModuleMappings()) {
+    for (const ModuleRegion& image : m_crashInfo.ModuleMappings()) {
         size += image.FileName().length();
     }
     // Notes must end on 4 byte alignment
@@ -338,7 +338,7 @@ DumpWriter::WriteNTFileInfo()
         return false;
     }
 
-    for (const MemoryRegion& image : m_crashInfo.ModuleMappings())
+    for (const ModuleRegion& image : m_crashInfo.ModuleMappings())
     {
         struct NTFileEntry entry { (unsigned long)image.StartAddress(), (unsigned long)image.EndAddress(), (unsigned long)(image.Offset() / pageSize) };
         if (!WriteData(&entry, sizeof(entry))) {
@@ -346,7 +346,7 @@ DumpWriter::WriteNTFileInfo()
         }
     }
 
-    for (const MemoryRegion& image : m_crashInfo.ModuleMappings())
+    for (const ModuleRegion& image : m_crashInfo.ModuleMappings())
     {
         if (!WriteData(image.FileName().c_str(), image.FileName().length()) ||
             !WriteData("\0", 1)) {

--- a/src/coreclr/debug/createdump/dumpwritermacho.cpp
+++ b/src/coreclr/debug/createdump/dumpwritermacho.cpp
@@ -268,7 +268,7 @@ DumpWriter::WriteSegments()
                 size_t bytesToRead = std::min(size, sizeof(m_tempBuffer));
                 size_t read = 0;
 
-                if (!m_crashInfo.ReadProcessMemory((void*)address, m_tempBuffer, bytesToRead, &read)) {
+                if (!m_crashInfo.ReadProcessMemory(address, m_tempBuffer, bytesToRead, &read)) {
                     printf_error("Error reading memory at %" PRIA PRIx64 " size %08zx FAILED %s (%x)\n", address, bytesToRead, mach_error_string(g_readProcessMemoryResult), g_readProcessMemoryResult);
                     return false;
                 }

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -113,6 +113,11 @@ private:
     std::string m_fileName;
 
 public:
+    ModuleRegion(uint32_t flags, uint64_t start, uint64_t end, uint64_t offset, char* filename) : MemoryRegion(flags, start, end, offset),
+        m_fileName(filename != nullptr ? filename : "")
+    {
+    }
+
     ModuleRegion(uint32_t flags, uint64_t start, uint64_t end, uint64_t offset, const std::string& filename) : MemoryRegion(flags, start, end, offset),
         m_fileName(filename)
     {

--- a/src/coreclr/debug/createdump/memoryregion.h
+++ b/src/coreclr/debug/createdump/memoryregion.h
@@ -9,6 +9,8 @@ extern long g_pageSize;
 #undef PAGE_MASK 
 #define PAGE_MASK (~(PAGE_SIZE-1))
 
+#define CONVERT_FROM_SIGN_EXTENDED(offset) ((ULONG_PTR)(offset))
+
 enum MEMORY_REGION_FLAGS : uint32_t
 {
     // PF_X        = 0x01,      // Execute


### PR DESCRIPTION
* Separate memory and module regions.
  Move std::string m_fileName out of MemoryRegion into ModuleRegion that is derived from MemoryRegion.
  Reduces createdump memory usage.

* Fix arm32 sign extension issues. Cleanup: make void* address parameters uint64_t.

* Don't add "(deleted)" files to the module list on Linux.
  Issue: https://github.com/dotnet/runtime/issues/90547