### PR TITLE
Remove some dead/redundant code in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -111,10 +111,6 @@ namespace System
             AllUriInfoSet = unchecked(0x80000000),
             IdnHost = 0x100000000,
             HasUnicode = 0x200000000,
-            HostUnicodeNormalized = 0x400000000,
-            RestUnicodeNormalized = 0x800000000,
-            UnicodeHost = 0x1000000000,
-            IntranetUri = 0x2000000000,
             // Is this component Iri canonical
             UserIriCanonical = 0x8000000000,
             PathIriCanonical = 0x10000000000,
@@ -1977,14 +1973,15 @@ namespace System
 
             int idx = (int)(_flags & Flags.IndexMask);
             int length = _string.Length;
-            string? newHost = null;      // stores newly parsed host when original strings are being switched
 
             // Means a custom UriParser did call "base" InitializeAndValidate()
             _flags &= ~(Flags.IndexMask | Flags.UserDrivenParsing);
 
             //STEP2: Parse up to the port
 
-            fixed (char* pUriString = (_flags & Flags.HostUnicodeNormalized) == 0 ? OriginalString : _string)
+            Debug.Assert(ReferenceEquals(_string, OriginalString));
+
+            fixed (char* pUriString = _string)
             {
                 // Cut trailing spaces in _string
                 if (length > idx && UriHelper.IsLWS(pUriString[length - 1]))
@@ -2113,7 +2110,7 @@ namespace System
                     else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                     {
                         // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.
-                        if ((_flags & (Flags.HasUnicode | Flags.HostUnicodeNormalized)) == Flags.HasUnicode)
+                        if (InFact(Flags.HasUnicode))
                         {
                             _string = _string.Substring(0, idx);
                         }
@@ -2131,7 +2128,7 @@ namespace System
                 else if (_syntax.NotAny(UriSyntaxFlags.MailToLikeUri))
                 {
                     // By now we know the URI has no Authority, so if the URI must be normalized, initialize it without one.
-                    if ((_flags & (Flags.HasUnicode | Flags.HostUnicodeNormalized)) == Flags.HasUnicode)
+                    if (InFact(Flags.HasUnicode))
                     {
                         _string = _string.Substring(0, idx);
                     }
@@ -2159,6 +2156,8 @@ namespace System
                 // We must ensure that known schemes do use a server-based authority
                 {
                     ParsingError err = ParsingError.None;
+                    string? newHost = null; // stores newly parsed host when original strings are being switched
+
                     idx = CheckAuthorityHelper(pUriString, idx, length, ref err, ref _flags, _syntax, ref newHost);
                     if (err != ParsingError.None)
                         return err;
@@ -2178,6 +2177,11 @@ namespace System
                             _syntax = UriParser.UnixFileUri;
                         }
                     }
+
+                    if (newHost is not null)
+                    {
+                        _string = newHost;
+                    }
                 }
 
                 // The Path (or Port) parsing index is reloaded on demand in CreateUriInfo when accessing a Uri property
@@ -2186,12 +2190,6 @@ namespace System
                 // The rest of the string will be parsed on demand
                 // The Host/Authority is all checked, the type is known but the host value string
                 // is not created/canonicalized at this point.
-            }
-
-            if (IriParsing && newHost != null)
-            {
-                // we have a new host!
-                _string = newHost;
             }
 
             return ParsingError.None;
@@ -3201,7 +3199,7 @@ namespace System
                 goto Done;
 
             // Do we have to continue building Iri'zed string from original string
-            bool buildIriStringFromPath = (_flags & (Flags.HasUnicode | Flags.RestUnicodeNormalized)) == Flags.HasUnicode;
+            bool buildIriStringFromPath = InFact(Flags.HasUnicode);
 
             int origIdx; // stores index to switched original string
             int idx = _info.Offset.Scheme;
@@ -3325,7 +3323,7 @@ namespace System
                 }
 
                 _info.Offset.Query = (ushort)idx;
-                _info.Offset.Fragment = (ushort)str.Length; // There is no fragment in UseRawTarget mode
+                _info.Offset.Fragment = (ushort)str.Length; // There is no fragment in DisablePathAndQueryCanonicalization mode
                 _info.Offset.End = (ushort)str.Length;
 
                 goto Done;
@@ -3603,7 +3601,7 @@ namespace System
             _info.Offset.End = (ushort)idx;
 
         Done:
-            cF |= Flags.AllUriInfoSet | Flags.RestUnicodeNormalized;
+            cF |= Flags.AllUriInfoSet;
             InterlockedSetFlags(cF);
         }
 
@@ -3788,16 +3786,13 @@ namespace System
             int startInput = idx;
             int start = idx;
             newHost = null;
-            bool justNormalized = false;
-            bool iriParsing = IriParsingStatic(syntax);
             bool hasUnicode = ((flags & Flags.HasUnicode) != 0);
-            bool hostNotUnicodeNormalized = hasUnicode && ((flags & Flags.HostUnicodeNormalized) == 0);
             UriSyntaxFlags syntaxFlags = syntax.Flags;
 
             Debug.Assert((_flags & Flags.HasUserInfo) == 0 && (_flags & Flags.HostTypeMask) == 0);
 
             // need to build new Iri'zed string
-            if (hostNotUnicodeNormalized)
+            if (hasUnicode)
             {
                 newHost = _originalUnicodeString.Substring(0, startInput);
             }
@@ -3815,11 +3810,6 @@ namespace System
                 }
                 else
                     err = ParsingError.BadHostName;
-
-                if (hostNotUnicodeNormalized)
-                {
-                    flags |= Flags.HostUnicodeNormalized; // no host
-                }
 
                 return idx;
             }
@@ -3841,7 +3831,7 @@ namespace System
                         flags |= Flags.HasUserInfo;
 
                         // Iri'ze userinfo
-                        if (iriParsing && hostNotUnicodeNormalized)
+                        if (hasUnicode)
                         {
                             // Normalize user info
                             newHost += IriHelper.EscapeUnescapeIri(pString, startInput, start + 1, UriComponents.UserInfo);
@@ -3864,11 +3854,9 @@ namespace System
             {
                 flags |= Flags.IPv6HostType;
 
-                if (hostNotUnicodeNormalized)
+                if (hasUnicode)
                 {
                     newHost = string.Concat(newHost, new ReadOnlySpan<char>(pString + start, end - start));
-                    flags |= Flags.HostUnicodeNormalized;
-                    justNormalized = true;
                 }
             }
             else if (char.IsAsciiDigit(ch) && syntax.InFact(UriSyntaxFlags.AllowIPv4Host) &&
@@ -3876,14 +3864,12 @@ namespace System
             {
                 flags |= Flags.IPv4HostType;
 
-                if (hostNotUnicodeNormalized)
+                if (hasUnicode)
                 {
                     newHost = string.Concat(newHost, new ReadOnlySpan<char>(pString + start, end - start));
-                    flags |= Flags.HostUnicodeNormalized;
-                    justNormalized = true;
                 }
             }
-            else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) && !iriParsing &&
+            else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) && !IriParsingStatic(syntax) &&
                 DomainNameHelper.IsValid(new ReadOnlySpan<char>(pString + start, end - start), iri: false, StaticNotAny(flags, Flags.ImplicitFile), out int domainNameLength))
             {
                 end = start + domainNameLength;
@@ -3898,13 +3884,13 @@ namespace System
                 }
             }
             else if (((syntaxFlags & UriSyntaxFlags.AllowDnsHost) != 0) &&
-                (hostNotUnicodeNormalized || syntax.InFact(UriSyntaxFlags.AllowIdn)) &&
+                (hasUnicode || syntax.InFact(UriSyntaxFlags.AllowIdn)) &&
                 DomainNameHelper.IsValid(new ReadOnlySpan<char>(pString + start, end - start), iri: true, StaticNotAny(flags, Flags.ImplicitFile), out domainNameLength))
             {
                 end = start + domainNameLength;
 
                 CheckAuthorityHelperHandleDnsIri(pString, start, end, hasUnicode,
-                    ref flags, ref justNormalized, ref newHost, ref err);
+                    ref flags, ref newHost, ref err);
             }
             else if ((syntaxFlags & UriSyntaxFlags.AllowUncHost) != 0)
             {
@@ -3916,11 +3902,9 @@ namespace System
                     if (end - start <= UncNameHelper.MaximumInternetNameLength)
                     {
                         flags |= Flags.UncHostType;
-                        if (hostNotUnicodeNormalized)
+                        if (hasUnicode)
                         {
                             newHost = string.Concat(newHost, new ReadOnlySpan<char>(pString + start, end - start));
-                            flags |= Flags.HostUnicodeNormalized;
-                            justNormalized = true;
                         }
                     }
                 }
@@ -3990,7 +3974,7 @@ namespace System
                         }
                     }
 
-                    if (hasUnicode && justNormalized)
+                    if (hasUnicode)
                     {
                         newHost = string.Concat(newHost, new ReadOnlySpan<char>(pString + startPort, idx - startPort));
                     }
@@ -4019,7 +4003,7 @@ namespace System
                         }
                     }
 
-                    if (hostNotUnicodeNormalized)
+                    if (hasUnicode)
                     {
                         // Normalize any other host or do idn
                         string user = new string(pString, startInput, end - startInput);
@@ -4032,8 +4016,6 @@ namespace System
                         {
                             err = ParsingError.BadHostName;
                         }
-
-                        flags |= Flags.HostUnicodeNormalized;
                     }
                 }
                 else
@@ -4067,7 +4049,7 @@ namespace System
                         //success
                         flags |= Flags.BasicHostType;
 
-                        if (hostNotUnicodeNormalized)
+                        if (hasUnicode)
                         {
                             // Normalize any other host
                             string user = new string(pString, startOtherHost, end - startOtherHost);
@@ -4080,8 +4062,6 @@ namespace System
                                 err = ParsingError.BadFormat;
                                 return idx;
                             }
-
-                            flags |= Flags.HostUnicodeNormalized;
                         }
                     }
                     else if (syntax.InFact(UriSyntaxFlags.MustHaveAuthority) ||
@@ -4098,7 +4078,7 @@ namespace System
 
         private static unsafe void CheckAuthorityHelperHandleDnsIri(char* pString, int start, int end,
             bool hasUnicode, ref Flags flags,
-            ref bool justNormalized, ref string? newHost, ref ParsingError err)
+            ref string? newHost, ref ParsingError err)
         {
             // comes here only if host has unicode chars and iri is on or idn is allowed
 
@@ -4115,9 +4095,7 @@ namespace System
                 {
                     err = ParsingError.BadHostName;
                 }
-                justNormalized = true;
             }
-            flags |= Flags.HostUnicodeNormalized;
         }
 
         //

--- a/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
@@ -54,15 +54,6 @@ namespace System
         // V1ToStringUnescape = 0x7FFF
     }
 
-    // This is used to control when host names are converted to idn names and
-    // vice versa
-    internal enum UriIdnScope
-    {
-        None,                   // Never use Idn
-        AllExceptIntranet,      // Use Idn in Internet and not intranet
-        All                     // Internet and intranet
-    }
-
     internal enum ParsingError
     {
         // looks good

--- a/src/libraries/System.Private.Uri/src/System/UriSyntax.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriSyntax.cs
@@ -38,8 +38,6 @@ namespace System
 
         V1_UnknownUri = 0x10000, // a Compatibility with V1 parser for an unknown scheme
         SimpleUserSyntax = 0x20000, // It is safe to not call virtual UriParser methods
-        BuiltInSyntax = 0x40000, // This is a simple Uri plus it is hardcoded in the product
-        ParserSchemeOnly = 0x80000, // This is a Parser that does only Uri scheme parsing
 
         AllowDOSPath = 0x100000,  // will check for "x:\"
         PathIsRooted = 0x200000,  // For an authority based Uri the first path char is '/'
@@ -50,8 +48,6 @@ namespace System
         AllowIdn = 0x4000000,    // IDN host conversion allowed
         AllowIriParsing = 0x10000000,   // Iri parsing. String is normalized, bidi control
                                         // characters are removed, unicode char limits are checked etc.
-
-        //      KeepTailLWS             = 0x8000000,
     }
 
     //
@@ -114,7 +110,7 @@ namespace System
             // All BuiltIn parsers use that ctor. They are marked with "simple" and "built-in" flags
             //
             internal BuiltInUriParser(string lwrCaseScheme, int defaultPort, UriSyntaxFlags syntaxFlags)
-                : base((syntaxFlags | UriSyntaxFlags.SimpleUserSyntax | UriSyntaxFlags.BuiltInSyntax))
+                : base(syntaxFlags | UriSyntaxFlags.SimpleUserSyntax)
             {
                 _scheme = lwrCaseScheme;
                 _port = defaultPort;
@@ -418,8 +414,6 @@ namespace System
                                         UriSyntaxFlags.PathIsRooted |
                                         UriSyntaxFlags.AllowIdn |
                                         UriSyntaxFlags.AllowIriParsing;
-
-        //                                        UriSyntaxFlags.KeepTailLWS |
 
         //Note that NNTP and NEWS are quite different in syntax
         private const UriSyntaxFlags NewsSyntaxFlags =


### PR DESCRIPTION
Some flags are just simply never used: `IntranetUri`, `BuiltInSyntax`, `ParserSchemeOnly`, `UriIdnScope`.

`HostUnicodeNormalized` is only set in `CheckAuthorityHelper`. Checking it in `PrivateParseMinimal` before calling into `CheckAuthorityHelper` is pointless since it couldn't have been set.

`RestUnicodeNormalized` is both checked and set only in `ParseRemaining`. But this method will be called exactly once if `HasUnicode` is set, so it will always be `false` for the one time it's checked.

Checking both `iriParsing` and `HasUnicode` is also redundant as `HasUnicode` can only be set if `iriParsing` was set.