### PR TITLE
[wasm] Decrease frequency of chrome version bumps

### DIFF
--- a/eng/testing/bump-chrome-version.proj
+++ b/eng/testing/bump-chrome-version.proj
@@ -1,69 +1,30 @@
 <Project DefaultTargets="UpdateChromeVersion">
 
   <Import Project="..\..\Directory.Build.props" />
-  <UsingTask AssemblyFile="$(WasmBuildTasksAssemblyPath)" TaskName="Microsoft.WebAssembly.Build.Tasks.GetChromeVersions" />
+  <UsingTask AssemblyFile="$(WasmBuildTasksAssemblyPath)" TaskName="Microsoft.WebAssembly.Build.Tasks.UpdateChromeVersions" />
   <PropertyGroup>
     <ChromeVersionsPath>$(RepositoryEngineeringDir)testing\ChromeVersions.props</ChromeVersionsPath>
   </PropertyGroup>
 
   <Target Name="UpdateChromeVersion">
-    <GetChromeVersions
-                OSIdentifier="linux"
-                OSPrefix="Linux_x64"
+    <UpdateChromeVersions
+                OSIdentifiers="linux;Windows"
+                OSPrefixes="Linux_x64;Win_x64"
                 Channel="$(ChromeChannel)"
                 MaxMajorVersionsToCheck="1"
                 IntermediateOutputPath="$(ArtifactsObjDir)"
-                ChromeVersionsPath="$(ChromeVersionsPath)">
-      <Output TaskParameter="ChromeVersion"      PropertyName="linux_ChromeVersion" />
-      <Output TaskParameter="V8Version"          PropertyName="linux_V8Version" />
-      <Output TaskParameter="BranchPosition"     PropertyName="linux_ChromeRevision" />
-      <Output TaskParameter="BaseSnapshotUrl"    PropertyName="linux_ChromeBaseSnapshotUrl" />
-      <Output TaskParameter="OverwriteVersions"  PropertyName="linux_OverwriteVersions" />
-    </GetChromeVersions>
-
-    <GetChromeVersions
-                OSIdentifier="Windows"
-                OSPrefix="Win_x64"
-                Channel="$(ChromeChannel)"
-                MaxMajorVersionsToCheck="1"
-                IntermediateOutputPath="$(ArtifactsObjDir)"
-                ChromeVersionsPath="$(ChromeVersionsPath)">
-      <Output TaskParameter="ChromeVersion"      PropertyName="win_ChromeVersion" />
-      <Output TaskParameter="V8Version"          PropertyName="win_V8Version" />
-      <Output TaskParameter="BranchPosition"     PropertyName="win_ChromeRevision" />
-      <Output TaskParameter="BaseSnapshotUrl"    PropertyName="win_ChromeBaseSnapshotUrl" />
-      <Output TaskParameter="OverwriteVersions"  PropertyName="win_OverwriteVersions" />
-    </GetChromeVersions>
+                ChromeVersionsPath="$(ChromeVersionsPath)">                
+      <Output TaskParameter="VersionsChanged" PropertyName="VersionsChanged" />
+    </UpdateChromeVersions>
 
     <ItemGroup>
       <!-- ensure newline at the end -->
       <EnvVarForPR Include="CHROME_LINUX_VER=$(linux_ChromeVersion)" />
       <EnvVarForPR Include="CHROME_WIN_VER=$(win_ChromeVersion)" />
     </ItemGroup>
-    <PropertyGroup>
-      <_ExecuteWriteVersionProps Condition="'$(linux_OverwriteVersions)' == 'true' OR '$(win_OverwriteVersions)' == 'true'">true</_ExecuteWriteVersionProps>
-      <_PropsContent>
-&lt;Project&gt;
-  &lt;PropertyGroup&gt;
-      &lt;linux_ChromeVersion&gt;$(linux_ChromeVersion)&lt;/linux_ChromeVersion&gt;
-      &lt;linux_ChromeRevision&gt;$(linux_ChromeRevision)&lt;/linux_ChromeRevision&gt;
-      &lt;linux_ChromeBaseSnapshotUrl&gt;$(linux_ChromeBaseSnapshotUrl)&lt;/linux_ChromeBaseSnapshotUrl&gt;
-      &lt;linux_V8Version&gt;$(linux_V8Version)&lt;/linux_V8Version&gt;
 
-      &lt;win_ChromeVersion&gt;$(win_ChromeVersion)&lt;/win_ChromeVersion&gt;
-      &lt;win_ChromeRevision&gt;$(win_ChromeRevision)&lt;/win_ChromeRevision&gt;
-      &lt;win_ChromeBaseSnapshotUrl&gt;$(win_ChromeBaseSnapshotUrl)&lt;/win_ChromeBaseSnapshotUrl&gt;
-      &lt;win_V8Version&gt;$(win_V8Version)&lt;/win_V8Version&gt;
-  &lt;/PropertyGroup&gt;
-&lt;/Project&gt;
-      </_PropsContent>
-    </PropertyGroup>
-
-    <Message Text="No major changes: skipping version props update." Importance="High" Condition="'$(_ExecuteWriteVersionProps)' != 'true'"/>
-    <Message Text="Version props update: $(_PropsContent)" Importance="High" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
-    <WriteLinesToFile Lines="$(_PropsContent)" File="$(ChromeVersionsPath)" Overwrite="true" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
-
-    <WriteLinesToFile Lines="@(EnvVarForPR)" File="$(RepositoryEngineeringDir)testing\bump-chrome-pr.env" Overwrite="true" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
+    <Message Text="No major changes: skipping version props update." Importance="High" Condition="'$(VersionsChanged)' != 'true'"/>
+    <Message Text="Version props got updated" Importance="High" Condition="'$(VersionsChanged)' == 'true'"/>
 
   </Target>
 

--- a/eng/testing/bump-chrome-version.proj
+++ b/eng/testing/bump-chrome-version.proj
@@ -2,6 +2,9 @@
 
   <Import Project="..\..\Directory.Build.props" />
   <UsingTask AssemblyFile="$(WasmBuildTasksAssemblyPath)" TaskName="Microsoft.WebAssembly.Build.Tasks.GetChromeVersions" />
+  <PropertyGroup>
+    <ChromeVersionsPath>$(RepositoryEngineeringDir)testing\ChromeVersions.props</ChromeVersionsPath>
+  </PropertyGroup>
 
   <Target Name="UpdateChromeVersion">
     <GetChromeVersions
@@ -9,11 +12,13 @@
                 OSPrefix="Linux_x64"
                 Channel="$(ChromeChannel)"
                 MaxMajorVersionsToCheck="1"
-                IntermediateOutputPath="$(ArtifactsObjDir)">
+                IntermediateOutputPath="$(ArtifactsObjDir)"
+                ChromeVersionsPath="$(ChromeVersionsPath)">
       <Output TaskParameter="ChromeVersion"      PropertyName="linux_ChromeVersion" />
       <Output TaskParameter="V8Version"          PropertyName="linux_V8Version" />
       <Output TaskParameter="BranchPosition"     PropertyName="linux_ChromeRevision" />
       <Output TaskParameter="BaseSnapshotUrl"    PropertyName="linux_ChromeBaseSnapshotUrl" />
+      <Output TaskParameter="OverwriteVersions"  PropertyName="linux_OverwriteVersions" />
     </GetChromeVersions>
 
     <GetChromeVersions
@@ -21,11 +26,13 @@
                 OSPrefix="Win_x64"
                 Channel="$(ChromeChannel)"
                 MaxMajorVersionsToCheck="1"
-                IntermediateOutputPath="$(ArtifactsObjDir)">
+                IntermediateOutputPath="$(ArtifactsObjDir)"
+                ChromeVersionsPath="$(ChromeVersionsPath)">
       <Output TaskParameter="ChromeVersion"      PropertyName="win_ChromeVersion" />
       <Output TaskParameter="V8Version"          PropertyName="win_V8Version" />
       <Output TaskParameter="BranchPosition"     PropertyName="win_ChromeRevision" />
       <Output TaskParameter="BaseSnapshotUrl"    PropertyName="win_ChromeBaseSnapshotUrl" />
+      <Output TaskParameter="OverwriteVersions"  PropertyName="win_OverwriteVersions" />
     </GetChromeVersions>
 
     <ItemGroup>
@@ -33,8 +40,8 @@
       <EnvVarForPR Include="CHROME_LINUX_VER=$(linux_ChromeVersion)" />
       <EnvVarForPR Include="CHROME_WIN_VER=$(win_ChromeVersion)" />
     </ItemGroup>
-
     <PropertyGroup>
+      <_ExecuteWriteVersionProps Condition="'$(linux_OverwriteVersions)' == 'true' OR '$(win_OverwriteVersions)' == 'true'">true</_ExecuteWriteVersionProps>
       <_PropsContent>
 &lt;Project&gt;
   &lt;PropertyGroup&gt;
@@ -52,10 +59,12 @@
       </_PropsContent>
     </PropertyGroup>
 
-    <Message Text="Writing version props: $(_PropsContent)" Importance="High" />
-    <WriteLinesToFile Lines="$(_PropsContent)" File="$(RepositoryEngineeringDir)testing\ChromeVersions.props" Overwrite="true" />
+    <Message Text="No major changes: skipping version props update." Importance="High" Condition="'$(_ExecuteWriteVersionProps)' != 'true'"/>
+    <Message Text="Version props update: $(_PropsContent)" Importance="High" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
+    <WriteLinesToFile Lines="$(_PropsContent)" File="$(ChromeVersionsPath)" Overwrite="true" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
 
-    <WriteLinesToFile Lines="@(EnvVarForPR)" File="$(RepositoryEngineeringDir)testing\bump-chrome-pr.env" Overwrite="true" />
+    <WriteLinesToFile Lines="@(EnvVarForPR)" File="$(RepositoryEngineeringDir)testing\bump-chrome-pr.env" Overwrite="true" Condition="'$(_ExecuteWriteVersionProps)' == 'true'"/>
+
   </Target>
 
   <Import Project="..\..\Directory.Build.targets" />

--- a/src/tasks/WasmBuildTasks/GetChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/GetChromeVersions.cs
@@ -102,18 +102,21 @@ public partial class GetChromeVersions : MBU.Task
         XmlDocument xmlDoc = new XmlDocument();
         xmlDoc.Load(ChromeVersionsPath);
 
-        if (version.os == "Linux")
+        if (string.Equals(version.os, "Linux", StringComparison.OrdinalIgnoreCase))
         {
             string linuxChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "linux_ChromeBaseSnapshotUrl");
             string linuxV8Version = GetNodeValue(xmlDoc, "linux_V8Version");
             return version.v8_version != linuxV8Version ||
                 baseUrl != linuxChromeBaseSnapshotUrl;
         }
-        // version.os == "Windows"
-        string winChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "win_ChromeBaseSnapshotUrl");
-        string winV8Version = GetNodeValue(xmlDoc, "win_V8Version");
-        return version.v8_version != winV8Version ||
-            baseUrl != winChromeBaseSnapshotUrl;
+        else if (string.Equals(version.os, "Windows", StringComparison.OrdinalIgnoreCase))
+        {
+            string winChromeBaseSnapshotUrl = GetNodeValue(xmlDoc, "win_ChromeBaseSnapshotUrl");
+            string winV8Version = GetNodeValue(xmlDoc, "win_V8Version");
+            return version.v8_version != winV8Version ||
+                baseUrl != winChromeBaseSnapshotUrl;
+        }
+        throw new Exception($"GetChromeVersions task was used with unknown OS: {version.os}");
     }
 
     private static string GetNodeValue(XmlDocument xmlDoc, string nodeName)


### PR DESCRIPTION
Partial fix for https://github.com/dotnet/runtime/issues/97364.

Added logic:
- Read current `ChromeVersions.props`
- Compare the latest versions with current
- If any platform, Linux or Windows has updated `ChromeBaseSnapshotUrl` or `V8Version`, then update the `*.props`
- Otherwise, log that we're skipping an update.

## Out of scope
Investigate why we can't find more snapshot urls - from this reason the original issue should stay opened.