### PR TITLE
Fix DangerousAddRef usage

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
@@ -153,7 +153,7 @@ namespace System.Net
             {
                 if (mustRelease)
                 {
-                    context.DangerousRelease();
+                    phContext.DangerousRelease();
                 }
             }
         }

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
@@ -62,16 +62,18 @@ namespace System.Net
 
         public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint qop)
         {
+            bool mustRelease = false;
             try
             {
-                bool ignore = false;
-
-                context.DangerousAddRef(ref ignore);
+                context.DangerousAddRef(ref mustRelease);
                 return Interop.SspiCli.EncryptMessage(ref context._handle, qop, ref inputOutput, 0);
             }
             finally
             {
-                context.DangerousRelease();
+                if (mustRelease)
+                {
+                    context.DangerousRelease();
+                }
             }
         }
 
@@ -80,15 +82,18 @@ namespace System.Net
             int status = (int)Interop.SECURITY_STATUS.InvalidHandle;
             uint qopTemp = 0;
 
+            bool mustRelease = false;
             try
             {
-                bool ignore = false;
-                context.DangerousAddRef(ref ignore);
+                context.DangerousAddRef(ref mustRelease);
                 status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, 0, &qopTemp);
             }
             finally
             {
-                context.DangerousRelease();
+                if (mustRelease)
+                {
+                    context.DangerousRelease();
+                }
             }
 
             qop = qopTemp;
@@ -138,15 +143,18 @@ namespace System.Net
 
         private static int GetSecurityContextToken(SafeDeleteContext phContext, out SecurityContextTokenHandle safeHandle)
         {
+            bool mustRelease = false;
             try
             {
-                bool ignore = false;
-                phContext.DangerousAddRef(ref ignore);
+                phContext.DangerousAddRef(ref mustRelease);
                 return Interop.SspiCli.QuerySecurityContextToken(ref phContext._handle, out safeHandle);
             }
             finally
             {
-                phContext.DangerousRelease();
+                if (mustRelease)
+                {
+                    context.DangerousRelease();
+                }
             }
         }
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
@@ -61,15 +61,18 @@ namespace System.Net
 
         public int EncryptMessage(SafeDeleteContext context, ref Interop.SspiCli.SecBufferDesc inputOutput, uint qop)
         {
+            bool mustRelease = false;
             try
             {
-                bool ignore = false;
-                context.DangerousAddRef(ref ignore);
+                context.DangerousAddRef(ref mustRelease);
                 return Interop.SspiCli.EncryptMessage(ref context._handle, qop, ref inputOutput, 0);
             }
             finally
             {
-                context.DangerousRelease();
+                if (mustRelease)
+                {
+                    context.DangerousRelease();
+                }
             }
         }
 
@@ -78,15 +81,18 @@ namespace System.Net
             int status = (int)Interop.SECURITY_STATUS.InvalidHandle;
             uint qopTemp = 0;
 
+            bool mustRelease = false;
             try
             {
-                bool ignore = false;
-                context.DangerousAddRef(ref ignore);
+                context.DangerousAddRef(ref mustRelease);
                 status = Interop.SspiCli.DecryptMessage(ref context._handle, ref inputOutput, 0, &qopTemp);
             }
             finally
             {
-                context.DangerousRelease();
+                if (mustRelease)
+                {
+                    context.DangerousRelease();
+                }
             }
 
             qop = qopTemp;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
@@ -101,10 +101,10 @@ namespace System.Security.Cryptography.X509Certificates
             ArraySegment<byte> encodedAuthSafe = default;
 
             bool gotRef = false;
-            password.DangerousAddRef(ref gotRef);
 
             try
             {
+                password.DangerousAddRef(ref gotRef);
                 ReadOnlySpan<char> passwordSpan = password.DangerousGetSpan();
 
                 int keyIdx = 0;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixExportProvider.cs
@@ -151,7 +151,11 @@ namespace System.Security.Cryptography.X509Certificates
             }
             finally
             {
-                password.DangerousRelease();
+                if (gotRef)
+                {
+                    password.DangerousRelease();
+                }
+
                 certAttrs.AsSpan(0, certCount).Clear();
                 certBags.AsSpan(0, certCount).Clear();
                 keyBags.AsSpan(0, certCount).Clear();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
@@ -236,7 +236,10 @@ namespace System.Security.Cryptography.X509Certificates
             }
             finally
             {
-                password.DangerousRelease();
+                if (hasRef)
+                {
+                    password.DangerousRelease();
+                }
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
@@ -188,10 +188,10 @@ namespace System.Security.Cryptography.X509Certificates
             _allowDoubleBind = !ephemeralSpecified;
 
             bool hasRef = false;
-            password.DangerousAddRef(ref hasRef);
 
             try
             {
+                password.DangerousAddRef(ref hasRef);
                 ReadOnlySpan<char> passwordChars = password.DangerousGetSpan();
 
                 if (_pfxAsn.MacData.HasValue)


### PR DESCRIPTION
This PR makes calls to `DangerousRelease` conditional on the flag returned from `DangerousAddRef` in few places where they were missing.

I used a rather fancy regex

```
(?<handle>\w+)\.DangerousAddRef\(ref (?<ignore>\w+)\).*?{\s+(?<if>if \(\k<ignore>\))?[^.]+?\k<handle>\.DangerousRelease\(\)
```

to find the offending usages and look for those where the `if` group wasn't matched. While it returns some false positives, I think it does not miss anything.