### PR TITLE
[browser][MT] JSSynchronizationContext_Send_Post_Items_Cancellation

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -226,11 +226,17 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (holder.CallbackReady != null)
                 {
                     var threadFlag = Monitor.ThrowOnBlockingWaitOnJSInteropThread;
-                    Monitor.ThrowOnBlockingWaitOnJSInteropThread = false;
-#pragma warning disable CA1416 // Validate platform compatibility
-                    holder.CallbackReady?.Wait();
-#pragma warning restore CA1416 // Validate platform compatibility
-                    Monitor.ThrowOnBlockingWaitOnJSInteropThread = threadFlag;
+                    try
+                    {
+                        Monitor.ThrowOnBlockingWaitOnJSInteropThread = false;
+    #pragma warning disable CA1416 // Validate platform compatibility
+                        holder.CallbackReady?.Wait();
+    #pragma warning restore CA1416 // Validate platform compatibility
+                    }
+                    finally
+                    {
+                        Monitor.ThrowOnBlockingWaitOnJSInteropThread = threadFlag;
+                    }
                 }
 #endif
                 var callback = holder.Callback!;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSWebWorker.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSWebWorker.cs
@@ -112,6 +112,9 @@ namespace System.Runtime.InteropServices.JavaScript
                         return;
                     }
 
+                    // JSSynchronizationContext also registers to _cancellationToken
+                    _jsSynchronizationContext = JSSynchronizationContext.InstallWebWorkerInterop(false, _cancellationToken);
+
                     // receive callback when the cancellation is requested
                     _cancellationRegistration = _cancellationToken.Register(static (o) =>
                     {
@@ -119,9 +122,6 @@ namespace System.Runtime.InteropServices.JavaScript
                         // this could be executing on any thread
                         self.PropagateCompletionAndDispose(Task.FromCanceled<T>(self._cancellationToken));
                     }, this);
-
-                    // JSSynchronizationContext also registers to _cancellationToken
-                    _jsSynchronizationContext = JSSynchronizationContext.InstallWebWorkerInterop(false, _cancellationToken);
 
                     var childScheduler = TaskScheduler.FromCurrentSynchronizationContext();
 


### PR DESCRIPTION
- fix JSSynchronizationContext_Send_Post_Items_Cancellation
   - broken in https://github.com/dotnet/runtime/pull/97052#issuecomment-1922009585
- simplify JSSynchronizationContext.Dispose
- add finally for ThrowOnBlockingWaitOnJSInteropThread

Fixes https://github.com/dotnet/runtime/issues/97112