### PR TITLE
[browser][debugger] Disabling tests failing on Firefox

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrame2Tests.cs
@@ -816,8 +816,9 @@ namespace DebuggerTests
                     ("mc.Method(instance2.propInt)", TNumber(12))
                 ); 
            });
-        
-        [Fact]
+
+        // https://github.com/dotnet/runtime/issues/98086
+        [ConditionalFact(nameof(RunningOnChrome))]
         public async Task EvaluateValueTypeWithFixedArrayAndMoreFields() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.EvaluateValueTypeWithFixedArray", "run", 3, "DebuggerTests.EvaluateValueTypeWithFixedArray.run",
             "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateValueTypeWithFixedArray:run'); })",
@@ -829,8 +830,9 @@ namespace DebuggerTests
                    ("myVar.myIntArray[1]", TNumber(2)),
                    ("myVar.myCharArray[2]", TChar('a')));
            });
-        
-        [Fact]
+
+        // https://github.com/dotnet/runtime/issues/98086
+        [ConditionalFact(nameof(RunningOnChrome))]
         public async Task EvaluateValueTypeWithObjectValueType() => await CheckInspectLocalsAtBreakpointSite(
             "DebuggerTests.EvaluateValueTypeWithObjectValueType", "run", 3, "DebuggerTests.EvaluateValueTypeWithObjectValueType.run",
             "window.setTimeout(function() { invoke_static_method ('[debugger-test] DebuggerTests.EvaluateValueTypeWithObjectValueType:run'); })",


### PR DESCRIPTION
Connected issue: https://github.com/dotnet/runtime/issues/98086.

Tests on firefox are not stable yet, we should block them.