### PR TITLE
JIT: Set edge likelihoods during patchpoint transformation

### DIFF
--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3517,7 +3517,7 @@ void EfficientEdgeCountReconstructor::Solve()
     //
     if (m_comp->fgPgoSource == ICorJitInfo::PgoSource::Dynamic)
     {
-        // assert(!m_mismatch);
+        assert(!m_mismatch);
     }
 
     // If issues arose earlier, then don't try solving.

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3517,7 +3517,7 @@ void EfficientEdgeCountReconstructor::Solve()
     //
     if (m_comp->fgPgoSource == ICorJitInfo::PgoSource::Dynamic)
     {
-        assert(!m_mismatch);
+        // assert(!m_mismatch);
     }
 
     // If issues arose earlier, then don't try solving.

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -153,8 +153,8 @@ private:
 
         FlowEdge* const falseEdge = compiler->fgAddRefPred(helperBlock, block);
         FlowEdge* const trueEdge  = compiler->fgGetPredForBlock(remainderBlock, block);
-        trueEdge->setLikelihood(HIGH_PROBABILITY / 100);
-        falseEdge->setLikelihood((100 - HIGH_PROBABILITY) / 100);
+        trueEdge->setLikelihood(HIGH_PROBABILITY / 100.0);
+        falseEdge->setLikelihood((100 - HIGH_PROBABILITY) / 100.0);
 
         FlowEdge* const newEdge = compiler->fgAddRefPred(remainderBlock, helperBlock);
         newEdge->setLikelihood(1.0);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -153,9 +153,6 @@ private:
 
         FlowEdge* const falseEdge = compiler->fgAddRefPred(helperBlock, block);
         FlowEdge* const trueEdge  = compiler->fgGetPredForBlock(remainderBlock, block);
-
-        // Likelihood should have been set in fgSplitBlockAtBeginning
-        assert(trueEdge->hasLikelihood());
         trueEdge->setLikelihood(HIGH_PROBABILITY / 100);
         falseEdge->setLikelihood((100 - HIGH_PROBABILITY) / 100);
 

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -151,8 +151,21 @@ private:
 
         helperBlock->SetFlags(BBF_BACKWARD_JUMP | BBF_NONE_QUIRK);
 
-        compiler->fgAddRefPred(helperBlock, block);
-        compiler->fgAddRefPred(remainderBlock, helperBlock);
+        FlowEdge* const falseEdge = compiler->fgAddRefPred(helperBlock, block);
+        FlowEdge* const trueEdge  = compiler->fgGetPredForBlock(remainderBlock, block);
+
+        if (trueEdge->hasLikelihood())
+        {
+            falseEdge->setLikelihood(1.0 - trueEdge->getLikelihood());
+        }
+        else
+        {
+            trueEdge->setLikelihood(0.5);
+            falseEdge->setLikelihood(0.5);
+        }
+
+        FlowEdge* const newEdge = compiler->fgAddRefPred(remainderBlock, helperBlock);
+        newEdge->setLikelihood(1.0);
 
         // Update weights
         remainderBlock->inheritWeight(block);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -156,10 +156,8 @@ private:
 
         // Likelihood should have been set in fgSplitBlockAtBeginning
         assert(trueEdge->hasLikelihood());
-
-        // Check should rarely pass
-        trueEdge->setLikelihood(0.1);
-        falseEdge->setLikelihood(0.9);
+        trueEdge->setLikelihood(HIGH_PROBABILITY / 100);
+        falseEdge->setLikelihood((100 - HIGH_PROBABILITY) / 100);
 
         FlowEdge* const newEdge = compiler->fgAddRefPred(remainderBlock, helperBlock);
         newEdge->setLikelihood(1.0);

--- a/src/coreclr/jit/patchpoint.cpp
+++ b/src/coreclr/jit/patchpoint.cpp
@@ -154,15 +154,12 @@ private:
         FlowEdge* const falseEdge = compiler->fgAddRefPred(helperBlock, block);
         FlowEdge* const trueEdge  = compiler->fgGetPredForBlock(remainderBlock, block);
 
-        if (trueEdge->hasLikelihood())
-        {
-            falseEdge->setLikelihood(1.0 - trueEdge->getLikelihood());
-        }
-        else
-        {
-            trueEdge->setLikelihood(0.5);
-            falseEdge->setLikelihood(0.5);
-        }
+        // Likelihood should have been set in fgSplitBlockAtBeginning
+        assert(trueEdge->hasLikelihood());
+
+        // Check should rarely pass
+        trueEdge->setLikelihood(0.1);
+        falseEdge->setLikelihood(0.9);
 
         FlowEdge* const newEdge = compiler->fgAddRefPred(remainderBlock, helperBlock);
         newEdge->setLikelihood(1.0);


### PR DESCRIPTION
Fixes #97892. During patchpoint expansion, make sure to set edge likelihoods for transformed blocks.