### PR TITLE
Replumb TensorPrimitives.ConvertToHalf/Single to be on operator plan

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.T.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.T.cs
@@ -672,13 +672,13 @@ namespace System.Numerics.Tensors
 
             if (typeof(TFrom) == typeof(float) && typeof(TTo) == typeof(Half))
             {
-                ConvertToHalf(Rename<TFrom, float>(source), Rename<TTo, Half>(destination));
+                InvokeSpanIntoSpan_2to1<float, ushort, NarrowSingleToHalfAsUInt16Operator>(Rename<TFrom, float>(source), Rename<TTo, ushort>(destination));
                 return true;
             }
 
             if (typeof(TFrom) == typeof(Half) && typeof(TTo) == typeof(float))
             {
-                ConvertToSingle(Rename<TFrom, Half>(source), Rename<TTo, float>(destination));
+                InvokeSpanIntoSpan_1to2<short, float, WidenHalfAsInt16ToSingleOperator>(Rename<TFrom, short>(source), Rename<TTo, float>(destination));
                 return true;
             }
 


### PR DESCRIPTION
ConvertToHalf and ConvertToSingle contain their own vectorized algorithms. Now that we have a framework for handling other conversions, we can move the core of their implementations into operators and then have them share the same logic as the rest of the conversions. Then ConvertToHalf/Single just delegate to ConvertTruncating and exist only as legacy. The implementations of SingleToHalfAsWidenedUInt32 and HalfAsWidenedUInt32ToSingle haven't changed at all; they've just moved and had the now-unnecessary suffixes removed from their names.