### PR TITLE
Suppress RS1041 analyzer rule

### DIFF
--- a/eng/generatorProjects.targets
+++ b/eng/generatorProjects.targets
@@ -3,6 +3,10 @@
   <PropertyGroup>
     <GeneratorProjectBaseTargetPath>analyzers/dotnet</GeneratorProjectBaseTargetPath>
     <GeneratorProjectBaseTargetPath Condition="'$(AnalyzerLanguage)' != ''">$(GeneratorProjectBaseTargetPath)/$(AnalyzerLanguage)</GeneratorProjectBaseTargetPath>
+
+    <!-- RS1041: Compiler extensions should be implemented in assemblies targeting netstandard2.0.
+         Runtime intentionally targets .NETCoreApp for nullable annotation warnings without shipping. -->
+    <NoWarn Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">$(NoWarn);RS1041</NoWarn>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/src/libraries/Microsoft.Extensions.Options/gen/Generator.cs
+++ b/src/libraries/Microsoft.Extensions.Options/gen/Generator.cs
@@ -12,9 +12,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.Extensions.Options.Generators
 {
-#pragma warning disable RS1041 // we're multi-targeting so this is fine
     [Generator]
-#pragma warning restore
     public class OptionsValidatorGenerator : IIncrementalGenerator
     {
         public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Roslyn4.0.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Roslyn4.0.cs
@@ -16,9 +16,7 @@ namespace System.Text.Json.SourceGeneration
     /// <summary>
     /// Generates source code to optimize serialization and deserialization with JsonSerializer.
     /// </summary>
-#pragma warning disable RS1041 // we're multi-targeting so this is fine
     [Generator]
-#pragma warning restore
     public sealed partial class JsonSourceGenerator : IIncrementalGenerator
     {
 #if ROSLYN4_4_OR_GREATER


### PR DESCRIPTION
> C:\Users\eitsarpa\devel\dotnet\runtime-feature\src\libraries\System.Text.RegularExpressions\gen\UpgradeToGeneratedRegexAnalyzer.cs(20,6): error RS1041: This compiler extension should not be implemented in an assembly with target framework '.NET 9.0'. References to other target f
rameworks will cause the compiler to behave unpredictably. (
https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1041.md)
[C:\Users\eitsarpa\devel\dotnet\runtime-feature\src\libraries\System.Text.RegularExpressions\gen\System.Text.RegularExpressions.Generator.csproj
::TargetFramework=net9.0]