### PR TITLE
Disable IL stripping in System.Runtime.Tests for Apple mobile

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
@@ -16,6 +16,8 @@
     <IlcKeepManagedDebuggerSupport>true</IlcKeepManagedDebuggerSupport>
     <!-- Same for ILLink -->
     <DebuggerSupport>true</DebuggerSupport>
+    <!-- Active issue: https://github.com/dotnet/runtime/issues/97809 -->
+    <ShouldILStrip>false</ShouldILStrip>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## Description

This PR disables IL stripping in System.Runtime.Tests for Apple mobile.

Contributes to https://github.com/dotnet/runtime/issues/97809