### PR TITLE
[NativeAOT/ARM] Fix RhpLockCmpXchg16

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm/Interlocked.S
+++ b/src/coreclr/nativeaot/Runtime/arm/Interlocked.S
@@ -36,6 +36,7 @@ LEAF_END RhpLockCmpXchg8, _TEXT
 // r1 = value
 // r2 = comparand
 LEAF_ENTRY RhpLockCmpXchg16, _TEXT
+          uxth         r2, r2
           dmb
 ALTERNATE_ENTRY RhpLockCmpXchg16AVLocation
 LOCAL_LABEL(CmpXchg16Retry):
@@ -46,7 +47,7 @@ LOCAL_LABEL(CmpXchg16Retry):
           cmp          r12, #0
           bne          LOCAL_LABEL(CmpXchg16Retry)
 LOCAL_LABEL(CmpXchg16Exit):
-          mov          r0, r3
+          sxth         r0, r3
           dmb
           bx           lr
 LEAF_END RhpLockCmpXchg16, _TEXT


### PR DESCRIPTION
Fixes #97730

Zero-extend `comparand` parameter of `RhpLockCmpXchg16` to match the managed prototype which uses signed type argument and is thus sign extended in the register. Conversely, sign extend the return value.