### PR TITLE
Update Enumerable.Range to support Vector<int>.Count <= 16

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -42,10 +42,10 @@ namespace System.Linq
                 ref int end = ref Unsafe.Add(ref pos, destination.Length);
 
                 if (Vector.IsHardwareAccelerated &&
-                    Vector<int>.Count <= 8 &&
+                    Vector<int>.Count <= 16 &&
                     destination.Length >= Vector<int>.Count)
                 {
-                    Vector<int> init = new Vector<int>((ReadOnlySpan<int>)[0, 1, 2, 3, 4, 5, 6, 7]);
+                    Vector<int> init = new Vector<int>((ReadOnlySpan<int>)[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
                     Vector<int> current = new Vector<int>(value) + init;
                     Vector<int> increment = new Vector<int>(Vector<int>.Count);
 


### PR DESCRIPTION
`Vector<T>` is being updated in https://github.com/dotnet/runtime/pull/97460 to support 512-bit vectors. Update Enumerable.Range to support it as well. In the future hopefully this can be replaced by a method that'll just do the "right thing" regardless of vector size.