### PR TITLE
Prevent IndexOutOfRangeException in RegexInterpreter

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -74,8 +74,15 @@ namespace System.Text.RegularExpressions
             int[] localruntrack = runtrack!;
             int localruntrackpos = runtrackpos;
 
-            localruntrack[--localruntrackpos] = i1;
-            localruntrack[--localruntrackpos] = _codepos;
+            if (localruntrackpos > 1)
+            {
+                localruntrack[--localruntrackpos] = i1;
+                localruntrack[--localruntrackpos] = _codepos;
+            }
+            else
+            {
+                localruntrackpos = 0;
+            }
 
             runtrackpos = localruntrackpos;
         }
@@ -121,9 +128,16 @@ namespace System.Text.RegularExpressions
             int[] localruntrack = runtrack!;
             int localruntrackpos = runtrackpos;
 
-            localruntrack[--localruntrackpos] = i1;
-            localruntrack[--localruntrackpos] = i2;
-            localruntrack[--localruntrackpos] = -_codepos;
+            if (localruntrackpos > 2)
+            {
+                localruntrack[--localruntrackpos] = i1;
+                localruntrack[--localruntrackpos] = i2;
+                localruntrack[--localruntrackpos] = -_codepos;
+            }
+            else
+            {
+                localruntrackpos = 0;
+            }
 
             runtrackpos = localruntrackpos;
         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -53,10 +53,7 @@ namespace System.Text.RegularExpressions
         private void Goto(int newpos)
         {
             // When branching backward, ensure storage.
-            if (newpos < _codepos)
-            {
-                EnsureStorage();
-            }
+            EnsureStorage();
 
             _codepos = newpos;
             SetOperator((RegexOpcode)_code.Codes[newpos]);
@@ -74,15 +71,8 @@ namespace System.Text.RegularExpressions
             int[] localruntrack = runtrack!;
             int localruntrackpos = runtrackpos;
 
-            if (localruntrackpos > 1)
-            {
-                localruntrack[--localruntrackpos] = i1;
-                localruntrack[--localruntrackpos] = _codepos;
-            }
-            else
-            {
-                localruntrackpos = 0;
-            }
+            localruntrack[--localruntrackpos] = i1;
+            localruntrack[--localruntrackpos] = _codepos;
 
             runtrackpos = localruntrackpos;
         }
@@ -128,16 +118,9 @@ namespace System.Text.RegularExpressions
             int[] localruntrack = runtrack!;
             int localruntrackpos = runtrackpos;
 
-            if (localruntrackpos > 2)
-            {
-                localruntrack[--localruntrackpos] = i1;
-                localruntrack[--localruntrackpos] = i2;
-                localruntrack[--localruntrackpos] = -_codepos;
-            }
-            else
-            {
-                localruntrackpos = 0;
-            }
+            localruntrack[--localruntrackpos] = i1;
+            localruntrack[--localruntrackpos] = i2;
+            localruntrack[--localruntrackpos] = -_codepos;
 
             runtrackpos = localruntrackpos;
         }
@@ -158,10 +141,7 @@ namespace System.Text.RegularExpressions
             SetOperator((RegexOpcode)(_code.Codes[newpos] | back));
 
             // When branching backward, ensure storage.
-            if (newpos < _codepos)
-            {
-                EnsureStorage();
-            }
+            EnsureStorage();
 
             _codepos = newpos;
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
@@ -454,19 +454,15 @@ namespace System.Text.RegularExpressions.Tests
                     };
                 }
 
-                if (engine != RegexEngine.Interpreter && // these tests currently fail with RegexInterpreter
-                    RuntimeFeature.IsDynamicCodeCompiled) // if dynamic code isn't compiled, RegexOptions.Compiled falls back to the interpreter, for which these tests currently fail
+                // Fails on .NET Framework: [ActiveIssue("https://github.com/dotnet/runtime/issues/62094")]
+                yield return new object[]
                 {
-                    // Fails on interpreter and .NET Framework: [ActiveIssue("https://github.com/dotnet/runtime/issues/62094")]
-                    yield return new object[]
+                    engine, @"(?:){93}", "x", RegexOptions.None, new[]
                     {
-                        engine, @"(?:){93}", "x", RegexOptions.None, new[]
-                        {
-                            new CaptureData("", 0, 0),
-                            new CaptureData("", 1, 0)
-                        }
-                    };
-                }
+                        new CaptureData("", 0, 0),
+                        new CaptureData("", 1, 0)
+                    }
+                };
 #endif
             }
         }


### PR DESCRIPTION
This update fixes the IndexOutOfRangeException in RegexInterpreter by enhancing the `TrackPush` and `TrackPush2` methods. The adjustment involves checking the runtrack position before decrementing it, ensuring that it doesn't become negative, which was the root cause of the exception. This prevents potential out-of-range errors when handling large numbers of repetitions in regular expressions.

Fix #62094