### PR TITLE
Enable use of RestoreConfigFile property in source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -51,6 +51,7 @@
       <InnerBuildArgs Condition="'$(OfficialBuildId)' != ''">$(InnerBuildArgs) /p:OfficialBuildId=$(OfficialBuildId)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(PortableBuild)' != ''">$(InnerBuildArgs) /p:PortableBuild=$(PortableBuild)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(RestoreConfigFile)' != ''">$(InnerBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3170

Backport of changes in https://github.com/dotnet/installer/pull/18478

### Description

Source-build needs to use `RestoreConfigFile` property during build to avoid modifications of `NuGet.config` files in source tree. This change enables passing this property to the inner build.