### PR TITLE
[wasm][mt] Improve blocking wait detection and tests

### DIFF
--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
@@ -46,8 +46,8 @@ namespace System.Threading
         [ThreadStatic]
         public static bool ThrowOnBlockingWaitOnJSInteropThread;
 
-        public static void AssureThreadValidity() { throw null; }
-        public static void ForceBlockingWait(Action action) { throw null; }
+        public static void AssureBlockingPossible() { throw null; }
+        public static void ForceBlockingWait(Action<object?> action, object? state) { throw null; }
     }
 }
 #endif

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.cs
@@ -41,10 +41,13 @@ namespace System.Diagnostics
 #if FEATURE_WASM_MANAGED_THREADS
 namespace System.Threading
 {
-    public partial class Monitor
+    public partial class Thread
     {
         [ThreadStatic]
         public static bool ThrowOnBlockingWaitOnJSInteropThread;
+
+        public static void AssureThreadValidity() { throw null; }
+        public static void ForceBlockingWait(Action action) { throw null; }
     }
 }
 #endif

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.txt
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.txt
@@ -5,4 +5,6 @@ T:System.Runtime.Serialization.DeserializationToken
 M:System.Runtime.Serialization.SerializationInfo.StartDeserialization
 T:System.Diagnostics.DebugProvider
 M:System.Diagnostics.Debug.SetProvider(System.Diagnostics.DebugProvider)
-F:System.Threading.Monitor.ThrowOnBlockingWaitOnJSInteropThread
+M:System.Threading.Thread.AssureThreadValidity
+F:System.Threading.Thread.ThrowOnBlockingWaitOnJSInteropThread
+F:System.Threading.Thread.ForceBlockingWait

--- a/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.txt
+++ b/src/libraries/System.Private.CoreLib/ref/System.Private.CoreLib.ExtraApis.txt
@@ -5,6 +5,6 @@ T:System.Runtime.Serialization.DeserializationToken
 M:System.Runtime.Serialization.SerializationInfo.StartDeserialization
 T:System.Diagnostics.DebugProvider
 M:System.Diagnostics.Debug.SetProvider(System.Diagnostics.DebugProvider)
-M:System.Threading.Thread.AssureThreadValidity
+M:System.Threading.Thread.AssureBlockingPossible
 F:System.Threading.Thread.ThrowOnBlockingWaitOnJSInteropThread
 F:System.Threading.Thread.ForceBlockingWait

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -4298,4 +4298,7 @@
   <data name="NotSupported_AssemblySave" xml:space="preserve">
     <value>This AssemblyBuilder instance doesn't support saving. Use AssemblyBuilder.DefinePersistedAssembly to create an AssemblyBuilder instance that supports saving.</value>
   </data>
+  <data name="WasmThreads_BlockingWaitNotSupportedOnJSInterop" xml:space="preserve">
+    <value>Blocking wait is not supported on the JS interop threads.</value>
+  </data>
 </root>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -286,7 +286,7 @@ namespace System.Threading
         {
             CheckDispose();
 #if FEATURE_WASM_MANAGED_THREADS
-            Thread.AssureThreadValidity();
+            Thread.AssureBlockingPossible();
 #endif
 
             if (millisecondsTimeout < -1)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -285,6 +285,9 @@ namespace System.Threading
         public bool Wait(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             CheckDispose();
+#if FEATURE_WASM_MANAGED_THREADS
+            Thread.AssureThreadValidity();
+#endif
 
             if (millisecondsTimeout < -1)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -676,7 +676,7 @@ namespace System.Threading
         [ThreadStatic]
         public static bool ThrowOnBlockingWaitOnJSInteropThread;
 
-        public static void AssureThreadValidity()
+        public static void AssureBlockingPossible()
         {
             if (ThrowOnBlockingWaitOnJSInteropThread)
             {
@@ -684,14 +684,14 @@ namespace System.Threading
             }
         }
 
-        public static void ForceBlockingWait(Action action)
+        public static void ForceBlockingWait(Action<object?> action, object? state = null)
         {
             var flag = ThrowOnBlockingWaitOnJSInteropThread;
             try
             {
                 ThrowOnBlockingWaitOnJSInteropThread = false;
 
-                action();
+                action(state);
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -671,5 +671,33 @@ namespace System.Threading
         // a speed check will determine refresh rate of the cache and will report if caching is not advisable.
         // we will record that in a readonly static so that it could become a JIT constant and bypass caching entirely.
         private static readonly bool s_isProcessorNumberReallyFast = ProcessorIdCache.ProcessorNumberSpeedCheck();
+
+#if FEATURE_WASM_MANAGED_THREADS
+        [ThreadStatic]
+        public static bool ThrowOnBlockingWaitOnJSInteropThread;
+
+        public static void AssureThreadValidity()
+        {
+            if (ThrowOnBlockingWaitOnJSInteropThread)
+            {
+                throw new PlatformNotSupportedException(SR.WasmThreads_BlockingWaitNotSupportedOnJSInterop);
+            }
+        }
+
+        public static void ForceBlockingWait(Action action)
+        {
+            var flag = ThrowOnBlockingWaitOnJSInteropThread;
+            try
+            {
+                ThrowOnBlockingWaitOnJSInteropThread = false;
+
+                action();
+            }
+            finally
+            {
+                ThrowOnBlockingWaitOnJSInteropThread = flag;
+            }
+        }
+#endif
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -234,7 +234,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 if (holder.CallbackReady != null)
                 {
 #pragma warning disable CA1416 // Validate platform compatibility
-                    Thread.ForceBlockingWait(() => holder.CallbackReady?.Wait());
+                    Thread.ForceBlockingWait(static (callbackReady) => ((ManualResetEventSlim)callbackReady!).Wait(), holder.CallbackReady);
 #pragma warning restore CA1416 // Validate platform compatibility
                 }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -233,18 +233,9 @@ namespace System.Runtime.InteropServices.JavaScript
 
                 if (holder.CallbackReady != null)
                 {
-                    var threadFlag = Monitor.ThrowOnBlockingWaitOnJSInteropThread;
-                    try
-                    {
-                        Monitor.ThrowOnBlockingWaitOnJSInteropThread = false;
 #pragma warning disable CA1416 // Validate platform compatibility
-                        holder.CallbackReady?.Wait();
+                    Thread.ForceBlockingWait(() => holder.CallbackReady?.Wait());
 #pragma warning restore CA1416 // Validate platform compatibility
-                    }
-                    finally
-                    {
-                        Monitor.ThrowOnBlockingWaitOnJSInteropThread = threadFlag;
-                    }
                 }
 
                 lock (ctx)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -217,7 +217,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
 
-            Thread.AssureThreadValidity();
+            Thread.AssureBlockingPossible();
 
             using (var signal = new ManualResetEventSlim(false))
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.JavaScript
             // - synchronous [JSExport] into managed code, which would block
             // - synchronous [JSImport] to another thread, which would block
             // see also https://github.com/dotnet/runtime/issues/76958#issuecomment-1921418290
-            Monitor.ThrowOnBlockingWaitOnJSInteropThread = true;
+            Thread.ThrowOnBlockingWaitOnJSInteropThread = true;
 
             var proxyContext = ctx.ProxyContext;
             JSProxyContext.CurrentThreadContext = proxyContext;
@@ -216,11 +216,8 @@ namespace System.Runtime.InteropServices.JavaScript
                 d(state);
                 return;
             }
-            // TODO, refactor into single assert method
-            if (Monitor.ThrowOnBlockingWaitOnJSInteropThread)
-            {
-                throw new PlatformNotSupportedException("Blocking wait is not supported on the JS interop threads.");
-            }
+
+            Thread.AssureThreadValidity();
 
             using (var signal = new ManualResetEventSlim(false))
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
@@ -85,18 +85,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 capturedSynchronizationContext = SynchronizationContext.Current;
                 jswReady.SetResult();
 
-                var threadFlag = Monitor.ThrowOnBlockingWaitOnJSInteropThread;
-                try
-                {
-                    Monitor.ThrowOnBlockingWaitOnJSInteropThread = false;
-                    
-                    // blocking the worker, so that JSSynchronizationContext could enqueue next tasks
-                    blocker.Wait();
-                }
-                finally
-                {
-                    Monitor.ThrowOnBlockingWaitOnJSInteropThread = threadFlag;
-                }
+                // blocking the worker, so that JSSynchronizationContext could enqueue next tasks
+                Thread.ForceBlockingWait(() => blocker.Wait());
 
                 return never.Task;
             }, cts.Token);
@@ -453,9 +443,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await executor.Execute(Task () =>
             {
                 Exception? exception = null;
-                try {
+                try
+                {
                     method.Call(cts.Token);
-                } catch (Exception ex) {
+                }
+                catch (Exception ex)
+                {
                     exception = ex;
                 }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
@@ -86,7 +86,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 jswReady.SetResult();
 
                 // blocking the worker, so that JSSynchronizationContext could enqueue next tasks
-                Thread.ForceBlockingWait(() => blocker.Wait());
+                Thread.ForceBlockingWait(static (b) => ((ManualResetEventSlim)b).Wait(), blocker);
 
                 return never.Task;
             }, cts.Token);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -158,6 +158,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                         mr.Wait(cts.Token);
                     } catch (OperationCanceledException) { /* ignore */ }
                 }},
+                new NamedCall { Name = "SemaphoreSlim.Wait", Call = delegate (CancellationToken ct) {
+                    using var sem = new SemaphoreSlim(2);
+                    var cts = new CancellationTokenSource(8);
+                    try {
+                        sem.Wait(cts.Token);
+                    } catch (OperationCanceledException) { /* ignore */ }
+                }},
         };
 
         public static IEnumerable<object[]> GetTargetThreadsAndBlockingCalls()

--- a/src/libraries/System.Threading.Thread/src/CompatibilitySuppressions.Threading.xml
+++ b/src/libraries/System.Threading.Thread/src/CompatibilitySuppressions.Threading.xml
@@ -22,10 +22,10 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Threading.Thread.AssureThreadValidity</Target>
+    <Target>M:System.Threading.Thread.AssureBlockingPossible</Target>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Threading.Thread.ForceBlockingWait(System.Action)</Target>
+    <Target>M:System.Threading.Thread.ForceBlockingWait(System.Action{System.Object},System.Object)</Target>
   </Suppression>
 </Suppressions>

--- a/src/libraries/System.Threading.Thread/src/CompatibilitySuppressions.Threading.xml
+++ b/src/libraries/System.Threading.Thread/src/CompatibilitySuppressions.Threading.xml
@@ -16,4 +16,16 @@
     <DiagnosticId>CP0014</DiagnosticId>
     <Target>M:System.Threading.Thread.UnsafeStart(System.Object):[T:System.Runtime.Versioning.UnsupportedOSPlatformAttribute]</Target>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:System.Threading.Thread.ThrowOnBlockingWaitOnJSInteropThread</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Threading.Thread.AssureThreadValidity</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Threading.Thread.ForceBlockingWait(System.Action)</Target>
+  </Suppression>
 </Suppressions>

--- a/src/libraries/System.Threading/src/CompatibilitySuppressions.Threading.xml
+++ b/src/libraries/System.Threading/src/CompatibilitySuppressions.Threading.xml
@@ -100,8 +100,4 @@
     <DiagnosticId>CP0014</DiagnosticId>
     <Target>M:System.Threading.Monitor.Wait(System.Object):[T:System.Runtime.Versioning.UnsupportedOSPlatformAttribute]</Target>
   </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>F:System.Threading.Monitor.ThrowOnBlockingWaitOnJSInteropThread</Target>
-  </Suppression>
 </Suppressions>

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
@@ -9,11 +9,6 @@ namespace System.Threading
 {
     public static partial class Monitor
     {
-#if FEATURE_WASM_MANAGED_THREADS
-        [ThreadStatic]
-        public static bool ThrowOnBlockingWaitOnJSInteropThread;
-#endif
-
         [Intrinsic]
         [MethodImplAttribute(MethodImplOptions.InternalCall)] // Interpreter is missing this intrinsic
         public static void Enter(object obj) => Enter(obj);
@@ -83,10 +78,7 @@ namespace System.Threading
         {
             ArgumentNullException.ThrowIfNull(obj);
 #if FEATURE_WASM_MANAGED_THREADS
-            if (ThrowOnBlockingWaitOnJSInteropThread)
-            {
-                throw new PlatformNotSupportedException("blocking Wait is not supported on the JS interop threads.");
-            }
+            Thread.AssureThreadValidity();
 #endif
             return ObjWait(millisecondsTimeout, obj);
         }

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Monitor.Mono.cs
@@ -78,7 +78,7 @@ namespace System.Threading
         {
             ArgumentNullException.ThrowIfNull(obj);
 #if FEATURE_WASM_MANAGED_THREADS
-            Thread.AssureThreadValidity();
+            Thread.AssureBlockingPossible();
 #endif
             return ObjWait(millisecondsTimeout, obj);
         }


### PR DESCRIPTION
Add check to the `SemaphoreSlim.Wait`. The wait will eventually continue to the `Monitor.Wait`, it can spin wait first though and return, so catch it earlier to avoid non-deterministic behavior.

Improve the blocking wait detection and extract it to the new method. Also introduce a helper method to force a blocking wait in places we want it happen on the JS interop threads too.