### PR TITLE
add supportf for Socket.DontFragment on macOS

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -264,7 +264,6 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [SkipOnPlatform(TestPlatforms.OSX | TestPlatforms.FreeBSD, "BSD like doesn't have an equivalent of DontFragment")]
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51392", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void DontFragment_Roundtrips()

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1794,11 +1794,13 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
                     *optName = IP_MTU_DISCOVER; // option values will also need to be translated
                     return true;
 #endif
+
 #ifdef IP_DONTFRAG
                 case SocketOptionName_SO_IP_DONTFRAGMENT:
                     *optName = IP_DONTFRAG;
                     return true;
 #endif
+
 #ifdef IP_ADD_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_ADD_SOURCE_MEMBERSHIP:
                     *optName = IP_ADD_SOURCE_MEMBERSHIP;
@@ -1966,6 +1968,7 @@ int32_t SystemNative_GetSockOpt(
     }
 
     int fd = ToFileDescriptor(socket);
+
     //
     // Handle some special cases for compatibility with Windows and OSX
     //

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1796,7 +1796,7 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
 #endif
 #ifdef IP_DONTFRAG
                 case SocketOptionName_SO_IP_DONTFRAGMENT:
-                    *optName = IP_DONTFRAG; // option values will also need to be translated
+                    *optName = IP_DONTFRAG;
                     return true;
 #endif
 #ifdef IP_ADD_SOURCE_MEMBERSHIP

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -1794,7 +1794,11 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionLevel, int32_t socket
                     *optName = IP_MTU_DISCOVER; // option values will also need to be translated
                     return true;
 #endif
-
+#ifdef IP_DONTFRAG
+                case SocketOptionName_SO_IP_DONTFRAGMENT:
+                    *optName = IP_DONTFRAG; // option values will also need to be translated
+                    return true;
+#endif
 #ifdef IP_ADD_SOURCE_MEMBERSHIP
                 case SocketOptionName_SO_IP_ADD_SOURCE_MEMBERSHIP:
                     *optName = IP_ADD_SOURCE_MEMBERSHIP;
@@ -1962,7 +1966,6 @@ int32_t SystemNative_GetSockOpt(
     }
 
     int fd = ToFileDescriptor(socket);
-
     //
     // Handle some special cases for compatibility with Windows and OSX
     //


### PR DESCRIPTION
fixes #76422
It seems like the option was added in 11.0 and we are calling support for 12+ and that is also where we run the tests. 

It works on UDP & ICMP and  it seems to be silently ignored by kernel on TCP.

![image](https://github.com/dotnet/runtime/assets/14356188/6b76fec9-4dd6-4d2f-ab56-9bc34e2ba9e4)

