### PR TITLE
Rework the  special instantiation type logic to be more effective (Take 2)

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1326,10 +1326,22 @@ void SystemDomain::LoadBaseSystemClasses()
         CoreLibBinder::GetModule()->AllocateRegularStaticHandles(DefaultDomain());
 
         // Boolean has to be loaded first to break cycle in IComparisonOperations and IEqualityOperators
-        CoreLibBinder::LoadPrimitiveType(ELEMENT_TYPE_BOOLEAN);
+        TypeHandle thBoolean(CoreLibBinder::LoadPrimitiveType(ELEMENT_TYPE_BOOLEAN));
+
+        Instantiation::CustomSpecialInstantiationTokens[0] = CoreLibBinder::GetClass(CLASS__ICOMPARISONOPERATORS)->GetCl();
+        Instantiation::CustomSpecialInstantiationTypes[0] = thBoolean;
+        Instantiation::CustomSpecialInstantiationIndices[0] = 2;
+
+        Instantiation::CustomSpecialInstantiationTokens[1] = CoreLibBinder::GetClass(CLASS__IEQUALITYOPERATORS)->GetCl();
+        Instantiation::CustomSpecialInstantiationTypes[1] = thBoolean;
+        Instantiation::CustomSpecialInstantiationIndices[1] = 2;
 
         // Int32 has to be loaded next to break cycle in IShiftOperators
-        CoreLibBinder::LoadPrimitiveType(ELEMENT_TYPE_I4);
+        TypeHandle thI4(CoreLibBinder::LoadPrimitiveType(ELEMENT_TYPE_I4));
+
+        Instantiation::CustomSpecialInstantiationTokens[2] = CoreLibBinder::GetClass(CLASS__ISHIFTOPERATORS)->GetCl();
+        Instantiation::CustomSpecialInstantiationTypes[2] = thI4;
+        Instantiation::CustomSpecialInstantiationIndices[2] = 1;
 
         // Make sure all primitive types are loaded
         for (int et = ELEMENT_TYPE_VOID; et <= ELEMENT_TYPE_R8; et++)

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -465,6 +465,10 @@ DEFINE_CLASS(VECTOR512T,            Intrinsics,             Vector512`1)
 
 DEFINE_CLASS(VECTORT,               Numerics,               Vector`1)
 
+DEFINE_CLASS(ISHIFTOPERATORS,       Numerics,               IShiftOperators`3)
+DEFINE_CLASS(ICOMPARISONOPERATORS,  Numerics,               IComparisonOperators`3)
+DEFINE_CLASS(IEQUALITYOPERATORS,    Numerics,               IEqualityOperators`3)
+
 DEFINE_CLASS(MEMBER,                Reflection,             MemberInfo)
 
 DEFINE_CLASS(METHODBASEINVOKER,     Reflection,             MethodBaseInvoker)

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -1401,7 +1401,7 @@ FORCEINLINE BOOL MethodTable::ImplementsInterfaceInline(MethodTable *pInterface)
     while (--numInterfaces);
 
     // Second scan, looking for the curiously recurring generic scenario
-    if (pInterface->HasInstantiation() && !ContainsGenericVariables() && pInterface->GetInstantiation().ContainsAllOneType(this))
+    if (pInterface->HasInstantiation() && !pInterface->IsGenericTypeDefinition() && pInterface->GetInstantiation().ContainsExpectedSpecialInstantiation(pInterface, this))
     {
         numInterfaces = GetNumInterfaces();
         pInfo = GetInterfaceMap();

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1518,9 +1518,11 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
 
                 Instantiation genericLoadInst(thisinst, ntypars);
 
-                if (pMTInterfaceMapOwner != NULL && genericLoadInst.ContainsAllOneType(pMTInterfaceMapOwner))
+                if (pMTInterfaceMapOwner != NULL && genericLoadInst.ContainsExpectedSpecialInstantiation(genericType.AsMethodTable(), pMTInterfaceMapOwner))
                 {
-                    thRet = ClassLoader::LoadTypeDefThrowing(pGenericTypeModule, tkGenericType, ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, level);
+                    ClassLoader::EnsureLoaded(genericType, level);
+                    thRet = genericType;
+                    _ASSERTE(thRet == ClassLoader::LoadTypeDefThrowing(pGenericTypeModule, tkGenericType, ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, level));
                 }
                 else
                 {

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -736,16 +736,30 @@ public:
         return m_pArgs;
     }
 
-    bool ContainsAllOneType(TypeHandle th)
+#define NUMBER_OF_EXTRA_SPECIAL_INTERFACE_TYPES 3
+    static mdToken CustomSpecialInstantiationTokens[NUMBER_OF_EXTRA_SPECIAL_INTERFACE_TYPES];
+    static DWORD CustomSpecialInstantiationIndices[NUMBER_OF_EXTRA_SPECIAL_INTERFACE_TYPES];
+    static TypeHandle CustomSpecialInstantiationTypes[NUMBER_OF_EXTRA_SPECIAL_INTERFACE_TYPES];
+
+    // Determine if the instantiation is the one which a Special Marker Type would be associated with
+    // IN: pMTGenericType - MethodTable of generic interface type to determine if it matches the expected instantiation. This may or may not be the open generic instance
+    //     pMTInterfaceMapOwner - MethodTable where an instantiation of the generic type def defined by pMTGenerictype will be instantiated over this instantiation.
+    // RESULT: a bool indicating whether or not this is the particular instantiation which can be efficiently represented by the Special Marker Type.
+    bool ContainsExpectedSpecialInstantiation(MethodTable *pMTGenericType, MethodTable *pMTInterfaceMapOwner);
+    bool ContainsExpectedSpecialInstantiationWithOwnerWithSpecificInstantiation(MethodTable *pMTGenericType, MethodTable *pMTInterfaceMapOwner, const Instantiation& instForOwnerMT);
+
+    bool Equals(const Instantiation& other)
     {
-        for (auto i = GetNumArgs(); i > 0;)
+        if (GetNumArgs() != other.GetNumArgs())
+            return false;
+        for (DWORD iArg = 0; iArg < m_nArgs; iArg++)
         {
-            if ((*this)[--i] != th)
+            if (m_pArgs[iArg] != other.m_pArgs[iArg])
                 return false;
         }
         return true;
     }
-
+    
 private:
     // Note that for DAC builds, m_pArgs may be host allocated buffer, not a copy of an object marshalled by DAC.
     TypeHandle* m_pArgs;


### PR DESCRIPTION
- Currently it only handles interfaces defined on valuetypes
- Change it to work for interfaces that are required implementation of other interfaces
  - (In that case, if the interface is generic, the special instantiation type is the first type parameter of the interface, not anything else.)

This change removes some safety checks that I can't find the rationale for. This may cause some entertaining failures in CI

Handle the various special cases for IComparisonOperators, IShiftOperators and IEqualityOperators

Fix missing detail of previous commit. We need to actually specialize around interface creation correctly.

This probably needs additional cleanup, but these are the changes so that default interface methods, and static virtual method lookup don't trigger unnecessary type loads. Effectively, what they do is carry along the expected instantiation with the open type for performing the checks necessary.

Reword special marker interface handling to work as a generalized interface instantiation computation arrangement
- Add an ability to represent the common patterns for collections interfaces
- But since collections are not commonly structs, this doesn't do much yet.

Enable arbitrary classes to use the special marker type interfaces by adjust interface expansion in LoadExactInterfaceMap to simply expand and attempt to use the special marker interfaces

Allow use of the special marker types on derived types.

Fix incorrect assert