### PR TITLE
[release/8.0-staging] [mono][jit] Fix passing of byref arguments in m…

### DIFF
--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1482,7 +1482,8 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 		g_assert (fsig->param_count < 16);
 		memcpy (new_args, args, fsig->param_count * sizeof (gpointer));
 		for (int i = 0; i < fsig->param_count; ++i) {
-			if (deref_args [i])
+			// If the argument is not a vtype or nullable, deref it
+			if (deref_args [i] && (deref_args [i] != MONO_GSHAREDVT_BOX_TYPE_VTYPE && deref_args [i] != MONO_GSHAREDVT_BOX_TYPE_NULLABLE))
 				new_args [i] = *(gpointer*)new_args [i];
 		}
 		args = new_args;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97625/Runtime_97625.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97625/Runtime_97625.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+public static class Runtime_97625
+{
+    public class CustomModel
+    {
+        public decimal Cost { get; set; }
+    }
+
+    [Fact]
+    public static int Test()
+    {
+        List<CustomModel> models = new List<CustomModel>();
+        models.Add(new CustomModel { Cost = 1 });
+        return models.Average (x => x.Cost) == 1 ? 100 : -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_97625/Runtime_97625.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_97625/Runtime_97625.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/97721 to release/8.0-staging

## Customer Impact

- [x] Customer reported
- [ ] Found internally

A customer reported an [issue](https://github.com/dotnet/runtime/issues/97625) where they were calling `Sum` or `Average` on a List type of ~20K items resulting in a crash with an unclear stacktrace. After triaging, we noticed the runtime was not properly dereferencing byref values. We went in and fixed the glitch.

## Regression

- [x] Yes
- [ ] No

## Testing

Regression test added on CI to make sure this usage passes.

Also manually tested .Sum in a foreach and it works as expected.

## Risk

Low
