### PR TITLE
[release/8.0] Fix Windows implementation of NegotiateAuthenticationPal.GetMIC

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Windows.cs
@@ -566,7 +566,7 @@ namespace System.Net
                     bool success = SSPIWrapper.QueryBlittableContextAttributes(GlobalSSPI.SSPIAuth, _securityContext, Interop.SspiCli.ContextAttribute.SECPKG_ATTR_SIZES, ref sizes);
                     Debug.Assert(success);
 
-                    Span<byte> signatureBuffer = signature.GetSpan(sizes.cbSecurityTrailer);
+                    Span<byte> signatureBuffer = signature.GetSpan(sizes.cbMaxSignature);
 
                     fixed (byte* messagePtr = message)
                     fixed (byte* signaturePtr = signatureBuffer)
@@ -577,7 +577,7 @@ namespace System.Net
                         Interop.SspiCli.SecBuffer* dataBuffer = &unmanagedBuffer[1];
                         tokenBuffer->BufferType = SecurityBufferType.SECBUFFER_TOKEN;
                         tokenBuffer->pvBuffer = (IntPtr)signaturePtr;
-                        tokenBuffer->cbBuffer = sizes.cbSecurityTrailer;
+                        tokenBuffer->cbBuffer = sizes.cbMaxSignature;
                         dataBuffer->BufferType = SecurityBufferType.SECBUFFER_DATA;
                         dataBuffer->pvBuffer = (IntPtr)messagePtr;
                         dataBuffer->cbBuffer = message.Length;
@@ -597,7 +597,7 @@ namespace System.Net
                             throw new Win32Exception(errorCode);
                         }
 
-                        signature.Advance(signatureBuffer.Length);
+                        signature.Advance(tokenBuffer->cbBuffer);
                     }
                 }
                 finally


### PR DESCRIPTION
Partial backport of PR #96712.

Fixes #97942.

## Customer Impact

- [x] Customer reported
- [x] Found internally

The `NegotiateStream` API sends incorrectly wrapped data on Windows when `ProtectionLevel.Sign` is used and NTLM is used as the underlying algorithm. Other platforms are not affected, other protection levels like `ProtectionLevel.EncryptAndSign` are not affected either.

## Regression

- [x] Yes
- [ ] No

Regression was introduced with PR #86948 in .NET 8. We lacked sufficient testing which was rectified in #96712 in .NET 9 when public APIs were added to expose the internal method. This PR backports the bug fix that was merged as part of PR #96712.

## Testing

Tests were added in #96712 in `main` branch when the functionality was exposed as public API. The bug in the Windows implementation was uncovered by those tests and fixed. The customer who reported this issue in #97942 for .NET 8 has verified that the scenario is now fixed on .NET 9 nightly builds.

Specific changes in this PR have also been tested against the repro provided in #97942.

## Risk

Low

The error is well understood, and the fix was already done in `main` branch last month. .NET 8 exposed this implementation detail only through the `NegotiateStream` API in a specific combination of parameters.