### PR TITLE
Call String.Contains(char) from String.Contains(string) for single-char literals

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -13,6 +13,12 @@ namespace System
             if (value == null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
 
+            if (RuntimeHelpers.IsKnownConstant(value) && value.Length == 1)
+            {
+                // Call the char overload, e.g. Contains("X") -> Contains('X')
+                return Contains(value[0]);
+            }
+
             return SpanHelpers.IndexOf(
                 ref _firstChar,
                 Length,


### PR DESCRIPTION
Addresses `String.Contains` performance concerns in this tweet: https://twitter.com/STeplyakov/status/1751858621212991573

Benchmark:
```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

public class MyBenchmarks
{
    readonly string _inputString = 
        "Permission is hereby granted, free of charge, to any person obtaining " +
        "a copy of the Unicode data files and any associated documentation";

    [Benchmark]
    public bool Contains_string() => _inputString.Contains("X");
}
```

| Method          | Toolchain                   | Mean     | Ratio |
|---------------- |---------------------------- |---------:|------:|
| Contains_string | \Core_Root_base\corerun.exe | 4.050 ns |  1.00 |
| Contains_string | \Core_Root_PR\corerun.exe      | **2.361 ns** |  0.58 |

It uses `IsKnownConstant` to avoid perf regressions for non-constant and non-single-char input (although, it's probably also beneficial for non-constant and single-char)