### PR TITLE
Fix source_file bug in mono_ppdb_lookup_location_internal

### DIFF
--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -409,7 +409,10 @@ mono_ppdb_lookup_location_internal (MonoImage *image, int idx, uint32_t offset, 
 		if (!first && delta_il == 0) {
 			/* document-record */
 			docidx = mono_metadata_decode_value (ptr, &ptr);
-			docname = get_docname (ppdb, image, docidx);
+			// check the current iloffset to ensure that we do not update docname after the target
+			// offset has been reached (the updated docname will be for the next sequence point)
+			if (iloffset < offset)
+				docname = get_docname (ppdb, image, docidx);
 			continue;
 		}
 		if (!first && iloffset + delta_il > offset)


### PR DESCRIPTION
document-records affect sequence points that follow in the byte stream, not points previously read.

When reading the document-record we may already be at the target offset. Do not update docname local if we have reached the end target already otherwise the wrong source_file will be reported for the requested offset

This is a fix from my recent [PR](https://github.com/dotnet/runtime/pull/96497) that was reverted [here](https://github.com/dotnet/runtime/pull/97359)