### PR TITLE
Clarify comments around VT_INT and VT_UINT

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ComVariant.cs
@@ -357,8 +357,11 @@ namespace System.Runtime.InteropServices.Marshalling
             {
                 throw new ArgumentException(SR.UnsupportedType, nameof(T));
             }
-            // We do not support mapping nint or nuint to VT_INT and VT_UINT respectively
-            // as this does not match the MS-OAUT spec.
+            // Historically, .NET built-in and dynamic-COM interop has mapped
+            // VT_INT and VT_UINT to use IntPtr. This is not valid per the MS-OAUT spec.
+            // The MS-OAUT spec specifies that VT_INT and VT_UINT map to 4-byte integers.
+            // As a result, do not support mapping nint or nuint to VT_INT and VT_UINT respectively
+            // how built-in interop traditionally has.
             // We do not map VT_BYREF automatically, nor do we map any of the array types.
             return variant;
         }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ComVariantTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/ComVariantTests.cs
@@ -487,6 +487,8 @@ namespace System.Runtime.InteropServices.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
         public void Raw_Int_WrongSize(VarEnum vt)
         {
+            // Validate that we follow the spec and map VT_INT and VT_UINT to 4-byte integers
+            // and that we don't allow pointer-sized integers (as built-in interop does in some cases). 
             Assert.Throws<ArgumentException>(() => ComVariant.CreateRaw(vt, (nint)42));
         }
     }


### PR DESCRIPTION
Clarify mentions of these variant types and what unmanaged types they map to and be clearer about mentions around nint/nuint (they're only mentioned as a comparison to built-in interop)

Fixes #97363
