### PR TITLE
Use collection expression syntax for library import fixer when possible

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/Analyzers/ConvertToLibraryImportFixer.cs
@@ -621,7 +621,7 @@ namespace Microsoft.Interop.Analyzers
 
                 if (preferCollectionExpressionsRule is "false" or "never")
                 {
-                    // User explicitly specified that he doesn't prefer collection expressions
+                    // User explicitly specified they don't prefer collection expressions
                     useCollectionExpression = false;
                 }
             }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/96964

We prefer collection expression for C# 12 and above unless user explicitly disabled them via [editorconfig rule](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0300#dotnet_style_prefer_collection_expression)