### PR TITLE
JIT: capture all write barrier helper addresses for SPMI

### DIFF
--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -173,6 +173,11 @@ public:
     bool genUseOptimizedWriteBarriers(GenTreeStoreInd* store);
     CorInfoHelpFunc genWriteBarrierHelperForWriteBarrierForm(GCInfo::WriteBarrierForm wbf);
 
+#ifdef DEBUG
+    bool genWriteBarrierUsed;
+    void WriteBarrierExtraSuperPmiQueries();
+#endif
+
     // The following property indicates whether the current method sets up
     // an explicit stack frame or not.
 private:

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -175,7 +175,6 @@ public:
 
 #ifdef DEBUG
     bool genWriteBarrierUsed;
-    void WriteBarrierExtraSuperPmiQueries();
 #endif
 
     // The following property indicates whether the current method sets up

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -240,7 +240,7 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
     }
 
     // Ignore any assignments of NULL.
-    GenTree* data = store->Data()->gtSkipReloadOrCopy();
+    GenTree* const data = store->Data()->gtSkipReloadOrCopy();
     if ((data->GetVN(VNK_Liberal) == ValueNumStore::VNForNull()) || data->IsIntegralConst(0))
     {
         return WBF_NoBarrier;
@@ -248,7 +248,7 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
 
     if ((store->gtFlags & GTF_IND_TGT_NOT_HEAP) != 0)
     {
-        // This indirection is not from to the heap.
+        // This indirection is not storing to the heap.
         // This case occurs for stack-allocated objects.
         return WBF_NoBarrier;
     }


### PR DESCRIPTION
When varying CSEs we can sometimes alter the write barrier that is needed. In particular if we CSE a heap address computation we may lose track of the fact that an indir is writing to the heap, and so change which write barrier needs to be used.

See #97534.

Even if that's fixed it seems like we still might change our minds for various reasons, so when running under SPMI, just collect all the possible write barrier helper addresses.