### PR TITLE
Avoid allocating HashSet in Distinct() for some counts

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
@@ -9,11 +9,50 @@ namespace System.Linq
     {
         private sealed partial class DistinctIterator<TSource> : IIListProvider<TSource>
         {
-            public TSource[] ToArray() => Enumerable.HashSetToArray(new HashSet<TSource>(_source, _comparer));
+            public TSource[] ToArray()
+            {
+                if (TryGetNonEnumeratedCount(_source, out int count) && count < 2)
+                {
+                    if (count == 1)
+                    {
+                        return [_source.First()];
+                    }
 
-            public List<TSource> ToList() => new List<TSource>(new HashSet<TSource>(_source, _comparer));
+                    return [];
+                }
 
-            public int GetCount(bool onlyIfCheap) => onlyIfCheap ? -1 : new HashSet<TSource>(_source, _comparer).Count;
+                return HashSetToArray(new HashSet<TSource>(_source, _comparer));
+            }
+
+            public List<TSource> ToList()
+            {
+                if (TryGetNonEnumeratedCount(_source, out int count) && count < 2)
+                {
+                    if (count == 1)
+                    {
+                        return new List<TSource>(1) { _source.First() };
+                    }
+
+                    return [];
+                }
+
+                return new List<TSource>(new HashSet<TSource>(_source, _comparer));
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (TryGetNonEnumeratedCount(_source, out int count) && count < 2)
+                {
+                    return count;
+                }
+
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
+
+                return new HashSet<TSource>(_source, _comparer).Count;
+            }
         }
     }
 }


### PR DESCRIPTION
If we can get the count for the underlying source and it's 0 or 1, we can avoid allocating the HashSet, as distinctness only matters when there are multiple elements.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Tests
{
    private List<int> _values;

    [Params(0, 1, 2)]
    public int Count { get; set; }

    [GlobalSetup]
    public void Setup() => _values = Enumerable.Range(0, Count).ToList();

    [Benchmark]
    public int[] DistinctToArray() => _values.Distinct().ToArray();

    [Benchmark]
    public List<int> DistinctToList() => _values.Distinct().ToList();

    [Benchmark]
    public int DistinctCount() => _values.Distinct().Count();
}
```

| Method          | Toolchain         | Count | Mean     | Ratio | Allocated | Alloc Ratio |
|---------------- |------------------ |------ |---------:|------:|----------:|------------:|
| DistinctToArray | \main\corerun.exe | 0     | 34.89 ns |  1.00 |     152 B |        1.00 |
| DistinctToArray | \pr\corerun.exe   | 0     | 15.71 ns |  0.45 |      64 B |        0.42 |
|                 |                   |       |          |       |           |             |
| DistinctToList  | \main\corerun.exe | 0     | 37.08 ns |  1.00 |     160 B |        1.00 |
| DistinctToList  | \pr\corerun.exe   | 0     | 21.97 ns |  0.59 |      96 B |        0.60 |
|                 |                   |       |          |       |           |             |
| DistinctCount   | \main\corerun.exe | 0     | 29.41 ns |  1.00 |     128 B |        1.00 |
| DistinctCount   | \pr\corerun.exe   | 0     | 23.39 ns |  0.83 |      64 B |        0.50 |
|                 |                   |       |          |       |           |             |
| DistinctToArray | \main\corerun.exe | 1     | 86.61 ns |  1.00 |     304 B |        1.00 |
| DistinctToArray | \pr\corerun.exe   | 1     | 27.08 ns |  0.30 |      96 B |        0.32 |
|                 |                   |       |          |       |           |             |
| DistinctToList  | \main\corerun.exe | 1     | 82.34 ns |  1.00 |     336 B |        1.00 |
| DistinctToList  | \pr\corerun.exe   | 1     | 35.33 ns |  0.50 |     128 B |        0.38 |
|                 |                   |       |          |       |           |             |
| DistinctCount   | \main\corerun.exe | 1     | 65.99 ns |  1.00 |     272 B |        1.00 |
| DistinctCount   | \pr\corerun.exe   | 1     | 17.41 ns |  0.26 |      64 B |        0.24 |
|                 |                   |       |          |       |           |             |
| DistinctToArray | \main\corerun.exe | 2     | 81.79 ns |  1.00 |     304 B |        1.00 |
| DistinctToArray | \pr\corerun.exe   | 2     | 86.24 ns |  1.06 |     304 B |        1.00 |
|                 |                   |       |          |       |           |             |
| DistinctToList  | \main\corerun.exe | 2     | 90.39 ns |  1.00 |     336 B |        1.00 |
| DistinctToList  | \pr\corerun.exe   | 2     | 93.72 ns |  1.04 |     336 B |        1.00 |
|                 |                   |       |          |       |           |             |
| DistinctCount   | \main\corerun.exe | 2     | 72.62 ns |  1.00 |     272 B |        1.00 |
| DistinctCount   | \pr\corerun.exe   | 2     | 75.89 ns |  1.05 |     272 B |        1.00 |