### PR TITLE
[mono][interp] Fix inlining of ldarga

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -7763,7 +7763,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				} else {
 					int loc_n = arg_locals [n];
 					interp_add_ins (td, MINT_LDLOCA_S);
-					interp_ins_set_sreg (td->last_ins, n);
+					interp_ins_set_sreg (td->last_ins, loc_n);
 					td->vars [loc_n].indirects++;
 				}
 				push_simple_type (td, STACK_TYPE_MP);


### PR DESCRIPTION
When inlining a method, all arguments are first copied to new vars. Ldarga is going to be applied on these copies. We were loading the address of the wrong var due to typo.

Fixes https://github.com/dotnet/runtime/issues/97377