### PR TITLE
Revert "Improve performance of Order{By}{Descending}(...).First/Last"

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Linq
@@ -156,7 +155,7 @@ namespace System.Linq
             return default;
         }
 
-        public virtual TElement? TryGetFirst(out bool found)
+        public TElement? TryGetFirst(out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();
             using (IEnumerator<TElement> e = _source.GetEnumerator())
@@ -183,7 +182,7 @@ namespace System.Linq
             }
         }
 
-        public virtual TElement? TryGetLast(out bool found)
+        public TElement? TryGetLast(out bool found)
         {
             using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
@@ -245,70 +244,6 @@ namespace System.Linq
         }
     }
 
-    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
-    {
-        // For complicated cases, rely on the base implementation that's more comprehensive.
-        // For the simple case of OrderBy(...).First() or OrderByDescending(...).First() (i.e. where
-        // there's just a single comparer we need to factor in), we can just do the iteration directly.
-
-        public override TElement? TryGetFirst(out bool found) =>
-            _parent is not null ?
-                base.TryGetFirst(out found) :
-                TryGetFirstOrLast(out found, first: !_descending);
-
-        public override TElement? TryGetLast(out bool found) =>
-            _parent is not null ?
-                base.TryGetLast(out found) :
-                TryGetFirstOrLast(out found, first: _descending);
-
-        private TElement? TryGetFirstOrLast(out bool found, bool first)
-        {
-            using IEnumerator<TElement> e = _source.GetEnumerator();
-
-            if (e.MoveNext())
-            {
-                IComparer<TKey> comparer = _comparer;
-                Func<TElement, TKey> keySelector = _keySelector;
-
-                TElement resultValue = e.Current;
-                TKey resultKey = keySelector(resultValue);
-
-                if (first)
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) < 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-                else
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) >= 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-
-                found = true;
-                return resultValue;
-            }
-
-            found = false;
-            return default;
-        }
-    }
-
     internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
     {
         public override TElement[] ToArray()
@@ -323,66 +258,6 @@ namespace System.Linq
             List<TElement> list = _source.ToList();
             Sort(CollectionsMarshal.AsSpan(list), _descending);
             return list;
-        }
-
-        public override TElement? TryGetFirst(out bool found) =>
-            TryGetFirstOrLast(out found, first: !_descending);
-
-        public override TElement? TryGetLast(out bool found) =>
-            TryGetFirstOrLast(out found, first: _descending);
-
-        private TElement? TryGetFirstOrLast(out bool found, bool first)
-        {
-            if (Enumerable.TryGetSpan(_source, out ReadOnlySpan<TElement> span))
-            {
-                if (span.Length != 0)
-                {
-                    Debug.Assert(Enumerable.TypeIsImplicitlyStable<TElement>(), "Using Min/Max has different semantics for floating-point values.");
-
-                    found = true;
-                    return first ?
-                        Enumerable.Min(_source) :
-                        Enumerable.Max(_source);
-                }
-            }
-            else
-            {
-                using IEnumerator<TElement> e = _source.GetEnumerator();
-
-                if (e.MoveNext())
-                {
-                    TElement resultValue = e.Current;
-
-                    if (first)
-                    {
-                        while (e.MoveNext())
-                        {
-                            TElement nextValue = e.Current;
-                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) < 0)
-                            {
-                                resultValue = nextValue;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        while (e.MoveNext())
-                        {
-                            TElement nextValue = e.Current;
-                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) >= 0)
-                            {
-                                resultValue = nextValue;
-                            }
-                        }
-                    }
-
-                    found = true;
-                    return resultValue;
-                }
-            }
-
-            found = false;
-            return default;
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -103,7 +103,7 @@ namespace System.Linq
         }
     }
 
-    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
+    internal sealed class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
         private readonly OrderedEnumerable<TElement>? _parent;
         private readonly Func<TElement, TKey> _keySelector;


### PR DESCRIPTION
Reverts dotnet/runtime#97483

Might have broken something in the SDK. Reverting for now and will investigate, then resubmit.