### PR TITLE
 [release/8.0-staging][mono][debugger] Fix decode_value_compute_size 

### DIFF
--- a/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
+++ b/src/mono/wasm/debugger/BrowserDebugProxy/JObjectValueCreator.cs
@@ -104,7 +104,6 @@ internal sealed class JObjectValueCreator
             case ElementType.U:
             case ElementType.Void:
             case (ElementType)ValueTypeId.VType:
-            case (ElementType)ValueTypeId.FixedArray:
                 ret = Create(value: "void", type: "void", description: "void");
                 break;
             case ElementType.Boolean:
@@ -418,5 +417,99 @@ internal sealed class JObjectValueCreator
                               className: className.ToString(),
                               objectId: "dotnet:array:" + objectId,
                               subtype: length.Rank == 1 ? "array" : null);
+    }
+
+    public async Task<JObject> CreateFixedArrayElement(MonoBinaryReader retDebuggerCmdReader, ElementType etype, string name, CancellationToken token)
+    {
+        JObject ret = null;
+        switch (etype)
+        {
+            case ElementType.I:
+            case ElementType.U:
+            case ElementType.Void:
+            case (ElementType)ValueTypeId.VType:
+                ret = Create(value: "void", type: "void", description: "void");
+                break;
+            case ElementType.Boolean:
+                {
+                    var value = retDebuggerCmdReader.ReadInt32();
+                    ret = CreateFromPrimitiveType(value == 1);
+                    break;
+                }
+            case ElementType.I1:
+                {
+                    var value = retDebuggerCmdReader.ReadSByte();
+                    ret = CreateJObjectForNumber<int>(value);
+                    break;
+                }
+            case ElementType.I2:
+            case ElementType.I4:
+                {
+                    var value = retDebuggerCmdReader.ReadInt32();
+                    ret = CreateJObjectForNumber<int>(value);
+                    break;
+                }
+            case ElementType.U1:
+                {
+                    var value = retDebuggerCmdReader.ReadUByte();
+                    ret = CreateJObjectForNumber<int>(value);
+                    break;
+                }
+            case ElementType.U2:
+                {
+                    var value = retDebuggerCmdReader.ReadUShort();
+                    ret = CreateJObjectForNumber<int>(value);
+                    break;
+                }
+            case ElementType.U4:
+                {
+                    var value = retDebuggerCmdReader.ReadUInt32();
+                    ret = CreateJObjectForNumber<uint>(value);
+                    break;
+                }
+            case ElementType.R4:
+                {
+                    float value = retDebuggerCmdReader.ReadSingle();
+                    ret = CreateJObjectForNumber<float>(value);
+                    break;
+                }
+            case ElementType.Char:
+                {
+                    var value = retDebuggerCmdReader.ReadInt32();
+                    ret = CreateJObjectForChar(value);
+                    break;
+                }
+            case ElementType.I8:
+                {
+                    long value = retDebuggerCmdReader.ReadInt64();
+                    ret = CreateJObjectForNumber<long>(value);
+                    break;
+                }
+            case ElementType.U8:
+                {
+                    ulong value = retDebuggerCmdReader.ReadUInt64();
+                    ret = CreateJObjectForNumber<ulong>(value);
+                    break;
+                }
+            case ElementType.R8:
+                {
+                    double value = retDebuggerCmdReader.ReadDouble();
+                    ret = CreateJObjectForNumber<double>(value);
+                    break;
+                }
+            case ElementType.FnPtr:
+            case ElementType.Ptr:
+                {
+                    ret = await ReadAsPtrValue(etype, retDebuggerCmdReader, name, token);
+                    break;
+                }
+            default:
+                {
+                    _logger.LogDebug($"Could not evaluate CreateFixedArrayElement invalid type {etype}");
+                    break;
+                }
+        }
+        ret["name"] = name;
+        return ret;
     }
 }

--- a/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -749,5 +749,28 @@ namespace DebuggerTests
                    ("f[f.numArray[f.numList[0]], f.numArray[f.numArray[i]]]", TNumber("4"))
                 ); 
            });
+
+        [Fact]
+        public async Task EvaluateValueTypeWithFixedArrayAndMoreFields() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateValueTypeWithFixedArray", "run", 3, "DebuggerTests.EvaluateValueTypeWithFixedArray.run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateValueTypeWithFixedArray:run'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               await RuntimeEvaluateAndCheck(
+                   ("myVar.MyMethod()", TNumber(13)),
+                   ("myVar.myIntArray[0]", TNumber(1)),
+                   ("myVar.myIntArray[1]", TNumber(2)),
+                   ("myVar.myCharArray[2]", TChar('a')));
+           });
+
+        [Fact]
+        public async Task EvaluateValueTypeWithObjectValueType() => await CheckInspectLocalsAtBreakpointSite(
+            "DebuggerTests.EvaluateValueTypeWithObjectValueType", "run", 3, "DebuggerTests.EvaluateValueTypeWithObjectValueType.run",
+            "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateValueTypeWithObjectValueType:run'); })",
+            wait_for_event_fn: async (pause_location) =>
+           {
+               await RuntimeEvaluateAndCheck(
+                   ("myVar.MyMethod()", TNumber(10)));
+           });
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-evaluate-test.cs
@@ -2182,4 +2182,50 @@ namespace DebuggerTests
             Console.WriteLine(dt);
         }
     }
+    public unsafe struct EvaluateValueTypeWithFixedArray
+    {
+        private fixed int myIntArray[4];
+        private fixed char myCharArray[3];
+        double myDouble;
+        public EvaluateValueTypeWithFixedArray()
+        {
+            myDouble = 10;
+            myIntArray[0] = 1;
+            myIntArray[1] = 2;
+            myCharArray[2] = 'a';
+        }
+        public int MyMethod()
+        {
+            Console.WriteLine(myDouble);
+            return myIntArray[0] + myIntArray[1] + (int)myDouble;
+        }
+        public static void run()
+        {
+            var myVar = new EvaluateValueTypeWithFixedArray();
+            Console.WriteLine("pause here");
+            myVar.MyMethod();
+        }
+    }
+
+    public struct EvaluateValueTypeWithObjectValueType
+    {
+        private object myObject;
+        double myDouble;
+        public EvaluateValueTypeWithObjectValueType()
+        {
+            myObject = new int();
+            myDouble = 10;
+        }
+        public int MyMethod()
+        {
+            Console.WriteLine(myDouble);
+            return (int)myObject + (int)myDouble;
+        }
+        public static void run()
+        {
+            var myVar = new EvaluateValueTypeWithObjectValueType();
+            Console.WriteLine("pause here");
+            myVar.MyMethod();
+        }
+    }
 }


### PR DESCRIPTION
Backport of #97418 to release/8.0-staging

/cc @thaystg

## Customer Impact

- [x] Customer reported
- [ ] Found internally

https://github.com/xamarin/xamarin-android/issues/8653
Avoid assertion on runtime while debugging.
Fix debugger experience when it's trying to evaluate an expression that has a value type with an object inside it like this:
```
public struct EvaluateValueTypeWithObjectValueType
{
        private object myObject;
        double myDouble;
        public EvaluateValueTypeWithObjectValueType()
        {
            myObject = new int();
            myDouble = 10;
        }
}
```

## Regression

- [x] Yes
- [ ] No

This was introduced in this PR: https://github.com/dotnet/runtime/pull/76332


## Testing
Manually tested. 
Also added a test case.

## Risk
Medium risk, only reading the debugger buffer correctly.


