### PR TITLE
Add API call for Arm64 Sve.LoadVectorNonFaulting

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -402,6 +402,7 @@ set( JIT_ARM64_HEADERS
     emitfmtsarm64.h
     emitfmtsarm64sve.h
     hwintrinsiclistarm64.h
+    hwintrinsiclistarm64sve.h
     instrsarm64.h
     instrsarm64sve.h
     registerarm64.h

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -5801,6 +5801,34 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     }
 }
 
+//  For the given 'elemsize' returns the 'arrangement' when used in a SVE vector register arrangement.
+//  Asserts and returns INS_OPTS_NONE if an invalid 'elemsize' is passed
+//
+/*static*/ insOpts emitter::optGetSveInsOpt(emitAttr elemsize)
+{
+    switch (elemsize)
+    {
+        case EA_1BYTE:
+            return INS_OPTS_SCALABLE_B;
+
+        case EA_2BYTE:
+            return INS_OPTS_SCALABLE_H;
+
+        case EA_4BYTE:
+            return INS_OPTS_SCALABLE_S;
+
+        case EA_8BYTE:
+            return INS_OPTS_SCALABLE_D;
+
+        case EA_16BYTE:
+            return INS_OPTS_SCALABLE_Q;
+
+        default:
+            assert(!"Invalid emitAttr for sve vector register");
+            return INS_OPTS_NONE;
+    }
+}
+
 //  For the given 'arrangement' returns the 'elemsize' specified by the SVE vector register arrangement
 //  asserts and returns EA_UNKNOWN if an invalid 'arrangement' value is passed
 //
@@ -9923,6 +9951,12 @@ void emitter::emitIns_R_R_R(instruction     ins,
             assert(isPredicateRegister(reg3)); // NNNN
             fmt = IF_SVE_CZ_4A;
             break;
+
+        case INS_sve_ldnf1b:
+        case INS_sve_ldnf1h:
+        case INS_sve_ldnf1w:
+        case INS_sve_ldnf1d:
+            return emitIns_R_R_R_I(ins, size, reg1, reg2, reg3, 0, opt);
 
         default:
             unreached();

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -726,6 +726,9 @@ static emitAttr optGetDatasize(insOpts arrangement);
 //  For the given 'arrangement' returns the 'elemsize' specified by the vector register arrangement
 static emitAttr optGetElemsize(insOpts arrangement);
 
+//  For the given 'elemsize' returns the 'arrangement' when used in a SVE vector register arrangement.
+static insOpts optGetSveInsOpt(emitAttr elemsize);
+
 //  For the given 'arrangement' returns the 'elemsize' specified by the SVE vector register arrangement
 static emitAttr optGetSveElemsize(insOpts arrangement);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -25711,8 +25711,11 @@ bool GenTreeHWIntrinsic::OperIsMemoryLoad(GenTree** pAddr) const
             case NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x2:
             case NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x3:
             case NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x4:
-
                 addr = Op(3);
+                break;
+
+            case NI_Sve_LoadVectorNonFaulting:
+                addr = Op(2);
                 break;
 #endif // TARGET_ARM64
 

--- a/src/coreclr/jit/hwintrinsic.h
+++ b/src/coreclr/jit/hwintrinsic.h
@@ -175,6 +175,13 @@ enum HWIntrinsicFlag : unsigned int
 
     // The intrinsic needs consecutive registers
     HW_Flag_NeedsConsecutiveRegisters = 0x4000,
+
+    // The intrinsic uses scalable registers
+    HW_Flag_Scalable = 0x8000,
+
+    // The intrinsic uses a mask in arg1 to predicate the result
+    HW_Flag_Predicated = 0x10000,
+
 #else
 #error Unsupported platform
 #endif
@@ -845,6 +852,19 @@ struct HWIntrinsicInfo
     {
         const HWIntrinsicFlag flags = lookupFlags(id);
         return (flags & HW_Flag_HasImmediateOperand) != 0;
+    }
+
+    static bool isScalable(NamedIntrinsic id)
+    {
+        const HWIntrinsicFlag flags = lookupFlags(id);
+        return (flags & HW_Flag_Scalable) != 0;
+    }
+
+    // TODO-SVE: Check this flag when register allocating
+    static bool HasPredicatedResult(NamedIntrinsic id)
+    {
+        const HWIntrinsicFlag flags = lookupFlags(id);
+        return (flags & HW_Flag_Predicated) != 0;
     }
 #endif // TARGET_ARM64
 

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -265,6 +265,12 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         emitSize = EA_UNKNOWN;
         opt      = INS_OPTS_NONE;
     }
+    else if (HWIntrinsicInfo::isScalable(intrin.id))
+    {
+        emitSize = EA_SCALABLE;
+        // TODO-SVE: This shouldn't require GetEmitter()
+        opt = GetEmitter()->optGetSveInsOpt(emitTypeSize(intrin.baseType));
+    }
     else
     {
         emitSize = emitActualTypeSize(Compiler::getSIMDTypeForSize(node->GetSimdSize()));

--- a/src/coreclr/jit/hwintrinsiclistarm64.h
+++ b/src/coreclr/jit/hwintrinsiclistarm64.h
@@ -802,6 +802,8 @@ HARDWARE_INTRINSIC(Sha256,        ScheduleUpdate1,                              
 
 #endif // FEATURE_HW_INTRINSIC
 
+#include "hwintrinsiclistarm64sve.h"
+
 #undef HARDWARE_INTRINSIC
 
 // clang-format on

--- a/src/coreclr/jit/hwintrinsiclistarm64sve.h
+++ b/src/coreclr/jit/hwintrinsiclistarm64sve.h
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/*****************************************************************************/
+#ifndef HARDWARE_INTRINSIC
+#error Define HARDWARE_INTRINSIC before including this file
+#endif
+/*****************************************************************************/
+
+// clang-format off
+
+#ifdef FEATURE_HW_INTRINSICS
+// ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
+//                 ISA            Function name                                              SIMD size  NumArg  EncodesExtraTypeArg                                                                                            Instructions                                                                                        Category                           Flags
+//                                                                                                                          {TYP_BYTE,           TYP_UBYTE,          TYP_SHORT,          TYP_USHORT,         TYP_INT,            TYP_UINT,           TYP_LONG,           TYP_ULONG,          TYP_FLOAT,          TYP_DOUBLE}
+// ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
+//  SVE Intrinsics
+
+// Sve
+HARDWARE_INTRINSIC(Sve,           LoadVectorNonFaulting,                                            -1,      2,      true,  {INS_sve_ldnf1b,     INS_sve_ldnf1b,     INS_sve_ldnf1h,     INS_sve_ldnf1h,     INS_sve_ldnf1w,     INS_sve_ldnf1w,     INS_sve_ldnf1d,     INS_sve_ldnf1d,     INS_sve_ldnf1w,     INS_sve_ldnf1d},  HW_Category_MemoryLoad,            HW_Flag_Scalable|HW_Flag_Predicated)
+
+#endif // FEATURE_HW_INTRINSIC
+
+#undef HARDWARE_INTRINSIC
+
+// clang-format on

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -271,6 +271,33 @@ regMaskTP LinearScan::lowSIMDRegs()
 #endif
 }
 
+
+#ifdef TARGET_ARM64
+
+//------------------------------------------------------------------------
+// allPredicateRegs(): Return the set of all predicate SVE registers.
+//
+// Return Value:
+// Register mask of the SVE predicate registers
+//
+regMaskTP LinearScan::allPredicateRegs()
+{
+    return (availablePredicateRegs & RBM_ALLPREDICATE);
+}
+
+//------------------------------------------------------------------------
+// lowPredicateRegs(): Return the set of all the lower predicate SVE registers.
+//
+// Return Value:
+// Register mask of the low SVE predicate registers
+//
+regMaskTP LinearScan::lowPredicateRegs()
+{
+    return (availablePredicateRegs & RBM_LOWPREDICATE);
+}
+
+#endif
+
 void LinearScan::updateNextFixedRef(RegRecord* regRecord, RefPosition* nextRefPosition)
 {
     LsraLocation nextLocation;
@@ -790,6 +817,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
     availableDoubleRegs = RBM_ALLDOUBLE;
 #if defined(TARGET_XARCH)
     availableMaskRegs = RBM_ALLMASK;
+#elif defined(TARGET_ARM64)
+    availablePredicateRegs = RBM_ALLPREDICATE;
 #endif
 
 #if defined(TARGET_AMD64) || defined(TARGET_ARM64)

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1098,6 +1098,10 @@ private:
     regMaskTP allSIMDRegs();
     regMaskTP lowSIMDRegs();
     regMaskTP internalFloatRegCandidates();
+#ifdef TARGET_ARM64
+    regMaskTP allPredicateRegs();
+    regMaskTP lowPredicateRegs();
+#endif
 
     void makeRegisterInactive(RegRecord* physRegRecord);
     void freeRegister(RegRecord* physRegRecord);
@@ -1664,6 +1668,8 @@ private:
     PhasedVar<regMaskTP> availableDoubleRegs;
 #if defined(TARGET_XARCH)
     PhasedVar<regMaskTP> availableMaskRegs;
+#elif defined(TARGET_ARM64)
+    PhasedVar<regMaskTP> availablePredicateRegs;
 #endif
     PhasedVar<regMaskTP>* availableRegs[TYP_COUNT];
 

--- a/src/coreclr/jit/targetarm64.h
+++ b/src/coreclr/jit/targetarm64.h
@@ -140,6 +140,10 @@
   #define REG_JUMP_THUNK_PARAM     REG_R12
   #define RBM_JUMP_THUNK_PARAM     RBM_R12
 
+  #define RBM_LOWPREDICATE        (RBM_P0 | RBM_P1 | RBM_P2 | RBM_P3 | RBM_P4 | RBM_P5 | RBM_P6 | RBM_P7)
+  #define RBM_HIGHPREDICATE       (RBM_P8 | RBM_P9 | RBM_P10 | RBM_P11 | RBM_P12 | RBM_P13 | RBM_P14 | RBM_P15)
+  #define RBM_ALLPREDICATE        (RBM_LOWPREDICATE | RBM_HIGHPREDICATE)
+
   // ARM64 write barrier ABI (see vm\arm64\asmhelpers.asm, vm\arm64\asmhelpers.S):
   // CORINFO_HELP_ASSIGN_REF (JIT_WriteBarrier), CORINFO_HELP_CHECKED_ASSIGN_REF (JIT_CheckedWriteBarrier):
   //     On entry:

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.NoArmIntrinsics.xml
@@ -51,5 +51,11 @@
     <type fullname="System.Runtime.Intrinsics.Arm.Sha256/Arm64">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
     </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Sve">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
+    <type fullname="System.Runtime.Intrinsics.Arm.Sve/Arm64">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+    </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2632,6 +2632,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Rdm.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sha1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sha256.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sve.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(SupportsArmIntrinsics)' != 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\AdvSimd.PlatformNotSupported.cs" />
@@ -2642,6 +2643,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Rdm.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sha1.PlatformNotSupported.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sha256.PlatformNotSupported.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Arm\Sve.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(SupportsWasmIntrinsics)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Intrinsics\Wasm\WasmBase.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Numerics;
+
+namespace System.Runtime.Intrinsics.Arm
+{
+    /// <summary>
+    /// This class provides access to the ARM SVE hardware instructions via intrinsics
+    /// </summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Sve : AdvSimd
+    {
+        internal Sve() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public new abstract class Arm64 : AdvSimd.Arm64
+        {
+            internal Arm64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+
+
+        ///  LoadVectorNonFaulting : Unextended load, non-faulting
+
+        /// <summary>
+        /// svint8_t svldnf1[_s8](svbool_t pg, const int8_t *base)
+        ///   LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<sbyte> LoadVectorNonFaulting(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svint16_t svldnf1[_s16](svbool_t pg, const int16_t *base)
+        ///   LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<short> LoadVectorNonFaulting(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svint32_t svldnf1[_s32](svbool_t pg, const int32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<int> LoadVectorNonFaulting(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svint64_t svldnf1[_s64](svbool_t pg, const int64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<long> LoadVectorNonFaulting(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svuint8_t svldnf1[_u8](svbool_t pg, const uint8_t *base)
+        ///   LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<byte> LoadVectorNonFaulting(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svuint16_t svldnf1[_u16](svbool_t pg, const uint16_t *base)
+        ///   LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<ushort> LoadVectorNonFaulting(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svuint32_t svldnf1[_u32](svbool_t pg, const uint32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<uint> LoadVectorNonFaulting(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svuint64_t svldnf1[_u64](svbool_t pg, const uint64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<ulong> LoadVectorNonFaulting(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svfloat32_t svldnf1[_f32](svbool_t pg, const float32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<float> LoadVectorNonFaulting(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
+
+        /// <summary>
+        /// svfloat64_t svldnf1[_f64](svbool_t pg, const float64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<double> LoadVectorNonFaulting(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
+
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.Intrinsics.Arm
     /// </summary>
     [Intrinsic]
     [CLSCompliant(false)]
+    [System.Runtime.Versioning.RequiresPreviewFeaturesAttribute("Sve is in preview.")]
     public abstract class Sve : AdvSimd
     {
         internal Sve() { }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Numerics;
+
+namespace System.Runtime.Intrinsics.Arm
+{
+    /// <summary>
+    /// This class provides access to the ARM SVE hardware instructions via intrinsics
+    /// </summary>
+    [Intrinsic]
+    [CLSCompliant(false)]
+    public abstract class Sve : AdvSimd
+    {
+        internal Sve() { }
+
+        public static new bool IsSupported { get => IsSupported; }
+
+        [Intrinsic]
+        public new abstract class Arm64 : AdvSimd.Arm64
+        {
+            internal Arm64() { }
+
+            public static new bool IsSupported { get => IsSupported; }
+        }
+
+        ///  LoadVectorNonFaulting : Unextended load, non-faulting
+
+        /// <summary>
+        /// svint8_t svldnf1[_s8](svbool_t pg, const int8_t *base)
+        ///   LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<sbyte> LoadVectorNonFaulting(Vector<sbyte> mask, sbyte* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svint16_t svldnf1[_s16](svbool_t pg, const int16_t *base)
+        ///   LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<short> LoadVectorNonFaulting(Vector<short> mask, short* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svint32_t svldnf1[_s32](svbool_t pg, const int32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<int> LoadVectorNonFaulting(Vector<int> mask, int* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svint64_t svldnf1[_s64](svbool_t pg, const int64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<long> LoadVectorNonFaulting(Vector<long> mask, long* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svuint8_t svldnf1[_u8](svbool_t pg, const uint8_t *base)
+        ///   LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<byte> LoadVectorNonFaulting(Vector<byte> mask, byte* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svuint16_t svldnf1[_u16](svbool_t pg, const uint16_t *base)
+        ///   LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<ushort> LoadVectorNonFaulting(Vector<ushort> mask, ushort* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svuint32_t svldnf1[_u32](svbool_t pg, const uint32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<uint> LoadVectorNonFaulting(Vector<uint> mask, uint* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svuint64_t svldnf1[_u64](svbool_t pg, const uint64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<ulong> LoadVectorNonFaulting(Vector<ulong> mask, ulong* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svfloat32_t svldnf1[_f32](svbool_t pg, const float32_t *base)
+        ///   LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<float> LoadVectorNonFaulting(Vector<float> mask, float* address) => LoadVectorNonFaulting(mask, address);
+
+        /// <summary>
+        /// svfloat64_t svldnf1[_f64](svbool_t pg, const float64_t *base)
+        ///   LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]
+        /// </summary>
+        public static unsafe Vector<double> LoadVectorNonFaulting(Vector<double> mask, double* address) => LoadVectorNonFaulting(mask, address);
+
+
+    }
+}

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -4142,6 +4142,23 @@ namespace System.Runtime.Intrinsics.Arm
             public static new bool IsSupported { get { throw null; } }
         }
     }
+    [System.CLSCompliantAttribute(false)]
+    public abstract partial class Sve : System.Runtime.Intrinsics.Arm.AdvSimd
+    {
+        internal Sve() { }
+        public static new bool IsSupported { get { throw null; } }
+
+        public static unsafe System.Numerics.Vector<sbyte> LoadVectorNonFaulting(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
+        public static unsafe System.Numerics.Vector<short> LoadVectorNonFaulting(System.Numerics.Vector<short> mask, short* address) { throw null; }
+        public static unsafe System.Numerics.Vector<int> LoadVectorNonFaulting(System.Numerics.Vector<int> mask, int* address) { throw null; }
+        public static unsafe System.Numerics.Vector<long> LoadVectorNonFaulting(System.Numerics.Vector<long> mask, long* address) { throw null; }
+        public static unsafe System.Numerics.Vector<byte> LoadVectorNonFaulting(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
+        public static unsafe System.Numerics.Vector<ushort> LoadVectorNonFaulting(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
+        public static unsafe System.Numerics.Vector<uint> LoadVectorNonFaulting(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
+        public static unsafe System.Numerics.Vector<ulong> LoadVectorNonFaulting(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
+        public static unsafe System.Numerics.Vector<float> LoadVectorNonFaulting(System.Numerics.Vector<float> mask, float* address) { throw null; }
+        public static unsafe System.Numerics.Vector<double> LoadVectorNonFaulting(System.Numerics.Vector<double> mask, double* address) { throw null; }
+    }
 }
 namespace System.Runtime.Intrinsics.X86
 {

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Program.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/Program.cs
@@ -21,6 +21,7 @@ namespace JIT.HardwareIntrinsics.Arm
             TestLibrary.TestFramework.LogInformation($"  Rdm:       {Rdm.IsSupported}");
             TestLibrary.TestFramework.LogInformation($"  Sha1:      {Sha1.IsSupported}");
             TestLibrary.TestFramework.LogInformation($"  Sha256:    {Sha256.IsSupported}");
+            TestLibrary.TestFramework.LogInformation($"  Sve:       {Sve.IsSupported}");
             TestLibrary.TestFramework.LogInformation(string.Empty);
         }
     }

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sve/Program.Sve.cs
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sve/Program.Sve.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/******************************************************************************
+ * This file is auto-generated from a template file by the GenerateTests.csx  *
+ * script in tests\src\JIT\HardwareIntrinsics.Arm\Shared. In order to make    *
+ * changes, please update the corresponding template and run according to the *
+ * directions listed in the file.                                             *
+ ******************************************************************************/
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Numerics;
+using Xunit;
+
+// TODO-SVE: This file should be replaced with a .template test.
+
+namespace JIT.HardwareIntrinsics.Arm._AdvSimd
+{
+    public static partial class Program
+    {
+        [Fact]
+        public static void SveTest()
+        {
+            var test = new SveTest__SveTest();
+            test.Succeeded = true;
+
+            if (test.IsSupported)
+            {
+                test.RunBasicScenario_LoadVector();
+            }
+            else
+            {
+                Console.WriteLine("SVE is not Supported.");
+            }
+
+            if (!test.Succeeded)
+            {
+                throw new Exception("One or more scenarios did not complete as expected.");
+            }
+        }
+    }
+
+    public sealed unsafe class SveTest__SveTest
+    {
+        public bool IsSupported => Sve.IsSupported;
+
+        public bool Succeeded { get; set; }
+
+        private static unsafe void* Align(byte* buffer, ulong expectedAlignment)
+        {
+            return (void*)(((ulong)buffer + expectedAlignment - 1) & ~(expectedAlignment - 1));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public Vector<int> do_LoadVectorNonFaulting(Vector<int> mask, int* address)
+        {
+            return Sve.LoadVectorNonFaulting(mask, address);
+        }
+
+        public void RunBasicScenario_LoadVector()
+        {
+            Vector<int> mask = Vector<int>.One;
+
+            int elemsInVector = 4;
+            int OpElementCount = elemsInVector * 2;
+            int[] inArray1 = new int[OpElementCount];
+            for (var i = 0; i < OpElementCount; i++) { inArray1[i] = i+1; }
+
+            GCHandle inHandle1;
+            inHandle1 = GCHandle.Alloc(inArray1, GCHandleType.Pinned);
+            int* inArray1Ptr = (int*)Align((byte*)(inHandle1.AddrOfPinnedObject().ToPointer()), 128);
+
+            Vector<int> outVector1 = do_LoadVectorNonFaulting(mask, inArray1Ptr);
+
+            // TODO-SVE: There is no register allocation for predicate registers.
+            // Instead, the jit will allocate a Z register for mask, but codegen will use the equivalent
+            // register number as a predicate. But that predicate register will have an invalid value
+            // (probably zero) and load the wrong vector elements.
+            for (var i = 0; i < elemsInVector; i++)
+            {
+                if (inArray1[i] != outVector1[i])
+                {
+                    Console.WriteLine("{0} {1} != {2}", i, inArray1[i], outVector1[i]);
+                    Succeeded = false;
+                }
+                Console.WriteLine(outVector1[i]);
+            }
+
+            Console.WriteLine("Done");
+        }
+    }
+}

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Sve/Sve.csproj
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Sve/Sve.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>AnyCPU;ARM64</Platforms>
+    <BuildAsStandalone>true</BuildAsStandalone>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.Sve.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds everything from the API down to calling the codegen.

LoadVectorNonFaulting() was chosen as it has been approved and requires no "hidden" mask nodes.