### PR TITLE
Add Arm64 encoding for IF_SVE_DE_1A group

### DIFF
--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -4822,6 +4822,16 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R(INS_sve_pfirst, EA_SCALABLE, REG_P0, REG_P15,
                             INS_OPTS_SCALABLE_B); // PFIRST  <Pdn>.B, <Pg>, <Pdn>.B
 
+    // IF_SVE_DE_1A
+    theEmitter->emitIns_R_PATTERN(INS_sve_ptrue, EA_SCALABLE, REG_P0, INS_OPTS_SCALABLE_B,
+                                  SVE_PATTERN_POW2); // PTRUE   <Pd>.<T>{, <pattern>}
+    theEmitter->emitIns_R_PATTERN(INS_sve_ptrue, EA_SCALABLE, REG_P7, INS_OPTS_SCALABLE_H,
+                                  SVE_PATTERN_MUL3); // PTRUE   <Pd>.<T>{, <pattern>}
+    theEmitter->emitIns_R_PATTERN(INS_sve_ptrues, EA_SCALABLE, REG_P8, INS_OPTS_SCALABLE_S,
+                                  SVE_PATTERN_ALL); // PTRUES  <Pd>.<T>{, <pattern>}
+    theEmitter->emitIns_R_PATTERN(INS_sve_ptrues, EA_SCALABLE, REG_P15,
+                                  INS_OPTS_SCALABLE_D); // PTRUES  <Pd>.<T>{, <pattern>}
+
     // IF_SVE_DG_2A
     theEmitter->emitIns_R_R(INS_sve_rdffr, EA_SCALABLE, REG_P10, REG_P15,
                             INS_OPTS_SCALABLE_B); // RDFFR   <Pd>.B, <Pg>/Z

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -1212,6 +1212,9 @@ void emitIns_R_R_FLAGS_COND(
 
 void emitIns_R_I_FLAGS_COND(instruction ins, emitAttr attr, regNumber reg1, int imm, insCflags flags, insCond cond);
 
+void emitIns_R_PATTERN(
+    instruction ins, emitAttr attr, regNumber reg1, insOpts opt, insSvePattern pattern = SVE_PATTERN_ALL);
+
 void emitIns_R_PATTERN_I(instruction ins, emitAttr attr, regNumber reg1, insSvePattern pattern, int imm);
 
 void emitIns_BARR(instruction ins, insBarrier barrier);


### PR DESCRIPTION
This group emits  instructions with pattern, `ptrue` and `ptrues`.

This clr output matches the one from capstone.
```
...
ptrue p0.b, pow2
ptrue p7.h, mul3
ptrues p8.s
ptrues p15.d
...
```

Contribute towards #94549.