### PR TITLE
Add InvokeSpanIntoSpan helper for TensorPrimitives.SinCos{Pi}

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.T.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.T.cs
@@ -2552,26 +2552,8 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void SinCos<T>(ReadOnlySpan<T> x, Span<T> sinDestination, Span<T> cosDestination)
-            where T : ITrigonometricFunctions<T>
-        {
-            if (x.Length > sinDestination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(sinDestination));
-            }
-            if (x.Length > cosDestination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(cosDestination));
-            }
-
-            ValidateInputOutputSpanNonOverlapping(x, sinDestination);
-            ValidateInputOutputSpanNonOverlapping(x, cosDestination);
-
-            // TODO: Vectorize
-            for (int i = 0; i < x.Length; i++)
-            {
-                (sinDestination[i], cosDestination[i]) = T.SinCos(x[i]);
-            }
-        }
+            where T : ITrigonometricFunctions<T> =>
+            InvokeSpanIntoSpan_TwoOutputs<T, SinCosOperator<T>>(x, sinDestination, cosDestination);
 
         /// <summary>Computes the element-wise sine and cosine of the value in the specified tensor that has been multiplied by Pi.</summary>
         /// <param name="x">The tensor, represented as a span.</param>
@@ -2589,26 +2571,8 @@ namespace System.Numerics.Tensors
         /// </para>
         /// </remarks>
         public static void SinCosPi<T>(ReadOnlySpan<T> x, Span<T> sinPiDestination, Span<T> cosPiDestination)
-            where T : ITrigonometricFunctions<T>
-        {
-            if (x.Length > sinPiDestination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(sinPiDestination));
-            }
-            if (x.Length > cosPiDestination.Length)
-            {
-                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(cosPiDestination));
-            }
-
-            ValidateInputOutputSpanNonOverlapping(x, sinPiDestination);
-            ValidateInputOutputSpanNonOverlapping(x, cosPiDestination);
-
-            // TODO: Vectorize
-            for (int i = 0; i < x.Length; i++)
-            {
-                (sinPiDestination[i], cosPiDestination[i]) = T.SinCosPi(x[i]);
-            }
-        }
+            where T : ITrigonometricFunctions<T> =>
+            InvokeSpanIntoSpan_TwoOutputs<T, SinCosPiOperator<T>>(x, sinPiDestination, cosPiDestination);
 
         /// <summary>Computes the softmax function over the specified non-empty tensor of numbers.</summary>
         /// <param name="x">The tensor, represented as a span.</param>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.netcore.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.netcore.cs
@@ -4532,6 +4532,130 @@ namespace System.Numerics.Tensors
             }
         }
 
+        /// <summary>Performs an element-wise operation on <paramref name="x"/> and writes the results to <paramref name="destination1"/> and <paramref name="destination2"/>.</summary>
+        /// <typeparam name="T">The element type.</typeparam>
+        /// <typeparam name="TUnaryOperator">Specifies the operation to perform on each element loaded from <paramref name="x"/>.</typeparam>
+        private static void InvokeSpanIntoSpan_TwoOutputs<T, TUnaryOperator>(
+            ReadOnlySpan<T> x, Span<T> destination1, Span<T> destination2)
+            where TUnaryOperator : struct, IUnaryInputBinaryOutput<T>
+        {
+            if (x.Length > destination1.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(destination1));
+            }
+
+            if (x.Length > destination2.Length)
+            {
+                ThrowHelper.ThrowArgument_DestinationTooShort(nameof(destination2));
+            }
+
+            ValidateInputOutputSpanNonOverlapping(x, destination1);
+            ValidateInputOutputSpanNonOverlapping(x, destination2);
+
+            ref T sourceRef = ref MemoryMarshal.GetReference(x);
+            ref T destination1Ref = ref MemoryMarshal.GetReference(destination1);
+            ref T destination2Ref = ref MemoryMarshal.GetReference(destination2);
+            int i = 0, oneVectorFromEnd;
+
+            if (Vector512.IsHardwareAccelerated && Vector512<T>.IsSupported && TUnaryOperator.Vectorizable)
+            {
+                oneVectorFromEnd = x.Length - Vector512<T>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / two destination vectors at a time.
+                    do
+                    {
+                        (Vector512<T> first, Vector512<T> second) = TUnaryOperator.Invoke(Vector512.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+
+                        i += Vector512<T>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector512<T>.Count;
+
+                        (Vector512<T> first, Vector512<T> second) = TUnaryOperator.Invoke(Vector512.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+                    }
+
+                    return;
+                }
+            }
+
+            if (Vector256.IsHardwareAccelerated && Vector256<T>.IsSupported && TUnaryOperator.Vectorizable)
+            {
+                oneVectorFromEnd = x.Length - Vector256<T>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / two destination vectors at a time.
+                    do
+                    {
+                        (Vector256<T> first, Vector256<T> second) = TUnaryOperator.Invoke(Vector256.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+
+                        i += Vector256<T>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector256<T>.Count;
+
+                        (Vector256<T> first, Vector256<T> second) = TUnaryOperator.Invoke(Vector256.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+                    }
+
+                    return;
+                }
+            }
+
+            if (Vector128.IsHardwareAccelerated && Vector128<T>.IsSupported && TUnaryOperator.Vectorizable)
+            {
+                oneVectorFromEnd = x.Length - Vector128<T>.Count;
+                if (i <= oneVectorFromEnd)
+                {
+                    // Loop handling one input vector / two destination vectors at a time.
+                    do
+                    {
+                        (Vector128<T> first, Vector128<T> second) = TUnaryOperator.Invoke(Vector128.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+
+                        i += Vector128<T>.Count;
+                    }
+                    while (i <= oneVectorFromEnd);
+
+                    // Handle any remaining elements with a final input vector.
+                    if (i != x.Length)
+                    {
+                        i = x.Length - Vector128<T>.Count;
+
+                        (Vector128<T> first, Vector128<T> second) = TUnaryOperator.Invoke(Vector128.LoadUnsafe(ref sourceRef, (uint)i));
+                        first.StoreUnsafe(ref destination1Ref, (uint)i);
+                        second.StoreUnsafe(ref destination2Ref, (uint)i);
+                    }
+
+                    return;
+                }
+            }
+
+            while (i < x.Length)
+            {
+                (T first, T second) = TUnaryOperator.Invoke(Unsafe.Add(ref sourceRef, i));
+                Unsafe.Add(ref destination1Ref, i) = first;
+                Unsafe.Add(ref destination2Ref, i) = second;
+                i++;
+            }
+        }
+
         /// <summary>
         /// Performs an element-wise operation on <paramref name="x"/> and <paramref name="y"/>,
         /// and writes the results to <paramref name="destination"/>.
@@ -15653,6 +15777,28 @@ namespace System.Numerics.Tensors
             }
         }
 
+        /// <summary>T.SinCos(x)</summary>
+        internal readonly struct SinCosOperator<T> : IUnaryInputBinaryOutput<T> where T : ITrigonometricFunctions<T>
+        {
+            public static bool Vectorizable => false; // TODO: vectorize
+
+            public static (T, T) Invoke(T x) => T.SinCos(x);
+            public static (Vector128<T> First, Vector128<T> Second) Invoke(Vector128<T> x) => throw new NotImplementedException();
+            public static (Vector256<T> First, Vector256<T> Second) Invoke(Vector256<T> x) => throw new NotImplementedException();
+            public static (Vector512<T> First, Vector512<T> Second) Invoke(Vector512<T> x) => throw new NotImplementedException();
+        }
+
+        /// <summary>T.SinCosPi(x)</summary>
+        internal readonly struct SinCosPiOperator<T> : IUnaryInputBinaryOutput<T> where T : ITrigonometricFunctions<T>
+        {
+            public static bool Vectorizable => false; // TODO: vectorize
+
+            public static (T, T) Invoke(T x) => T.SinCosPi(x);
+            public static (Vector128<T> First, Vector128<T> Second) Invoke(Vector128<T> x) => throw new NotImplementedException();
+            public static (Vector256<T> First, Vector256<T> Second) Invoke(Vector256<T> x) => throw new NotImplementedException();
+            public static (Vector512<T> First, Vector512<T> Second) Invoke(Vector512<T> x) => throw new NotImplementedException();
+        }
+
         /// <summary>Operator that takes one input value and returns a single value.</summary>
         /// <remarks>The input and output type must be of the same size if vectorization is desired.</remarks>
         private interface IUnaryOperator<TInput, TOutput>
@@ -15684,6 +15830,16 @@ namespace System.Numerics.Tensors
             static abstract Vector128<TOutput> Invoke(Vector128<TInput> lower, Vector128<TInput> upper);
             static abstract Vector256<TOutput> Invoke(Vector256<TInput> lower, Vector256<TInput> upper);
             static abstract Vector512<TOutput> Invoke(Vector512<TInput> lower, Vector512<TInput> upper);
+        }
+
+        /// <summary>Operator that takes one input value and returns two output values.</summary>
+        private interface IUnaryInputBinaryOutput<T>
+        {
+            static abstract bool Vectorizable { get; }
+            static abstract (T, T) Invoke(T x);
+            static abstract (Vector128<T> First, Vector128<T> Second) Invoke(Vector128<T> x);
+            static abstract (Vector256<T> First, Vector256<T> Second) Invoke(Vector256<T> x);
+            static abstract (Vector512<T> First, Vector512<T> Second) Invoke(Vector512<T> x);
         }
 
         /// <summary>Operator that takes one input value and returns a single value.</summary>


### PR DESCRIPTION
Removes the last two for loops from the TensorPrimitives.T.cs file.