### PR TITLE
[NativeAOT/ARM] Emit correct unwind codes for VPOP

### DIFF
--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -169,6 +169,7 @@ void Compiler::unwindPushPopCFI(regNumber reg)
     createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL,
                   reg >= REG_FP_FIRST ? 2 * REGSIZE_BYTES : REGSIZE_BYTES);
 #else
+    assert(reg < REG_FP_FIRST);
     createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, REGSIZE_BYTES);
 #endif
     if (relOffsetMask & genRegMask(reg))

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -166,7 +166,8 @@ void Compiler::unwindPushPopCFI(regNumber reg)
         ;
 
 #if defined(TARGET_ARM)
-    createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, reg >= REG_FP_FIRST ? 2 * REGSIZE_BYTES : REGSIZE_BYTES);
+    createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL,
+                  reg >= REG_FP_FIRST ? 2 * REGSIZE_BYTES : REGSIZE_BYTES);
 #else
     createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, REGSIZE_BYTES);
 #endif

--- a/src/coreclr/jit/unwind.cpp
+++ b/src/coreclr/jit/unwind.cpp
@@ -165,7 +165,11 @@ void Compiler::unwindPushPopCFI(regNumber reg)
 #endif
         ;
 
+#if defined(TARGET_ARM)
+    createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, reg >= REG_FP_FIRST ? 2 * REGSIZE_BYTES : REGSIZE_BYTES);
+#else
     createCfiCode(func, cbProlog, CFI_ADJUST_CFA_OFFSET, DWARF_REG_ILLEGAL, REGSIZE_BYTES);
+#endif
     if (relOffsetMask & genRegMask(reg))
     {
         createCfiCode(func, cbProlog, CFI_REL_OFFSET, mapRegNumToDwarfReg(reg));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Eabi/EabiUnwindConverter.cs
@@ -252,13 +252,14 @@ namespace ILCompiler.ObjectWriter
 
                     // Pop VFP double precision registers D[16+ssss]-D[16+ssss+cccc] saved (as if) by VPUSH
                     // 11001000 sssscccc
-                    uint mask = (pendingVPopMask >> 16);
+                    uint mask = pendingVPopMask >> 16;
                     while (mask > 0)
                     {
                         int leadingZeros = BitOperations.LeadingZeroCount(mask);
                         int bitRunLength = BitOperations.LeadingZeroCount(~(mask << leadingZeros));
+                        leadingZeros -= 16; // Using uint but working only with low 16 bits
                         unwindData[unwindDataOffset++] = 0xc8;
-                        unwindData[unwindDataOffset++] = (byte)(((15 - leadingZeros) << 8) | bitRunLength);
+                        unwindData[unwindDataOffset++] = (byte)(((16 - leadingZeros - bitRunLength) << 4) | (bitRunLength - 1));
                         mask &= (uint)(1u << (16 - leadingZeros - bitRunLength)) - 1u;
                     }
 
@@ -269,8 +270,9 @@ namespace ILCompiler.ObjectWriter
                     {
                         int leadingZeros = BitOperations.LeadingZeroCount(mask);
                         int bitRunLength = BitOperations.LeadingZeroCount(~(mask << leadingZeros));
+                        leadingZeros -= 16; // Using uint but working only with low 16 bits
                         unwindData[unwindDataOffset++] = 0xc9;
-                        unwindData[unwindDataOffset++] = (byte)(((15 - leadingZeros) << 8) | bitRunLength);
+                        unwindData[unwindDataOffset++] = (byte)(((16 - leadingZeros - bitRunLength) << 4) | (bitRunLength - 1));
                         mask &= (uint)(1u << (16 - leadingZeros - bitRunLength)) - 1u;
                     }
 


### PR DESCRIPTION
Tested on JIT tests

Unwind codes:
```
0x1c70 <MathCeilingSingle_ro_MathCeilingSingleTest_Program__TestEntryPoint>: @0x428
  Compact model index: 1
  0x01      vsp = vsp + 8
  0xc9 0x81 pop {D8-D9}
  0x84 0x8f pop {r4, r5, r6, r7, r11, r14}
  0xb0      finish

0x37370 <System.Globalization.CalendricalCalculationsHelper__EquationOfTime>: @0x9f54
  Compact model index: 1
  0x09      vsp = vsp + 40
  0xc9 0x86 pop {D8-D14}
  0x84 0x80 pop {r11, r14}
  0xb0      finish
```

Corresponding prologs:
```
00001c70 <_fram0MathCeilingSingle_ro_MathCeilingSingleTest_Program__TestEntryPoint>:
    1c70: 2d e9 f0 48   push.w  {r4, r5, r6, r7, r11, lr}
    1c74: 2d ed 04 8b   vpush   {d8, d9}
    1c78: 82 b0         sub     sp, #8

00037370 <_fram0System.Globalization.CalendricalCalculationsHelper__EquationOfTime>:
   37370: 2d e9 00 48   push.w  {r11, lr}
   37374: 2d ed 0e 8b   vpush   {d8, d9, d10, d11, d12, d13, d14}
   37378: 8a b0         sub     sp, #40
```