### PR TITLE
Perform SKI encode and decode using managed implementation

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/IX509Pal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/IX509Pal.cs
@@ -21,7 +21,5 @@ namespace System.Security.Cryptography.X509Certificates
         void DecodeX509BasicConstraints2Extension(byte[] encoded, out bool certificateAuthority, out bool hasPathLengthConstraint, out int pathLengthConstraint);
         byte[] EncodeX509EnhancedKeyUsageExtension(OidCollection usages);
         void DecodeX509EnhancedKeyUsageExtension(byte[] encoded, out OidCollection usages);
-        byte[] EncodeX509SubjectKeyIdentifierExtension(ReadOnlySpan<byte> subjectKeyIdentifier);
-        void DecodeX509SubjectKeyIdentifierExtension(byte[] encoded, out byte[] subjectKeyIdentifier);
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedCertificateFinder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedCertificateFinder.cs
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         // The extension exposes the value as a hexadecimal string, or we can decode here.
                         // Enough parsing has gone on, let's decode.
-                        certKeyId = ManagedX509ExtensionProcessor.DecodeX509SubjectKeyIdentifierExtension(ext.RawData);
+                        certKeyId = X509SubjectKeyIdentifierExtension.DecodeX509SubjectKeyIdentifierExtension(ext.RawData);
                     }
                     else
                     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedX509ExtensionProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedX509ExtensionProcessor.cs
@@ -162,54 +162,6 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public virtual byte[] EncodeX509SubjectKeyIdentifierExtension(ReadOnlySpan<byte> subjectKeyIdentifier)
-        {
-            // https://tools.ietf.org/html/rfc5280#section-4.2.1.2
-            //
-            // subjectKeyIdentifier EXTENSION ::= {
-            //     SYNTAX SubjectKeyIdentifier
-            //     IDENTIFIED BY id - ce - subjectKeyIdentifier
-            // }
-            //
-            // SubjectKeyIdentifier::= KeyIdentifier
-            //
-            // KeyIdentifier ::= OCTET STRING
-
-            AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
-            writer.WriteOctetString(subjectKeyIdentifier);
-            return writer.Encode();
-        }
-
-        public virtual void DecodeX509SubjectKeyIdentifierExtension(byte[] encoded, out byte[] subjectKeyIdentifier)
-        {
-            subjectKeyIdentifier = DecodeX509SubjectKeyIdentifierExtension(encoded);
-        }
-
-        internal static byte[] DecodeX509SubjectKeyIdentifierExtension(byte[] encoded)
-        {
-            ReadOnlySpan<byte> contents;
-
-            try
-            {
-                bool gotContents = AsnDecoder.TryReadPrimitiveOctetString(
-                    encoded,
-                    AsnEncodingRules.BER,
-                    out contents,
-                    out int consumed);
-
-                if (!gotContents || consumed != encoded.Length)
-                {
-                    throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                }
-            }
-            catch (AsnContentException e)
-            {
-                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-            }
-
-            return contents.ToArray();
-        }
-
         private static byte ReverseBitOrder(byte b)
         {
             return (byte)(unchecked(b * 0x0202020202ul & 0x010884422010ul) % 1023);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.CustomExtensions.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.Windows.CustomExtensions.cs
@@ -157,32 +157,5 @@ namespace System.Security.Cryptography.X509Certificates
                     });
             }
         }
-
-        public byte[] EncodeX509SubjectKeyIdentifierExtension(ReadOnlySpan<byte> subjectKeyIdentifier)
-        {
-            unsafe
-            {
-                fixed (byte* pSubkectKeyIdentifier = subjectKeyIdentifier)
-                {
-                    Interop.Crypt32.DATA_BLOB blob = new Interop.Crypt32.DATA_BLOB(new IntPtr(pSubkectKeyIdentifier), (uint)subjectKeyIdentifier.Length);
-                    return Interop.crypt32.EncodeObject(Oids.SubjectKeyIdentifier, &blob);
-                }
-            }
-        }
-
-        public void DecodeX509SubjectKeyIdentifierExtension(byte[] encoded, out byte[] subjectKeyIdentifier)
-        {
-            unsafe
-            {
-                subjectKeyIdentifier = encoded.DecodeObject(
-                    Oids.SubjectKeyIdentifier,
-                    static delegate (void* pvDecoded, int cbDecoded)
-                    {
-                        Debug.Assert(cbDecoded >= sizeof(Interop.Crypt32.DATA_BLOB));
-                        Interop.Crypt32.DATA_BLOB* pBlob = (Interop.Crypt32.DATA_BLOB*)pvDecoded;
-                        return pBlob->ToByteArray();
-                    });
-            }
-        }
     }
 }


### PR DESCRIPTION
I'm not aware of Windows' SKI decoding doing anything "Windows-y", so settle on using managed everywhere and remove the Windows decoding implementation.