### PR TITLE
[release/8.0-staging][mono][interp] Fix inlining of ldarga

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -8018,7 +8018,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				} else {
 					int loc_n = arg_locals [n];
 					interp_add_ins (td, MINT_LDLOCA_S);
-					interp_ins_set_sreg (td->last_ins, n);
+					interp_ins_set_sreg (td->last_ins, loc_n);
 					td->locals [loc_n].indirects++;
 				}
 				push_simple_type (td, STACK_TYPE_MP);


### PR DESCRIPTION
When inlining a method, all arguments are first copied to new vars. Ldarga is going to be applied on these copies. We were loading the address of the wrong var due to typo.

Backport of https://github.com/dotnet/runtime/pull/97553

## Customer Impact

Inlining of methods containing the `ldarga` opcode is broken on mono interpreter. This was reported as a regression from .net 7 (on Blazor WASM project), indirectly caused by an increase of the inline limit for methods.

## Testing

Tested on customer provided sample.

## Risk

Very low. The fix is isolated to the code gen for `ldarga` opcode during inlining, which was completely broken before.
