### PR TITLE
[release/8.0-staging] Stop trying to format HOST_RUNTIME_CONTRACT property with locale settings

### DIFF
--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -280,7 +280,8 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
 
     for (const auto& config : m_probes)
     {
-        trace::verbose(_X("  Using probe config: %s"), config.as_str().c_str());
+        if (trace::is_enabled())
+            trace::verbose(_X("  Using probe config: %s"), config.as_str().c_str());
 
         if (config.is_servicing() && !entry.is_serviceable)
         {

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -378,9 +378,9 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
         }
 
         host_contract.get_runtime_property = &get_runtime_property;
-        pal::stringstream_t ptr_stream;
-        ptr_stream << "0x" << std::hex << (size_t)(&host_contract);
-        if (!coreclr_properties.add(_STRINGIFY(HOST_PROPERTY_RUNTIME_CONTRACT), ptr_stream.str().c_str()))
+        pal::char_t buffer[STRING_LENGTH("0xffffffffffffffff")];
+        pal::snwprintf(buffer, ARRAY_SIZE(buffer), _X("0x%zx"), (size_t)(&host_contract));
+        if (!coreclr_properties.add(_STRINGIFY(HOST_PROPERTY_RUNTIME_CONTRACT), buffer))
         {
             log_duplicate_property_error(_STRINGIFY(HOST_PROPERTY_RUNTIME_CONTRACT));
             return StatusCode::LibHostDuplicateProperty;


### PR DESCRIPTION
Partial backport of https://github.com/dotnet/runtime/pull/95801 to release/8.0-staging - skips the changes to utils for ends_with / starts_with.

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported in:
- https://github.com/dotnet/runtime/issues/97086

In environments with certain locale settings, the runtime fails to initialize due to an incorrect runtime property. The host passes a runtime contract pointer as a property to the runtime, but it is incorrectly formatting it based on locale settings. The  fix switches the computation of the property to use a function that is non-locale-dependent (stops using stringstream in favour of printf).

## Regression

- [x] Yes
- [ ] No

This is a new property in 8.0. It used the same mechanism that was used a different property in past releases (which would have the same issue), but that was only for single-file. In this case, it is for general initialization.

## Testing

Manual

## Risk

Low