### PR TITLE
Revert "Don't copy runner to test output during regular builds"

### DIFF
--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -68,8 +68,8 @@
 
   <!-- ResolveAssemblyReferences is the target that populates ReferenceCopyLocalPaths which is what is copied to output directory. -->
   <Target Name="CopyRunnerToOutputDirectory" BeforeTargets="ResolveAssemblyReferences" Condition="'$(TargetsMobile)' != 'true' or '$(BundleXunitRunner)' == 'true'">
-    <ItemGroup Condition="'$(ArchiveTests)' == 'true'">
-      <!-- When ArchiveTests is set, copy xunit.runner.console to output directory -->
+    <ItemGroup>
+      <!-- Copy test runner to output directory -->
       <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
             Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;
                      $([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe;
@@ -84,6 +84,14 @@
             Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(XunitConsoleNetCore21AppPath)' != ''"
             CopyToOutputDirectory="PreserveNewest"
             Visible="false" />
+    </ItemGroup>
+
+    <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
+    <ItemGroup Condition="'$(ArchiveTests)' != 'true'">
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.utility.net452.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.reporters.net452.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Reverts dotnet/runtime#96826

@akoeplinger let me know this regressed:
> it looks like
https://github.com/dotnet/runtime/pull/96826
is breaking a couple things 
> - A couple wasm projects set BundleXunitRunner but now they don't get the xunit.console.dll locally unless they set ArchiveTests=true
> - It also breaks the enterprise-linux pipeline since it uses dotnet build /t:Test instead of dotnet test: https://dev.azure.com/dnceng-public/public/_build/results?buildId=537464&view=logs&j=03b95830-93c2-599b-7e4d-1efb940adc28&t=deab5cac-2f83-5667-2973-63a6919b97de
>
> The latter seems more problematic since we document /t:Test in a couple places and I know many people are still in the habit of using it vs dotnet test and in some cases you don't want the vstest runner

Undoing this for now.  Probably we need to allow for another property to be set here, or we fix those places that broke to use the path to the runner inside the package instead (as was recommended by Xunit).