### PR TITLE
[NativeAOT] ELF ARM: Produce different relocation type for B and BL

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -55,6 +55,7 @@ namespace ILCompiler.DependencyAnalysis
 
         // Linux arm32
         IMAGE_REL_ARM_PREL31                 = 0x10D,
+        IMAGE_REL_ARM_JUMP24                 = 0x10E,
 
         //
         // Relocations for R2R image production


### PR DESCRIPTION
Release builds produce tail calls. When the target of a tail call is external function it was generated with `B.W` instruction and `R_ARM_THM_CALL` relocation. The linker then incorrectly overwrote some bits of the instruction.

Object file:
```
000564b0 <System.Math__Ceiling>:
   564b0:       b508            push    {r3, lr}
   564b2:       b001            add     sp, #4
   564b4:       f85d eb04       ldr.w   lr, [sp], #4
   564b8:       f7ff bffe       b.w     0 <ceil>
   564bc:       0000            movs    r0, r0
```

Incorrectly linked executable:
```
002a6f60 <System.Math__Ceiling>:
  2a6f60:       b508            push    {r3, lr}
  2a6f62:       b001            add     sp, #4
  2a6f64:       f85d eb04       ldr.w   lr, [sp], #4
  2a6f68:       f14a afba       bpl.w   371ee0
  2a6f6c:       0000            movs    r0, r0
```

Correctly linked executable:
```
002a6f60 <System.Math__Ceiling>:
  2a6f60:       b508            push    {r3, lr}
  2a6f62:       b001            add     sp, #4
  2a6f64:       f85d eb04       ldr.w   lr, [sp], #4
  2a6f68:       f149 beb8       b.w     3f0cdc <__ThumbV7PILongThunk_ceil>
  2a6f6c:       0000            movs    r0, r0
```

Contributes to #97729