### PR TITLE
[NativeAOT/ARM] Bail out on IMAGE_REL_BASED_THUMB_BRANCH24 with >24-bit addends

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -163,7 +163,7 @@ namespace ILCompiler.DependencyAnalysis
         //*****************************************************************************
         // Returns whether the offset fits into bl instruction
         //*****************************************************************************
-        private static bool FitsInThumb2BlRel24(int imm24)
+        public static bool FitsInThumb2BlRel24(int imm24)
         {
             return ((imm24 << 7) >> 7) == imm24;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs
@@ -184,7 +184,7 @@ namespace ILCompiler.ObjectWriter
                     adjustedAddend |= definedSymbol.Value & maskThumbBitIn;
                     adjustedAddend -= offset;
 
-                    if (relocType is IMAGE_REL_BASED_THUMB_BRANCH24 && (uint)adjustedAddend >= 0xFFFFFF)
+                    if (relocType is IMAGE_REL_BASED_THUMB_BRANCH24 && !Relocation.FitsInThumb2BlRel24((int)adjustedAddend))
                     {
                         EmitRelocation(sectionIndex, offset, data, relocType, symbolName, addend);
                     }


### PR DESCRIPTION
... and let the linker generate thunks.

Fixes #97750