### PR TITLE
Ensure that constant folding for SIMD shifts on xarch follow the correct behavior on overshift

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -934,7 +934,7 @@ GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdT
             GenTree* op2 = impPopStack().val;
             GenTree* op1 = impSIMDPopStack();
 
-            GenTree* tmpOp = gtNewSimdCreateScalarUnsafeNode(TYP_SIMD16, op2, CORINFO_TYPE_INT, 16);
+            GenTree* tmpOp = gtNewSimdCreateScalarNode(TYP_SIMD16, op2, CORINFO_TYPE_INT, 16);
             return gtNewSimdHWIntrinsicNode(simdType, op1, tmpOp, intrinsic, simdBaseJitType, genTypeSize(simdType));
         }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7561,6 +7561,11 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 
                     if (genTypeSize(baseType) != 8)
                     {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
                         arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
                     }
                     else
@@ -7594,6 +7599,11 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 
                     if (genTypeSize(baseType) != 8)
                     {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
                         arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
                     }
                     else
@@ -7626,6 +7636,11 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
 
                     if (genTypeSize(baseType) != 8)
                     {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
                         arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
                     }
                     else

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
@@ -11,7 +11,7 @@ public static class Runtime_93698
     [Fact]
     public static void TestShiftLeftLogicalOvershift()
     {
-        if (Sse.IsSupported)
+        if (Sse2.IsSupported)
         {
             var result1 = Sse2.ShiftLeftLogical(Vector128.Create(-1, +2, -3, +4), 32);
             Assert.Equal(Vector128<int>.Zero, result1);
@@ -24,7 +24,7 @@ public static class Runtime_93698
     [Fact]
     public static void TestShiftRightLogicalOvershift()
     {
-        if (Sse.IsSupported)
+        if (Sse2.IsSupported)
         {
             var result1 = Sse2.ShiftRightLogical(Vector128.Create(-1, +2, -3, +4), 32);
             Assert.Equal(Vector128<int>.Zero, result1);
@@ -37,7 +37,7 @@ public static class Runtime_93698
     [Fact]
     public static void TestShiftRightArithmeticOvershift()
     {
-        if (Sse.IsSupported)
+        if (Sse2.IsSupported)
         {
             var result1 = Sse2.ShiftRightArithmetic(Vector128.Create(-1, +2, -3, +4), 32);
             Assert.Equal(Vector128.Create(-1, 0, -1, 0), result1);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public static class Runtime_93698
+{
+    [Fact]
+    public static void TestShiftLeftLogicalOvershift()
+    {
+        if (Sse.IsSupported)
+        {
+            var result1 = Sse2.ShiftLeftLogical(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128<int>.Zero, result1);
+
+            var result2 = Sse2.ShiftLeftLogical(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128<int>.Zero, result2);
+        }
+    }
+
+    [Fact]
+    public static void TestShiftRightLogicalOvershift()
+    {
+        if (Sse.IsSupported)
+        {
+            var result1 = Sse2.ShiftRightLogical(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128<int>.Zero, result1);
+
+            var result2 = Sse2.ShiftRightLogical(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128<int>.Zero, result2);
+        }
+    }
+
+    [Fact]
+    public static void TestShiftRightArithmeticOvershift()
+    {
+        if (Sse.IsSupported)
+        {
+            var result1 = Sse2.ShiftRightArithmetic(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128.Create(-1, 0, -1, 0), result1);
+
+            var result2 = Sse2.ShiftRightArithmetic(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128.Create(-1, 0, -1, 0), result2);
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This resolves #93698 by ensuring the correct behavior is followed. As per the comments in the code, the xplat paths already enforce masking of the constant to ensure that it is "in range" and so they can never hit the constant folding path with an overshift. Only direct user usage of `Sse2.ShiftLeftLogical` (or similar) can hit this path.