### PR TITLE
Ensure that TYP_MASK locals are properly tracked and have correct info in the JIT dump

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3659,6 +3659,12 @@ void Compiler::dumpRegMask(regMaskTP regs) const
     {
         printf("[allDouble]");
     }
+#ifdef TARGET_XARCH
+    else if (regs == RBM_ALLMASK)
+    {
+        printf("[allMask]");
+    }
+#endif // TARGET_XARCH
     else
     {
         dspRegMask(regs);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1010,14 +1010,19 @@ public:
         regMaskTP regMask = RBM_NONE;
         if (GetRegNum() != REG_STK)
         {
-            if (varTypeUsesIntReg(this))
+            if (varTypeUsesFloatReg(this))
             {
-                regMask = genRegMask(GetRegNum());
+                regMask = genRegMaskFloat(GetRegNum() ARM_ARG(TypeGet()));
             }
             else
             {
-                assert(varTypeUsesFloatReg(this));
-                regMask = genRegMaskFloat(GetRegNum() ARM_ARG(TypeGet()));
+#ifdef TARGET_XARCH
+                assert(varTypeUsesIntReg(this) || varTypeUsesMaskReg(this));
+#else
+                assert(varTypeUsesIntReg(this));
+#endif
+
+                regMask = genRegMask(GetRegNum());
             }
         }
         return regMask;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7901,8 +7901,7 @@ public:
     static bool varTypeNeedsPartialCalleeSave(var_types type)
     {
         assert(type != TYP_STRUCT);
-        assert((type < TYP_SIMD32) || (type == TYP_SIMD32) || (type == TYP_SIMD64));
-        return type >= TYP_SIMD32;
+        return (type == TYP_SIMD32) || (type == TYP_SIMD64);
     }
 #elif defined(TARGET_ARM64)
     static bool varTypeNeedsPartialCalleeSave(var_types type)

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3651,6 +3651,7 @@ void Compiler::lvaSortByRefCount()
 #if defined(TARGET_XARCH)
                 case TYP_SIMD32:
                 case TYP_SIMD64:
+                case TYP_MASK:
 #endif // TARGET_XARCH
 #endif // FEATURE_SIMD
                 case TYP_STRUCT:

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1695,6 +1695,7 @@ bool LinearScan::isRegCandidate(LclVarDsc* varDsc)
 #if defined(TARGET_XARCH)
         case TYP_SIMD32:
         case TYP_SIMD64:
+        case TYP_MASK:
 #endif // TARGET_XARCH
         {
             return !varDsc->lvPromoted;

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -453,6 +453,55 @@ void dspRegMask(regMaskTP regMask, size_t minSiz)
         regPrev = regNum;
     }
 
+#ifdef TARGET_XARCH
+    if (strlen(sep) > 0)
+    {
+        // We've already printed something.
+        sep = " ";
+    }
+    inRegRange = false;
+    regPrev    = REG_NA;
+    regHead    = REG_NA;
+    for (regNumber regNum = REG_MASK_FIRST; regNum <= REG_MASK_LAST; regNum = REG_NEXT(regNum))
+    {
+        regMaskTP regBit = genRegMask(regNum);
+
+        if (regMask & regBit)
+        {
+            if (!inRegRange || (regNum == REG_MASK_LAST))
+            {
+                const char* nam = getRegName(regNum);
+                printf("%s%s", sep, nam);
+                minSiz -= strlen(sep) + strlen(nam);
+                sep     = "-";
+                regHead = regNum;
+            }
+            inRegRange = true;
+        }
+        else
+        {
+            if (inRegRange)
+            {
+                if (regPrev != regHead)
+                {
+                    const char* nam = getRegName(regPrev);
+                    printf("%s%s", sep, nam);
+                    minSiz -= (strlen(sep) + strlen(nam));
+                }
+                sep = " ";
+            }
+            inRegRange = false;
+        }
+
+        if (regBit > regMask)
+        {
+            break;
+        }
+
+        regPrev = regNum;
+    }
+#endif // TARGET_XARCH
+
     printf("]");
 
     while ((int)minSiz > 0)


### PR DESCRIPTION
### Code

```csharp
public static Vector512<float> M(Vector512<float> x, Vector512<float> y, Vector512<float> z)
{
    var tmp = Avx512F.BlendVariable(x, y, Avx512F.CompareEqual(y, z));
    return Avx512F.BlendVariable(tmp, z, Avx512F.CompareEqual(y, z));
}
```

### Before

```asm
; Method Program:M(System.Runtime.Intrinsics.Vector512`1[float],System.Runtime.Intrinsics.Vector512`1[float],System.Runtime.Intrinsics.Vector512`1[float]):System.Runtime.Intrinsics.Vector512`1[float] (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rax
       vzeroupper 

G_M000_IG02:                ;; offset=0x0004
       vmovups  zmm0, zmmword ptr [rdx]
       vmovups  zmm1, zmmword ptr [r8]
       vmovups  zmm2, zmmword ptr [r9]
       vcmpps   k1, zmm1, zmm2, 0
       kmovq    qword ptr [rsp], k1
       vblendmps zmm0 {k1}, zmm0, zmm1
       kmovq    k1, qword ptr [rsp]
       vblendmps zmm0 {k1}, zmm0, zmm2
       vmovups  zmmword ptr [rcx], zmm0
       mov      rax, rcx

G_M000_IG03:                ;; offset=0x003E
       vzeroupper 
       add      rsp, 8
       ret      
; Total bytes of code: 70
```

### After

```asm
; Method Program:M(System.Runtime.Intrinsics.Vector512`1[float],System.Runtime.Intrinsics.Vector512`1[float],System.Runtime.Intrinsics.Vector512`1[float]):System.Runtime.Intrinsics.Vector512`1[float] (FullOpts)
G_M53186_IG01:  ;; offset=0x0000
       vzeroupper 
						;; size=3 bbWeight=1 PerfScore 1.00

G_M53186_IG02:  ;; offset=0x0003
       vmovups  zmm0, zmmword ptr [rdx]
       vmovups  zmm1, zmmword ptr [r8]
       vmovups  zmm2, zmmword ptr [r9]
       vcmpps   k1, zmm1, zmm2, 0
       vblendmps zmm0 {k1}, zmm0, zmm1
       vblendmps zmm0 {k1}, zmm0, zmm2
       vmovups  zmmword ptr [rcx], zmm0
       mov      rax, rcx
						;; size=46 bbWeight=1 PerfScore 18.25

G_M53186_IG03:  ;; offset=0x0031
       vzeroupper 
       ret      
						;; size=4 bbWeight=1 PerfScore 2.00
; Total bytes of code: 53
```