### PR TITLE
Microsoft.Extensions.Logging.Console.Tests dispose threads

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleFormatterTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Console.Test
 {
-    public class ConsoleFormatterTests
+    public class ConsoleFormatterTests : ConsoleTestsBase
     {
         protected const string _loggerName = "test";
         protected const string _state = "This is a test, and {curly braces} are just fine!";
@@ -25,42 +25,6 @@ namespace Microsoft.Extensions.Logging.Console.Test
         protected string GetMessage(List<ConsoleContext> contexts)
         {
             return string.Join("", contexts.Select(c => c.Message));
-        }
-
-        internal class SetupDisposeHelper : IDisposable
-        {
-            public ConsoleLogger Logger;
-            public ConsoleSink Sink;
-            public ConsoleSink ErrorSink;
-            public Func<LogLevel, string> GetLevelPrefix;
-            public int WritesPerMsg;
-            public TestLoggerProcessor LoggerProcessor;
-            public SetupDisposeHelper(ConsoleLogger logger, ConsoleSink sink, ConsoleSink errorSink, Func<LogLevel, string> getLevelPrefix, int writesPerMsg, TestLoggerProcessor loggerProcessor)
-            {
-                Logger = logger;
-                Sink = sink;
-                ErrorSink = errorSink;
-                GetLevelPrefix = getLevelPrefix;
-                WritesPerMsg = writesPerMsg;
-                LoggerProcessor = loggerProcessor;
-            }
-
-            private bool _isDisposed;
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (!_isDisposed)
-                {
-                    LoggerProcessor.Dispose();
-                    _isDisposed = true;
-                }
-            }
-
-            public void Dispose()
-            {
-                Dispose(disposing: true);
-                GC.SuppressFinalize(this);
-            }
         }
 
         internal static SetupDisposeHelper SetUp(

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerProcessorTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
+            using var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor,
                 new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(new SimpleConsoleFormatterOptions())),
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
+            using var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor,
                 new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(new SimpleConsoleFormatterOptions())),
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
+            using var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.MaxQueueLength = invalidMaxQueueLength);
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Arrange
             var sink = new ConsoleSink();
             var console = new TestConsole(sink);
-            var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
+            using var processor = new ConsoleLoggerProcessor(console, null!, ConsoleLoggerQueueFullMode.Wait, 1024);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() => processor.FullMode = (ConsoleLoggerQueueFullMode)10);
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var errorConsole = new TimesWriteCalledConsole();
             string queueName = nameof(CheckForNotificationWhenQueueIsFull) + (okToDrop ? "InDropWriteMode" : "InWaitMode");
             var fullMode = okToDrop ? ConsoleLoggerQueueFullMode.DropWrite : ConsoleLoggerQueueFullMode.Wait;
-            var processor = new ConsoleLoggerProcessor(console, errorConsole, fullMode, maxQueueLength: 1);
+            using var processor = new ConsoleLoggerProcessor(console, errorConsole, fullMode, maxQueueLength: 1);
             var formatter = new SimpleConsoleFormatter(new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(
                 new SimpleConsoleFormatterOptions()));
 
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         {
             var console = new TimesWriteCalledConsole();
             var writeThrowingConsole = new WriteThrowingConsole();
-            var processor = new ConsoleLoggerProcessor(
+            using var processor = new ConsoleLoggerProcessor(
                 console,
                 writeThrowingConsole,
                 ConsoleLoggerQueueFullMode.Wait,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.Logging.Console.Test
 {
-    public class ConsoleLoggerTest
+    public class ConsoleLoggerTest : ConsoleTestsBase
     {
         private const string _paddingString = "      ";
         private const string _loggerName = "test";
@@ -32,48 +32,12 @@ namespace Microsoft.Extensions.Logging.Console.Test
             var defaultMonitor = new TestFormatterOptionsMonitor<SimpleConsoleFormatterOptions>(simpleOptions ?? new SimpleConsoleFormatterOptions());
             var systemdMonitor = new TestFormatterOptionsMonitor<ConsoleFormatterOptions>(systemdOptions ?? new ConsoleFormatterOptions());
             var jsonMonitor = new TestFormatterOptionsMonitor<JsonConsoleFormatterOptions>(jsonOptions ?? new JsonConsoleFormatterOptions());
-            var formatters = new List<ConsoleFormatter>() { 
+            var formatters = new List<ConsoleFormatter>() {
                 new SimpleConsoleFormatter(defaultMonitor),
                 new SystemdConsoleFormatter(systemdMonitor),
                 new JsonConsoleFormatter(jsonMonitor)
             };
             return formatters;
-        }
-
-        internal class SetupDisposeHelper : IDisposable
-        {
-            public ConsoleLogger Logger;
-            public ConsoleSink Sink;
-            public ConsoleSink ErrorSink;
-            public Func<LogLevel, string> GetLevelPrefix;
-            public int WritesPerMsg;
-            public TestLoggerProcessor LoggerProcessor;
-            public SetupDisposeHelper(ConsoleLogger logger, ConsoleSink sink, ConsoleSink errorSink, Func<LogLevel, string> getLevelPrefix, int writesPerMsg, TestLoggerProcessor loggerProcessor)
-            {
-                Logger= logger;
-                Sink= sink;
-                ErrorSink= errorSink;
-                GetLevelPrefix = getLevelPrefix;
-                WritesPerMsg = writesPerMsg;
-                LoggerProcessor = loggerProcessor;
-            }
-
-            private bool _isDisposed;
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (!_isDisposed)
-                {
-                    LoggerProcessor.Dispose();
-                    _isDisposed = true;
-                }
-            }
-
-            public void Dispose()
-            {
-                Dispose(disposing: true);
-                GC.SuppressFinalize(this);
-            }
         }
 
         private static SetupDisposeHelper SetUp(ConsoleLoggerOptions options = null)
@@ -122,13 +86,13 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 Assert.Equal(formatter.FormatterOptions.IncludeScopes, logger.Options.IncludeScopes);
                 Assert.Equal(formatter.FormatterOptions.UseUtcTimestamp, logger.Options.UseUtcTimestamp);
                 Assert.Equal(formatter.FormatterOptions.TimestampFormat, logger.Options.TimestampFormat);
-                Assert.Equal(formatter.FormatterOptions.ColorBehavior, 
-                    logger.Options.DisableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled);   
+                Assert.Equal(formatter.FormatterOptions.ColorBehavior,
+                    logger.Options.DisableColors ? LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled);
             }
             else
             {
                 var formatter = Assert.IsType<SystemdConsoleFormatter>(logger.Formatter);
-                Assert.Equal(formatter.FormatterOptions.IncludeScopes, logger.Options.IncludeScopes);   
+                Assert.Equal(formatter.FormatterOptions.IncludeScopes, logger.Options.IncludeScopes);
                 Assert.Equal(formatter.FormatterOptions.UseUtcTimestamp, logger.Options.UseUtcTimestamp);
                 Assert.Equal(formatter.FormatterOptions.TimestampFormat, logger.Options.TimestampFormat);
             }
@@ -139,7 +103,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // kept for deprecated apis:
             if (formatter is SimpleConsoleFormatter defaultFormatter)
             {
-                defaultFormatter.FormatterOptions.ColorBehavior = deprecatedFromOptions.DisableColors ? 
+                defaultFormatter.FormatterOptions.ColorBehavior = deprecatedFromOptions.DisableColors ?
                     LoggerColorBehavior.Disabled : LoggerColorBehavior.Enabled;
                 defaultFormatter.FormatterOptions.IncludeScopes = deprecatedFromOptions.IncludeScopes;
                 defaultFormatter.FormatterOptions.TimestampFormat = deprecatedFromOptions.TimestampFormat;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Logging.Test.Console;
+
+namespace Microsoft.Extensions.Logging.Console.Test
+{
+    public class ConsoleTestsBase
+    {
+        internal sealed record SetupDisposeHelper(
+            ConsoleLogger Logger,
+            ConsoleSink Sink,
+            ConsoleSink ErrorSink,
+            Func<LogLevel, string> GetLevelPrefix,
+            int WritesPerMsg,
+            TestLoggerProcessor LoggerProcessor) : IDisposable
+        {
+            public void Dispose() => LoggerProcessor.Dispose();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
@@ -8,14 +8,32 @@ namespace Microsoft.Extensions.Logging.Console.Test
 {
     public class ConsoleTestsBase
     {
-        internal sealed record SetupDisposeHelper(
-            ConsoleLogger Logger,
-            ConsoleSink Sink,
-            ConsoleSink ErrorSink,
-            Func<LogLevel, string> GetLevelPrefix,
-            int WritesPerMsg,
-            TestLoggerProcessor LoggerProcessor) : IDisposable
+        // converting to record fails on net462
+        internal sealed class SetupDisposeHelper : IDisposable
         {
+            public ConsoleLogger Logger;
+            public ConsoleSink Sink;
+            public ConsoleSink ErrorSink;
+            public Func<LogLevel, string> GetLevelPrefix;
+            public int WritesPerMsg;
+            public TestLoggerProcessor LoggerProcessor;
+
+            public SetupDisposeHelper(
+                ConsoleLogger logger,
+                ConsoleSink sink,
+                ConsoleSink errorSink,
+                Func<LogLevel, string> getLevelPrefix,
+                int writesPerMsg,
+                TestLoggerProcessor loggerProcessor)
+            {
+                Logger = logger;
+                Sink = sink;
+                ErrorSink = errorSink;
+                GetLevelPrefix = getLevelPrefix;
+                WritesPerMsg = writesPerMsg;
+                LoggerProcessor = loggerProcessor;
+            }
+
             public void Dispose() => LoggerProcessor.Dispose();
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleTestsBase.cs
@@ -8,32 +8,14 @@ namespace Microsoft.Extensions.Logging.Console.Test
 {
     public class ConsoleTestsBase
     {
-        // converting to record fails on net462
-        internal sealed class SetupDisposeHelper : IDisposable
+        internal sealed record SetupDisposeHelper(
+            ConsoleLogger Logger,
+            ConsoleSink Sink,
+            ConsoleSink ErrorSink,
+            Func<LogLevel, string> GetLevelPrefix,
+            int WritesPerMsg,
+            TestLoggerProcessor LoggerProcessor) : IDisposable
         {
-            public ConsoleLogger Logger;
-            public ConsoleSink Sink;
-            public ConsoleSink ErrorSink;
-            public Func<LogLevel, string> GetLevelPrefix;
-            public int WritesPerMsg;
-            public TestLoggerProcessor LoggerProcessor;
-
-            public SetupDisposeHelper(
-                ConsoleLogger logger,
-                ConsoleSink sink,
-                ConsoleSink errorSink,
-                Func<LogLevel, string> getLevelPrefix,
-                int writesPerMsg,
-                TestLoggerProcessor loggerProcessor)
-            {
-                Logger = logger;
-                Sink = sink;
-                ErrorSink = errorSink;
-                GetLevelPrefix = getLevelPrefix;
-                WritesPerMsg = writesPerMsg;
-                LoggerProcessor = loggerProcessor;
-            }
-
             public void Dispose() => LoggerProcessor.Dispose();
         }
     }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_TimestampFormatSet_ContainsTimestamp()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_NullMessage_LogsWhenMessageIsNotProvided()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_ExceptionWithMessage_ExtractsInfo()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -180,7 +180,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_IncludeScopes_ContainsDuplicateNamedPropertiesInScope_AcceptableJson()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -213,7 +213,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_StateAndScopeAreCollections_IncludesMessageAndCollectionValues()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -249,7 +249,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_StateAndScopeContainsSpecialCaseValue_SerializesValueAsExpected(object value, string expectedJsonValue)
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -279,7 +279,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_StateAndScopeContainsFloatingPointType_SerializesValue(object value)
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -317,7 +317,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_StateAndScopeContainsNullValue_SerializesNull()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,
@@ -346,7 +346,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_ScopeIsIEnumerable_SerializesKeyValuePair()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 simpleOptions: null,
                 systemdOptions: null,

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/Microsoft.Extensions.Logging.Console.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Logging.Console\src\Microsoft.Extensions.Logging.Console.csproj" SkipUseReferenceAssembly="true" />
   </ItemGroup>
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/SimpleConsoleFormatterTests.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Extensions.Logging.Console.Test
     public class SimpleConsoleFormatterTests : ConsoleFormatterTests
     {
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [InlineData(LoggerColorBehavior.Default)]
         [InlineData(LoggerColorBehavior.Enabled)]
         [InlineData(LoggerColorBehavior.Disabled)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/97382", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_WritingScopes_LogsWithCorrectColorsWhenColorEnabled(LoggerColorBehavior colorBehavior)
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Simple },
                 new SimpleConsoleFormatterOptions { IncludeScopes = true, ColorBehavior = colorBehavior }
                 );
@@ -55,11 +55,10 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_NoLogScope_DoesNotWriteAnyScopeContentToOutput()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Simple },
                 new SimpleConsoleFormatterOptions { IncludeScopes = true, ColorBehavior = LoggerColorBehavior.Enabled }
             );
@@ -83,7 +82,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         public void Log_SingleLine_LogsWhenMessageIsNotProvided()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Simple },
                 new SimpleConsoleFormatterOptions { SingleLine = true, ColorBehavior = LoggerColorBehavior.Enabled }
             );
@@ -111,11 +110,10 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Log_SingleLine_LogsWhenBothMessageAndExceptionProvided()
         {
             // Arrange
-            var t = SetUp(
+            using var t = SetUp(
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Simple },
                 new SimpleConsoleFormatterOptions { SingleLine = true, ColorBehavior = LoggerColorBehavior.Enabled }
             );

--- a/src/libraries/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -483,7 +483,6 @@ namespace System.Collections.Concurrent.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(100, 1, 10)]
         [InlineData(4, 100000, 10)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void BlockingCollection_WrappingCollection_ExpectedElementsTransferred(int numThreadsPerConsumerProducer, int numItemsPerThread, int producerSpin)
         {
             var bc = new BlockingCollection<int>(CreateProducerConsumerCollection());


### PR DESCRIPTION
Dispose threads after use, they are scarce/expensive resource in the browser.
After not freeing about 240 threads the browser will run out of memory and crash.

[Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-97270-merge-bfdc5d40b1a749ae9b/WasmTestOnBrowser-Microsoft.Extensions.Logging.Console.Tests/1/console.daad6a54.log?helixlogtype=result)
```
[18:19:55] warn: MONO_WASM [0xdc19c-main]: Failed to find loaded WebWorker, this may deadlock. Please increase the pthreadPoolSize. Running threads 235. Loading workers: 8
[18:19:55] info: [2024-01-22T18:19:55.534Z] [PASS] Microsoft.Extensions.Logging.Console.Test.JsonConsoleFormatterTests.NoMessageOrException_Noop(formatterName: "systemd", level: Critical)
[18:19:56] info: [2024-01-22T18:19:56.631Z] [STRT] Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerExtensionsTests.AddConsole_FormatterNameIsSet_UsingSystemdFormat_IgnoreDeprecatedAndUseFormatterOptionsInstead(formatterName: "Systemd")
[18:20:38] info: Unable to evaluate script: tab crashed
```