### PR TITLE
JIT: Assertprop improvements

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -697,9 +697,7 @@ void Compiler::optAssertionInit(bool isLocalProp)
         static const AssertionIndex countFunc[] = {64, 128, 256, 64};
         static const unsigned       upperBound  = ArrLen(countFunc) - 1;
         const unsigned              codeSize    = info.compILCodeSize / 512;
-
-        // CI test
-        optMaxAssertionCount = 256; // countFunc[min(upperBound, codeSize)];
+        optMaxAssertionCount                    = countFunc[min(upperBound, codeSize)];
 
         optValueNumToAsserts =
             new (getAllocator(CMK_AssertionProp)) ValueNumToAssertsMap(getAllocator(CMK_AssertionProp));

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6347,17 +6347,14 @@ bool ValueNumStore::IsVNRelop(ValueNum vn)
 bool ValueNumStore::IsVNConstantBound(ValueNum vn)
 {
     VNFuncApp funcApp;
-    if (GetVNFunc(vn, &funcApp))
+    if ((vn != NoVN) && GetVNFunc(vn, &funcApp))
     {
-        switch ((genTreeOps)funcApp.m_func)
+        if ((funcApp.m_func == (VNFunc)GT_LE) || (funcApp.m_func == (VNFunc)GT_GE) ||
+            (funcApp.m_func == (VNFunc)GT_LT) || (funcApp.m_func == (VNFunc)GT_GT))
         {
-            case GT_LE:
-            case GT_LT:
-            case GT_GE:
-            case GT_GT:
-                return IsVNInt32Constant(funcApp.m_args[0]) || IsVNInt32Constant(funcApp.m_args[1]);
-            default:
-                break;
+            const bool op1IsConst = IsVNInt32Constant(funcApp.m_args[0]);
+            const bool op2IsConst = IsVNInt32Constant(funcApp.m_args[1]);
+            return op1IsConst != op2IsConst;
         }
     }
     return false;


### PR DESCRIPTION
This PR does:
1) Removes bound checks for https://github.com/dotnet/runtime/issues/81160 (closes it)
2) Improves assertions around MOD/UMOD, e.g:
```cs
static int Test(int x)
{
    if ((uint)x < 100)
        return x % 8; // x is proven to be never-negative, can be optimized
    return 0;
}
```
Codegen diff:
```diff
; Method Program:Test(int):int (FullOpts)
G_M46009_IG01:
G_M46009_IG02:
       xor      eax, eax
       mov      edx, ecx
-      sar      edx, 31
       and      edx, 7
-      add      edx, ecx
-      and      edx, -8
-      mov      r8d, ecx
-      sub      r8d, edx
       cmp      ecx, 100
-      cmovb    eax, r8d
+      cmovb    eax, edx
G_M46009_IG03:
       ret      
-; Total bytes of code: 29
+; Total bytes of code: 14
```