### PR TITLE
Make JsonReaderState a readonly struct.

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -190,10 +190,10 @@ namespace System.Text.Json
         public System.Text.Json.JsonCommentHandling CommentHandling { readonly get { throw null; } set { } }
         public int MaxDepth { readonly get { throw null; } set { } }
     }
-    public partial struct JsonReaderState
+    public readonly partial struct JsonReaderState
     {
-        private object _dummy;
-        private int _dummyPrimitive;
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public JsonReaderState(System.Text.Json.JsonReaderOptions options = default(System.Text.Json.JsonReaderOptions)) { throw null; }
         public System.Text.Json.JsonReaderOptions Options { get { throw null; } }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderState.cs
@@ -11,18 +11,18 @@ namespace System.Text.Json
     /// this type can survive across async/await boundaries and hence this type is required to provide
     /// support for reading in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader"/>.
     /// </summary>
-    public struct JsonReaderState
+    public readonly struct JsonReaderState
     {
-        internal long _lineNumber;
-        internal long _bytePositionInLine;
-        internal bool _inObject;
-        internal bool _isNotPrimitive;
-        internal bool _valueIsEscaped;
-        internal bool _trailingCommaBeforeComment;
-        internal JsonTokenType _tokenType;
-        internal JsonTokenType _previousTokenType;
-        internal JsonReaderOptions _readerOptions;
-        internal BitStack _bitStack;
+        internal readonly long _lineNumber;
+        internal readonly long _bytePositionInLine;
+        internal readonly bool _inObject;
+        internal readonly bool _isNotPrimitive;
+        internal readonly bool _valueIsEscaped;
+        internal readonly bool _trailingCommaBeforeComment;
+        internal readonly JsonTokenType _tokenType;
+        internal readonly JsonTokenType _previousTokenType;
+        internal readonly JsonReaderOptions _readerOptions;
+        internal readonly BitStack _bitStack;
 
         /// <summary>
         /// Constructs a new <see cref="JsonReaderState"/> instance.
@@ -51,6 +51,30 @@ namespace System.Text.Json
             // Only allocate if the user reads a JSON payload beyond the depth that the _allocationFreeContainer can handle.
             // This way we avoid allocations in the common, default cases, and allocate lazily.
             _bitStack = default;
+        }
+
+        internal JsonReaderState(
+            long lineNumber,
+            long bytePositionInLine,
+            bool inObject,
+            bool isNotPrimitive,
+            bool valueIsEscaped,
+            bool trailingCommaBeforeComment,
+            JsonTokenType tokenType,
+            JsonTokenType previousTokenType,
+            JsonReaderOptions readerOptions,
+            BitStack bitStack)
+        {
+            _lineNumber = lineNumber;
+            _bytePositionInLine = bytePositionInLine;
+            _inObject = inObject;
+            _isNotPrimitive = isNotPrimitive;
+            _valueIsEscaped = valueIsEscaped;
+            _trailingCommaBeforeComment = trailingCommaBeforeComment;
+            _tokenType = tokenType;
+            _previousTokenType = previousTokenType;
+            _readerOptions = readerOptions;
+            _bitStack = bitStack;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.cs
@@ -47,11 +47,11 @@ namespace System.Text.Json
         private SequencePosition _currentPosition;
         private readonly ReadOnlySequence<byte> _sequence;
 
-        private bool IsLastSpan => _isFinalBlock && (!_isMultiSegment || _isLastSegment);
+        private readonly bool IsLastSpan => _isFinalBlock && (!_isMultiSegment || _isLastSegment);
 
-        internal ReadOnlySequence<byte> OriginalSequence => _sequence;
+        internal readonly ReadOnlySequence<byte> OriginalSequence => _sequence;
 
-        internal ReadOnlySpan<byte> OriginalSpan => _sequence.IsEmpty ? _buffer : default;
+        internal readonly ReadOnlySpan<byte> OriginalSpan => _sequence.IsEmpty ? _buffer : default;
 
         internal readonly int ValueLength => HasValueSequence ? checked((int)ValueSequence.Length) : ValueSpan.Length;
 
@@ -184,18 +184,18 @@ namespace System.Text.Json
         /// in more data asynchronously before continuing with a new instance of the <see cref="Utf8JsonReader"/>.
         /// </summary>
         public readonly JsonReaderState CurrentState => new JsonReaderState
-        {
-            _lineNumber = _lineNumber,
-            _bytePositionInLine = _bytePositionInLine,
-            _inObject = _inObject,
-            _isNotPrimitive = _isNotPrimitive,
-            _valueIsEscaped = ValueIsEscaped,
-            _trailingCommaBeforeComment = _trailingCommaBeforeComment,
-            _tokenType = _tokenType,
-            _previousTokenType = _previousTokenType,
-            _readerOptions = _readerOptions,
-            _bitStack = _bitStack,
-        };
+        (
+            lineNumber: _lineNumber,
+            bytePositionInLine: _bytePositionInLine,
+            inObject: _inObject,
+            isNotPrimitive: _isNotPrimitive,
+            valueIsEscaped: ValueIsEscaped,
+            trailingCommaBeforeComment: _trailingCommaBeforeComment,
+            tokenType: _tokenType,
+            previousTokenType: _previousTokenType,
+            readerOptions: _readerOptions,
+            bitStack: _bitStack
+        );
 
         /// <summary>
         /// Constructs a new <see cref="Utf8JsonReader"/> instance.


### PR DESCRIPTION
Explicitly marks the `JsonReaderState` type a readonly struct, which should help avoid creating defensive copies of this rather large value type in certain scenaria. This is not a breaking change and shouldn't require API review to go ahead.