### PR TITLE
Make Enumerable.First/Last/GetElement faster on various enumerables

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
@@ -89,6 +89,65 @@ namespace System.Linq
                     return result;
                 }
             }
+
+            public override TSource? TryGetElementAt(int index, out bool found)
+            {
+                if (index >= 0)
+                {
+                    foreach (IEnumerable<TSource> source in (ReadOnlySpan<IEnumerable<TSource>>)[_first, _second])
+                    {
+                        if (TryGetNonEnumeratedCount(source, out int count))
+                        {
+                            if (index < count)
+                            {
+                                found = true;
+                                return source.ElementAt(index);
+                            }
+
+                            index -= count;
+                        }
+                        else
+                        {
+                            using IEnumerator<TSource> e = source.GetEnumerator();
+                            while (e.MoveNext())
+                            {
+                                if (index == 0)
+                                {
+                                    found = true;
+                                    return e.Current;
+                                }
+
+                                index--;
+                            }
+                        }
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public override TSource? TryGetFirst(out bool found)
+            {
+                TSource? result = _first.TryGetFirst(out found);
+                if (!found)
+                {
+                    result = _second.TryGetFirst(out found);
+                }
+
+                return result;
+            }
+
+            public override TSource? TryGetLast(out bool found)
+            {
+                TSource? result = _second.TryGetLast(out found);
+                if (!found)
+                {
+                    result = _first.TryGetLast(out found);
+                }
+
+                return result;
+            }
         }
 
         private sealed partial class ConcatNIterator<TSource> : ConcatIterator<TSource>
@@ -210,9 +269,80 @@ namespace System.Linq
 
                 return array;
             }
+
+            public override TSource? TryGetElementAt(int index, out bool found)
+            {
+                if (index >= 0)
+                {
+                    IEnumerable<TSource>? source;
+                    for (int i = 0; (source = GetEnumerable(i)) is not null; i++)
+                    {
+                        if (TryGetNonEnumeratedCount(source, out int count))
+                        {
+                            if (index < count)
+                            {
+                                found = true;
+                                return source.ElementAt(index);
+                            }
+
+                            index -= count;
+                        }
+                        else
+                        {
+                            using IEnumerator<TSource> e = source.GetEnumerator();
+                            while (e.MoveNext())
+                            {
+                                if (index == 0)
+                                {
+                                    found = true;
+                                    return e.Current;
+                                }
+
+                                index--;
+                            }
+                        }
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public override TSource? TryGetFirst(out bool found)
+            {
+                IEnumerable<TSource>? source;
+                for (int i = 0; (source = GetEnumerable(i)) is not null; i++)
+                {
+                    TSource? result = source.TryGetFirst(out found);
+                    if (found)
+                    {
+                        return result;
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public override TSource? TryGetLast(out bool found)
+            {
+                ConcatNIterator<TSource>? node = this;
+                do
+                {
+                    TSource? result = node._head.TryGetLast(out found);
+                    if (found)
+                    {
+                        return result;
+                    }
+                }
+                while ((node = node!.PreviousN) is not null);
+
+                found = false;
+                return default;
+            }
         }
 
-        private abstract partial class ConcatIterator<TSource> : IIListProvider<TSource>
+        private abstract partial class ConcatIterator<TSource> : IPartition<TSource>
         {
             public abstract int GetCount(bool onlyIfCheap);
 
@@ -236,6 +366,17 @@ namespace System.Linq
 
                 return list;
             }
+
+            public abstract TSource? TryGetElementAt(int index, out bool found);
+
+            public abstract TSource? TryGetFirst(out bool found);
+
+            public abstract TSource? TryGetLast(out bool found);
+
+            public IPartition<TSource>? Skip(int count) => new EnumerablePartition<TSource>(this, count, -1);
+
+            public IPartition<TSource>? Take(int count) => new EnumerablePartition<TSource>(this, 0, count - 1);
+
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.SpeedOpt.cs
@@ -1,14 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Generic;
 
 namespace System.Linq
 {
     public static partial class Enumerable
     {
-        private sealed partial class ReverseIterator<TSource> : IIListProvider<TSource>
+        private sealed partial class ReverseIterator<TSource> : IPartition<TSource>
         {
             public TSource[] ToArray()
             {
@@ -24,21 +23,103 @@ namespace System.Linq
                 return list;
             }
 
-            public int GetCount(bool onlyIfCheap)
+            public int GetCount(bool onlyIfCheap) =>
+                !onlyIfCheap ? _source.Count() :
+                TryGetNonEnumeratedCount(_source, out int count) ? count :
+                -1;
+
+            public TSource? TryGetElementAt(int index, out bool found)
             {
-                if (onlyIfCheap)
+                if (_source is IList<TSource> list)
                 {
-                    return _source switch
+                    int count = list.Count;
+                    if ((uint)index < (uint)count)
                     {
-                        IIListProvider<TSource> listProv => listProv.GetCount(onlyIfCheap: true),
-                        ICollection<TSource> colT => colT.Count,
-                        ICollection col => col.Count,
-                        _ => -1,
-                    };
+                        found = true;
+                        return list[count - index - 1];
+                    }
+                }
+                else if (index >= 0)
+                {
+                    TSource[] array = _source.ToArray();
+                    if (index < array.Length)
+                    {
+                        found = true;
+                        return array[array.Length - index - 1];
+                    }
                 }
 
-                return _source.Count();
+                found = false;
+                return default;
             }
+
+            public TSource? TryGetFirst(out bool found)
+            {
+                if (_source is IPartition<TSource> partition)
+                {
+                    return partition.TryGetLast(out found);
+                }
+                else if (_source is IList<TSource> list)
+                {
+                    int count = list.Count;
+                    if (count > 0)
+                    {
+                        found = true;
+                        return list[count - 1];
+                    }
+                }
+                else
+                {
+                    using IEnumerator<TSource> e = _source.GetEnumerator();
+                    if (e.MoveNext())
+                    {
+                        TSource result;
+                        do
+                        {
+                            result = e.Current;
+                        }
+                        while (e.MoveNext());
+
+                        found = true;
+                        return result;
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public TSource? TryGetLast(out bool found)
+            {
+                if (_source is IPartition<TSource> partition)
+                {
+                    return partition.TryGetFirst(out found);
+                }
+                else if (_source is IList<TSource> list)
+                {
+                    if (list.Count > 0)
+                    {
+                        found = true;
+                        return list[0];
+                    }
+                }
+                else
+                {
+                    using IEnumerator<TSource> e = _source.GetEnumerator();
+                    if (e.MoveNext())
+                    {
+                        found = true;
+                        return e.Current;
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public IPartition<TSource>? Skip(int count) => new EnumerablePartition<TSource>(this, count, -1);
+
+            public IPartition<TSource>? Take(int count) => new EnumerablePartition<TSource>(this, 0, count - 1);
         }
     }
 }

--- a/src/libraries/System.Linq/tests/LifecycleTests.cs
+++ b/src/libraries/System.Linq/tests/LifecycleTests.cs
@@ -162,9 +162,9 @@ namespace System.Linq.Tests
             yield return new Sink(nameof(Enumerable.First), e => e.First(i => false));
             yield return new Sink(nameof(Enumerable.FirstOrDefault), e => e.FirstOrDefault(), shortCircuits: true);
             yield return new Sink(nameof(Enumerable.FirstOrDefault), e => e.FirstOrDefault(i => false));
-            yield return new Sink(nameof(Enumerable.Last), e => e.Last());
+            yield return new Sink(nameof(Enumerable.Last), e => e.Last(), shortCircuits: true);
             yield return new Sink(nameof(Enumerable.Last), e => e.Last(i => true));
-            yield return new Sink(nameof(Enumerable.LastOrDefault), e => e.LastOrDefault());
+            yield return new Sink(nameof(Enumerable.LastOrDefault), e => e.LastOrDefault(), shortCircuits: true);
             yield return new Sink(nameof(Enumerable.LastOrDefault), e => e.LastOrDefault(i => true));
             yield return new Sink(nameof(Enumerable.LongCount), e => e.LongCount());
             yield return new Sink(nameof(Enumerable.LongCount), e => e.LongCount(i => true));


### PR DESCRIPTION
Implement IPartition on more (existing) custom iterator types, in particular on the types for Where.Select, Concat, and Reverse.

| Method                  | Toolchain         | Mean          | Ratio | Allocated | Alloc Ratio |
|------------------------ |------------------ |--------------:|------:|----------:|------------:|
| WhereSelect_First       | \main\corerun.exe |     29.161 ns |  1.00 |     104 B |        1.00 |
| WhereSelect_First       | \pr\corerun.exe   |     13.829 ns |  0.47 |      40 B |        0.38 |
|                         |                   |               |       |           |             |
| WhereSelect_Last        | \main\corerun.exe |  2,815.028 ns |  1.00 |     104 B |        1.00 |
| WhereSelect_Last        | \pr\corerun.exe   |  1,361.385 ns |  0.48 |      40 B |        0.38 |
|                         |                   |               |       |           |             |
| ArrayReverse_First      | \main\corerun.exe |    440.176 ns |  1.00 |    4072 B |        1.00 |
| ArrayReverse_First      | \pr\corerun.exe   |      8.615 ns |  0.02 |         - |        0.00 |
|                         |                   |               |       |           |             |
| ArrayReverse_Last       | \main\corerun.exe |  1,991.332 ns | 1.000 |    4072 B |        1.00 |
| ArrayReverse_Last       | \pr\corerun.exe   |      8.688 ns | 0.004 |         - |        0.00 |
|                         |                   |               |       |           |             |
| ConcatComplicated_First | \main\corerun.exe |     46.294 ns |  1.00 |     168 B |        1.00 |
| ConcatComplicated_First | \pr\corerun.exe   |     23.029 ns |  0.50 |      40 B |        0.24 |
|                         |                   |               |       |           |             |
| ConcatComplicated_Last  | \main\corerun.exe | 22,536.189 ns | 1.000 |    8416 B |        1.00 |
| ConcatComplicated_Last  | \pr\corerun.exe   |     18.410 ns | 0.001 |         - |        0.00 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
public class Tests
{
    private IEnumerable<int> _whereSelect;
    private IEnumerable<int> _arrayReverse;
    private IEnumerable<int> _concatComplicated;

    [GlobalSetup]
    public void Setup()
    {
        _whereSelect = Enumerable.Range(0, 1000).Where(i => i % 2 == 0).Select(i => i * 2);
        _arrayReverse = Enumerable.Range(0, 1000).ToArray().Reverse();
        _concatComplicated = _whereSelect.Concat(_arrayReverse).Concat(_whereSelect).Concat(_arrayReverse);
    }

    [Benchmark] public int WhereSelect_First() => _whereSelect.First();
    [Benchmark] public int WhereSelect_Last() => _whereSelect.Last();

    [Benchmark] public int ArrayReverse_First() => _arrayReverse.First();
    [Benchmark] public int ArrayReverse_Last() => _arrayReverse.Last();

    [Benchmark] public int ConcatComplicated_First() => _concatComplicated.First();
    [Benchmark] public int ConcatComplicated_Last() => _concatComplicated.Last();
}
```