### PR TITLE
Add Arm64 encodings for SVE_DD_2A & SVE_DG_2A

### DIFF
--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -4818,6 +4818,16 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R_I(INS_sve_cmpls, EA_SCALABLE, REG_P0, REG_P3, REG_V9, 127,
                                 INS_OPTS_SCALABLE_D); /* CMPLS   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, #<imm> */
 
+    // IF_SVE_DD_2A
+    theEmitter->emitIns_R_R(INS_sve_pfirst, EA_SCALABLE, REG_P0, REG_P15,
+                            INS_OPTS_SCALABLE_B); // PFIRST  <Pdn>.B, <Pg>, <Pdn>.B
+
+    // IF_SVE_DG_2A
+    theEmitter->emitIns_R_R(INS_sve_rdffr, EA_SCALABLE, REG_P10, REG_P15,
+                            INS_OPTS_SCALABLE_B); // RDFFR   <Pd>.B, <Pg>/Z
+    theEmitter->emitIns_R_R(INS_sve_rdffrs, EA_SCALABLE, REG_P7, REG_P14,
+                            INS_OPTS_SCALABLE_B); // RDFFRS  <Pd>.B, <Pg>/Z
+
     // IF_SVE_EP_3A
     theEmitter->emitIns_R_R_R(INS_sve_shadd, EA_SCALABLE, REG_V15, REG_P0, REG_V10,
                               INS_OPTS_SCALABLE_B); // SHADD   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -14793,10 +14793,12 @@ void emitter::emitIns_Call(EmitCallType          callType,
         case IF_SVE_CX_4A_A:
         case IF_SVE_CY_3A:
         case IF_SVE_CY_3B:
-        case IF_SVE_DG_2A:
         case IF_SVE_GE_4A:
         case IF_SVE_HT_4A:
             assert((regpos == 1) || (regpos == 2));
+            return ((regpos == 1) ? PREDICATE_SIZED : PREDICATE_ZERO);
+
+        case IF_SVE_DG_2A:
             return ((regpos == 1) ? PREDICATE_SIZED : PREDICATE_ZERO);
 
         default:


### PR DESCRIPTION
These groups emit predicated version of `pfirst`, `rdffr` & `rdffrs` instructions.

This clr output matches the one from capstone.

```
...
pfirst p0.b, p15, p0.b
rdffr p10.b, p15/z
rdffrs p7.b, p14/z
...
```

Contribute towards #94549.