### PR TITLE
Deduplicate LSDA data in the object writer

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/INodeWithCodeInfo.cs
@@ -16,7 +16,7 @@ namespace ILCompiler.DependencyAnalysis
         HasAssociatedData   = 0x10,
     }
 
-    public struct FrameInfo
+    public struct FrameInfo : IEquatable<FrameInfo>
     {
         public readonly FrameInfoFlags Flags;
         public readonly int StartOffset;
@@ -29,6 +29,24 @@ namespace ILCompiler.DependencyAnalysis
             StartOffset = startOffset;
             EndOffset = endOffset;
             BlobData = blobData;
+        }
+
+        public bool Equals(FrameInfo other)
+            => Flags == other.Flags
+            && StartOffset == other.StartOffset
+            && EndOffset == other.EndOffset
+            && ((ReadOnlySpan<byte>)BlobData).SequenceEqual(other.BlobData);
+
+        public override bool Equals(object obj) => obj is FrameInfo other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            HashCode hash = default;
+            hash.Add(Flags);
+            hash.Add(StartOffset);
+            hash.Add(EndOffset);
+            hash.AddBytes(BlobData);
+            return hash.ToHashCode();
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodAssociatedDataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodAssociatedDataNode.cs
@@ -51,7 +51,7 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append("_associatedData_").Append(nameMangler.GetMangledMethodName(_methodNode.Method));
         }
 
-        public static bool MethodHasAssociatedData(NodeFactory factory, IMethodNode methodNode)
+        public static bool MethodHasAssociatedData(IMethodNode methodNode)
         {
             // Instantiating unboxing stubs. We need to store their non-unboxing target pointer (looked up by runtime)
             ISpecialUnboxThunkNode unboxThunk = methodNode as ISpecialUnboxThunkNode;
@@ -63,7 +63,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
         {
-            Debug.Assert(MethodHasAssociatedData(factory, _methodNode));
+            Debug.Assert(MethodHasAssociatedData(_methodNode));
 
             ObjectDataBuilder objData = new ObjectDataBuilder(factory, relocsOnly);
             objData.RequireInitialAlignment(1);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.cs
@@ -187,7 +187,7 @@ namespace ILCompiler.ObjectWriter
                 else
                 {
                     lsdaSectionWriter = _lsdaSectionWriter;
-                    if (LsdaCache.IsCacheable(nodeWithCodeInfo))
+                    if (LsdaCache.IsCacheable(nodeWithCodeInfo) && !useFrameNames)
                     {
                         emittedLsdaSymbols = _lsdaCache.FindCachedLsda(nodeWithCodeInfo);
                         if (emittedLsdaSymbols == null)
@@ -215,6 +215,7 @@ namespace ILCompiler.ObjectWriter
                         if (newLsdaSymbols != null)
                             newLsdaSymbols[i] = lsdaSymbolName;
                         lsdaSectionWriter.EmitSymbolDefinition(lsdaSymbolName);
+                        EmitLsda(nodeWithCodeInfo, frameInfos, i, _lsdaSectionWriter, ref mainLsdaOffset);
                     }
 
                     string framSymbolName = $"_fram{i}{currentSymbolName}";
@@ -237,9 +238,6 @@ namespace ILCompiler.ObjectWriter
                             personalitySymbolName: null);
                         _dwarfEhFrame.AddFde(fde);
                     }
-
-                    if (emittedLsdaSymbols == null)
-                        EmitLsda(nodeWithCodeInfo, frameInfos, i, _lsdaSectionWriter, ref mainLsdaOffset);
                 }
 
                 if (newLsdaSymbols != null)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -91,7 +91,7 @@ namespace ILCompiler.DependencyAnalysis
                 dependencies.Add(_ehInfo, "Exception handling information");
             }
 
-            if (MethodAssociatedDataNode.MethodHasAssociatedData(factory, this))
+            if (MethodAssociatedDataNode.MethodHasAssociatedData(this))
             {
                 dependencies ??= new DependencyList();
                 dependencies.Add(new DependencyListEntry(factory.MethodAssociatedData(this), "Method associated data"));
@@ -121,7 +121,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ISymbolNode GetAssociatedDataNode(NodeFactory factory)
         {
-            if (MethodAssociatedDataNode.MethodHasAssociatedData(factory, this))
+            if (MethodAssociatedDataNode.MethodHasAssociatedData(this))
                 return factory.MethodAssociatedData(this);
 
             return null;


### PR DESCRIPTION
Extracting a piece of #87045 that I had to revert in that PR. Native linkers don't like when LSDA is in a COMDAT so fold these in the object writer instead. Seems to save about 1.2% in the Stage1 app. Obviously Unix only.

Cc @dotnet/ilc-contrib