### PR TITLE
Fix handling of loop alignment targets

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -2224,7 +2224,7 @@ inline PredBlockList::iterator& PredBlockList::iterator::operator++()
  *  emitter to convert a basic block to its corresponding emitter cookie.
  */
 
-void* emitCodeGetCookie(BasicBlock* block);
+void* emitCodeGetCookie(const BasicBlock* block);
 
 // An enumerator of a block's all successors. In some cases (e.g. SsaBuilder::TopologicalSort)
 // using iterators is not exactly efficient, at least because they contain an unnecessary

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -327,11 +327,9 @@ void CodeGen::genPrepForCompiler()
 // 1. the target of jumps (fall-through flow doesn't require a label),
 // 2. referenced labels such as for "switch" codegen,
 // 3. needed to denote the range of EH regions to the VM.
-// 4. needed to denote the range of code for alignment processing.
 //
 // No labels will be in the IR before now, but future codegen might annotate additional blocks
 // with this flag, such as "switch" codegen, or codegen-created blocks from genCreateTempLabel().
-// Also, the alignment processing code marks BBJ_COND fall-through labels elsewhere.
 //
 // To report exception handling information to the VM, we need the size of the exception
 // handling regions. To compute that, we need to emit labels for the beginning block of

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2586,7 +2586,6 @@ void CodeGen::genReportEH()
                 }
                 else
                 {
-                    assert(bbLabel->bbEmitCookie != nullptr);
                     hndEnd = compiler->ehCodeOffset(bbLabel);
                 }
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5318,8 +5318,8 @@ bool Compiler::shouldAlignLoop(FlowGraphNaturalLoop* loop, BasicBlock* top)
 
     if (top->Prev()->isBBCallFinallyPairTail())
     {
-        // If the previous block is the BBJ_ALWAYS of a
-        // BBJ_CALLFINALLY/BBJ_ALWAYS pair, then we can't add alignment
+        // If the previous block is the BBJ_CALLFINALLYRET of a
+        // BBJ_CALLFINALLY/BBJ_CALLFINALLYRET pair, then we can't add alignment
         // because we can't add instructions in that block. In the
         // FEATURE_EH_CALLFINALLY_THUNKS case, it would affect the
         // reported EH, as above.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3488,7 +3488,7 @@ inline void Compiler::compUpdateLife(VARSET_VALARG_TP newLife)
  *  the cookie associated with the given basic block.
  */
 
-inline void* emitCodeGetCookie(BasicBlock* block)
+inline void* emitCodeGetCookie(const BasicBlock* block)
 {
     assert(block);
     return block->bbEmitCookie;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -5620,14 +5620,14 @@ void emitter::emitCheckAlignFitInCurIG(unsigned nAlignInstr)
 }
 
 //-----------------------------------------------------------------------------
+//  emitLoopAlign: The next instruction will be a loop head. Insert an alignment instruction
+//  here so we can properly align the code.
 //
-//  emitLoopAlign: The next instruction will be a loop head entry point
-//                 So insert an alignment instruction of "paddingBytes" to ensure that
-//                 the code is properly aligned.
 //  Arguments:
 //      paddingBytes - Number of padding bytes to insert.
 //      isFirstAlign - For multiple 'align' instructions case, if this is the first
 //                     'align' instruction of that group.
+//      isPlacedBehindJmp - DEBUG only. 'true' if this align instruction is placed after an unconditional jump.
 //
 void emitter::emitLoopAlign(unsigned paddingBytes, bool isFirstAlign DEBUG_ARG(bool isPlacedBehindJmp))
 {
@@ -5693,16 +5693,15 @@ void emitter::emitLoopAlign(unsigned paddingBytes, bool isFirstAlign DEBUG_ARG(b
 }
 
 //-----------------------------------------------------------------------------
-//
-//  emitLongLoopAlign: The next instruction will be a loop head entry point
-//  So insert alignment instruction(s) here to ensure that
-//  we can properly align the code.
+//  emitLongLoopAlign: The next instruction will be a loop head. Insert alignment instruction(s)
+//  here so we can properly align the code.
 //
 //  This emits more than one `INS_align` instruction depending on the
 //  alignmentBoundary parameter.
 //
 //  Arguments:
 //      alignmentBoundary - The boundary at which loop needs to be aligned.
+//      isPlacedBehindJmp - DEBUG only. 'true' if this align instruction is placed after an unconditional jump.
 //
 void emitter::emitLongLoopAlign(unsigned alignmentBoundary DEBUG_ARG(bool isPlacedBehindJmp))
 {
@@ -5811,24 +5810,27 @@ bool emitter::emitEndsWithAlignInstr()
 }
 
 //-----------------------------------------------------------------------------
-//  getLoopSize: Starting from loopHeaderIg, find the size of the smallest possible loop
+//  getLoopSize: Starting from igLoopHeader, find the size of the smallest possible loop
 //               such that it doesn't exceed the maxLoopSize.
 //
 //  Arguments:
-//       igLoopHeader    - The header IG of a loop
-//       maxLoopSize     - Maximum loop size. If the loop is bigger than this value, we will just
-//                         return this value.
-//       isAlignAdjusted - Determine if adjustments are done to the align instructions or not.
-//                         During generating code, it is 'false' (because we haven't adjusted the size yet).
-//                         During outputting code, it is 'true'.
-//      containingIGNum  - IG number of IG that contains the current align instruction we are processing.
-//      loopHeadPredIGNum - IG number of IG that preceds the IG that we are aligning with current align instruction.
+//      igLoopHeader      - The header IG of a loop
+//      maxLoopSize       - Maximum loop size. If the loop is bigger than this value, we will just
+//                          return this value.
+//      isAlignAdjusted   - DEBUG only. Determine if adjustments are done to the align instructions or not.
+//                          During generating code, it is 'false' (because we haven't adjusted the size yet).
+//                          During outputting code, it is 'true'.
+//      containingIGNum   - DEBUG only. IG number of IG that contains the current align instruction we are processing.
+//      loopHeadPredIGNum - DEBUG only. IG number of IG that precedes the IG that we are aligning with current align
+//                          instruction.
 //
 //  Returns:  size of a loop in bytes.
 //
 unsigned emitter::getLoopSize(insGroup* igLoopHeader,
-                              unsigned maxLoopSize DEBUG_ARG(bool isAlignAdjusted)
-                                  DEBUG_ARG(UNATIVE_OFFSET containingIGNum) DEBUG_ARG(UNATIVE_OFFSET loopHeadPredIGNum))
+                              unsigned  maxLoopSize                     //
+                              DEBUG_ARG(bool isAlignAdjusted)           //
+                              DEBUG_ARG(UNATIVE_OFFSET containingIGNum) //
+                              DEBUG_ARG(UNATIVE_OFFSET loopHeadPredIGNum))
 {
     unsigned loopSize = 0;
 
@@ -5841,44 +5843,45 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
 
         if (igInLoop->endsWithAlignInstr() || igInLoop->hadAlignInstr())
         {
-// If IGF_HAS_ALIGN is present, igInLoop contains align instruction at the end,
-// for next IG or some future IG.
-//
-// For both cases, remove the padding bytes from igInLoop's size so it is not included in loopSize.
-//
-// If the loop was formed because of forward jumps like the loop IG18 below, the backedge is not
-// set for them and such loops are not aligned. For such cases, the loop size threshold will never
-// be met and we would break as soon as loopSize > maxLoopSize.
-//
-// IG05:
-//      ...
-//      jmp IG18
-// ...
-// IG18:
-//      ...
-//      jne IG05
-//
-// If igInLoop is a legitimate loop, and igInLoop's end with another 'align' instruction for different IG
-// representing a loop that needs alignment, then igInLoop should be the last IG of the current loop and
-// should have backedge to current loop header.
-//
-// Below, IG05 is the last IG of loop IG04-IG05 and its backedge points to IG04.
-//
-// IG03:
-//      ...
-//      align
-// IG04:
-//      ...
-//      ...
-// IG05:
-//      ...
-//      jne IG04
-//      align     ; <---
-// IG06:
-//      ...
-//      jne IG06
-//
-//
+            // If IGF_HAS_ALIGN is present, igInLoop contains align instruction at the end,
+            // for next IG or some future IG.
+            //
+            // For both cases, remove the padding bytes from igInLoop's size so it is not included in loopSize.
+            //
+            // If the loop was formed because of forward jumps like the loop IG18 below, the backedge is not
+            // set for them and such loops are not aligned. For such cases, the loop size threshold will never
+            // be met and we would break as soon as loopSize > maxLoopSize.
+            //
+            // IG05:
+            //      ...
+            //      jmp IG18
+            // ...
+            // IG18:
+            //      ...
+            //      jne IG05
+            //
+            // If igInLoop is a legitimate loop, and igInLoop's end with another 'align' instruction for different IG
+            // representing a loop that needs alignment, then igInLoop should be the last IG of the current loop and
+            // should have backedge to current loop header.
+            //
+            // Below, IG05 is the last IG of loop IG04-IG05 and its backedge points to IG04.
+            //
+            // IG03:
+            //      ...
+            //      align
+            // IG04:
+            //      ...
+            //      ...
+            // IG05:
+            //      ...
+            //      jne IG04
+            //      align     ; <---
+            // IG06:
+            //      ...
+            //      jne IG06
+            //
+            //
+            CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef DEBUG
             if ((igInLoop->igLoopBackEdge != nullptr) && (igInLoop->igLoopBackEdge != igLoopHeader))
@@ -5889,8 +5892,8 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
                 written += sprintf_s(buffer + written, 100, "loopHeadPredIG: IG%02u\n", loopHeadPredIGNum);
                 written += sprintf_s(buffer + written, 100, "loopHeadIG: IG%02u\n", igLoopHeader->igNum);
                 written += sprintf_s(buffer + written, 100, "igInLoop: IG%02u\n", igInLoop->igNum);
-                written +=
-                    sprintf_s(buffer + written, 100, "igInLoop->backEdge: IG%02u\n", igInLoop->igLoopBackEdge->igNum);
+                written += sprintf_s(buffer + written, 100, "igInLoop->igLoopBackEdge: IG%02u\n",
+                                     igInLoop->igLoopBackEdge->igNum);
 
 #if EMIT_BACKWARDS_NAVIGATION
                 if (igInLoop->endsWithAlignInstr())
@@ -5904,16 +5907,19 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
 #endif // EMIT_BACKWARDS_NAVIGATION
 
                 written += sprintf_s(buffer + written, 35, "Loop:\n");
-                for (insGroup* igInLoop = igLoopHeader; igInLoop != nullptr; igInLoop = igInLoop->igNext)
+                insGroup* igIter;
+                for (igIter = igLoopHeader; (igIter != nullptr) && (igIter->igLoopBackEdge != igLoopHeader);
+                     igIter = igIter->igNext)
                 {
-                    if (igInLoop->igLoopBackEdge == igLoopHeader)
-                    {
-                        break;
-                    }
-                    written += sprintf_s(buffer + written, 100, "\tIG%02u\n", igInLoop->igNum);
+                    written += sprintf_s(buffer + written, 100, "\tIG%02u\n", igIter->igNum);
                 }
-                printf("%s", buffer);
-                assert(false);
+                if (igIter == nullptr)
+                {
+                    written += sprintf_s(buffer + written, 100, "Did not find IG with back edge to IG%02u\n",
+                                         igLoopHeader->igNum);
+                }
+                printf("\n\n%s", buffer);
+                assert(false && !"Mismatch in align instruction");
             }
 
             if (isAlignAdjusted)
@@ -5951,7 +5957,7 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
                 loopSize -= adjustedPadding;
             }
             else
-#endif
+#endif // DEBUG
             {
                 JITDUMP(" but ends with align instruction, taking off %u bytes.",
                         emitComp->opts.compJitAlignPaddingLimit);
@@ -5964,14 +5970,14 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
 #ifdef DEBUG
             if (igInLoop->igLoopBackEdge == igLoopHeader)
             {
-                JITDUMP(" -- Found the back edge.");
+                JITDUMP(" -- Found the back edge.\n");
             }
             else
             {
-                JITDUMP(" -- loopSize exceeded the threshold of %u bytes.", maxLoopSize);
+                JITDUMP(" -- loopSize exceeded the threshold of %u bytes.\n", maxLoopSize);
             }
-            JITDUMP("\n");
-#endif
+#endif // DEBUG
+
             break;
         }
         JITDUMP("\n");
@@ -5986,122 +5992,132 @@ unsigned emitter::getLoopSize(insGroup* igLoopHeader,
 //                       if currIG has back-edge to dstIG.
 //
 // Notes:
-//    Despite we align only inner most loop, we might see intersected loops because of control flow
+//    Although we align only inner-most loops, we might see intersected loops because of control flow
 //    re-arrangement like adding a split edge in LSRA.
 //
 //    If there is an intersection of current loop with last loop that is already marked as align,
-//    then *do not align* one of the loop that completely encloses the other one. Or if they both intersect,
-//    then *do not align* either of them because since the flow is complicated enough that aligning one of them
-//    will not improve the performance.
+//    then *do not align* one of the loops that completely encloses the other one. Or if they both intersect,
+//    then *do not align* either of them since the flow is complicated enough that aligning one of them
+//    will not improve performance.
 //
 void emitter::emitSetLoopBackEdge(BasicBlock* loopTopBlock)
 {
-    insGroup* dstIG            = (insGroup*)loopTopBlock->bbEmitCookie;
-    bool      alignCurrentLoop = true;
-    bool      alignLastLoop    = true;
-
-    // With (dstIG != nullptr), ensure that only back edges are tracked.
-    // If there is forward jump, dstIG is not yet generated.
-    //
-    // We don't rely on (block->GetTarget()->bbNum <= block->bbNum) because the basic
-    // block numbering is not guaranteed to be sequential.
-    if ((dstIG != nullptr) && (dstIG->igNum <= emitCurIG->igNum))
+    insGroup* dstIG = (insGroup*)loopTopBlock->bbEmitCookie;
+    if (dstIG == nullptr)
     {
-        unsigned currLoopStart = dstIG->igNum;
-        unsigned currLoopEnd   = emitCurIG->igNum;
+        // This is a forward branch.
+        JITDUMP("ALIGN: loop block " FMT_BB
+                " needing alignment has not been generated yet; not marking IG back edge.\n",
+                loopTopBlock->bbNum);
+        return;
+    }
 
-        // Only mark back-edge if current loop starts after the last inner loop ended.
-        if (emitLastLoopEnd < currLoopStart)
-        {
-            emitCurIG->igLoopBackEdge = dstIG;
+    if (dstIG->igNum > emitCurIG->igNum)
+    {
+        // Is this possible?
+        JITDUMP("ALIGN: found forward branch from IG%02u to IG%02u; not marking IG back edge.\n", emitCurIG->igNum,
+                dstIG->igNum);
+        return;
+    }
 
-            JITDUMP("** IG%02u jumps back to IG%02u forming a loop.\n", currLoopEnd, currLoopStart);
+    bool alignCurrentLoop = true;
+    bool alignLastLoop    = true;
 
-            emitLastLoopStart = currLoopStart;
-            emitLastLoopEnd   = currLoopEnd;
-        }
-        else if (currLoopStart == emitLastLoopStart)
-        {
-            // Note: If current and last loop starts at same point,
-            // retain the alignment flag of the smaller loop.
-            //               |
-            //         .---->|<----.
-            //   last  |     |     |
-            //   loop  |     |     | current
-            //         .---->|     | loop
-            //               |     |
-            //               |-----.
-            //
-        }
-        else if ((currLoopStart < emitLastLoopStart) && (emitLastLoopEnd < currLoopEnd))
-        {
-            // if current loop completely encloses last loop,
-            // then current loop should not be aligned.
-            alignCurrentLoop = false;
-        }
-        else if ((emitLastLoopStart < currLoopStart) && (currLoopEnd < emitLastLoopEnd))
-        {
-            // if last loop completely encloses current loop,
-            // then last loop should not be aligned.
-            alignLastLoop = false;
-        }
-        else
-        {
-            // The loops intersect and should not align either of the loops
-            alignLastLoop    = false;
-            alignCurrentLoop = false;
-        }
+    unsigned currLoopStart = dstIG->igNum;
+    unsigned currLoopEnd   = emitCurIG->igNum;
 
-        if (!alignLastLoop || !alignCurrentLoop)
+    // Only mark back-edge if current loop starts after the last inner loop ended.
+    if (emitLastLoopEnd < currLoopStart)
+    {
+        assert(emitCurIG->igLoopBackEdge == nullptr);
+        emitCurIG->igLoopBackEdge = dstIG;
+
+        JITDUMP("** IG%02u jumps back to IG%02u forming a loop.\n", currLoopEnd, currLoopStart);
+
+        emitLastLoopStart = currLoopStart;
+        emitLastLoopEnd   = currLoopEnd;
+    }
+    else if (currLoopStart == emitLastLoopStart)
+    {
+        // Note: If current and last loop start at the same point,
+        // retain the alignment flag of the smaller loop.
+        //               |
+        //         .---->|<----.
+        //   last  |     |     |
+        //   loop  |     |     | current
+        //         .---->|     | loop
+        //               |     |
+        //               |-----.
+        //
+    }
+    else if ((currLoopStart < emitLastLoopStart) && (emitLastLoopEnd < currLoopEnd))
+    {
+        // if current loop completely encloses last loop,
+        // then current loop should not be aligned.
+        alignCurrentLoop = false;
+    }
+    else if ((emitLastLoopStart < currLoopStart) && (currLoopEnd < emitLastLoopEnd))
+    {
+        // if last loop completely encloses current loop,
+        // then last loop should not be aligned.
+        alignLastLoop = false;
+    }
+    else
+    {
+        // The loops intersect and should not align either of the loops
+        alignLastLoop    = false;
+        alignCurrentLoop = false;
+    }
+
+    if (!alignLastLoop || !alignCurrentLoop)
+    {
+        instrDescAlign* alignInstr     = emitAlignList;
+        bool            markedLastLoop = alignLastLoop;
+        bool            markedCurrLoop = alignCurrentLoop;
+        while (alignInstr != nullptr)
         {
-            instrDescAlign* alignInstr     = emitAlignList;
-            bool            markedLastLoop = alignLastLoop;
-            bool            markedCurrLoop = alignCurrentLoop;
-            while ((alignInstr != nullptr))
+            insGroup* loopHeadIG = alignInstr->loopHeadIG();
+
+            // Find the IG that has 'align' instruction to align the current loop
+            // and clear the IGF_HAS_ALIGN flag.
+            if (!alignCurrentLoop && (loopHeadIG == dstIG))
             {
-                insGroup* loopHeadIG = alignInstr->loopHeadIG();
+                assert(!markedCurrLoop);
 
-                // Find the IG that has 'align' instruction to align the current loop
-                // and clear the IGF_HAS_ALIGN flag.
-                if (!alignCurrentLoop && (loopHeadIG == dstIG))
-                {
-                    assert(!markedCurrLoop);
+                // This IG should no longer contain alignment instruction
+                alignInstr->removeAlignFlags();
 
-                    // This IG should no longer contain alignment instruction
-                    alignInstr->removeAlignFlags();
-
-                    markedCurrLoop = true;
-                    JITDUMP(";; Skip alignment for current loop IG%02u ~ IG%02u because it encloses an aligned loop "
-                            "IG%02u ~ IG%02u.\n",
-                            currLoopStart, currLoopEnd, emitLastLoopStart, emitLastLoopEnd);
-                }
-
-                // Find the IG that has 'align' instruction to align the last loop
-                // and clear the IGF_HAS_ALIGN flag.
-                if (!alignLastLoop && (loopHeadIG != nullptr) && (loopHeadIG->igNum == emitLastLoopStart))
-                {
-                    assert(!markedLastLoop);
-                    assert(alignInstr->idaIG->endsWithAlignInstr() || alignInstr->idaIG->hadAlignInstr());
-
-                    // This IG should no longer contain alignment instruction
-                    alignInstr->removeAlignFlags();
-
-                    markedLastLoop = true;
-                    JITDUMP(";; Skip alignment for aligned loop IG%02u ~ IG%02u because it encloses the current loop "
-                            "IG%02u ~ IG%02u.\n",
-                            emitLastLoopStart, emitLastLoopEnd, currLoopStart, currLoopEnd);
-                }
-
-                if (markedLastLoop && markedCurrLoop)
-                {
-                    break;
-                }
-
-                alignInstr = emitAlignInNextIG(alignInstr);
+                markedCurrLoop = true;
+                JITDUMP(";; Skip alignment for current loop IG%02u ~ IG%02u because it encloses an aligned loop "
+                        "IG%02u ~ IG%02u.\n",
+                        currLoopStart, currLoopEnd, emitLastLoopStart, emitLastLoopEnd);
             }
 
-            assert(markedLastLoop && markedCurrLoop);
+            // Find the IG that has 'align' instruction to align the last loop
+            // and clear the IGF_HAS_ALIGN flag.
+            if (!alignLastLoop && (loopHeadIG != nullptr) && (loopHeadIG->igNum == emitLastLoopStart))
+            {
+                assert(!markedLastLoop);
+                assert(alignInstr->idaIG->endsWithAlignInstr() || alignInstr->idaIG->hadAlignInstr());
+
+                // This IG should no longer contain alignment instruction
+                alignInstr->removeAlignFlags();
+
+                markedLastLoop = true;
+                JITDUMP(";; Skip alignment for aligned loop IG%02u ~ IG%02u because it encloses the current loop "
+                        "IG%02u ~ IG%02u.\n",
+                        emitLastLoopStart, emitLastLoopEnd, currLoopStart, currLoopEnd);
+            }
+
+            if (markedLastLoop && markedCurrLoop)
+            {
+                break;
+            }
+
+            alignInstr = emitAlignInNextIG(alignInstr);
         }
+
+        assert(markedLastLoop && markedCurrLoop);
     }
 }
 
@@ -6448,6 +6464,7 @@ unsigned emitter::emitCalculatePaddingForLoopAlignment(insGroup* loopHeadIG,
     return paddingToAdd;
 }
 
+//-----------------------------------------------------------------------------
 // emitAlignInNextIG: On xarch, for adaptive alignment, this will usually return the next instruction in
 //                    'emitAlignList'. But for arm64 or non-adaptive alignment on xarch, where multiple
 //                    align instructions are emitted, this method will skip the 'align' instruction present

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2508,7 +2508,7 @@ private:
                              DEBUG_ARG(UNATIVE_OFFSET loopHeadPredIGNum)); // Get the smallest loop size
     void emitLoopAlignment(DEBUG_ARG1(bool isPlacedBehindJmp));
     bool emitEndsWithAlignInstr(); // Validate if newLabel is appropriate
-    void emitSetLoopBackEdge(BasicBlock* loopTopBlock);
+    bool emitSetLoopBackEdge(const BasicBlock* loopTopBlock);
     void     emitLoopAlignAdjustments(); // Predict if loop alignment is needed and make appropriate adjustments
     unsigned emitCalculatePaddingForLoopAlignment(insGroup* ig,
                                                   size_t offset DEBUG_ARG(bool isAlignAdjusted)


### PR DESCRIPTION
Now that `BBJ_COND` block false target is not necessarily fall-through, the loop alignment code needs to consider the false target as what induces a loop via a false target back edge.

Also, stop marking blocks after possible loop back edges for aligned loops as needing labels; they do not need to be so marked.