### PR TITLE
[NativeAOT] Convert operand of newarr to int when producing reverse P/Invoke array marshalling

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1078,6 +1078,8 @@ namespace Internal.TypeSystem.Interop
 
                     if (sizeConst.HasValue)
                         codeStream.Emit(ILOpcode.add);
+
+                    codeStream.Emit(ILOpcode.conv_ovf_i4);
                 }
 
                 if (!sizeConst.HasValue && !sizeParamIndex.HasValue)
@@ -1085,8 +1087,6 @@ namespace Internal.TypeSystem.Interop
                     // if neither sizeConst or sizeParamIndex are specified, default to 1
                     codeStream.EmitLdc(1);
                 }
-
-                codeStream.Emit(ILOpcode.conv_ovf_i4);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1086,7 +1086,7 @@ namespace Internal.TypeSystem.Interop
                     codeStream.EmitLdc(1);
                 }
 
-                codeStream.Emit(ILOpcode.conv_ovf_i);
+                codeStream.Emit(ILOpcode.conv_ovf_i4);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1086,7 +1086,7 @@ namespace Internal.TypeSystem.Interop
                     codeStream.EmitLdc(1);
                 }
 
-                codeStream.Emit(ILOpcode.conv_i);
+                codeStream.Emit(ILOpcode.conv_ovf_i);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1085,6 +1085,8 @@ namespace Internal.TypeSystem.Interop
                     // if neither sizeConst or sizeParamIndex are specified, default to 1
                     codeStream.EmitLdc(1);
                 }
+
+                codeStream.Emit(ILOpcode.conv_i);
             }
         }
 


### PR DESCRIPTION
Fixes the following error on linux-arm (https://github.com/dotnet/runtime/pull/98022):
```
ILC: /home/navara/runtime/src/coreclr/jit/importer.cpp:9382
ILC: Assertion failed 'genActualTypeIsIntOrI(op2) : Possibly bad IL with CEE_newarr at offset 002Bh (op1=NULL op2=long stkDepth=0)' in 'SizeParamIndex.PInvoke.PassingByOutTest:MarshalCStyleArrayLong_AsByOut_AsSizeParamIndex(byref,byref):ubyte' during 'Importation' (IL size 147; hash 0x8bc3ebdf; FullOpts)

ILC: /home/navara/runtime/src/coreclr/jit/importer.cpp:9382
ILC: Assertion failed 'genActualTypeIsIntOrI(op2) : Possibly bad IL with CEE_newarr at offset 000Ch (op1=NULL op2=long stkDepth=0)' in 'Internal.CompilerGenerated.<Module>:ReverseDelegateStub__DelUlongArrByRefAsCdeclCaller(uint,uint):int' during 'Importation' (IL size 204; hash 0x41204394; FullOpts)
```