### PR TITLE
[NativeAOT/ARM] Fix trashing r4 register in RhpCallCatchFunclet

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
@@ -266,6 +266,7 @@ NESTED_ENTRY RhpCallCatchFunclet, _TEXT, NoHandler
 	                                   // REGDISPLAY and ExInfo later
         PROLOG_VPUSH {d8-d15}
 
+#define rsp_offset_r0 (8 * 8)
 #define rsp_offset_r2 (8 * 8) + 4
 #define rsp_offset_r3 (8 * 8) + 8
 
@@ -321,7 +322,7 @@ LOCAL_LABEL(ClearSuccess_Catch):
 
         EXPORT_POINTER_TO_ADDRESS PointerToRhpCallCatchFunclet2
 
-        mov         r4, r0    // Save the result
+        str         r0, [sp, #rsp_offset_r0]             // Save the result
 
         INLINE_GETTHREAD                                 // r0 <- Thread*
         // We must unhijack the thread at this point because the section of stack where the
@@ -341,9 +342,11 @@ LOCAL_LABEL(DonePopping):
 
         str         r3, [r0, #OFFSETOF__Thread__m_pExInfoStackHead]   // store the new head on the Thread
 
+        ldr         r0, [sp, #rsp_offset_r0]             // Load the result
+
         // reset RSP and jump to the continuation address
         mov         sp, r2
-        bx          r4
+        bx          r0
 
 NESTED_END RhpCallCatchFunclet, _TEXT
 


### PR DESCRIPTION
The `r4` register is callee saved, it should be preserved. This caused crashes in Release builds.

Contributes to #97729