### PR TITLE
 [browser][MT] Unblock `RandomTests.Shared_ParallelUsage`

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
@@ -516,7 +516,6 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/91538", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public void Shared_ParallelUsage()
         {
             using var barrier = new Barrier(2);

--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -189,7 +189,7 @@ export function normalizeConfig() {
     }
 
     if (MonoWasmThreads && !Number.isInteger(config.pthreadPoolSize)) {
-        // ActiveIssue https://github.com/dotnet/runtime/issues/91538
+        // ActiveIssue https://github.com/dotnet/runtime/issues/75602
         config.pthreadPoolSize = 7;
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/91538.

Cannot reproduce the failure in 1k runs. Checking on CI and unblocking if green.

The issue the is getting closed is not about pthreads being pinned to a fixed number (it used to, in the past). Editing the comment to contain a more suitable issue.