### PR TITLE
Add ARM64 encodings for group IF_SVE_CT_3A

### DIFF
--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -4767,8 +4767,6 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     // IF_SVE_CT_3A
     theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V1, REG_P0, REG_V6);  // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
     theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V5, REG_P7, REG_V12); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
-    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V7, REG_P3, REG_V11); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
-    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V28, REG_P4, REG_V3); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
 
     // IF_SVE_CX_4A
     theEmitter->emitIns_R_R_R_R(INS_sve_cmpeq, EA_SCALABLE, REG_P15, REG_P0, REG_V0, REG_V10,

--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -4754,6 +4754,12 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R(INS_sve_clastb, EA_8BYTE, REG_R3, REG_P6, REG_V9,
                               INS_OPTS_SCALABLE_D); // CLASTB  <R><dn>, <Pg>, <R><dn>, <Zm>.<T>
 
+    // IF_SVE_CT_3A
+    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V1, REG_P0, REG_V6);  // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
+    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V5, REG_P7, REG_V12); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
+    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V7, REG_P3, REG_V11); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
+    theEmitter->emitIns_R_R_R(INS_sve_revd, EA_SCALABLE, REG_V28, REG_P4, REG_V3); // REVD    <Zd>.Q, <Pg>/M, <Zn>.Q
+
     // IF_SVE_CX_4A
     theEmitter->emitIns_R_R_R_R(INS_sve_cmpeq, EA_SCALABLE, REG_P15, REG_P0, REG_V0, REG_V10,
                                 INS_OPTS_SCALABLE_B); // CMPEQ   <Pd>.<T>, <Pg>/Z, <Zn>.<T>, <Zm>.<T>

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1102,6 +1102,12 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             assert(isPredicateRegister(id->idReg3())); // MMMM
             break;
 
+        case IF_SVE_CT_3A:                             // ................ ...gggnnnnnddddd -- SVE reverse doublewords
+            assert(isVectorRegister(id->idReg3()));    // ddddd
+            assert(isPredicateRegister(id->idReg2())); // ggg
+            assert(isVectorRegister(id->idReg1()));    // nnnnn
+            break;
+
         // Scalable, 4 regs, to predicate register.
         case IF_SVE_CX_4A: // ........xx.mmmmm ...gggnnnnn.DDDD -- SVE integer compare vectors
             elemsize = id->idOpSize();
@@ -10015,6 +10021,13 @@ void emitter::emitIns_R_R_R(instruction     ins,
                 assert(isVectorRegister(reg1));
                 fmt = IF_SVE_CR_3A;
             }
+            break;
+
+        case INS_sve_revd:
+            assert(isVectorRegister(reg1));    // ddddd
+            assert(isPredicateRegister(reg2)); // ggg
+            assert(isVectorRegister(reg3));    // nnnnn
+            fmt = IF_SVE_CT_3A;
             break;
 
         case INS_sve_rbit:
@@ -20051,6 +20064,14 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             dst += emitOutput_Instr(dst, code);
             break;
 
+        case IF_SVE_CT_3A: // ................ ...gggnnnnnddddd -- SVE reverse doublewords
+            code = emitInsCodeSve(ins, fmt);
+            code |= insEncodeReg_V_4_to_0(id->idReg1());   // ddddd
+            code |= insEncodeReg_P_12_to_10(id->idReg2()); // ggg
+            code |= insEncodeReg_V_9_to_5(id->idReg3());   // nnnnn
+            dst += emitOutput_Instr(dst, code);
+            break;
+
         case IF_SVE_CV_3A: // ........xx...... ...VVVnnnnnddddd -- SVE vector splice (destructive)
         case IF_SVE_CV_3B: // ........xx...... ...VVVmmmmmddddd -- SVE vector splice (destructive)
             code = emitInsCodeSve(ins, fmt);
@@ -23244,6 +23265,13 @@ void emitter::emitDispInsHelp(
             emitDispReg(encodingZRtoSP(id->idReg3()), size, false);                             // mmmmm
             break;
 
+        // <Zd>.Q, <Pg>/M, <Zn>.Q
+        case IF_SVE_CT_3A: // ................ ...gggnnnnnddddd -- SVE reverse doublewords
+            emitDispSveReg(id->idReg1(), INS_OPTS_SCALABLE_Q, true);                            // ddddd
+            emitDispPredicateReg(id->idReg2(), insGetPredicateType(fmt), id->idInsOpt(), true); // ggg
+            emitDispSveReg(id->idReg3(), INS_OPTS_SCALABLE_Q, false);                           // nnnnn
+            break;
+
         // <Zd>.<T>, <Pv>, {<Zn1>.<T>, <Zn2>.<T>}
         case IF_SVE_CV_3A: // ........xx...... ...VVVnnnnnddddd -- SVE vector splice (destructive)
             emitDispSveReg(id->idReg1(), id->idInsOpt(), true);                                             // ddddd
@@ -26383,6 +26411,11 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         case IF_SVE_CQ_3A: // ........xx...... ...gggnnnnnddddd -- SVE copy general register to vector (predicated)
             result.insLatency    = PERFSCORE_LATENCY_5C;
             result.insThroughput = PERFSCORE_THROUGHPUT_1C;
+            break;
+
+        case IF_SVE_CT_3A: // ................ ...gggnnnnnddddd -- SVE reverse doublewords
+            result.insThroughput = PERFSCORE_THROUGHPUT_140C; // @ToDo Currently undocumented.
+            result.insLatency    = PERFSCORE_LATENCY_140C;
             break;
 
         case IF_SVE_CV_3A: // ........xx...... ...VVVnnnnnddddd -- SVE vector splice (destructive)

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -1110,10 +1110,10 @@ void emitter::emitInsSanityCheck(instrDesc* id)
             assert(isPredicateRegister(id->idReg2()));       // NNNN
             break;
 
-        case IF_SVE_CT_3A:                             // ................ ...gggnnnnnddddd -- SVE reverse doublewords
-            assert(isVectorRegister(id->idReg3()));    // ddddd
-            assert(isPredicateRegister(id->idReg2())); // ggg
-            assert(isVectorRegister(id->idReg1()));    // nnnnn
+        case IF_SVE_CT_3A:                          // ................ ...gggnnnnnddddd -- SVE reverse doublewords
+            assert(isVectorRegister(id->idReg1())); // ddddd
+            assert(isLowPredicateRegister(id->idReg2())); // ggg
+            assert(isVectorRegister(id->idReg3()));       // nnnnn
             break;
 
         // Scalable, 4 regs, to predicate register.
@@ -10039,9 +10039,9 @@ void emitter::emitIns_R_R_R(instruction     ins,
             break;
 
         case INS_sve_revd:
-            assert(isVectorRegister(reg1));    // ddddd
-            assert(isPredicateRegister(reg2)); // ggg
-            assert(isVectorRegister(reg3));    // nnnnn
+            assert(isVectorRegister(reg1));       // ddddd
+            assert(isLowPredicateRegister(reg2)); // ggg
+            assert(isVectorRegister(reg3));       // nnnnn
             fmt = IF_SVE_CT_3A;
             break;
 


### PR DESCRIPTION
Adds support for encoding `revd`. Matching capstone:

```
revd z1.q, p0/m, z6.q
revd z5.q, p7/m, z12.q
revd z7.q, p3/m, z11.q
revd z28.q, p4/m, z3.q
```
Contributing towards #94549.