### PR TITLE
JIT: Improve call args interference checking when stores are involved

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3487,7 +3487,7 @@ public:
     bool gtMarkAddrMode(GenTree* addr, int* costEx, int* costSz, var_types type);
 
     unsigned gtSetEvalOrder(GenTree* tree);
-    bool gtHaveStoreInterference(GenTree* treeWithStores, GenTree* tree);
+    bool gtMayHaveStoreInterference(GenTree* treeWithStores, GenTree* tree);
     bool gtTreeHasLocalRead(GenTree* tree, unsigned lclNum);
 
     void gtSetStmtInfo(Statement* stmt);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3487,6 +3487,8 @@ public:
     bool gtMarkAddrMode(GenTree* addr, int* costEx, int* costSz, var_types type);
 
     unsigned gtSetEvalOrder(GenTree* tree);
+    bool gtHaveStoreInterference(GenTree* treeWithStores, GenTree* tree);
+    bool gtTreeHasLocalRead(GenTree* tree, unsigned lclNum);
 
     void gtSetStmtInfo(Statement* stmt);
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -3350,21 +3350,6 @@ void Compiler::fgDebugCheckFlags(GenTree* tree, BasicBlock* block)
                 assert(doesMethodHaveRecursiveTailcall());
                 assert(block->HasFlag(BBF_RECURSIVE_TAILCALL));
             }
-
-            for (CallArg& arg : call->gtArgs.Args())
-            {
-                // TODO-Cleanup: this is a patch for a violation in our GTF_ASG propagation.
-                // see https://github.com/dotnet/runtime/issues/13758
-                if (arg.GetEarlyNode() != nullptr)
-                {
-                    actualFlags |= arg.GetEarlyNode()->gtFlags & GTF_ASG;
-                }
-
-                if (arg.GetLateNode() != nullptr)
-                {
-                    actualFlags |= arg.GetLateNode()->gtFlags & GTF_ASG;
-                }
-            }
         }
         break;
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6327,9 +6327,10 @@ DONE:
 //
 // Returns:
 //   False if there is no interference. Returns true if there is any GT_LCL_VAR
-//   or GT_LCL_FLD node whose value depends on "lclNum". May also return true
-//   in cases without interference if the trees are too large and the function
-//   runs out of budget.
+//   or GT_LCL_FLD in "tree" whose value depends on a local stored in
+//   "treeWithStores". May also return true in cases without interference if
+//   the trees are too large and the function runs out of budget, or in
+//   MinOpts.
 //
 bool Compiler::gtMayHaveStoreInterference(GenTree* treeWithStores, GenTree* tree)
 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6329,8 +6329,7 @@ DONE:
 //   False if there is no interference. Returns true if there is any GT_LCL_VAR
 //   or GT_LCL_FLD in "tree" whose value depends on a local stored in
 //   "treeWithStores". May also return true in cases without interference if
-//   the trees are too large and the function runs out of budget, or in
-//   MinOpts.
+//   the trees are too large and the function runs out of budget.
 //
 bool Compiler::gtMayHaveStoreInterference(GenTree* treeWithStores, GenTree* tree)
 {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -6338,7 +6338,7 @@ bool Compiler::gtHaveStoreInterference(GenTree* treeWithStores, GenTree* tree)
 
     class Visitor final : public GenTreeVisitor<Visitor>
     {
-        GenTree* m_op1;
+        GenTree* m_readTree;
 
     public:
         enum
@@ -6346,7 +6346,7 @@ bool Compiler::gtHaveStoreInterference(GenTree* treeWithStores, GenTree* tree)
             DoPreOrder = true,
         };
 
-        Visitor(Compiler* compiler, GenTree* op1) : GenTreeVisitor(compiler), m_op1(op1)
+        Visitor(Compiler* compiler, GenTree* readTree) : GenTreeVisitor(compiler), m_readTree(readTree)
         {
         }
 
@@ -6360,7 +6360,7 @@ bool Compiler::gtHaveStoreInterference(GenTree* treeWithStores, GenTree* tree)
 
             if (node->OperIsLocalStore())
             {
-                if (m_compiler->gtTreeHasLocalRead(m_op1, node->AsLclVarCommon()->GetLclNum()))
+                if (m_compiler->gtTreeHasLocalRead(m_readTree, node->AsLclVarCommon()->GetLclNum()))
                 {
                     return WALK_ABORT;
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -960,7 +960,8 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                     continue;
                 }
 
-                if (comp->gtMayHaveStoreInterference(argx, prevArg.GetEarlyNode()))
+                if (((prevArg.GetEarlyNode()->gtFlags & GTF_ALL_EFFECT) != 0) ||
+                    comp->gtMayHaveStoreInterference(argx, prevArg.GetEarlyNode()))
                 {
                     SetNeedsTemp(&prevArg);
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -955,7 +955,7 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                 }
 #endif
 
-                if (prevArg.GetEarlyNode() == nullptr)
+                if ((prevArg.GetEarlyNode() == nullptr) || prevArg.m_needTmp)
                 {
                     continue;
                 }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -912,20 +912,15 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
         }
 #endif // FEATURE_ARG_SPLIT
 
-        /* If the argument tree contains an assignment (GTF_ASG) then the argument and
-           and every earlier argument (except constants) must be evaluated into temps
-           since there may be other arguments that follow and they may use the value being assigned.
-
-           EXAMPLE: ArgTab is "a, a=5, a"
-                    -> when we see the second arg "a=5"
-                       we know the first two arguments "a, a=5" have to be evaluated into temps
-
-           For the case of an assignment, we only know that there exist some assignment someplace
-           in the tree.  We don't know what is being assigned so we are very conservative here
-           and assume that any local variable could have been assigned.
-         */
-
-        if (argx->gtFlags & GTF_ASG)
+        // If the argument tree contains an assignment (GTF_ASG) then the argument and
+        // and every earlier argument (except constants) must be evaluated into temps
+        // since there may be other arguments that follow and they may use the value being assigned.
+        //
+        // EXAMPLE: ArgTab is "a, a=5, a"
+        //          -> when we see the second arg "a=5"
+        //             we know the first two arguments "a, a=5" have to be evaluated into temps
+        //
+        if ((argx->gtFlags & GTF_ASG) != 0)
         {
             // If this is not the only argument, or it's a copyblk, or it
             // already evaluates the expression to a tmp then we need a temp in
@@ -942,8 +937,8 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                 assert(argx->IsValue());
             }
 
-            // For all previous arguments, unless they are a simple constant
-            //  we require that they be evaluated into temps
+            // For all previous arguments that may interfere with the store we
+            // require that they be evaluated into temps.
             for (CallArg& prevArg : Args())
             {
                 if (&prevArg == &arg)
@@ -960,7 +955,15 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                 }
 #endif
 
-                if ((prevArg.GetEarlyNode() != nullptr) && !prevArg.GetEarlyNode()->IsInvariant())
+                if (prevArg.GetEarlyNode() == nullptr)
+                {
+                    continue;
+                }
+
+                bool interferes = comp->opts.OptimizationEnabled()
+                                      ? comp->gtHaveStoreInterference(argx, prevArg.GetEarlyNode())
+                                      : !prevArg.GetEarlyNode()->IsInvariant();
+                if (interferes)
                 {
                     SetNeedsTemp(&prevArg);
                 }
@@ -1827,6 +1830,7 @@ void CallArgs::EvalArgsToTemps(Compiler* comp, GenTreeCall* call)
         if (setupArg != nullptr)
         {
             arg.SetEarlyNode(setupArg);
+            call->gtFlags |= setupArg->gtFlags & GTF_SIDE_EFFECT;
 
             // Make sure we do not break recognition of retbuf-as-local
             // optimization here. If this is hit it indicates that we are
@@ -3382,6 +3386,11 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
         if (makeOutArgCopy)
         {
             fgMakeOutgoingStructArgCopy(call, &arg);
+
+            if (arg.GetEarlyNode() != nullptr)
+            {
+                flagsSummary |= arg.GetEarlyNode()->gtFlags;
+            }
         }
 
         if (argx->gtOper == GT_MKREFANY)
@@ -3413,6 +3422,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
             // Change the expression to "(tmp=val)"
             arg.SetEarlyNode(store);
             call->gtArgs.SetTemp(&arg, tmp);
+            flagsSummary |= GTF_ASG;
             hasMultiregStructArgs |= ((arg.AbiInfo.ArgType == TYP_STRUCT) && !arg.AbiInfo.PassedByRef);
 #endif // !TARGET_X86
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -960,10 +960,7 @@ void CallArgs::ArgsComplete(Compiler* comp, GenTreeCall* call)
                     continue;
                 }
 
-                bool interferes = comp->opts.OptimizationEnabled()
-                                      ? comp->gtHaveStoreInterference(argx, prevArg.GetEarlyNode())
-                                      : !prevArg.GetEarlyNode()->IsInvariant();
-                if (interferes)
+                if (comp->gtMayHaveStoreInterference(argx, prevArg.GetEarlyNode()))
                 {
                     SetNeedsTemp(&prevArg);
                 }

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2038,10 +2038,18 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
             continue;
         }
 
+        if (!prevTree->OperIs(GT_STORE_LCL_VAR))
+        {
+            JITDUMP(" -- prev tree not STORE_LCL_VAR\n");
+            break;
+        }
+
+        GenTree* const prevTreeData = prevTree->AsLclVar()->Data();
+
         // If prevTree has side effects, bail, unless it is in the immediately preceding statement.
         // We'll handle exceptional side effects with VNs below.
         //
-        if ((prevTree->gtFlags & (GTF_CALL | GTF_ORDER_SIDEEFF)) != 0)
+        if (((prevTree->gtFlags & (GTF_CALL | GTF_ORDER_SIDEEFF)) != 0) || ((prevTreeData->gtFlags & GTF_ASG) != 0))
         {
             if (prevStmt->GetNextStmt() != stmt)
             {
@@ -2053,28 +2061,11 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
             sideEffect = true;
         }
 
-        if (!prevTree->OperIs(GT_STORE_LCL_VAR))
-        {
-            JITDUMP(" -- prev tree not STORE_LCL_VAR\n");
-            break;
-        }
-
-        GenTree* const prevTreeData = prevTree->AsLclVar()->Data();
-
         // If we are seeing PHIs we have run out of interesting stmts.
         //
         if (prevTreeData->OperIs(GT_PHI))
         {
             JITDUMP(" -- prev tree is a phi\n");
-            break;
-        }
-
-        // Bail if value has an embedded assignment. We could handle this
-        // if we generalized the interference check we run below.
-        //
-        if ((prevTreeData->gtFlags & GTF_ASG) != 0)
-        {
-            JITDUMP(" -- prev tree RHS has embedded assignment\n");
             break;
         }
 
@@ -2101,6 +2092,14 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         }
 
         definedLocals[definedLocalsCount++] = prevTreeLclNum;
+
+        // Heuristic: only forward sub a relop
+        //
+        if (!prevTreeData->OperIsCompare())
+        {
+            JITDUMP(" -- prev tree is not relop\n");
+            continue;
+        }
 
         // If the normal liberal VN of RHS is the normal liberal VN of the current tree, or is "related",
         // consider forward sub.
@@ -2148,7 +2147,7 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
 
         for (unsigned int i = 0; i < definedLocalsCount; i++)
         {
-            if (gtHasRef(prevTreeData, definedLocals[i]))
+            if (gtTreeHasLocalRead(prevTreeData, definedLocals[i]))
             {
                 JITDUMP(" -- prev tree ref to V%02u interferes\n", definedLocals[i]);
                 interferes = true;
@@ -2161,12 +2160,10 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
             break;
         }
 
-        // Heuristic: only forward sub a relop
-        //
-        if (!prevTreeData->OperIsCompare())
+        if (gtMayHaveStoreInterference(prevTreeData, tree))
         {
-            JITDUMP(" -- prev tree is not relop\n");
-            continue;
+            JITDUMP(" -- prev tree has an embedded store that interferes with [%06u]\n", dspTreeID(tree));
+            break;
         }
 
         // If the lcl defined here is live out, forward sub is problematic.
@@ -2191,7 +2188,7 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
             // replacing.
             for (Statement* cur = prevStmt->GetNextStmt(); cur != stmt; cur = cur->GetNextStmt())
             {
-                if (gtHasRef(cur->GetRootNode(), prevTreeLclNum))
+                if (gtTreeHasLocalRead(cur->GetRootNode(), prevTreeLclNum))
                 {
                     JITDUMP("-- prev tree has GTF_GLOB_REF and " FMT_STMT " has an interfering use\n", cur->GetID());
                     hasExtraUses = true;

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -2093,14 +2093,6 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
 
         definedLocals[definedLocalsCount++] = prevTreeLclNum;
 
-        // Heuristic: only forward sub a relop
-        //
-        if (!prevTreeData->OperIsCompare())
-        {
-            JITDUMP(" -- prev tree is not relop\n");
-            continue;
-        }
-
         // If the normal liberal VN of RHS is the normal liberal VN of the current tree, or is "related",
         // consider forward sub.
         //
@@ -2164,6 +2156,14 @@ bool Compiler::optRedundantRelop(BasicBlock* const block)
         {
             JITDUMP(" -- prev tree has an embedded store that interferes with [%06u]\n", dspTreeID(tree));
             break;
+        }
+
+        // Heuristic: only forward sub a relop
+        //
+        if (!prevTreeData->OperIsCompare())
+        {
+            JITDUMP(" -- prev tree is not relop\n");
+            continue;
         }
 
         // If the lcl defined here is live out, forward sub is problematic.


### PR DESCRIPTION
- Fix the propagation of `GTF_ASG` during call args morphing
- Introduce `Compiler::gtMayHaveStoreInterference` that can check whether two trees interfere with each other due to a store in one tree that stores to a local read by the other tree
- Use the new helper when checking for whether we should reverse `GT_STOREIND` nodes
- Use the new helper when deciding whether previous args need to be evaluated to temps because we see an argument with an embedded store (typically a call now that we propagate flags correctly).
- Use the new helpers when checking interference in `optRedundantRelop`

Fix #13758