### PR TITLE
Try to fold basic arithmetic operations as part of import

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4648,12 +4648,12 @@ GenTree* Compiler::optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tr
 //   based on assertions
 //
 // Arguments:
-//   op - tree to check
+//   op          - tree to check
 //   assertions  - set of live assertions
-//   pVnBased - [out] set to true if value numbers were used
-//   pIndex - [out] the assertion used in the proof
+//   pVnBased    - [out] set to true if value numbers were used
+//   pIndex      - [out] the assertion used in the proof
 //
-// Returns:
+// Return Value:
 //   true if the tree's value will be non-null
 //
 // Notes:
@@ -4703,11 +4703,11 @@ bool Compiler::optAssertionIsNonNull(GenTree*         op,
 //   be non-null based on assertions
 //
 // Arguments:
-//   op - tree to check
-//   assertions  - set of live assertions
-//   pVnBased - [out] set to true if value numbers were used
+//   op         - tree to check
+//   assertions - set of live assertions
+//   pVnBased   - [out] set to true if value numbers were used
 //
-// Returns:
+// Return Value:
 //   index of assertion, or NO_ASSERTION_INDEX
 //
 AssertionIndex Compiler::optAssertionIsNonNullInternal(GenTree*         op,
@@ -4813,6 +4813,7 @@ AssertionIndex Compiler::optAssertionIsNonNullInternal(GenTree*         op,
     }
     return NO_ASSERTION_INDEX;
 }
+
 /*****************************************************************************
  *
  *  Given a tree consisting of a call and a set of available assertions, we
@@ -4903,12 +4904,12 @@ bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree*
 //   based on assertions
 //
 // Arguments:
-//   op - tree to check
-//   assertions  - set of live assertions
-//   pVnBased - [out] set to true if value numbers were used
-//   pIndex - [out] the assertion used in the proof
+//   op         - tree to check
+//   assertions - set of live assertions
+//   pVnBased   - [out] set to true if value numbers were used
+//   pIndex     - [out] the assertion used in the proof
 //
-// Returns:
+// Return Value:
 //   true if the tree's value will be not GC-tracked
 //
 // Notes:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4955,7 +4955,7 @@ bool Compiler::optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree*
 {
     assert(indir->OperIsIndir());
 
-    if (!indir->OperIs(GT_STOREIND))
+    if (!indir->OperIs(GT_STOREIND) || (indir->gtFlags & GTF_IND_TGT_NOT_HEAP) != 0)
     {
         return false;
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7771,6 +7771,8 @@ public:
     AssertionIndex optAssertionIsNonNullInternal(GenTree* op, ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased));
     bool optAssertionIsNonNull(GenTree*         op,
                                ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased) DEBUGARG(AssertionIndex* pIndex));
+    bool optAssertionIsNonHeap(GenTree*         op,
+                               ASSERT_VALARG_TP assertions DEBUGARG(bool* pVnBased) DEBUGARG(AssertionIndex* pIndex));
 
     AssertionIndex optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP assertions, GenTree* op1, GenTree* op2);
     AssertionIndex optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_TP assertions, GenTree* op1);
@@ -7807,6 +7809,7 @@ public:
     GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
+    bool optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 
     // Implied assertion functions.
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -249,7 +249,8 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
     if ((store->gtFlags & GTF_IND_TGT_NOT_HEAP) != 0)
     {
         // This indirection is not storing to the heap.
-        // This case occurs for stack-allocated objects.
+        // This case occurs for stack-allocated objects
+        // and for some types of CSE'd frozen object handles.
         return WBF_NoBarrier;
     }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -19333,8 +19333,8 @@ FieldSeq* FieldSeqStore::Append(FieldSeq* a, FieldSeq* b)
     // complex optimizations, inlining, etc. In release we'll still do the right thing by returning
     // nullptr here, but the more conservative assert can help avoid JIT bugs
 
-    assert(a->GetKind() == FieldKind::SimpleStaticKnownAddress);
-    assert(b->GetKind() == FieldKind::SimpleStaticKnownAddress);
+    assert(a->GetKind() == FieldSeq::FieldKind::SimpleStaticKnownAddress);
+    assert(b->GetKind() == FieldSeq::FieldKind::SimpleStaticKnownAddress);
 
     return nullptr;
 }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15671,6 +15671,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     break;
 
                 case GT_ADD:
+                {
                     itemp = i1 + i2;
                     if (tree->gtOverflow() && CheckedOps::AddOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
                     {
@@ -15688,6 +15689,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     }
                     fieldSeq = GetFieldSeqStore()->Append(op1FieldSeq, op2FieldSeq);
                     break;
+                }
                 case GT_SUB:
                     itemp = i1 - i2;
                     if (tree->gtOverflow() && CheckedOps::SubOverflows(INT32(i1), INT32(i2), tree->IsUnsigned()))
@@ -15883,6 +15885,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     goto FOLD_COND;
 
                 case GT_ADD:
+                {
                     ltemp = lval1 + lval2;
                     if (tree->gtOverflow() && CheckedOps::AddOverflows(lval1, lval2, tree->IsUnsigned()))
                     {
@@ -15902,6 +15905,7 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     fieldSeq = GetFieldSeqStore()->Append(op1FieldSeq, op2FieldSeq);
 #endif // TARGET_64BIT
                     break;
+                }
 
                 case GT_SUB:
                     ltemp = lval1 - lval2;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15676,8 +15676,17 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                     {
                         goto INTEGRAL_OVF;
                     }
-                    i1       = itemp;
-                    fieldSeq = GetFieldSeqStore()->Append(op1->AsIntCon()->gtFieldSeq, op2->AsIntCon()->gtFieldSeq);
+                    i1 = itemp;
+
+                    FieldSeq* op1FieldSeq = op1->AsIntCon()->gtFieldSeq;
+                    FieldSeq* op2FieldSeq = op2->AsIntCon()->gtFieldSeq;
+
+                    if ((op1FieldSeq != nullptr) && (op2FieldSeq != nullptr))
+                    {
+                        // We cannot combine two field sequences
+                        return nullptr;
+                    }
+                    fieldSeq = GetFieldSeqStore()->Append(op1FieldSeq, op2FieldSeq);
                     break;
                 case GT_SUB:
                     itemp = i1 - i2;
@@ -15880,9 +15889,18 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
                         goto INTEGRAL_OVF;
                     }
                     lval1 = ltemp;
+
 #ifdef TARGET_64BIT
-                    fieldSeq = GetFieldSeqStore()->Append(op1->AsIntCon()->gtFieldSeq, op2->AsIntCon()->gtFieldSeq);
-#endif
+                    FieldSeq* op1FieldSeq = op1->AsIntCon()->gtFieldSeq;
+                    FieldSeq* op2FieldSeq = op2->AsIntCon()->gtFieldSeq;
+
+                    if ((op1FieldSeq != nullptr) && (op2FieldSeq != nullptr))
+                    {
+                        // We cannot combine two field sequences
+                        return nullptr;
+                    }
+                    fieldSeq = GetFieldSeqStore()->Append(op1FieldSeq, op2FieldSeq);
+#endif // TARGET_64BIT
                     break;
 
                 case GT_SUB:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -480,7 +480,7 @@ enum GenTreeFlags : unsigned int
     GTF_INX_RNGCHK              = 0x80000000, // GT_INDEX_ADDR -- this array address should be range-checked
     GTF_INX_ADDR_NONNULL        = 0x40000000, // GT_INDEX_ADDR -- this array address is not null
 
-    GTF_IND_TGT_NOT_HEAP        = 0x80000000, // GT_IND -- the target is not on the heap
+    GTF_IND_TGT_NOT_HEAP        = 0x80000000, // GT_IND -- the target is not GC-tracked, such as an object on the nongc heap
     GTF_IND_VOLATILE            = 0x40000000, // OperIsIndir() -- the load or store must use volatile semantics (this is a nop on X86)
     GTF_IND_NONFAULTING         = 0x20000000, // OperIsIndir() -- An indir that cannot fault.
     GTF_IND_TGT_HEAP            = 0x10000000, // GT_IND -- the target is on the heap

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -7203,6 +7203,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     }
                 }
 
+                // Fold result, if possible.
+                op1 = gtFoldExpr(op1);
+
                 impPushOnStack(op1, tiRetVal);
                 break;
 
@@ -7225,14 +7228,23 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                 type = genActualType(op1->TypeGet());
                 op1  = gtNewOperNode(oper, type, op1, op2);
 
+                // Fold result, if possible.
+                op1 = gtFoldExpr(op1);
+
                 impPushOnStack(op1, tiRetVal);
                 break;
 
             case CEE_NOT:
                 op1 = impPopStack().val;
                 impBashVarAddrsToI(op1, nullptr);
+
                 type = genActualType(op1->TypeGet());
-                impPushOnStack(gtNewOperNode(GT_NOT, type, op1), tiRetVal);
+                op1  = gtNewOperNode(GT_NOT, type, op1);
+
+                // Fold result, if possible.
+                op1 = gtFoldExpr(op1);
+
+                impPushOnStack(op1, tiRetVal);
                 break;
 
             case CEE_CKFINITE:
@@ -7960,7 +7972,12 @@ void Compiler::impImportBlockCode(BasicBlock* block)
             case CEE_NEG:
                 op1 = impPopStack().val;
                 impBashVarAddrsToI(op1, nullptr);
-                impPushOnStack(gtNewOperNode(GT_NEG, genActualType(op1->gtType), op1), tiRetVal);
+                op1 = gtNewOperNode(GT_NEG, genActualType(op1->gtType), op1);
+
+                // Fold result, if possible.
+                op1 = gtFoldExpr(op1);
+
+                impPushOnStack(op1, tiRetVal);
                 break;
 
             case CEE_POP:


### PR DESCRIPTION
This resolves a user reported issue where despite inlining, the JIT may not see that a given value is constant during import due to these operations not getting folded: https://github.com/SixLabors/ImageSharp/pull/2654#discussion_r1475667200

This resulted in massively pessimized codegen since hardware intrinsics have to fallback to a call and a very large jump table instead to ensure the right behavior is executed.

The fix was simple and just involves calling `gtFoldExpr` before pushing the resulting node on the stack, as we're already doing for several other scenarios such as comparisons and similar cases.

It is not a "complete" fix and there may still be other places where something becomes a constant after importation. That fix, however, is much more involved and requires us transforming an intrinsic node back into a call to managed fairly late (rationalization or lowering).