### PR TITLE
Handle NativeOverlapped* coming from both the Windows or Portable thread pool in NativeRuntimeEventSource

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.RemoteExecutor;
-using System.Diagnostics.Tracing;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -229,62 +226,6 @@ namespace System.Net.Sockets.Tests
                 Assert.False(listener.Pending());
                 await connectTask;
             }
-        }
-
-        internal sealed class RuntimeEventListener : EventListener
-        {
-            protected override void OnEventSourceCreated(EventSource source)
-            {
-                if (source.Name.Equals("Microsoft-Windows-DotNETRuntime"))
-                {
-                    EnableEvents(source, EventLevel.Verbose, (EventKeywords)0x10000);
-                }
-            }
-        }
-
-        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        public void ReadAsyncTest()
-        {
-            RemoteExecutor.Invoke(async () =>
-            {
-                using (RuntimeEventListener eventListener = new RuntimeEventListener())
-                {
-                    TaskCompletionSource<int> portTcs = new TaskCompletionSource<int>();
-                    async Task StartListenerAsync()
-                    {
-                        TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
-                        listener.Start();
-                        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
-                        portTcs.SetResult(port);
-                        TcpClient client = await listener.AcceptTcpClientAsync();
-                        using (NetworkStream stream = client.GetStream())
-                        {
-                            byte[] buffer = new byte[1024];
-                            int bytesRead;
-                            while ((bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length)) > 0);
-                        }
-                        listener.Stop();
-                    }
-
-                    async Task StartClientAsync()
-                    {
-                        int port = await portTcs.Task;
-                        using (TcpClient client = new TcpClient(new IPEndPoint(IPAddress.Loopback, 0)))
-                        {
-                            await client.ConnectAsync(IPAddress.Loopback, port);
-                            using (NetworkStream stream = client.GetStream())
-                            {
-                                byte[] data = Encoding.UTF8.GetBytes(new string('*', 1 << 26));
-                                await stream.WriteAsync(data, 0, data.Length);
-                            }
-                        }
-                    }
-
-                    Task listenerTask = StartListenerAsync();
-                    Task clientTask = StartClientAsync();
-                    await Task.WhenAll(listenerTask, clientTask);
-                }
-            }).Dispose();
         }
 
         [Fact]

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/TcpListenerTest.cs
@@ -249,7 +249,6 @@ namespace System.Net.Sockets.Tests
             {
                 using (RuntimeEventListener eventListener = new RuntimeEventListener())
                 {
-                    Task.Run(() => Console.WriteLine(Environment.StackTrace)).Wait();
                     TaskCompletionSource<int> portTcs = new TaskCompletionSource<int>();
                     async Task StartListenerAsync()
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -228,13 +228,13 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOEnqueue(NativeOverlapped* nativeOverlapped)
         {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
+            {
 #if TARGET_WINDOWS
                 IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #else
                 IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #endif
-            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
-            {
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
                     overlapped,
@@ -269,13 +269,13 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIODequeue(NativeOverlapped* nativeOverlapped)
         {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
+            {
 #if TARGET_WINDOWS
                 IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #else
                 IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #endif
-            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
-            {
                 ThreadPoolIODequeue(
                     (IntPtr)nativeOverlapped,
                     overlapped);
@@ -308,13 +308,13 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOPack(NativeOverlapped* nativeOverlapped)
         {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
+            {
 #if TARGET_WINDOWS
                 IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #else
                 IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #endif
-            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
-            {
                 ThreadPoolIOPack(
                     (IntPtr)nativeOverlapped,
                     overlapped);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -230,18 +230,9 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
-                IntPtr hashCode;
-                if (ThreadPool.UseWindowsThreadPool) {
-                    hashCode = (IntPtr)Win32ThreadPoolNativeOverlapped.FromNativeOverlapped(overlapped)->GetHashCode();
-                }
-                else
-                {
-                    hashCode = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
-                }
-
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    hashCode,
+                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
                     false);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -230,9 +230,18 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
+                IntPtr hashCode;
+                if (ThreadPool.UseWindowsThreadPool) {
+                    hashCode = (IntPtr)Win32ThreadPoolNativeOverlapped.FromNativeOverlapped(overlapped)->GetHashCode();
+                }
+                else
+                {
+                    hashCode = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+                }
+
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
+                    hashCode,
                     false);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -217,7 +217,7 @@ namespace System.Diagnostics.Tracing
         [Event(63, Level = EventLevel.Verbose, Message = Messages.IOEnqueue, Task = Tasks.ThreadPool, Opcode = Opcodes.IOEnqueue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
         private unsafe void ThreadPoolIOEnqueue(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             bool MultiDequeues,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
@@ -228,11 +228,16 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOEnqueue(NativeOverlapped* nativeOverlapped)
         {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
+                    overlapped,
                     false);
             }
         }
@@ -254,7 +259,7 @@ namespace System.Diagnostics.Tracing
         [Event(64, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IODequeue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
         private unsafe void ThreadPoolIODequeue(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
             LogThreadPoolIODequeue(NativeOverlapped, Overlapped, ClrInstanceID);
@@ -264,11 +269,16 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIODequeue(NativeOverlapped* nativeOverlapped)
         {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
                 ThreadPoolIODequeue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode());
+                    overlapped);
             }
         }
 
@@ -298,18 +308,23 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOPack(NativeOverlapped* nativeOverlapped)
         {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
             {
                 ThreadPoolIOPack(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode());
+                    overlapped);
             }
         }
 
         [Event(65, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IOPack, Version = 0, Keywords = Keywords.ThreadingKeyword)]
         private unsafe void ThreadPoolIOPack(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped,  // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
             LogThreadPoolIOPack(NativeOverlapped, Overlapped, ClrInstanceID);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -426,7 +426,7 @@ namespace System.Diagnostics.Tracing
 #endif
                 ThreadPoolIODequeue(
                     (IntPtr)nativeOverlapped,
-                    overlapped;
+                    overlapped);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -340,7 +340,7 @@ namespace System.Diagnostics.Tracing
         [Event(63, Level = EventLevel.Verbose, Message = Messages.IOEnqueue, Task = Tasks.ThreadPool, Opcode = Opcodes.IOEnqueue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
         private unsafe void ThreadPoolIOEnqueue(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             bool MultiDequeues,
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
@@ -367,9 +367,14 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
+                    overlapped,
                     false);
             }
         }
@@ -392,7 +397,7 @@ namespace System.Diagnostics.Tracing
         [Event(64, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IODequeue, Version = 0, Keywords = Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword)]
         private unsafe void ThreadPoolIODequeue(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
             EventData* data = stackalloc EventData[3];
@@ -414,9 +419,14 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
                 ThreadPoolIODequeue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode());
+                    overlapped;
             }
         }
 
@@ -454,11 +464,16 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOPack(NativeOverlapped* nativeOverlapped)
         {
+#if TARGET_WINDOWS
+                IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#else
+                IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+#endif
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
             {
                 ThreadPoolIOPack(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode());
+                    overlapped);
             }
         }
 
@@ -466,7 +481,7 @@ namespace System.Diagnostics.Tracing
         [Event(65, Level = EventLevel.Verbose, Message = Messages.IO, Task = Tasks.ThreadPool, Opcode = Opcodes.IOPack, Version = 0, Keywords = Keywords.ThreadingKeyword)]
         private unsafe void ThreadPoolIOPack(
             IntPtr NativeOverlapped,
-            IntPtr Overlapped,
+            IntPtr Overlapped, // 0 if the Windows thread pool is used, the relevant info could be obtained from the NativeOverlapped* if necessary
             ushort ClrInstanceID = DefaultClrInstanceId)
         {
             EventData* data = stackalloc EventData[3];

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -464,13 +464,13 @@ namespace System.Diagnostics.Tracing
         [MethodImpl(MethodImplOptions.NoInlining)]
         public unsafe void ThreadPoolIOPack(NativeOverlapped* nativeOverlapped)
         {
+            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
+            {
 #if TARGET_WINDOWS
                 IntPtr overlapped = ThreadPool.UseWindowsThreadPool ? 0 : (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #else
                 IntPtr overlapped = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
 #endif
-            if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))
-            {
                 ThreadPoolIOPack(
                     (IntPtr)nativeOverlapped,
                     overlapped);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -367,18 +367,9 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
-                IntPtr hashCode;
-                if (ThreadPool.UseWindowsThreadPool) {
-                    hashCode = (IntPtr)Win32ThreadPoolNativeOverlapped.FromNativeOverlapped(overlapped)->GetHashCode();
-                }
-                else
-                {
-                    hashCode = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
-                }
-
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    hashCode,
+                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
                     false);
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -367,9 +367,18 @@ namespace System.Diagnostics.Tracing
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
             {
+                IntPtr hashCode;
+                if (ThreadPool.UseWindowsThreadPool) {
+                    hashCode = (IntPtr)Win32ThreadPoolNativeOverlapped.FromNativeOverlapped(overlapped)->GetHashCode();
+                }
+                else
+                {
+                    hashCode = (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode();
+                }
+
                 ThreadPoolIOEnqueue(
                     (IntPtr)nativeOverlapped,
-                    (IntPtr)Overlapped.GetOverlappedFromNative(nativeOverlapped).GetHashCode(),
+                    hashCode,
                     false);
             }
         }


### PR DESCRIPTION
Fix ThreadPoolIOEnqueue, ThreadPoolIODequeue, ThreadPoolIOPack in Native Runtime Event Source which are based on the assumption that the NativeOverlapped* comes from the Portable thread pool implementation but it can come from the Windows thread pool implementation as well.