### PR TITLE
[RISC-V] Implement replacing safe-point call instructions under GC_STRESS

### DIFF
--- a/src/coreclr/vm/gccover.cpp
+++ b/src/coreclr/vm/gccover.cpp
@@ -1057,7 +1057,7 @@ static PBYTE getTargetOfCall(PBYTE instrPtr, PCONTEXT regs, PBYTE* nextInstr) {
         int bit11 = imm & ~(-1 << 1);
         imm >>= 1;
         int bits1to10 = imm & ~(-1 << 10);
-        imm >> 10;
+        imm >>= 10;
         int signBits = imm;
 
         int offset = (bits1to10 << 1) | (bit11 << 11) | (bits12to19 << 12) | (signBits << 20);

--- a/src/coreclr/vm/gccover.h
+++ b/src/coreclr/vm/gccover.h
@@ -113,10 +113,10 @@ typedef DPTR(GCCoverageInfo) PTR_GCCoverageInfo; // see code:GCCoverageInfo::sav
 #define INTERRUPT_INSTR_PROTECT_RET     0xffffff0d
 
 #elif defined(TARGET_RISCV64)
-// TODO-RISCV64: Confirm the following encodings are undefined
-#define INTERRUPT_INSTR                 0x20000000
-#define INTERRUPT_INSTR_CALL            0x20010000
-#define INTERRUPT_INSTR_PROTECT_RET     0x20020000
+// The following encodings are undefined.
+#define INTERRUPT_INSTR                 0x20000000  // unimp, fld
+#define INTERRUPT_INSTR_CALL            0x20010000  // unimp, jal
+#define INTERRUPT_INSTR_PROTECT_RET     0x20020000  // unimp, fld
 
 #endif // _TARGET_*
 
@@ -181,8 +181,15 @@ inline bool IsGcCoverageInterruptInstructionVal(UINT32 instrVal)
         }
     }
 #elif defined(TARGET_RISCV64)
-    _ASSERTE(!"RISCV64:NYI");
-    return false;
+    switch (instrVal)
+    {
+    case INTERRUPT_INSTR:
+    case INTERRUPT_INSTR_CALL:
+    case INTERRUPT_INSTR_PROTECT_RET:
+        return true;
+    default:
+        return false;
+    }
 
 #else // x64 and x86
 


### PR DESCRIPTION
Fixes: DOTNET_GCStress=4 JIT/Methodical/tailcall/deep_array_nz_r/deep_array_nz_r.sh

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @bajtazar