### PR TITLE
Use PreferredRegOptionalOperand for HWIntrinsic nodes

### DIFF
--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -261,7 +261,7 @@ private:
     bool IsCallTargetInRange(void* addr);
 
 #if defined(TARGET_XARCH)
-    GenTree* PreferredRegOptionalOperand(GenTree* tree);
+    GenTree* PreferredRegOptionalOperand(GenTree* op1, GenTree* op2);
 
     // ------------------------------------------------------------------
     // SetRegOptionalBinOp - Indicates which of the operands of a bin-op
@@ -299,7 +299,7 @@ private:
 
         if (op1Legal)
         {
-            regOptionalOperand = op2Legal ? PreferredRegOptionalOperand(tree) : op1;
+            regOptionalOperand = op2Legal ? PreferredRegOptionalOperand(op1, op2) : op1;
         }
         else if (op2Legal)
         {

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6511,8 +6511,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 //
 //
 // Arguments:
-//     tree  -  a binary-op tree node that is either commutative
-//              or a compare oper.
+//     op1  - The first operand of the binary operation to consider
+//     op2  - The second operand of the binary operation to consider
 //
 // Returns:
 //     Returns op1 or op2 of tree node that is preferred for

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6521,18 +6521,8 @@ bool Lowering::IsContainableImmed(GenTree* parentNode, GenTree* childNode) const
 // Note: if the tree oper is neither commutative nor a compare oper
 // then only op2 can be reg optional on xarch and hence no need to
 // call this routine.
-GenTree* Lowering::PreferredRegOptionalOperand(GenTree* tree)
+GenTree* Lowering::PreferredRegOptionalOperand(GenTree* op1, GenTree* op2)
 {
-    assert(GenTree::OperIsBinary(tree->OperGet()));
-    assert(tree->OperIsCommutative() || tree->OperIsCompare() || tree->OperIs(GT_CMP, GT_TEST));
-
-    GenTree* op1 = tree->gtGetOp1();
-    GenTree* op2 = tree->gtGetOp2();
-    assert(!op1->IsRegOptional() && !op2->IsRegOptional());
-
-    // We default to op1, as op2 is likely to have the shorter lifetime.
-    GenTree* preferredOp = op1;
-
     // This routine uses the following heuristics:
     //
     // a) If both are register candidates, marking the one with lower weighted
@@ -6568,27 +6558,43 @@ GenTree* Lowering::PreferredRegOptionalOperand(GenTree* tree)
     //
     // f) If neither of them are local vars (i.e. tree temps), prefer to
     // mark op1 as reg optional for the same reason as mentioned in (d) above.
-    if (op1->OperGet() == GT_LCL_VAR && op2->OperGet() == GT_LCL_VAR)
-    {
-        LclVarDsc* v1 = comp->lvaGetDesc(op1->AsLclVarCommon());
-        LclVarDsc* v2 = comp->lvaGetDesc(op2->AsLclVarCommon());
 
-        bool v1IsRegCandidate = !v1->lvDoNotEnregister;
-        bool v2IsRegCandidate = !v2->lvDoNotEnregister;
-        if (v1IsRegCandidate && v2IsRegCandidate)
+    assert(!op1->IsRegOptional());
+    assert(!op2->IsRegOptional());
+
+    // We default to op1, as op2 is likely to have the shorter lifetime.
+    GenTree* preferredOp = op1;
+
+    if (op1->OperIs(GT_LCL_VAR))
+    {
+        if (op2->OperIs(GT_LCL_VAR))
         {
-            // Both are enregisterable locals.  The one with lower weight is less likely
-            // to get a register and hence beneficial to mark the one with lower
-            // weight as reg optional.
-            // If either is not tracked, it may be that it was introduced after liveness
-            // was run, in which case we will always prefer op1 (should we use raw refcnt??).
-            if (v1->lvTracked && v2->lvTracked && (v1->lvRefCntWtd() >= v2->lvRefCntWtd()))
+            LclVarDsc* v1 = comp->lvaGetDesc(op1->AsLclVarCommon());
+            LclVarDsc* v2 = comp->lvaGetDesc(op2->AsLclVarCommon());
+
+            bool v1IsRegCandidate = !v1->lvDoNotEnregister;
+            bool v2IsRegCandidate = !v2->lvDoNotEnregister;
+
+            if (v1IsRegCandidate && v2IsRegCandidate)
             {
-                preferredOp = op2;
+                // Both are enregisterable locals.  The one with lower weight is less likely
+                // to get a register and hence beneficial to mark the one with lower
+                // weight as reg optional.
+                //
+                // If either is not tracked, it may be that it was introduced after liveness
+                // was run, in which case we will always prefer op1 (should we use raw refcnt??).
+
+                if (v1->lvTracked && v2->lvTracked)
+                {
+                    if (v1->lvRefCntWtd() > v2->lvRefCntWtd())
+                    {
+                        preferredOp = op2;
+                    }
+                }
             }
         }
     }
-    else if (!(op1->OperGet() == GT_LCL_VAR) && (op2->OperGet() == GT_LCL_VAR))
+    else if (op2->OperIs(GT_LCL_VAR))
     {
         preferredOp = op2;
     }
@@ -7438,7 +7444,7 @@ void Lowering::ContainCheckCompare(GenTreeOp* cmp)
             // One of op1 or op2 could be marked as reg optional
             // to indicate that codegen can still generate code
             // if one of them is on stack.
-            GenTree* regOptionalCandidate = op1->IsCnsIntOrI() ? op2 : PreferredRegOptionalOperand(cmp);
+            GenTree* regOptionalCandidate = op1->IsCnsIntOrI() ? op2 : PreferredRegOptionalOperand(op1, op2);
 
             bool setRegOptional =
                 (regOptionalCandidate == op1) ? IsSafeToMarkRegOptional(cmp, op1) : IsSafeToMarkRegOptional(cmp, op2);
@@ -9170,19 +9176,30 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                         // Swap the operands here to make the containment checks in codegen significantly simpler
                         std::swap(node->Op(1), node->Op(2));
                     }
+                    else if (supportsOp1RegOptional)
+                    {
+                        if (supportsOp2RegOptional)
+                        {
+                            GenTree* regOptionalOperand = PreferredRegOptionalOperand(op1, op2);
+                            MakeSrcRegOptional(node, regOptionalOperand);
+
+                            if (regOptionalOperand == op1)
+                            {
+                                // Swap the operands here to make the containment checks in codegen simpler
+                                std::swap(node->Op(1), node->Op(2));
+                            }
+                        }
+                        else
+                        {
+                            MakeSrcRegOptional(node, op1);
+
+                            // Swap the operands here to make the containment checks in codegen simpler
+                            std::swap(node->Op(1), node->Op(2));
+                        }
+                    }
                     else if (supportsOp2RegOptional)
                     {
                         MakeSrcRegOptional(node, op2);
-
-                        // TODO-XArch-CQ: For commutative nodes, either operand can be reg-optional.
-                        //                https://github.com/dotnet/runtime/issues/6358
-                    }
-                    else if (supportsOp1RegOptional)
-                    {
-                        MakeSrcRegOptional(node, op1);
-
-                        // Swap the operands here to make the containment checks in codegen significantly simpler
-                        std::swap(node->Op(1), node->Op(2));
                     }
                     break;
                 }
@@ -9528,22 +9545,44 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                             // result = ([op1] * op2) + op3
                             MakeSrcContained(node, op1);
                         }
-                        else if (supportsOp3RegOptional)
+                        else if (supportsOp1RegOptional)
                         {
-                            assert(resultOpNum != 3);
-                            MakeSrcRegOptional(node, op3);
+                            if (supportsOp2RegOptional)
+                            {
+                                GenTree* regOptionalOperand = PreferredRegOptionalOperand(op1, op2);
 
-                            // TODO-XArch-CQ: Any operand can be reg-optional.
-                            //                https://github.com/dotnet/runtime/issues/6358
+                                if (supportsOp3RegOptional)
+                                {
+                                    regOptionalOperand = PreferredRegOptionalOperand(regOptionalOperand, op3);
+                                }
+
+                                MakeSrcRegOptional(node, regOptionalOperand);
+                            }
+                            else if (supportsOp3RegOptional)
+                            {
+                                GenTree* regOptionalOperand = PreferredRegOptionalOperand(op1, op3);
+                                MakeSrcRegOptional(node, regOptionalOperand);
+                            }
+                            else
+                            {
+                                MakeSrcRegOptional(node, op1);
+                            }
                         }
                         else if (supportsOp2RegOptional)
                         {
-                            assert(resultOpNum != 2);
-                            MakeSrcRegOptional(node, op2);
+                            if (supportsOp3RegOptional)
+                            {
+                                GenTree* regOptionalOperand = PreferredRegOptionalOperand(op2, op3);
+                                MakeSrcRegOptional(node, regOptionalOperand);
+                            }
+                            else
+                            {
+                                MakeSrcRegOptional(node, op2);
+                            }
                         }
-                        else if (supportsOp1RegOptional)
+                        else if (supportsOp3RegOptional)
                         {
-                            MakeSrcRegOptional(node, op1);
+                            MakeSrcRegOptional(node, op3);
                         }
                     }
                     else if (HWIntrinsicInfo::IsPermuteVar2x(intrinsicId))
@@ -9592,19 +9631,30 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                             // Swap the operands here to make the containment checks in codegen significantly simpler
                             swapOperands = true;
                         }
+                        else if (supportsOp1RegOptional)
+                        {
+                            if (supportsOp3RegOptional)
+                            {
+                                GenTree* regOptionalOperand = PreferredRegOptionalOperand(op1, op3);
+                                MakeSrcRegOptional(node, regOptionalOperand);
+
+                                if (regOptionalOperand == op1)
+                                {
+                                    // Swap the operands here to make the containment checks in codegen simpler
+                                    swapOperands = true;
+                                }
+                            }
+                            else
+                            {
+                                MakeSrcRegOptional(node, op1);
+
+                                // Swap the operands here to make the containment checks in codegen simpler
+                                swapOperands = true;
+                            }
+                        }
                         else if (supportsOp3RegOptional)
                         {
                             MakeSrcRegOptional(node, op3);
-
-                            // TODO-XArch-CQ: Either op1 or op3 can be reg-optional.
-                            //                https://github.com/dotnet/runtime/issues/6358
-                        }
-                        else if (supportsOp1RegOptional)
-                        {
-                            MakeSrcRegOptional(node, op1);
-
-                            // Swap the operands here to make the containment checks in codegen significantly simpler
-                            swapOperands = true;
                         }
 
                         if (swapOperands)
@@ -9820,19 +9870,42 @@ void Lowering::ContainCheckHWIntrinsic(GenTreeHWIntrinsic* node)
                             case NI_BMI2_MultiplyNoFlags:
                             case NI_BMI2_X64_MultiplyNoFlags:
                             {
-                                if (IsContainableHWIntrinsicOp(node, op2, &supportsRegOptional))
+                                bool supportsOp1RegOptional = false;
+                                bool supportsOp2RegOptional = false;
+
+                                if (IsContainableHWIntrinsicOp(node, op2, &supportsOp2RegOptional))
                                 {
                                     MakeSrcContained(node, op2);
                                 }
-                                else if (IsContainableHWIntrinsicOp(node, op1, &supportsRegOptional))
+                                else if (IsContainableHWIntrinsicOp(node, op1, &supportsOp1RegOptional))
                                 {
                                     MakeSrcContained(node, op1);
-                                    // MultiplyNoFlags is a Commutative operation, so swap the first two operands here
-                                    // to make the containment checks in codegen significantly simpler
-                                    node->Op(1) = op2;
-                                    node->Op(2) = op1;
+
+                                    // Swap the operands here to make the containment checks in codegen simpler
+                                    std::swap(node->Op(1), node->Op(2));
                                 }
-                                else if (supportsRegOptional)
+                                else if (supportsOp1RegOptional)
+                                {
+                                    if (supportsOp2RegOptional)
+                                    {
+                                        GenTree* regOptionalOperand = PreferredRegOptionalOperand(op1, op2);
+                                        MakeSrcRegOptional(node, regOptionalOperand);
+
+                                        if (regOptionalOperand == op1)
+                                        {
+                                            // Swap the operands here to make the containment checks in codegen simpler
+                                            std::swap(node->Op(1), node->Op(2));
+                                        }
+                                    }
+                                    else
+                                    {
+                                        MakeSrcRegOptional(node, op1);
+
+                                        // Swap the operands here to make the containment checks in codegen simpler
+                                        std::swap(node->Op(1), node->Op(2));
+                                    }
+                                }
+                                else if (supportsOp2RegOptional)
                                 {
                                     MakeSrcRegOptional(node, op2);
                                 }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6586,7 +6586,7 @@ GenTree* Lowering::PreferredRegOptionalOperand(GenTree* op1, GenTree* op2)
 
                 if (v1->lvTracked && v2->lvTracked)
                 {
-                    if (v1->lvRefCntWtd() > v2->lvRefCntWtd())
+                    if (v1->lvRefCntWtd() >= v2->lvRefCntWtd())
                     {
                         preferredOp = op2;
                     }


### PR DESCRIPTION
We had this function that was designed to encompass the general heuristics, but HWIntrinsic nodes weren't using it. This fixes that so we get the same heuristics for any regOptional marking where the choice is between multiple options.