### PR TITLE
Issue 96277: Order by memory footprint

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -56,6 +56,7 @@ namespace System.Linq
 
         internal TElement[] ToArray(int minIdx, int maxIdx)
         {
+            // TODO: Also apply Heap-Sort?
             TElement[] buffer = _source.ToArray();
             if (buffer.Length <= minIdx)
             {
@@ -81,6 +82,7 @@ namespace System.Linq
 
         internal List<TElement> ToList(int minIdx, int maxIdx)
         {
+            // TODO: Also apply Heap-Sort?
             TElement[] buffer = _source.ToArray();
             if (buffer.Length <= minIdx)
             {
@@ -136,6 +138,7 @@ namespace System.Linq
 
         public TElement? TryGetElementAt(int index, out bool found)
         {
+            // TODO: Also apply Heap-Sort?
             if (index == 0)
             {
                 return TryGetFirst(out found);
@@ -211,6 +214,7 @@ namespace System.Linq
 
         public TElement? TryGetLast(int minIdx, int maxIdx, out bool found)
         {
+            // TODO: Also apply Heap-Sort?
             TElement[] buffer = _source.ToArray();
             if (minIdx < buffer.Length)
             {

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -58,6 +58,7 @@ namespace System.Linq
 
         internal TElement[] ToArray(int minIdx, int maxIdx)
         {
+            // TODO: Also apply Heap-Sort?
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             int count = buffer._count;
             if (count <= minIdx)
@@ -84,6 +85,7 @@ namespace System.Linq
 
         internal List<TElement> ToList(int minIdx, int maxIdx)
         {
+            // TODO: Also apply Heap-Sort?
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             int count = buffer._count;
             if (count <= minIdx)
@@ -140,6 +142,7 @@ namespace System.Linq
 
         public TElement? TryGetElementAt(int index, out bool found)
         {
+            // TODO: Also apply Heap-Sort?
             if (index == 0)
             {
                 return TryGetFirst(out found);
@@ -216,6 +219,7 @@ namespace System.Linq
 
         public TElement? TryGetLast(int minIdx, int maxIdx, out bool found)
         {
+            // TODO: Also apply Heap-Sort?
             Buffer<TElement> buffer = new Buffer<TElement>(_source);
             int count = buffer._count;
             if (minIdx >= count)

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -172,7 +172,7 @@ namespace System.Linq
             int pos = 0;
             foreach (TElement element in _source)
             {
-                SortPriority<TKey> priority = new(_keySelector(element), pos++);
+                SortPriority<TKey> priority = new(_keySelector(element), pos++, _descending);
 
                 if (priorityQueue.Count == queueSize)
                 {
@@ -203,21 +203,23 @@ namespace System.Linq
     {
         private readonly TKey _key;
         private readonly int _sourcePos;
+        private readonly int _descending;
 
-        public SortPriority(TKey key, int sourcePos) : this()
+        public SortPriority(TKey key, int sourcePos, bool descending) : this()
         {
             _key = key;
             _sourcePos = sourcePos;
+            _descending = descending ? 1 : -1;
         }
 
 
         public int CompareTo(SortPriority<TKey> other)
         {
-            int result = -Comparer<TKey>.Default.Compare(_key, other._key);
+            int result = _descending * Comparer<TKey>.Default.Compare(_key, other._key);
 
             if (result == 0)
             {
-                result = _sourcePos.CompareTo(other._sourcePos);
+                result = _descending * _sourcePos.CompareTo(other._sourcePos);
             }
             return result;
         }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -31,7 +31,7 @@ namespace System.Linq
             }
         }
 
-        internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
+        internal virtual IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
         {
             TElement[] buffer = _source.ToArray();
             int count = buffer.Length;
@@ -155,6 +155,74 @@ namespace System.Linq
                 : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
             return _parent != null ? _parent.GetComparer(cmp) : cmp;
         }
+
+        internal override IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
+        {
+            if (_parent is null && maxIdx < 1024)
+            {
+                return SortSubset(minIdx, maxIdx);
+
+            }
+
+            return base.GetEnumerator(minIdx, maxIdx);
+        }
+
+        private IEnumerator<TElement> SortSubset(int minIdx, int maxIdx)
+        {
+            int queueSize = maxIdx + 1;
+
+            PriorityQueue<TElement, SortPriority<TKey>> priorityQueue = new(queueSize);
+
+            int pos = 0;
+            IEnumerator<TElement> enumerator = _source.GetEnumerator();
+
+            while (priorityQueue.Count < queueSize && enumerator.MoveNext())
+            {
+                priorityQueue.Enqueue(enumerator.Current, new() { Key = _keySelector(enumerator.Current), SourcePos = pos });
+                pos++;
+            }
+
+            while (enumerator.MoveNext())
+            {
+                priorityQueue.EnqueueDequeue(enumerator.Current, new() { Key = _keySelector(enumerator.Current), SourcePos = pos });
+                pos++;
+            }
+
+            TElement[] result = new TElement[priorityQueue.Count];
+
+            int targetPos = result.Length - 1;
+            while (priorityQueue.TryDequeue(out TElement? element, out _))
+            {
+                result[targetPos--] = element;
+            }
+
+            for (int i = minIdx; i < result.Length; i++)
+            {
+                yield return result[i];
+            }
+        }
+    }
+
+    internal readonly struct SortPriority<TKey> : IComparable<SortPriority<TKey>>
+    {
+        public TKey Key { get; init; }
+        public int SourcePos { get; init; }
+
+        public int CompareTo(SortPriority<TKey> other)
+        {
+            int result = -Comparer<TKey>.Default.Compare(Key, other.Key);
+
+            if (result == 0)
+            {
+                result = SourcePos.CompareTo(other.SourcePos);
+            }
+            return result;
+        }
+    }
+
+    internal abstract class ElementComparer<TElement> : IComparer<TElement>
+    {
+        public abstract int Compare(TElement? x, TElement? y);
     }
 
     /// <summary>An ordered enumerable used by Order/OrderDescending for Ts that are bitwise indistinguishable for any considered equal.</summary>


### PR DESCRIPTION
#96277: Improve LINQ's `OrderBy` memory footprint for skip / take scenarios using "top-n-heap-sort"