### PR TITLE
[wasm][debugger] Fix method overload resolution for arguments of type array in debugger's eval

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MemberReferenceResolver.cs
@@ -598,10 +598,12 @@ namespace Microsoft.WebAssembly.Diagnostics
             foreach ((ParameterInfo paramInfo, object indexObj) in paramInfos.Zip(indexObjects))
             {
                 string argumentType = "", argumentClassName = "";
+                bool isArray = false;
                 if (indexObj is JObject indexJObj)
                 {
                     argumentType = indexJObj["type"]?.Value<string>();
                     argumentClassName = indexJObj["className"]?.Value<string>();
+                    isArray = indexJObj["subtype"]?.Value<string>()?.Equals("array") == true;
                 }
                 else if (indexObj is LiteralExpressionSyntax literal)
                 {
@@ -628,13 +630,13 @@ namespace Microsoft.WebAssembly.Diagnostics
                             continue;
                     }
                 }
-                if (!CheckParameterCompatibility(paramInfo.TypeCode, argumentType, argumentClassName))
+                if (!CheckParameterCompatibility(paramInfo.TypeCode, argumentType, argumentClassName, isArray))
                     return false;
             }
             return true;
         }
 
-        private static bool CheckParameterCompatibility(ElementType? paramTypeCode, string argumentType, string argumentClassName="")
+        private static bool CheckParameterCompatibility(ElementType? paramTypeCode, string argumentType, string argumentClassName, bool isArray)
         {
             if (!paramTypeCode.HasValue)
                 return true;
@@ -642,7 +644,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             switch (paramTypeCode.Value)
             {
                 case ElementType.Object:
-                    if (argumentType != "object")
+                    if (argumentType != "object" || isArray)
                         return false;
                     break;
                 case ElementType.I2:


### PR DESCRIPTION
In the `EvaluateObjectByNonIntLocals` test we were trying to evaluate an expression like this `s[arr]`.
We are trying to call get_Item method that expects an object as a parameter and this is not correct. 
With the PR we are calling the get_Item that expects an array as a parameter .

Error on CI:
https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-97752-merge-dc23193aa5e44908bf/chrome-DebuggerTests.EvaluateOnCallFrameTests/1/console.e4d5ccf7.log?helixlogtype=result

Error message:
`Unexpected runtime error/warning message detected: console.error: [MONO] * Assertion at /__w/1/s/src/mono/mono/component/debugger-agent.c:2018, condition `<disabled>' not met`
