### PR TITLE
Delete most of InteropExtensions

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/InteropExtensions.cs
@@ -1,89 +1,17 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Threading;
-
-using Internal.Runtime.Augments;
-using Internal.Runtime.CompilerServices;
-
 namespace System.Runtime.InteropServices
 {
-    /// <summary>
-    ///     Hooks for interop code to access internal functionality in System.Private.CoreLib.dll.
-    /// </summary>
     internal static unsafe class InteropExtensions
     {
-        internal static bool MightBeBlittable(this RuntimeTypeHandle handle)
+        public static bool IsBlittable(this RuntimeTypeHandle handle)
         {
             //
             // This is used as the approximate implementation of MethodTable::IsBlittable(). It  will err in the direction of declaring
             // things blittable since it is used for argument validation only.
             //
             return !handle.ToMethodTable()->ContainsGCPointers;
-        }
-
-        public static bool IsBlittable(this RuntimeTypeHandle handle)
-        {
-            return handle.MightBeBlittable();
-        }
-
-        public static bool IsGenericType(this RuntimeTypeHandle handle)
-        {
-            return handle.ToMethodTable()->IsGeneric;
-        }
-
-        public static bool IsGenericTypeDefinition(this RuntimeTypeHandle handle)
-        {
-            return handle.ToMethodTable()->IsGenericTypeDefinition;
-        }
-
-        //
-        // Returns the raw function pointer for a open static delegate - if the function has a jump stub
-        // it returns the jump target. Therefore the function pointer returned
-        // by two delegates may NOT be unique
-        //
-        public static IntPtr GetRawFunctionPointerForOpenStaticDelegate(this Delegate del)
-        {
-            //If it is not open static then return IntPtr.Zero
-            if (!del.IsOpenStatic)
-                return IntPtr.Zero;
-
-            IntPtr funcPtr = del.GetFunctionPointer(out RuntimeTypeHandle _, out bool _, out bool _);
-            return funcPtr;
-        }
-
-        public static int GetValueTypeSize(this RuntimeTypeHandle handle)
-        {
-            return (int)handle.ToMethodTable()->ValueTypeSize;
-        }
-
-        public static bool IsValueType(this RuntimeTypeHandle handle)
-        {
-            return handle.ToMethodTable()->IsValueType;
-        }
-
-        public static bool IsEnum(this RuntimeTypeHandle handle)
-        {
-            return handle.ToMethodTable()->IsEnum;
-        }
-
-        public static bool IsInterface(this RuntimeTypeHandle handle)
-        {
-            return handle.ToMethodTable()->IsInterface;
-        }
-
-        public static bool AreTypesAssignable(RuntimeTypeHandle sourceType, RuntimeTypeHandle targetType)
-        {
-            return RuntimeImports.AreTypesAssignable(sourceType.ToMethodTable(), targetType.ToMethodTable());
-        }
-
-        public static RuntimeTypeHandle GetTypeHandle(this object target)
-        {
-            return new RuntimeTypeHandle(target.GetMethodTable());
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.NativeAot.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+using Internal.Runtime;
 using Internal.Runtime.Augments;
 using Internal.Runtime.CompilerHelpers;
 
@@ -29,7 +30,7 @@ namespace System.Runtime.InteropServices
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static IntPtr OffsetOf(Type t, string fieldName)
+        public static unsafe IntPtr OffsetOf(Type t, string fieldName)
         {
             ArgumentNullException.ThrowIfNull(t);
 
@@ -43,7 +44,7 @@ namespace System.Runtime.InteropServices
                 throw new ArgumentException(SR.Argument_MustBeRuntimeFieldInfo, nameof(fieldName));
             }
 
-            if (t.TypeHandle.IsGenericTypeDefinition())
+            if (t.TypeHandle.ToMethodTable()->IsGenericTypeDefinition)
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(t));
 
             return new IntPtr(RuntimeInteropData.GetStructFieldOffset(t.TypeHandle, fieldName));
@@ -61,7 +62,8 @@ namespace System.Runtime.InteropServices
 
         internal static unsafe void PtrToStructureImpl(IntPtr ptr, object structure)
         {
-            RuntimeTypeHandle structureTypeHandle = structure.GetType().TypeHandle;
+            MethodTable* structureMT = structure.GetMethodTable();
+            RuntimeTypeHandle structureTypeHandle = new RuntimeTypeHandle(structureMT);
 
             IntPtr unmarshalStub;
             if (structureTypeHandle.IsBlittable())
@@ -78,7 +80,7 @@ namespace System.Runtime.InteropServices
 
             if (unmarshalStub != IntPtr.Zero)
             {
-                if (structureTypeHandle.IsValueType())
+                if (structureMT->IsValueType)
                 {
                     ((delegate*<ref byte, ref byte, void>)unmarshalStub)(ref *(byte*)ptr, ref structure.GetRawData());
                 }
@@ -104,12 +106,12 @@ namespace System.Runtime.InteropServices
 
             RuntimeTypeHandle structureTypeHandle = structuretype.TypeHandle;
 
-            if (structureTypeHandle.IsGenericType())
+            if (structureTypeHandle.ToMethodTable()->IsGeneric)
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(structuretype));
 
-            if (structureTypeHandle.IsEnum() ||
-                structureTypeHandle.IsInterface() ||
-                InteropExtensions.AreTypesAssignable(typeof(Delegate).TypeHandle, structureTypeHandle))
+            if (structureTypeHandle.ToMethodTable()->IsEnum ||
+                structureTypeHandle.ToMethodTable()->IsInterface ||
+                RuntimeImports.AreTypesAssignable(MethodTable.Of<Delegate>(), structureTypeHandle.ToMethodTable()))
             {
                 throw new ArgumentException(SR.Format(SR.Argument_MustHaveLayoutOrBeBlittable, structuretype));
             }
@@ -137,9 +139,10 @@ namespace System.Runtime.InteropServices
             ArgumentNullException.ThrowIfNull(structure);
             ArgumentNullException.ThrowIfNull(ptr);
 
-            RuntimeTypeHandle structureTypeHandle = structure.GetType().TypeHandle;
+            MethodTable* structureMT = structure.GetMethodTable();
+            RuntimeTypeHandle structureTypeHandle = new RuntimeTypeHandle(structureMT);
 
-            if (structureTypeHandle.IsGenericType())
+            if (structureMT->IsGeneric)
             {
                 throw new ArgumentException(SR.Argument_NeedNonGenericObject, nameof(structure));
             }
@@ -164,7 +167,7 @@ namespace System.Runtime.InteropServices
 
             if (marshalStub != IntPtr.Zero)
             {
-                if (structureTypeHandle.IsValueType())
+                if (structureMT->IsValueType)
                 {
                     ((delegate*<ref byte, ref byte, void>)marshalStub)(ref structure.GetRawData(), ref *(byte*)ptr);
                 }


### PR DESCRIPTION
These existed due to some 5+ year old layering issue.

I left `IsBlittable`. Pretty much every single use of this is a bug (https://github.com/dotnet/runtime/issues/75666).

Cc @dotnet/ilc-contrib 