### PR TITLE
Fix isKnonwNonNull for box and unbox

### DIFF
--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -150,13 +150,13 @@ ValueNumFuncDef(JitNewArr, 3, false, true, false, false)
 ValueNumFuncDef(JitNewMdArr, 4, false, true, false, false)
 ValueNumFuncDef(JitReadyToRunNew, 2, false, true, false, false)
 ValueNumFuncDef(JitReadyToRunNewArr, 3, false, true, false, false)
-ValueNumFuncDef(Box, 3, false, false, false, false)
+ValueNumFuncDef(Box, 3, false, true, false, false)
 ValueNumFuncDef(BoxNullable, 3, false, false, false, false)
 
 ValueNumFuncDef(LazyStrCns, 2, false, true, false, false)            // Lazy-initialized string literal (helper)
 ValueNumFuncDef(InvariantLoad, 1, false, false, false, false)        // Args: 0: (VN of) the address.
 ValueNumFuncDef(InvariantNonNullLoad, 1, false, true, false, false)  // Args: 0: (VN of) the address.
-ValueNumFuncDef(Unbox, 2, false, true, false, false)
+ValueNumFuncDef(Unbox, 2, false, false, false, false)
 
 ValueNumFuncDef(LT_UN, 2, false, false, false, false)      // unsigned or unordered comparisons
 ValueNumFuncDef(LE_UN, 2, false, false, false, false)


### PR DESCRIPTION
`VNF_Box` function is not marked as "never-null" (unlikely to have an effect)
`VNF_Unbox` was marked as "never-null" which is not correct as it might return 0.