### PR TITLE
Fix reflection-getting function pointer fields

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -285,7 +285,7 @@ namespace Internal.Runtime.Augments
 
             if (fieldTypeHandle.ToMethodTable()->IsFunctionPointer)
                 return ptrValue;
-            
+
             return ReflectionPointer.Box((void*)ptrValue, Type.GetTypeFromHandle(fieldTypeHandle));
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -194,6 +194,9 @@ namespace Internal.Runtime.Augments
 
         public static unsafe object LoadPointerTypeField(IntPtr address, RuntimeTypeHandle fieldType)
         {
+            if (fieldType.ToMethodTable()->IsFunctionPointer)
+                return *(IntPtr*)address;
+
             return ReflectionPointer.Box(*(void**)address, Type.GetTypeFromHandle(fieldType));
         }
 
@@ -212,6 +215,10 @@ namespace Internal.Runtime.Augments
         public static unsafe object LoadPointerTypeField(object obj, int fieldOffset, RuntimeTypeHandle fieldType)
         {
             ref byte address = ref Unsafe.AddByteOffset(ref obj.GetRawData(), new IntPtr(fieldOffset - ObjectHeaderSize));
+
+            if (fieldType.ToMethodTable()->IsFunctionPointer)
+                return RuntimeImports.RhBox(MethodTable.Of<IntPtr>(), ref address);
+
             return ReflectionPointer.Box((void*)Unsafe.As<byte, IntPtr>(ref address), Type.GetTypeFromHandle(fieldType));
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -281,9 +281,11 @@ namespace Internal.Runtime.Augments
         public static unsafe object LoadPointerTypeFieldValueFromValueType(TypedReference typedReference, int fieldOffset, RuntimeTypeHandle fieldTypeHandle)
         {
             Debug.Assert(TypedReference.TargetTypeToken(typedReference).ToMethodTable()->IsValueType);
-            Debug.Assert(fieldTypeHandle.ToMethodTable()->IsPointer);
-
             IntPtr ptrValue = Unsafe.As<byte, IntPtr>(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset));
+
+            if (fieldType.ToMethodTable()->IsFunctionPointer)
+                return ptrValue;
+            
             return ReflectionPointer.Box((void*)ptrValue, Type.GetTypeFromHandle(fieldTypeHandle));
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/Augments/RuntimeAugments.cs
@@ -283,7 +283,7 @@ namespace Internal.Runtime.Augments
             Debug.Assert(TypedReference.TargetTypeToken(typedReference).ToMethodTable()->IsValueType);
             IntPtr ptrValue = Unsafe.As<byte, IntPtr>(ref Unsafe.Add<byte>(ref typedReference.Value, fieldOffset));
 
-            if (fieldType.ToMethodTable()->IsFunctionPointer)
+            if (fieldTypeHandle.ToMethodTable()->IsFunctionPointer)
                 return ptrValue;
             
             return ReflectionPointer.Box((void*)ptrValue, Type.GetTypeFromHandle(fieldTypeHandle));

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForInstanceFields.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForInstanceFields.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 
 using Internal.Runtime.Augments;
 
@@ -26,12 +27,14 @@ namespace Internal.Reflection.Execution.FieldAccessors
 
         protected sealed override void UncheckedSetField(object obj, object value)
         {
-            RuntimeAugments.StoreValueTypeField(obj, OffsetPlusHeader, value, typeof(IntPtr).TypeHandle);
+            Debug.Assert(value.GetType() == typeof(UIntPtr) || value.GetType() == typeof(IntPtr));
+            RuntimeAugments.StoreValueTypeField(obj, OffsetPlusHeader, value, value.GetType().TypeHandle);
         }
 
         protected sealed override void UncheckedSetFieldDirectIntoValueType(TypedReference typedReference, object value)
         {
-            RuntimeAugments.StoreValueTypeFieldValueIntoValueType(typedReference, this.Offset, value, typeof(IntPtr).TypeHandle);
+            Debug.Assert(value.GetType() == typeof(UIntPtr) || value.GetType() == typeof(IntPtr));
+            RuntimeAugments.StoreValueTypeFieldValueIntoValueType(typedReference, this.Offset, value, value.GetType().TypeHandle);
         }
     }
 }

--- a/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForStaticFields.cs
+++ b/src/coreclr/nativeaot/System.Private.Reflection.Execution/src/Internal/Reflection/Execution/FieldAccessors/PointerTypeFieldAccessorForStaticFields.cs
@@ -36,20 +36,22 @@ namespace Internal.Reflection.Execution.FieldAccessors
 
         protected sealed override unsafe void UncheckedSetFieldBypassCctor(object value)
         {
+            Debug.Assert(value.GetType() == typeof(UIntPtr) || value.GetType() == typeof(IntPtr));
+
             if (FieldBase == FieldTableFlags.GCStatic)
             {
                 object gcStaticsRegion = RuntimeAugments.LoadReferenceTypeField(StaticsBase);
-                RuntimeAugments.StoreValueTypeField(gcStaticsRegion, FieldOffset, value, typeof(IntPtr).TypeHandle);
+                RuntimeAugments.StoreValueTypeField(gcStaticsRegion, FieldOffset, value, value.GetType().TypeHandle);
             }
             else if (FieldBase == FieldTableFlags.NonGCStatic)
             {
-                RuntimeAugments.StoreValueTypeField(StaticsBase + FieldOffset, value, typeof(IntPtr).TypeHandle);
+                RuntimeAugments.StoreValueTypeField(StaticsBase + FieldOffset, value, value.GetType().TypeHandle);
             }
             else
             {
                 Debug.Assert(FieldBase == FieldTableFlags.ThreadStatic);
                 object threadStaticsRegion = RuntimeAugments.GetThreadStaticBase(StaticsBase);
-                RuntimeAugments.StoreValueTypeField(threadStaticsRegion, FieldOffset, value, typeof(IntPtr).TypeHandle);
+                RuntimeAugments.StoreValueTypeField(threadStaticsRegion, FieldOffset, value, value.GetType().TypeHandle);
             }
         }
     }


### PR DESCRIPTION
Fixes #97833.

Also fixed an issue around reflection-setting these. I didn't try to make this pretty because we're likely going to rewrite this to reuse the CoreCLR code or at least use the same scheme.

Cc @dotnet/ilc-contrib 