### PR TITLE
[debugger][mt] Unify multithreading switches

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -45,7 +45,7 @@ namespace DebuggerTests
 #else
             => false;
 #endif
-        public static bool WasmMultiThreaded => EnvironmentVariables.WasmTestsUsingVariant == "multithreaded";
+        public static bool WasmMultiThreaded => EnvironmentVariables.WasmEnableThreads;
 
         public static bool WasmSingleThreaded => !WasmMultiThreaded;
 

--- a/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
@@ -9,10 +9,11 @@ namespace DebuggerTests;
 
 internal static class EnvironmentVariables
 {
-    public static readonly string? DebuggerTestPath = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
-    public static readonly string? TestLogPath      = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
-    public static readonly bool    SkipCleanup      = GetEnvironmentVariableValue("SKIP_CLEANUP");
-    public static readonly bool WasmEnableThreads   = GetEnvironmentVariableValue("WasmEnableThreads");
+    public static readonly string? DebuggerTestPath  = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
+    public static readonly string? TestLogPath       = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
+    public static readonly bool    SkipCleanup       = GetEnvironmentVariableValue("SKIP_CLEANUP");
+    public static readonly bool    WasmEnableThreads = GetEnvironmentVariableValue("WasmEnableThreads");
+
     private static GetEnvironmentVariableValue(string envVariable)
     {
         string? str = Environment.GetEnvironmentVariable(envVariable);

--- a/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
@@ -12,6 +12,7 @@ internal static class EnvironmentVariables
     public static readonly string? DebuggerTestPath = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
     public static readonly string? TestLogPath      = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
     public static readonly bool    SkipCleanup      = Environment.GetEnvironmentVariable("SKIP_CLEANUP") == "1" ||
-                                                       Environment.GetEnvironmentVariable("SKIP_CLEANUP") == "true";
-    public static readonly string? WasmTestsUsingVariant = Environment.GetEnvironmentVariable("WASM_TESTS_USING_VARIANT");
+                                                        Environment.GetEnvironmentVariable("SKIP_CLEANUP") == "true";
+    public static readonly bool WasmEnableThreads = Environment.GetEnvironmentVariable("WasmEnableThreads") == "1" ||
+                                                    Environment.GetEnvironmentVariable("WasmEnableThreads") == "true";
 }

--- a/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
@@ -14,13 +14,13 @@ internal static class EnvironmentVariables
     public static readonly bool    SkipCleanup       = GetEnvironmentVariableValue("SKIP_CLEANUP");
     public static readonly bool    WasmEnableThreads = GetEnvironmentVariableValue("WasmEnableThreads");
 
-    private static GetEnvironmentVariableValue(string envVariable)
+    private static bool GetEnvironmentVariableValue(string envVariable)
     {
         string? str = Environment.GetEnvironmentVariable(envVariable);
         if (str is null)
             return false;
         
-        if (str == "1" || bool.IsTrueStringIgnoreCase(str))
+        if (str == "1" || str.ToLower() == "true")
             return true;
 
         return false;

--- a/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EnvironmentVariables.cs
@@ -11,8 +11,17 @@ internal static class EnvironmentVariables
 {
     public static readonly string? DebuggerTestPath = Environment.GetEnvironmentVariable("DEBUGGER_TEST_PATH");
     public static readonly string? TestLogPath      = Environment.GetEnvironmentVariable("TEST_LOG_PATH");
-    public static readonly bool    SkipCleanup      = Environment.GetEnvironmentVariable("SKIP_CLEANUP") == "1" ||
-                                                        Environment.GetEnvironmentVariable("SKIP_CLEANUP") == "true";
-    public static readonly bool WasmEnableThreads = Environment.GetEnvironmentVariable("WasmEnableThreads") == "1" ||
-                                                    Environment.GetEnvironmentVariable("WasmEnableThreads") == "true";
+    public static readonly bool    SkipCleanup      = GetEnvironmentVariableValue("SKIP_CLEANUP");
+    public static readonly bool WasmEnableThreads   = GetEnvironmentVariableValue("WasmEnableThreads");
+    private static GetEnvironmentVariableValue(string envVariable)
+    {
+        string? str = Environment.GetEnvironmentVariable(envVariable);
+        if (str is null)
+            return false;
+        
+        if (str == "1" || bool.IsTrueStringIgnoreCase(str))
+            return true;
+
+        return false;
+    }
 }

--- a/src/mono/browser/debugger/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
+++ b/src/mono/browser/debugger/Wasm.Debugger.Tests/Wasm.Debugger.Tests.csproj
@@ -70,7 +70,7 @@
       <_DotnetCommand Condition="'$(OS)' == 'Windows_NT'">dotnet.exe</_DotnetCommand>
 
       <RunScriptCommand>$(_DotnetCommand) test DebuggerTestSuite/DebuggerTestSuite.dll</RunScriptCommand>
-      <RunScriptCommand Condition="'$(WasmEnableThreads)' == 'true'">$(RunScriptCommand) /e:WASM_TESTS_USING_VARIANT=multithreaded</RunScriptCommand>
+      <RunScriptCommand>$(RunScriptCommand) /e:WasmEnableThreads=$(WasmEnableThreads)</RunScriptCommand>
       <RunScriptCommand>$(RunScriptCommand) &quot;-l:trx%3BLogFileName=testResults.trx&quot;</RunScriptCommand>
       <RunScriptCommand Condition="'$(ContinuousIntegrationBuild)' == 'true'">$(RunScriptCommand) &quot;-l:console%3BVerbosity=normal&quot;</RunScriptCommand>
 

--- a/src/mono/wasm/threads.md
+++ b/src/mono/wasm/threads.md
@@ -80,7 +80,7 @@ a worker thread will use `async_run_in_main_thread` to queue up work for the mai
 
 To run the debugger tests in the runtime [built with enabled support for multi-threading](#building-the-runtime) we use:
 ```
-dotnet test src/mono/wasm/debugger/DebuggerTestSuite -e RuntimeConfiguration=Debug -e Configuration=Debug -e DebuggerHost=chrome -e WasmEnableThreads=true -e WASM_TESTS_USING_VARIANT=multithreaded
+dotnet test src/mono/wasm/debugger/DebuggerTestSuite -e RuntimeConfiguration=Debug -e Configuration=Debug -e DebuggerHost=chrome -e WasmEnableThreads=true
 ```
 
 ## JS interop on dedicated threads ##


### PR DESCRIPTION
Follow-up for https://github.com/dotnet/runtime/pull/97560.
Debugger should also pass only one flag, in this case it's an env variable. The name does not follow the env var naming convention to keep using only one, `WasmEnableThreads` name everywhere.