### PR TITLE
Update DebuggerUserBreakpoint::IsFrameInDebuggerNamespace to avoid UTF8 to Unicode conversation for empty strings

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8327,7 +8327,8 @@ bool DebuggerUserBreakpoint::IsFrameInDebuggerNamespace(FrameInfo * pFrame)
         LPCUTF8 szNamespace = NULL;
         LPCUTF8 szClassName = pMT->GetFullyQualifiedNameInfo(&szNamespace);
 
-        if (szClassName != NULL && szNamespace != NULL)
+        if (szClassName != NULL && szNamespace != NULL && 
+            *szClassName != '\0' && *szNamespace != '\0')
         {
             MAKE_WIDEPTR_FROMUTF8(wszNamespace, szNamespace); // throw
             MAKE_WIDEPTR_FROMUTF8(wszClassName, szClassName);


### PR DESCRIPTION
Fixes #97261