### PR TITLE
JIT: Improve consistency around indir flags; directly copy flags in `gtCloneExpr`

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3341,6 +3341,9 @@ public:
     GenTreeBlk* gtNewStoreBlkNode(
         ClassLayout* layout, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY);
 
+    GenTreeStoreDynBlk* gtNewStoreDynBlkNode(
+        GenTree* addr, GenTree* data, GenTree* dynamicSize, GenTreeFlags indirFlags = GTF_EMPTY);
+
     GenTreeStoreInd* gtNewStoreIndNode(
         var_types type, GenTree* addr, GenTree* data, GenTreeFlags indirFlags = GTF_EMPTY);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -8583,7 +8583,7 @@ GenTree* Compiler::gtNewLoadValueNode(var_types type, ClassLayout* layout, GenTr
 //
 // Arguments:
 //    layout     - The struct layout
-//    addr       - Destionation address
+//    addr       - Destination address
 //    data       - Value to store
 //    indirFlags - Indirection flags
 //
@@ -8607,13 +8607,13 @@ GenTreeBlk* Compiler::gtNewStoreBlkNode(ClassLayout* layout, GenTree* addr, GenT
 // gtNewStoreDynBlkNode : Create a dynamic block store node.
 //
 // Arguments:
-//    addr       - Destionation address
-//    data       - Value to store (init val or indirection representing a location)
-//
-//    indirFlags - Indirection flags
+//    addr        - Destination address
+//    data        - Value to store (init val or indirection representing a location)
+//    dynamicSize - Node that computes number of bytes to store
+//    indirFlags  - Indirection flags
 //
 // Return Value:
-//    The created GT_STORE_BLK node.
+//    The created GT_STORE_DYN_BLK node.
 //
 GenTreeStoreDynBlk* Compiler::gtNewStoreDynBlkNode(GenTree*     addr,
                                                    GenTree*     data,

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -7481,10 +7481,7 @@ public:
     GenTreeStoreDynBlk(GenTree* dstAddr, GenTree* data, GenTree* dynamicSize)
         : GenTreeBlk(GT_STORE_DYN_BLK, TYP_VOID, dstAddr, data, nullptr), gtDynamicSize(dynamicSize)
     {
-        // Conservatively the 'dstAddr' could be null or point into the global heap.
-        // Likewise, this is a store and so must be marked with the GTF_ASG flag.
-        gtFlags |= (GTF_ASG | GTF_EXCEPT | GTF_GLOB_REF);
-        gtFlags |= (dynamicSize->gtFlags & GTF_ALL_EFFECT);
+        gtFlags |= dynamicSize->gtFlags & GTF_ALL_EFFECT;
     }
 
 #if DEBUGGABLE_GENTREE

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -10296,8 +10296,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     op3 = gtNewCastNode(TYP_I_IMPL, op3, /* fromUnsigned */ true, TYP_I_IMPL);
 #endif
 
-                    op1 = new (this, GT_STORE_DYN_BLK) GenTreeStoreDynBlk(op1, op2, op3);
-                    op1->gtFlags |= indirFlags;
+                    op1 = gtNewStoreDynBlkNode(op1, op2, op3, indirFlags);
                 }
                 goto SPILL_APPEND;
             }


### PR DESCRIPTION
- Switch `GT_STORE_DYN_BLK` to be on the same plan as other indirs; add a `gtNewStoreDynBlkNode` and use `gtInitializeIndirNode` to set its flags correctly. Add support for it to `GenTree::SetIndirExceptionFlags`. Remove conservative flag setting from its constructor.
- Fix propagation of `GTF_EXCEPT` from `GT_CMPXCHG`'s data source inside `GenTree::SetIndirExceptionFlags`
- Set flags directly from the source node in `gtCloneExpr`

Fix #97524