### PR TITLE
[browser][MT] Enable `DerivedCancellationTokenSource`, `AbandonExisting`

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/CancellationTokenTests.cs
@@ -874,7 +874,6 @@ namespace System.Threading.Tasks.Tests
 
         // Several tests for deriving custom user types from CancellationTokenSource
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/94486", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void DerivedCancellationTokenSource()
         {
             // Verify that a derived CTS is functional

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -421,7 +421,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91547", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         [MemberData(nameof(AbandonExisting_MemberData))]
         public void AbandonExisting(
             string name,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/94486 https://github.com/dotnet/runtime/issues/91547.

Cannot reproduce locally (1k trials on repeat), enabling to test on CI.