### PR TITLE
Improve performance of Order{By}{Descending}(...).First/Last

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Linq
@@ -155,7 +156,7 @@ namespace System.Linq
             return default;
         }
 
-        public TElement? TryGetFirst(out bool found)
+        public virtual TElement? TryGetFirst(out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();
             using (IEnumerator<TElement> e = _source.GetEnumerator())
@@ -182,7 +183,7 @@ namespace System.Linq
             }
         }
 
-        public TElement? TryGetLast(out bool found)
+        public virtual TElement? TryGetLast(out bool found)
         {
             using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
@@ -244,6 +245,70 @@ namespace System.Linq
         }
     }
 
+    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
+    {
+        // For complicated cases, rely on the base implementation that's more comprehensive.
+        // For the simple case of OrderBy(...).First() or OrderByDescending(...).First() (i.e. where
+        // there's just a single comparer we need to factor in), we can just do the iteration directly.
+
+        public override TElement? TryGetFirst(out bool found) =>
+            _parent is not null ?
+                base.TryGetFirst(out found) :
+                TryGetFirstOrLast(out found, first: !_descending);
+
+        public override TElement? TryGetLast(out bool found) =>
+            _parent is not null ?
+                base.TryGetLast(out found) :
+                TryGetFirstOrLast(out found, first: _descending);
+
+        private TElement? TryGetFirstOrLast(out bool found, bool first)
+        {
+            using IEnumerator<TElement> e = _source.GetEnumerator();
+
+            if (e.MoveNext())
+            {
+                IComparer<TKey> comparer = _comparer;
+                Func<TElement, TKey> keySelector = _keySelector;
+
+                TElement resultValue = e.Current;
+                TKey resultKey = keySelector(resultValue);
+
+                if (first)
+                {
+                    while (e.MoveNext())
+                    {
+                        TElement nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (comparer.Compare(nextKey, resultKey) < 0)
+                        {
+                            resultKey = nextKey;
+                            resultValue = nextValue;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        TElement nextValue = e.Current;
+                        TKey nextKey = keySelector(nextValue);
+                        if (comparer.Compare(nextKey, resultKey) >= 0)
+                        {
+                            resultKey = nextKey;
+                            resultValue = nextValue;
+                        }
+                    }
+                }
+
+                found = true;
+                return resultValue;
+            }
+
+            found = false;
+            return default;
+        }
+    }
+
     internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
     {
         public override TElement[] ToArray()
@@ -258,6 +323,66 @@ namespace System.Linq
             List<TElement> list = _source.ToList();
             Sort(CollectionsMarshal.AsSpan(list), _descending);
             return list;
+        }
+
+        public override TElement? TryGetFirst(out bool found) =>
+            TryGetFirstOrLast(out found, first: !_descending);
+
+        public override TElement? TryGetLast(out bool found) =>
+            TryGetFirstOrLast(out found, first: _descending);
+
+        private TElement? TryGetFirstOrLast(out bool found, bool first)
+        {
+            if (Enumerable.TryGetSpan(_source, out ReadOnlySpan<TElement> span))
+            {
+                if (span.Length != 0)
+                {
+                    Debug.Assert(Enumerable.TypeIsImplicitlyStable<TElement>(), "Using Min/Max has different semantics for floating-point values.");
+
+                    found = true;
+                    return first ?
+                        Enumerable.Min(_source) :
+                        Enumerable.Max(_source);
+                }
+            }
+            else
+            {
+                using IEnumerator<TElement> e = _source.GetEnumerator();
+
+                if (e.MoveNext())
+                {
+                    TElement resultValue = e.Current;
+
+                    if (first)
+                    {
+                        while (e.MoveNext())
+                        {
+                            TElement nextValue = e.Current;
+                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) < 0)
+                            {
+                                resultValue = nextValue;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        while (e.MoveNext())
+                        {
+                            TElement nextValue = e.Current;
+                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) >= 0)
+                            {
+                                resultValue = nextValue;
+                            }
+                        }
+                    }
+
+                    found = true;
+                    return resultValue;
+                }
+            }
+
+            found = false;
+            return default;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -103,7 +103,7 @@ namespace System.Linq
         }
     }
 
-    internal sealed class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
+    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
         private readonly OrderedEnumerable<TElement>? _parent;
         private readonly Func<TElement, TKey> _keySelector;


### PR DESCRIPTION
When there's no ThenBy, we can take a more optimized path that uses the TKey's comparer directly.  We already have a fast path for this case that converts the O(n log n) operation into O(n), but it employs a comparer that's much more complicated, and as that comparer is used in the inner loop, it makes a meaningful difference.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Runtime.InteropServices;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Tests
{
    [Params(8, 8000)]
    public int Count { get; set; }

    private List<double> _doubles;
    private List<int> _ints;
    private string[] _strings;

    [GlobalSetup]
    public void Setup()
    {
        _doubles = new(Enumerable.Range(-Count, Count * 2).Select(x => (double)x));
        new Random(42).Shuffle(CollectionsMarshal.AsSpan(_doubles));

        _ints = new(Enumerable.Range(-Count, Count * 2));
        new Random(42).Shuffle(CollectionsMarshal.AsSpan(_doubles));

        _strings = Enumerable.Range(-Count, Count * 2).Select(x => x.ToString()).ToArray();
        new Random(42).Shuffle(_strings);
    }

    [Benchmark] public double OrderByFirst_Double() => _doubles.OrderBy(x => x).First();
    [Benchmark] public double OrderLast_Double() => _doubles.Order().Last();

    [Benchmark] public int OrderByFirst_Int32() => _ints.OrderBy(x => x).First();
    [Benchmark] public int OrderLast_Int32() => _ints.Order().Last();

    [Benchmark] public string OrderByFirst_String() => _strings.OrderBy(x => x).First();
    [Benchmark] public string OrderLast_String() => _strings.Order().Last();
}
```

| Method              | Toolchain         | Count | Mean          | Ratio |
|-------------------- |------------------ |------ |--------------:|------:|
| OrderByFirst_Double | \main\corerun.exe | 8     |     113.16 ns |  1.00 |
| OrderByFirst_Double | \pr\corerun.exe   | 8     |      63.40 ns |  0.56 |
|                     |                   |       |               |       |
| OrderLast_Double    | \main\corerun.exe | 8     |     120.98 ns |  1.00 |
| OrderLast_Double    | \pr\corerun.exe   | 8     |      58.75 ns |  0.49 |
|                     |                   |       |               |       |
| OrderByFirst_Int32  | \main\corerun.exe | 8     |     112.58 ns |  1.00 |
| OrderByFirst_Int32  | \pr\corerun.exe   | 8     |      57.93 ns |  0.51 |
|                     |                   |       |               |       |
| OrderLast_Int32     | \main\corerun.exe | 8     |     106.44 ns |  1.00 |
| OrderLast_Int32     | \pr\corerun.exe   | 8     |      21.46 ns |  0.20 |
|                     |                   |       |               |       |
| OrderByFirst_String | \main\corerun.exe | 8     |     768.86 ns |  1.00 |
| OrderByFirst_String | \pr\corerun.exe   | 8     |     710.81 ns |  0.93 |
|                     |                   |       |               |       |
| OrderLast_String    | \main\corerun.exe | 8     |     684.53 ns |  1.00 |
| OrderLast_String    | \pr\corerun.exe   | 8     |     682.01 ns |  1.01 |
|                     |                   |       |               |       |
| OrderByFirst_Double | \main\corerun.exe | 8000  |  77,141.19 ns |  1.00 |
| OrderByFirst_Double | \pr\corerun.exe   | 8000  |  31,144.22 ns |  0.40 |
|                     |                   |       |               |       |
| OrderLast_Double    | \main\corerun.exe | 8000  |  71,845.74 ns |  1.00 |
| OrderLast_Double    | \pr\corerun.exe   | 8000  |  31,260.30 ns |  0.44 |
|                     |                   |       |               |       |
| OrderByFirst_Int32  | \main\corerun.exe | 8000  |  66,197.03 ns |  1.00 |
| OrderByFirst_Int32  | \pr\corerun.exe   | 8000  |  34,464.89 ns |  0.52 |
|                     |                   |       |               |       |
| OrderLast_Int32     | \main\corerun.exe | 8000  |  55,260.46 ns |  1.00 |
| OrderLast_Int32     | \pr\corerun.exe   | 8000  |     598.10 ns |  0.01 |
|                     |                   |       |               |       |
| OrderByFirst_String | \main\corerun.exe | 8000  | 835,626.65 ns |  1.00 |
| OrderByFirst_String | \pr\corerun.exe   | 8000  | 824,369.56 ns |  0.99 |
|                     |                   |       |               |       |
| OrderLast_String    | \main\corerun.exe | 8000  | 714,980.82 ns |  1.00 |
| OrderLast_String    | \pr\corerun.exe   | 8000  | 676,364.24 ns |  0.95 |

Fixes https://github.com/dotnet/runtime/issues/87921