### PR TITLE
Patch libunwind manually to fix the access violation to unblock source build

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -6,3 +6,4 @@ Apply https://github.com/libunwind/libunwind/pull/701
 Apply https://github.com/libunwind/libunwind/pull/703
 Apply https://github.com/libunwind/libunwind/pull/704
 Revert https://github.com/libunwind/libunwind/pull/503 # issue: https://github.com/libunwind/libunwind/issues/702
+Apply https://github.com/libunwind/libunwind/pull/714


### PR DESCRIPTION
This is meant to port https://github.com/libunwind/libunwind/pull/717 directly from libunwind to unblock source build.

It is meant to be temporarily, once we have the libunwind updated we will revert this an take a proper update from there.

See the conversation [here](https://github.com/dotnet/runtime/pull/97679#issuecomment-1921182993) for the context.

@am11, @EgorBo 