### PR TITLE
JIT: Canonicalize loop exits

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5035,7 +5035,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         }
     }
 
-    optLoopsRequirePreHeaders = false;
+    optLoopsCanonical = false;
 
 #ifdef DEBUG
     DoPhase(this, PHASE_STRESS_SPLIT_TREE, &Compiler::StressSplitTree);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6791,7 +6791,6 @@ public:
 
     void optFindLoops();
     bool optCanonicalizeLoops();
-    void optFindAndCanonicalizeLoops();
 
     void optCompactLoops();
     void optCompactLoop(FlowGraphNaturalLoop* loop);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6802,6 +6802,8 @@ public:
 
     bool optCanonicalizeExits(FlowGraphNaturalLoop* loop);
     bool optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit);
+    weight_t optEstimateEdgeLikelihood(BasicBlock* from, BasicBlock* to, bool* fromProfile);
+    void optSetExitWeight(FlowGraphNaturalLoop* loop, BasicBlock* exit);
 
     PhaseStatus optCloneLoops();
     void optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* context);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4974,9 +4974,10 @@ public:
     FlowGraphDominatorTree* m_domTree;
     BlockReachabilitySets* m_reachabilitySets;
 
-    // Do we require loops to be in canonical form?
+    // Do we require loops to be in canonical form? The canonical form ensures that:
     // 1. All loops have preheaders (single entry blocks that always enter the loop)
-    // 2. All regular loop exits have only loop predecessors 
+    // 2. All loop exits where bbIsHandlerBeg(exit) is false have only loop predecessors.
+    //
     bool optLoopsCanonical;
     unsigned optNumNaturalLoopsFound; // Number of natural loops found in the loop finding phase
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2184,6 +2184,9 @@ public:
     template<typename TFunc>
     BasicBlockVisit VisitLoopBlocksLexical(TFunc func);
 
+    template<typename TFunc>
+    BasicBlockVisit VisitRegularExitBlocks(TFunc func);
+
     BasicBlock* GetLexicallyTopMostBlock();
     BasicBlock* GetLexicallyBottomMostBlock();
 
@@ -4971,7 +4974,10 @@ public:
     FlowGraphDominatorTree* m_domTree;
     BlockReachabilitySets* m_reachabilitySets;
 
-    bool optLoopsRequirePreHeaders; // Do we require that all loops (in m_loops) have pre-headers?
+    // Do we require loops to be in canonical form?
+    // 1. All loops have preheaders (single entry blocks that always enter the loop)
+    // 2. All regular loop exits have only loop predecessors 
+    bool optLoopsCanonical;
     unsigned optNumNaturalLoopsFound; // Number of natural loops found in the loop finding phase
 
     bool fgBBVarSetsInited;
@@ -5906,7 +5912,7 @@ public:
 
     PhaseStatus fgCanonicalizeFirstBB();
 
-    void fgSetEHRegionForNewPreheader(BasicBlock* preheader);
+    void fgSetEHRegionForNewPreheaderOrExit(BasicBlock* preheader);
 
     void fgUnreachableBlock(BasicBlock* block);
 
@@ -6785,12 +6791,17 @@ public:
 
     void optFindLoops();
     bool optCanonicalizeLoops();
+    void optFindAndCanonicalizeLoops();
+
     void optCompactLoops();
     void optCompactLoop(FlowGraphNaturalLoop* loop);
     BasicBlock* optFindLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* top);
     BasicBlock* optTryAdvanceLoopCompactionInsertionPoint(FlowGraphNaturalLoop* loop, BasicBlock* insertionPoint, BasicBlock* top, BasicBlock* bottom);
     bool optCreatePreheader(FlowGraphNaturalLoop* loop);
     void optSetPreheaderWeight(FlowGraphNaturalLoop* loop, BasicBlock* preheader);
+
+    bool optCanonicalizeExits(FlowGraphNaturalLoop* loop);
+    bool optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit);
 
     PhaseStatus optCloneLoops();
     void optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* context);

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4719,12 +4719,20 @@ void Compiler::fgDebugCheckLoops()
     {
         return;
     }
-    if (optLoopsRequirePreHeaders)
+    if (optLoopsCanonical)
     {
         for (FlowGraphNaturalLoop* loop : m_loops->InReversePostOrder())
         {
             assert(loop->EntryEdges().size() == 1);
             assert(loop->EntryEdge(0)->getSourceBlock()->KindIs(BBJ_ALWAYS));
+
+            loop->VisitRegularExitBlocks([=](BasicBlock* exit) {
+                for (BasicBlock* pred : exit->PredBlocks())
+                {
+                    assert(loop->ContainsBlock(pred));
+                }
+                return BasicBlockVisit::Continue;
+            });
         }
     }
 }

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -2057,41 +2057,6 @@ void Compiler::optCloneLoop(FlowGraphNaturalLoop* loop, LoopCloneContext* contex
     assert(condLast->NextIs(fastPreheader));
     condLast->SetFalseTarget(fastPreheader);
     fgAddRefPred(fastPreheader, condLast);
-
-    //// Now canonicalize exits for both the cold and hot loops.
-    // ArrayStack<BasicBlock*> exitBlocks(getAllocator(CMK_LoopClone));
-    // loop->VisitRegularExitBlocks([&exitBlocks](BasicBlock* exit) {
-    //    exitBlocks.Push(exit);
-    //    return BasicBlockVisit::Continue;
-    //});
-
-    // for (int i = 0; i < exitBlocks.Height(); i++)
-    //{
-    //    BasicBlock* exit = exitBlocks.Bottom(i);
-    //    // Canonicalization should have already ensured this.
-    //    assert(!exit->KindIs(BBJ_CALLFINALLY));
-
-    //    BasicBlock* coldExit = fgNewBBbefore(BBJ_ALWAYS, exit, false, exit);
-    //    coldExit->SetFlags(BBF_NONE_QUIRK | BBF_INTERNAL);
-    //    coldExit->bbCodeOffs = exit->bbCodeOffs;
-    //    fgSetEHRegionForNewPreheader(coldExit);
-    //    fgAddRefPred(exit, coldExit);
-
-    //    BasicBlock* hotExit = fgNewBBbefore(BBJ_ALWAYS, exit, false, exit);
-    //    hotExit->SetFlags(BBF_NONE_QUIRK | BBF_INTERNAL);
-    //    hotExit->bbCodeOffs = exit->bbCodeOffs;
-    //    fgSetEHRegionForNewPreheader(hotExit);
-    //    fgAddRefPred(exit, hotExit);
-
-    //    for (BasicBlock* pred : exit->PredBlocks())
-    //    {
-    //        if (loop->ContainsBlock(pred))
-    //        {
-    //            fgReplaceJumpTarget(pred, exit, hotExit);
-    //            fgReplaceJumpTarget((*blockMap)[pred], exit, coldExit);
-    //        }
-    //    }
-    //}
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3162,8 +3162,8 @@ bool Compiler::optCanonicalizeExits(FlowGraphNaturalLoop* loop)
 }
 
 //-----------------------------------------------------------------------------
-// optCanonicalizeExit: Canonicalize a single exit block
-// they have only loop predecessors.
+// optCanonicalizeExit: Canonicalize a single exit block to have only loop
+// predecessors.
 //
 // Parameters:
 //   loop - The loop

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -3210,7 +3210,8 @@ bool Compiler::optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit)
         else
         {
             // Otherwise just do the heavy-handed thing and insert it anywhere in the right region.
-            newExit = fgNewBBinRegion(BBJ_ALWAYS, finallyBlock->bbHndIndex, 0, nullptr, exit, false, false, true);
+            newExit = fgNewBBinRegion(BBJ_ALWAYS, finallyBlock->bbHndIndex, 0, nullptr, exit, /* putInFilter */ false,
+                                      /* runRarely */ false, /* insertAtEnd */ true);
         }
     }
     else


### PR DESCRIPTION
This adds another canonicalization requirement for loops during the
optimization phases, namely that all regular loop exit blocks have only
loop predecessors. This gives natural places to insert IR that we want
to run only when we know the loop was exited.

Exceptional loop exit blocks can still have non-loop predecessors, so
these must still be accounted for by optimizations.

We could also have a stronger property, namely that all loop exits have only a single predecessor. However the main motivation for the canonicalization is #97865 which does not require this stronger canonicalization.

Example flowgraph: [before](https://edotor.net/?engine=dot?engine=dot#digraph%20FlowGraph%20%7B%0A%20%20%20%20graph%20%5Blabel%20%3D%20%22Test%5Cnafter%5CnFind%20loops%22%5D%3B%0A%20%20%20%20node%20%5Bshape%20%3D%20%22Box%22%5D%3B%0A%20%20%20%20BB01%20%5Blabel%20%3D%20%22BB01%5Cn%5BCOMMA%5D%20%3C%20V01%22%2C%20shape%20%3D%20%22house%22%5D%3B%0A%20%20%20%20BB02%20%5Blabel%20%3D%20%22BB02%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB03%20%5Blabel%20%3D%20%22BB03%5Cn%5BCOMMA%5D%20%3C%20V01%22%5D%3B%0A%20%20%20%20BB04%20%5Blabel%20%3D%20%22BB04%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB05%20%5Blabel%20%3D%20%22BB05%5Cn%5BCOMMA%5D%20%3E%3D%200%22%5D%3B%0A%20%20%20%20BB06%20%5Blabel%20%3D%20%22BB06%5Cn%5BCOMMA%5D%20%3E%3D%20V01%22%5D%3B%0A%20%20%20%20BB07%20%5Blabel%20%3D%20%22BB07%5Cn%5BCOMMA%5D%20%3E%3D%20V01%22%5D%3B%0A%20%20%20%20BB08%20%5Blabel%20%3D%20%22BB08%22%2C%20shape%20%3D%20%22invhouse%22%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB02%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB02%20-%3E%20BB03%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB07%20-%3E%20BB03%20%5Bcolor%3Dgreen%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB04%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB04%20-%3E%20BB05%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB05%20%5Bcolor%3Dgreen%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB06%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB07%20%5B%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB07%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB08%20%5B%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB08%20%5B%5D%3B%0A%20%20%20%20BB07%20-%3E%20BB08%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB02%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB02%20-%3E%20BB03%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB04%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB04%20-%3E%20BB05%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB06%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB07%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB07%20-%3E%20BB08%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20subgraph%20cluster_0%20%7B%0A%20%20%20%20%20%20%20%20label%20%3D%20%22L00%22%3B%0A%20%20%20%20%20%20%20%20color%20%3D%20blue%3B%0A%20%20%20%20%20%20%20%20BB03%3BBB04%3B%0A%20%20%20%20%20%20%20%20subgraph%20cluster_1%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20label%20%3D%20%22L01%22%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20color%20%3D%20blue%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20BB05%3BBB06%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20BB07%3B%0A%20%20%20%20%7D%0A%7D%0A), [after](https://edotor.net/?engine=dot?engine=dot#digraph%20FlowGraph%20%7B%0A%20%20%20%20graph%20%5Blabel%20%3D%20%22Test%5Cnafter%5CnFind%20loops%22%5D%3B%0A%20%20%20%20node%20%5Bshape%20%3D%20%22Box%22%5D%3B%0A%20%20%20%20BB01%20%5Blabel%20%3D%20%22BB01%5Cn%5BCOMMA%5D%20%3C%20V01%22%2C%20shape%20%3D%20%22house%22%5D%3B%0A%20%20%20%20BB02%20%5Blabel%20%3D%20%22BB02%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB03%20%5Blabel%20%3D%20%22BB03%5Cn%5BCOMMA%5D%20%3C%20V01%22%5D%3B%0A%20%20%20%20BB04%20%5Blabel%20%3D%20%22BB04%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB05%20%5Blabel%20%3D%20%22BB05%5Cn%5BCOMMA%5D%20%3E%3D%200%22%5D%3B%0A%20%20%20%20BB06%20%5Blabel%20%3D%20%22BB06%5Cn%5BCOMMA%5D%20%3E%3D%20V01%22%5D%3B%0A%20%20%20%20BB07%20%5Blabel%20%3D%20%22BB07%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB08%20%5Blabel%20%3D%20%22BB08%5Cn%5BCOMMA%5D%20%3E%3D%20V01%22%5D%3B%0A%20%20%20%20BB09%20%5Blabel%20%3D%20%22BB09%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB10%20%5Blabel%20%3D%20%22BB10%22%2C%20shape%20%3D%20%22note%22%5D%3B%0A%20%20%20%20BB11%20%5Blabel%20%3D%20%22BB11%22%2C%20shape%20%3D%20%22invhouse%22%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB02%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB02%20-%3E%20BB03%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB08%20-%3E%20BB03%20%5Bcolor%3Dgreen%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB04%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB04%20-%3E%20BB05%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB05%20%5Bcolor%3Dgreen%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB06%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB07%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB08%20%5B%5D%3B%0A%20%20%20%20BB07%20-%3E%20BB08%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB09%20%5B%5D%3B%0A%20%20%20%20BB08%20-%3E%20BB10%20%5B%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB11%20%5B%5D%3B%0A%20%20%20%20BB09%20-%3E%20BB11%20%5B%5D%3B%0A%20%20%20%20BB10%20-%3E%20BB11%20%5Bcolor%3Dblue%2C%20weight%3D20%5D%3B%0A%20%20%20%20BB01%20-%3E%20BB02%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB02%20-%3E%20BB03%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB03%20-%3E%20BB04%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB04%20-%3E%20BB05%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB05%20-%3E%20BB06%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB06%20-%3E%20BB07%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB07%20-%3E%20BB08%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB08%20-%3E%20BB09%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB09%20-%3E%20BB10%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20BB10%20-%3E%20BB11%20%5Bstyle%3D%22invis%22%2C%20weight%3D25%5D%3B%0A%20%20%20%20subgraph%20cluster_0%20%7B%0A%20%20%20%20%20%20%20%20label%20%3D%20%22L00%22%3B%0A%20%20%20%20%20%20%20%20color%20%3D%20blue%3B%0A%20%20%20%20%20%20%20%20BB03%3BBB04%3B%0A%20%20%20%20%20%20%20%20subgraph%20cluster_1%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20label%20%3D%20%22L01%22%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20color%20%3D%20blue%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20BB05%3BBB06%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20BB07%3BBB08%3B%0A%20%20%20%20%7D%0A%7D%0A)