### PR TITLE
Update latest roslyn version to 4.8

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -7,13 +7,13 @@
     <UsagePattern IdentityGlob="System.Composition*/*6.*" />
     <UsagePattern IdentityGlob="System.Composition*/*7.*" />
     <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.4.*" />
-    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.7.*" />
+    <UsagePattern IdentityGlob="Microsoft.CodeAnalysis*/*4.8.*" />
 
     <!-- Allowed and pinned to major version due to https://github.com/dotnet/source-build/issues/3228 -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Crossgen2.linux-x64/*9.*" />
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Runtime.linux-x64/*9.*" />
     <UsagePattern IdentityGlob="*Microsoft.DotNet.ILCompiler/*9.*" />
-    
+
     <!-- Allowed and pinned to SDK version -->
     <UsagePattern IdentityGlob="Microsoft.NET.ILLink.Tasks/*9.*" />
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -54,11 +54,13 @@
     <!-- Compatibility with VS 17.0/.NET SDK 6.0.1xx  -->
     <MicrosoftCodeAnalysisVersion_4_0>4.0.1</MicrosoftCodeAnalysisVersion_4_0>
     <!-- Compatibility with VS 17.4/.NET SDK 7.0.1xx -->
+    <MicrosoftCodeAnalysisVersion_4_4>4.4.0</MicrosoftCodeAnalysisVersion_4_4>
+    <!-- Compatibility with VS 17.8/.NET SDK 8.0.1xx -->
     <!--
       The exact version is a moving target until we ship.
       It should never go ahead of the Roslyn version included in the SDK version in dotnet/arcade's global.json to avoid causing breaks in product construction.
     -->
-    <MicrosoftCodeAnalysisVersion_4_4>4.4.0</MicrosoftCodeAnalysisVersion_4_4>
+    <MicrosoftCodeAnalysisVersion_4_8>4.8.0</MicrosoftCodeAnalysisVersion_4_8>
     <!-- Compatibility with the latest Visual Studio Preview release -->
     <!--
       The exact version is always a moving target. This version should never go ahead of the version of Roslyn that is included in the most recent

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -68,7 +68,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.7.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>4.8.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,10 +56,6 @@
     <!-- Compatibility with VS 17.4/.NET SDK 7.0.1xx -->
     <MicrosoftCodeAnalysisVersion_4_4>4.4.0</MicrosoftCodeAnalysisVersion_4_4>
     <!-- Compatibility with VS 17.8/.NET SDK 8.0.1xx -->
-    <!--
-      The exact version is a moving target until we ship.
-      It should never go ahead of the Roslyn version included in the SDK version in dotnet/arcade's global.json to avoid causing breaks in product construction.
-    -->
     <MicrosoftCodeAnalysisVersion_4_8>4.8.0</MicrosoftCodeAnalysisVersion_4_8>
     <!-- Compatibility with the latest Visual Studio Preview release -->
     <!--

--- a/src/coreclr/tools/Directory.Build.props
+++ b/src/coreclr/tools/Directory.Build.props
@@ -6,7 +6,7 @@
     <!-- None of the tools is localized. Strip System.CommandLine localized resources from the output. -->
     <SatelliteResourceLanguages>en-US</SatelliteResourceLanguages>
   </PropertyGroup>
-  
+
   <!-- MSBuild doesn't understand the Checked configuration -->
   <PropertyGroup Condition="'$(Configuration)' == 'Checked'">
     <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
@@ -17,7 +17,7 @@
     These packages affect the design-time experience in VS, we update them
     at the same cadance as the MicrosoftCodeAnalysisVersion_LatestVS version.
     This property is set eng/Versions.props but we override it because the current
-    version 4.7.0 flags several warnings that need area-owner expertise to resolve.
+    version 4.8.0 flags several warnings that need area-owner expertise to resolve.
     TODO: https://github.com/dotnet/runtime/issues/91028.
   -->
   <PropertyGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_4_8)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is required to use new language features like collection expressions e.g. in https://github.com/dotnet/runtime/issues/96964