### PR TITLE
[RISC-V] Put scalar stack args with sign extension

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5050,7 +5050,8 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
 
         // When passed in registers or on the stack, integer scalars narrower than XLEN bits
         // are widened according to the sign of their type up to 32 bits, then sign-extended to XLEN bits.
-        if (EA_SIZE(storeAttr) < EA_PTRSIZE && varTypeUsesIntReg(slotType)) {
+        if (EA_SIZE(storeAttr) < EA_PTRSIZE && varTypeUsesIntReg(slotType))
+        {
             storeAttr = EA_PTRSIZE;
             storeIns  = INS_sd;
         }

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -5048,6 +5048,13 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
         instruction storeIns  = ins_Store(slotType);
         emitAttr    storeAttr = emitTypeSize(slotType);
 
+        // When passed in registers or on the stack, integer scalars narrower than XLEN bits
+        // are widened according to the sign of their type up to 32 bits, then sign-extended to XLEN bits.
+        if (EA_SIZE(storeAttr) < EA_PTRSIZE && varTypeUsesIntReg(slotType)) {
+            storeAttr = EA_PTRSIZE;
+            storeIns  = INS_sd;
+        }
+
         // If it is contained then source must be the integer constant zero
         if (source->isContained())
         {


### PR DESCRIPTION
According to [Integer calling convention](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc#integer-calling-convention) arguments on stack narrower than XLEN bits are stored on stack with sign extension to XLEN according to theirs type.

Part of #84834 
cc @clamp03 @tomeksowi @gbalykov @denis-paranichev @ashaurtaev 