### PR TITLE
Fix interpreter

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -312,13 +312,7 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
         //
         ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
 
-#ifdef FEATURE_INTERPRETER
-        _ASSERTE(isCallConv(m_methodSig.GetCallingConvention(), IMAGE_CEE_CS_CALLCONV_DEFAULT)
-                 || isCallConv(m_methodSig.GetCallingConvention(), CorCallingConvention(IMAGE_CEE_CS_CALLCONV_C))
-                 || isCallConv(m_methodSig.GetCallingConvention(), CorCallingConvention(IMAGE_CEE_CS_CALLCONV_VARARG))
-                 || isCallConv(m_methodSig.GetCallingConvention(), CorCallingConvention(IMAGE_CEE_CS_CALLCONV_NATIVEVARARG))
-                 || isCallConv(m_methodSig.GetCallingConvention(), CorCallingConvention(IMAGE_CEE_CS_CALLCONV_STDCALL)));
-#else
+#ifndef FEATURE_INTERPRETER
         _ASSERTE(isCallConv(m_methodSig.GetCallingConvention(), IMAGE_CEE_CS_CALLCONV_DEFAULT));
         _ASSERTE(!(m_methodSig.GetCallingConventionInfo() & CORINFO_CALLCONV_PARAMTYPE));
 #endif

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -11728,7 +11728,7 @@ static const char* CorInfoTypeNames[] = {
 };
 
 // Also see Compiler::lookupNamedIntrinsic
-InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd)
+Interpreter::InterpreterNamedIntrinsics Interpreter::getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd)
 {
     InterpreterNamedIntrinsics result = NI_Illegal;
 
@@ -11773,7 +11773,7 @@ InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HAN
 
 // Simple version of getMethodName which supports IL Stubs such as IL_STUB_PInvoke additionally.
 // Also see getMethodNameFromMetadata and printMethodName in corinfo.h
-const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName, const char **enclosingClassName)
+const char* Interpreter::getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName, const char **enclosingClassName)
 {
     MethodDesc *pMD = GetMethod(hnd);
     if (pMD->IsILStub())
@@ -11801,7 +11801,7 @@ const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const 
     const char* returnType = NULL;
 
     const char* className;
-    const char* methodName = getMethodName(info, hnd, &className);
+    const char* methodName = Interpreter::getMethodName(info, hnd, &className);
     if (clsName != NULL)
     {
         *clsName = className;

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -10876,10 +10876,10 @@ void Interpreter::DoGetIsSupported()
 void Interpreter::DoGetArrayDataReference()
 {
     CONTRACTL {
-            THROWS;
-            GC_TRIGGERS;
-            MODE_COOPERATIVE;
-        } CONTRACTL_END;
+        THROWS;
+        GC_TRIGGERS;
+        MODE_COOPERATIVE;
+    } CONTRACTL_END;
 
     _ASSERTE(m_curStackHt > 0);
     unsigned ind = m_curStackHt - 1;

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -9286,11 +9286,15 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
             const char* className = NULL;
             const char* methodName = getMethodName(&m_interpCeeInfo, (CORINFO_METHOD_HANDLE)methToCall, &className, &namespaceName, NULL);
             if (
+                (strcmp(namespaceName, "System.Runtime.Intrinsics") == 0 ||
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
-                strcmp(namespaceName, "System.Runtime.Intrinsics.X86") == 0 &&
+                strcmp(namespaceName, "System.Runtime.Intrinsics.X86") == 0
 #elif defined(TARGET_ARM64)
-                strcmp(namespaceName, "System.Runtime.Intrinsics.Arm") == 0 &&
-#endif // defined(TARGET_X86) || defined(TARGET_AMD64)
+                strcmp(namespaceName, "System.Runtime.Intrinsics.Arm") == 0
+#else
+                0
+#endif
+                ) &&
                 strcmp(methodName, "get_IsSupported") == 0
             )
             {
@@ -9298,7 +9302,8 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                 DoGetIsSupported();
                 didIntrinsic = true;
             }
-            else if (strcmp(methodName, "get_IsHardwareAccelerated") == 0 && strcmp(namespaceName, "System.Runtime.Intrinsics") == 0)
+
+            if (strcmp(methodName, "get_IsHardwareAccelerated") == 0 && strcmp(namespaceName, "System.Runtime.Intrinsics") == 0)
             {
                 GCX_COOP();
                 DoGetIsSupported();

--- a/src/coreclr/vm/interpreter.cpp
+++ b/src/coreclr/vm/interpreter.cpp
@@ -9294,6 +9294,12 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
                 DoGetIsSupported();
                 didIntrinsic = true;
             }
+            else if (strcmp(methodName, "get_IsHardwareAccelerated") == 0 && strncmp(className, "Vector", 6) == 0 && strcmp(namespaceName, "System.Runtime.Intrinsics") == 0)
+            {
+                GCX_COOP();
+                DoGetIsSupported();
+                didIntrinsic = true;
+            }
         }
 
 #if FEATURE_SIMD

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -538,6 +538,7 @@ struct CachedItem
 };
 
 
+const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL, const char **enclosingClassName = NULL);
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName = NULL);
 
 // The per-InterpMethodInfo cache may map generic instantiation information to the

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -537,17 +537,7 @@ struct CachedItem
     }
 };
 
-// Also see namedintrinsiclist.h
-enum InterpreterNamedIntrinsics : unsigned short
-{
-    NI_Illegal = 0,
-    NI_System_StubHelpers_GetStubContext,
-    NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference,
-};
 
-InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd);
-
-const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL, const char **enclosingClassName = NULL);
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName = NULL);
 
 // The per-InterpMethodInfo cache may map generic instantiation information to the
@@ -923,6 +913,16 @@ public:
     OBJECTREF* GetAddressOfSecurityObject() { return &m_securityObject; }
 
     void*      GetParamTypeArg() { return m_genericsCtxtArg; }
+
+    // Also see namedintrinsiclist.h
+    enum InterpreterNamedIntrinsics : unsigned short
+    {
+        NI_Illegal = 0,
+        NI_System_StubHelpers_GetStubContext,
+        NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference,
+    };
+    static InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd);
+    static const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL, const char **enclosingClassName = NULL);
 
 private:
     // Architecture-dependent helpers.

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -542,6 +542,7 @@ enum InterpreterNamedIntrinsics : unsigned short
 {
     NI_Illegal = 0,
     NI_System_StubHelpers_GetStubContext,
+    NI_System_Runtime_InteropService_MemoryMarshal_GetArrayDataReference,
 };
 
 InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd);
@@ -1788,6 +1789,7 @@ private:
     void DoGetTypeFromHandle();
     void DoSIMDHwAccelerated();
     void DoGetIsSupported();
+    void DoGetArrayDataReference();
 
     // Returns the proper generics context for use in resolving tokens ("precise" in the sense of including generic instantiation
     // information).

--- a/src/coreclr/vm/interpreter.h
+++ b/src/coreclr/vm/interpreter.h
@@ -537,6 +537,14 @@ struct CachedItem
     }
 };
 
+// Also see namedintrinsiclist.h
+enum InterpreterNamedIntrinsics : unsigned short
+{
+    NI_Illegal = 0,
+    NI_System_StubHelpers_GetStubContext,
+};
+
+InterpreterNamedIntrinsics getNamedIntrinsicID(CEEInfo* info, CORINFO_METHOD_HANDLE methodHnd);
 
 const char* getMethodName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** className, const char** namespaceName = NULL, const char **enclosingClassName = NULL);
 const char* eeGetMethodFullName(CEEInfo* info, CORINFO_METHOD_HANDLE hnd, const char** clsName = NULL);


### PR DESCRIPTION
This PR fixes CoreCLR interpreter at HelloWorld level.

IL code of Program:
```
.assembly a {}
.method void Main()
{
.entrypoint
ldstr "Hello World!"
call void [System.Private.CoreLib]Internal.Console::WriteLine(string)
ret
}
```

Run with command `corerun -c /home/nikola/work/runtime/artifacts/bin/coreclr/linux.x64.Debug /home/nikola/work/runtime/t/hello.exe` and following environment variables:
```
DOTNET_JitFunctionTrace=1
DOTNET_ForceInterpreter=1
DOTNET_Interpret=*
DOTNET_ZapDisable=1
DOTNET_ReadyToRun=0
DOTNET_DumpInterpreterStubs=1
DOTNET_TraceInterpreterEntries=1
DOTNET_TraceInterpreterIL=
DOTNET_TraceInterpreterOstack=
DOTNET_InterpreterHWIntrinsicsIsSupportedFalse=1
DOTNET_InterpreterDoLoopMethods=1
DOTNET_InterpretExclude=
DOTNET_TieredCompilation=0
```