### PR TITLE
Improve Math.Round, Math.ILogB, and do some minor cleanup of Half, Single, and Double

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -2373,65 +2373,34 @@ double FloatingPointUtils::round(double x)
     //            MathF.Round(float), and FloatingPointUtils::round(float)
     // ************************************************************************************
 
-    // This is based on the 'Berkeley SoftFloat Release 3e' algorithm
+    // This represents the boundary at which point we can only represent whole integers
+    const double IntegerBoundary = 4503599627370496.0; // 2^52
 
-    uint64_t bits     = *reinterpret_cast<uint64_t*>(&x);
-    int32_t  exponent = (int32_t)(bits >> 52) & 0x07FF;
-
-    if (exponent <= 0x03FE)
+    if (fabs(x) >= IntegerBoundary)
     {
-        if ((bits << 1) == 0)
-        {
-            // Exactly +/- zero should return the original value
-            return x;
-        }
-
-        // Any value less than or equal to 0.5 will always round to exactly zero
-        // and any value greater than 0.5 will always round to exactly one. However,
-        // we need to preserve the original sign for IEEE compliance.
-
-        double result = ((exponent == 0x03FE) && ((bits & UI64(0x000FFFFFFFFFFFFF)) != 0)) ? 1.0 : 0.0;
-        return _copysign(result, x);
-    }
-
-    if (exponent >= 0x0433)
-    {
-        // Any value greater than or equal to 2^52 cannot have a fractional part,
-        // So it will always round to exactly itself.
-
+        // Values above this boundary don't have a fractional
+        // portion and so we can simply return them as-is.
         return x;
     }
 
-    // The absolute value should be greater than or equal to 1.0 and less than 2^52
-    assert((0x03FF <= exponent) && (exponent <= 0x0432));
+    // Otherwise, since floating-point takes the inputs, performs
+    // the computation as if to infinite precision and unbounded
+    // range, and then rounds to the nearest representable result
+    // using the current rounding mode, we can rely on this to
+    // cheaply round.
+    //
+    // In particular, .NET doesn't support changing the rounding
+    // mode and defaults to "round to nearest, ties to even", thus
+    // by adding the original value to the IntegerBoundary we get
+    // an exactly represented whole integer that is precisely the
+    // IntegerBoundary greater in magnitude than the answer we want.
+    //
+    // We can then simply remove that offset to get the correct answer,
+    // noting that we also need to copy back the original sign to
+    // correctly handle -0.0
 
-    // Determine the last bit that represents the integral portion of the value
-    // and the bits representing the fractional portion
-
-    uint64_t lastBitMask   = UI64(1) << (0x0433 - exponent);
-    uint64_t roundBitsMask = lastBitMask - 1;
-
-    // Increment the first fractional bit, which represents the midpoint between
-    // two integral values in the current window.
-
-    bits += lastBitMask >> 1;
-
-    if ((bits & roundBitsMask) == 0)
-    {
-        // If that overflowed and the rest of the fractional bits are zero
-        // then we were exactly x.5 and we want to round to the even result
-
-        bits &= ~lastBitMask;
-    }
-    else
-    {
-        // Otherwise, we just want to strip the fractional bits off, truncating
-        // to the current integer value.
-
-        bits &= ~roundBitsMask;
-    }
-
-    return *reinterpret_cast<double*>(&bits);
+    double temp = _copysign(IntegerBoundary, x);
+    return _copysign((x + temp) - temp, x);
 }
 
 // Windows x86 and Windows ARM/ARM64 may not define _copysignf() but they do define _copysign().
@@ -2455,65 +2424,40 @@ float FloatingPointUtils::round(float x)
     //            Math.Round(double), and FloatingPointUtils::round(double)
     // ************************************************************************************
 
-    // This is based on the 'Berkeley SoftFloat Release 3e' algorithm
+    // This code is based on `nearbyint` from amd/aocl-libm-ose
+    // Copyright (C) 2008-2022 Advanced Micro Devices, Inc. All rights reserved.
+    //
+    // Licensed under the BSD 3-Clause "New" or "Revised" License
+    // See THIRD-PARTY-NOTICES.TXT for the full license text
 
-    uint32_t bits     = *reinterpret_cast<uint32_t*>(&x);
-    int32_t  exponent = (int32_t)(bits >> 23) & 0xFF;
+    // This represents the boundary at which point we can only represent whole integers
+    const float IntegerBoundary = 8388608.0f; // 2^23
 
-    if (exponent <= 0x7E)
+    if (fabsf(x) >= IntegerBoundary)
     {
-        if ((bits << 1) == 0)
-        {
-            // Exactly +/- zero should return the original value
-            return x;
-        }
-
-        // Any value less than or equal to 0.5 will always round to exactly zero
-        // and any value greater than 0.5 will always round to exactly one. However,
-        // we need to preserve the original sign for IEEE compliance.
-
-        float result = ((exponent == 0x7E) && ((bits & 0x007FFFFF) != 0)) ? 1.0f : 0.0f;
-        return _copysignf(result, x);
-    }
-
-    if (exponent >= 0x96)
-    {
-        // Any value greater than or equal to 2^52 cannot have a fractional part,
-        // So it will always round to exactly itself.
-
+        // Values above this boundary don't have a fractional
+        // portion and so we can simply return them as-is.
         return x;
     }
 
-    // The absolute value should be greater than or equal to 1.0 and less than 2^52
-    assert((0x7F <= exponent) && (exponent <= 0x95));
+    // Otherwise, since floating-point takes the inputs, performs
+    // the computation as if to infinite precision and unbounded
+    // range, and then rounds to the nearest representable result
+    // using the current rounding mode, we can rely on this to
+    // cheaply round.
+    //
+    // In particular, .NET doesn't support changing the rounding
+    // mode and defaults to "round to nearest, ties to even", thus
+    // by adding the original value to the IntegerBoundary we get
+    // an exactly represented whole integer that is precisely the
+    // IntegerBoundary greater in magnitude than the answer we want.
+    //
+    // We can then simply remove that offset to get the correct answer,
+    // noting that we also need to copy back the original sign to
+    // correctly handle -0.0
 
-    // Determine the last bit that represents the integral portion of the value
-    // and the bits representing the fractional portion
-
-    uint32_t lastBitMask   = 1U << (0x96 - exponent);
-    uint32_t roundBitsMask = lastBitMask - 1;
-
-    // Increment the first fractional bit, which represents the midpoint between
-    // two integral values in the current window.
-
-    bits += lastBitMask >> 1;
-
-    if ((bits & roundBitsMask) == 0)
-    {
-        // If that overflowed and the rest of the fractional bits are zero
-        // then we were exactly x.5 and we want to round to the even result
-
-        bits &= ~lastBitMask;
-    }
-    else
-    {
-        // Otherwise, we just want to strip the fractional bits off, truncating
-        // to the current integer value.
-
-        bits &= ~roundBitsMask;
-    }
-
-    return *reinterpret_cast<float*>(&bits);
+    float temp = _copysignf(IntegerBoundary, x);
+    return _copysignf((x + temp) - temp, x);
 }
 
 bool FloatingPointUtils::isNormal(double x)

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -84,6 +84,7 @@ namespace System
 
         internal const ulong BiasedExponentMask = 0x7FF0_0000_0000_0000;
         internal const int BiasedExponentShift = 52;
+        internal const int BiasedExponentLength = 11;
         internal const ushort ShiftedExponentMask = (ushort)(BiasedExponentMask >> BiasedExponentShift);
 
         internal const ulong TrailingSignificandMask = 0x000F_FFFF_FFFF_FFFF;
@@ -105,8 +106,9 @@ namespace System
         internal const int TrailingSignificandLength = 52;
         internal const int SignificandLength = TrailingSignificandLength + 1;
 
-        internal const long PositiveInfinityBits = 0x7FF00000_00000000;
-        internal const long SmallestNormalBits = 0x00100000_00000000;
+        internal const ulong PositiveInfinityBits = 0x7FF0_0000_0000_0000;
+        internal const ulong NegativeInfinityBits = 0xFFF0_0000_0000_0000;
+        internal const ulong SmallestNormalBits = 0x0010_0000_0000_0000;
 
         internal ushort BiasedExponent
         {
@@ -153,27 +155,28 @@ namespace System
         }
 
         /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        /// <remarks>This effectively checks the value is not NaN and not infinite.</remarks>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsFinite(double d)
+        public static bool IsFinite(double d)
         {
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            return (bits & 0x7FFFFFFFFFFFFFFF) < 0x7FF0000000000000;
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return (~bits & PositiveInfinityBits) != 0;
         }
 
         /// <summary>Determines whether the specified value is infinite.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsInfinity(double d)
+        public static bool IsInfinity(double d)
         {
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            return (bits & 0x7FFFFFFFFFFFFFFF) == 0x7FF0000000000000;
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return (bits & ~SignMask) == PositiveInfinityBits;
         }
 
         /// <summary>Determines whether the specified value is NaN.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNaN(double d)
+        public static bool IsNaN(double d)
         {
             // A NaN will never equal itself so this is an
             // easy and efficient way to check for NaN.
@@ -183,10 +186,18 @@ namespace System
             #pragma warning restore CS1718
         }
 
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNaNOrZero(double d)
+        {
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return ((bits - 1) & ~SignMask) >= PositiveInfinityBits;
+        }
+
         /// <summary>Determines whether the specified value is negative.</summary>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static unsafe bool IsNegative(double d)
+        public static bool IsNegative(double d)
         {
             return BitConverter.DoubleToInt64Bits(d) < 0;
         }
@@ -199,14 +210,14 @@ namespace System
             return d == NegativeInfinity;
         }
 
-        /// <summary>Determines whether the specified value is normal.</summary>
+        /// <summary>Determines whether the specified value is normal (finite, but not zero or subnormal).</summary>
+        /// <remarks>This effectively checks the value is not NaN, not infinite, not subnormal, and not zero.</remarks>
         [NonVersionable]
-        // This is probably not worth inlining, it has branches and should be rarely called
-        public static unsafe bool IsNormal(double d)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNormal(double d)
         {
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            bits &= 0x7FFFFFFFFFFFFFFF;
-            return (bits < 0x7FF0000000000000) && (bits != 0) && ((bits & 0x7FF0000000000000) != 0);
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return ((bits & ~SignMask) - SmallestNormalBits) < (PositiveInfinityBits - SmallestNormalBits);
         }
 
         /// <summary>Determines whether the specified value is positive infinity.</summary>
@@ -217,14 +228,21 @@ namespace System
             return d == PositiveInfinity;
         }
 
-        /// <summary>Determines whether the specified value is subnormal.</summary>
+        /// <summary>Determines whether the specified value is subnormal (finite, but not zero or normal).</summary>
+        /// <remarks>This effectively checks the value is not NaN, not infinite, not normal, and not zero.</remarks>
         [NonVersionable]
-        // This is probably not worth inlining, it has branches and should be rarely called
-        public static unsafe bool IsSubnormal(double d)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsSubnormal(double d)
         {
-            long bits = BitConverter.DoubleToInt64Bits(d);
-            bits &= 0x7FFFFFFFFFFFFFFF;
-            return (bits < 0x7FF0000000000000) && (bits != 0) && ((bits & 0x7FF0000000000000) == 0);
+            ulong bits = BitConverter.DoubleToUInt64Bits(d);
+            return ((bits & ~SignMask) - 1) < MaxTrailingSignificand;
+        }
+
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsZero(double d)
+        {
+            return d == 0;
         }
 
         // Compares this object to another object, returning an instance of System.Relation.
@@ -326,13 +344,12 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // 64-bit constants make the IL unusually large that makes the inliner to reject the method
         public override int GetHashCode()
         {
-            long bits = Unsafe.As<double, long>(ref Unsafe.AsRef(in m_value));
+            ulong bits = BitConverter.DoubleToUInt64Bits(m_value);
 
-            // Optimized check for IsNan() || IsZero()
-            if (((bits - 1) & 0x7FFFFFFFFFFFFFFF) >= 0x7FF0000000000000)
+            if (IsNaNOrZero(m_value))
             {
                 // Ensure that all NaNs and both zeros have the same hash code
-                bits &= 0x7FF0000000000000;
+                bits &= PositiveInfinityBits;
             }
 
             return unchecked((int)bits) ^ ((int)(bits >> 32));
@@ -1116,7 +1133,7 @@ namespace System
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
-        static bool INumberBase<double>.IsZero(double value) => (value == 0);
+        static bool INumberBase<double>.IsZero(double value) => IsZero(value);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/Half.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Half.cs
@@ -280,7 +280,7 @@ namespace System
         public static bool IsNormal(Half value)
         {
             uint bits = value._value;
-            return ((bits & ~SignMask) - SmallestNormalBits) < (PositiveInfinityBits - SmallestNormalBits);
+            return (ushort)((bits & ~SignMask) - SmallestNormalBits) < (PositiveInfinityBits - SmallestNormalBits);
         }
 
         /// <summary>Determines whether the specified value is positive infinity.</summary>
@@ -296,7 +296,7 @@ namespace System
         public static bool IsSubnormal(Half value)
         {
             uint bits = value._value;
-            return ((bits & ~SignMask) - 1) < MaxTrailingSignificand;
+            return (ushort)((bits & ~SignMask) - 1) < MaxTrailingSignificand;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1253,65 +1253,40 @@ namespace System
             //            FloatingPointUtils::round(double), and FloatingPointUtils::round(float)
             // ************************************************************************************
 
-            // This is based on the 'Berkeley SoftFloat Release 3e' algorithm
+            // This code is based on `nearbyint` from amd/aocl-libm-ose
+            // Copyright (C) 2008-2022 Advanced Micro Devices, Inc. All rights reserved.
+            //
+            // Licensed under the BSD 3-Clause "New" or "Revised" License
+            // See THIRD-PARTY-NOTICES.TXT for the full license text
 
-            ulong bits = BitConverter.DoubleToUInt64Bits(a);
-            ushort biasedExponent = double.ExtractBiasedExponentFromBits(bits);
+            // This represents the boundary at which point we can only represent whole integers
+            const double IntegerBoundary = 4503599627370496.0; // 2^52
 
-            if (biasedExponent <= 0x03FE)
+            if (Abs(a) >= IntegerBoundary)
             {
-                if ((bits << 1) == 0)
-                {
-                    // Exactly +/- zero should return the original value
-                    return a;
-                }
-
-                // Any value less than or equal to 0.5 will always round to exactly zero
-                // and any value greater than 0.5 will always round to exactly one. However,
-                // we need to preserve the original sign for IEEE compliance.
-
-                double result = ((biasedExponent == 0x03FE) && (double.ExtractTrailingSignificandFromBits(bits) != 0)) ? 1.0 : 0.0;
-                return CopySign(result, a);
-            }
-
-            if (biasedExponent >= 0x0433)
-            {
-                // Any value greater than or equal to 2^52 cannot have a fractional part,
-                // So it will always round to exactly itself.
-
+                // Values above this boundary don't have a fractional
+                // portion and so we can simply return them as-is.
                 return a;
             }
 
-            // The absolute value should be greater than or equal to 1.0 and less than 2^52
-            Debug.Assert((0x03FF <= biasedExponent) && (biasedExponent <= 0x0432));
+            // Otherwise, since floating-point takes the inputs, performs
+            // the computation as if to infinite precision and unbounded
+            // range, and then rounds to the nearest representable result
+            // using the current rounding mode, we can rely on this to
+            // cheaply round.
+            //
+            // In particular, .NET doesn't support changing the rounding
+            // mode and defaults to "round to nearest, ties to even", thus
+            // by adding the original value to the IntegerBoundary we get
+            // an exactly represented whole integer that is precisely the
+            // IntegerBoundary greater in magnitude than the answer we want.
+            //
+            // We can then simply remove that offset to get the correct answer,
+            // noting that we also need to copy back the original sign to
+            // correctly handle -0.0
 
-            // Determine the last bit that represents the integral portion of the value
-            // and the bits representing the fractional portion
-
-            ulong lastBitMask = 1UL << (0x0433 - biasedExponent);
-            ulong roundBitsMask = lastBitMask - 1;
-
-            // Increment the first fractional bit, which represents the midpoint between
-            // two integral values in the current window.
-
-            bits += lastBitMask >> 1;
-
-            if ((bits & roundBitsMask) == 0)
-            {
-                // If that overflowed and the rest of the fractional bits are zero
-                // then we were exactly x.5 and we want to round to the even result
-
-                bits &= ~lastBitMask;
-            }
-            else
-            {
-                // Otherwise, we just want to strip the fractional bits off, truncating
-                // to the current integer value.
-
-                bits &= ~roundBitsMask;
-            }
-
-            return BitConverter.UInt64BitsToDouble(bits);
+            double temp = CopySign(IntegerBoundary, a);
+            return CopySign((a + temp) - temp, a);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -239,7 +239,7 @@ namespace System
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(x);
 
-            if (!double.IsFinite(bits))
+            if (!double.IsFinite(x))
             {
                 // NaN returns NaN
                 // -Infinity returns -Infinity

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -53,7 +53,7 @@ namespace System
         {
             uint bits = BitConverter.SingleToUInt32Bits(x);
 
-            if (!float.IsFinite(bits))
+            if (!float.IsFinite(x))
             {
                 // NaN returns NaN
                 // -Infinity returns -Infinity

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
@@ -333,7 +333,7 @@ namespace System.Runtime.Intrinsics
                 // double.IsZero(x) | (x < 0) | double.IsNaN(x) | double.IsPositiveInfinity(x)
                 TVectorDouble temp = zeroMask
                                    | lessThanZeroMask
-                                   | Unsafe.BitCast<TVectorInt64, TVectorDouble>(TVectorInt64.GreaterThanOrEqual(xBits, TVectorInt64.Create(double.PositiveInfinityBits)));
+                                   | Unsafe.BitCast<TVectorInt64, TVectorDouble>(TVectorInt64.GreaterThanOrEqual(xBits, TVectorInt64.Create((long)double.PositiveInfinityBits)));
 
                 // subnormal
                 TVectorDouble subnormalMask = TVectorDouble.AndNot(Unsafe.BitCast<TVectorUInt64, TVectorDouble>(specialMask), temp);
@@ -613,7 +613,7 @@ namespace System.Runtime.Intrinsics
                 // double.IsZero(x) | (x < 0) | double.IsNaN(x) | double.IsPositiveInfinity(x)
                 TVectorDouble temp = zeroMask
                                    | lessThanZeroMask
-                                   | Unsafe.BitCast<TVectorInt64, TVectorDouble>(TVectorInt64.GreaterThanOrEqual(xBits, TVectorInt64.Create(double.PositiveInfinityBits)));
+                                   | Unsafe.BitCast<TVectorInt64, TVectorDouble>(TVectorInt64.GreaterThanOrEqual(xBits, TVectorInt64.Create((long)double.PositiveInfinityBits)));
 
                 // subnormal
                 TVectorDouble subnormalMask = TVectorDouble.AndNot(Unsafe.BitCast<TVectorUInt64, TVectorDouble>(specialMask), temp);
@@ -762,7 +762,7 @@ namespace System.Runtime.Intrinsics
                 // (x < 0) | float.IsZero(x) | float.IsNaN(x) | float.IsPositiveInfinity(x)
                 TVectorSingle temp = zeroMask
                                    | lessThanZeroMask
-                                   | Unsafe.BitCast<TVectorInt32, TVectorSingle>(TVectorInt32.GreaterThanOrEqual(xBits, TVectorInt32.Create(float.PositiveInfinityBits)));
+                                   | Unsafe.BitCast<TVectorInt32, TVectorSingle>(TVectorInt32.GreaterThanOrEqual(xBits, TVectorInt32.Create((int)float.PositiveInfinityBits)));
 
                 // subnormal
                 TVectorSingle subnormalMask = TVectorSingle.AndNot(Unsafe.BitCast<TVectorUInt32, TVectorSingle>(specialMask), temp);

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -84,6 +84,7 @@ namespace System
 
         internal const uint BiasedExponentMask = 0x7F80_0000;
         internal const int BiasedExponentShift = 23;
+        internal const int BiasedExponentLength = 8;
         internal const byte ShiftedBiasedExponentMask = (byte)(BiasedExponentMask >> BiasedExponentShift);
 
         internal const uint TrailingSignificandMask = 0x007F_FFFF;
@@ -105,8 +106,9 @@ namespace System
         internal const int TrailingSignificandLength = 23;
         internal const int SignificandLength = TrailingSignificandLength + 1;
 
-        internal const int PositiveInfinityBits = 0x7F80_0000;
-        internal const int SmallestNormalBits = 0x0080_0000;
+        internal const uint PositiveInfinityBits = 0x7F80_0000;
+        internal const uint NegativeInfinityBits = 0xFF80_0000;
+        internal const uint SmallestNormalBits = 0x0080_0000;
 
         internal byte BiasedExponent
         {
@@ -153,12 +155,13 @@ namespace System
         }
 
         /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        /// <remarks>This effectively checks the value is not NaN and not infinite.</remarks>
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsFinite(float f)
         {
-            int bits = BitConverter.SingleToInt32Bits(f);
-            return (bits & 0x7FFFFFFF) < 0x7F800000;
+            uint bits = BitConverter.SingleToUInt32Bits(f);
+            return (~bits & PositiveInfinityBits) != 0;
         }
 
         /// <summary>Determines whether the specified value is infinite.</summary>
@@ -166,8 +169,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsInfinity(float f)
         {
-            int bits = BitConverter.SingleToInt32Bits(f);
-            return (bits & 0x7FFFFFFF) == 0x7F800000;
+            uint bits = BitConverter.SingleToUInt32Bits(f);
+            return (bits & ~SignMask) == PositiveInfinityBits;
         }
 
         /// <summary>Determines whether the specified value is NaN.</summary>
@@ -181,6 +184,14 @@ namespace System
 #pragma warning disable CS1718
             return f != f;
 #pragma warning restore CS1718
+        }
+
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsNaNOrZero(float f)
+        {
+            uint bits = BitConverter.SingleToUInt32Bits(f);
+            return ((bits - 1) & ~SignMask) >= PositiveInfinityBits;
         }
 
         /// <summary>Determines whether the specified value is negative.</summary>
@@ -199,14 +210,14 @@ namespace System
             return f == NegativeInfinity;
         }
 
-        /// <summary>Determines whether the specified value is normal.</summary>
+        /// <summary>Determines whether the specified value is normal (finite, but not zero or subnormal).</summary>
+        /// <remarks>This effectively checks the value is not NaN, not infinite, not subnormal, and not zero.</remarks>
         [NonVersionable]
-        // This is probably not worth inlining, it has branches and should be rarely called
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsNormal(float f)
         {
-            int bits = BitConverter.SingleToInt32Bits(f);
-            bits &= 0x7FFFFFFF;
-            return (bits < 0x7F800000) && (bits != 0) && ((bits & 0x7F800000) != 0);
+            uint bits = BitConverter.SingleToUInt32Bits(f);
+            return ((bits & ~SignMask) - SmallestNormalBits) < (PositiveInfinityBits - SmallestNormalBits);
         }
 
         /// <summary>Determines whether the specified value is positive infinity.</summary>
@@ -217,14 +228,21 @@ namespace System
             return f == PositiveInfinity;
         }
 
-        /// <summary>Determines whether the specified value is subnormal.</summary>
+        /// <summary>Determines whether the specified value is subnormal (finite, but not zero or normal).</summary>
+        /// <remarks>This effectively checks the value is not NaN, not infinite, not normal, and not zero.</remarks>
         [NonVersionable]
-        // This is probably not worth inlining, it has branches and should be rarely called
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool IsSubnormal(float f)
         {
-            int bits = BitConverter.SingleToInt32Bits(f);
-            bits &= 0x7FFFFFFF;
-            return (bits < 0x7F800000) && (bits != 0) && ((bits & 0x7F800000) == 0);
+            uint bits = BitConverter.SingleToUInt32Bits(f);
+            return ((bits & ~SignMask) - 1) < MaxTrailingSignificand;
+        }
+
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsZero(float f)
+        {
+            return f == 0;
         }
 
         // Compares this object to another object, returning an integer that
@@ -322,16 +340,15 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode()
         {
-            int bits = Unsafe.As<float, int>(ref Unsafe.AsRef(in m_value));
+            uint bits = BitConverter.SingleToUInt32Bits(m_value);
 
-            // Optimized check for IsNan() || IsZero()
-            if (((bits - 1) & 0x7FFFFFFF) >= 0x7F800000)
+            if (IsNaNOrZero(m_value))
             {
                 // Ensure that all NaNs and both zeros have the same hash code
-                bits &= 0x7F800000;
+                bits &= PositiveInfinityBits;
             }
 
-            return bits;
+            return (int)bits;
         }
 
         public override string ToString()
@@ -1100,7 +1117,7 @@ namespace System
         }
 
         /// <inheritdoc cref="INumberBase{TSelf}.IsZero(TSelf)" />
-        static bool INumberBase<float>.IsZero(float value) => (value == 0);
+        static bool INumberBase<float>.IsZero(float value) => IsZero(value);
 
         /// <inheritdoc cref="INumberBase{TSelf}.MaxMagnitude(TSelf, TSelf)" />
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -106,8 +106,16 @@ namespace System
         internal const int TrailingSignificandLength = 23;
         internal const int SignificandLength = TrailingSignificandLength + 1;
 
+        // Constants representing the private bit-representation for various default values
+
+        internal const uint PositiveZeroBits = 0x0000_0000;
+        internal const uint NegativeZeroBits = 0x8000_0000;
+
+        internal const uint EpsilonBits = 0x0000_0001;
+
         internal const uint PositiveInfinityBits = 0x7F80_0000;
         internal const uint NegativeInfinityBits = 0xFF80_0000;
+
         internal const uint SmallestNormalBits = 0x0080_0000;
 
         internal byte BiasedExponent
@@ -253,39 +261,38 @@ namespace System
         //
         public int CompareTo(object? value)
         {
-            if (value == null)
+            if (value is not float other)
             {
-                return 1;
+                return (value is null) ? 1 : throw new ArgumentException(SR.Arg_MustBeSingle);
             }
-
-            if (value is float f)
-            {
-                if (m_value < f) return -1;
-                if (m_value > f) return 1;
-                if (m_value == f) return 0;
-
-                // At least one of the values is NaN.
-                if (IsNaN(m_value))
-                    return IsNaN(f) ? 0 : -1;
-                else // f is NaN.
-                    return 1;
-            }
-
-            throw new ArgumentException(SR.Arg_MustBeSingle);
+            return CompareTo(other);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int CompareTo(float value)
         {
-            if (m_value < value) return -1;
-            if (m_value > value) return 1;
-            if (m_value == value) return 0;
+            if (m_value < value)
+            {
+                return -1;
+            }
 
-            // At least one of the values is NaN.
-            if (IsNaN(m_value))
-                return IsNaN(value) ? 0 : -1;
-            else // f is NaN.
+            if (m_value > value)
+            {
                 return 1;
+            }
+
+            if (m_value == value)
+            {
+                return 0;
+            }
+
+            if (IsNaN(m_value))
+            {
+                return IsNaN(value) ? 0 : -1;
+            }
+
+            Debug.Assert(IsNaN(value));
+            return 1;
         }
 
         /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Equality(TSelf, TOther)" />
@@ -314,17 +321,7 @@ namespace System
 
         public override bool Equals([NotNullWhen(true)] object? obj)
         {
-            if (!(obj is float))
-            {
-                return false;
-            }
-            float temp = ((float)obj).m_value;
-            if (temp == m_value)
-            {
-                return true;
-            }
-
-            return IsNaN(temp) && IsNaN(m_value);
+            return (obj is float other) && Equals(other);
         }
 
         public bool Equals(float obj)
@@ -333,7 +330,6 @@ namespace System
             {
                 return true;
             }
-
             return IsNaN(obj) && IsNaN(m_value);
         }
 


### PR DESCRIPTION
As per the title this improves the software fallback used for `Math.Round` and `Math.ILogB` to be significantly simpler/faster.

It additionally does some cleanup of functions in Half, Single, and Double to ensure they remain performant and consistent with eachother where possible.