### PR TITLE
Enable native AOT for non-portable crossgen2

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -16,6 +16,11 @@
     <WriteLinesToFile
       File="$(RuntimeBinDir)/aotsdk/debugucrt.txt"
       Condition="'$(TargetsWindows)'=='true' and '$(Configuration)' != 'Release'" />
+
+    <!-- Create breadcrumb to add additional libraries for non-portable builds -->
+    <WriteLinesToFile
+      File="$(RuntimeBinDir)/aotsdk/nonportable.txt"
+      Condition="'$(TargetsWindows)'!='true' and '$(PortableBuild)' != 'true'" />
   </Target>
 
   <Target Name="Restore" />

--- a/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
+++ b/src/coreclr/nativeaot/BuildIntegration/BuildIntegration.proj
@@ -15,12 +15,18 @@
     <!-- Create breadcrumb to disable dynamic linking of release crt for debug runtime -->
     <WriteLinesToFile
       File="$(RuntimeBinDir)/aotsdk/debugucrt.txt"
+      Overwrite="true"
       Condition="'$(TargetsWindows)'=='true' and '$(Configuration)' != 'Release'" />
 
     <!-- Create breadcrumb to add additional libraries for non-portable builds -->
     <WriteLinesToFile
       File="$(RuntimeBinDir)/aotsdk/nonportable.txt"
+      Overwrite="true"
       Condition="'$(TargetsWindows)'!='true' and '$(PortableBuild)' != 'true'" />
+    <Delete
+      Files="$(RuntimeBinDir)/aotsdk/nonportable.txt"
+      Condition="'$(TargetsWindows)'=='true' or '$(PortableBuild)' == 'true'" />
+
   </Target>
 
   <Target Name="Restore" />

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -142,6 +142,11 @@ The .NET Foundation licenses this file to you under the MIT license.
       <StaticICULibs Include="-Wl,-Bdynamic" Condition="'$(StaticExecutable)' != 'true'" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(StaticOpenSslLinking)' != 'true' and Exists('$(IlcSdkPath)nonportable.txt')">
+      <NativeSystemLibrary Include="ssl" />
+      <NativeSystemLibrary Include="crypto" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(StaticOpenSslLinking)' == 'true' and '$(NativeLib)' != 'Static'">
       <NativeLibrary Include="$(IntermediateOutputPath)libs/System.Security.Cryptography.Native/build/libSystem.Security.Cryptography.Native.OpenSsl.a" />
       <DirectPInvoke Include="libSystem.Security.Cryptography.Native.OpenSsl" />

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -7,8 +7,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <!-- Can't use NativeAOT in non-portable build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(PortableBuild)' != 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.EndsWith('-arm')) == 'true'">false</NativeAotSupported>
     <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -20,8 +20,6 @@
     <ShouldVerifyClosure>false</ShouldVerifyClosure>
     <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->
     <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
-    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(DotNetBuildFromSource)' == 'true'">false</NativeAotSupported>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Add a breadcrumb for non-portable build into the Native AOT runtime pack
- Use the breadcrumb to add system OpenSSL libs to the linker command line

Contributes to #66859