### PR TITLE
[wasm][debugger] Fixes exception while debugging on Chrome as IDE

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -1591,7 +1591,8 @@ namespace Microsoft.WebAssembly.Diagnostics
             await SendEvent(sessionId, "Debugger.scriptParsed", scriptSource, token);
             if (!resolveBreakpoints)
                 return;
-            foreach (var req in context.BreakpointRequests.Values)
+            var breakpointRequests = context.BreakpointRequests.Values.ToList<BreakpointRequest>(); //this can be changed while we are looping it and cause an exception
+            foreach (var req in breakpointRequests)
             {
                 if (req.TryResolve(source))
                 {


### PR DESCRIPTION
Fixes this error when trying to debug using chrome as IDE and the BrowserDebugProxy is already started.

```
fail: DevToolsProxy[0]
      failed: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
         at System.Collections.Generic.Dictionary`2.ValueCollection.Enumerator.MoveNext()
         at Microsoft.WebAssembly.Diagnostics.MonoProxy.OnSourceFileAdded(SessionId sessionId, SourceFile source, ExecutionContext context, CancellationToken token, Boolean resolveBreakpoints)
         at Microsoft.WebAssembly.Diagnostics.MonoProxy.LoadStore(SessionId sessionId, Boolean tryUseDebuggerProtocol, CancellationToken token)
         at Microsoft.WebAssembly.Diagnostics.MonoProxy.LoadStore(SessionId sessionId, Boolean tryUseDebuggerProtocol, CancellationToken token)
```