### PR TITLE
Suppress unused variable warnings for PERFTRACING_DISABLE CMake vars

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -584,6 +584,7 @@
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_PERFTRACING_LISTEN_PORTS=1"/>
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_DEFAULT_LISTEN_PORT=1"/>
       <_MonoCMakeArgs Include="-DFEATURE_PERFTRACING_DISABLE_CONNECT_PORTS=1" />
+      <_MonoCMakeArgs Include="--no-warn-unused-cli" />
     </ItemGroup>
 
     <!-- Components -->


### PR DESCRIPTION
FEATURE_PERFTRACING_DISABLE_* can sometimes throw unused variable cmake errors, so suppress unused variable warnings entirely. We already use this suppression in gen-buildsys (used by CoreCLR but not Mono).