### PR TITLE
Exclude tests for Apple platforms on hybrid mode

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
@@ -98,8 +98,9 @@ namespace System.Globalization.Tests
             yield return new object[] { '\u2029', thaiCmpInfo }; // ParagraphSeparator: PARAGRAPH SEPARATOR
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization), nameof(PlatformDetection.IsNotHybridGlobalizationOnApplePlatform))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
         [MemberData(nameof(CheckHashingOfSkippedChars_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/95338", typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnApplePlatform))]
         public void CheckHashingOfSkippedChars(char character, CompareInfo cmpInfo)
         {
             string str1 = $"a{character}b";

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CompareInfo/CompareInfoTests.HashCode.cs
@@ -25,7 +25,8 @@ namespace System.Globalization.Tests
 
             if (!PlatformDetection.IsHybridGlobalizationOnBrowser)
             {
-                yield return new object[] { new CultureInfo("en-GB").CompareInfo, "100", "100!", CompareOptions.IgnoreSymbols }; // HG: equal: True, hashCodesEqual: False
+                if (PlatformDetection.IsNotHybridGlobalizationOnApplePlatform)
+                    yield return new object[] { new CultureInfo("en-GB").CompareInfo, "100", "100!", CompareOptions.IgnoreSymbols }; // HG: equal: True, hashCodesEqual: False
                 yield return new object[] { new CultureInfo("ja-JP").CompareInfo, "\u30A2", "\u3042", CompareOptions.IgnoreKanaType }; // HG: equal: True, hashCodesEqual: False
                 yield return new object[] { new CultureInfo("en-GB").CompareInfo, "caf\u00E9", "cafe\u0301", CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreKanaType }; // HG: equal: True, hashCodesEqual: False
             }
@@ -97,7 +98,7 @@ namespace System.Globalization.Tests
             yield return new object[] { '\u2029', thaiCmpInfo }; // ParagraphSeparator: PARAGRAPH SEPARATOR
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization), nameof(PlatformDetection.IsNotHybridGlobalizationOnApplePlatform))]
         [MemberData(nameof(CheckHashingOfSkippedChars_TestData))]
         public void CheckHashingOfSkippedChars(char character, CompareInfo cmpInfo)
         {


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/97299 , ICU specific tests started to fail on Apple platforms for HybridGlobalization.

- `IgnoreSymbols` is not supported in `HybridGlobalization` for Apple platforms , exclude this test case.
- Mark as ActiveIssue https://github.com/dotnet/runtime/issues/95338 `HashCode` related failures.

