### PR TITLE
JIT: optimize non-constant stackalloc to constant

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5382,9 +5382,9 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
             int lowerBound;
             int upperBound;
             if (optAssertionProp_GetInt32Range(assertions, tree->gtGetOp1(), &lowerBound, &upperBound) &&
-                (lowerBound >= 0) && (upperBound <= stackallocThreshold))
+                (lowerBound >= 0) && (upperBound <= stackallocThreshold) && (upperBound > 0))
             {
-                tree->AsOp()->gtOp1 = gtNewIconNode(stackallocThreshold, TYP_I_IMPL);
+                tree->AsOp()->gtOp1 = gtNewIconNode(upperBound, TYP_I_IMPL);
                 fgUpdateConstTreeValueNumber(tree->gtGetOp1());
                 return optAssertionProp_Update(tree, tree, stmt);
             }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7808,6 +7808,8 @@ public:
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 
+    bool optAssertionProp_GetInt32Range(ASSERT_VALARG_TP assertions, GenTree* tree, int* fromIncl, int* toIncl);
+
     // Implied assertion functions.
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);
     void optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6365,19 +6365,15 @@ bool ValueNumStore::IsVNConstantBoundUnsigned(ValueNum vn)
     VNFuncApp funcApp;
     if ((vn != NoVN) && GetVNFunc(vn, &funcApp))
     {
-        const bool op1IsPositiveConst = IsVNPositiveInt32Constant(funcApp.m_args[0]);
-        const bool op2IsPositiveConst = IsVNPositiveInt32Constant(funcApp.m_args[1]);
-        if (!op1IsPositiveConst && op2IsPositiveConst)
+        switch (funcApp.m_func)
         {
-            // (uint)index < CNS
-            // (uint)index >= CNS
-            return (funcApp.m_func == VNF_LT_UN) || (funcApp.m_func == VNF_GE_UN);
-        }
-        else if (op1IsPositiveConst && !op2IsPositiveConst)
-        {
-            // CNS > (uint)index
-            // CNS <= (uint)index
-            return (funcApp.m_func == VNF_GT_UN) || (funcApp.m_func == VNF_LE_UN);
+            case VNF_LT_UN:
+            case VNF_LE_UN:
+            case VNF_GE_UN:
+            case VNF_GT_UN:
+                return IsVNPositiveInt32Constant(funcApp.m_args[0]) || IsVNPositiveInt32Constant(funcApp.m_args[1]);
+            default:
+                return false;
         }
     }
     return false;


### PR DESCRIPTION
This PR optimizes 
```
span = x <= 64 ? stackalloc byte[n] : ...
```
to
```
span = x <= 64 ? stackalloc byte[64] : ...
```
because the latter is faster to zero (single instruction). Although, this consumes more stack, so the threshold is low.

Also, I need the generic `optAssertionProp_GetInt32Range` function in future opts I wanted to try.

Example:
```cs
static void Test(int n)
{
    Span<byte> span = (uint)n <= 64 ? stackalloc byte[n] : new byte[n];
    Consume(span);
}

[MethodImpl(MethodImplOptions.NoInlining)]
static void Consume(Span<byte> span){}
```

Codegen diff for `Test()`: https://www.diffchecker.com/s6pIRCSa/