### PR TITLE
Avoiding loading and processing same cert file to improve cold start performance …

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             if (s_rootStoreFile != null)
             {
-                _ = TryStatFile(s_rootStoreFile, out DateTime lastModified);
+                _ = TryStatFile(s_rootStoreFile, out DateTime lastModified, out _);
                 if (lastModified != s_fileLastWrite)
                 {
                     return true;
@@ -366,16 +366,13 @@ namespace System.Security.Cryptography.X509Certificates
             return directories;
         }
 
-        private static bool TryStatFile(string path, out DateTime lastModified)
-            => CallStat(path, Interop.Sys.FileTypes.S_IFREG, out lastModified, out _);
-
         private static bool TryStatDirectory(string path, out DateTime lastModified)
-            => CallStat(path, Interop.Sys.FileTypes.S_IFDIR, out lastModified, out _);
+            => TryStat(path, Interop.Sys.FileTypes.S_IFDIR, out lastModified, out _);
 
         private static bool TryStatFile(string path, out DateTime lastModified, out (long, long) fileId)
-            => CallStat(path, Interop.Sys.FileTypes.S_IFREG, out lastModified, out fileId);
+            => TryStat(path, Interop.Sys.FileTypes.S_IFREG, out lastModified, out fileId);
 
-        private static bool CallStat(string path, int fileType, out DateTime lastModified, out (long, long) fileId)
+        private static bool TryStat(string path, int fileType, out DateTime lastModified, out (long, long) fileId)
         {
             lastModified = default;
             fileId = default;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
@@ -149,6 +149,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             var uniqueRootCerts = new HashSet<X509Certificate2>();
             var uniqueIntermediateCerts = new HashSet<X509Certificate2>();
+            var processedFiles = new HashSet<string>();
             bool firstLoad = (s_nativeCollections == null);
 
             if (firstLoad)
@@ -216,6 +217,12 @@ namespace System.Security.Cryptography.X509Certificates
                     return false;
                 }
 
+                string originalFile = Interop.Sys.ReadLink(file) ?? file;
+                if (processedFiles.Contains(originalFile))
+                {
+                    return true;
+                }
+
                 using (SafeBioHandle fileBio = Interop.Crypto.BioNewFile(file, "rb"))
                 {
                     // The handle may be invalid, for example when we don't have read permission for the file.
@@ -279,6 +286,11 @@ namespace System.Security.Cryptography.X509Certificates
                         // and one-big-file trusted certificate stores. Anything that wasn't unique will end up here.
                         cert.Dispose();
                     }
+                }
+
+               if (readData)
+                {
+                    processedFiles.Add(originalFile);
                 }
 
                 return readData;


### PR DESCRIPTION
This PR is to improve cold start performance which occurs during certificate load #96740 . This happens across multiple distros(checked in AmazonLinux2023 and RHEL(9.3)), the same file (in this case **/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem**) is getting re-processed twice. 


```
[ec2-user@ip-172-31-31-127 ~]$ openssl version -d
OPENSSLDIR: "/etc/pki/tls"
**File Processing**
[ec2-user@ip-172-31-31-127 ~]$ ls -la /etc/pki/tls/cert.pem 
lrwxrwxrwx. 1 root root 49 Aug 29 17:21 /etc/pki/tls/cert.pem -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
**Directory Processing**
[ec2-user@ip-172-31-31-127 ~]$ ls -la /etc/pki/tls/certs
total 0
drwxr-xr-x. 2 root root  54 Nov  8 07:41 .
drwxr-xr-x. 5 root root 126 Nov  8 07:41 ..
lrwxrwxrwx. 1 root root  49 Aug 29 17:21 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx. 1 root root  55 Aug 29 17:21 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
```


Tested the method with above fix I see the total time reduced from **103ms to 65ms.**.