### PR TITLE
[NativeAOT][8.0] Use ld_classic in ILC build and in build integration

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -175,7 +175,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(_IsApplePlatform)' == 'true'">
+    <ItemGroup Condition="'$(UseLdClassicXCodeLinker)' != 'false' and '$(_IsApplePlatform)' == 'true'">
       <CustomLinkerArg Condition="'$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -163,6 +163,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-L/usr/local/lib -linotify" Condition="'$(_targetOS)' == 'freebsd'" />
       <LinkerArg Include="@(ExtraLinkerArg->'-Wl,%(Identity)')" />
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
+      <LinkerArg Include="-ld_classic" Condition="'$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />
     </ItemGroup>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -163,8 +163,20 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-L/usr/local/lib -linotify" Condition="'$(_targetOS)' == 'freebsd'" />
       <LinkerArg Include="@(ExtraLinkerArg->'-Wl,%(Identity)')" />
       <LinkerArg Include="@(NativeFramework->'-framework %(Identity)')" Condition="'$(_IsApplePlatform)' == 'true'" />
-      <LinkerArg Include="-ld_classic" Condition="'$(_IsApplePlatform)' == 'true'" />
       <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />
+    </ItemGroup>
+
+    <Exec Command="xcodebuild -version" Condition="'$(_IsApplePlatform)' == 'true'" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+      <Output TaskParameter="ExitCode" PropertyName="_XcodeVersionStringExitCode" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
+    </Exec>
+
+    <PropertyGroup Condition="'$(_XcodeVersionStringExitCode)' &gt;= '0' and '$(_XcodeVersionString)' != ''">
+      <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
+      <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true' and '$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -171,12 +171,12 @@ The .NET Foundation licenses this file to you under the MIT license.
       <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
     </Exec>
 
-    <PropertyGroup Condition="'$(_XcodeVersionStringExitCode)' &gt;= '0' and '$(_XcodeVersionString)' != ''">
+    <PropertyGroup Condition="('$(_XcodeVersionStringExitCode)' == '0' or '$(_XcodeVersionStringExitCode)' == '1') and '$(_XcodeVersionString)' != ''">
       <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
-      <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true' and '$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
+    <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(_IsApplePlatform)' == 'true'">
+      <CustomLinkerArg Condition="'$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -79,6 +79,7 @@
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
+    <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true'" Include="-ld_classic" />
   </ItemGroup>
 
   <Target Name="PublishCompiler"

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -70,6 +70,19 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_CC_LDFLAGS" />
     </Exec>
 
+    <Exec Command="xcodebuild -version" Condition="'$(_IsApplePlatform)' == 'true'" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+      <Output TaskParameter="ExitCode" PropertyName="_XcodeVersionStringExitCode" />
+      <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
+    </Exec>
+
+    <PropertyGroup Condition="'$(_XcodeVersionStringExitCode)' &gt;= '0' and '$(_XcodeVersionString)' != ''">
+      <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
+      <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true' and '$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
+    </ItemGroup>
+
     <PropertyGroup>
       <CppLinker>$(_CC_LDFLAGS.SubString(0, $(_CC_LDFLAGS.IndexOf(';'))))</CppLinker>
       <_LDFLAGS>$(_CC_LDFLAGS.SubString($([MSBuild]::Add($(_CC_LDFLAGS.IndexOf(';')), 1))))</_LDFLAGS>
@@ -79,7 +92,6 @@
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
-    <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true'" Include="-ld_classic" />
   </ItemGroup>
 
   <Target Name="PublishCompiler"

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -75,12 +75,12 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
     </Exec>
 
-    <PropertyGroup Condition="'$(_XcodeVersionStringExitCode)' &gt;= '0' and '$(_XcodeVersionString)' != ''">
+    <PropertyGroup Condition="('$(_XcodeVersionStringExitCode)' == '0' or '$(_XcodeVersionStringExitCode)' == '1') and '$(_XcodeVersionString)' != ''">
       <_XcodeVersion>$([System.Text.RegularExpressions.Regex]::Match($(_XcodeVersionString), '[1-9]\d*'))</_XcodeVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
-      <CustomLinkerArg Condition="'$(_IsApplePlatform)' == 'true' and '$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
+    <ItemGroup Condition="'$(NativeAotSupported)' == 'true' and '$(_IsApplePlatform)' == 'true'">
+      <CustomLinkerArg Condition="'$(_XcodeVersion)' &gt;= '15'" Include="-ld_classic" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes: #97745 

## Customer Impact

Programs produced in an environment running XCode version 15 or higher will experience various crashes upon starting.

Also, if a build machine is upgraded to xcode 15+ it can't complete the build successfully as ILC, being a NativeAOT component, will not be runnable, thus stages such as building tests would fail.

## Analysis

XCode 15 has introduced a new linker that contains a number of incompatibilities. Some of those incompatibilities may be unintentional and may eventually be fixed. It seems possible that point releases (i.e 15.0 vs. 15.2) have different set of issues.  
For the time being there is a way to force the use of the old (aka "classic") linker and get around incompatibilities. 

While we can chase incompatibilities and adapt to them in the active development branch, in 8.0 branch it makes more sense to opt for "classic" behavior.

## Testing

Manual testing locally with XCode 15.2 and regular lab run with XCode 14 that is still used by the lab.

## Risk

Low. This change conditionally reintroduces preexisting linker behavior.

There is a risk that at some point "classic" linker will no longer be supported. 
It will likely be far enough in the future that the "prime" linker becomes more stable and the runtime/compiler could be adapted to work with it at that time.


