### PR TITLE
Update SystemDataSqlClientVersion from 4.8.5 -> 4.8.6

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -124,7 +124,7 @@
     <SystemBuffersVersion>4.5.1</SystemBuffersVersion>
     <SystemCollectionsImmutableVersion>7.0.0</SystemCollectionsImmutableVersion>
     <SystemComponentModelAnnotationsVersion>5.0.0</SystemComponentModelAnnotationsVersion>
-    <SystemDataSqlClientVersion>4.8.5</SystemDataSqlClientVersion>
+    <SystemDataSqlClientVersion>4.8.6</SystemDataSqlClientVersion>
     <SystemDrawingCommonVersion>8.0.0</SystemDrawingCommonVersion>
     <SystemIOFileSystemAccessControlVersion>5.0.0</SystemIOFileSystemAccessControlVersion>
     <SystemMemoryVersion>4.5.5</SystemMemoryVersion>


### PR DESCRIPTION
Update SystemDataSqlClientVersion from 4.8.5 -> 4.8.6 for component governance warning.
Same idea as previous update: https://github.com/dotnet/runtime/pull/78774