### PR TITLE
Fix handling invalid collection items in configuration

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -709,7 +709,11 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         break;
                     case ComplexTypeSpec complexType when _typeIndex.CanInstantiate(complexType):
                         {
+                            // If a section possesses a null or empty string value and lacks any children, we bind to the default value of the type.
+                            // In the case of a non-null or non-empty string value without any section children, binding cannot be performed at that moment,
+                            // and this section should be skipped.
                             EmitBindCheckForSectionValue();
+
                             EmitBindingLogic(complexType, Identifier.value, Identifier.section, InitializationKind.Declaration, ValueDefaulting.None);
                             _writer.WriteLine($"{addExpr}({Identifier.value});");
                         }
@@ -721,6 +725,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             // EmitBindCheckForSectionValue produce the following code:
             // if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext()) { continue; }
+            //
+            // If a section possesses a null or empty string value and lacks any children, we bind to the default value of the type.
+            // In the case of a non-null or non-empty string value without any section children, binding cannot be performed at that moment,
+            // and this section should be skipped.
             private void EmitBindCheckForSectionValue()
             {
                 // We utilize GetEnumerator().MoveNext() instead of employing Linq's Any() since there is no assurance that the System.Linq reference is included.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/CoreBindingHelpers.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 IEnumerable<PropertySpec> initOnlyProps = type.Properties.Where(prop => prop is { SetOnInit: true });
                 List<string> ctorArgList = new();
 
-                EmitStartBlock($"public static {type.TypeRef.FullyQualifiedName} {GetInitalizeMethodDisplayString(type)}({Identifier.IConfiguration} {Identifier.configuration}, {Identifier.BinderOptions}? {Identifier.binderOptions})");
+                EmitStartBlock($"public static {type.TypeRef.FullyQualifiedName} {GetInitializeMethodDisplayString(type)}({Identifier.IConfiguration} {Identifier.configuration}, {Identifier.BinderOptions}? {Identifier.binderOptions})");
                 _emitBlankLineBeforeNextStatement = false;
 
                 foreach (ParameterSpec parameter in type.ConstructorParameters)
@@ -709,12 +709,23 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         break;
                     case ComplexTypeSpec complexType when _typeIndex.CanInstantiate(complexType):
                         {
+                            EmitBindCheckForSectionValue();
                             EmitBindingLogic(complexType, Identifier.value, Identifier.section, InitializationKind.Declaration, ValueDefaulting.None);
                             _writer.WriteLine($"{addExpr}({Identifier.value});");
                         }
                         break;
                 }
 
+                EmitEndBlock();
+            }
+
+            // EmitBindCheckForSectionValue produce the following code:
+            // if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext()) { continue; }
+            private void EmitBindCheckForSectionValue()
+            {
+                // We utilize GetEnumerator().MoveNext() instead of employing Linq's Any() since there is no assurance that the System.Linq reference is included.
+                EmitStartBlock($"if (!string.IsNullOrEmpty({Expression.sectionValue}) && !{Identifier.section}.{Identifier.GetChildren}().{Identifier.GetEnumerator}().{Identifier.MoveNext}())");
+                _writer.WriteLine($@"continue;");
                 EmitEndBlock();
             }
 
@@ -1132,7 +1143,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     else
                     {
                         Debug.Assert(strategy is ObjectInstantiationStrategy.ParameterizedConstructor);
-                        string initMethodIdentifier = GetInitalizeMethodDisplayString(((ObjectSpec)type));
+                        string initMethodIdentifier = GetInitializeMethodDisplayString(((ObjectSpec)type));
                         initExpr = $"{initMethodIdentifier}({configArgExpr}, {Identifier.binderOptions})";
                     }
                 }
@@ -1175,7 +1186,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         break;
                     default:
                         {
-                            Debug.Fail($"Invaild initialization kind: {initKind}");
+                            Debug.Fail($"Invalid initialization kind: {initKind}");
                         }
                         break;
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Emitter/Helpers.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 public const string Get = nameof(Get);
                 public const string GetBinderOptions = nameof(GetBinderOptions);
                 public const string GetChildren = nameof(GetChildren);
+                public const string GetEnumerator = nameof(GetEnumerator);
                 public const string GetSection = nameof(GetSection);
                 public const string GetValue = nameof(GetValue);
                 public const string HasConfig = nameof(HasConfig);
@@ -121,6 +122,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 public const string IOptionsChangeTokenSource = nameof(IOptionsChangeTokenSource);
                 public const string IServiceCollection = nameof(IServiceCollection);
                 public const string Length = nameof(Length);
+                public const string MoveNext = nameof(MoveNext);
                 public const string Name = nameof(Name);
                 public const string NumberStyles = nameof(NumberStyles);
                 public const string Parse = nameof(Parse);
@@ -261,7 +263,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             private string GetIncrementalIdentifier(string prefix) => $"{prefix}{_valueSuffixIndex++}";
 
-            private static string GetInitalizeMethodDisplayString(ObjectSpec type) =>
+            private static string GetInitializeMethodDisplayString(ObjectSpec type) =>
                 $"{nameof(MethodsToGen_CoreBindingHelper.Initialize)}{type.IdentifierCompatibleSubstring}";
         }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
-                if (isParentCollection && bindingPoint.Value is null)
+                if (isParentCollection && bindingPoint.Value is null && string.IsNullOrEmpty(configValue))
                 {
                     // If we don't have an instance, try to create one
                     bindingPoint.TrySetValue(CreateInstance(type, config, options));

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 #if BUILDING_SOURCE_GENERATOR_TESTS
 using Microsoft.Extensions.Configuration;
 #endif
@@ -286,7 +288,7 @@ namespace Microsoft.Extensions
             var config = configurationBuilder.Build();
 
             var options = new Dictionary<T, string>();
-#pragma warning disable SYSLIB1104 
+#pragma warning disable SYSLIB1104
             config.GetSection("IntegerKeyDictionary").Bind(options);
 #pragma warning restore SYSLIB1104
 
@@ -724,13 +726,13 @@ namespace Microsoft.Extensions
         }
 
         [Fact]
-        public void ObjectDictionaryWithHarcodedElements()
+        public void ObjectDictionaryWithHardcodedElements()
         {
             var input = new Dictionary<string, string>
             {
                 {"ObjectDictionary:abc:Integer", "1"},
-                {"ObjectDictionary:def", "null"},
-                {"ObjectDictionary:ghi", "null"}
+                {"ObjectDictionary:def", null },
+                {"ObjectDictionary:ghi", null }
             };
 
             var configurationBuilder = new ConfigurationBuilder();
@@ -2330,6 +2332,40 @@ namespace Microsoft.Extensions
             Assert.Equal(2, dict["Key"].Length);
             Assert.Equal("InitialValue", dict["Key"][0]);
             Assert.Equal("NewValue", dict["Key"][1]);
+        }
+
+        [Fact]
+        public void TestCollectionWithNullOrEmptyItems()
+        {
+            string json = @"
+                {
+                    ""CollectionContainer"": [
+                    {
+                        ""Elements"":
+                        {
+                            ""Typdde"": ""UserCredentials"",
+                            ""poop"": ""00"",
+                            ""111"": """",
+                            ""BaseUrl"": ""cccccc"",
+                            ""Valid"": {
+                                ""Type"": ""System.Boolean""
+                            },
+                        }
+                    }
+                    ]
+                }
+            ";
+
+            var builder = new ConfigurationBuilder();
+            Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            builder.AddJsonStream(stream);
+            IConfigurationRoot config = builder.Build();
+
+            List<CollectionContainer> result = config.GetSection("CollectionContainer").Get<List<CollectionContainer>>();
+            Assert.Equal(1, result.Count);
+            Assert.Equal(2, result[0].Elements.Count);
+            Assert.Null(result[0].Elements[0].Type);
+            Assert.Equal("System.Boolean", result[0].Elements[1].Type);
         }
 
         // Test behavior for root level arrays.

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.Collections.cs
@@ -2344,7 +2344,7 @@ namespace Microsoft.Extensions
                         ""Elements"":
                         {
                             ""Typdde"": ""UserCredentials"",
-                            ""poop"": ""00"",
+                            ""foo"": ""00"",
                             ""111"": """",
                             ""BaseUrl"": ""cccccc"",
                             ""Valid"": {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.TestClasses.Collections.cs
@@ -377,5 +377,16 @@ namespace Microsoft.Extensions
             public IList<string> UnInstantiatedIList { get; set; }
             public IReadOnlyList<string> UnInstantiatedIReadOnlyList { get; set; }
         }
+
+        public class CollectionContainer
+        {
+            public string Name { get; set; }
+            public List<Element> Elements { get; set; }
+        }
+
+        public class Element
+        {
+            public string Type { get; set; }
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T.generated.txt
@@ -119,6 +119,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -119,6 +119,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_name.generated.txt
@@ -119,6 +119,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/net462/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -113,6 +113,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T.generated.txt
@@ -113,6 +113,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_BinderOptions.generated.txt
@@ -113,6 +113,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_name.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_name.generated.txt
@@ -113,6 +113,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Baselines/netcoreapp/ServiceCollection/Configure_T_name_BinderOptions.generated.txt
@@ -107,6 +107,10 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
         {
             foreach (IConfigurationSection section in configuration.GetChildren())
             {
+                if (!string.IsNullOrEmpty(section.Value) && !section.GetChildren().GetEnumerator().MoveNext())
+                {
+                    continue;
+                }
                 var value = new global::Program.MyClass2();
                 BindCore(section, ref value, defaultValueIfNotFound: false, binderOptions);
                 instance.Add(value);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/97558

In .NET 8.0, a [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/8.0/dictionary-configuration-binding) was introduced through [PR](https://github.com/dotnet/runtime/pull/86485). This modification aimed to enable the recognition of empty or null collection items in configuration. However, it inadvertently led to the acceptance of invalid non-null or non-empty items as well. This fix addresses the issue both in the runtime binder and the source generator.
