### PR TITLE
enforce FIELD_OFFSET_LAST_REAL_OFFSET size limit for InlineArrays

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -498,8 +498,8 @@ namespace Internal.TypeSystem
                 long size = instanceByteSizeAndAlignment.Size.AsInt;
                 size *= repeat;
 
-                // limit the max size of array instance to 1MiB
-                const int maxSize = 1024 * 1024;
+                // limit the max size of array instance to FIELD_OFFSET_LAST_REAL_OFFSET for compatibility with coreclr
+                const int maxSize = ((1 << 27) - 1) - 6;
                 if (size > maxSize)
                 {
                     ThrowHelper.ThrowTypeLoadException(ExceptionStringID.ClassLoadValueClassTooLarge, type);

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -1765,7 +1765,13 @@ MethodTableBuilder::BuildMethodTableThrowing(
 
         if (bmtFP->NumInlineArrayElements != 0)
         {
-            GetLayoutInfo()->m_cbManagedSize *= bmtFP->NumInlineArrayElements;
+            INT64 extendedSize = (INT64)GetLayoutInfo()->m_cbManagedSize * (INT64)bmtFP->NumInlineArrayElements;
+            if (extendedSize > FIELD_OFFSET_LAST_REAL_OFFSET)
+            {
+                BuildMethodTableThrowException(IDS_CLASSLOAD_FIELDTOOLARGE);
+            }
+
+            GetLayoutInfo()->m_cbManagedSize = (UINT32)extendedSize;
         }
 
         bmtFP->NumInstanceFieldBytes = GetLayoutInfo()->m_cbManagedSize;
@@ -8445,9 +8451,7 @@ VOID    MethodTableBuilder::PlaceInstanceFields(MethodTable ** pByValueClassCach
         if (bmtFP->NumInlineArrayElements > 1)
         {
             INT64 extendedSize = (INT64)dwNumInstanceFieldBytes * (INT64)bmtFP->NumInlineArrayElements;
-            // limit the max size of array instance to 1MiB
-            const INT64 maxSize = 1024 * 1024;
-            if (extendedSize > maxSize)
+            if (extendedSize > FIELD_OFFSET_LAST_REAL_OFFSET)
             {
                 BuildMethodTableThrowException(IDS_CLASSLOAD_FIELDTOOLARGE);
             }

--- a/src/tests/Loader/classloader/InlineArray/InlineArrayInvalid.cs
+++ b/src/tests/Loader/classloader/InlineArray/InlineArrayInvalid.cs
@@ -38,7 +38,7 @@ public unsafe class Validate
         });
     }
 
-    [InlineArray(0x20000000)]
+    [InlineArray(16777216)]
     private struct TooLarge
     {
         public long field;

--- a/src/tests/Loader/classloader/InlineArray/InvalidCSharpInlineArray.il
+++ b/src/tests/Loader/classloader/InlineArray/InvalidCSharpInlineArray.il
@@ -23,15 +23,6 @@
     .field public int32 'field'
 }
 
-.class public sequential ansi sealed beforefieldinit TooLarge
-    extends [System.Runtime]System.ValueType
-{
-    .custom instance void [System.Runtime]System.Runtime.CompilerServices.InlineArrayAttribute::.ctor(int32) = (
-        01 00 00 00 00 20 00 00
-    )
-    .field public int64 'field'
-}
-
 .class public sequential ansi sealed beforefieldinit NegativeLength
     extends [System.Runtime]System.ValueType
 {


### PR DESCRIPTION
Fixes: #95193

- Fixes a faulty test that was passing for a wrong reason
- Enforces the limit in a case of sequential layout 
- Increases the limit to `FIELD_OFFSET_LAST_REAL_OFFSET`
