### PR TITLE
[release/8.0-staging] Ensure that constant folding for SIMD shifts on xarch follow the correct behavior on overshift

### DIFF
--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -924,7 +924,7 @@ GenTree* Compiler::impNonConstFallback(NamedIntrinsic intrinsic, var_types simdT
             GenTree* op2 = impPopStack().val;
             GenTree* op1 = impSIMDPopStack();
 
-            GenTree* tmpOp = gtNewSimdCreateScalarUnsafeNode(TYP_SIMD16, op2, CORINFO_TYPE_INT, 16);
+            GenTree* tmpOp = gtNewSimdCreateScalarNode(TYP_SIMD16, op2, CORINFO_TYPE_INT, 16);
             return gtNewSimdHWIntrinsicNode(simdType, op1, tmpOp, intrinsic, simdBaseJitType, genTypeSize(simdType));
         }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7518,6 +7518,31 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
             case NI_AVX512BW_ShiftLeftLogical:
 #endif
             {
+#ifdef TARGET_XARCH
+                if (TypeOfVN(arg1VN) == TYP_SIMD16)
+                {
+                    // The xarch shift instructions support taking the shift amount as
+                    // a simd16, in which case they take the shift amount from the lower
+                    // 64-bits.
+
+                    uint64_t shiftAmount = GetConstantSimd16(arg1VN).u64[0];
+
+                    if (genTypeSize(baseType) != 8)
+                    {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
+                        arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
+                    }
+                    else
+                    {
+                        arg1VN = VNForLongCon(static_cast<int64_t>(shiftAmount));
+                    }
+                }
+#endif // TARGET_XARCH
+
                 return EvaluateBinarySimd(this, GT_LSH, /* scalar */ false, type, baseType, arg0VN, arg1VN);
             }
 
@@ -7531,6 +7556,31 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
             case NI_AVX512BW_ShiftRightArithmetic:
 #endif
             {
+#ifdef TARGET_XARCH
+                if (TypeOfVN(arg1VN) == TYP_SIMD16)
+                {
+                    // The xarch shift instructions support taking the shift amount as
+                    // a simd16, in which case they take the shift amount from the lower
+                    // 64-bits.
+
+                    uint64_t shiftAmount = GetConstantSimd16(arg1VN).u64[0];
+
+                    if (genTypeSize(baseType) != 8)
+                    {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
+                        arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
+                    }
+                    else
+                    {
+                        arg1VN = VNForLongCon(static_cast<int64_t>(shiftAmount));
+                    }
+                }
+#endif // TARGET_XARCH
+
                 return EvaluateBinarySimd(this, GT_RSH, /* scalar */ false, type, baseType, arg0VN, arg1VN);
             }
 
@@ -7543,6 +7593,31 @@ ValueNum ValueNumStore::EvalHWIntrinsicFunBinary(var_types      type,
             case NI_AVX512BW_ShiftRightLogical:
 #endif
             {
+#ifdef TARGET_XARCH
+                if (TypeOfVN(arg1VN) == TYP_SIMD16)
+                {
+                    // The xarch shift instructions support taking the shift amount as
+                    // a simd16, in which case they take the shift amount from the lower
+                    // 64-bits.
+
+                    uint64_t shiftAmount = GetConstantSimd16(arg1VN).u64[0];
+
+                    if (genTypeSize(baseType) != 8)
+                    {
+                        if (shiftAmount > INT_MAX)
+                        {
+                            // Ensure we don't lose track the the amount is an overshift
+                            shiftAmount = -1;
+                        }
+                        arg1VN = VNForIntCon(static_cast<int32_t>(shiftAmount));
+                    }
+                    else
+                    {
+                        arg1VN = VNForLongCon(static_cast<int64_t>(shiftAmount));
+                    }
+                }
+#endif // TARGET_XARCH
+
                 return EvaluateBinarySimd(this, GT_RSZ, /* scalar */ false, type, baseType, arg0VN, arg1VN);
             }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+using Xunit;
+
+public static class Runtime_93698
+{
+    [Fact]
+    public static void TestShiftLeftLogicalOvershift()
+    {
+        if (Sse2.IsSupported)
+        {
+            var result1 = Sse2.ShiftLeftLogical(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128<int>.Zero, result1);
+
+            var result2 = Sse2.ShiftLeftLogical(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128<int>.Zero, result2);
+        }
+    }
+
+    [Fact]
+    public static void TestShiftRightLogicalOvershift()
+    {
+        if (Sse2.IsSupported)
+        {
+            var result1 = Sse2.ShiftRightLogical(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128<int>.Zero, result1);
+
+            var result2 = Sse2.ShiftRightLogical(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128<int>.Zero, result2);
+        }
+    }
+
+    [Fact]
+    public static void TestShiftRightArithmeticOvershift()
+    {
+        if (Sse2.IsSupported)
+        {
+            var result1 = Sse2.ShiftRightArithmetic(Vector128.Create(-1, +2, -3, +4), 32);
+            Assert.Equal(Vector128.Create(-1, 0, -1, 0), result1);
+
+            var result2 = Sse2.ShiftRightArithmetic(Vector128.Create(-5, +6, -7, +8), Vector128.Create(0, 32, 0, 0));
+            Assert.Equal(Vector128.Create(-1, 0, -1, 0), result2);
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93698/Runtime_93698.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/98001 to release/8.0-staging

/cc @tannergooding

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Developers who are shifting by a constant amount while using the platform specific APIs may see incorrect results.

## Regression

- [x] Yes
- [ ] No

Support for constant folding some primitive SIMD intrinsics was added in .NET 8. For the most part, the behavior of these intrinsics is consistent across platforms and consistent with the underlying scalar APIs users will typically consume from C#. However, "overshifting" is not well-defined behavior and can differ across platforms. Overshifting, in particular, is when you provide a shift amount more than the number of bits available in the underlying data type. For example, given `int x`, doing `x << 32` is not "well-defined" across languages and platforms.

IL leaves this as strictly undefined behavior and leaves it to the underlying platform, while C# makes it well defined and prescribes that it is actually `x << (32 % (sizeof(int) * 8))`, which is equivalent to it wrapping around and thus is the same as `x << 0`. This matches what quite a bit of hardware does, such as `x86/x64` for their scalar shift instructions. However, the vector shift instructions for x86/x64 differ and instead treat it as actually shifting by 1, 32 times. Thus it produces a value that is all zero.

While we have tests covering overshifting, we missed a test covering the combination of overshifting by a constant amount and thus the edge case that can occur in some kinds of user code.

## Testing

A regression test covering the scenario was added as well as other potentially interesting combinations.

## Risk

Low. The issue is well understood, the other constant folding support added has been checked for potential edge cases, and the functionality has also been checked against Arm64.