### PR TITLE
JIT: Generalize jump threading very slightly

### DIFF
--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1258,10 +1258,10 @@ bool Compiler::optJumpThreadDom(BasicBlock* const block, BasicBlock* const domBl
             continue;
         }
 
-        const bool isTruePred = ((predBlock == domBlock) && (domTrueSuccessor == block)) ||
-                                optReachable(domTrueSuccessor, predBlock, domBlock);
-        const bool isFalsePred = ((predBlock == domBlock) && (domFalseSuccessor == block)) ||
-                                 optReachable(domFalseSuccessor, predBlock, domBlock);
+        const bool isTruePred =
+            (predBlock == domBlock) ? (domTrueSuccessor == block) : optReachable(domTrueSuccessor, predBlock, domBlock);
+        const bool isFalsePred = (predBlock == domBlock) ? (domFalseSuccessor == block)
+                                                         : optReachable(domFalseSuccessor, predBlock, domBlock);
 
         if (isTruePred == isFalsePred)
         {


### PR DESCRIPTION
If the dominator is a direct predecessor then it should be ok to jump thread its direct edge, even if the other edge also reaches. I think.

(Noticed this while looking at the case in https://github.com/dotnet/runtime/pull/98096#issuecomment-1932282106, where we considered `BB33` to be an ambiguous pred of `BB38`, but it seems we should be able to consider it to be a "true" pred.)