### PR TITLE
Alternative fix for ARM64 signed small type cmpxchg without LSE

### DIFF
--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -76,7 +76,7 @@ GTNODE(XAND             , GenTreeOp          ,0,1,GTK_BINOP)
 GTNODE(XORR             , GenTreeOp          ,0,1,GTK_BINOP)
 GTNODE(XADD             , GenTreeOp          ,0,1,GTK_BINOP)
 GTNODE(XCHG             , GenTreeOp          ,0,1,GTK_BINOP)
-GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,1,GTK_SPECIAL)
+GTNODE(CMPXCHG          , GenTreeCmpXchg     ,0,1,GTK_SPECIAL)            // atomic CAS, small types need the comparand to be zero extended
 
 GTNODE(IND              , GenTreeIndir       ,0,1,GTK_UNOP)                                 // Load indirection
 GTNODE(STOREIND         , GenTreeStoreInd    ,0,1,GTK_BINOP|GTK_EXOP|GTK_NOVALUE|GTK_STORE) // Store indirection

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3464,7 +3464,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 assert(callType != TYP_STRUCT);
                 assert(sig->numArgs == 3);
 
-                GenTree* op3 = impPopStack().val; // comparand
+                GenTree* op3 = gtNewCastNode(genActualType(callType), impPopStack().val, /* uns */ false, varTypeToUnsigned(callType)); // comparand
                 GenTree* op2 = impPopStack().val; // value
                 GenTree* op1 = impPopStack().val; // location
                 retNode      = gtNewAtomicNode(GT_CMPXCHG, callType, op1, op2, op3);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3464,7 +3464,13 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 assert(callType != TYP_STRUCT);
                 assert(sig->numArgs == 3);
 
-                GenTree* op3 = gtNewCastNode(genActualType(callType), impPopStack().val, /* uns */ false, varTypeToUnsigned(callType)); // comparand
+                // comparand
+                GenTree* op3 = impPopStack().val;
+                if (varTypeIsSmall(callType))
+                {
+                    // small types need the comparand to have its upper bits zeroed
+                    op3 = gtNewCastNode(genActualType(callType), op3, /* uns */ false, varTypeToUnsigned(callType));
+                }
                 GenTree* op2 = impPopStack().val; // value
                 GenTree* op1 = impPopStack().val; // location
                 retNode      = gtNewAtomicNode(GT_CMPXCHG, callType, op1, op2, op3);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3464,8 +3464,7 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                 assert(callType != TYP_STRUCT);
                 assert(sig->numArgs == 3);
 
-                // comparand
-                GenTree* op3 = impPopStack().val;
+                GenTree* op3 = impPopStack().val; // comparand
                 if (varTypeIsSmall(callType))
                 {
                     // small types need the comparand to have its upper bits zeroed


### PR DESCRIPTION
Better fix for #97839.