### PR TITLE
Move wasm threading library tests job from runtime-extra-platforms to runtime

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -8,8 +8,7 @@ parameters:
   platforms: []
   scenarios: ['normal']
   shouldContinueOnError: false
-  shouldRunSmokeOnly: false 
-  shouldRunOnLibrariesAndIllinkChanges: true
+  shouldRunSmokeOnly: false
 
 jobs:
 
@@ -35,13 +34,26 @@ jobs:
         value: $[
           or(
             eq(variables['wasmDarcDependenciesChanged'], true),
-            and(eq(${{ parameters.shouldRunOnLibrariesAndIllinkChanges }}, true), eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true)),
-            and(eq(${{ parameters.shouldRunOnLibrariesAndIllinkChanges }}, true), eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true)),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+            eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true))
          ]
+      - name: shouldRunSmokeOnlyVar
+        value: $[
+          or(
+            eq('${{ parameters.shouldRunSmokeOnly }}', 'true'),
+            and(
+              eq('${{ parameters.shouldRunSmokeOnly }}', 'onLibrariesAndIllinkChanges'),
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true)
+              )
+            )
+          )
+          ]
       - name: _wasmRunSmokeTestsOnlyArg
-        value: /p:RunSmokeTestsOnly=${{ eq(parameters.shouldRunSmokeOnly, true) }}
+        value: /p:RunSmokeTestsOnly=$(shouldRunSmokeOnlyVar)
       - name: chromeInstallArg
         ${{ if containsValue(parameters.scenarios, 'wasmtestonbrowser') }}:
           value: /p:InstallChromeForTests=true

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -9,6 +9,7 @@ parameters:
   scenarios: ['normal']
   shouldContinueOnError: false
   shouldRunSmokeOnly: false 
+  shouldRunOnLibrariesAndIllinkChanges: true
 
 jobs:
 
@@ -34,8 +35,8 @@ jobs:
         value: $[
           or(
             eq(variables['wasmDarcDependenciesChanged'], true),
-            eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
-            eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+            and(eq(${{ parameters.shouldRunOnLibrariesAndIllinkChanges }}, true), eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true)),
+            and(eq(${{ parameters.shouldRunOnLibrariesAndIllinkChanges }}, true), eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true)),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true))
          ]

--- a/eng/pipelines/common/templates/wasm-library-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-tests.yml
@@ -39,16 +39,22 @@ jobs:
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true),
             eq(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true))
          ]
+      # run smoke tests only if:
+      # - explicitly requested
+      # - libraries or illink changed and no wasm specific changes
       - name: shouldRunSmokeOnlyVar
         value: $[
           or(
             eq('${{ parameters.shouldRunSmokeOnly }}', 'true'),
             and(
               eq('${{ parameters.shouldRunSmokeOnly }}', 'onLibrariesAndIllinkChanges'),
+              ne(variables['wasmDarcDependenciesChanged'], true),
               or(
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true)
-              )
+              ),
+              ne(dependencies.evaluate_paths.outputs['SetPathVars_wasm_chrome.containsChange'], true),
+              ne(dependencies.evaluate_paths.outputs['SetPathVars_wasm_specific_except_wbt_dbg.containsChange'], true)
             )
           )
           ]

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -117,24 +117,6 @@ jobs:
         - WasmTestOnBrowser
         - WasmTestOnNodeJS
 
-  # Library tests with full threading
-  - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-    parameters:
-      platforms:
-        - browser_wasm
-        #- browser_wasm_win
-      nameSuffix: _Threading
-      extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      # Always run for runtime-wasm because tests are not run in runtime
-      alwaysRun: ${{ parameters.isWasmOnlyBuild }}
-
-      scenarios:
-        - WasmTestOnBrowser
-        #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592
-
-
   # EAT Library tests - only run on linux
   - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
     parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -530,7 +530,7 @@ extends:
           nameSuffix: _Threading
           extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
           alwaysRun: ${{ variables.isRollingBuild }}
-          shouldRunOnLibrariesAndIllinkChanges: false
+          shouldRunSmokeOnly: onLibrariesAndIllinkChanges
           scenarios:
             - WasmTestOnBrowser
             #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592
@@ -608,18 +608,6 @@ extends:
             - browser_wasm
           alwaysRun: ${{ variables.isRollingBuild }}
           extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-
-      # Build and Smoke Tests only - Wasm Threading Legs
-      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
-        parameters:
-          platforms:
-            - browser_wasm
-          nameSuffix: _Threading_Smoke
-          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
-          shouldRunSmokeOnly: true
-          alwaysRun: ${{ variables.isRollingBuild }}
-          scenarios:
-            - WasmTestOnBrowser
 
       # WASI/WASM
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -521,6 +521,20 @@ extends:
           scenarios:
             - WasmTestOnBrowser
 
+      # Library tests with full threading
+      - template: /eng/pipelines/common/templates/wasm-library-tests.yml
+        parameters:
+          platforms:
+            - browser_wasm
+            #- browser_wasm_win
+          nameSuffix: _Threading
+          extraBuildArgs: /p:WasmEnableThreads=true /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+          alwaysRun: ${{ variables.isRollingBuild }}
+          shouldRunOnLibrariesAndIllinkChanges: false
+          scenarios:
+            - WasmTestOnBrowser
+            #- WasmTestOnNodeJS - this is not supported yet, https://github.com/dotnet/runtime/issues/85592
+
       # EAT Library tests - only run on linux
       - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
         parameters:


### PR DESCRIPTION
Only trigger it for wasm-specific changes in PRs, not libraries/illink.