### PR TITLE
Make OCSP stapling tests more stable

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -154,6 +154,17 @@ namespace System.Net.Security
             return ValueTask.FromResult(_ocspResponse);
         }
 
+        internal ValueTask<byte[]?> WaitForPendingOcspFetchAsync()
+        {
+            Task<byte[]?>? pending = _pendingDownload;
+            if (pending is not null && !pending.IsFaulted)
+            {
+                return new ValueTask<byte[]?>(pending);
+            }
+
+            return ValueTask.FromResult(DateTimeOffset.UtcNow <= _ocspExpiration ? _ocspResponse : null);
+        }
+
         private ValueTask<byte[]?> DownloadOcspAsync()
         {
             Task<byte[]?>? pending = _pendingDownload;

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -172,12 +172,12 @@ public class SslStreamCertificateContextOcspLinuxTests
             responder.RespondKind = RespondKind.Invalid;
             for (int i = 0; i < 2; i++)
             {
-                await Task.Delay(SslStreamCertificateContext.RefreshAfterFailureBackOffInterval);
                 byte[] ocsp2 = await ctx.GetOcspResponseAsync();
                 Assert.Equal(ocsp, ocsp2);
+                await Task.Delay(SslStreamCertificateContext.RefreshAfterFailureBackOffInterval);
             }
 
-            // wait until backoff expires
+            // make sure we try again only after backoff expires
             await ctx.WaitForPendingOcspFetchAsync();
             await Task.Delay(SslStreamCertificateContext.RefreshAfterFailureBackOffInterval);
 

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -153,7 +153,7 @@ public class SslStreamCertificateContextOcspLinuxTests
     }
 
     [Fact]
-    //[OuterLoop("Takes about 15 seconds")]
+    [OuterLoop("Takes about 15 seconds")]
     [PlatformSpecific(TestPlatforms.Linux)]
     public async Task RefreshOcspResponse_FirstInvalidThenValid()
     {


### PR DESCRIPTION
Fixes #97836, #97779 and #97936.

The instability of the tests was caused by the tests racing with refreshing the OCSP staple on the background. This PR adds waiting for the background refresh to complete where it was assumed it will complete fast enough.

I kept the tests running for a bit on my machine, and did not reproduce the failure after the changes.