### PR TITLE
Call VariantInit to initialize variants

### DIFF
--- a/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
+++ b/src/tests/Interop/PInvoke/IEnumerator/IEnumeratorNative.cpp
@@ -26,6 +26,7 @@ extern "C" DLL_EXPORT HRESULT STDMETHODCALLTYPE VerifyIntegerEnumerator(IEnumVAR
     HRESULT hr = S_OK;
 
     VARIANT element;
+    VariantInit(&element);
     ULONG numFetched;
 
     for (int i = start; i < start + count; ++i)
@@ -68,6 +69,7 @@ extern "C" DLL_EXPORT HRESULT STDMETHODCALLTYPE VerifyIntegerEnumeration(IDispat
 {
     DISPPARAMS params{};
     VARIANT result;
+    VariantInit(&result);
     HRESULT hr = pDisp->Invoke(
         DISPID_NEWENUM,
         IID_NULL,


### PR DESCRIPTION
Should fix ASAN failures on Windows that were caused by VariantClear calls on uninitialized VARIANTs that happened to have a VarType that would lead to additional freeing.

Fixes #96154