### PR TITLE
Add support for ref-readonly in the .NET interop source generators

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/ComInterfaceGenerator.cs
@@ -298,7 +298,6 @@ namespace Microsoft.Interop
                             var managedSignatureAsNativeOut = returnSwappedSignatureElements[i] with
                             {
                                 RefKind = RefKind.Out,
-                                RefKindSyntax = SyntaxKind.OutKeyword,
                                 ManagedIndex = TypePositionInfo.ReturnIndex,
                                 NativeIndex = symbol.Parameters.Length
                             };

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BreakingChangeDetector.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/BreakingChangeDetector.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Interop
             }
 
             // Breaking change: [MarshalAs(UnmanagedType.Struct)] in object in unmanaged-to-managed scenarios will not respect VT_BYREF.
-            if (info is { RefKind: RefKind.In, MarshallingAttributeInfo: NativeMarshallingAttributeInfo(ManagedTypeInfo(_, TypeNames.ComVariantMarshaller), _) }
+            if (info is { RefKind: RefKind.In or RefKind.RefReadOnlyParameter, MarshallingAttributeInfo: NativeMarshallingAttributeInfo(ManagedTypeInfo(_, TypeNames.ComVariantMarshaller), _) }
                 && context.Direction == MarshalDirection.UnmanagedToManaged)
             {
                 gen = ResolvedGenerator.ResolvedWithDiagnostics(

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallingGeneratorExtensions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Interop
         private static ParameterSyntax GenerateForwardingParameter(TypePositionInfo info, string identifier)
         {
             ParameterSyntax param = Parameter(Identifier(identifier))
-                .WithModifiers(TokenList(Token(info.RefKindSyntax)))
+                .WithModifiers(MarshallerHelpers.GetManagedParameterModifiers(info))
                 .WithType(info.ManagedType.Syntax);
 
             List<AttributeSyntax> rehydratedAttributes = new();
@@ -143,7 +143,7 @@ namespace Microsoft.Interop
             return generator.GetValueBoundaryBehavior(info, context) switch
             {
                 ValueBoundaryBehavior.ManagedIdentifier when !info.IsByRef => Argument(IdentifierName(managedIdentifier)),
-                ValueBoundaryBehavior.ManagedIdentifier when info.IsByRef => Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(Token(info.RefKindSyntax)),
+                ValueBoundaryBehavior.ManagedIdentifier when info.IsByRef => Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(MarshallerHelpers.GetManagedArgumentRefKindKeyword(info)),
                 ValueBoundaryBehavior.NativeIdentifier => Argument(IdentifierName(nativeIdentifier)),
                 ValueBoundaryBehavior.AddressOfNativeIdentifier => Argument(PrefixUnaryExpression(SyntaxKind.AddressOfExpression, IdentifierName(nativeIdentifier))),
                 ValueBoundaryBehavior.CastNativeIdentifier => Argument(CastExpression(generator.AsParameter(info, context).Type, IdentifierName(nativeIdentifier))),
@@ -156,7 +156,7 @@ namespace Microsoft.Interop
             var (managedIdentifier, _) = context.GetIdentifiers(info);
             if (info.IsByRef)
             {
-                return Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(Token(info.RefKindSyntax));
+                return Argument(IdentifierName(managedIdentifier)).WithRefKindKeyword(MarshallerHelpers.GetManagedArgumentRefKindKeyword(info));
             }
             return Argument(IdentifierName(managedIdentifier));
         }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/SignatureContext.cs
@@ -42,24 +42,9 @@ namespace Microsoft.Interop
                     if (typeInfo.ManagedIndex != TypePositionInfo.UnsetIndex
                         && typeInfo.ManagedIndex != TypePositionInfo.ReturnIndex)
                     {
-                        SyntaxTokenList tokens = TokenList();
-
-                        // "out" parameters are implicitly scoped, so we can't put the "scoped" keyword on them.
-                        // All other cases of explicit parameters are only scoped when the "scoped" keyword is present.
-                        // When the "scoped" keyword is present, it must be present on all declarations.
-                        if (typeInfo.ScopedKind != ScopedKind.None && typeInfo.RefKind != RefKind.Out)
-                        {
-                            tokens = tokens.Add(Token(SyntaxKind.ScopedKeyword));
-                        }
-
-                        if (typeInfo.IsByRef)
-                        {
-                            tokens = tokens.Add(Token(typeInfo.RefKindSyntax));
-                        }
-
                         yield return Parameter(Identifier(typeInfo.InstanceIdentifier))
                             .WithType(typeInfo.ManagedType.Syntax)
-                            .WithModifiers(tokens);
+                            .WithModifiers(MarshallerHelpers.GetManagedParameterModifiers(typeInfo));
                     }
                 }
             }

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Interop
         public string InstanceIdentifier { get; init; } = string.Empty;
 
         public RefKind RefKind { get; init; } = RefKind.None;
-        public SyntaxKind RefKindSyntax { get; init; } = SyntaxKind.None;
 
         public bool IsByRef => RefKind != RefKind.None;
 
@@ -87,7 +86,6 @@ namespace Microsoft.Interop
             {
                 InstanceIdentifier = ParseToken(paramSymbol.Name).IsReservedKeyword() ? $"@{paramSymbol.Name}" : paramSymbol.Name,
                 RefKind = paramSymbol.RefKind,
-                RefKindSyntax = RefKindToSyntax(paramSymbol.RefKind),
                 ByValueContentsMarshalKind = byValueContentsMarshalKind,
                 ByValueMarshalAttributeLocations = (inLocation, outLocation),
                 ScopedKind = paramSymbol.ScopedKind
@@ -131,18 +129,6 @@ namespace Microsoft.Interop
             }
 
             return (marshalKind, inAttributeLocation, outAttributeLocation);
-        }
-
-        private static SyntaxKind RefKindToSyntax(RefKind refKind)
-        {
-            return refKind switch
-            {
-                RefKind.In => SyntaxKind.InKeyword,
-                RefKind.Ref => SyntaxKind.RefKeyword,
-                RefKind.Out => SyntaxKind.OutKeyword,
-                RefKind.None => SyntaxKind.None,
-                _ => throw new NotImplementedException("Support for some RefKind"),
-            };
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -257,6 +257,7 @@ namespace LibraryImportGenerator.UnitTests
 
             // Parameter modifiers
             yield return new[] { ID(), CodeSnippets.SingleParameterWithModifier("int", "scoped ref") };
+            yield return new[] { ID(), CodeSnippets.SingleParameterWithModifier("int", "ref readonly") };
         }
 
         public static IEnumerable<object[]> CustomCollections()


### PR DESCRIPTION
Treat `ref readonly` the same as we treat `in`.

Fixes #97706