### PR TITLE
[wasm] Disable jiterpreter_do_jit_call to address issues with disabling Wasm EH on 8.0.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2726,21 +2726,8 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 	interp_push_lmf (&ext, frame);
 
 	if (mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP) {
-#if JITERPRETER_ENABLE_SPECIALIZED_JIT_CALL
-		/*
-		 * invoke jit_call_cb via a single indirect function call that dispatches to
-		 *  either a specialized JS implementation or a specialized WASM EH version
-		 * see jiterpreter-jit-call.ts and do-jit-call.wat
-		 * NOTE: the first argument must ALWAYS be jit_call_cb for the specialization.
-		 *  the actual implementation cannot verify this at runtime, so get it right
-		 * this is faster than mono_llvm_cpp_catch_exception by avoiding the use of
-		 *  emscripten invoke_vi to find and invoke jit_call_cb indirectly
-		 */
-		jiterpreter_do_jit_call(jit_call_cb, &cb_data, &thrown);
-#else
 		/* Catch the exception thrown by the native code using a try-catch */
 		mono_llvm_cpp_catch_exception (jit_call_cb, &cb_data, &thrown);
-#endif
 	} else {
 		jit_call_cb (&cb_data);
 	}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -53,10 +53,6 @@ void jiterp_preserve_module (void);
 static gint32 jiterpreter_abort_counts[MINT_LASTOP + 1] = { 0 };
 static int64_t jiterp_trace_bailout_counts[256] = { 0 };
 
-// This function pointer is used by interp.c to invoke jit_call_cb for exception handling purposes
-// See jiterpreter-jit-call.ts mono_jiterp_do_jit_call_indirect
-WasmDoJitCall jiterpreter_do_jit_call = mono_jiterp_do_jit_call_indirect;
-
 // We disable this diagnostic because EMSCRIPTEN_KEEPALIVE makes it a false alarm, the keepalive
 //  functions are being used externally. Having a bunch of prototypes is pointless since these
 //  functions are not consumed by C anywhere else
@@ -951,15 +947,8 @@ mono_jiterp_get_options_as_json ()
 EMSCRIPTEN_KEEPALIVE void
 mono_jiterp_update_jit_call_dispatcher (WasmDoJitCall dispatcher)
 {
-	// If we received a 0 dispatcher that means the TS side failed to compile
-	//  any kind of dispatcher - this likely indicates that content security policy
-	//  blocked the use of Module.addFunction
-	if (!dispatcher)
-		dispatcher = (WasmDoJitCall)mono_llvm_cpp_catch_exception;
-	else if (((int)(void*)dispatcher)==-1)
-		dispatcher = mono_jiterp_do_jit_call_indirect;
-
-	jiterpreter_do_jit_call = dispatcher;
+	// Disabled in 8.0 to address issues when building with Wasm EH disabled.
+	// This system is entirely gone in 9.0. -kg
 }
 
 EMSCRIPTEN_KEEPALIVE int

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -5,12 +5,8 @@
 
 #ifdef DISABLE_THREADS
 #define JITERPRETER_ENABLE_JIT_CALL_TRAMPOLINES 1
-// enables specialized mono_llvm_cpp_catch_exception replacement (see jiterpreter-jit-call.ts)
-// works even if the jiterpreter is otherwise disabled.
-#define JITERPRETER_ENABLE_SPECIALIZED_JIT_CALL 1
 #else
 #define JITERPRETER_ENABLE_JIT_CALL_TRAMPOLINES 0
-#define JITERPRETER_ENABLE_SPECIALIZED_JIT_CALL 0
 #endif // DISABLE_THREADS
 
 // mono_interp_tier_prepare_jiterpreter will return these special values if it doesn't
@@ -148,8 +144,6 @@ ptrdiff_t
 mono_jiterp_monitor_trace (const guint16 *ip, void *frame, void *locals);
 
 #endif // __MONO_MINI_INTERPRETER_INTERNALS_H__
-
-extern WasmDoJitCall jiterpreter_do_jit_call;
 
 #endif // HOST_BROWSER
 


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [ ] Found internally

This code causes a startup failure in AOT'd wasm applications if they are rebuilt with exception handling turned off.

The functionality being removed is already gone in 9.0, and isn't terribly important. We just didn't get around to removing it before 8.0 released. It's not clear to me what's wrong with it, but I can verify locally that doing AOT builds with EH switched off causes it to misbehave, and removing it makes my local repros not break anymore.

The exported C function is kept (as a no-op) so that any TS/JS code touching it won't break.

I believe this will fix https://github.com/dotnet/runtime/issues/95963 but haven't been able to verify that locally yet.

## Regression

- [ ] Yes
- [x] No

I don't have any reason to believe this code regressed after it was initially added, though I recall testing it and having it work. We don't (AFAIK) have much CI coverage for this scenario, and we rarely test it manually.

## Testing

Manual verification. I may look into adding a WBT test for it later, but I can't build/run WBTs right now due to an unrelated problem.

## Risk

Low risk. We did this on main (9.0) a while ago, and the code being removed is an optimization, so we're falling back to well-tested old code.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.