### PR TITLE
Support ClientCertificateContext on QuicConnection

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -92,13 +92,22 @@ internal static class MsQuicConfiguration
 
         X509Certificate? certificate = null;
         ReadOnlyCollection<X509Certificate2>? intermediates = default;
-        if (authenticationOptions.ServerCertificateContext is not null)
+
+        // the order of checking here matches the order of checking in SslStream
+        if (authenticationOptions.ServerCertificateSelectionCallback is not null)
+        {
+            certificate = authenticationOptions.ServerCertificateSelectionCallback.Invoke(authenticationOptions, targetHost);
+        }
+        else if (authenticationOptions.ServerCertificateContext is not null)
         {
             certificate = authenticationOptions.ServerCertificateContext.TargetCertificate;
             intermediates = authenticationOptions.ServerCertificateContext.IntermediateCertificates;
         }
+        else if (authenticationOptions.ServerCertificate is not null)
+        {
+            certificate = authenticationOptions.ServerCertificate;
+        }
 
-        certificate ??= authenticationOptions.ServerCertificate ?? authenticationOptions.ServerCertificateSelectionCallback?.Invoke(authenticationOptions, targetHost);
         if (certificate is null)
         {
             throw new ArgumentException(SR.Format(SR.net_quic_not_null_ceritifcate, nameof(SslServerAuthenticationOptions.ServerCertificate), nameof(SslServerAuthenticationOptions.ServerCertificateContext), nameof(SslServerAuthenticationOptions.ServerCertificateSelectionCallback)), nameof(options));

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -30,7 +30,13 @@ internal static class MsQuicConfiguration
 
         // Find the first certificate with private key, either from selection callback or from a provided collection.
         X509Certificate? certificate = null;
-        if (authenticationOptions.LocalCertificateSelectionCallback != null)
+        ReadOnlyCollection<X509Certificate2>? intermediates = null;
+        if (authenticationOptions.ClientCertificateContext is not null)
+        {
+            certificate = authenticationOptions.ClientCertificateContext.TargetCertificate;
+            intermediates = authenticationOptions.ClientCertificateContext.IntermediateCertificates;
+        }
+        else if (authenticationOptions.LocalCertificateSelectionCallback != null)
         {
             X509Certificate selectedCertificate = authenticationOptions.LocalCertificateSelectionCallback(
                 options,
@@ -69,7 +75,7 @@ internal static class MsQuicConfiguration
             }
         }
 
-        return Create(options, flags, certificate, null, authenticationOptions.ApplicationProtocols, authenticationOptions.CipherSuitesPolicy, authenticationOptions.EncryptionPolicy);
+        return Create(options, flags, certificate, intermediates, authenticationOptions.ApplicationProtocols, authenticationOptions.CipherSuitesPolicy, authenticationOptions.EncryptionPolicy);
     }
 
     public static MsQuicSafeHandle Create(QuicServerConnectionOptions options, string? targetHost)


### PR DESCRIPTION
This closes a gap we introduced in #80182, where we forgot to add the support for the same property in QuicConnection.

I also noticed we are inconsistent between SslStream and QuicConnection w.r.t. priority of server certificate selection methods. This PR makes sure the server selection is:
- ServerCertificateSelectionCallback
- ServerCertificateContext
- ServerCertificate

On client, the order is (still):
- ClientCertificateContext
- CertificateSelectionDelegate
- ClientCertificates collection