### PR TITLE
Fix ARM64 signed small type cmpxchg for 8.0 atomics

### DIFF
--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3996,6 +3996,12 @@ void CodeGen::genCodeForCmpXchg(GenTreeCmpXchg* treeNode)
             ins = INS_casalh;
         }
         GetEmitter()->emitIns_R_R_R(ins, dataSize, targetReg, dataReg, addrReg);
+
+        if (varTypeIsSmall(treeNode->TypeGet()) && varTypeIsSigned(treeNode->TypeGet()))
+        {
+            instruction mov = varTypeIsShort(treeNode->TypeGet()) ? INS_sxth : INS_sxtb;
+            GetEmitter()->emitIns_Mov(mov, EA_4BYTE, targetReg, targetReg, /* canSkip */ false);
+        }
     }
     else
     {
@@ -4059,6 +4065,12 @@ void CodeGen::genCodeForCmpXchg(GenTreeCmpXchg* treeNode)
         // The following instruction includes a acquire half barrier
         GetEmitter()->emitIns_R_R(insLd, dataSize, targetReg, addrReg);
 
+        if (varTypeIsSmall(treeNode->TypeGet()) && varTypeIsSigned(treeNode->TypeGet()))
+        {
+            instruction mov = varTypeIsShort(treeNode->TypeGet()) ? INS_sxth : INS_sxtb;
+            GetEmitter()->emitIns_Mov(mov, EA_4BYTE, targetReg, targetReg, /* canSkip */ false);
+        }
+
         if (comparand->isContainedIntOrIImmed())
         {
             if (comparand->IsIntegralConst(0))
@@ -4088,12 +4100,6 @@ void CodeGen::genCodeForCmpXchg(GenTreeCmpXchg* treeNode)
         instGen_MemoryBarrier();
 
         gcInfo.gcMarkRegSetNpt(addr->gtGetRegMask());
-    }
-
-    if (varTypeIsSmall(treeNode->TypeGet()) && varTypeIsSigned(treeNode->TypeGet()))
-    {
-        instruction mov = varTypeIsShort(treeNode->TypeGet()) ? INS_sxth : INS_sxtb;
-        GetEmitter()->emitIns_Mov(mov, EA_4BYTE, targetReg, targetReg, /* canSkip */ false);
     }
 
     genProduceReg(treeNode);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -343,7 +343,7 @@ CONFIG_INTEGER(EnableSSSE3,                 W("EnableSSSE3"),               1) /
 #elif defined(TARGET_ARM64)
 CONFIG_INTEGER(EnableArm64AdvSimd,          W("EnableArm64AdvSimd"),        1) // Allows Arm64 AdvSimd+ hardware intrinsics to be disabled
 CONFIG_INTEGER(EnableArm64Aes,              W("EnableArm64Aes"),            1) // Allows Arm64 Aes+ hardware intrinsics to be disabled
-CONFIG_INTEGER(EnableArm64Atomics,          W("EnableArm64Atomics"),        1) // Allows Arm64 Atomics+ hardware intrinsics to be disabled
+CONFIG_INTEGER(EnableArm64Atomics,          W("EnableArm64Atomics"),        0) // Allows Arm64 Atomics+ hardware intrinsics to be disabled
 CONFIG_INTEGER(EnableArm64Crc32,            W("EnableArm64Crc32"),          1) // Allows Arm64 Crc32+ hardware intrinsics to be disabled
 CONFIG_INTEGER(EnableArm64Dczva,            W("EnableArm64Dczva"),          1) // Allows Arm64 Dczva+ hardware intrinsics to be disabled
 CONFIG_INTEGER(EnableArm64Dp,               W("EnableArm64Dp"),             1) // Allows Arm64 Dp+ hardware intrinsics to be disabled


### PR DESCRIPTION
Small type signed cmpxchg failed on machines without LSE, CI passed due to not having such machines.

Move sign extension before the compare to fix the issue.