### PR TITLE
[wasi/wasm] EmccCompile.cs: quote the compiler path

### DIFF
--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -193,7 +193,7 @@ namespace Microsoft.WebAssembly.Build.Tasks
                 string tmpObjFile = Path.GetTempFileName();
                 try
                 {
-                    string command = $"{CompilerBinaryPath} {Arguments} -c -o \"{tmpObjFile}\" \"{srcFile}\"";
+                    string command = $"\"{CompilerBinaryPath}\" {Arguments} -c -o \"{tmpObjFile}\" \"{srcFile}\"";
                     var startTime = DateTime.Now;
 
                     // Log the command in a compact format which can be copy pasted


### PR DESCRIPTION
This broke in PR #95051 which changed the task to use a custom path to
the compiler instead of using `emcc` from `PATH`.

Fixes https://github.com/dotnet/AspNetCore-ManualTests/issues/2594 .
