### PR TITLE
JIT: Fold *obj using assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4970,6 +4970,12 @@ GenTree* Compiler::optExactTypeAssertionProp_Ind(ASSERT_VALARG_TP assertions, Ge
         return nullptr;
     }
 
+    if (opts.IsReadyToRun())
+    {
+        // TODO:
+        return nullptr;
+    }
+
     CORINFO_CLASS_HANDLE objType = optAssertionGetExactType(assertions, tree->AsIndir()->Addr());
     if (objType != NO_CLASS_HANDLE)
     {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4940,15 +4940,13 @@ CORINFO_CLASS_HANDLE Compiler::optAssertionGetExactType(ASSERT_VALARG_TP asserti
             assert(curAssertion->op2.HasIconFlag());
             assert(objType != NO_CLASS_HANDLE);
 
-            if (curAssertion->op1.kind == O1K_SUBTYPE)
+            if (curAssertion->op1.kind != O1K_SUBTYPE || info.compCompHnd->isExactType(objType))
             {
-                if (((info.compCompHnd->getClassAttribs(objType) & CORINFO_FLG_SHAREDINST) != 0) ||
-                    !info.compCompHnd->isExactType(objType))
+                if ((info.compCompHnd->getClassAttribs(objType) & CORINFO_FLG_SHAREDINST) == 0)
                 {
-                    continue;
+                    return objType;
                 }
             }
-            return objType;
         }
     }
     return NO_CLASS_HANDLE;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4940,7 +4940,7 @@ CORINFO_CLASS_HANDLE Compiler::optAssertionGetExactType(ASSERT_VALARG_TP asserti
             assert(curAssertion->op2.HasIconFlag());
             assert(objType != NO_CLASS_HANDLE);
 
-            if ((curAssertion->op1.kind == O1K_SUBTYPE))
+            if (curAssertion->op1.kind == O1K_SUBTYPE)
             {
                 if (((info.compCompHnd->getClassAttribs(objType) & CORINFO_FLG_SHAREDINST) != 0) ||
                     !info.compCompHnd->isExactType(objType))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4973,9 +4973,7 @@ GenTree* Compiler::optExactTypeAssertionProp_Ind(ASSERT_VALARG_TP assertions, Ge
     CORINFO_CLASS_HANDLE objType = optAssertionGetExactType(assertions, tree->AsIndir()->Addr());
     if (objType != NO_CLASS_HANDLE)
     {
-        GenTree* newTree = gtNewIconEmbClsHndNode(objType);
-        fgUpdateConstTreeValueNumber(newTree);
-
+        GenTree* newTree     = gtNewIconEmbClsHndNode(objType);
         GenTree* sideEffects = nullptr;
         gtExtractSideEffList(tree, &sideEffects, GTF_SIDE_EFFECT);
         if (sideEffects != nullptr)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7813,7 +7813,10 @@ public:
     GenTree* optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
+
+    CORINFO_CLASS_HANDLE optAssertionGetExactType(ASSERT_VALARG_TP assertions, GenTree* tree);
     GenTree* optExactTypeAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
+
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
     bool optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7813,6 +7813,7 @@ public:
     GenTree* optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt);
     GenTree* optAssertionProp_Update(GenTree* newTree, GenTree* tree, Statement* stmt);
     GenTree* optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCall* call);
+    GenTree* optExactTypeAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
     bool optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 


### PR DESCRIPTION
Example:

```cs
void Test(object o)
{
    if (o is MyClass1)
    {
        if (o is MyClass2) // this condition is never true
        {
            Console.WriteLine("!");
        }
    }
}
```
Was:
```asm
; Method Program:Test(System.Object) (FullOpts)
G_M3485_IG01:
       sub      rsp, 40
G_M3485_IG02:
       mov      rax, rcx
       test     rax, rax
       je       SHORT G_M3485_IG05
G_M3485_IG03:
       mov      rdx, 0x7FF8C1B30DA8      ; MyClass1
       cmp      qword ptr [rax], rdx
       jne      SHORT G_M3485_IG05
G_M3485_IG04:
       mov      rax, 0x7FF8C1B30F08      ; MyClass2
       cmp      qword ptr [rcx], rax
       jne      SHORT G_M3485_IG05
       mov      rcx, 0x1EF80009480      ; '!'
       call     [System.Console:WriteLine(System.String)]
G_M3485_IG05:
       nop      
G_M3485_IG06:
       add      rsp, 40
       ret      
; Total bytes of code: 64
```
Now:
```asm
; Method Program:Test(System.Object) (FullOpts)
G_M3485_IG01:  ;; offset=0x0000
G_M3485_IG02:  ;; offset=0x0000
       ret      
; Total bytes of code: 1
```