### PR TITLE
Fixed wrong comment in XxHash64

### DIFF
--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash64.cs
@@ -196,7 +196,7 @@ namespace System.IO.Hashing
         /// <param name="seed">The seed value for this hash computation. The default is zero.</param>
         /// <returns>
         ///   <see langword="true"/> if <paramref name="destination"/> is long enough to receive
-        ///   the computed hash value (4 bytes); otherwise, <see langword="false"/>.
+        ///   the computed hash value (8 bytes); otherwise, <see langword="false"/>.
         /// </returns>
         public static bool TryHash(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesWritten, long seed = 0)
         {


### PR DESCRIPTION
This seems to be a copy paste mistake from XxHash32