### PR TITLE
Fix S.T.Json's ArrayPool threshold

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -61,7 +61,12 @@ namespace System.Text.Json
         public const int MaxExpansionFactorWhileTranscoding = 3;
 
         // When transcoding from UTF8 -> UTF16, the byte count threshold where we rent from the array pool before performing a normal alloc.
-        public const long ArrayPoolMaxSizeBeforeUsingNormalAlloc = 1024 * 1024;
+        public const long ArrayPoolMaxSizeBeforeUsingNormalAlloc =
+#if NET6_0_OR_GREATER
+            1024 * 1024 * 1024;
+#else
+            1024 * 1024;
+#endif
 
         // The maximum number of characters allowed when writing raw UTF-16 JSON. This is the maximum length that we can guarantee can
         // be safely transcoded to UTF-8 and fit within an integer-length span, given the max expansion factor of a single character (3).

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json
         // When transcoding from UTF8 -> UTF16, the byte count threshold where we rent from the array pool before performing a normal alloc.
         public const long ArrayPoolMaxSizeBeforeUsingNormalAlloc =
 #if NET6_0_OR_GREATER
-            1024 * 1024 * 1024;
+            1024 * 1024 * 1024; // ArrayPool limit increased in .NET 6
 #else
             1024 * 1024;
 #endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.String.cs
@@ -429,9 +429,11 @@ namespace System.Text.Json
             byte[]? tempArray = null;
 
             // For performance, avoid obtaining actual byte count unless memory usage is higher than the threshold.
-            Span<byte> utf8 = json.Length <= (JsonConstants.ArrayPoolMaxSizeBeforeUsingNormalAlloc / JsonConstants.MaxExpansionFactorWhileTranscoding) ?
-                // Use a pooled alloc.
-                tempArray = ArrayPool<byte>.Shared.Rent(json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) :
+            Span<byte> utf8 =
+                // Use stack memory
+                json.Length <= (JsonConstants.StackallocByteThreshold / JsonConstants.MaxExpansionFactorWhileTranscoding) ? stackalloc byte[JsonConstants.StackallocByteThreshold] :
+                // Use a pooled array
+                json.Length <= (JsonConstants.ArrayPoolMaxSizeBeforeUsingNormalAlloc / JsonConstants.MaxExpansionFactorWhileTranscoding) ? tempArray = ArrayPool<byte>.Shared.Rent(json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) :
                 // Use a normal alloc since the pool would create a normal alloc anyway based on the threshold (per current implementation)
                 // and by using a normal alloc we can avoid the Clear().
                 new byte[JsonReaderHelper.GetUtf8ByteCount(json)];
@@ -458,9 +460,11 @@ namespace System.Text.Json
             byte[]? tempArray = null;
 
             // For performance, avoid obtaining actual byte count unless memory usage is higher than the threshold.
-            Span<byte> utf8 = json.Length <= (JsonConstants.ArrayPoolMaxSizeBeforeUsingNormalAlloc / JsonConstants.MaxExpansionFactorWhileTranscoding) ?
-                // Use a pooled alloc.
-                tempArray = ArrayPool<byte>.Shared.Rent(json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) :
+            Span<byte> utf8 =
+                // Use stack memory
+                json.Length <= (JsonConstants.StackallocByteThreshold / JsonConstants.MaxExpansionFactorWhileTranscoding) ? stackalloc byte[JsonConstants.StackallocByteThreshold] :
+                // Use a pooled array
+                json.Length <= (JsonConstants.ArrayPoolMaxSizeBeforeUsingNormalAlloc / JsonConstants.MaxExpansionFactorWhileTranscoding) ? tempArray = ArrayPool<byte>.Shared.Rent(json.Length * JsonConstants.MaxExpansionFactorWhileTranscoding) :
                 // Use a normal alloc since the pool would create a normal alloc anyway based on the threshold (per current implementation)
                 // and by using a normal alloc we can avoid the Clear().
                 new byte[JsonReaderHelper.GetUtf8ByteCount(json)];


### PR DESCRIPTION
A few code paths hardcoded "current" knowledge of the ArrayPool's upper bound. But that bound changed in .NET 6, so now STJ is allocating large byte arrays in places it could be using pooling.  This fixes the limit.

Also, most STJ code paths that use the ArrayPool try to stackalloc instead, but a few paths don't. This fixes them to do so as well where possible.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.Json;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Tests
{
    private Utf8JsonWriter _writer = new Utf8JsonWriter(Stream.Null);
    private string _largeRawValue = $$"""{ "name": "{{new string('s', 350_000)}}" }""";

    [Benchmark]
    public void Write_Small()
    {
        _writer.Reset();
        _writer.WriteStartObject();
        _writer.WritePropertyName("payload"u8);
        _writer.WriteRawValue("""{ "name": "stephen" }""");
        _writer.WriteEndObject();
    }

    [Benchmark]
    public void Write_Large()
    {
        _writer.Reset();
        _writer.WriteStartObject();
        _writer.WritePropertyName("payload"u8);
        _writer.WriteRawValue(_largeRawValue);
        _writer.WriteEndObject();
    }
}
```

| Method      | Toolchain         | Mean         | Ratio | Allocated | Alloc Ratio |
|------------ |------------------ |-------------:|------:|----------:|------------:|
| Write_Small | \main\corerun.exe |     150.3 ns |  1.00 |         - |          NA |
| Write_Small | \pr\corerun.exe   |     118.8 ns |  0.79 |         - |          NA |
|             |                   |              |       |           |             |
| Write_Large | \main\corerun.exe | 287,243.5 ns |  1.00 |  350028 B |        1.00 |
| Write_Large | \pr\corerun.exe   |  50,106.4 ns |  0.17 |         - |        0.00 |