### PR TITLE
[release/9.0-preview1] Revert late cast expansion

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5050,9 +5050,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Expand thread local access
     DoPhase(this, PHASE_EXPAND_TLS, &Compiler::fgExpandThreadLocalAccess);
 
-    // Expand casts
-    DoPhase(this, PHASE_EXPAND_CASTS, &Compiler::fgLateCastExpansion);
-
     // Insert GC Polls
     DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);
 


### PR DESCRIPTION
Disables late casts expansions (basically, reverts https://github.com/dotnet/runtime/pull/97075 and https://github.com/dotnet/runtime/pull/97237) due to a bug in the impl. Fixes https://github.com/dotnet/source-build/issues/4007

The actual bug no longer reproduces with https://github.com/dotnet/runtime/pull/97387 and https://github.com/dotnet/runtime/pull/97480 on Main