### PR TITLE
[mono][tests] Disabling crashing System.Linq tests on ios-like platforms

### DIFF
--- a/src/libraries/System.Linq/tests/AverageTests.cs
+++ b/src/libraries/System.Linq/tests/AverageTests.cs
@@ -499,6 +499,7 @@ namespace System.Linq.Tests
             Assert.Equal(expected, source.Average(x => x));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/97224", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsAppleMobile))]
         [Fact]
         public void Decimal_WithSelector()
         {
@@ -545,6 +546,7 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("selector", () => Enumerable.Empty<decimal?>().Average(selector));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/97224", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime), nameof(PlatformDetection.IsAppleMobile))]
         [Fact]
         public void NullableDecimal_WithSelector()
         {


### PR DESCRIPTION
This PR disables System.Linq tests that are crashing on tvos blocking green CI:

- Decimal_WithSelector
- NullableDecimal_WithSelector

All lanes running tvos library tests job are affected.

The tests in question are causing crashes but the CI logging and reports do not show the root cause of failed jobs and are shadowed by:
- XHarness exit code: 92 (TCP_CONNECTION_FAILED) or
- ERROR: WORKLOAD TIMED OUT - Killing user command..

---
Related to: https://github.com/dotnet/runtime/issues/97224