### PR TITLE
Fix yaml parser error on runtime-wasm-perf.yml

### DIFF
--- a/eng/pipelines/runtime-wasm-perf.yml
+++ b/eng/pipelines/runtime-wasm-perf.yml
@@ -39,7 +39,7 @@ extends:
           runProfile: 'v8'
           collectHelixLogsScript: ${{ variables._wasmCollectHelixLogsScript }}
           onlySanityCheck: true
-          #perfForkToUse: - dummy change
+          #perfForkToUse: # dummy change
             #url: https://github.com/radical/performance
             #branch: fix-build
           #downloadSpecificBuild:


### PR DESCRIPTION
The runtime-wasm-perf pipeline is complaining about the `-` inside a comment in the YAML file for some reason and so the pipeline is not being run at all. Likely caused by a bug in the YAML parser, but changing it to a comment to see if it fixes the issue. 