### PR TITLE
IL test entry points should be in types so test discovery can occur.

### DIFF
--- a/src/tests/JIT/Directed/IL/PInvokeTail/PInvokeTail.il
+++ b/src/tests/JIT/Directed/IL/PInvokeTail/PInvokeTail.il
@@ -49,46 +49,50 @@
     ret
 } // end of global method 'callputs2'
 
-.method public static int32 main() il managed
+.class public auto ansi abstract sealed beforefieldinit PInvokeTail
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
-    .maxstack 4
-    .locals init (char& pinned)
+  .method public static int32 main() il managed
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
+      .maxstack 4
+      .locals init (char& pinned)
 
-    ldstr bytearray(48 65 6C 6C 6F 20 57 6F 72 6C 64 21 00 00 00 00) // "Hello World!"
-    call instance char& modreq([mscorlib]System.Runtime.InteropServices.InAttribute) [mscorlib]System.String::GetPinnableReference()
-    stloc.0
+      ldstr bytearray(48 65 6C 6C 6F 20 57 6F 72 6C 64 21 00 00 00 00) // "Hello World!"
+      call instance char& modreq([mscorlib]System.Runtime.InteropServices.InAttribute) [mscorlib]System.String::GetPinnableReference()
+      stloc.0
 
-    ldloc.0
-    call        int32 callputs1(char&)
-    ldc.i4      0x0
-    bge         PASS_1
+      ldloc.0
+      call        int32 callputs1(char&)
+      ldc.i4      0x0
+      bge         PASS_1
 
-    call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-    ldstr       "puts() failed"
-    callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-    ldc.i4      0x1
-    ret
+      call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+      ldstr       "puts() failed"
+      callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+      ldc.i4      0x1
+      ret
 
-    PASS_1:
-    ldloc.0
-    call        int32 callputs2(char&)
-    ldc.i4      0x0
-    bge         PASS_2
+      PASS_1:
+      ldloc.0
+      call        int32 callputs2(char&)
+      ldc.i4      0x0
+      bge         PASS_2
 
-    call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-    ldstr       "puts() failed"
-    callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-    ldc.i4      0x1
-    ret
+      call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+      ldstr       "puts() failed"
+      callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+      ldc.i4      0x1
+      ret
 
-    PASS_2:
-    call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-    ldstr       "Passed"
-    callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
-    ldc.i4      0x64
-    ret
-} // end of global method 'main'
+      PASS_2:
+      call        class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+      ldstr       "Passed"
+      callvirt    instance void [mscorlib]System.IO.TextWriter::WriteLine(string)
+      ldc.i4      0x64
+      ret
+  } // end of global method 'main'
+}

--- a/src/tests/JIT/Directed/IL/PInvokeTail/tailwinapi.il
+++ b/src/tests/JIT/Directed/IL/PInvokeTail/tailwinapi.il
@@ -98,102 +98,107 @@
 
 //Global methods
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.method public static int32 main() il managed
+
+.class public auto ansi abstract sealed beforefieldinit TailWinApi
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  // Method begins at RVA 0x10c0
-  // Code size       241 (0xf1)
-  .maxstack  3
-  .locals (class [mscorlib]System.Text.StringBuilder V_0,
-           int32 V_1,
-           class TailWin32 V_2,
-           int32 V_3)
+  .method public static int32 main() il managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    // Method begins at RVA 0x10c0
+    // Code size       241 (0xf1)
+    .maxstack  3
+    .locals (class [mscorlib]System.Text.StringBuilder V_0,
+            int32 V_1,
+            class TailWin32 V_2,
+            int32 V_3)
 
-  IL_0000:  ldc.i4     0x100
-  IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
-  IL_000a:  stloc.0
-  IL_000b:  ldc.i4     0x1
-  IL_0010:  stloc.1
-  IL_0011:  newobj     instance void TailWin32::.ctor()
-  IL_0016:  stloc.2
-  IL_0017:  ldloc.0
-  IL_0018:  ldc.i4     0x100
-  IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0022:  stloc.3
-  IL_0023:  ldloc.0
-  IL_0024:  castclass  [mscorlib]System.Object
-  IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_002e:  ldloc.3
-  IL_002f:  ldc.i4     0x0
-  IL_0034:  bne.un     IL_004e
+    IL_0000:  ldc.i4     0x100
+    IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
+    IL_000a:  stloc.0
+    IL_000b:  ldc.i4     0x1
+    IL_0010:  stloc.1
+    IL_0011:  newobj     instance void TailWin32::.ctor()
+    IL_0016:  stloc.2
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4     0x100
+    IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0022:  stloc.3
+    IL_0023:  ldloc.0
+    IL_0024:  castclass  [mscorlib]System.Object
+    IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_002e:  ldloc.3
+    IL_002f:  ldc.i4     0x0
+    IL_0034:  bne.un     IL_004e
 
-  IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
-  IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0048:  ldc.i4     0x0
-  IL_004d:  stloc.1
-  IL_004e:  ldloc.2
-  IL_004f:  ldloc.0
-  IL_0050:  ldc.i4     0x100
-  IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_005a:  stloc.3
-  IL_005b:  ldloc.0
-  IL_005c:  castclass  [mscorlib]System.Object
-  IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_0066:  ldloc.3
-  IL_0067:  ldc.i4     0x0
-  IL_006c:  bne.un     IL_0086
+    IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
+    IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0048:  ldc.i4     0x0
+    IL_004d:  stloc.1
+    IL_004e:  ldloc.2
+    IL_004f:  ldloc.0
+    IL_0050:  ldc.i4     0x100
+    IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_005a:  stloc.3
+    IL_005b:  ldloc.0
+    IL_005c:  castclass  [mscorlib]System.Object
+    IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_0066:  ldloc.3
+    IL_0067:  ldc.i4     0x0
+    IL_006c:  bne.un     IL_0086
 
-  IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
-  IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0080:  ldc.i4     0x0
-  IL_0085:  stloc.1
-  IL_0086:  ldloc.0
-  IL_0087:  ldc.i4     0x100
-  IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0091:  stloc.3
-  IL_0092:  ldloc.0
-  IL_0093:  castclass  [mscorlib]System.Object
-  IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_009d:  ldloc.3
-  IL_009e:  ldc.i4     0x0
-  IL_00a3:  bne.un     IL_00bc
+    IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
+    IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0080:  ldc.i4     0x0
+    IL_0085:  stloc.1
+    IL_0086:  ldloc.0
+    IL_0087:  ldc.i4     0x100
+    IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0091:  stloc.3
+    IL_0092:  ldloc.0
+    IL_0093:  castclass  [mscorlib]System.Object
+    IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_009d:  ldloc.3
+    IL_009e:  ldc.i4     0x0
+    IL_00a3:  bne.un     IL_00bc
 
-  IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
-  IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00b7:  br         IL_00dc
+    IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
+    IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00b7:  br         IL_00dc
 
-  IL_00bc:  ldloc.1
-  IL_00bd:  ldc.i4     0x0
-  IL_00c2:  beq        IL_00dc
+    IL_00bc:  ldloc.1
+    IL_00bd:  ldc.i4     0x0
+    IL_00c2:  beq        IL_00dc
 
-  IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
-  IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00d6:  ldc.i4     0x64
-  IL_00db:  ret
+    IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
+    IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00d6:  ldc.i4     0x64
+    IL_00db:  ret
 
-  IL_00dc:  ldstr "failed"//ldptr      D_00003100
-  IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00eb:  ldc.i4     0x1
-  IL_00f0:  ret
-} // end of global method 'main'
+    IL_00dc:  ldstr "failed"//ldptr      D_00003100
+    IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00eb:  ldc.i4     0x1
+    IL_00f0:  ret
+  } // end of global method 'main'
 
-.method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
-{
-  // Method begins at RVA 0x11c0
-  // Code size       6 (0x6)
-  .maxstack  1
+  .method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
+  {
+    // Method begins at RVA 0x11c0
+    // Code size       6 (0x6)
+    .maxstack  1
 
-  IL_0000:  call       int32 main()
-  IL_0005:  ret
-} // end of global method '_mainMSIL'
+    IL_0000:  call       int32 main()
+    IL_0005:  ret
+  } // end of global method '_mainMSIL'
+}
 
 .data D_00003000 = bytearray (
                  43 00 61 00 6C 00 6C 00 20 00 61 00 6E 00 73 00  // C.a.l.l. .a.n.s.
@@ -215,7 +220,7 @@
                  61 00 69 00 6C 00 65 00 64 00 00 00)             // a.i.l.e.d...
 .data D_000030EC = bytearray (
                  50 00 61 00 73 00 73 00 65 00 64 00 21 00 21 00  // P.a.s.s.e.d.!.!.
-                 00 00 00 00) 
+                 00 00 00 00)
 .data D_00003100 = bytearray (
                  46 00 61 00 69 00 6C 00 65 00 64 00 21 00 21 00  // F.a.i.l.e.d.!.!.
-                 00 00) 
+                 00 00)

--- a/src/tests/JIT/Directed/IL/PInvokeTail/tailwinapi.il
+++ b/src/tests/JIT/Directed/IL/PInvokeTail/tailwinapi.il
@@ -195,7 +195,7 @@
     // Code size       6 (0x6)
     .maxstack  1
 
-    IL_0000:  call       int32 main()
+    IL_0000:  call       int32 TailWinApi::main()
     IL_0005:  ret
   } // end of global method '_mainMSIL'
 }

--- a/src/tests/JIT/Directed/coverage/oldtests/Desktop/callipinvoke.il
+++ b/src/tests/JIT/Directed/coverage/oldtests/Desktop/callipinvoke.il
@@ -103,100 +103,103 @@
 
 //Global methods
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.method public static int32 main() il managed
+.class public auto ansi abstract sealed beforefieldinit callipinvoke2
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  // Method begins at RVA 0x10c0
-  // Code size       241 (0xf1)
-  .maxstack  3
-  .locals init (class [mscorlib]System.Text.StringBuilder V_0,
-           int32 V_1,
-           class TailWin32 V_2,
-           int32 V_3)
+  .method public static int32 main() il managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    // Method begins at RVA 0x10c0
+    // Code size       241 (0xf1)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Text.StringBuilder V_0,
+            int32 V_1,
+            class TailWin32 V_2,
+            int32 V_3)
 
-  IL_0000:  ldc.i4     0x100
-  IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
-  IL_000a:  stloc.0
-  IL_000b:  ldc.i4     0x1
-  IL_0010:  stloc.1
-  IL_0011:  newobj     instance void TailWin32::.ctor()
-  IL_0016:  stloc.2
-  IL_0017:  ldloc.0
-  IL_0018:  ldc.i4     0x100
-  IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0022:  stloc.3
-  IL_0023:  ldloc.0
-  IL_0024:  castclass  [mscorlib]System.Object
-  IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_002e:  ldloc.3
-  IL_002f:  ldc.i4     0x0
-  IL_0034:  bne.un     IL_004e
+    IL_0000:  ldc.i4     0x100
+    IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
+    IL_000a:  stloc.0
+    IL_000b:  ldc.i4     0x1
+    IL_0010:  stloc.1
+    IL_0011:  newobj     instance void TailWin32::.ctor()
+    IL_0016:  stloc.2
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4     0x100
+    IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0022:  stloc.3
+    IL_0023:  ldloc.0
+    IL_0024:  castclass  [mscorlib]System.Object
+    IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_002e:  ldloc.3
+    IL_002f:  ldc.i4     0x0
+    IL_0034:  bne.un     IL_004e
 
-  IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
-  IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0048:  ldc.i4     0x0
-  IL_004d:  stloc.1
-  IL_004e:  ldloc.2
-  IL_004f:  ldloc.0
-  IL_0050:  ldc.i4     0x100
-  IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_005a:  stloc.3
-  IL_005b:  ldloc.0
-  IL_005c:  castclass  [mscorlib]System.Object
-  IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_0066:  ldloc.3
-  IL_0067:  ldc.i4     0x0
-  IL_006c:  bne.un     IL_0086
+    IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
+    IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0048:  ldc.i4     0x0
+    IL_004d:  stloc.1
+    IL_004e:  ldloc.2
+    IL_004f:  ldloc.0
+    IL_0050:  ldc.i4     0x100
+    IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_005a:  stloc.3
+    IL_005b:  ldloc.0
+    IL_005c:  castclass  [mscorlib]System.Object
+    IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_0066:  ldloc.3
+    IL_0067:  ldc.i4     0x0
+    IL_006c:  bne.un     IL_0086
 
-  IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
-  IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0080:  ldc.i4     0x0
-  IL_0085:  stloc.1
-  IL_0086:  ldloc.0
-  IL_0087:  ldc.i4     0x100
-  IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0091:  stloc.3
-  IL_0092:  ldloc.0
-  IL_0093:  castclass  [mscorlib]System.Object
-  IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_009d:  ldloc.3
-  IL_009e:  ldc.i4     0x0
-  IL_00a3:  bne.un     IL_00bc
+    IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
+    IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0080:  ldc.i4     0x0
+    IL_0085:  stloc.1
+    IL_0086:  ldloc.0
+    IL_0087:  ldc.i4     0x100
+    IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0091:  stloc.3
+    IL_0092:  ldloc.0
+    IL_0093:  castclass  [mscorlib]System.Object
+    IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_009d:  ldloc.3
+    IL_009e:  ldc.i4     0x0
+    IL_00a3:  bne.un     IL_00bc
 
-  IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
-  IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00b7:  br         IL_00dc
+    IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
+    IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00b7:  br         IL_00dc
 
-  IL_00bc:  ldloc.1
-  IL_00bd:  ldc.i4     0x0
-  IL_00c2:  beq        IL_00dc
+    IL_00bc:  ldloc.1
+    IL_00bd:  ldc.i4     0x0
+    IL_00c2:  beq        IL_00dc
 
-  IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
-  IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00d6:  ldc.i4     100
-  IL_00db:  ret
+    IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
+    IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00d6:  ldc.i4     100
+    IL_00db:  ret
 
-  IL_00dc:  ldstr "failed"//ldptr      D_00003100
-  IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00eb:  ldc.i4     1
-  IL_00f0:  ret
-} // end of global method 'main'
+    IL_00dc:  ldstr "failed"//ldptr      D_00003100
+    IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00eb:  ldc.i4     1
+    IL_00f0:  ret
+  } // end of global method 'main'
 
-.method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
-{
-  // Method begins at RVA 0x11c0
-  // Code size       6 (0x6)
-  .maxstack  1
+  .method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
+  {
+    // Method begins at RVA 0x11c0
+    // Code size       6 (0x6)
+    .maxstack  1
 
-  IL_0000:  call       int32 main()
-  IL_0005:  ret
-} // end of global method '_mainMSIL'
-
+    IL_0000:  call       int32 main()
+    IL_0005:  ret
+  } // end of global method '_mainMSIL'
+}

--- a/src/tests/JIT/Directed/coverage/oldtests/Desktop/callipinvoke.il
+++ b/src/tests/JIT/Directed/coverage/oldtests/Desktop/callipinvoke.il
@@ -199,7 +199,7 @@
     // Code size       6 (0x6)
     .maxstack  1
 
-    IL_0000:  call       int32 main()
+    IL_0000:  call       int32 callipinvoke2::main()
     IL_0005:  ret
   } // end of global method '_mainMSIL'
 }

--- a/src/tests/JIT/Directed/coverage/oldtests/callipinvoke.il
+++ b/src/tests/JIT/Directed/coverage/oldtests/callipinvoke.il
@@ -101,100 +101,104 @@
 
 //Global methods
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.method public static int32 main() il managed
+.class public auto ansi abstract sealed beforefieldinit callipinvoke
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  // Method begins at RVA 0x10c0
-  // Code size       241 (0xf1)
-  .maxstack  3
-  .locals init (class [mscorlib]System.Text.StringBuilder V_0,
-           int32 V_1,
-           class TailWin32 V_2,
-           int32 V_3)
+  .method public static int32 main() il managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    // Method begins at RVA 0x10c0
+    // Code size       241 (0xf1)
+    .maxstack  3
+    .locals init (class [mscorlib]System.Text.StringBuilder V_0,
+            int32 V_1,
+            class TailWin32 V_2,
+            int32 V_3)
 
-  IL_0000:  ldc.i4     0x100
-  IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
-  IL_000a:  stloc.0
-  IL_000b:  ldc.i4     0x1
-  IL_0010:  stloc.1
-  IL_0011:  newobj     instance void TailWin32::.ctor()
-  IL_0016:  stloc.2
-  IL_0017:  ldloc.0
-  IL_0018:  ldc.i4     0x100
-  IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0022:  stloc.3
-  IL_0023:  ldloc.0
-  IL_0024:  castclass  [mscorlib]System.Object
-  IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_002e:  ldloc.3
-  IL_002f:  ldc.i4     0x0
-  IL_0034:  bne.un     IL_004e
+    IL_0000:  ldc.i4     0x100
+    IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
+    IL_000a:  stloc.0
+    IL_000b:  ldc.i4     0x1
+    IL_0010:  stloc.1
+    IL_0011:  newobj     instance void TailWin32::.ctor()
+    IL_0016:  stloc.2
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4     0x100
+    IL_001d:  call       unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0022:  stloc.3
+    IL_0023:  ldloc.0
+    IL_0024:  castclass  [mscorlib]System.Object
+    IL_0029:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_002e:  ldloc.3
+    IL_002f:  ldc.i4     0x0
+    IL_0034:  bne.un     IL_004e
 
-  IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
-  IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0048:  ldc.i4     0x0
-  IL_004d:  stloc.1
-  IL_004e:  ldloc.2
-  IL_004f:  ldloc.0
-  IL_0050:  ldc.i4     0x100
-  IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_005a:  stloc.3
-  IL_005b:  ldloc.0
-  IL_005c:  castclass  [mscorlib]System.Object
-  IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_0066:  ldloc.3
-  IL_0067:  ldc.i4     0x0
-  IL_006c:  bne.un     IL_0086
+    IL_0039:  ldstr "Call ansi API failed"//ldptr      D_00003000
+    IL_003e:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_0043:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0048:  ldc.i4     0x0
+    IL_004d:  stloc.1
+    IL_004e:  ldloc.2
+    IL_004f:  ldloc.0
+    IL_0050:  ldc.i4     0x100
+    IL_0055:  call       instance unsigned int32 TailWin32::GetSystemDirectory(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_005a:  stloc.3
+    IL_005b:  ldloc.0
+    IL_005c:  castclass  [mscorlib]System.Object
+    IL_0061:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_0066:  ldloc.3
+    IL_0067:  ldc.i4     0x0
+    IL_006c:  bne.un     IL_0086
 
-  IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
-  IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_0080:  ldc.i4     0x0
-  IL_0085:  stloc.1
-  IL_0086:  ldloc.0
-  IL_0087:  ldc.i4     0x100
-  IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0091:  stloc.3
-  IL_0092:  ldloc.0
-  IL_0093:  castclass  [mscorlib]System.Object
-  IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
-  IL_009d:  ldloc.3
-  IL_009e:  ldc.i4     0x0
-  IL_00a3:  bne.un     IL_00bc
+    IL_0071:  ldstr "Called unicode/ansi based." //ldptr      D_00003030
+    IL_0076:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_007b:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_0080:  ldc.i4     0x0
+    IL_0085:  stloc.1
+    IL_0086:  ldloc.0
+    IL_0087:  ldc.i4     0x100
+    IL_008c:  call       unsigned int32 TailWin32::GetSystemDirectoryAuto(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0091:  stloc.3
+    IL_0092:  ldloc.0
+    IL_0093:  castclass  [mscorlib]System.Object
+    IL_0098:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+    IL_009d:  ldloc.3
+    IL_009e:  ldc.i4     0x0
+    IL_00a3:  bne.un     IL_00bc
 
-  IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
-  IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00b7:  br         IL_00dc
+    IL_00a8:  ldstr "Call unicode/ansi" //ldptr      D_000030A0
+    IL_00ad:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00b2:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00b7:  br         IL_00dc
 
-  IL_00bc:  ldloc.1
-  IL_00bd:  ldc.i4     0x0
-  IL_00c2:  beq        IL_00dc
+    IL_00bc:  ldloc.1
+    IL_00bd:  ldc.i4     0x0
+    IL_00c2:  beq        IL_00dc
 
-  IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
-  IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00d6:  ldc.i4     100
-  IL_00db:  ret
+    IL_00c7:  ldstr "Passed" //ldptr      D_000030EC
+    IL_00cc:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00d1:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00d6:  ldc.i4     100
+    IL_00db:  ret
 
-  IL_00dc:  ldstr "failed"//ldptr      D_00003100
-  IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
-  IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
-  IL_00eb:  ldc.i4     1
-  IL_00f0:  ret
-} // end of global method 'main'
+    IL_00dc:  ldstr "failed"//ldptr      D_00003100
+    IL_00e1:  //newobj     instance void [mscorlib]System.String::.ctor(wchar*)
+    IL_00e6:  call       void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_00eb:  ldc.i4     1
+    IL_00f0:  ret
+  } // end of global method 'main'
 
-.method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
-{
-  // Method begins at RVA 0x11c0
-  // Code size       6 (0x6)
-  .maxstack  1
+  .method public static int32 _mainMSIL(int32 argc,int8** argv,int8** envp) il managed
+  {
+    // Method begins at RVA 0x11c0
+    // Code size       6 (0x6)
+    .maxstack  1
 
-  IL_0000:  call       int32 main()
-  IL_0005:  ret
-} // end of global method '_mainMSIL'
+    IL_0000:  call       int32 main()
+    IL_0005:  ret
+  } // end of global method '_mainMSIL'
+}
 

--- a/src/tests/JIT/Directed/coverage/oldtests/callipinvoke.il
+++ b/src/tests/JIT/Directed/coverage/oldtests/callipinvoke.il
@@ -197,7 +197,7 @@
     // Code size       6 (0x6)
     .maxstack  1
 
-    IL_0000:  call       int32 main()
+    IL_0000:  call       int32 callipinvoke::main()
     IL_0005:  ret
   } // end of global method '_mainMSIL'
 }

--- a/src/tests/JIT/Directed/tls/MutualRecurThd-TLS.il
+++ b/src/tests/JIT/Directed/tls/MutualRecurThd-TLS.il
@@ -3241,77 +3241,81 @@ stsfld	int32 Thread_EA::TLSFieldData
   IL_003d:  ret
 }
 
-.method public static int32 main() il managed
+.class public auto ansi abstract sealed beforefieldinit mutualrecurthd
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .maxstack  4
-  .locals (class [System.Threading.Thread]System.Threading.Thread[] thrd,
-           class Thread_EA ThdObj,
-           int32 V_2)
+  .method public static int32 main() il managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .maxstack  4
+    .locals (class [System.Threading.Thread]System.Threading.Thread[] thrd,
+            class Thread_EA ThdObj,
+            int32 V_2)
 
-    call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-call       class [mscorlib]System.IO.TextWriter [mscorlib]System.IO.TextWriter::Synchronized(class [mscorlib]System.IO.TextWriter)
-call       void [System.Console]System.Console::SetOut(class [mscorlib]System.IO.TextWriter)
+      call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+  call       class [mscorlib]System.IO.TextWriter [mscorlib]System.IO.TextWriter::Synchronized(class [mscorlib]System.IO.TextWriter)
+  call       void [System.Console]System.Console::SetOut(class [mscorlib]System.IO.TextWriter)
 
-  IL_0000:  ldc.i4     0xa
-  IL_0005:  newarr     [System.Threading.Thread]System.Threading.Thread
-  IL_000a:  stloc.0
-  IL_000b:  newobj     instance void Thread_EA::.ctor()
-  IL_0010:  stloc.1
-  IL_0011: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-  IL_0016:  ldstr "test started"
-  IL_001b:
-  IL_0020:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
-  IL_0025:  ldc.i4     0x0
-  IL_002a:  stloc.2
-  IL_002b:  br         IL_0038
+    IL_0000:  ldc.i4     0xa
+    IL_0005:  newarr     [System.Threading.Thread]System.Threading.Thread
+    IL_000a:  stloc.0
+    IL_000b:  newobj     instance void Thread_EA::.ctor()
+    IL_0010:  stloc.1
+    IL_0011: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+    IL_0016:  ldstr "test started"
+    IL_001b:
+    IL_0020:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
+    IL_0025:  ldc.i4     0x0
+    IL_002a:  stloc.2
+    IL_002b:  br         IL_0038
 
-  IL_0030:  ldloc.2
-  IL_0031:  ldc.i4     0x1
-  IL_0036:  add
-  IL_0037:  stloc.2
-  IL_0038:  ldloc.2
-  IL_0039:  ldc.i4     0xa
-  IL_003e:  bge        IL_0064
+    IL_0030:  ldloc.2
+    IL_0031:  ldc.i4     0x1
+    IL_0036:  add
+    IL_0037:  stloc.2
+    IL_0038:  ldloc.2
+    IL_0039:  ldc.i4     0xa
+    IL_003e:  bge        IL_0064
 
-  IL_0043:  ldloc.0
-  IL_0044:  ldloc.2
-  IL_0045:  ldloc.1
-  IL_0046:  ldftn      instance void Thread_EA::Run()
-  IL_004c:  newobj     instance void [System.Threading.Thread]System.Threading.ThreadStart::.ctor(class [mscorlib]System.Object,native int)
-  IL_0051:  newobj     instance void [System.Threading.Thread]System.Threading.Thread::.ctor(class [System.Threading.Thread]System.Threading.ThreadStart)
-  IL_0056:  stelem.ref
-  IL_0057:  ldloc.0
-  IL_0058:  ldloc.2
-  IL_0059:  ldelem.ref
-  IL_005a:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Start()
-  IL_005f:  br         IL_0030
+    IL_0043:  ldloc.0
+    IL_0044:  ldloc.2
+    IL_0045:  ldloc.1
+    IL_0046:  ldftn      instance void Thread_EA::Run()
+    IL_004c:  newobj     instance void [System.Threading.Thread]System.Threading.ThreadStart::.ctor(class [mscorlib]System.Object,native int)
+    IL_0051:  newobj     instance void [System.Threading.Thread]System.Threading.Thread::.ctor(class [System.Threading.Thread]System.Threading.ThreadStart)
+    IL_0056:  stelem.ref
+    IL_0057:  ldloc.0
+    IL_0058:  ldloc.2
+    IL_0059:  ldelem.ref
+    IL_005a:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Start()
+    IL_005f:  br         IL_0030
 
-  IL_0064:  ldc.i4     0x0
-  IL_0069:  stloc.2
-  IL_006a:  br         IL_0077
+    IL_0064:  ldc.i4     0x0
+    IL_0069:  stloc.2
+    IL_006a:  br         IL_0077
 
-  IL_006f:  ldloc.2
-  IL_0070:  ldc.i4     0x1
-  IL_0075:  add
-  IL_0076:  stloc.2
-  IL_0077:  ldloc.2
-  IL_0078:  ldc.i4     0xa
-  IL_007d:  bge        IL_008f
+    IL_006f:  ldloc.2
+    IL_0070:  ldc.i4     0x1
+    IL_0075:  add
+    IL_0076:  stloc.2
+    IL_0077:  ldloc.2
+    IL_0078:  ldc.i4     0xa
+    IL_007d:  bge        IL_008f
 
-  IL_0082:  ldloc.0
-  IL_0083:  ldloc.2
-  IL_0084:  ldelem.ref
-  IL_0085:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Join()
-  IL_008a:  br         IL_006f
+    IL_0082:  ldloc.0
+    IL_0083:  ldloc.2
+    IL_0084:  ldelem.ref
+    IL_0085:  callvirt   instance void [System.Threading.Thread]System.Threading.Thread::Join()
+    IL_008a:  br         IL_006f
 
-  IL_008f: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
-  IL_0094:  ldstr "Mututalrecurthd test passed"
-  IL_0099:
-  IL_009e:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
-  IL_00a3:  ldc.i4     0x64
-  IL_00a8:  ret
+    IL_008f: 	call	    class [mscorlib]System.IO.TextWriter [System.Console]System.Console::get_Out()
+    IL_0094:  ldstr "Mututalrecurthd test passed"
+    IL_0099:
+    IL_009e:  callvirt   instance void [mscorlib]System.IO.TextWriter::WriteLine(class [mscorlib]System.String)
+    IL_00a3:  ldc.i4     0x64
+    IL_00a8:  ret
+  }
 }

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.il
@@ -11,11 +11,11 @@
 .assembly 'b28901'
 {
 }
-.class public auto ansi Win32 
+.class public auto ansi Win32
 {
   .method public family static pinvokeimpl("kernel32.dll" ansi winapi) unsigned int32 GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder lpText,unsigned int32 uSize) il managed preservesig
   { }
-  .method public specialname rtspecialname instance void .ctor() il managed 
+  .method public specialname rtspecialname instance void .ctor() il managed
   {
     .maxstack  1
     IL_0000:  ldarg.0
@@ -24,9 +24,9 @@
   } // end of method 'Win32::.ctor'
 } // end of class 'Win32'
 
-.class public auto ansi TailWin32 extends Win32 
+.class public auto ansi TailWin32 extends Win32
 {
-  .method public static vararg unsigned int32 GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder lpText,unsigned int32 uSize) il managed 
+  .method public static vararg unsigned int32 GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder lpText,unsigned int32 uSize) il managed
   {
     .maxstack  2
     IL_0000:  ldarg.0
@@ -38,43 +38,47 @@
 
 //Global methods
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.method public static int32 main() il managed 
+.class public auto ansi abstract sealed beforefieldinit b28901
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .maxstack  3
-  .locals init (class [mscorlib]System.Text.StringBuilder V_0,
-           int32 V_1,
-           class TailWin32 V_2,
-           int32 V_3)
+  .method public static int32 main() il managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .maxstack  3
+    .locals init (class [mscorlib]System.Text.StringBuilder V_0,
+            int32 V_1,
+            class TailWin32 V_2,
+            int32 V_3)
 
-  IL_0000:  ldc.i4     0x100
-  IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
-  IL_000a:  stloc.0
-  
-  IL_000b:  ldc.i4     0x1
-  IL_0010:  stloc.1
-  
-  IL_0017:  ldloc.0
-  IL_0018:  ldc.i4     0x100
-  IL_001d:  call vararg unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
-  IL_0022:  stloc.3
-  
-    IL_00bc:  ldloc.1
-  IL_00bd:  ldc.i4     0x0
-  IL_00c2:  beq        IL_00dc
+    IL_0000:  ldc.i4     0x100
+    IL_0005:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
+    IL_000a:  stloc.0
 
-  IL_00c7:  ldstr      "Passed"
-  IL_00d1:  call void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+    IL_000b:  ldc.i4     0x1
+    IL_0010:  stloc.1
 
-  IL_00d6:  ldc.i4     100
-  IL_00db:  ret
+    IL_0017:  ldloc.0
+    IL_0018:  ldc.i4     0x100
+    IL_001d:  call vararg unsigned int32 TailWin32::GetSystemDirectoryA(class [mscorlib]System.Text.StringBuilder,unsigned int32)
+    IL_0022:  stloc.3
 
-  IL_00dc:  ldstr      "Failed"
-  IL_00e6:  call void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+      IL_00bc:  ldloc.1
+    IL_00bd:  ldc.i4     0x0
+    IL_00c2:  beq        IL_00dc
 
-  IL_00eb:  ldc.i4     0x1
-  IL_00f0:  ret
-} // end of global method 'main'
+    IL_00c7:  ldstr      "Passed"
+    IL_00d1:  call void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+
+    IL_00d6:  ldc.i4     100
+    IL_00db:  ret
+
+    IL_00dc:  ldstr      "Failed"
+    IL_00e6:  call void [System.Console]System.Console::WriteLine(class [mscorlib]System.String)
+
+    IL_00eb:  ldc.i4     0x1
+    IL_00f0:  ret
+  } // end of global method 'main'
+}

--- a/src/tests/Loader/classloader/Casting/castclasspointer.il
+++ b/src/tests/Loader/classloader/Casting/castclasspointer.il
@@ -42,40 +42,44 @@ OK:
   ret
 }
 
-.method public static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit castclasspointer
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-
-  ldnull
-  castclass void*
-  pop
-
-  newobj instance void [mscorlib]System.Object::.ctor()
-  isinst void*
-  brtrue BAD
-
-  .try
+  .method public static int32 Main()
   {
-    newobj instance void [mscorlib]System.Object::.ctor()
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+
+    ldnull
     castclass void*
     pop
-    leave BAD
+
+    newobj instance void [mscorlib]System.Object::.ctor()
+    isinst void*
+    brtrue BAD
+
+    .try
+    {
+      newobj instance void [mscorlib]System.Object::.ctor()
+      castclass void*
+      pop
+      leave BAD
+    }
+    catch [mscorlib]System.InvalidCastException
+    {
+      pop
+      leave OK
+    }
+
+  BAD:
+    ldc.i4 1
+    ret
+
+  OK:
+
+    call int32 Main<valuetype MyGen`1<object>>()
+    ret
   }
-  catch [mscorlib]System.InvalidCastException
-  {
-    pop
-    leave OK
-  }
-
-BAD:
-  ldc.i4 1
-  ret
-
-OK:
-
-  call int32 Main<valuetype MyGen`1<object>>()
-  ret
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2.il
@@ -81,75 +81,79 @@
   ret
 }
 
-.method public hidebysig static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit constrained2
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+  .method public hidebysig static int32 Main()
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
 
-    .locals init (
-      valuetype Adder`1<object>,
-      int32
-    )
+      .locals init (
+        valuetype Adder`1<object>,
+        int32
+      )
 
-    // This will end up calling the implementation of IAdder<string>.PlusPlus
-    // provided by the Adder valuetype.
-    // The sum returned by the Check method will be 2+4+6+8 = 20.
-    ldloc.0
-    call int32 Check<valuetype Adder`1<object>,string>(!!0)
-    ldc.i4 20
-    ceq
-    brtrue String_OK
-
-    ldc.i4 1
-    ret
-
-String_OK:
-
-    // This will end up calling the implementation of IAdder<object>.PlusPlus
-    // provided by the default interface method.
-    // The sum returned by the Check method will be 1+1+2+4 = 8.
-
-    // This requires a runtime that can generate boxing stubs. We will support
-    // both the case when this is not supported, and when it's implemented.
-    ldc.i4.8
-    stloc.1
-
-    .try
-    {
-      ldloca 0
-      initobj valuetype Adder`1<object>
+      // This will end up calling the implementation of IAdder<string>.PlusPlus
+      // provided by the Adder valuetype.
+      // The sum returned by the Check method will be 2+4+6+8 = 20.
       ldloc.0
-      call int32 Check<valuetype Adder`1<object>,object>(!!0)
+      call int32 Check<valuetype Adder`1<object>,string>(!!0)
+      ldc.i4 20
+      ceq
+      brtrue String_OK
+
+      ldc.i4 1
+      ret
+
+  String_OK:
+
+      // This will end up calling the implementation of IAdder<object>.PlusPlus
+      // provided by the default interface method.
+      // The sum returned by the Check method will be 1+1+2+4 = 8.
+
+      // This requires a runtime that can generate boxing stubs. We will support
+      // both the case when this is not supported, and when it's implemented.
+      ldc.i4.8
       stloc.1
 
-      ldstr "Runtime supports lookups with runtime determined boxing"
+      .try
+      {
+        ldloca 0
+        initobj valuetype Adder`1<object>
+        ldloc.0
+        call int32 Check<valuetype Adder`1<object>,object>(!!0)
+        stloc.1
+
+        ldstr "Runtime supports lookups with runtime determined boxing"
+        call void [mscorlib]System.Console::WriteLine(string)
+
+        leave AfterBoxingCall
+      }
+      catch [mscorlib]System.Exception
+      {
+        pop
+        leave AfterFailedBoxingCall
+      }
+
+  AfterFailedBoxingCall:
+      ldstr "Runtime does not support lookups with runtime determined boxing"
       call void [mscorlib]System.Console::WriteLine(string)
 
-      leave AfterBoxingCall
-    }
-    catch [mscorlib]System.Exception
-    {
-      pop
-      leave AfterFailedBoxingCall
-    }
+  AfterBoxingCall:
+      ldloc.1
+      ldc.i4 8
+      ceq
+      brtrue Object_OK
 
-AfterFailedBoxingCall:
-    ldstr "Runtime does not support lookups with runtime determined boxing"
-    call void [mscorlib]System.Console::WriteLine(string)
+      ldc.i4.2
+      ret
 
-AfterBoxingCall:
-    ldloc.1
-    ldc.i4 8
-    ceq
-    brtrue Object_OK
+  Object_OK:
 
-    ldc.i4.2
-    ret
-
-Object_OK:
-
-    ldc.i4 100
-    ret
+      ldc.i4 100
+      ret
+  }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained2_gm.il
@@ -81,75 +81,79 @@
   ret
 }
 
-.method public hidebysig static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit constrained2_gm
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+  .method public hidebysig static int32 Main()
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
 
-    .locals init (
-      valuetype Adder`1<object>,
-      int32
-    )
+      .locals init (
+        valuetype Adder`1<object>,
+        int32
+      )
 
-    // This will end up calling the implementation of IAdder<string>.PlusPlus
-    // provided by the Adder valuetype.
-    // The sum returned by the Check method will be 2+4+6+8 = 20.
-    ldloc.0
-    call int32 Check<valuetype Adder`1<object>,string>(!!0)
-    ldc.i4 20
-    ceq
-    brtrue String_OK
-
-    ldc.i4 1
-    ret
-
-String_OK:
-
-    // This will end up calling the implementation of IAdder<object>.PlusPlus
-    // provided by the default interface method.
-    // The sum returned by the Check method will be 1+1+2+4 = 8.
-
-    // This requires a runtime that can generate boxing stubs. We will support
-    // both the case when this is not supported, and when it's implemented.
-    ldc.i4.8
-    stloc.1
-
-    .try
-    {
-      ldloca 0
-      initobj valuetype Adder`1<object>
+      // This will end up calling the implementation of IAdder<string>.PlusPlus
+      // provided by the Adder valuetype.
+      // The sum returned by the Check method will be 2+4+6+8 = 20.
       ldloc.0
-      call int32 Check<valuetype Adder`1<object>,object>(!!0)
+      call int32 Check<valuetype Adder`1<object>,string>(!!0)
+      ldc.i4 20
+      ceq
+      brtrue String_OK
+
+      ldc.i4 1
+      ret
+
+  String_OK:
+
+      // This will end up calling the implementation of IAdder<object>.PlusPlus
+      // provided by the default interface method.
+      // The sum returned by the Check method will be 1+1+2+4 = 8.
+
+      // This requires a runtime that can generate boxing stubs. We will support
+      // both the case when this is not supported, and when it's implemented.
+      ldc.i4.8
       stloc.1
 
-      ldstr "Runtime supports lookups with runtime determined boxing"
+      .try
+      {
+        ldloca 0
+        initobj valuetype Adder`1<object>
+        ldloc.0
+        call int32 Check<valuetype Adder`1<object>,object>(!!0)
+        stloc.1
+
+        ldstr "Runtime supports lookups with runtime determined boxing"
+        call void [mscorlib]System.Console::WriteLine(string)
+
+        leave AfterBoxingCall
+      }
+      catch [mscorlib]System.Exception
+      {
+        pop
+        leave AfterFailedBoxingCall
+      }
+
+  AfterFailedBoxingCall:
+      ldstr "Runtime does not support lookups with runtime determined boxing"
       call void [mscorlib]System.Console::WriteLine(string)
 
-      leave AfterBoxingCall
-    }
-    catch [mscorlib]System.Exception
-    {
-      pop
-      leave AfterFailedBoxingCall
-    }
+  AfterBoxingCall:
+      ldloc.1
+      ldc.i4 8
+      ceq
+      brtrue Object_OK
 
-AfterFailedBoxingCall:
-    ldstr "Runtime does not support lookups with runtime determined boxing"
-    call void [mscorlib]System.Console::WriteLine(string)
+      ldc.i4.2
+      ret
 
-AfterBoxingCall:
-    ldloc.1
-    ldc.i4 8
-    ceq
-    brtrue Object_OK
+  Object_OK:
 
-    ldc.i4.2
-    ret
-
-Object_OK:
-
-    ldc.i4 100
-    ret
+      ldc.i4 100
+      ret
+  }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3.il
@@ -45,25 +45,29 @@
 {
 }
 
-.method public hidebysig static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit constrained3
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+  .method public hidebysig static int32 Main()
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
 
-    .locals init (
-      valuetype Adder`1<object, string>
-    )
+      .locals init (
+        valuetype Adder`1<object, string>
+      )
 
-    ldloca.s 0
-    constrained. valuetype Adder`1<object, string>
-    callvirt instance int32 class IFrobber`1<object>::Frob()
+      ldloca.s 0
+      constrained. valuetype Adder`1<object, string>
+      callvirt instance int32 class IFrobber`1<object>::Frob()
 
-    ldloca.s 0
-    constrained. valuetype Adder`1<object, string>
-    callvirt instance int32 class IFrobber`1<string>::Frob()
-    add
+      ldloca.s 0
+      constrained. valuetype Adder`1<object, string>
+      callvirt instance int32 class IFrobber`1<string>::Frob()
+      add
 
-    ret
+      ret
+  }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3_gm.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrained3_gm.il
@@ -45,25 +45,29 @@
 {
 }
 
-.method public hidebysig static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit constrained3_gm
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+  .method public hidebysig static int32 Main()
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
 
-    .locals init (
-      valuetype Adder`1<object, string>
-    )
+      .locals init (
+        valuetype Adder`1<object, string>
+      )
 
-    ldloca.s 0
-    constrained. valuetype Adder`1<object, string>
-    callvirt instance int32 class IFrobber`1<object>::Frob<object>()
+      ldloca.s 0
+      constrained. valuetype Adder`1<object, string>
+      callvirt instance int32 class IFrobber`1<object>::Frob<object>()
 
-    ldloca.s 0
-    constrained. valuetype Adder`1<object, string>
-    callvirt instance int32 class IFrobber`1<string>::Frob<object>()
-    add
+      ldloca.s 0
+      constrained. valuetype Adder`1<object, string>
+      callvirt instance int32 class IFrobber`1<string>::Frob<object>()
+      add
 
-    ret
+      ret
+  }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/constrainedcall/constrainedcall.il
@@ -77,113 +77,117 @@
   ret
 }
 
-.method public hidebysig static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit constrainedcall
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+  .method public hidebysig static int32 Main()
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
 
-    .locals init (
-      valuetype Adder`1<object>,
-      int32,
-      valuetype Adder`1<valuetype Atom>
-    )
+      .locals init (
+        valuetype Adder`1<object>,
+        int32,
+        valuetype Adder`1<valuetype Atom>
+      )
 
-    // This will end up calling the implementation of IAdder<IGen1<object>>.PlusPlus
-    // provided by the Adder valuetype.
-    // The sum returned by the Check method will be 2+4 = 6.
-    ldloc.0
-    call int32 Check<valuetype Adder`1<object>,class IGen1`1<object>>(!!0)
-    ldc.i4.6
-    ceq
-    brtrue IGen1_OK
-
-    ldc.i4.1
-    ret
-
-IGen1_OK:
-
-    // This will end up calling the implementation of IAdder<IGen2<object>>.PlusPlus
-    // provided by the Adder valuetype.
-    // The sum returned by the Check method will be 3+6 = 9.
-    ldloca 0
-    initobj valuetype Adder`1<object>
-    ldloc.0
-    call int32 Check<valuetype Adder`1<object>,class IGen2`1<object>>(!!0)
-    ldc.i4 9
-    ceq
-    brtrue IGen2_OK
-
-    ldc.i4.2
-    ret
-
-IGen2_OK:
-
-    ldstr "Constrained calls that require runtime lookup are OK"
-    call void [mscorlib]System.Console::WriteLine(string)
-
-
-    // Store a successful result in case the implementation throws.
-    // We consider both a throw and a successful dispatch a success.
-    // The throwing behavior is an implementation limitation.
-    // Successful dispatch is what the spec mandates.
-    ldc.i4.2
-    stloc.1
-
-    ldloca 0
-    initobj valuetype Adder`1<object>
-
-    // This will end up calling the default implementation of IAdder<IGen3<object>>.PlusPlus
-    // Since each constrained call in Check is going to box, the sum will end up 1+1 = 2.
-    .try
-    {
+      // This will end up calling the implementation of IAdder<IGen1<object>>.PlusPlus
+      // provided by the Adder valuetype.
+      // The sum returned by the Check method will be 2+4 = 6.
       ldloc.0
-      call int32 Check<valuetype Adder`1<object>,class IGen3`1<object>>(!!0)
-      stloc.1
+      call int32 Check<valuetype Adder`1<object>,class IGen1`1<object>>(!!0)
+      ldc.i4.6
+      ceq
+      brtrue IGen1_OK
 
-      ldstr "Runtime supports lookups with runtime determined boxing"
+      ldc.i4.1
+      ret
+
+  IGen1_OK:
+
+      // This will end up calling the implementation of IAdder<IGen2<object>>.PlusPlus
+      // provided by the Adder valuetype.
+      // The sum returned by the Check method will be 3+6 = 9.
+      ldloca 0
+      initobj valuetype Adder`1<object>
+      ldloc.0
+      call int32 Check<valuetype Adder`1<object>,class IGen2`1<object>>(!!0)
+      ldc.i4 9
+      ceq
+      brtrue IGen2_OK
+
+      ldc.i4.2
+      ret
+
+  IGen2_OK:
+
+      ldstr "Constrained calls that require runtime lookup are OK"
       call void [mscorlib]System.Console::WriteLine(string)
 
-      leave AfterBoxingCall
-    }
-    catch [mscorlib]System.Exception
-    {
-      pop
-      leave AfterFailedBoxingCall
-    }
 
-AfterFailedBoxingCall:
-    ldstr "Runtime does not support lookups with runtime determined boxing"
-    call void [mscorlib]System.Console::WriteLine(string)
+      // Store a successful result in case the implementation throws.
+      // We consider both a throw and a successful dispatch a success.
+      // The throwing behavior is an implementation limitation.
+      // Successful dispatch is what the spec mandates.
+      ldc.i4.2
+      stloc.1
 
-AfterBoxingCall:
-    ldloc.1
-    ldc.i4.2
-    ceq
-    brtrue IGen3_OK
+      ldloca 0
+      initobj valuetype Adder`1<object>
 
-    ldc.i4.3
-    ret
+      // This will end up calling the default implementation of IAdder<IGen3<object>>.PlusPlus
+      // Since each constrained call in Check is going to box, the sum will end up 1+1 = 2.
+      .try
+      {
+        ldloc.0
+        call int32 Check<valuetype Adder`1<object>,class IGen3`1<object>>(!!0)
+        stloc.1
 
-IGen3_OK:
+        ldstr "Runtime supports lookups with runtime determined boxing"
+        call void [mscorlib]System.Console::WriteLine(string)
 
-    ldloca 0
-    initobj valuetype Adder`1<valuetype Atom>
+        leave AfterBoxingCall
+      }
+      catch [mscorlib]System.Exception
+      {
+        pop
+        leave AfterFailedBoxingCall
+      }
 
-    ldloc.0
-    call int32 Check<valuetype Adder`1<valuetype Atom>,valuetype Atom>(!!0)
-    ldc.i4 2
-    ceq
-    brtrue AllOK
+  AfterFailedBoxingCall:
+      ldstr "Runtime does not support lookups with runtime determined boxing"
+      call void [mscorlib]System.Console::WriteLine(string)
 
-    ldc.i4.4
-    ret
+  AfterBoxingCall:
+      ldloc.1
+      ldc.i4.2
+      ceq
+      brtrue IGen3_OK
 
-AllOK:
-    ldstr "Compile time constraint resolution to default interface method OK"
-    call void [mscorlib]System.Console::WriteLine(string)
+      ldc.i4.3
+      ret
 
-    ldc.i4 100
-    ret
+  IGen3_OK:
+
+      ldloca 0
+      initobj valuetype Adder`1<valuetype Atom>
+
+      ldloc.0
+      call int32 Check<valuetype Adder`1<valuetype Atom>,valuetype Atom>(!!0)
+      ldc.i4 2
+      ceq
+      brtrue AllOK
+
+      ldc.i4.4
+      ret
+
+  AllOK:
+      ldstr "Compile time constraint resolution to default interface method OK"
+      call void [mscorlib]System.Console::WriteLine(string)
+
+      ldc.i4 100
+      ret
+  }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/reabstraction/reabstraction.il
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/reabstraction/reabstraction.il
@@ -4,7 +4,7 @@
 
 .assembly extern mscorlib { }
 .assembly extern xunit.core {}
-.assembly extern System.Runtime { }
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 
 .assembly reabstraction { }
 
@@ -87,7 +87,7 @@
   extends [mscorlib]System.Object
   implements I2
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -101,7 +101,7 @@
   extends [mscorlib]System.Object
   implements I3
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -115,7 +115,7 @@
   extends [mscorlib]System.Object
   implements I2, I4
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -129,7 +129,7 @@
   extends [mscorlib]System.Object
   implements I6
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -138,85 +138,89 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit reabstraction
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-
-  .try
+  .method public hidebysig static int32 Main() cil managed
   {
-    newobj instance void C1::.ctor()
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+
+    .try
+    {
+      newobj instance void C1::.ctor()
+      ldc.i4.0
+      callvirt instance int32 I1::Add(int32)
+      pop
+      leave Fail
+    }
+    catch [mscorlib]System.EntryPointNotFoundException
+    {
+      pop
+      leave PureVirtualOK
+    }
+  PureVirtualOK:
+
+    .try
+    {
+      newobj instance void C1::.ctor()
+      dup
+      ldvirtftn instance int32 I1::Add(int32)
+      newobj instance void class [mscorlib]System.Func`2<int32,int32>::.ctor(object,
+                                                                            native int)
+      pop
+      leave Fail
+    }
+    catch [mscorlib]System.EntryPointNotFoundException
+    {
+      pop
+      leave PureVirtualDelegateOK
+    }
+  PureVirtualDelegateOK:
+
+    newobj instance void C2::.ctor()
     ldc.i4.0
     callvirt instance int32 I1::Add(int32)
-    pop
-    leave Fail
-  }
-  catch [mscorlib]System.EntryPointNotFoundException
-  {
-    pop
-    leave PureVirtualOK
-  }
-PureVirtualOK:
+    ldc.i4.2
+    bne.un Fail
 
-  .try
-  {
-    newobj instance void C1::.ctor()
-    dup
-    ldvirtftn instance int32 I1::Add(int32)
-    newobj instance void class [mscorlib]System.Func`2<int32,int32>::.ctor(object,
-                                                                           native int)
-    pop
-    leave Fail
-  }
-  catch [mscorlib]System.EntryPointNotFoundException
-  {
-    pop
-    leave PureVirtualDelegateOK
-  }
-PureVirtualDelegateOK:
+    .try
+    {
+      newobj instance void C3::.ctor()
+      ldc.i4.0
+      callvirt instance int32 I1::Add(int32)
+      pop
+      leave Fail
+    }
+    catch [System.Runtime]System.Runtime.AmbiguousImplementationException
+    {
+      pop
+      leave DiamondCaseOK
+    }
+  DiamondCaseOK:
 
-  newobj instance void C2::.ctor()
-  ldc.i4.0
-  callvirt instance int32 I1::Add(int32)
-  ldc.i4.2
-  bne.un Fail
+    .try
+    {
+      newobj instance void C4::.ctor()
+      ldc.i4.0
+      callvirt instance int32 I5::Add(int32)
+      pop
+      leave Fail
+    }
+    catch [mscorlib]System.EntryPointNotFoundException
+    {
+      pop
+      leave NeverImplementedOK
+    }
+  NeverImplementedOK:
 
-  .try
-  {
-    newobj instance void C3::.ctor()
-    ldc.i4.0
-    callvirt instance int32 I1::Add(int32)
-    pop
-    leave Fail
-  }
-  catch [System.Runtime]System.Runtime.AmbiguousImplementationException
-  {
-    pop
-    leave DiamondCaseOK
-  }
-DiamondCaseOK:
+    ldc.i4 100
+    ret
 
-  .try
-  {
-    newobj instance void C4::.ctor()
-    ldc.i4.0
-    callvirt instance int32 I5::Add(int32)
-    pop
-    leave Fail
+  Fail:
+    ldc.i4.m1
+    ret
   }
-  catch [mscorlib]System.EntryPointNotFoundException
-  {
-    pop
-    leave NeverImplementedOK
-  }
-NeverImplementedOK:
-
-  ldc.i4 100
-  ret
-
-Fail:
-  ldc.i4.m1
-  ret
 }

--- a/src/tests/Loader/classloader/nesting/Tests/nesting7.il
+++ b/src/tests/Loader/classloader/nesting/Tests/nesting7.il
@@ -108,38 +108,42 @@
 
 // entry point location: GlobalManaged
 
-.method public static int32 Main()
+.class public auto ansi abstract sealed beforefieldinit nesting7
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .locals init (class [mscorlib]System.Exception V_0,
-                int32 V_1)
-
-  .try
+  .method public static int32 Main()
   {
-    newobj instance void class Client::.ctor()
-    call   instance void class Client::method2()
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .locals init (class [mscorlib]System.Exception V_0,
+                  int32 V_1)
 
-    ldstr      "PASS"
-    call       void [System.Console]System.Console::WriteLine(string)
-    ldc.i4.s   100
-    stloc.1
-    leave.s    end
+    .try
+    {
+      newobj instance void class Client::.ctor()
+      call   instance void class Client::method2()
+
+      ldstr      "PASS"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s   100
+      stloc.1
+      leave.s    end
+    }
+    catch [mscorlib]System.Exception
+    {
+      stloc.0
+      ldstr      "{0}Caught unexpected exception."
+      ldloc.0
+      call void [System.Console]System.Console::WriteLine(string,object)
+      ldstr      "FAIL"
+      call       void [System.Console]System.Console::WriteLine(string)
+      ldc.i4.s   101
+      stloc.1
+      leave.s    end
+    }
+    end: ldloc.1
+    ret
   }
-  catch [mscorlib]System.Exception
-  {
-    stloc.0
-    ldstr      "{0}Caught unexpected exception."
-    ldloc.0
-    call void [System.Console]System.Console::WriteLine(string,object)
-    ldstr      "FAIL"
-    call       void [System.Console]System.Console::WriteLine(string)
-    ldc.i4.s   101
-    stloc.1
-    leave.s    end
-  }
-  end: ldloc.1
-  ret
 }

--- a/src/tests/Regressions/coreclr/15241/genericcontext.il
+++ b/src/tests/Regressions/coreclr/15241/genericcontext.il
@@ -9,8 +9,8 @@
 {
   .method public hidebysig newslot virtual instance bool IsInst(valuetype [mscorlib]System.RuntimeTypeHandle a) cil managed
   {
-    ldarg.0 
-    ldarg.1 
+    ldarg.0
+    ldarg.1
     call instance bool class IFoo`1<!T>::IsInstImpl(valuetype [mscorlib]System.RuntimeTypeHandle)
 
     ret
@@ -18,9 +18,9 @@
 
   .method private hidebysig instance bool IsInstImpl(valuetype [mscorlib]System.RuntimeTypeHandle a) cil managed
   {
-    ldarga 1 
-    ldtoken !T 
-    call instance bool valuetype [mscorlib]System.RuntimeTypeHandle::Equals(valuetype [mscorlib]System.RuntimeTypeHandle) 
+    ldarga 1
+    ldtoken !T
+    call instance bool valuetype [mscorlib]System.RuntimeTypeHandle::Equals(valuetype [mscorlib]System.RuntimeTypeHandle)
     ret
   }
 }
@@ -33,7 +33,7 @@
        extends [mscorlib]System.Object
        implements class IFoo`1<class Gen`1<!T>>
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -44,10 +44,10 @@
 
 .method public hidebysig static int32  RunTest() cil managed
 {
-  newobj instance void class Fooer`1<object>::.ctor() 
-  ldtoken class Gen`1<class [mscorlib]System.Object> 
-  callvirt instance bool class IFoo`1<class Gen`1<object>>::IsInst(valuetype [mscorlib]System.RuntimeTypeHandle) 
-  
+  newobj instance void class Fooer`1<object>::.ctor()
+  ldtoken class Gen`1<class [mscorlib]System.Object>
+  callvirt instance bool class IFoo`1<class Gen`1<object>>::IsInst(valuetype [mscorlib]System.RuntimeTypeHandle)
+
   // If IFoo::IsInst returns true, return 100 else 0
   brtrue.s   PASS
   ldc.i4 0
@@ -57,22 +57,26 @@
   ret
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit genericcontext
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-  ldstr "DefaultImplementationsOfInterfaces"
-  call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
+    ldstr "DefaultImplementationsOfInterfaces"
+    call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
 
-  // If default interfaces are not supported, consider the test successful.
-  brtrue DoRunTest
-  ldc.i4 100
-  ret
+    // If default interfaces are not supported, consider the test successful.
+    brtrue DoRunTest
+    ldc.i4 100
+    ret
 
-DoRunTest:
-  call int32 RunTest()
-  ret
+  DoRunTest:
+    call int32 RunTest()
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/15647/interfacestatics.il
+++ b/src/tests/Regressions/coreclr/15647/interfacestatics.il
@@ -39,59 +39,63 @@
   }
 }
 
-.method public static hidebysig int32 Main()
+.class public auto ansi abstract sealed beforefieldinit interfacestatics
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
+  .method public static hidebysig int32 Main()
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-  ldsfld class [System.Runtime]System.Type class IFoo<object>::O
-  ldtoken object[]
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
-  ceq
-  brtrue IFoo_object_O_Okay
-  ldc.i4.1
-  ret
+    ldsfld class [System.Runtime]System.Type class IFoo<object>::O
+    ldtoken object[]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue IFoo_object_O_Okay
+    ldc.i4.1
+    ret
 
-IFoo_object_O_Okay:
-  ldsfld class [System.Runtime]System.Type class IFoo<string>::O
-  ldtoken string[]
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
-  ceq
-  brtrue IFoo_string_O_Okay
-  ldc.i4.2
-  ret
+  IFoo_object_O_Okay:
+    ldsfld class [System.Runtime]System.Type class IFoo<string>::O
+    ldtoken string[]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue IFoo_string_O_Okay
+    ldc.i4.2
+    ret
 
-IFoo_string_O_Okay:
-  call class [System.Runtime]System.Type class IFoo<object>::GimmeT()
-  ldtoken object[0...]
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
-  ceq
-  brtrue IFoo_object_Gimme_T_Okay
-  ldc.i4.3
-  ret
+  IFoo_string_O_Okay:
+    call class [System.Runtime]System.Type class IFoo<object>::GimmeT()
+    ldtoken object[0...]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue IFoo_object_Gimme_T_Okay
+    ldc.i4.3
+    ret
 
-IFoo_object_Gimme_T_Okay:
-  call class [System.Runtime]System.Type class IFoo<object>::GimmeU<string>()
-  ldtoken string
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
-  ceq
-  brtrue IFoo_object_Gimme_U_Okay
-  ldc.i4.4
-  ret
+  IFoo_object_Gimme_T_Okay:
+    call class [System.Runtime]System.Type class IFoo<object>::GimmeU<string>()
+    ldtoken string
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue IFoo_object_Gimme_U_Okay
+    ldc.i4.4
+    ret
 
-IFoo_object_Gimme_U_Okay:
-  call class [System.Runtime]System.Type class IFoo<object>::GimmeU_T<string>()
-  ldtoken string[0...]
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)    
-  ceq
-  brtrue IFoo_object_Gimme_U_T_Okay
-  ldc.i4.5
-  ret
+  IFoo_object_Gimme_U_Okay:
+    call class [System.Runtime]System.Type class IFoo<object>::GimmeU_T<string>()
+    ldtoken string[0...]
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue IFoo_object_Gimme_U_T_Okay
+    ldc.i4.5
+    ret
 
-IFoo_object_Gimme_U_T_Okay:
+  IFoo_object_Gimme_U_T_Okay:
 
-  ldc.i4 100
-  ret
+    ldc.i4 100
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/15650/interfacecctor.il
+++ b/src/tests/Regressions/coreclr/15650/interfacecctor.il
@@ -7,7 +7,7 @@
 
 .class interface private abstract auto ansi IFoo
 {
-  .method private hidebysig specialname rtspecialname static 
+  .method private hidebysig specialname rtspecialname static
           void  .cctor() cil managed
   {
     .maxstack  8
@@ -16,7 +16,7 @@
     ret
   }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance void Frob() cil managed
   {
     .maxstack  8
@@ -28,7 +28,7 @@
        extends [mscorlib]System.Object
        implements IFoo
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void  .ctor() cil managed
   {
     .maxstack  8
@@ -40,16 +40,20 @@
 
 .field public static int32 s_result
 
-.method public hidebysig static int32 
-        Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit interfacecctor
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .maxstack  8
-  newobj     instance void Fooer::.ctor()
-  callvirt   instance void IFoo::Frob()
-  ldsfld int32 s_result
-  ret
+  .method public hidebysig static int32
+          Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .maxstack  8
+    newobj     instance void Fooer::.ctor()
+    callvirt   instance void IFoo::Frob()
+    ldsfld int32 s_result
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/15827/nonvirtualcall.il
+++ b/src/tests/Regressions/coreclr/15827/nonvirtualcall.il
@@ -38,7 +38,7 @@
        extends [System.Runtime]System.Object
        implements IBar
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -54,22 +54,26 @@
   ret
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit nonvirtualcall
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-  ldstr "DefaultImplementationsOfInterfaces"
-  call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
+    ldstr "DefaultImplementationsOfInterfaces"
+    call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
 
-  // If default interfaces are not supported, consider the test successful.
-  brtrue DoRunTest
-  ldc.i4 100
-  ret
+    // If default interfaces are not supported, consider the test successful.
+    brtrue DoRunTest
+    ldc.i4 100
+    ret
 
-DoRunTest:
-  call int32 RunTest()
-  ret
+  DoRunTest:
+    call int32 RunTest()
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16064/methodimpl.il
+++ b/src/tests/Regressions/coreclr/16064/methodimpl.il
@@ -33,7 +33,7 @@
        extends [System.Runtime]System.Object
        implements IBar
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -42,25 +42,29 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit methodimpl
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  ldstr "DefaultImplementationsOfInterfaces"
-  call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    ldstr "DefaultImplementationsOfInterfaces"
+    call bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
 
-  // If default interfaces are not supported, consider the test successful.
-  brtrue DoRunTest
-  ldc.i4 100
-  ret
+    // If default interfaces are not supported, consider the test successful.
+    brtrue DoRunTest
+    ldc.i4 100
+    ret
 
-DoRunTest:
-  newobj instance void Fooer::.ctor()
-  callvirt instance int32 IFoo::Frob()
-  newobj instance void Fooer::.ctor()
-  callvirt instance int32 IFoo::Unrelated()
-  add
-  ret
+  DoRunTest:
+    newobj instance void Fooer::.ctor()
+    callvirt instance int32 IFoo::Frob()
+    newobj instance void Fooer::.ctor()
+    callvirt instance int32 IFoo::Unrelated()
+    add
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16123/ambiguousconstraint.il
+++ b/src/tests/Regressions/coreclr/16123/ambiguousconstraint.il
@@ -68,14 +68,18 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit ambiguousconstraint
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .locals init (valuetype Fooer)
-  ldloc.0
-  call int32 class Gen`1<valuetype Fooer>::Check(!0)
-  ret
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .locals init (valuetype Fooer)
+    ldloc.0
+    call int32 class Gen`1<valuetype Fooer>::Check(!0)
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16354/notimplemented.il
+++ b/src/tests/Regressions/coreclr/16354/notimplemented.il
@@ -40,7 +40,7 @@
   }
 }
 
-.method private hidebysig static void LoadFooer() cil managed noinlining
+.method public hidebysig static void LoadFooer() cil managed noinlining
 {
   newobj instance void Fooer::.ctor()
   pop

--- a/src/tests/Regressions/coreclr/16354/notimplemented.il
+++ b/src/tests/Regressions/coreclr/16354/notimplemented.il
@@ -31,7 +31,7 @@
        extends [System.Runtime]System.Object
        implements IBar, class IFoo`1<class [System.Runtime]System.ValueType>
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -47,29 +47,33 @@
   ret
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit notimplemented
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-
-  .try
+  .method public hidebysig static int32 Main() cil managed
   {
-    call void LoadFooer()
-    leave DidNotThrow
-  }
-  catch [System.Runtime]System.TypeLoadException
-  {
-    pop
-    leave Okay
-  }
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-Okay:
-  ldc.i4 100
-  ret
+    .try
+    {
+      call void LoadFooer()
+      leave DidNotThrow
+    }
+    catch [System.Runtime]System.TypeLoadException
+    {
+      pop
+      leave Okay
+    }
 
-DidNotThrow:
-  ldc.i4.m1
-  ret
+  Okay:
+    ldc.i4 100
+    ret
+
+  DidNotThrow:
+    ldc.i4.m1
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16355/boring.il
+++ b/src/tests/Regressions/coreclr/16355/boring.il
@@ -58,7 +58,7 @@
        extends [System.Runtime]System.Object
        implements IBar
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -67,67 +67,71 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit boring
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<string>::Frob()
-  ldc.i4.1
-  ceq
-  brtrue IFoo_String_Frob_Okay
-  ldc.i4.1
-  ret
-IFoo_String_Frob_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<string>::Frob()
+    ldc.i4.1
+    ceq
+    brtrue IFoo_String_Frob_Okay
+    ldc.i4.1
+    ret
+  IFoo_String_Frob_Okay:
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<object>::Frob()
-  ldc.i4.1
-  ceq
-  brtrue IFoo_Object_Frob_Okay
-  ldc.i4.2
-  ret
-IFoo_Object_Frob_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<object>::Frob()
+    ldc.i4.1
+    ceq
+    brtrue IFoo_Object_Frob_Okay
+    ldc.i4.2
+    ret
+  IFoo_Object_Frob_Okay:
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<class [System.Runtime]System.ValueType>::Frob()
-  ldc.i4.2
-  ceq
-  brtrue IFoo_ValueType_Frob_Okay
-  ldc.i4.3
-  ret
-IFoo_ValueType_Frob_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<class [System.Runtime]System.ValueType>::Frob()
+    ldc.i4.2
+    ceq
+    brtrue IFoo_ValueType_Frob_Okay
+    ldc.i4.3
+    ret
+  IFoo_ValueType_Frob_Okay:
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<string>::Bark()
-  ldc.i4.3
-  ceq
-  brtrue IFoo_String_Bark_Okay
-  ldc.i4.4
-  ret
-IFoo_String_Bark_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<string>::Bark()
+    ldc.i4.3
+    ceq
+    brtrue IFoo_String_Bark_Okay
+    ldc.i4.4
+    ret
+  IFoo_String_Bark_Okay:
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<object>::Bark()
-  ldc.i4.m1
-  ceq
-  brtrue IFoo_Object_Bark_Okay
-  ldc.i4.5
-  ret
-IFoo_Object_Bark_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<object>::Bark()
+    ldc.i4.m1
+    ceq
+    brtrue IFoo_Object_Bark_Okay
+    ldc.i4.5
+    ret
+  IFoo_Object_Bark_Okay:
 
-  newobj instance void class Fooer::.ctor()
-  callvirt instance int32 class IFoo`1<class [System.Runtime]System.ValueType>::Bark()
-  ldc.i4.4
-  ceq
-  brtrue IFoo_ValueType_Bark_Okay
-  ldc.i4.6
-  ret
-IFoo_ValueType_Bark_Okay:
+    newobj instance void class Fooer::.ctor()
+    callvirt instance int32 class IFoo`1<class [System.Runtime]System.ValueType>::Bark()
+    ldc.i4.4
+    ceq
+    brtrue IFoo_ValueType_Bark_Okay
+    ldc.i4.6
+    ret
+  IFoo_ValueType_Bark_Okay:
 
-  ldc.i4 100
-  ret
+    ldc.i4 100
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16355/variance.il
+++ b/src/tests/Regressions/coreclr/16355/variance.il
@@ -29,7 +29,7 @@
        extends [System.Runtime]System.Object
        implements class IBar`1<class [System.Runtime]System.Object>
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -38,25 +38,29 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit variance
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .locals (valuetype [System.Runtime]System.RuntimeTypeHandle)
-  newobj instance void class Fooer::.ctor()
-  ldnull
-  callvirt instance valuetype [System.Runtime]System.RuntimeTypeHandle class IContravariant`1<string>::Frob(!0)
-  stloc.0
-  ldloca 0
-  ldtoken object
-  call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
-  brtrue Okay
-  ldc.i4.m1
-  ret
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .locals (valuetype [System.Runtime]System.RuntimeTypeHandle)
+    newobj instance void class Fooer::.ctor()
+    ldnull
+    callvirt instance valuetype [System.Runtime]System.RuntimeTypeHandle class IContravariant`1<string>::Frob(!0)
+    stloc.0
+    ldloca 0
+    ldtoken object
+    call instance bool valuetype [System.Runtime]System.RuntimeTypeHandle::Equals(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    brtrue Okay
+    ldc.i4.m1
+    ret
 
-Okay:
-  ldc.i4 100
-  ret
+  Okay:
+    ldc.i4 100
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/16775/sharedinterfacemethod.il
+++ b/src/tests/Regressions/coreclr/16775/sharedinterfacemethod.il
@@ -18,7 +18,7 @@
        implements class IFoo`1<class [System.Runtime]System.Object>,
                   class IFoo`1<valuetype [System.Runtime]System.Int32>
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -27,69 +27,73 @@
   }
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit sharedinterfacemethod
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
 
-  // Callvirt to a shared interface method
+    // Callvirt to a shared interface method
 
-  newobj instance void Fooer::.ctor()
-  callvirt instance class [System.Runtime]System.Type class IFoo`1<valuetype [System.Runtime]System.Int32>::Frob()
-  ldtoken valuetype [System.Runtime]System.Int32
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-  ceq
-  brtrue UnsharedCallvirtIsGood
+    newobj instance void Fooer::.ctor()
+    callvirt instance class [System.Runtime]System.Type class IFoo`1<valuetype [System.Runtime]System.Int32>::Frob()
+    ldtoken valuetype [System.Runtime]System.Int32
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue UnsharedCallvirtIsGood
 
-  ldc.i4.1
-  ret
+    ldc.i4.1
+    ret
 
-UnsharedCallvirtIsGood:
+  UnsharedCallvirtIsGood:
 
-  // Call to a shared interface
+    // Call to a shared interface
 
-  newobj instance void Fooer::.ctor()
-  call instance class [System.Runtime]System.Type class IFoo`1<valuetype [System.Runtime]System.Int32>::Frob()
-  ldtoken valuetype [System.Runtime]System.Int32
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-  ceq
-  brtrue UnsharedCallIsGood
+    newobj instance void Fooer::.ctor()
+    call instance class [System.Runtime]System.Type class IFoo`1<valuetype [System.Runtime]System.Int32>::Frob()
+    ldtoken valuetype [System.Runtime]System.Int32
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue UnsharedCallIsGood
 
-  ldc.i4.2
-  ret
+    ldc.i4.2
+    ret
 
-UnsharedCallIsGood:
+  UnsharedCallIsGood:
 
-  // Callvirt to an unshared interface method
+    // Callvirt to an unshared interface method
 
-  newobj instance void Fooer::.ctor()
-  callvirt instance class [System.Runtime]System.Type class IFoo`1<class [System.Runtime]System.Object>::Frob()
-  ldtoken class [System.Runtime]System.Object
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-  ceq
-  brtrue SharedCallvirtIsGood
+    newobj instance void Fooer::.ctor()
+    callvirt instance class [System.Runtime]System.Type class IFoo`1<class [System.Runtime]System.Object>::Frob()
+    ldtoken class [System.Runtime]System.Object
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue SharedCallvirtIsGood
 
-  ldc.i4.3
-  ret
+    ldc.i4.3
+    ret
 
-SharedCallvirtIsGood:
+  SharedCallvirtIsGood:
 
-  // Call to an unshared interface method
+    // Call to an unshared interface method
 
-  newobj instance void Fooer::.ctor()
-  call instance class [System.Runtime]System.Type class IFoo`1<class [System.Runtime]System.Object>::Frob()
-  ldtoken class [System.Runtime]System.Object
-  call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
-  ceq
-  brtrue SharedCallIsGood
+    newobj instance void Fooer::.ctor()
+    call instance class [System.Runtime]System.Type class IFoo`1<class [System.Runtime]System.Object>::Frob()
+    ldtoken class [System.Runtime]System.Object
+    call class [System.Runtime]System.Type class [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    ceq
+    brtrue SharedCallIsGood
 
-  ldc.i4.4
-  ret
+    ldc.i4.4
+    ret
 
-SharedCallIsGood:
+  SharedCallIsGood:
 
-  ldc.i4 100
-  ret
+    ldc.i4 100
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/20452/twopassvariance.il
+++ b/src/tests/Regressions/coreclr/20452/twopassvariance.il
@@ -134,196 +134,200 @@
     }
 }
 
-.method public static int32 main()
+.class public auto ansi abstract sealed beforefieldinit twopassvariance
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
+    .method public static int32 main()
+    {
+        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+            01 00 00 00
+        )
+        .entrypoint
 
-    newobj instance void Fooer1::.ctor()
-    castclass class IFoo<class SuperDerived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IFoo<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer1_IFoo_SuperDerivedOK
-    ldc.i4.1
-    ret
+        newobj instance void Fooer1::.ctor()
+        castclass class IFoo<class SuperDerived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IFoo<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer1_IFoo_SuperDerivedOK
+        ldc.i4.1
+        ret
 
-Fooer1_IFoo_SuperDerivedOK:
-    newobj instance void Fooer2::.ctor()
-    castclass class IFoo<class SuperDerived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IFoo<class Derived>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer2_IFoo_SuperDerivedOK
-    ldc.i4.2
-    ret
+    Fooer1_IFoo_SuperDerivedOK:
+        newobj instance void Fooer2::.ctor()
+        castclass class IFoo<class SuperDerived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IFoo<class Derived>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer2_IFoo_SuperDerivedOK
+        ldc.i4.2
+        ret
 
-Fooer2_IFoo_SuperDerivedOK:
-    newobj instance void Fooer3::.ctor()
-    castclass class IFoo<class Base>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer3_IFoo_BaseOK
-    ldc.i4.3
-    ret
+    Fooer2_IFoo_SuperDerivedOK:
+        newobj instance void Fooer3::.ctor()
+        castclass class IFoo<class Base>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer3_IFoo_BaseOK
+        ldc.i4.3
+        ret
 
-Fooer3_IFoo_BaseOK:
-    newobj instance void Fooer3::.ctor()
-    castclass class IFoo<class Derived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Derived>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer3_IFoo_DerivedOK
-    ldc.i4.4
-    ret
+    Fooer3_IFoo_BaseOK:
+        newobj instance void Fooer3::.ctor()
+        castclass class IFoo<class Derived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Derived>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer3_IFoo_DerivedOK
+        ldc.i4.4
+        ret
 
-Fooer3_IFoo_DerivedOK:
-    newobj instance void Fooer3::.ctor()
-    castclass class IFoo<class SuperDerived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer3_IFoo_SuperDerivedOK
-    ldc.i4.5
-    ret
+    Fooer3_IFoo_DerivedOK:
+        newobj instance void Fooer3::.ctor()
+        castclass class IFoo<class SuperDerived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer3_IFoo_SuperDerivedOK
+        ldc.i4.5
+        ret
 
-Fooer3_IFoo_SuperDerivedOK:
-    newobj instance void Fooer4::.ctor()
-    castclass class IFoo<class Base>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken IQux
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer4_IFoo_BaseOK
-    ldc.i4.6
-    ret
+    Fooer3_IFoo_SuperDerivedOK:
+        newobj instance void Fooer4::.ctor()
+        castclass class IFoo<class Base>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken IQux
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer4_IFoo_BaseOK
+        ldc.i4.6
+        ret
 
-Fooer4_IFoo_BaseOK:
-    newobj instance void Fooer4::.ctor()
-    castclass class IFoo<class Derived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Derived>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer4_IFoo_DerivedOK
-    ldc.i4.7
-    ret
+    Fooer4_IFoo_BaseOK:
+        newobj instance void Fooer4::.ctor()
+        castclass class IFoo<class Derived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Derived>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer4_IFoo_DerivedOK
+        ldc.i4.7
+        ret
 
-Fooer4_IFoo_DerivedOK:
-    newobj instance void Fooer4::.ctor()
-    castclass class IFoo<class SuperDerived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken IQux
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer4_IFoo_SuperDerivedOK
-    ldc.i4.8
-    ret
+    Fooer4_IFoo_DerivedOK:
+        newobj instance void Fooer4::.ctor()
+        castclass class IFoo<class SuperDerived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken IQux
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer4_IFoo_SuperDerivedOK
+        ldc.i4.8
+        ret
 
-Fooer4_IFoo_SuperDerivedOK:
-    newobj instance void Fooer5::.ctor()
-    castclass class IFoo<class SuperDerived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Derived>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer5_IFoo_SuperDerivedOK
-    ldc.i4 9
-    ret
+    Fooer4_IFoo_SuperDerivedOK:
+        newobj instance void Fooer5::.ctor()
+        castclass class IFoo<class SuperDerived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class SuperDerived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Derived>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer5_IFoo_SuperDerivedOK
+        ldc.i4 9
+        ret
 
-Fooer5_IFoo_SuperDerivedOK:
-    newobj instance void Fooer6::.ctor()
-    castclass class IFoo<class Base>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer6_IFoo_BaseOK
-    ldc.i4 10
-    ret
+    Fooer5_IFoo_SuperDerivedOK:
+        newobj instance void Fooer6::.ctor()
+        castclass class IFoo<class Base>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer6_IFoo_BaseOK
+        ldc.i4 10
+        ret
 
-Fooer6_IFoo_BaseOK:
-    newobj instance void Fooer6::.ctor()
-    castclass class IFoo<class Derived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer6_IFoo_DerivedOK
-    ldc.i4 11
-    ret
+    Fooer6_IFoo_BaseOK:
+        newobj instance void Fooer6::.ctor()
+        castclass class IFoo<class Derived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer6_IFoo_DerivedOK
+        ldc.i4 11
+        ret
 
-Fooer6_IFoo_DerivedOK:
-    newobj instance void Fooer7::.ctor()
-    castclass class IFoo<class Base>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer7_IFoo_BaseOK
-    ldc.i4 12
-    ret
+    Fooer6_IFoo_DerivedOK:
+        newobj instance void Fooer7::.ctor()
+        castclass class IFoo<class Base>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Base>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer7_IFoo_BaseOK
+        ldc.i4 12
+        ret
 
-Fooer7_IFoo_BaseOK:
-    newobj instance void Fooer7::.ctor()
-    castclass class IFoo<class Derived>
-    callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
-    dup
-    callvirt instance string [mscorlib]System.Object::ToString()
-    call void [mscorlib]System.Console::WriteLine(string)
-    ldtoken class IBar<class Base>
-    call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    ceq
-    brtrue Fooer7_IFoo_DerivedOK
-    ldc.i4 13
-    ret
+    Fooer7_IFoo_BaseOK:
+        newobj instance void Fooer7::.ctor()
+        castclass class IFoo<class Derived>
+        callvirt instance class [mscorlib]System.Type class IFoo<class Derived>::Gimme()
+        dup
+        callvirt instance string [mscorlib]System.Object::ToString()
+        call void [mscorlib]System.Console::WriteLine(string)
+        ldtoken class IBar<class Base>
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        ceq
+        brtrue Fooer7_IFoo_DerivedOK
+        ldc.i4 13
+        ret
 
-Fooer7_IFoo_DerivedOK:
+    Fooer7_IFoo_DerivedOK:
 
-    ldc.i4 100
-    ret
+        ldc.i4 100
+        ret
+    }
 }

--- a/src/tests/Regressions/coreclr/22386/debug3.il
+++ b/src/tests/Regressions/coreclr/22386/debug3.il
@@ -15,7 +15,7 @@
   {
   }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Add(int32 x) cil managed
   {
     ldarg.0
@@ -51,7 +51,7 @@
   {
   }
 
-  .method public hidebysig newslot virtual 
+  .method public hidebysig newslot virtual
           instance int32  Add(int32 x) cil managed
   {
     ldarg.0
@@ -96,88 +96,92 @@
 }
 
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit debug3
+    extends [System.Runtime]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-  .locals init (class I1 V_0,
-             valuetype Test1 V_1,
-             class [System.Runtime]System.Func`2<int32, int32> V_2,
-             class I2`1<class [System.Runtime]System.String> V_3,
-             valuetype Test2`1<class [System.Runtime]System.String> V_4)
+  .method public hidebysig static int32 Main() cil managed
+  {
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+    .locals init (class I1 V_0,
+              valuetype Test1 V_1,
+              class [System.Runtime]System.Func`2<int32, int32> V_2,
+              class I2`1<class [System.Runtime]System.String> V_3,
+              valuetype Test2`1<class [System.Runtime]System.String> V_4)
 
-  //
-  // Nongeneric case
-  //
+    //
+    // Nongeneric case
+    //
 
-  ldloca.s   V_1
-  initobj    Test1
+    ldloca.s   V_1
+    initobj    Test1
 
-  // V_1.Value = 30
-  ldloca.s   V_1
-  ldc.i4 30
-  stfld int32 Test1::Value
+    // V_1.Value = 30
+    ldloca.s   V_1
+    ldc.i4 30
+    stfld int32 Test1::Value
 
-  // V_0 = (I1)V_1;
-  ldloc.1
-  box        Test1
-  stloc.0
+    // V_0 = (I1)V_1;
+    ldloc.1
+    box        Test1
+    stloc.0
 
-  // V_2 = V_0.Add
-  ldloc.0
-  dup
-  ldvirtftn  instance int32 I1::Add(int32)
-  newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
-  stloc.2
+    // V_2 = V_0.Add
+    ldloc.0
+    dup
+    ldvirtftn  instance int32 I1::Add(int32)
+    newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
+    stloc.2
 
-  // V_2(2)
-  ldloc.2
-  ldc.i4.2
-  callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+    // V_2(2)
+    ldloc.2
+    ldc.i4.2
+    callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
 
-  //
-  // We expect 33 on the stack now
-  //
+    //
+    // We expect 33 on the stack now
+    //
 
-  //
-  // Generic case
-  //
+    //
+    // Generic case
+    //
 
-  ldloca.s   V_4
-  initobj    valuetype Test2`1<class [System.Runtime]System.String>
+    ldloca.s   V_4
+    initobj    valuetype Test2`1<class [System.Runtime]System.String>
 
-  // V_4.Value = 36
-  ldloca.s   V_4
-  ldc.i4 36
-  stfld int32 valuetype Test2`1<class [System.Runtime]System.String>::Value
+    // V_4.Value = 36
+    ldloca.s   V_4
+    ldc.i4 36
+    stfld int32 valuetype Test2`1<class [System.Runtime]System.String>::Value
 
-  // V_3 = (I1)V_4;
-  ldloc.s    4
-  box        valuetype Test2`1<class [System.Runtime]System.String>
-  stloc.3
+    // V_3 = (I1)V_4;
+    ldloc.s    4
+    box        valuetype Test2`1<class [System.Runtime]System.String>
+    stloc.3
 
-  // V_2 = V_3.Add
-  ldloc.3
-  dup
-  ldvirtftn  instance int32 class I2`1<class [System.Runtime]System.String>::Add(int32)
-  newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
-  stloc.2
+    // V_2 = V_3.Add
+    ldloc.3
+    dup
+    ldvirtftn  instance int32 class I2`1<class [System.Runtime]System.String>::Add(int32)
+    newobj     instance void class [System.Runtime]System.Func`2<int32, int32>::.ctor(object, native int)
+    stloc.2
 
-  ldloc.2
-  ldc.i4.2
-  callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
+    ldloc.2
+    ldc.i4.2
+    callvirt   instance !1 class [System.Runtime]System.Func`2<int32, int32>::Invoke(!0)
 
-  //
-  // We expect this return 67
-  //
+    //
+    // We expect this return 67
+    //
 
-  //
-  // Add the two results - sum should be 100
-  //
+    //
+    // Add the two results - sum should be 100
+    //
 
-  add
+    add
 
-  ret
+    ret
+  }
 }

--- a/src/tests/Regressions/coreclr/22407/abstractcalls.il
+++ b/src/tests/Regressions/coreclr/22407/abstractcalls.il
@@ -19,7 +19,7 @@
   extends [mscorlib]System.Object
   implements I1
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -37,7 +37,7 @@
   extends [mscorlib]System.Object
   implements I1
 {
-  .method public hidebysig specialname rtspecialname 
+  .method public hidebysig specialname rtspecialname
           instance void .ctor() cil managed
   {
     ldarg.0
@@ -78,43 +78,47 @@
   ret
 }
 
-.method public hidebysig static int32 Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit abstractcalls
+    extends [mscorlib]System.Object
 {
-  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-      01 00 00 00
-  )
-  .entrypoint
-
-  .try
+  .method public hidebysig static int32 Main() cil managed
   {
-    call void CallClass()
-    leave Fail
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .entrypoint
+
+    .try
+    {
+      call void CallClass()
+      leave Fail
+    }
+    catch [mscorlib]System.BadImageFormatException
+    {
+      pop
+      leave AbstractClassOK
+    }
+
+  AbstractClassOK:
+
+    .try
+    {
+      call void CallInterface()
+      leave Fail
+    }
+    catch [mscorlib]System.BadImageFormatException
+    {
+      pop
+      leave AbstractInterfaceOK
+    }
+
+  AbstractInterfaceOK:
+
+    ldc.i4 100
+    ret
+
+  Fail:
+    ldc.i4.m1
+    ret
   }
-  catch [mscorlib]System.BadImageFormatException
-  {
-    pop
-    leave AbstractClassOK
-  }
-
-AbstractClassOK:
-
-  .try
-  {
-    call void CallInterface()
-    leave Fail
-  }
-  catch [mscorlib]System.BadImageFormatException
-  {
-    pop
-    leave AbstractInterfaceOK
-  }
-
-AbstractInterfaceOK:
-
-  ldc.i4 100
-  ret
-
-Fail:
-  ldc.i4.m1
-  ret
 }

--- a/src/tests/Regressions/coreclr/22407/abstractcalls.il
+++ b/src/tests/Regressions/coreclr/22407/abstractcalls.il
@@ -60,7 +60,7 @@
   }
 }
 
-.method private hidebysig static void CallClass() cil managed
+.method public hidebysig static void CallClass() cil managed
 {
   newobj instance void C2::.ctor()
   ldc.i4.0
@@ -69,7 +69,7 @@
   ret
 }
 
-.method private hidebysig static void CallInterface() cil managed
+.method public hidebysig static void CallInterface() cil managed
 {
   newobj instance void C2::.ctor()
   ldc.i4.0

--- a/src/tests/Regressions/coreclr/GitHub_68278/runtime68278.il
+++ b/src/tests/Regressions/coreclr/GitHub_68278/runtime68278.il
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+.assembly extern mscorlib { }
 .assembly runtime68278 { }
 .assembly extern xunit.core {}
 
@@ -21,14 +22,18 @@
     .field public static int8 s_fiftyEight
 }
 
-.method public static int32 main()
+.class public auto ansi abstract sealed beforefieldinit runtime68278
+    extends [mscorlib]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
-    ldsfld int8 IHasCctor::s_fortyTwo
-    ldsfld int8 IUnrelated::s_fiftyEight
-    add
-    ret
+    .method public static int32 main()
+    {
+        .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+            01 00 00 00
+        )
+        .entrypoint
+        ldsfld int8 IHasCctor::s_fortyTwo
+        ldsfld int8 IUnrelated::s_fiftyEight
+        add
+        ret
+    }
 }

--- a/src/tests/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
+++ b/src/tests/baseservices/compilerservices/RuntimeFeature/DefaultImplementationsOfInterfaces.il
@@ -32,7 +32,7 @@
     ret
 }
 
-.method private hidebysig static bool  SupportsDefaultInterfaces() cil managed
+.method public hidebysig static bool  SupportsDefaultInterfaces() cil managed
 {
     .maxstack  1
     .try
@@ -56,23 +56,27 @@
     ret
   }
 
-.method public hidebysig static int32
-        Main() cil managed
+.class public auto ansi abstract sealed beforefieldinit DefaultImplementationsOfInterfaces
+    extends [System.Runtime]System.Object
 {
-    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
-        01 00 00 00
-    )
-    .entrypoint
-    .maxstack  2
-    ldstr      "DefaultImplementationsOfInterfaces"
-    call       bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
-    call       bool SupportsDefaultInterfaces()
-    beq        Good
+  .method public hidebysig static int32
+          Main() cil managed
+  {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+          01 00 00 00
+      )
+      .entrypoint
+      .maxstack  2
+      ldstr      "DefaultImplementationsOfInterfaces"
+      call       bool [System.Runtime]System.Runtime.CompilerServices.RuntimeFeature::IsSupported(string)
+      call       bool SupportsDefaultInterfaces()
+      beq        Good
 
-    ldc.i4.m1
-    ret
+      ldc.i4.m1
+      ret
 
-  Good:
-    ldc.i4     100
-    ret
+    Good:
+      ldc.i4     100
+      ret
+  }
 }


### PR DESCRIPTION
Post test merge, none of these tests were running because the test discovery mechansim doesn't detect when an entry point is a global function.