### PR TITLE
[NativeAOT] ARM: Implement the EABI

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNodeSection.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectNodeSection.cs
@@ -10,6 +10,7 @@ namespace ILCompiler.DependencyAnalysis
         Executable,
         Uninitialized,
         Debug,
+        UnwindData,
     }
 
     /// <summary>

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -53,6 +53,9 @@ namespace ILCompiler.DependencyAnalysis
         IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_HI12    = 0x10B,
         IMAGE_REL_AARCH64_TLSLE_ADD_TPREL_LO12_NC = 0x10C,
 
+        // Linux arm32
+        IMAGE_REL_ARM_PREL31                 = 0x10D,
+
         //
         // Relocations for R2R image production
         //

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfCfiOpcode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfCfiOpcode.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ILCompiler.ObjectWriter
+{
+    /// <summary>
+    /// JIT enum used in the CFI code blob.
+    /// </summary>
+    internal enum CFI_OPCODE
+    {
+        CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
+        CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
+        CFI_REL_OFFSET,           // Register is saved at offset from the current CFA
+        CFI_DEF_CFA               // Take address from register and add offset to it.
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfFde.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfFde.cs
@@ -36,14 +36,6 @@ namespace ILCompiler.ObjectWriter
             PersonalitySymbolName = personalitySymbolName;
         }
 
-        private enum CFI_OPCODE
-        {
-            CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
-            CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
-            CFI_REL_OFFSET,           // Register is saved at offset from the current CFA
-            CFI_DEF_CFA               // Take address from register and add offset to it.
-        }
-
         /// <summary>
         /// Convert JIT version of CFI blob into the the DWARF byte code form.
         /// </summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiAttributesBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiAttributesBuilder.cs
@@ -13,6 +13,11 @@ using static ILCompiler.ObjectWriter.EabiNative;
 
 namespace ILCompiler.ObjectWriter
 {
+    /// <summary>
+    /// Builder class for constructing the .ARM.attributes table that
+    /// describes the parameters of the emitted ARM code for use by the
+    /// linker or debugger.
+    /// </summary>
     internal sealed class EabiAttributesBuilder
     {
         private readonly SectionWriter _sectionWriter;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiAttributesBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiAttributesBuilder.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+using static ILCompiler.ObjectWriter.EabiNative;
+
+namespace ILCompiler.ObjectWriter
+{
+    internal sealed class EabiAttributesBuilder
+    {
+        private readonly SectionWriter _sectionWriter;
+        private long _sectionSizePosition;
+        private byte[] _sectionSize;
+        private long _subsectionSizePosition;
+        private byte[] _subsectionSize;
+
+        public EabiAttributesBuilder(SectionWriter sectionWriter)
+        {
+            _sectionWriter = sectionWriter;
+
+            // Version
+            _sectionWriter.WriteByte(0x41);
+        }
+
+        public void StartSection(string vendor)
+        {
+            Debug.Assert(_sectionSize is null);
+            Debug.Assert(_subsectionSize is null);
+
+            _sectionSizePosition = _sectionWriter.Position;
+            _sectionSize = new byte[4];
+            _sectionWriter.EmitData(_sectionSize);
+
+            _sectionWriter.WriteUtf8String(vendor);
+
+            _sectionWriter.WriteByte((byte)Tag_File);
+
+            _subsectionSizePosition = _sectionWriter.Position;
+            _subsectionSize = new byte[4];
+            _sectionWriter.EmitData(_subsectionSize);
+        }
+
+        public void EndSection()
+        {
+            Debug.Assert(_sectionSize is not null);
+            Debug.Assert(_subsectionSize is not null);
+
+            BinaryPrimitives.WriteUInt32LittleEndian(_subsectionSize, (uint)(_sectionWriter.Position - _subsectionSizePosition));
+            BinaryPrimitives.WriteUInt32LittleEndian(_sectionSize, (uint)(_sectionWriter.Position - _sectionSizePosition));
+
+            _sectionSize = null;
+            _subsectionSize = null;
+        }
+
+        public void WriteAttribute(uint tag, ulong value)
+        {
+            Debug.Assert(_subsectionSize is not null);
+
+            _sectionWriter.WriteULEB128(tag);
+            _sectionWriter.WriteULEB128(value);
+        }
+
+        public void WriteAttribute(uint tag, string value)
+        {
+            Debug.Assert(_subsectionSize is not null);
+
+            _sectionWriter.WriteULEB128(tag);
+            _sectionWriter.WriteUtf8String(value);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiNative.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace ILCompiler.ObjectWriter
+{
+    /// <summary>
+    /// Native constants and enumerations for ARM EABI binary format.
+    /// </summary>
+    internal static class EabiNative
+    {
+        public const uint Tag_File = 1;
+        public const uint Tag_CPU_raw_name = 4;
+        public const uint Tag_CPU_name = 5;
+        public const uint Tag_CPU_arch = 6;
+        public const uint Tag_CPU_arch_profile = 7;
+        public const uint Tag_ARM_ISA_use = 8;
+        public const uint Tag_THUMB_ISA_use = 9;
+        public const uint Tag_FP_arch = 10;
+        public const uint Tag_ABI_PCS_R9_use = 14;
+        public const uint Tag_ABI_PCS_RW_data = 15;
+        public const uint Tag_ABI_PCS_RO_data = 16;
+        public const uint Tag_ABI_PCS_GOT_use = 17;
+        public const uint Tag_ABI_PCS_wchar_t = 18;
+        public const uint Tag_ABI_FP_rounding = 19;
+        public const uint Tag_ABI_FP_denormal = 20;
+        public const uint Tag_ABI_FP_exceptions = 21;
+        public const uint Tag_ABI_FP_user_exceptions = 22;
+        public const uint Tag_ABI_FP_number_model = 23;
+        public const uint Tag_ABI_align_needed = 24;
+        public const uint Tag_ABI_align_preserved = 25;
+        public const uint Tag_ABI_enum_size = 26;
+        public const uint Tag_ABI_optimization_goals = 30;
+        public const uint Tag_CPU_unaligned_access = 34;
+        public const uint Tag_ABI_FP_16bit_format = 38;
+        public const uint Tag_conformance = 67;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
@@ -36,7 +36,7 @@ namespace ILCompiler.ObjectWriter
 
             // The maximum sequence length of the ARM EHABI unwinding code is 1024
             // bytes.
-            byte[] unwindData = new byte[1024];
+            byte[] unwindData = ArrayPool<byte>.Shared.Rent(1024);
             int unwindDataOffset = 0;
 
             // The DWARF CFI data produced by the JIT describe the method prolog that
@@ -126,7 +126,9 @@ namespace ILCompiler.ObjectWriter
 
             FlushPendingOperation();
 
-            return unwindData[..unwindDataOffset];
+            var result = unwindData[..unwindDataOffset];
+            ArrayPool<byte>.Shared.Return(unwindData);
+            return result;
 
             void EmitPop(uint popMask)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+using static ILCompiler.ObjectWriter.EabiNative;
+
+namespace ILCompiler.ObjectWriter
+{
+    internal static class EabiUnwindConverter
+    {
+        private enum CFI_OPCODE
+        {
+            CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
+            CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
+            CFI_REL_OFFSET,           // Register is saved at offset from the current CFA
+            CFI_DEF_CFA               // Take address from register and add offset to it.
+        }
+
+        public static byte[] ConvertCFIToEabi(byte[] blobData)
+        {
+            if (blobData == null || blobData.Length == 0)
+            {
+                return blobData;
+            }
+
+            Debug.Assert(blobData.Length % 8 == 0);
+
+            // The maximum sequence length of the ARM EHABI unwinding code is 1024
+            // bytes.
+            byte[] unwindData = new byte[1024];
+            int unwindDataOffset = 0;
+            int popOffset = 0;
+            uint pendingPopMask = 0;
+            uint pendingVPopMask = 0;
+            int pendingSpAdjustment = 0;
+
+            // Walk the CFI data backwards
+            for (int offset = blobData.Length - 8; offset >= 0; offset -= 8)
+            {
+                CFI_OPCODE opcode = (CFI_OPCODE)blobData[offset + 1];
+                short dwarfReg = BinaryPrimitives.ReadInt16LittleEndian(blobData.AsSpan(offset + 2));
+                int cfiOffset = BinaryPrimitives.ReadInt32LittleEndian(blobData.AsSpan(offset + 4));
+
+                switch (opcode)
+                {
+                    case CFI_OPCODE.CFI_DEF_CFA_REGISTER:
+                        Debug.Assert(dwarfReg != 13); // SP
+                        Debug.Assert(dwarfReg < 15);
+
+                        FlushPendingOperation();
+                        // Set vsp = r[nnnn]
+                        unwindData[unwindDataOffset++] = (byte)(0x90 | dwarfReg);
+                        break;
+
+                    case CFI_OPCODE.CFI_REL_OFFSET:
+                        Debug.Assert(cfiOffset == popOffset);
+                        if (dwarfReg >= 0 && dwarfReg <= 15)
+                        {
+                            EmitPop((uint)(1u << dwarfReg));
+                            popOffset += 4;
+                        }
+                        else if (dwarfReg >= 256 && dwarfReg <= 271)
+                        {
+                            dwarfReg -= 256;
+                            EmitVPop((uint)(3u << (dwarfReg << 1)));
+                            popOffset += 8;
+                        }
+                        else
+                        {
+                            Debug.Fail("Unknown register");
+                        }
+                        break;
+
+                    case CFI_OPCODE.CFI_ADJUST_CFA_OFFSET:
+                        cfiOffset -= popOffset;
+                        popOffset = 0;
+                        if (cfiOffset != 0)
+                        {
+                            EmitSpAdjustment(cfiOffset);
+                        }
+                        break;
+                }
+            }
+
+            FlushPendingOperation();
+
+            return unwindData[..unwindDataOffset];
+
+            void EmitPop(uint popMask)
+            {
+                if (pendingPopMask == 0)
+                    FlushPendingOperation();
+                pendingPopMask |= popMask;
+            }
+
+            void EmitVPop(uint vpopMask)
+            {
+                if (pendingVPopMask == 0)
+                    FlushPendingOperation();
+                pendingVPopMask |= vpopMask;
+            }
+
+            void EmitSpAdjustment(int spAdjustment)
+            {
+                if (pendingSpAdjustment == 0)
+                    FlushPendingOperation();
+                pendingSpAdjustment += spAdjustment;
+            }
+
+            void FlushPendingOperation()
+            {
+                if (pendingSpAdjustment != 0)
+                {
+                    Debug.Assert(pendingSpAdjustment > 0);
+                    if (pendingSpAdjustment <= 0x100)
+                    {
+                        // vsp = vsp + (xxxxxx << 2) + 4.
+                        unwindData[unwindDataOffset++] = (byte)((pendingSpAdjustment >> 2) - 1);
+                    }
+                    else if (pendingSpAdjustment <= 0x200)
+                    {
+                        // vsp = vsp + (0x3f << 2) + 4.
+                        unwindData[unwindDataOffset++] = (byte)0x3f;
+                        pendingSpAdjustment -= 0x100;
+                        // vsp = vsp + (xxxxxx << 2) + 4.
+                        unwindData[unwindDataOffset++] = (byte)((pendingSpAdjustment >> 2) - 1);
+                    }
+                    else
+                    {
+                        // vsp = vsp + 0x204 + (uleb128 << 2)
+                        unwindData[unwindDataOffset++] = (byte)0xb2;
+                        unwindDataOffset += DwarfHelper.WriteULEB128(unwindData.AsSpan(unwindDataOffset), (uint)((pendingSpAdjustment - 0x204) >> 2));
+                    }
+                    pendingSpAdjustment = 0;
+                }
+                else if (pendingPopMask != 0)
+                {
+                    // TODO: Efficient encodings!
+
+                    if ((pendingPopMask & 0xFFF0) != 0)
+                    {
+                        ushort ins = (ushort)(0x8000u | (pendingPopMask >> 4));
+                        unwindData[unwindDataOffset++] = (byte)(ins >> 8);
+                        unwindData[unwindDataOffset++] = (byte)(ins & 0xff);
+                    }
+
+                    if ((pendingPopMask & 0xF) != 0)
+                    {
+                        ushort ins = (ushort)(0xB100u | (pendingPopMask & 0xf));
+                        unwindData[unwindDataOffset++] = (byte)(ins >> 8);
+                        unwindData[unwindDataOffset++] = (byte)(ins & 0xff);
+                    }
+
+                    pendingPopMask = 0;
+                }
+                else if (pendingVPopMask != 0)
+                {
+                    Debug.Fail("VPOP unwinding not implemented");
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfNative.cs
@@ -44,7 +44,8 @@ namespace ILCompiler.ObjectWriter
         public const uint SHT_PREINIT_ARRAY = 16;
         public const uint SHT_GROUP = 17;
         public const uint SHT_SYMTAB_SHNDX = 18;
-        public const uint SHT_IA_64_UNWIND = 1879048193;
+        public const uint SHT_IA_64_UNWIND = 0x70000001;
+        public const uint SHT_ARM_ATTRIBUTES = 0x70000003;
 
         // Section header flags
         public const uint SHF_WRITE = 1;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfNative.cs
@@ -45,6 +45,7 @@ namespace ILCompiler.ObjectWriter
         public const uint SHT_GROUP = 17;
         public const uint SHT_SYMTAB_SHNDX = 18;
         public const uint SHT_IA_64_UNWIND = 0x70000001;
+        public const uint SHT_ARM_EXIDX = 0x70000001;
         public const uint SHT_ARM_ATTRIBUTES = 0x70000003;
 
         // Section header flags

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
@@ -487,7 +487,6 @@ namespace ILCompiler.ObjectWriter
             if (nodeWithCodeInfo.FrameInfos is FrameInfo[] frameInfos &&
                 nodeWithCodeInfo is ISymbolDefinitionNode)
             {
-                bool shareSymbol = ShouldShareSymbol((ObjectNode)nodeWithCodeInfo);
                 SectionWriter exidxSectionWriter;
                 SectionWriter extabSectionWriter;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.cs
@@ -693,6 +693,8 @@ namespace ILCompiler.ObjectWriter
                 SectionHeaderEntrySize = (ushort)ElfSectionHeader.GetSize<TSize>(),
                 SectionHeaderEntryCount = sectionCount < SHN_LORESERVE ? (ushort)sectionCount : (ushort)0u,
                 StringTableIndex = strTabSectionIndex < SHN_LORESERVE ? (ushort)strTabSectionIndex : (ushort)SHN_XINDEX,
+                // For ARM32 claim conformance with the EABI specification
+                Flags = _machine is EM_ARM ? 0x05000000u : 0u,
             };
             elfHeader.Write<TSize>(outputFileStream);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.cs
@@ -32,8 +32,8 @@ namespace ILCompiler.ObjectWriter
 
         protected int EhFrameSectionIndex => _ehFrameSectionIndex;
 
-        private static readonly ObjectNodeSection LsdaSection = new ObjectNodeSection(".dotnet_eh_table", SectionType.ReadOnly, null);
-        private static readonly ObjectNodeSection EhFrameSection = new ObjectNodeSection(".eh_frame", SectionType.ReadOnly, null);
+        private static readonly ObjectNodeSection LsdaSection = new ObjectNodeSection(".dotnet_eh_table", SectionType.ReadOnly);
+        private static readonly ObjectNodeSection EhFrameSection = new ObjectNodeSection(".eh_frame", SectionType.UnwindData);
         private static readonly ObjectNodeSection DebugInfoSection = new ObjectNodeSection(".debug_info", SectionType.Debug);
         private static readonly ObjectNodeSection DebugStringSection = new ObjectNodeSection(".debug_str", SectionType.Debug);
         private static readonly ObjectNodeSection DebugAbbrevSection = new ObjectNodeSection(".debug_abbrev", SectionType.Debug);
@@ -67,6 +67,53 @@ namespace ILCompiler.ObjectWriter
 
         private protected virtual bool UseFrameNames => false;
 
+        private protected void EmitLsda(
+            INodeWithCodeInfo nodeWithCodeInfo,
+            FrameInfo[] frameInfos,
+            int frameInfoIndex,
+            SectionWriter lsdaSectionWriter,
+            ref long mainLsdaOffset)
+        {
+            FrameInfo frameInfo = frameInfos[frameInfoIndex];
+            FrameInfoFlags flags = frameInfo.Flags;
+
+            if (frameInfoIndex != 0)
+            {
+                lsdaSectionWriter.WriteByte((byte)flags);
+                lsdaSectionWriter.WriteLittleEndian<int>((int)(mainLsdaOffset - lsdaSectionWriter.Position));
+                // Emit relative offset from the main function
+                lsdaSectionWriter.WriteLittleEndian<uint>((uint)(frameInfo.StartOffset - frameInfos[0].StartOffset));
+            }
+            else
+            {
+                MethodExceptionHandlingInfoNode ehInfo = nodeWithCodeInfo.EHInfo;
+                ISymbolNode associatedDataNode = nodeWithCodeInfo.GetAssociatedDataNode(_nodeFactory) as ISymbolNode;
+
+                flags |= ehInfo is not null ? FrameInfoFlags.HasEHInfo : 0;
+                flags |= associatedDataNode is not null ? FrameInfoFlags.HasAssociatedData : 0;
+
+                mainLsdaOffset = lsdaSectionWriter.Position;
+                lsdaSectionWriter.WriteByte((byte)flags);
+
+                if (associatedDataNode is not null)
+                {
+                    string symbolName = GetMangledName(associatedDataNode);
+                    lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
+                }
+
+                if (ehInfo is not null)
+                {
+                    string symbolName = GetMangledName(ehInfo);
+                    lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
+                }
+
+                if (nodeWithCodeInfo.GCInfo is not null)
+                {
+                    lsdaSectionWriter.Write(nodeWithCodeInfo.GCInfo);
+                }
+            }
+        }
+
         private protected override void EmitUnwindInfo(
             SectionWriter sectionWriter,
             INodeWithCodeInfo nodeWithCodeInfo,
@@ -75,12 +122,7 @@ namespace ILCompiler.ObjectWriter
             if (nodeWithCodeInfo.FrameInfos is FrameInfo[] frameInfos &&
                 nodeWithCodeInfo is ISymbolDefinitionNode)
             {
-                // On ARM we always use frame names, even for first frame to ensure that
-                // DWARF data uses PC references without the Thumb bit set. Using a function
-                // symbol would propagate the bit. Unfortunately, the R_ARM_REL32_NOI
-                // relocation is not widely implemented, so using that is not an option.
-                bool isArm = _nodeFactory.Target.Architecture == TargetArchitecture.ARM;
-                bool useFrameNames = isArm || UseFrameNames;
+                bool useFrameNames = UseFrameNames;
                 SectionWriter lsdaSectionWriter;
 
                 if (ShouldShareSymbol((ObjectNode)nodeWithCodeInfo))
@@ -92,7 +134,7 @@ namespace ILCompiler.ObjectWriter
                     lsdaSectionWriter = _lsdaSectionWriter;
                 }
 
-                long mainLsdaOffset = lsdaSectionWriter.Position;
+                long mainLsdaOffset = 0;
                 for (int i = 0; i < frameInfos.Length; i++)
                 {
                     FrameInfo frameInfo = frameInfos[i];
@@ -105,49 +147,12 @@ namespace ILCompiler.ObjectWriter
                     string framSymbolName = $"_fram{i}{currentSymbolName}";
 
                     lsdaSectionWriter.EmitSymbolDefinition(lsdaSymbolName);
-                    if (useFrameNames && (isArm || start != 0))
+                    if (useFrameNames && start != 0)
                     {
                         sectionWriter.EmitSymbolDefinition(framSymbolName, start);
                     }
 
-                    FrameInfoFlags flags = frameInfo.Flags;
-
-                    if (i != 0)
-                    {
-                        lsdaSectionWriter.WriteByte((byte)flags);
-                        lsdaSectionWriter.WriteLittleEndian<int>((int)(mainLsdaOffset - lsdaSectionWriter.Position));
-                        // Emit relative offset from the main function
-                        lsdaSectionWriter.WriteLittleEndian<uint>((uint)(start - frameInfos[0].StartOffset));
-                    }
-                    else
-                    {
-                        MethodExceptionHandlingInfoNode ehInfo = nodeWithCodeInfo.EHInfo;
-                        ISymbolNode associatedDataNode = nodeWithCodeInfo.GetAssociatedDataNode(_nodeFactory) as ISymbolNode;
-
-                        flags |= ehInfo is not null ? FrameInfoFlags.HasEHInfo : 0;
-                        flags |= associatedDataNode is not null ? FrameInfoFlags.HasAssociatedData : 0;
-
-                        lsdaSectionWriter.WriteByte((byte)flags);
-
-                        if (associatedDataNode is not null)
-                        {
-                            string symbolName = GetMangledName(associatedDataNode);
-                            lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
-                        }
-
-                        if (ehInfo is not null)
-                        {
-                            string symbolName = GetMangledName(ehInfo);
-                            lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
-                        }
-
-                        if (nodeWithCodeInfo.GCInfo is not null)
-                        {
-                            lsdaSectionWriter.Write(nodeWithCodeInfo.GCInfo);
-                        }
-                    }
-
-                    string startSymbolName = useFrameNames && (isArm || start != 0) ? framSymbolName : currentSymbolName;
+                    string startSymbolName = useFrameNames && start != 0 ? framSymbolName : currentSymbolName;
                     ulong length = (ulong)(end - start);
                     if (!EmitCompactUnwinding(startSymbolName, length, lsdaSymbolName, blob))
                     {
@@ -161,6 +166,8 @@ namespace ILCompiler.ObjectWriter
                             personalitySymbolName: null);
                         _dwarfEhFrame.AddFde(fde);
                     }
+
+                    EmitLsda(nodeWithCodeInfo, frameInfos, i, _lsdaSectionWriter, ref mainLsdaOffset);
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -593,6 +593,7 @@
     <Compile Include="Compiler\DependencyAnalysis\Target_LoongArch64\LoongArch64UnboxingStubNode.cs" />
     <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfAbbrev.cs" />
     <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfBuilder.cs" />
+    <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfCfiOpcode.cs" />
     <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfCie.cs" />
     <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfEhFrame.cs" />
     <Compile Include="Compiler\ObjectWriter\Dwarf\DwarfExpressionBuilder.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -608,6 +608,8 @@
     <Compile Include="Compiler\ObjectWriter\CodeView\CodeViewNative.cs" />
     <Compile Include="Compiler\ObjectWriter\CodeView\CodeViewSymbolsBuilder.cs" />
     <Compile Include="Compiler\ObjectWriter\CodeView\CodeViewTypesBuilder.cs" />
+    <Compile Include="Compiler\ObjectWriter\Eabi\EabiAttributesBuilder.cs" />
+    <Compile Include="Compiler\ObjectWriter\Eabi\EabiNative.cs" />
     <Compile Include="Compiler\ObjectWriter\LegacyObjectWriter.cs" />
     <Compile Include="Compiler\ObjectWriter\ObjectWriter.cs" />
     <Compile Include="Compiler\ObjectWriter\ObjectWritingOptions.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -610,6 +610,7 @@
     <Compile Include="Compiler\ObjectWriter\CodeView\CodeViewTypesBuilder.cs" />
     <Compile Include="Compiler\ObjectWriter\Eabi\EabiAttributesBuilder.cs" />
     <Compile Include="Compiler\ObjectWriter\Eabi\EabiNative.cs" />
+    <Compile Include="Compiler\ObjectWriter\Eabi\EabiUnwindConverter.cs" />
     <Compile Include="Compiler\ObjectWriter\LegacyObjectWriter.cs" />
     <Compile Include="Compiler\ObjectWriter\ObjectWriter.cs" />
     <Compile Include="Compiler\ObjectWriter\ObjectWritingOptions.cs" />

--- a/src/native/external/llvm-libunwind/include/__libunwind_config.h
+++ b/src/native/external/llvm-libunwind/include/__libunwind_config.h
@@ -14,10 +14,6 @@
 #if defined(__arm__) && !defined(__USING_SJLJ_EXCEPTIONS__) && \
     !defined(__ARM_DWARF_EH__) && !defined(__SEH__)
 #define _LIBUNWIND_ARM_EHABI
-// Until ObjWriter is modified to convert DWARF to EHABI we want to
-// support both.
-#define _LIBUNWIND_SUPPORT_DWARF_UNWIND 1
-#define _LIBUNWIND_SUPPORT_DWARF_INDEX 1
 #endif
 
 #define _LIBUNWIND_HIGHEST_DWARF_REGISTER_X86       8

--- a/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
+++ b/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
@@ -956,6 +956,7 @@ public:
 private:
 
 #if defined(_LIBUNWIND_ARM_EHABI)
+public:
   bool getInfoFromEHABISection(pint_t pc, const UnwindInfoSections &sects);
 
   int stepWithEHABI() {


### PR DESCRIPTION
This replaces DWARF exception unwinding on linux-arm with the compact EHABI representation. It also emits the `.ARM.attributes` section to aid debuggers and linkers.

Majority of methods use single unwind word (4 bytes) to describe the method and two words in the index table (8 bytes). For something like the Exceptions smoke test we see the following file sizes of the `Exceptions.o` object file.

Before: 16,769,298 bytes
After: 16,431,639 bytes

So, we saved 337,659 bytes and that doesn't even include the EH frame index produced by the linker for DWARF. It's not entirely fair comparison since the DWARF information emitted on ARM was overly verbose but it's a real size saving.