### PR TITLE
Add the barebones support for using embedded masking with AVX512

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -779,9 +779,7 @@ protected:
 #define _idBound _idCustom1 /* jump target / frame offset bound */
 #define _idTlsGD _idCustom2 /* Used to store information related to TLS GD access on linux */
 #define _idNoGC _idCustom3  /* Some helpers don't get recorded in GC tables */
-#define _idEvexAaaContext                                                                                              \
-    ((_idCustom3 << 2) | (_idCustom2 << 1) | _idCustom1) /* bits used for the EVEX.aaa context                         \
-                                                                                              */
+#define _idEvexAaaContext (_idCustom3 << 2) | (_idCustom2 << 1) | _idCustom1 /* bits used for the EVEX.aaa context */
 
 #if !defined(TARGET_ARMARCH)
         unsigned _idCustom4 : 1;
@@ -1594,30 +1592,36 @@ protected:
 
         bool idIsBound() const
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             return _idBound != 0;
         }
         void idSetIsBound()
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             _idBound = 1;
         }
 
 #ifndef TARGET_ARMARCH
         bool idIsCallRegPtr() const
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             return _idCallRegPtr != 0;
         }
         void idSetIsCallRegPtr()
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             _idCallRegPtr = 1;
         }
 #endif // !TARGET_ARMARCH
 
         bool idIsTlsGD() const
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             return _idTlsGD != 0;
         }
         void idSetTlsGD()
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             _idTlsGD = 1;
         }
 
@@ -1626,10 +1630,12 @@ protected:
         // code, it is not necessary to generate GC info for a call so labeled.
         bool idIsNoGC() const
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             return _idNoGC != 0;
         }
         void idSetIsNoGC(bool val)
         {
+            assert(!IsAvx512OrPriorInstruction(_idIns));
             _idNoGC = val;
         }
 
@@ -1668,6 +1674,7 @@ protected:
 
         unsigned idGetEvexAaaContext() const
         {
+            assert(IsAvx512OrPriorInstruction(_idIns));
             return _idEvexAaaContext;
         }
 
@@ -1683,6 +1690,7 @@ protected:
 
         bool idIsEvexZContextSet() const
         {
+            assert(IsAvx512OrPriorInstruction(_idIns));
             return _idEvexZContext != 0;
         }
 

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -779,14 +779,16 @@ protected:
 #define _idBound _idCustom1 /* jump target / frame offset bound */
 #define _idTlsGD _idCustom2 /* Used to store information related to TLS GD access on linux */
 #define _idNoGC _idCustom3  /* Some helpers don't get recorded in GC tables */
-#define _idEvexAaaContext ((_idCustom3 << 2) | (_idCustom2 << 1) | _idCustom1) /* bits used for the EVEX.aaa context */
+#define _idEvexAaaContext                                                                                              \
+    ((_idCustom3 << 2) | (_idCustom2 << 1) | _idCustom1) /* bits used for the EVEX.aaa context                         \
+                                                                                              */
 
 #if !defined(TARGET_ARMARCH)
-        unsigned    _idCustom4 : 1;
+        unsigned _idCustom4 : 1;
 
-#define _idCallRegPtr _idCustom4 /* IL indirect calls : addr in reg */
+#define _idCallRegPtr _idCustom4   /* IL indirect calls : addr in reg */
 #define _idEvexZContext _idCustom4 /* bits used for the EVEX.z context */
-#endif // !TARGET_ARMARCH
+#endif                             // !TARGET_ARMARCH
 
 #if defined(TARGET_XARCH)
         // EVEX.b can indicate several context: embedded broadcast, embedded rounding.

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -768,12 +768,26 @@ protected:
         unsigned _idLargeDsp : 1;  // does a large displacement follow?
         unsigned _idLargeCall : 1; // large call descriptor used
 
-        unsigned _idBound : 1; // jump target / frame offset bound
-#ifndef TARGET_ARMARCH
-        unsigned _idCallRegPtr : 1; // IL indirect calls: addr in reg
-#endif
-        unsigned _idTlsGD : 1; // Used to store information related to TLS GD access on linux
-        unsigned _idNoGC : 1;  // Some helpers don't get recorded in GC tables
+        // We have several pieces of information we need to encode but which are only applicable
+        // to a subset of instrDescs. To accommodate that, we define a several _idCustom# bitfields
+        // and then some defineds to make accessing them simpler
+
+        unsigned _idCustom1 : 1;
+        unsigned _idCustom2 : 1;
+        unsigned _idCustom3 : 1;
+
+#define _idBound _idCustom1 /* jump target / frame offset bound */
+#define _idTlsGD _idCustom2 /* Used to store information related to TLS GD access on linux */
+#define _idNoGC _idCustom3  /* Some helpers don't get recorded in GC tables */
+#define _idEvexAaaContext ((_idCustom3 << 2) | (_idCustom2 << 1) | _idCustom1) /* bits used for the EVEX.aaa context */
+
+#if !defined(TARGET_ARMARCH)
+        unsigned    _idCustom4 : 1;
+
+#define _idCallRegPtr _idCustom4 /* IL indirect calls : addr in reg */
+#define _idEvexZContext _idCustom4 /* bits used for the EVEX.z context */
+#endif // !TARGET_ARMARCH
+
 #if defined(TARGET_XARCH)
         // EVEX.b can indicate several context: embedded broadcast, embedded rounding.
         // For normal and embedded broadcast intrinsics, EVEX.L'L has the same semantic, vector length.
@@ -1594,7 +1608,7 @@ protected:
         {
             _idCallRegPtr = 1;
         }
-#endif
+#endif // !TARGET_ARMARCH
 
         bool idIsTlsGD() const
         {
@@ -1625,7 +1639,8 @@ protected:
 
         void idSetEvexbContext(insOpts instOptions)
         {
-            assert(_idEvexbContext == 0);
+            assert(!idIsEvexbContextSet());
+
             if (instOptions == INS_OPTS_EVEX_eb_er_rd)
             {
                 _idEvexbContext = 1;
@@ -1647,6 +1662,32 @@ protected:
         unsigned idGetEvexbContext() const
         {
             return _idEvexbContext;
+        }
+
+        unsigned idGetEvexAaaContext() const
+        {
+            return _idEvexAaaContext;
+        }
+
+        void idSetEvexAaaContext(insOpts instOptions)
+        {
+            assert(idGetEvexAaaContext() == 0);
+            unsigned value = static_cast<unsigned>((instOptions & INS_OPTS_EVEX_aaa_MASK) >> 2);
+
+            _idCustom1 = ((value >> 0) & 1);
+            _idCustom2 = ((value >> 1) & 1);
+            _idCustom3 = ((value >> 2) & 1);
+        }
+
+        bool idIsEvexZContextSet() const
+        {
+            return _idEvexZContext != 0;
+        }
+
+        void idSetEvexZContext()
+        {
+            assert(!idIsEvexZContextSet());
+            _idEvexZContext = 1;
         }
 #endif
 
@@ -2222,6 +2263,7 @@ protected:
     void emitDispInsHex(instrDesc* id, BYTE* code, size_t sz);
     void emitDispEmbBroadcastCount(instrDesc* id);
     void emitDispEmbRounding(instrDesc* id);
+    void emitDispEmbMasking(instrDesc* id);
     void emitDispIns(instrDesc* id,
                      bool       isNew,
                      bool       doffs,

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12955,7 +12955,7 @@ GOT_DSP:
 #else
                     dst += emitOutputLong(dst, dsp);
 #endif
-                    if ((ins == INS_call) && id->idIsTlsGD())
+                    if (!IsAvx512OrPriorInstruction(ins) && id->idIsTlsGD())
                     {
                         addlDelta = -4;
                         emitRecordRelocationWithAddlDelta((void*)(dst - sizeof(INT32)), (void*)dsp, IMAGE_REL_TLSGD,

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -346,14 +346,39 @@ code_t AddSimdPrefixIfNeeded(const instrDesc* id, code_t code, emitAttr size)
 //    instOptions - emit options
 void SetEvexBroadcastIfNeeded(instrDesc* id, insOpts instOptions)
 {
-    if ((instOptions & INS_OPTS_b_MASK) == INS_OPTS_EVEX_eb_er_rd)
+    if ((instOptions & INS_OPTS_EVEX_b_MASK) == INS_OPTS_EVEX_eb_er_rd)
     {
         assert(UseEvexEncoding());
         id->idSetEvexbContext(instOptions);
     }
     else
     {
-        assert(instOptions == 0);
+        assert((instOptions & INS_OPTS_EVEX_b_MASK) == 0);
+    }
+}
+
+//------------------------------------------------------------------------
+// SetEvexEmbMaskIfNeeded: set embedded mask if needed.
+//
+// Arguments:
+//    id          - instruction descriptor
+//    instOptions - emit options
+//
+void SetEvexEmbMaskIfNeeded(instrDesc* id, insOpts instOptions)
+{
+    if ((instOptions & INS_OPTS_EVEX_aaa_MASK) != 0)
+    {
+        assert(UseEvexEncoding());
+        id->idSetEvexAaaContext(instOptions);
+
+        if ((instOptions & INS_OPTS_EVEX_z_MASK) == INS_OPTS_EVEX_em_zero)
+        {
+            id->idSetEvexZContext();
+        }
+    }
+    else
+    {
+        assert((instOptions & INS_OPTS_EVEX_z_MASK) == 0);
     }
 }
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -106,7 +106,6 @@ unsigned insSSval(unsigned scale);
 
 static bool IsSSEInstruction(instruction ins);
 static bool IsSSEOrAVXInstruction(instruction ins);
-static bool IsAvx512OrPriorInstruction(instruction ins);
 static bool IsAVXOnlyInstruction(instruction ins);
 static bool IsAvx512OnlyInstruction(instruction ins);
 static bool IsFMAInstruction(instruction ins);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -17920,9 +17920,13 @@ bool GenTree::canBeContained() const
     }
 
     // It is not possible for nodes that do not produce values or that are not containable values to be contained.
-    if (!IsValue() || ((DebugOperKind() & DBK_NOCONTAIN) != 0) || (OperIsHWIntrinsic() && !isContainableHWIntrinsic()))
+    if (!IsValue() || ((DebugOperKind() & DBK_NOCONTAIN) != 0))
     {
         return false;
+    }
+    else if (OperIsHWIntrinsic() && !isContainableHWIntrinsic())
+    {
+        return isEvexEmbeddedMaskingCompatibleHWIntrinsic();
     }
 
     return true;
@@ -19655,6 +19659,28 @@ bool GenTree::isRMWHWIntrinsic(Compiler* comp)
 
     switch (intrinsicId)
     {
+        case NI_AVX512F_BlendVariableMask:
+        {
+            GenTree* op2 = hwintrinsic->Op(2);
+
+            if (op2->IsEmbMaskOp())
+            {
+                GenTree* op1 = hwintrinsic->Op(1);
+
+                if (op1->isContained())
+                {
+                    assert(op1->IsVectorZero());
+                    return false;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         case NI_AVX512F_Fixup:
         case NI_AVX512F_FixupScalar:
         case NI_AVX512F_VL_Fixup:
@@ -19745,18 +19771,31 @@ bool GenTree::isRMWHWIntrinsic(Compiler* comp)
 // Return Value:
 // true if the intrisic node lowering instruction has an EVEX form
 //
-bool GenTree::isEvexCompatibleHWIntrinsic()
+bool GenTree::isEvexCompatibleHWIntrinsic() const
 {
-    assert(gtOper == GT_HWINTRINSIC);
+    return OperIsHWIntrinsic() && HWIntrinsicInfo::HasEvexSemantics(AsHWIntrinsic()->GetHWIntrinsicId());
+}
 
-// TODO-XARCH-AVX512 remove the ReturnsPerElementMask check once K registers have been properly
-// implemented in the register allocator
-#if defined(TARGET_AMD64)
-    return HWIntrinsicInfo::HasEvexSemantics(AsHWIntrinsic()->GetHWIntrinsicId()) &&
-           !HWIntrinsicInfo::ReturnsPerElementMask(AsHWIntrinsic()->GetHWIntrinsicId());
-#else
+//------------------------------------------------------------------------
+// isEvexEmbeddedMaskingCompatibleHWIntrinsic: Checks if the intrinsic is compatible
+// with the EVEX embedded masking form for its intended lowering instruction.
+//
+// Return Value:
+// true if the intrisic node lowering instruction has an EVEX embedded masking
+//
+bool GenTree::isEvexEmbeddedMaskingCompatibleHWIntrinsic() const
+{
+#if defined(TARGET_XARCH)
+    if (OperIsHWIntrinsic())
+    {
+        // TODO-AVX512F-CQ: Expand this to the full set of APIs and make it table driven
+        // using IsEmbMaskingCompatible. For now, however, limit it to some explicit ids
+        // for prototyping purposes.
+        return (AsHWIntrinsic()->GetHWIntrinsicId() == NI_AVX512F_Add);
+    }
+#endif // TARGET_XARCH
+
     return false;
-#endif
 }
 
 GenTreeHWIntrinsic* Compiler::gtNewSimdHWIntrinsicNode(var_types      type,

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19773,7 +19773,10 @@ bool GenTree::isRMWHWIntrinsic(Compiler* comp)
 //
 bool GenTree::isEvexCompatibleHWIntrinsic() const
 {
-    return OperIsHWIntrinsic() && HWIntrinsicInfo::HasEvexSemantics(AsHWIntrinsic()->GetHWIntrinsicId());
+    // TODO-XARCH-AVX512 remove the ReturnsPerElementMask check once K registers have been properly
+    // implemented in the register allocator
+    return OperIsHWIntrinsic() && HWIntrinsicInfo::HasEvexSemantics(AsHWIntrinsic()->GetHWIntrinsicId()) &&
+           !HWIntrinsicInfo::ReturnsPerElementMask(AsHWIntrinsic()->GetHWIntrinsicId());
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -557,9 +557,9 @@ enum GenTreeFlags : unsigned int
 
     GTF_MDARRLOWERBOUND_NONFAULTING = 0x20000000, // GT_MDARR_LOWER_BOUND -- An MD array lower bound operation that cannot fault. Same as GT_IND_NONFAULTING.
 
-#ifdef TARGET_XARCH
+#if defined(TARGET_XARCH) && defined(FEATURE_HW_INTRINSICS)
     GTF_HW_EM_OP                  = 0x10000000, // GT_HWINTRINSIC -- node is used as an operand to an embedded mask
-#endif // TARGET_XARCH
+#endif // TARGET_XARCH && FEATURE_HW_INTRINSICS
 };
 
 inline constexpr GenTreeFlags operator ~(GenTreeFlags a)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -556,6 +556,10 @@ enum GenTreeFlags : unsigned int
     GTF_MDARRLEN_NONFAULTING    = 0x20000000, // GT_MDARR_LENGTH -- An MD array length operation that cannot fault. Same as GT_IND_NONFAULTING.
 
     GTF_MDARRLOWERBOUND_NONFAULTING = 0x20000000, // GT_MDARR_LOWER_BOUND -- An MD array lower bound operation that cannot fault. Same as GT_IND_NONFAULTING.
+
+#ifdef TARGET_XARCH
+    GTF_HW_EM_OP                  = 0x10000000, // GT_HWINTRINSIC -- node is used as an operand to an embedded mask
+#endif // TARGET_XARCH
 };
 
 inline constexpr GenTreeFlags operator ~(GenTreeFlags a)
@@ -1486,7 +1490,8 @@ public:
     bool isCommutativeHWIntrinsic() const;
     bool isContainableHWIntrinsic() const;
     bool isRMWHWIntrinsic(Compiler* comp);
-    bool isEvexCompatibleHWIntrinsic();
+    bool isEvexCompatibleHWIntrinsic() const;
+    bool isEvexEmbeddedMaskingCompatibleHWIntrinsic() const;
 #else
     bool isCommutativeHWIntrinsic() const
     {
@@ -1503,7 +1508,12 @@ public:
         return false;
     }
 
-    bool isEvexCompatibleHWIntrinsic()
+    bool isEvexCompatibleHWIntrinsic() const
+    {
+        return false;
+    }
+
+    bool isEvexEmbeddedMaskingCompatibleHWIntrinsic() const
     {
         return false;
     }
@@ -2231,6 +2241,22 @@ public:
         assert(gtOper == GT_CNS_INT);
         gtFlags &= ~GTF_ICON_HDL_MASK;
     }
+
+#if defined(TARGET_XARCH) && defined(FEATURE_HW_INTRINSICS)
+    bool IsEmbMaskOp()
+    {
+        bool result = (gtFlags & GTF_HW_EM_OP) != 0;
+        assert(!result || (gtOper == GT_HWINTRINSIC));
+        return result;
+    }
+
+    void MakeEmbMaskOp()
+    {
+        assert(!IsEmbMaskOp());
+        gtFlags |= GTF_HW_EM_OP;
+    }
+
+#endif // TARGET_XARCH && FEATURE_HW_INTRINSICS
 
     bool IsCall() const
     {

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -205,7 +205,10 @@ enum HWIntrinsicFlag : unsigned int
     HW_Flag_EmbBroadcastCompatible = 0x8000000,
 
     // The intrinsic is an embedded rounding compatible intrinsic
-    HW_Flag_EmbRoundingCompatible = 0x10000000
+    HW_Flag_EmbRoundingCompatible = 0x10000000,
+
+    // The intrinsic is an embedded masking incompatible intrinsic
+    HW_Flag_EmbMaskingIncompatible = 0x20000000,
 #endif // TARGET_XARCH
 };
 
@@ -595,6 +598,12 @@ struct HWIntrinsicInfo
     {
         HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_EmbRoundingCompatible) != 0;
+    }
+
+    static bool IsEmbMaskingCompatible(NamedIntrinsic id)
+    {
+        HWIntrinsicFlag flags = lookupFlags(id);
+        return (flags & HW_Flag_EmbMaskingIncompatible) == 0;
     }
 
     static size_t EmbRoundingArgPos(NamedIntrinsic id)

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -1223,7 +1223,7 @@ bool CodeGenInterface::IsEmbeddedBroadcastEnabled(instruction ins, GenTree* op)
 //
 static insOpts AddEmbBroadcastMode(insOpts instOptions)
 {
-    assert((instOptions & INS_OPTS_b_MASK) == 0);
+    assert((instOptions & INS_OPTS_EVEX_b_MASK) == 0);
     unsigned result = static_cast<unsigned>(instOptions);
     return static_cast<insOpts>(result | INS_OPTS_EVEX_eb_er_rd);
 }

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -205,13 +205,36 @@ enum insOpts: unsigned
 {
     INS_OPTS_NONE = 0,
 
-    INS_OPTS_EVEX_eb_er_rd = 1, // Embedded Broadcast or Round down
+    // Two-bits: 0b0000_0011
+    INS_OPTS_EVEX_b_MASK = 0x03,         // mask for EVEX.b related features.
 
-    INS_OPTS_EVEX_er_ru = 2, // Round up
+    INS_OPTS_EVEX_eb_er_rd = 1,     // Embedded Broadcast or Round down
 
-    INS_OPTS_EVEX_er_rz = 3, // Round towards zero
+    INS_OPTS_EVEX_er_ru = 2,        // Round up
 
-    INS_OPTS_b_MASK = (INS_OPTS_EVEX_eb_er_rd | INS_OPTS_EVEX_er_ru | INS_OPTS_EVEX_er_rz), // mask for Evex.b related features.
+    INS_OPTS_EVEX_er_rz = 3,        // Round towards zero
+
+    // Two-bits: 0b0001_1100
+    INS_OPTS_EVEX_aaa_MASK = 0x1C,  // mask for EVEX.aaa related features
+
+    INS_OPTS_EVEX_em_k1 = 1 << 2,   // Embedded mask uses K1
+
+    INS_OPTS_EVEX_em_k2 = 2 << 2,   // Embedded mask uses K2
+
+    INS_OPTS_EVEX_em_k3 = 3 << 2,   // Embedded mask uses K3
+
+    INS_OPTS_EVEX_em_k4 = 4 << 2,   // Embedded mask uses K4
+
+    INS_OPTS_EVEX_em_k5 = 5 << 2,   // Embedded mask uses K5
+
+    INS_OPTS_EVEX_em_k6 = 6 << 2,   // Embedded mask uses K6
+
+    INS_OPTS_EVEX_em_k7 = 7 << 2,   // Embedded mask uses K7
+
+    // One-bit:  0b0010_0000
+    INS_OPTS_EVEX_z_MASK = 0x20,    // mask for EVEX.z related features
+
+    INS_OPTS_EVEX_em_zero,          // Embedded mask merges with zero
 };
 
 #elif defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -84,6 +84,26 @@ enum instruction : uint32_t
     INS_count = INS_none
 };
 
+//------------------------------------------------------------------------
+// IsAvx512OrPriorInstruction: Is this an Avx512 or Avx or Sse or K (opmask) instruction.
+// Technically, K instructions would be considered under the VEX encoding umbrella, but due to
+// the instruction table encoding had to be pulled out with the rest of the `INST5` definitions.
+//
+// Arguments:
+//    ins - The instruction to check.
+//
+// Returns:
+//    `true` if it is a sse or avx or avx512 instruction.
+//
+inline bool IsAvx512OrPriorInstruction(instruction ins)
+{
+#if defined(TARGET_XARCH)
+    return (ins >= INS_FIRST_SSE_INSTRUCTION) && (ins <= INS_LAST_AVX512_INSTRUCTION);
+#else
+    return false;
+#endif // TARGET_XARCH
+}
+
 /*****************************************************************************/
 
 enum insUpdateModes

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -2488,6 +2488,52 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
                 break;
             }
 
+            case NI_AVX512F_BlendVariableMask:
+            {
+                assert(numArgs == 3);
+
+                if (op2->IsEmbMaskOp())
+                {
+                    // TODO-AVX512-CQ: Ensure we can support embedded operations on RMW intrinsics
+                    assert(!op2->isRMWHWIntrinsic(compiler));
+
+                    if (isRMW)
+                    {
+                        assert(!op1->isContained());
+
+                        tgtPrefUse = BuildUse(op1);
+                        srcCount += 1;
+
+                        assert(op2->isContained());
+
+                        for (GenTree* operand : op2->AsHWIntrinsic()->Operands())
+                        {
+                            assert(varTypeIsSIMD(operand));
+                            srcCount += BuildDelayFreeUses(operand, op1);
+                        }
+                    }
+                    else
+                    {
+                        assert(op1->isContained() && op1->IsVectorZero());
+                        srcCount += BuildOperandUses(op1);
+
+                        assert(op2->isContained());
+
+                        for (GenTree* operand : op2->AsHWIntrinsic()->Operands())
+                        {
+                            assert(varTypeIsSIMD(operand));
+                            srcCount += BuildOperandUses(operand);
+                        }
+                    }
+
+                    assert(!op3->isContained());
+                    srcCount += BuildOperandUses(op3);
+
+                    buildUses = false;
+                }
+                break;
+            }
+
             case NI_AVX512F_PermuteVar8x64x2:
             case NI_AVX512F_PermuteVar16x32x2:
             case NI_AVX512F_VL_PermuteVar2x64x2:


### PR DESCRIPTION
As per the title, this adds the minimal recognition/support for emitting AVX-512 instructions with embedded masking support.

It currently only targets `Avx512F.Add` but can be trivially expanded to other instructions via a table driven approach after this first PR is merged.

For something like:
```csharp
public static Vector512<double> M(Vector512<double> x, Vector512<double> y)
{
    return Vector512.ConditionalSelect(Vector512.Equals(x, x), x + x, y + y);
}
```

We will emit the following:
```asm
vmovups  zmm0, zmmword ptr [rdx]
vcmppd   k1, zmm0, zmm0, 0
vmovups  zmm1, zmmword ptr [r8]
vaddpd   zmm1, zmm1, zmm1
vaddpd   zmm1 {k1}, zmm0, zmm0   ; <--- embedded mask used here
vmovups  zmmword ptr [rcx], zmm1
mov      rax, rcx
```