### PR TITLE
Use Replace helper when converting backslashes

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4576,6 +4576,11 @@ namespace System
         //
         private static int Compress(Span<char> span, UriParser syntax)
         {
+            if (syntax.InFact(UriSyntaxFlags.ConvertPathSlashes))
+            {
+                span.Replace('\\', '/');
+            }
+
             int slashCount = 0;
             int lastSlash = 0;
             int dotCount = 0;
@@ -4584,10 +4589,6 @@ namespace System
             for (int i = span.Length - 1; i >= 0; i--)
             {
                 char ch = span[i];
-                if (ch == '\\' && syntax.InFact(UriSyntaxFlags.ConvertPathSlashes))
-                {
-                    span[i] = ch = '/';
-                }
 
                 // compress multiple '/' for file URI
                 if (ch == '/')


### PR DESCRIPTION
Instead of doing it inside the loop, we can do it upfront with a vectorized helper