### PR TITLE
JIT: Skip loop unrolling when the test is not a backedge

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.cs
@@ -7,7 +7,7 @@ public class Runtime_97321
     public static int TestEntryPoint() => Foo(false);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static int Foo(bool b)
+    private static int Foo(bool b)
     {
         int sum = 1;
         int i = 0;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_97321
+{
+    [Fact]
+    public static int TestEntryPoint() => Foo(false);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static int Foo(bool b)
+    {
+        int sum = 1;
+        int i = 0;
+        goto Header;
+Top:;
+        sum += 33;
+
+Header:;
+        if (b)
+        {
+            goto Header;
+        }
+
+Bottom:
+        i++;
+        if (i < 4)
+        {
+            goto Top;
+        }
+
+        return sum;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97321/Runtime_97321.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Otherwise we will skip all code on the path from the loop test to the header, since our loop unrolling works by unconditionally redirecting the loop test to the next clone.

Fix #97321