### PR TITLE
Remove remaining references to obsolete JIT configuration variables

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -3047,19 +3047,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
     }
 
-// These are left for backward compatibility, to be removed
-#ifdef DEBUG
-    if (JitConfig.JitDasmWithAlignmentBoundaries())
-    {
-        opts.disAlignment = true;
-    }
-    if (JitConfig.JitDiffableDasm())
-    {
-        opts.disDiffable = true;
-        opts.dspDiffable = true;
-    }
-#endif // DEBUG
-
 //-------------------------------------------------------------------------
 
 #ifdef DEBUG

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -261,12 +261,6 @@ CONFIG_INTEGER(JitDisasmWithAlignmentBoundaries, W("JitDisasmWithAlignmentBounda
 CONFIG_INTEGER(JitDisasmWithCodeBytes, W("JitDisasmWithCodeBytes"), 0) // Print the instruction code bytes
 CONFIG_STRING(JitStdOutFile, W("JitStdOutFile")) // If set, sends JIT's stdout output to this file.
 
-// These are supported for backward compatibility, to be removed:
-#ifdef DEBUG
-CONFIG_INTEGER(JitDiffableDasm, W("JitDiffableDasm"), 0)
-CONFIG_INTEGER(JitDasmWithAlignmentBoundaries, W("JitDasmWithAlignmentBoundaries"), 0)
-#endif
-
 CONFIG_INTEGER(RichDebugInfo, W("RichDebugInfo"), 0) // If 1, keep rich debug info and report it back to the EE
 
 #ifdef DEBUG

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/jithost.cpp
@@ -34,7 +34,6 @@ bool RecordVariable(const WCHAR* key)
         W("EnableExtraSuperPmiQueries"),
         W("JitDisasm"),
         W("JitDump"),
-        W("JitDasmWithAlignmentBoundaries"), // to be removed
         W("JitDisasmWithAlignmentBoundaries"),
         W("JitDumpASCII"),
         W("JitHashBreak"),

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -152,7 +152,7 @@ if [[ ( -z "$DOTNET_JitStress" ) && ( -z "$DOTNET_JitStressRegs" ) && ( -z "$DOT
     ERRORLEVEL=$?
     export DOTNET_JitDisasm=`cat $(BashDisasmListOutputFile)`
     export DOTNET_JitDisasmTesting=1
-    export DOTNET_JitDiffableDasm=1
+    export DOTNET_JitDisasmDiffable=1
     export DOTNET_JitStdOutFile=$(BashDisasmOutputFile)
     rm -f $(BashDisasmOutputFile)
     if [[ $ERRORLEVEL -ne 0 ]]
@@ -200,7 +200,7 @@ IF "%DOTNET_JitStress%"=="" IF "%DOTNET_JitStressRegs%"=="" IF "%DOTNET_Tailcall
     )', '%0d%0a')
     for /F "delims=" %%g in ($(BatchDisasmListOutputFile)) do set DOTNET_JitDisasm=%%g
     set DOTNET_JitDisasmTesting=1
-    set DOTNET_JitDiffableDasm=1
+    set DOTNET_JitDisasmDiffable=1
     set DOTNET_JitStdOutFile=$(BatchDisasmOutputFile)
     del $(BatchDisasmOutputFile) >nul 2>&1
 )


### PR DESCRIPTION
Rename a couple remaining references:

`DOTNET_JitDiffableDasm` => `DOTNET_JitDisasmDiffable`
`DOTNET_JitDasmWithAlignmentBoundaries` => `DOTNET_JitDisasmWithAlignmentBoundaries`

Follow-up to #82666