### PR TITLE
For Debug, make sure we use right register selection heuristics to match with Release

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -12297,7 +12297,11 @@ LinearScan::RegisterSelection::RegisterSelection(LinearScan* linearScan)
     {
         ordering = W("ABCDEFGHIJKLMNOPQ");
 
-        if (!linearScan->enregisterLocalVars && linearScan->compiler->opts.OptimizationDisabled())
+        if (!linearScan->enregisterLocalVars && linearScan->compiler->opts.OptimizationDisabled()
+#ifdef TARGET_ARM64
+            && !linearScan->compiler->info.compNeedsConsecutiveRegisters
+#endif
+            )
         {
             ordering = W("MQQQQQQQQQQQQQQQQ");
         }


### PR DESCRIPTION
If a method needs consecutive register, we do not use `*minimal()` register allocation strategy added in https://github.com/dotnet/runtime/pull/96386. The reason being that in some cases, the `*minimal` might allocate registers that will sometime obstruct us from allocating consecutive registers. Also, to handle consecutive registers scenarios in `*minimal()` methods eats up the massive TP gain that we see in Arm64 for MinOpts because of the checks we need to add if `refPosition` needs consecutive register or not. I forgot to add a condition for consecutive register while deciding the selection heuristics.

Fixes: https://github.com/dotnet/runtime/issues/97638