### PR TITLE
Ensure `HashSet.TrimExcess()` does not change the count

### DIFF
--- a/src/libraries/Common/tests/System/Collections/TestBase.Generic.cs
+++ b/src/libraries/Common/tests/System/Collections/TestBase.Generic.cs
@@ -255,12 +255,13 @@ namespace System.Collections.Tests
             return set;
         }
 
+#if NETCOREAPP
         /// <summary>
         /// Create a HashSet with a specific initial capacity and fill it with a specific number of elements.
         /// </summary>
         protected HashSet<T> CreateHashSetWithCapacity(int count, int capacity)
         {
-            HashSet<T> set = new HashSet<T>(capacity, GetIEqualityComparer());
+            var set = new HashSet<T>(capacity, GetIEqualityComparer());
             int seed = 528;
 
             for (int i = 0; i < count; i++)
@@ -270,6 +271,7 @@ namespace System.Collections.Tests
 
             return set;
         }
+#endif
 
         /// <summary>
         /// Helper function to create an SortedSet fulfilling the given specific parameters. The function will

--- a/src/libraries/Common/tests/System/Collections/TestBase.Generic.cs
+++ b/src/libraries/Common/tests/System/Collections/TestBase.Generic.cs
@@ -256,6 +256,22 @@ namespace System.Collections.Tests
         }
 
         /// <summary>
+        /// Create a HashSet with a specific initial capacity and fill it with a specific number of elements.
+        /// </summary>
+        protected HashSet<T> CreateHashSetWithCapacity(int count, int capacity)
+        {
+            HashSet<T> set = new HashSet<T>(capacity, GetIEqualityComparer());
+            int seed = 528;
+
+            for (int i = 0; i < count; i++)
+            {
+                while (!set.Add(CreateT(seed++)));
+            }
+
+            return set;
+        }
+
+        /// <summary>
         /// Helper function to create an SortedSet fulfilling the given specific parameters. The function will
         /// create an SortedSet using the Comparer constructor and then add values
         /// to it until it is full. It will begin by adding the desired number of matching,

--- a/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
+++ b/src/libraries/System.Collections/tests/Generic/HashSet/HashSet.Generic.Tests.cs
@@ -212,12 +212,39 @@ namespace System.Collections.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>(() => hashSet.TrimExcess(newCapacity));
         }
 
-        [Fact]
-        public void TrimExcess_Generic_LargeInitialCapacity_TrimReducesSize()
+        [Theory]
+        [InlineData(0, 20, 7)]
+        [InlineData(10, 20, 10)]
+        [InlineData(10, 20, 13)]
+        public void HashHet_Generic_TrimExcess_LargePopulatedHashSet_TrimReducesSize(int initialCount, int initialCapacity, int trimCapacity)
         {
-            var set = new HashSet<T>(20);
-            set.TrimExcess(7);
-            Assert.Equal(7, set.Capacity);
+            HashSet<T> set = CreateHashSetWithCapacity(initialCount, initialCapacity);
+            HashSet<T> clone = new(set, set.Comparer);
+
+            Assert.True(set.Capacity >= initialCapacity);
+            Assert.Equal(initialCount, set.Count);
+
+            set.TrimExcess(trimCapacity);
+
+            Assert.True(trimCapacity <= set.Capacity && set.Capacity < initialCapacity);
+            Assert.Equal(initialCount, set.Count);
+            Assert.Equal(clone, set);
+        }
+
+        [Theory]
+        [InlineData(10, 20, 0)]
+        [InlineData(10, 20, 7)]
+        public void HashHet_Generic_TrimExcess_LargePopulatedHashSet_TrimCapacityIsLessThanCount_ThrowsArgumentOutOfRangeException(int initialCount, int initialCapacity, int trimCapacity)
+        {
+            HashSet<T> set = CreateHashSetWithCapacity(initialCount, initialCapacity);
+
+            Assert.True(set.Capacity >= initialCapacity);
+            Assert.Equal(initialCount, set.Count);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => set.TrimExcess(trimCapacity));
+
+            Assert.True(set.Capacity >= initialCapacity);
+            Assert.Equal(initialCount, set.Count);
         }
 
         [Theory]

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -1010,7 +1010,7 @@ namespace System.Collections.Generic
         /// Sets the capacity of a <see cref="HashSet{T}"/> object to the actual number of elements it contains,
         /// rounded up to a nearby, implementation-specific value.
         /// </summary>
-        public void TrimExcess() => SetCapacity(Count);
+        public void TrimExcess() => TrimExcess(Count);
 
         /// <summary>
         /// Sets the capacity of a <see cref="HashSet{T}"/> object to the specified number of entries,
@@ -1022,12 +1022,6 @@ namespace System.Collections.Generic
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(capacity, Count);
 
-            SetCapacity(capacity);
-        }
-
-        private void SetCapacity(int capacity)
-        {
-            Debug.Assert(capacity >= Count);
             int newSize = HashHelpers.GetPrime(capacity);
             Entry[]? oldEntries = _entries;
             int currentCapacity = oldEntries == null ? 0 : oldEntries.Length;
@@ -1055,7 +1049,7 @@ namespace System.Collections.Generic
                 }
             }
 
-            _count = capacity;
+            _count = count;
             _freeCount = 0;
         }
 


### PR DESCRIPTION
Fix #97947.