### PR TITLE
Fix XML docs in TimeProvider

### DIFF
--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -121,7 +121,7 @@ namespace System
         /// Gets the elapsed time since the <paramref name="startingTimestamp"/> value retrieved using <see cref="GetTimestamp"/>.
         /// </summary>
         /// <param name="startingTimestamp">The timestamp marking the beginning of the time period.</param>
-        /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting timestamp and the time of this call./></returns>
+        /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting timestamp and the time of this call</returns>
         public TimeSpan GetElapsedTime(long startingTimestamp) => GetElapsedTime(startingTimestamp, GetTimestamp());
 
         /// <summary>Creates a new <see cref="ITimer"/> instance, using <see cref="TimeSpan"/> values to measure time intervals.</summary>

--- a/src/libraries/Common/src/System/TimeProvider.cs
+++ b/src/libraries/Common/src/System/TimeProvider.cs
@@ -121,7 +121,7 @@ namespace System
         /// Gets the elapsed time since the <paramref name="startingTimestamp"/> value retrieved using <see cref="GetTimestamp"/>.
         /// </summary>
         /// <param name="startingTimestamp">The timestamp marking the beginning of the time period.</param>
-        /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting timestamp and the time of this call</returns>
+        /// <returns>A <see cref="TimeSpan"/> for the elapsed time between the starting timestamp and the time of this call.</returns>
         public TimeSpan GetElapsedTime(long startingTimestamp) => GetElapsedTime(startingTimestamp, GetTimestamp());
 
         /// <summary>Creates a new <see cref="ITimer"/> instance, using <see cref="TimeSpan"/> values to measure time intervals.</summary>


### PR DESCRIPTION
Right now the docs are rendered this way:
![image](https://github.com/dotnet/runtime/assets/6381023/100d844e-ab09-42b8-9803-dcc08dd995f1)
