### PR TITLE
JIT: ARM64 SVE format encodings, `SVE_ID_2A` to `SVE_JH_2A`

### DIFF
--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -6948,58 +6948,46 @@ void CodeGen::genArm64EmitterUnitTestsSve()
                                 INS_OPTS_SCALABLE_D); // ST1B    {<Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
 
     // IF_SVE_ID_2A
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 0); // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 76);   // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -25);  // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -256); // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 255);  // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
+    // LDR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 0);
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 76);
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -25);
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -256);
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 255);
 
     // IF_SVE_JG_2A
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 0); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 221);  // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -117); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -256); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 255);  // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}] 
+    // STR <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 0);
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 221);
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -117);
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -256); 
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 255);
 
     // IF_SVE_IE_2A
+    // LDR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
     theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 0, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 33, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -173, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -256, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 255, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
 
     // IF_SVE_JH_2A
+    // STR <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 0, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 71, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -165, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -256, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 255, INS_OPTS_NONE,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                               // VL}]
+                              INS_SCALABLE_OPTS_UNPREDICATED);
 }
 
 #endif // defined(TARGET_ARM64) && defined(DEBUG)

--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -6946,6 +6946,28 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     // IF_SVE_JK_4B
     theEmitter->emitIns_R_R_R_R(INS_sve_st1b, EA_SCALABLE, REG_V6, REG_P3, REG_R0, REG_V4,
                                 INS_OPTS_SCALABLE_D); // ST1B    {<Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
+
+    // IF_SVE_IE_2A
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 0); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 33);   // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -173); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -256); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 255);  // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+
+    // IF_SVE_JH_2A
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 0); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 71);   // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -165); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -256); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 255);  // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
 }
 
 #endif // defined(TARGET_ARM64) && defined(DEBUG)

--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -6960,7 +6960,7 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 0);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 221);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -117);
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -256); 
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -256);
     theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 255);
 
     // IF_SVE_IE_2A

--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -6947,27 +6947,59 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R_R(INS_sve_st1b, EA_SCALABLE, REG_V6, REG_P3, REG_R0, REG_V4,
                                 INS_OPTS_SCALABLE_D); // ST1B    {<Zt>.D }, <Pg>, [<Xn|SP>, <Zm>.D]
 
-    // IF_SVE_IE_2A
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 0); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 33);   // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+    // IF_SVE_ID_2A
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 0); // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 76);   // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
                                                                                // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -173); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -25);  // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
                                                                                // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -256); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, -256); // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
                                                                                // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 255);  // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_P1, REG_R5, 255);  // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL
                                                                                // VL}]
 
+    // IF_SVE_JG_2A
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 0); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 221);  // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -117); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, -256); // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_P3, REG_R1, 255);  // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL
+                                                                               // VL}] 
+
+    // IF_SVE_IE_2A
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 0, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 33, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -173, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, -256, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_ldr, EA_SCALABLE, REG_V3, REG_R4, 255, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+
     // IF_SVE_JH_2A
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 0); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 71);   // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -165); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -256); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
-    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 255);  // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
-                                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 0, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 71, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -165, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, -256, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
+    theEmitter->emitIns_R_R_I(INS_sve_str, EA_SCALABLE, REG_V2, REG_R3, 255, INS_OPTS_NONE,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL
+                                                               // VL}]
 }
 
 #endif // defined(TARGET_ARM64) && defined(DEBUG)

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -24101,7 +24101,8 @@ void emitter::emitDispInsHelp(
                            // offsets)
             emitDispSveConsecutiveRegList(id->idReg1(), insGetSveReg1ListSize(ins), id->idInsOpt(), true); // ttttt
             emitDispPredicateReg(id->idReg2(), insGetPredicateType(fmt), id->idInsOpt(), true);            // ggg
-            emitDispSveModAddr(ins, id->idReg3(), id->idReg4(), id->idInsOpt(), fmt);                      // nnnnn                                                                                                          // mmmmm
+            emitDispSveModAddr(ins, id->idReg3(), id->idReg4(), id->idInsOpt(), fmt);                      // nnnnn
+                                                                                                           // mmmmm
             break;
 
         // {<Zt>.<T>}, <Pg>, [<Xn|SP>{, #<imm>, MUL VL}]

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -24616,10 +24616,6 @@ void emitter::getMemoryOperation(instrDesc* id, unsigned* pMemAccessKind, bool* 
                 }
                 break;
             case IF_LARGELDC:
-            case IF_SVE_ID_2A:
-            case IF_SVE_JG_2A:
-            case IF_SVE_IE_2A:
-            case IF_SVE_JH_2A:
                 isLocalAccess = false;
                 break;
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -543,6 +543,9 @@ static code_t insEncodeSveElemsize_dtype_ld1w(instruction ins, insFormat fmt, em
 // Returns the encoding for the immediate value as 4-bits at bit locations '19-16'.
 static code_t insEncodeSimm4_19_to_16(ssize_t imm);
 
+// Returns the encoding for the immediate value as 9-bits at bit locations '21-16' for high and '12-10' for low.
+static code_t insEncodeSimm9h9l_21_to_16_and_12_to_10(ssize_t imm);
+
 // Returns the encoding for the immediate value that is a multiple of 2 as 4-bits at bit locations '19-16'.
 static code_t insEncodeSimm4_MultipleOf2_19_to_16(ssize_t imm);
 
@@ -609,6 +612,12 @@ static bool isStackRegister(regNumber reg)
 static bool isValidSimm4(ssize_t value)
 {
     return (-8 <= value) && (value <= 7);
+};
+
+// Returns true if 'value' is a legal signed immediate 9 bit encoding (such as for LDR).
+static bool isValidSimm9(ssize_t value)
+{
+    return (-256 <= value) && (value <= 255);
 };
 
 // Returns true if 'value' is a legal signed multiple of 2 immediate 4 bit encoding (such as for LD2Q).

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -52,6 +52,7 @@ void emitDispExtendOpts(insOpts opt);
 void emitDispSveExtendOpts(insOpts opt);
 void emitDispSveExtendOptsModN(insOpts opt, int n);
 void emitDispSveModAddr(instruction ins, regNumber reg1, regNumber reg2, insOpts opt, insFormat fmt);
+void emitDispSveImmMulVl(regNumber reg1, ssize_t imm);
 void emitDispLSExtendOpts(insOpts opt);
 void emitDispReg(regNumber reg, emitAttr attr, bool addComma);
 void emitDispSveReg(regNumber reg, insOpts opt, bool addComma);

--- a/src/coreclr/jit/instrsarm64sve.h
+++ b/src/coreclr/jit/instrsarm64sve.h
@@ -942,13 +942,13 @@ INST3(stnt1d,            "stnt1d",                0,                       IF_SV
 
 
 //    enum               name                     info                                              SVE_ID_2A        SVE_IE_2A                   
-INST2(ldr,               "ldr",                   LD,                      IF_SVE_2AA,              0x85800000,      0x85804000                  )
+INST2(ldr,               "ldr",                   0,                       IF_SVE_2AA,              0x85800000,      0x85804000                  )
     // LDR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]                                         SVE_ID_2A           1000010110iiiiii 000iiinnnnn0TTTT     8580 0000   
     // LDR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]                                         SVE_IE_2A           1000010110iiiiii 010iiinnnnnttttt     8580 4000   
 
 
 //    enum               name                     info                                              SVE_JG_2A        SVE_JH_2A                   
-INST2(str,               "str",                   ST,                      IF_SVE_2AB,              0xE5800000,      0xE5804000                  )
+INST2(str,               "str",                   0,                       IF_SVE_2AB,              0xE5800000,      0xE5804000                  )
     // STR     <Pt>, [<Xn|SP>{, #<imm>, MUL VL}]                                         SVE_JG_2A           1110010110iiiiii 000iiinnnnn0TTTT     E580 0000   
     // STR     <Zt>, [<Xn|SP>{, #<imm>, MUL VL}]                                         SVE_JH_2A           1110010110iiiiii 010iiinnnnnttttt     E580 4000   
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/94549

Adds 4 formats
- SVE_ID_2A
- SVE_JG_2A
- SVE_IE_2A
- SVE_JH_2A

This one is pretty short.

Left: Capstone,
Right: Jit
<img width="479" alt="image" src="https://github.com/dotnet/runtime/assets/1278959/013aa5f5-1cf2-4b79-ac73-20506856ebdc">
