### PR TITLE
libraries/tests: skip System.Numerics.Tensors.Net8.Tests when DotNetBuildFromSource.

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -100,6 +100,12 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Transactions.Local\tests\System.Transactions.Local.Tests.csproj" />
   </ItemGroup>
 
+  <!-- Projects that won't work when DotNetBuildFromSource. -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <!-- Project targets an older target framework which does not get built. -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Tensors\tests\Net8Tests\System.Numerics.Tensors.Net8.Tests.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetArchitecture)' == 'ARMv6'">
     <!-- https://github.com/dotnet/runtime/issues/64673 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Ping\tests\FunctionalTests\System.Net.Ping.Functional.Tests.csproj" />


### PR DESCRIPTION
This project expects to use the net8.0 target of System.Numerics.Tensors which doesn't get built when DotNetBuildFromSource is true.

@ViktorHofer ptal.