### PR TITLE
Fix access to m_pDynamicStaticsInfo

### DIFF
--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1567,7 +1567,7 @@ DWORD Module::AllocateDynamicEntry(MethodTable *pMT)
         if (m_pDynamicStaticsInfo)
             memcpy(pNewDynamicStaticsInfo, m_pDynamicStaticsInfo, sizeof(DynamicStaticsInfo) * m_maxDynamicEntries);
 
-        m_pDynamicStaticsInfo = pNewDynamicStaticsInfo;
+        VolatileStore(&m_pDynamicStaticsInfo, pNewDynamicStaticsInfo);
         m_maxDynamicEntries = maxDynamicEntries;
     }
 

--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -463,7 +463,7 @@ inline MethodTable* Module::GetDynamicClassMT(DWORD dynamicClassID)
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(m_cDynamicEntries > dynamicClassID);
-    return m_pDynamicStaticsInfo[dynamicClassID].pEnclosingMT;
+    return VolatileLoadWithoutBarrier(&m_pDynamicStaticsInfo)[dynamicClassID].pEnclosingMT;
 }
 
 #ifdef FEATURE_CODE_VERSIONING


### PR DESCRIPTION
- Remove race condition where it is possible that an updated dynamic statics info pointer is published without ensuring that the data is also considered written.
- Use VolatileLoadWithoutBarrier at the read site (where locks are not taken) to ensure that there are no difficult to examine reads of this pointer.