### PR TITLE
[wasm][debugger] Force sourceUrl with a suffix .cdp

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -293,7 +293,10 @@ namespace Microsoft.WebAssembly.Diagnostics
         public bool silent { get; set; }
         public bool returnByValue { get; set; } = true;
 
-        public MonoCommands(string expression) => this.expression = expression;
+        public MonoCommands(string expression)
+        {
+            this.expression = $"{expression} //# sourceURL=eval-dotnet.cdp";
+        }
 
         public static MonoCommands GetDebuggerAgentBufferReceived(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_dbg_command_info()");
 
@@ -324,13 +327,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
 
         public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
-        internal JObject ToObject(bool addUrl)
-        {
-            JObject obj = JObject.FromObject(this);
-            if (addUrl)
-                obj[nameof(expression)] = $"{expression}//# sourceURL=cdp://dotnet/mono{expression.GetHashCode()}.cdp";
-            return obj;
-        }
+
     }
 
     internal enum MonoErrorCodes

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -326,7 +326,6 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
         internal JObject ToObject(bool addUrl)
         {
-            System.Diagnostics.Debugger.Launch();
             if (!addUrl)
                 return JObject.FromObject(this);
             JObject obj = JObject.FromObject(this);

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -295,7 +295,7 @@ namespace Microsoft.WebAssembly.Diagnostics
 
         public MonoCommands(string expression)
         {
-            this.expression = $"{expression} //# sourceURL=eval-dotnet.cdp";
+            this.expression = $"{expression} //# sourceURL=cdp://debug/eval.cdp";
         }
 
         public static MonoCommands GetDebuggerAgentBufferReceived(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_dbg_command_info()");

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -472,6 +472,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal bool FirstBreakpoint { get; set; }
 
         internal bool Destroyed { get; set; }
+
         public DebugStore Store
         {
             get

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -327,7 +327,6 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
 
         public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
-
     }
 
     internal enum MonoErrorCodes

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -324,6 +324,15 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands ReleaseObject(int runtimeId, DotnetObjectId objectId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_release_object('{objectId}')");
 
         public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
+        internal JObject ToObject(bool addUrl)
+        {
+            System.Diagnostics.Debugger.Launch();
+            if (!addUrl)
+                return JObject.FromObject(this);
+            JObject obj = JObject.FromObject(this);
+            obj[nameof(expression)] = expression + $"//# sourceURL=cdp://dotnet/mono{expression.GetHashCode()}.cdp";
+            return obj;
+        }
     }
 
     internal enum MonoErrorCodes
@@ -464,7 +473,6 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal bool FirstBreakpoint { get; set; }
 
         internal bool Destroyed { get; set; }
-
         public DebugStore Store
         {
             get

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -326,9 +326,9 @@ namespace Microsoft.WebAssembly.Diagnostics
         public static MonoCommands GetWasmFunctionIds(int runtimeId) => new MonoCommands($"getDotnetRuntime({runtimeId}).INTERNAL.mono_wasm_get_func_id_to_name_mappings()");
         internal JObject ToObject(bool addUrl)
         {
-            if (!addUrl)
-                return JObject.FromObject(this);
             JObject obj = JObject.FromObject(this);
+            if (!addUrl)
+                return obj;
             obj[nameof(expression)] = expression + $"//# sourceURL=cdp://dotnet/mono{expression.GetHashCode()}.cdp";
             return obj;
         }

--- a/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/DevToolsHelper.cs
@@ -327,9 +327,8 @@ namespace Microsoft.WebAssembly.Diagnostics
         internal JObject ToObject(bool addUrl)
         {
             JObject obj = JObject.FromObject(this);
-            if (!addUrl)
-                return obj;
-            obj[nameof(expression)] = expression + $"//# sourceURL=cdp://dotnet/mono{expression.GetHashCode()}.cdp";
+            if (addUrl)
+                obj[nameof(expression)] = $"{expression}//# sourceURL=cdp://dotnet/mono{expression.GetHashCode()}.cdp";
             return obj;
         }
     }

--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -32,7 +32,6 @@ namespace Microsoft.WebAssembly.Diagnostics
         // index of the runtime in a same JS page/process
         public int RuntimeId { get; private init; }
         public bool JustMyCode { get; private set; }
-        public bool DebuggingFromVS { get; private set; }
         private PauseOnExceptionsKind _defaultPauseOnExceptions { get; set; }
 
         public MonoProxy(ILogger logger, int runtimeId = 0, string loggerId = "", ProxyOptions options = null) : base(options, logger, loggerId)
@@ -43,7 +42,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             JustMyCode = options?.JustMyCode ?? false;
         }
 
-        internal virtual Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", cmd.ToObject(DebuggingFromVS), token);
+        internal virtual Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", JObject.FromObject(cmd), token);
 
         internal void SendLog(SessionId sessionId, string message, CancellationToken token, string type = "warning")
         {
@@ -310,8 +309,6 @@ namespace Microsoft.WebAssembly.Diagnostics
                 return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
             }
 
-            if (!DebuggingFromVS && method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase))
-                DebuggingFromVS = true;
             switch (method)
             {
                 case "Target.attachToTarget":

--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -32,6 +32,7 @@ namespace Microsoft.WebAssembly.Diagnostics
         // index of the runtime in a same JS page/process
         public int RuntimeId { get; private init; }
         public bool JustMyCode { get; private set; }
+        public bool DebuggingFromVS { get; private set; }
         private PauseOnExceptionsKind _defaultPauseOnExceptions { get; set; }
 
         public MonoProxy(ILogger logger, int runtimeId = 0, string loggerId = "", ProxyOptions options = null) : base(options, logger, loggerId)
@@ -42,7 +43,7 @@ namespace Microsoft.WebAssembly.Diagnostics
             JustMyCode = options?.JustMyCode ?? false;
         }
 
-        internal virtual Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", JObject.FromObject(cmd), token);
+        internal virtual Task<Result> SendMonoCommand(SessionId id, MonoCommands cmd, CancellationToken token) => SendCommand(id, "Runtime.evaluate", cmd.ToObject(DebuggingFromVS), token);
 
         internal void SendLog(SessionId sessionId, string message, CancellationToken token, string type = "warning")
         {
@@ -309,6 +310,8 @@ namespace Microsoft.WebAssembly.Diagnostics
                 return method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase);
             }
 
+            if (!DebuggingFromVS && method.StartsWith("DotnetDebugger.", StringComparison.OrdinalIgnoreCase))
+                DebuggingFromVS = true;
             switch (method)
             {
                 case "Target.attachToTarget":

--- a/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/DebuggerTestBase.cs
@@ -229,6 +229,10 @@ namespace DebuggerTests
                 dicScriptsIdToUrl[script_id] = dbgUrl;
                 dicFileToUrl[dbgUrl] = args["url"]?.Value<string>();
             }
+            else if (url.StartsWith("cdp://"))
+            {
+                //ignore them as it's done by the browser and vscode-js-debug
+            }
             else if (!String.IsNullOrEmpty(url))
             {
                 var dbgUrl = args["url"]?.Value<string>();


### PR DESCRIPTION
Add .cdp suffix to sourceUrl to all the evaluation that is done internally by the dotnet debugger.
This will avoid slowness in VS.