### PR TITLE
[JsonSerializer] Add support for out-of-order metadata reads.

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
+++ b/src/libraries/System.Text.Json/Common/JsonSourceGenerationOptionsAttribute.cs
@@ -41,6 +41,11 @@ namespace System.Text.Json.Serialization
         }
 
         /// <summary>
+        /// Specifies the default value of <see cref="JsonSerializerOptions.AllowOutOfOrderMetadataProperties"/> when set.
+        /// </summary>
+        public bool AllowOutOfOrderMetadataProperties { get; set; }
+
+        /// <summary>
         /// Specifies the default value of <see cref="JsonSerializerOptions.AllowTrailingCommas"/> when set.
         /// </summary>
         public bool AllowTrailingCommas { get; set; }

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1105,6 +1105,9 @@ namespace System.Text.Json.SourceGeneration
                 writer.WriteLine('{');
                 writer.Indentation++;
 
+                if (optionsSpec.AllowOutOfOrderMetadataProperties is bool allowOutOfOrderMetadataProperties)
+                    writer.WriteLine($"AllowOutOfOrderMetadataProperties = {FormatBool(allowOutOfOrderMetadataProperties)},");
+
                 if (optionsSpec.AllowTrailingCommas is bool allowTrailingCommas)
                     writer.WriteLine($"AllowTrailingCommas = {FormatBool(allowTrailingCommas)},");
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -263,6 +263,7 @@ namespace System.Text.Json.SourceGeneration
                 JsonSourceGenerationMode? generationMode = null;
                 List<TypeRef>? converters = null;
                 JsonSerializerDefaults? defaults = null;
+                bool? allowOutOfOrderMetadataProperties = null;
                 bool? allowTrailingCommas = null;
                 int? defaultBufferSize = null;
                 JsonIgnoreCondition? defaultIgnoreCondition = null;
@@ -293,6 +294,10 @@ namespace System.Text.Json.SourceGeneration
                 {
                     switch (namedArg.Key)
                     {
+                        case nameof(JsonSourceGenerationOptionsAttribute.AllowOutOfOrderMetadataProperties):
+                            allowOutOfOrderMetadataProperties = (bool)namedArg.Value.Value!;
+                            break;
+
                         case nameof(JsonSourceGenerationOptionsAttribute.AllowTrailingCommas):
                             allowTrailingCommas = (bool)namedArg.Value.Value!;
                             break;
@@ -396,6 +401,7 @@ namespace System.Text.Json.SourceGeneration
                 {
                     GenerationMode = generationMode,
                     Defaults = defaults,
+                    AllowOutOfOrderMetadataProperties = allowOutOfOrderMetadataProperties,
                     AllowTrailingCommas = allowTrailingCommas,
                     DefaultBufferSize = defaultBufferSize,
                     Converters = converters?.ToImmutableEquatableArray(),

--- a/src/libraries/System.Text.Json/gen/Model/SourceGenerationOptionsSpec.cs
+++ b/src/libraries/System.Text.Json/gen/Model/SourceGenerationOptionsSpec.cs
@@ -16,6 +16,8 @@ namespace System.Text.Json.SourceGeneration
 
         public required JsonSerializerDefaults? Defaults { get; init; }
 
+        public required bool? AllowOutOfOrderMetadataProperties { get; init; }
+
         public required bool? AllowTrailingCommas { get; init; }
 
         public required ImmutableEquatableArray<TypeRef>? Converters { get; init; }

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -368,6 +368,7 @@ namespace System.Text.Json
         public JsonSerializerOptions() { }
         public JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults defaults) { }
         public JsonSerializerOptions(System.Text.Json.JsonSerializerOptions options) { }
+        public bool AllowOutOfOrderMetadataProperties { get { throw null; } set { } }
         public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonConverter> Converters { get { throw null; } }
         public static System.Text.Json.JsonSerializerOptions Default { [System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications."), System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.")] get { throw null; } }
@@ -1060,6 +1061,7 @@ namespace System.Text.Json.Serialization
     {
         public JsonSourceGenerationOptionsAttribute() { }
         public JsonSourceGenerationOptionsAttribute(System.Text.Json.JsonSerializerDefaults defaults) { }
+        public bool AllowOutOfOrderMetadataProperties { get { throw null; } set { } }
         public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Type[]? Converters { get { throw null; } set { } }
         public int DefaultBufferSize { get { throw null; } set { } }

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -382,8 +382,11 @@
   <data name="DeserializeNoConstructor" xml:space="preserve">
     <value>Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with '{0}' is not supported. Type '{1}'.</value>
   </data>
-  <data name="DeserializePolymorphicInterface" xml:space="preserve">
-    <value>Deserialization of interface types is not supported. Type '{0}'.</value>
+  <data name="DeserializeInterfaceOrAbstractType" xml:space="preserve">
+    <value>Deserialization of interface or abstract types is not supported. Type '{0}'.</value>
+  </data>
+  <data name="DeserializationMustSpecifyTypeDiscriminator" xml:space="preserve">
+    <value>The JSON payload for interface or abstract type '{0}' must specify a type discriminator.</value>
   </data>
   <data name="SerializationConverterOnAttributeNotCompatible" xml:space="preserve">
     <value>The converter specified on '{0}' is not compatible with the type '{1}'.</value>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -439,8 +439,8 @@
   <data name="MetadataDuplicateIdFound" xml:space="preserve">
     <value>The value of the '$id' metadata property '{0}' conflicts with an existing identifier.</value>
   </data>
-  <data name="MetadataIdIsNotFirstProperty" xml:space="preserve">
-    <value>The metadata property '$id' must be the first reference preservation property in the JSON object.</value>
+  <data name="MetadataIdCannotBeCombinedWithRef" xml:space="preserve">
+    <value>The metadata property '$id' cannot be used together with '$ref' metadata properties.</value>
   </data>
   <data name="MetadataInvalidReferenceToValueType" xml:space="preserve">
     <value>Invalid reference to value type '{0}'.</value>
@@ -477,8 +477,8 @@
   <data name="UnmappedJsonProperty" xml:space="preserve">
     <value>The JSON property '{0}' could not be mapped to any .NET member contained in type '{1}'.</value>
   </data>
-  <data name="MetadataDuplicateTypeProperty" xml:space="preserve">
-    <value>Deserialized object contains a duplicate type discriminator metadata property.</value>
+  <data name="DuplicateMetadataProperty" xml:space="preserve">
+    <value>Deserialized object contains a duplicate '{0}' metadata property.</value>
   </data>
   <data name="MultipleMembersBindWithConstructorParameter" xml:space="preserve">
     <value>Members '{0}' and '{1}' on type '{2}' cannot both bind with parameter '{3}' in the deserialization constructor.</value>

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -386,7 +386,7 @@
     <value>Deserialization of interface or abstract types is not supported. Type '{0}'.</value>
   </data>
   <data name="DeserializationMustSpecifyTypeDiscriminator" xml:space="preserve">
-    <value>The JSON payload for interface or abstract type '{0}' must specify a type discriminator.</value>
+    <value>The JSON payload for polymorphic interface or abstract type '{0}' must specify a type discriminator.</value>
   </data>
   <data name="SerializationConverterOnAttributeNotCompatible" xml:space="preserve">
     <value>The converter specified on '{0}' is not compatible with the type '{1}'.</value>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -34,17 +34,7 @@ namespace System.Text.Json.Serialization
 
             if (typeInfo.CreateObject is null)
             {
-                // The contract model was not able to produce a default constructor for two possible reasons:
-                // 1. Either the declared collection type is abstract and cannot be instantiated.
-                // 2. The collection type does not specify a default constructor.
-                if (Type.IsAbstract || Type.IsInterface)
-                {
-                    ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(Type, ref reader, ref state);
-                }
-                else
-                {
-                    ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(Type, ref reader, ref state);
-                }
+                ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(typeInfo, ref reader, ref state);
             }
 
             state.Current.ReturnValue = typeInfo.CreateObject();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -269,7 +269,7 @@ namespace System.Text.Json.Serialization
                             Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
                             if (options.AllowOutOfOrderMetadataProperties)
                             {
-                                Debug.Assert(JsonSerializer.IsMetadataPropertyName(reader.GetUnescapedSpan(), jsonTypeInfo.PolymorphicTypeResolver), "should only be hit if metadata property.");
+                                Debug.Assert(JsonSerializer.IsMetadataPropertyName(reader.GetUnescapedSpan(), (state.Current.BaseJsonTypeInfo ?? jsonTypeInfo).PolymorphicTypeResolver), "should only be hit if metadata property.");
                                 bool result = reader.TrySkipPartial(reader.CurrentDepth - 1); // skip to the end of the object
                                 Debug.Assert(result, "Metadata reader must have buffered all contents.");
                                 Debug.Assert(reader.TokenType is JsonTokenType.EndObject);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonCollectionConverter.cs
@@ -267,7 +267,17 @@ namespace System.Text.Json.Serialization
                         if (reader.TokenType != JsonTokenType.EndObject)
                         {
                             Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
-                            ThrowHelper.ThrowJsonException_MetadataInvalidPropertyInArrayMetadata(ref state, typeToConvert, reader);
+                            if (options.AllowOutOfOrderMetadataProperties)
+                            {
+                                Debug.Assert(JsonSerializer.IsMetadataPropertyName(reader.GetUnescapedSpan(), jsonTypeInfo.PolymorphicTypeResolver), "should only be hit if metadata property.");
+                                bool result = reader.TrySkipPartial(reader.CurrentDepth - 1); // skip to the end of the object
+                                Debug.Assert(result, "Metadata reader must have buffered all contents.");
+                                Debug.Assert(reader.TokenType is JsonTokenType.EndObject);
+                            }
+                            else
+                            {
+                                ThrowHelper.ThrowJsonException_MetadataInvalidPropertyInArrayMetadata(ref state, typeToConvert, reader);
+                            }
                         }
                     }
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -256,10 +256,19 @@ namespace System.Text.Json.Serialization
 
                         if (state.Current.CanContainMetadata)
                         {
-                            ReadOnlySpan<byte> propertyName = reader.GetSpan();
+                            ReadOnlySpan<byte> propertyName = reader.GetUnescapedSpan();
                             if (JsonSerializer.IsMetadataPropertyName(propertyName, state.Current.BaseJsonTypeInfo.PolymorphicTypeResolver))
                             {
-                                ThrowHelper.ThrowUnexpectedMetadataException(propertyName, ref reader, ref state);
+                                if (options.AllowOutOfOrderMetadataProperties)
+                                {
+                                    reader.SkipWithVerify();
+                                    state.Current.EndElement();
+                                    continue;
+                                }
+                                else
+                                {
+                                    ThrowHelper.ThrowUnexpectedMetadataException(propertyName, ref reader, ref state);
+                                }
                             }
                         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/JsonDictionaryConverter.cs
@@ -49,20 +49,10 @@ namespace System.Text.Json.Serialization
 
             if (typeInfo.CreateObject is null)
             {
-                // The contract model was not able to produce a default constructor for two possible reasons:
-                // 1. Either the declared collection type is abstract and cannot be instantiated.
-                // 2. The collection type does not specify a default constructor.
-                if (Type.IsAbstract || Type.IsInterface)
-                {
-                    ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(Type, ref reader, ref state);
-                }
-                else
-                {
-                    ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(Type, ref reader, ref state);
-                }
+                ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(typeInfo, ref reader, ref state);
             }
 
-            state.Current.ReturnValue = typeInfo.CreateObject()!;
+            state.Current.ReturnValue = typeInfo.CreateObject();
             Debug.Assert(state.Current.ReturnValue is TDictionary);
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -40,10 +40,10 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     if (jsonTypeInfo.CreateObject == null)
                     {
-                        ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
+                        ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo, ref reader, ref state);
                     }
 
-                    obj = jsonTypeInfo.CreateObject()!;
+                    obj = jsonTypeInfo.CreateObject();
                 }
 
                 PopulatePropertiesFastPath(obj, jsonTypeInfo, options, ref reader, ref state);
@@ -116,10 +116,10 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (jsonTypeInfo.CreateObject == null)
                         {
-                            ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo.Type, ref reader, ref state);
+                            ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(jsonTypeInfo, ref reader, ref state);
                         }
 
-                        obj = jsonTypeInfo.CreateObject()!;
+                        obj = jsonTypeInfo.CreateObject();
                     }
 
                     if ((state.Current.MetadataPropertyNames & MetadataPropertyName.Id) != 0)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -266,9 +266,7 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         // This method is using aggressive inlining to avoid extra stack frame for deep object graphs.
-#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static void PopulatePropertiesFastPath(object obj, JsonTypeInfo jsonTypeInfo, JsonSerializerOptions options, ref Utf8JsonReader reader, scoped ref ReadStack state)
         {
             jsonTypeInfo.OnDeserializing?.Invoke(obj);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -279,9 +279,7 @@ namespace System.Text.Json.Serialization.Converters
         /// <summary>
         /// Performs a full first pass of the JSON input and deserializes the ctor args.
         /// </summary>
-#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private void ReadConstructorArguments(scoped ref ReadStack state, ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             BeginRead(ref state, options);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/BooleanConverter.cs
@@ -21,7 +21,7 @@ namespace System.Text.Json.Serialization.Converters
         internal override bool ReadAsPropertyNameCore(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
-            ReadOnlySpan<byte> propertyName = reader.GetSpan();
+            ReadOnlySpan<byte> propertyName = reader.GetUnescapedSpan();
             if (!(Utf8Parser.TryParse(propertyName, out bool value, out int bytesConsumed)
                   && propertyName.Length == bytesConsumed))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.MetadataHandling.cs
@@ -152,15 +152,15 @@ namespace System.Text.Json.Serialization
                     }
 
                     resolver.PushReferenceForCycleDetection(value);
-                    // WriteStack reuses root-level stackframes for its children as a performance optimization;
+                    // WriteStack reuses root-level stack frames for its children as a performance optimization;
                     // we want to avoid writing any data for the root-level object to avoid corrupting the stack.
                     // This is fine since popping the root object at the end of serialization is not essential.
                     state.Current.IsPushedReferenceForCycleDetection = state.CurrentDepth > 0;
                     break;
 
                 case ReferenceHandlingStrategy.Preserve:
-                    bool canHaveIdMetata = polymorphicConverter?.CanHaveMetadata ?? CanHaveMetadata;
-                    if (canHaveIdMetata && JsonSerializer.TryGetReferenceForValue(value, ref state, writer))
+                    bool canHaveIdMetadata = polymorphicConverter?.CanHaveMetadata ?? CanHaveMetadata;
+                    if (canHaveIdMetadata && JsonSerializer.TryGetReferenceForValue(value, ref state, writer))
                     {
                         // We found a repeating reference and wrote the relevant metadata; serialization complete.
                         return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -77,9 +77,7 @@ namespace System.Text.Json
             return jsonPropertyInfo;
         }
 
-#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static ReadOnlySpan<byte> GetPropertyName(
             scoped ref ReadStack state,
             ref Utf8JsonReader reader,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Caching.cs
@@ -504,6 +504,7 @@ namespace System.Text.Json
                     left._unmappedMemberHandling == right._unmappedMemberHandling &&
                     left._defaultBufferSize == right._defaultBufferSize &&
                     left._maxDepth == right._maxDepth &&
+                    left._allowOutOfOrderMetadataProperties == right._allowOutOfOrderMetadataProperties &&
                     left._allowTrailingCommas == right._allowTrailingCommas &&
                     left._ignoreNullValues == right._ignoreNullValues &&
                     left._ignoreReadOnlyProperties == right._ignoreReadOnlyProperties &&
@@ -560,6 +561,7 @@ namespace System.Text.Json
                 AddHashCode(ref hc, options._unmappedMemberHandling);
                 AddHashCode(ref hc, options._defaultBufferSize);
                 AddHashCode(ref hc, options._maxDepth);
+                AddHashCode(ref hc, options._allowOutOfOrderMetadataProperties);
                 AddHashCode(ref hc, options._allowTrailingCommas);
                 AddHashCode(ref hc, options._ignoreNullValues);
                 AddHashCode(ref hc, options._ignoreReadOnlyProperties);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -83,6 +83,7 @@ namespace System.Text.Json
 
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
+        private bool _allowOutOfOrderMetadataProperties;
         private bool _allowTrailingCommas;
         private bool _ignoreNullValues;
         private bool _ignoreReadOnlyProperties;
@@ -134,6 +135,7 @@ namespace System.Text.Json
 
             _defaultBufferSize = options._defaultBufferSize;
             _maxDepth = options._maxDepth;
+            _allowOutOfOrderMetadataProperties = options._allowOutOfOrderMetadataProperties;
             _allowTrailingCommas = options._allowTrailingCommas;
             _ignoreNullValues = options._ignoreNullValues;
             _ignoreReadOnlyProperties = options._ignoreReadOnlyProperties;
@@ -247,6 +249,32 @@ namespace System.Text.Json
         /// </remarks>
         public IList<IJsonTypeInfoResolver> TypeInfoResolverChain => _typeInfoResolverChain ??= new(this);
         private OptionsBoundJsonTypeInfoResolverChain? _typeInfoResolverChain;
+
+        /// <summary>
+        /// Allows JSON metadata properties to be specified after regular properties in a deserialized JSON object.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        /// <remarks>
+        /// When set to <see langword="true" />, removes the requirement that JSON metadata properties
+        /// such as $id and $type should be specified at the very start of the deserialized JSON object.
+        ///
+        /// It should be noted that enabling this setting can result in over-buffering
+        /// when deserializing large JSON payloads in the context of streaming deserialization.
+        /// </remarks>
+        public bool AllowOutOfOrderMetadataProperties
+        {
+            get
+            {
+                return _allowOutOfOrderMetadataProperties;
+            }
+            set
+            {
+                VerifyMutable();
+                _allowOutOfOrderMetadataProperties = value;
+            }
+        }
 
         /// <summary>
         /// Defines whether an extra comma at the end of a list of JSON values in an object or array

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -88,7 +88,9 @@ namespace System.Text.Json.Serialization.Metadata
         private protected abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, Type? declaringType, JsonSerializerOptions options);
 
         // AggressiveInlining used although a large method it is only called from one location and is on a hot path.
+#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         internal JsonPropertyInfo GetProperty(
             ReadOnlySpan<byte> propertyName,
             ref ReadStackFrame frame,
@@ -244,7 +246,9 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         // AggressiveInlining used although a large method it is only called from one location and is on a hot path.
+#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         internal JsonParameterInfo? GetParameter(
             ReadOnlySpan<byte> propertyName,
             ref ReadStackFrame frame,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfo.Cache.cs
@@ -88,9 +88,7 @@ namespace System.Text.Json.Serialization.Metadata
         private protected abstract JsonPropertyInfo CreateJsonPropertyInfo(JsonTypeInfo declaringTypeInfo, Type? declaringType, JsonSerializerOptions options);
 
         // AggressiveInlining used although a large method it is only called from one location and is on a hot path.
-#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal JsonPropertyInfo GetProperty(
             ReadOnlySpan<byte> propertyName,
             ref ReadStackFrame frame,
@@ -246,9 +244,7 @@ namespace System.Text.Json.Serialization.Metadata
         }
 
         // AggressiveInlining used although a large method it is only called from one location and is on a hot path.
-#if !DEBUG
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal JsonParameterInfo? GetParameter(
             ReadOnlySpan<byte> propertyName,
             ref ReadStackFrame frame,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/PolymorphicTypeResolver.cs
@@ -75,20 +75,19 @@ namespace System.Text.Json.Serialization.Metadata
                 }
 
                 string propertyName = polymorphismOptions.TypeDiscriminatorPropertyName;
-
-                JsonEncodedText jsonEncodedName = propertyName == JsonSerializer.TypePropertyName
-                    ? JsonSerializer.s_metadataType
-                    : JsonEncodedText.Encode(propertyName, options.Encoder);
-
-                // Check if the property name conflicts with other metadata property names
-                if ((JsonSerializer.GetMetadataPropertyName(jsonEncodedName.EncodedUtf8Bytes, resolver: null) & ~MetadataPropertyName.Type) != 0)
+                if (!propertyName.Equals(JsonSerializer.TypePropertyName, StringComparison.Ordinal))
                 {
-                    ThrowHelper.ThrowInvalidOperationException_InvalidCustomTypeDiscriminatorPropertyName();
-                }
+                    byte[] utf8EncodedName = Encoding.UTF8.GetBytes(propertyName);
 
-                TypeDiscriminatorPropertyName = propertyName;
-                TypeDiscriminatorPropertyNameUtf8 = jsonEncodedName.EncodedUtf8Bytes.ToArray();
-                CustomTypeDiscriminatorPropertyNameJsonEncoded = jsonEncodedName;
+                    // Check if the property name conflicts with other metadata property names
+                    if ((JsonSerializer.GetMetadataPropertyName(utf8EncodedName, resolver: null) & ~MetadataPropertyName.Type) != 0)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_InvalidCustomTypeDiscriminatorPropertyName();
+                    }
+
+                    CustomTypeDiscriminatorPropertyNameUtf8 = utf8EncodedName;
+                    CustomTypeDiscriminatorPropertyNameJsonEncoded = JsonEncodedText.Encode(propertyName, options.Encoder);
+                }
             }
         }
 
@@ -96,8 +95,7 @@ namespace System.Text.Json.Serialization.Metadata
         public JsonUnknownDerivedTypeHandling UnknownDerivedTypeHandling { get; }
         public bool UsesTypeDiscriminators { get; }
         public bool IgnoreUnrecognizedTypeDiscriminators { get; }
-        public string? TypeDiscriminatorPropertyName { get; }
-        public byte[]? TypeDiscriminatorPropertyNameUtf8 { get; }
+        public byte[]? CustomTypeDiscriminatorPropertyNameUtf8 { get; }
         public JsonEncodedText? CustomTypeDiscriminatorPropertyNameJsonEncoded { get; }
 
         public bool TryGetDerivedJsonTypeInfo(Type runtimeType, [NotNullWhen(true)] out JsonTypeInfo? jsonTypeInfo, out object? typeDiscriminator)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadBufferState.cs
@@ -28,9 +28,9 @@ namespace System.Text.Json.Serialization
             _isFinalBlock = false;
         }
 
-        public bool IsFinalBlock => _isFinalBlock;
+        public readonly bool IsFinalBlock => _isFinalBlock;
 
-        public ReadOnlySpan<byte> Bytes => _buffer.AsSpan(_offset, _count);
+        public readonly ReadOnlySpan<byte> Bytes => _buffer.AsSpan(_offset, _count);
 
         /// <summary>
         /// Read from the stream until either our buffer is filled or we hit EOF.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -662,10 +662,10 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_MetadataIdIsNotFirstProperty(ReadOnlySpan<byte> propertyName, scoped ref ReadStack state)
+        public static void ThrowJsonException_MetadataIdCannotBeCombinedWithRef(ReadOnlySpan<byte> propertyName, scoped ref ReadStack state)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
-            ThrowJsonException(SR.MetadataIdIsNotFirstProperty);
+            ThrowJsonException(SR.MetadataIdCannotBeCombinedWithRef);
         }
 
         [DoesNotReturn]
@@ -698,9 +698,9 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
-        public static void ThrowJsonException_MetadataDuplicateTypeProperty()
+        public static void ThrowJsonException_DuplicateMetadataProperty(ReadOnlySpan<byte> utf8PropertyName)
         {
-            ThrowJsonException(SR.MetadataDuplicateTypeProperty);
+            ThrowJsonException(SR.Format(SR.DuplicateMetadataProperty, JsonHelpers.Utf8GetString(utf8PropertyName)));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ReferenceHandlerTests/ReferenceHandlerTests.Deserialize.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Tests
 {
     public abstract partial class ReferenceHandlerTests : SerializerTests
     {
-        private static readonly JsonSerializerOptions s_deserializerOptionsPreserve = new JsonSerializerOptions { ReferenceHandler = ReferenceHandler.Preserve };
+        private static readonly JsonSerializerOptions s_deserializerOptionsPreserve = new() { ReferenceHandler = ReferenceHandler.Preserve };
 
         public class EmployeeWithContacts
         {
@@ -1514,12 +1514,12 @@ namespace System.Text.Json.Serialization.Tests
                 ""\u0024test"": ""test""
             }";
 
-            // \u0024.* Valid (i.e: \u0024test)
-            EmployeeExtensionData employee = await Serializer.DeserializeWrapper<EmployeeExtensionData>(json, s_deserializerOptionsPreserve);
-            Assert.Equal("test", ((JsonElement)employee.ExtensionData["$test"]).GetString());
+            // Escaped JSON properties still not valid
+            ex = await Assert.ThrowsAsync<JsonException>(async () => await Serializer.DeserializeWrapper<EmployeeExtensionData>(json, s_deserializerOptionsPreserve));
+            Assert.Equal("$.$test", ex.Path);
 
-            Dictionary<string, string> dictionary = await Serializer.DeserializeWrapper<Dictionary<string, string>>(json, s_deserializerOptionsPreserve);
-            Assert.Equal("test", dictionary["$test"]);
+            ex = await Assert.ThrowsAsync<JsonException>(async () => await Serializer.DeserializeWrapper<Dictionary<string, string>>(json, s_deserializerOptionsPreserve));
+            Assert.Equal("$.$test", ex.Path);
         }
         #endregion
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/JsonSourceGenerationOptionsTests.cs
@@ -61,6 +61,7 @@ namespace System.Text.Json.SourceGeneration.Tests
         {
             JsonSerializerOptions expected = new(JsonSerializerDefaults.Web)
             {
+                AllowOutOfOrderMetadataProperties = true,
                 AllowTrailingCommas = true,
                 Converters = { new JsonStringEnumConverter<BindingFlags>(), new JsonStringEnumConverter<JsonIgnoreCondition>() },
                 DefaultBufferSize = 128,
@@ -90,8 +91,9 @@ namespace System.Text.Json.SourceGeneration.Tests
         }
 
         [JsonSourceGenerationOptions(JsonSerializerDefaults.Web,
+            AllowOutOfOrderMetadataProperties = true,
             AllowTrailingCommas = true,
-            Converters = new[] { typeof(JsonStringEnumConverter<BindingFlags>), typeof(JsonStringEnumConverter<JsonIgnoreCondition>) },
+            Converters = [typeof(JsonStringEnumConverter<BindingFlags>), typeof(JsonStringEnumConverter<JsonIgnoreCondition>)],
             DefaultBufferSize = 128,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
             DictionaryKeyPolicy = JsonKnownNamingPolicy.SnakeCaseUpper,

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/CacheTests.cs
@@ -353,6 +353,7 @@ namespace System.Text.Json.Serialization.Tests
 
             static IEnumerable<(PropertyInfo, object)> GetPropertiesWithSettersAndNonDefaultValues()
             {
+                yield return (GetProp(nameof(JsonSerializerOptions.AllowOutOfOrderMetadataProperties)), true);
                 yield return (GetProp(nameof(JsonSerializerOptions.AllowTrailingCommas)), true);
                 yield return (GetProp(nameof(JsonSerializerOptions.DefaultBufferSize)), 42);
                 yield return (GetProp(nameof(JsonSerializerOptions.Encoder)), JavaScriptEncoder.UnsafeRelaxedJsonEscaping);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/OptionsTests.cs
@@ -73,6 +73,7 @@ namespace System.Text.Json.Serialization.Tests
 
             // Setters should always throw; we don't check to see if the value is the same or not.
             Assert.Throws<InvalidOperationException>(() => options.AllowTrailingCommas = options.AllowTrailingCommas);
+            Assert.Throws<InvalidOperationException>(() => options.AllowOutOfOrderMetadataProperties = options.AllowOutOfOrderMetadataProperties);
             Assert.Throws<InvalidOperationException>(() => options.DefaultBufferSize = options.DefaultBufferSize);
             Assert.Throws<InvalidOperationException>(() => options.DictionaryKeyPolicy = options.DictionaryKeyPolicy);
             Assert.Throws<InvalidOperationException>(() => options.Encoder = JavaScriptEncoder.Default);

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -2692,6 +2692,22 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public async Task PolymorphicAbstractClass_NoDiscriminatorInPayload_ThrowsNotSupportedException()
+        {
+            string json = """{"Value" : 42}""";
+            NotSupportedException exn = await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.DeserializeWrapper<PolymorphicAbstractClass>(json));
+            Assert.Contains($"The JSON payload for interface or abstract type '{typeof(PolymorphicAbstractClass)}' must specify a type discriminator.", exn.Message);
+        }
+
+        [JsonDerivedType(typeof(Derived), "derived")]
+        public abstract class PolymorphicAbstractClass
+        {
+            public int Value { get; set; }
+
+            public class Derived : PolymorphicAbstractClass;
+        }
+
+        [Fact]
         public async Task PolymorphicClass_CustomConverter_NoTypeDiscriminator_Serialization()
         {
             var value = new PolymorphicClass_CustomConverter_NoTypeDiscriminator.DerivedClass { Number = 42 };

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -2696,7 +2696,7 @@ namespace System.Text.Json.Serialization.Tests
         {
             string json = """{"Value" : 42}""";
             NotSupportedException exn = await Assert.ThrowsAsync<NotSupportedException>(() => Serializer.DeserializeWrapper<PolymorphicAbstractClass>(json));
-            Assert.Contains($"The JSON payload for interface or abstract type '{typeof(PolymorphicAbstractClass)}' must specify a type discriminator.", exn.Message);
+            Assert.Contains($"The JSON payload for polymorphic interface or abstract type '{typeof(PolymorphicAbstractClass)}' must specify a type discriminator.", exn.Message);
         }
 
         [JsonDerivedType(typeof(Derived), "derived")]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/PolymorphicTests.CustomTypeHierarchies.cs
@@ -15,6 +15,8 @@ namespace System.Text.Json.Serialization.Tests
 {
     public abstract partial class PolymorphicTests
     {
+        private readonly JsonSerializerOptions s_optionsWithAllowOutOfOrderMetadata = new() { AllowOutOfOrderMetadataProperties = true };
+
         #region Polymorphic Class
         [Theory]
         [MemberData(nameof(Get_PolymorphicClass_TestData_Serialization))]
@@ -75,6 +77,52 @@ namespace System.Text.Json.Serialization.Tests
         public async Task PolymorphicClass_InvalidTypeDiscriminatorMetadata_ShouldThrowJsonException(string expectedJsonPath, string json)
         {
             JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass>(json));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_PolymorphicClass_TestData_Deserialization))]
+        public Task PolymorphicClass_TestData_AllowOutOfOrderMetadata_Deserialization(PolymorphicClass.TestData testData)
+            => TestMultiContextDeserialization<PolymorphicClass>(
+                testData.ExpectedJson,
+                testData.ExpectedRoundtripValue,
+                testData.ExpectedDeserializationException,
+                options: s_optionsWithAllowOutOfOrderMetadata,
+                equalityComparer: PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+
+        [Theory]
+        [InlineData("""{"Number":42, "$type":"derivedClass1", "String": "str"}""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
+        [InlineData("""{"Number":42, "String": "str", "$type":"derivedClass1"}""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
+        [InlineData("""{"Number":42, "$type": -1, "String": "str" }""", typeof(PolymorphicClass.DerivedClass_IntegerTypeDiscriminator))]
+        [InlineData("""{"Number":42, "\u0024type": -1, "String": "str" }""", typeof(PolymorphicClass.DerivedClass_IntegerTypeDiscriminator))]
+        [InlineData("""{"Number":42, "String": "str", "$type": -1 }""", typeof(PolymorphicClass.DerivedClass_IntegerTypeDiscriminator))]
+        [InlineData("""{"$values": [42,42,42], "$type":"derivedCollection"}""", typeof(PolymorphicClass.DerivedCollection_TypeDiscriminator))]
+        [InlineData("""{"$values": [42,42,42], "$type":"derivedCollectionOfDerivedCollection"}""", typeof(PolymorphicClass.DerivedCollection_TypeDiscriminator.DerivedClass))]
+        [InlineData("""{"dictionaryKey" : 42, "$type":"derivedDictionary"}""", typeof(PolymorphicClass.DerivedDictionary_TypeDiscriminator))]
+        [InlineData("""{"dictionaryKey" : 42, "$type":"derivedDictionaryOfDerivedDictionary"}""", typeof(PolymorphicClass.DerivedDictionary_TypeDiscriminator.DerivedClass))]
+        [InlineData("""{"Number":42, "$type":"derivedClassWithCtor"}""", typeof(PolymorphicClass.DerivedClassWithConstructor_TypeDiscriminator))]
+        [InlineData("""{"Number":42, "$type":"derivedClassOfDerivedClassWithCtor"}""", typeof(PolymorphicClass.DerivedClassWithConstructor_TypeDiscriminator.DerivedClass))]
+        public async Task PolymorphicClass_AllowOutOfOrderMetadata_AcceptsOutOfOrderInputs(string json, Type expectedResultType)
+        {
+            PolymorphicClass? result = await Serializer.DeserializeWrapper<PolymorphicClass>(json, s_optionsWithAllowOutOfOrderMetadata);
+            Assert.IsType(expectedResultType, result);
+
+            if (result is IEnumerable collection)
+            {
+                Assert.NotEmpty(collection);
+            }
+        }
+
+        [Theory]
+        [InlineData("$.$type", """{"Number":42, "$type":"derivedClass1", "String": "str", "$type":"derivedClass1"}""")]
+        [InlineData("$.$type", """{"$type":"derivedCollection", "$values": [42,42,42], "$type":"derivedCollection"}""")]
+        [InlineData("$.$values", """{"$type":"derivedCollection", "NonMetadataProp": {}, "$values": [42,42,42]}""")]
+        [InlineData("$.NonMetadataProp", """{"$type":"derivedCollection", "$values": [42,42,42], "NonMetadataProp": {}}""")]
+        [InlineData("$.NonMetadataProp", """{"$values": [42,42,42], "$type":"derivedCollection", "NonMetadataProp": {}}""")]
+        [InlineData("$.$values", """{"$type":"derivedCollection", "$values": [42,42,42], "$values": [42,42,42]}""")]
+        public async Task PolymorphicClass_AllowOutOfOrderMetadata_RejectsInvalidInputs(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass>(json, s_optionsWithAllowOutOfOrderMetadata));
             Assert.Equal(expectedJsonPath, exception.Path);
         }
 
@@ -2237,6 +2285,81 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClassWithCustomTypeDiscriminator>.Instance);
         }
 
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_AllowOutOfOrderMetadata_SingleValue_Deserialization(PolymorphicClass expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json = jsonTemplate("1"); // root values have reference id "1"
+            PolymorphicClass actualValue = await Serializer.DeserializeWrapper<PolymorphicClass>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
+            Assert.Equal(expectedValue, actualValue, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_ReferencePreservation_TestData_Boxed))]
+        public async Task ReferencePreservation_AllowOutOfOrderMetadata_RepeatingValue_Deserialization(PolymorphicClass expectedValue, Func<string, string> jsonTemplate)
+        {
+            string json =
+                $@"{{""$id"":""1"",
+                     ""$values"":[
+                          {jsonTemplate("2")},
+                          {{""$ref"":""2""}} ]
+                }}";
+
+            var result = await Serializer.DeserializeWrapper<List<PolymorphicClass>>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(expectedValue, result[0], PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+            Assert.Same(result[0], result[1]);
+        }
+
+        [Fact]
+        public async Task ReferencePreservation_AllowOutOfOrderMetadata_MultipleRepeatingValues_Deserialization()
+        {
+            (PolymorphicClass Value, Func<string, string> JsonTemplate)[] data = Get_ReferencePreservation_TestData().ToArray();
+            PolymorphicClass[] expectedValues = data.Select(entry => entry.Value).Concat(data.Select(entry => entry.Value)).ToArray();
+
+            IEnumerable<string> idValues = data.Select((entry, i) => entry.JsonTemplate((i + 1).ToString()));
+            IEnumerable<string> refValues = Enumerable.Range(1, data.Length).Select(x => $@"{{ ""$ref"" : ""{x}""}}");
+            string json = "[" + string.Join(", ", idValues.Concat(refValues)) + "]";
+
+            PolymorphicClass[] result = await Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
+            Assert.Equal(expectedValues, result, PolymorphicEqualityComparer<PolymorphicClass>.Instance);
+        }
+
+        [Theory]
+        [InlineData("""[{ "$type" : "derivedClass1", "Number" : 42, "$id" : "1", "String" : "str" }, { "$ref" : "1" }]""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
+        [InlineData("""[{ "$id" : "1", "Number" : 42, "$type" : "derivedClass1", "String" : "str" }, { "$ref" : "1" }]""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
+        [InlineData("""[{ "$type" : "derivedClass1", "Number" : 42, "String" : "str", "$id" : "1" }, { "$ref" : "1" }]""", typeof(PolymorphicClass.DerivedClass1_TypeDiscriminator))]
+        [InlineData("""[{ "$values": [42,42,42], "$type" : "derivedCollection", "$id" : "1" }, { "$ref" : "1" }]""", typeof(PolymorphicClass.DerivedCollection_TypeDiscriminator))]
+        [InlineData("""[{ "$type" : "derivedCollection", "$values": [42,42,42], "$id" : "1" }, { "$ref" : "1" }]""", typeof(PolymorphicClass.DerivedCollection_TypeDiscriminator))]
+        public async Task ReferencePreservation_AllowOutOfOrderMetadata_AcceptsOutOfOrderMetadata(string json, Type expectedType)
+        {
+            PolymorphicClass[] result = await Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead);
+            Assert.Equal(2, result.Length);
+            Assert.IsType(expectedType, result[0]);
+            Assert.Same(result[0], result[1]);
+        }
+
+        [Theory]
+        [InlineData("$[1].$ref", """[{ "$id" : "1" }, { "NonMetadataProperty": [1,2,3], "$ref" : "1" }]""")]
+        [InlineData("$[1].NonMetadataProperty", """[{ "$id" : "1" }, { "$ref" : "1", "NonMetadataProperty": [1,2,3] }]""")]
+        [InlineData("$[1].$ref", """[{ "$id" : "1" }, { "$type": "derivedType1", "$ref" : "1" }]""")]
+        [InlineData("$[1].$type", """[{ "$id" : "1" }, { "$ref" : "1", "$type": "derivedType1" }]""")]
+        [InlineData("$[1].$id", """[{ "$id" : "1" }, { "$ref" : "1", "$id": "1" }]""")]
+        [InlineData("$[1].$ref", """[{ "$id" : "1" }, { "$id": "1", "$ref" : "1" }]""")]
+        [InlineData("$[1].$ref", """[{ "$id" : "1" }, { "$values": [1, 2, 3], "$ref" : "1" }]""")]
+        [InlineData("$[1].$values", """[{ "$id" : "1" }, { "$ref" : "1", "$values": [1, 2, 3] }]""")]
+        [InlineData("$[0].NonMetadataProperty", """[{ "$type" : "derivedCollection", "$values": [42,42,42], "$id" : "1", "NonMetadataProperty": {}}, { "$ref" : "1" }]""")]
+        [InlineData("$[0].$values", """[{ "$type" : "derivedCollection", "$id" : "1", "NonMetadataProperty": {}, "$values": [42,42,42]}, { "$ref" : "1" }]""")]
+        [InlineData("$[1].$ref", """[{ "$type" : "derivedCollection", "$id" : "1", "$values": [42,42,42]}, { "$type" : "derivedCollection", "$ref" : "1" }]""")]
+        [InlineData("$[1].$values", """[{ "$type" : "derivedCollection", "$id" : "1", "$values": [42,42,42]}, { "$ref" : "1", "$values" : [1,2,3] }]""")]
+        [InlineData("$[1].$ref", """[{ "$type" : "derivedCollection", "$id" : "1", "$values": [42,42,42]}, { "$values" : [1,2,3], "$ref" : "1" }]""")]
+        public async Task ReferencePreservation_AllowOutOfOrderMetadata_RejectsInvalidMetadata(string expectedJsonPath, string json)
+        {
+            JsonException exception = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<PolymorphicClass[]>(json, s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead));
+            Assert.Equal(expectedJsonPath, exception.Path);
+        }
+
         [JsonPolymorphic(TypeDiscriminatorPropertyName = "case")]
         [JsonDerivedType(typeof(PolymorphicClassWithCustomTypeDiscriminator), "baseClass")]
         [JsonDerivedType(typeof(DerivedClass), "derivedClass")]
@@ -2286,6 +2409,12 @@ namespace System.Text.Json.Serialization.Tests
         private readonly static JsonSerializerOptions s_jsonSerializerOptionsPreserveRefs = new JsonSerializerOptions
         {
             ReferenceHandler = ReferenceHandler.Preserve
+        };
+
+        private readonly static JsonSerializerOptions s_jsonSerializerOptionsPreserveRefsAndAllowReadAhead = new JsonSerializerOptions
+        {
+            ReferenceHandler = ReferenceHandler.Preserve,
+            AllowOutOfOrderMetadataProperties = true,
         };
         #endregion
 


### PR DESCRIPTION
Makes the following changes:

1. Adds support for out-of-order metadata reads in JsonSerializer.
2. Ensures that read JSON property names are always unescaped.

Fix #72604.