### PR TITLE
JIT: Remove optLoopCompactionFixupFallThrough

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6779,11 +6779,11 @@ public:
 
     void optFindLoops();
     bool optCanonicalizeLoops();
-    bool optCompactLoops();
-    bool optCompactLoop(FlowGraphNaturalLoop* loop);
+    void optCompactLoops();
+    void optCompactLoop(FlowGraphNaturalLoop* loop);
     BasicBlock* optFindLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* top);
     BasicBlock* optTryAdvanceLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* insertionPoint, BasicBlock* top, BasicBlock* bottom);
-    bool optLoopCompactionFixupFallThrough(BasicBlock* block, BasicBlock* newNext);
+    void optLoopCompactionFixupFallThrough(BasicBlock* block, BasicBlock* newNext);
     bool optCreatePreheader(FlowGraphNaturalLoop* loop);
     void optSetPreheaderWeight(FlowGraphNaturalLoop* loop, BasicBlock* preheader);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6783,7 +6783,6 @@ public:
     void optCompactLoop(FlowGraphNaturalLoop* loop);
     BasicBlock* optFindLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* top);
     BasicBlock* optTryAdvanceLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* insertionPoint, BasicBlock* top, BasicBlock* bottom);
-    void optLoopCompactionFixupFallThrough(BasicBlock* block, BasicBlock* newNext);
     bool optCreatePreheader(FlowGraphNaturalLoop* loop);
     void optSetPreheaderWeight(FlowGraphNaturalLoop* loop, BasicBlock* preheader);
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3498,12 +3498,28 @@ bool Compiler::fgReorderBlocks(bool useProfile)
         {
             if (block->KindIs(BBJ_COND) && !block->NextIs(block->GetFalseTarget()))
             {
-                BasicBlock* jmpBlk = fgConnectFallThrough(block, block->GetFalseTarget());
-                assert(jmpBlk != nullptr);
-                assert(block->NextIs(jmpBlk));
+                if (block->CanRemoveJumpToTarget(block->GetTrueTarget(), this))
+                {
+                    // Reverse the jump condition
+                    GenTree* test = block->lastNode();
+                    assert(test->OperIsConditionalJump());
+                    test->AsOp()->gtOp1 = gtReverseCond(test->AsOp()->gtOp1);
 
-                // Skip next block
-                block = jmpBlk;
+                    BasicBlock* newFalseTarget = block->GetTrueTarget();
+                    BasicBlock* newTrueTarget  = block->GetFalseTarget();
+                    block->SetTrueTarget(newTrueTarget);
+                    block->SetFalseTarget(newFalseTarget);
+                    assert(block->CanRemoveJumpToTarget(newFalseTarget, this));
+                }
+                else
+                {
+                    BasicBlock* jmpBlk = fgConnectFallThrough(block, block->GetFalseTarget());
+                    assert(jmpBlk != nullptr);
+                    assert(block->NextIs(jmpBlk));
+
+                    // Skip next block
+                    block = jmpBlk;
+                }
             }
         }
     }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -3491,7 +3491,7 @@ bool Compiler::fgReorderBlocks(bool useProfile)
         }
     }
 
-    // If we will be reordering blocks, re-establish implicit fallthrough for BBJ_COND blocks
+    // If we will be reordering blocks, ensure the false target of a BBJ_COND block is its next block
     if (useProfile)
     {
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->Next())


### PR DESCRIPTION
#97488 removed the logic for maintaining implicit fallthrough for BBJ_COND blocks into their false targets via jump insertion, but otherwise left `optLoopCompactionFixupFallThrough` intact. This method also tries to maintain fallthrough behavior by reversing the conditional, if the next block is the true target; per #93020, we should defer condition reversals until block reordering, so we might as well get rid of `optLoopCompactionFixupFallThrough`. By removing this method altogether, we don't have to worry about rebuilding the DFS tree due to the flowgraph being modified, improving TP. This removal caused relatively dramatic diffs locally, which are reduced somewhat by reversing branches (when possible) when restoring implicit fallthrough before block reordering.

Thanks @jakobbotsch for pointing out we can remove this.