### PR TITLE
[NativeAOT/ARM] Initialize R12 pointer from context in StackFrameIterator

### DIFF
--- a/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
+++ b/src/coreclr/nativeaot/Runtime/StackFrameIterator.cpp
@@ -186,7 +186,6 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, PInvokeTransitionF
 
 #ifdef TARGET_ARM
     m_RegDisplay.pLR = (PTR_UIntNative)PTR_HOST_MEMBER(PInvokeTransitionFrame, pFrame, m_RIP);
-    m_RegDisplay.pR11 = (PTR_UIntNative)PTR_HOST_MEMBER(PInvokeTransitionFrame, pFrame, m_ChainPointer);
 
     if (pFrame->m_Flags & PTFF_SAVE_R4)  { m_RegDisplay.pR4 = pPreservedRegsCursor++; }
     if (pFrame->m_Flags & PTFF_SAVE_R5)  { m_RegDisplay.pR5 = pPreservedRegsCursor++; }
@@ -632,6 +631,7 @@ void StackFrameIterator::InternalInit(Thread * pThreadToWalk, NATIVE_CONTEXT* pC
     m_RegDisplay.pR9 = (PTR_UIntNative)PTR_TO_REG(pCtx, R9);
     m_RegDisplay.pR10 = (PTR_UIntNative)PTR_TO_REG(pCtx, R10);
     m_RegDisplay.pR11 = (PTR_UIntNative)PTR_TO_REG(pCtx, R11);
+    m_RegDisplay.pR12 = (PTR_UIntNative)PTR_TO_REG(pCtx, R12);
     m_RegDisplay.pLR = (PTR_UIntNative)PTR_TO_REG(pCtx, Lr);
 #else
     PORTABILITY_ASSERT("StackFrameIterator::InternalInit");

--- a/src/coreclr/nativeaot/Runtime/unix/UnixContext.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixContext.cpp
@@ -266,6 +266,7 @@
 #define MCREG_R9(mc)        ((mc).arm_r9)
 #define MCREG_R10(mc)       ((mc).arm_r10)
 #define MCREG_R11(mc)       ((mc).arm_fp)
+#define MCREG_R12(mc)       ((mc).arm_ip)
 
 #elif defined(HOST_X86)
 
@@ -526,6 +527,7 @@ uint64_t GetPC(void* context)
     uint64_t& UNIX_CONTEXT::R9(){ return (uint64_t&)MCREG_R9(ctx.uc_mcontext); }
     uint64_t& UNIX_CONTEXT::R10(){ return (uint64_t&)MCREG_R10(ctx.uc_mcontext); }
     uint64_t& UNIX_CONTEXT::R11(){ return (uint64_t&)MCREG_R11(ctx.uc_mcontext); }
+    uint64_t& UNIX_CONTEXT::R12(){ return (uint64_t&)MCREG_R12(ctx.uc_mcontext); }
 
 #else
     PORTABILITY_ASSERT("UNIX_CONTEXT");

--- a/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixContext.h
@@ -136,6 +136,7 @@ struct UNIX_CONTEXT
     uint64_t& R9();
     uint64_t& R10();
     uint64_t& R11();
+    uint64_t& R12();
 
     uintptr_t GetIp() { return (uintptr_t)Pc(); }
     uintptr_t GetSp() { return (uintptr_t)Sp(); }
@@ -155,6 +156,7 @@ struct UNIX_CONTEXT
         lambda((size_t*)&R9());
         lambda((size_t*)&R10());
         lambda((size_t*)&R11());
+        lambda((size_t*)&R12());
     }
 #else
     PORTABILITY_ASSERT("UNIX_CONTEXT");


### PR DESCRIPTION
Fixes remaining failure in NativeAOT smoke tests in Release configuration.

Contributes to #97729