### PR TITLE
Update build.ps1

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -255,7 +255,7 @@ if ($vs) {
   # Disable .NET runtime signature validation errors which errors for local builds
   $env:VSDebugger_ValidateDotnetDebugLibSignatures=0;
 
-  # Respect the RuntimeConfiguration variable for building inside VS with different runtime configurations	
+  # Respect the RuntimeConfiguration variable for building inside VS with different runtime configurations
   if ($runtimeConfiguration)
   {
     $env:RUNTIMECONFIGURATION=$runtimeConfiguration


### PR DESCRIPTION
Respect `TargetOS` and `TargetArchitecture` set variables when invoking Visual Studio.

Helps with https://github.com/dotnet/runtime/pull/97969