### PR TITLE
ARM64: Optimize overflow and divbyzero checks with assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3942,18 +3942,18 @@ void Compiler::optAssertionProp_IntegralRangeProperties(ASSERT_VALARG_TP asserti
 }
 
 //------------------------------------------------------------------------
-// optAssertionProp_ModDiv: Optimizes DIV/MOD via assertions
+// optAssertionProp_ModDiv: Optimizes DIV/UDIV/MOD/UMOD via assertions
 //    1) Convert DIV/MOD to UDIV/UMOD if both operands are proven to be never negative
-//    2) Marks DIV/MOD with GTF_DIV_MOD_NO_BY_ZERO if divisor is proven to be never zero
-//    3) Marks DIV/MOD with GTF_DIV_MOD_NO_OVERFLOW if both operands are proven to be never negative
+//    2) Marks DIV/UDIV/MOD/UMOD with GTF_DIV_MOD_NO_BY_ZERO if divisor is proven to be never zero
+//    3) Marks DIV/UDIV/MOD/UMOD with GTF_DIV_MOD_NO_OVERFLOW if both operands are proven to be never negative
 //
 // Arguments:
 //    assertions - set of live assertions
-//    tree       - the DIV/MOD node to optimize
-//    stmt       - statement containing DIV/MOD
+//    tree       - the DIV/UDIV/MOD/UMOD node to optimize
+//    stmt       - statement containing DIV/UDIV/MOD/UMOD
 //
 // Returns:
-//    Updated DIV/MOD node, or nullptr
+//    Updated DIV/UDIV/MOD/UMOD node, or nullptr
 //
 GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeOp* tree, Statement* stmt)
 {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3825,7 +3825,7 @@ GenTree* Compiler::optAssertionProp_BlockStore(ASSERT_VALARG_TP assertions, GenT
 }
 
 //------------------------------------------------------------------------
-// optAssertionProp_IntegralRangeProperties: Obtains range properties for an integral tree
+// optAssertionProp_RangeProperties: Obtains range properties for an arbitrary tree
 //
 // Arguments:
 //    assertions         - set of live assertions
@@ -3833,16 +3833,17 @@ GenTree* Compiler::optAssertionProp_BlockStore(ASSERT_VALARG_TP assertions, GenT
 //    isKnownNonZero     - [OUT] set to true if the tree is known to be non-zero
 //    isKnownNonNegative - [OUT] set to true if the tree is known to be non-negative
 //
-void Compiler::optAssertionProp_IntegralRangeProperties(ASSERT_VALARG_TP assertions,
-                                                        GenTree*         tree,
-                                                        bool*            isKnownNonZero,
-                                                        bool*            isKnownNonNegative)
+void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
+                                                GenTree*         tree,
+                                                bool*            isKnownNonZero,
+                                                bool*            isKnownNonNegative)
 {
     *isKnownNonZero     = false;
     *isKnownNonNegative = false;
 
     if (!varTypeIsIntegral(tree))
     {
+        // We only support integral types for now.
         return;
     }
 
@@ -3950,12 +3951,15 @@ void Compiler::optAssertionProp_IntegralRangeProperties(ASSERT_VALARG_TP asserti
 //
 GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeOp* tree, Statement* stmt)
 {
+    GenTree* op1 = tree->gtGetOp1();
+    GenTree* op2 = tree->gtGetOp2();
+
     bool op1IsNotZero;
     bool op2IsNotZero;
     bool op1IsNotNegative;
     bool op2IsNotNegative;
-    optAssertionProp_IntegralRangeProperties(assertions, tree->gtGetOp1(), &op1IsNotZero, &op1IsNotNegative);
-    optAssertionProp_IntegralRangeProperties(assertions, tree->gtGetOp2(), &op2IsNotZero, &op2IsNotNegative);
+    optAssertionProp_RangeProperties(assertions, op1, &op1IsNotZero, &op1IsNotNegative);
+    optAssertionProp_RangeProperties(assertions, op2, &op2IsNotZero, &op2IsNotNegative);
 
     bool changed = false;
     if (op1IsNotNegative && op2IsNotNegative && tree->OperIs(GT_DIV, GT_MOD))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3992,7 +3992,13 @@ GenTree* Compiler::optAssertionProp_ModDiv(ASSERT_VALARG_TP assertions, GenTreeO
         changed = true;
     }
 
-    return changed ? optAssertionProp_Update(tree, tree, stmt) : nullptr;
+    if (changed)
+    {
+        // It's possible we no longer have side-effects on the tree.
+        gtUpdateNodeSideEffects(tree);
+        return optAssertionProp_Update(tree, tree, stmt);
+    }
+    return nullptr;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3841,9 +3841,9 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
     *isKnownNonZero     = false;
     *isKnownNonNegative = false;
 
-    if (!varTypeIsIntegral(tree))
+    if (optLocalAssertionProp || !varTypeIsIntegral(tree) || BitVecOps::MayBeUninit(assertions) ||
+        BitVecOps::IsEmpty(apTraits, assertions))
     {
-        // We only support integral types for now.
         return;
     }
 
@@ -3854,11 +3854,6 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
     if (*isKnownNonZero && *isKnownNonNegative)
     {
         // TP: We already have both properties, no need to check assertions.
-        return;
-    }
-
-    if (optLocalAssertionProp || BitVecOps::MayBeUninit(assertions) || BitVecOps::IsEmpty(apTraits, assertions))
-    {
         return;
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7824,6 +7824,11 @@ public:
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
     bool optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 
+    void optAssertionProp_IntegralRangeProperties(ASSERT_VALARG_TP assertions,
+                                                  GenTree*         tree,
+                                                  bool*            isKnownNonZero,
+                                                  bool*            isKnownNonNegative);
+
     // Implied assertion functions.
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);
     void optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7824,10 +7824,10 @@ public:
     bool optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
     bool optNonHeapAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir);
 
-    void optAssertionProp_IntegralRangeProperties(ASSERT_VALARG_TP assertions,
-                                                  GenTree*         tree,
-                                                  bool*            isKnownNonZero,
-                                                  bool*            isKnownNonNegative);
+    void optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
+                                          GenTree*         tree,
+                                          bool*            isKnownNonZero,
+                                          bool*            isKnownNonNegative);
 
     // Implied assertion functions.
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2707,7 +2707,7 @@ AGAIN:
     {
         return false;
     }
-    if ((oper == GT_MOD) || (oper == GT_UMOD) || (oper == GT_DIV) || (oper == GT_UDIV))
+    if (op1->OperIs(GT_MOD, GT_UMOD, GT_DIV, GT_UDIV))
     {
         if ((op1->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) !=
             (op2->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)))

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2707,6 +2707,14 @@ AGAIN:
     {
         return false;
     }
+    if ((oper == GT_MOD) || (oper == GT_UMOD) || (oper == GT_DIV) || (oper == GT_UDIV))
+    {
+        if ((op1->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)) !=
+            (op2->gtFlags & (GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW)))
+        {
+            return false;
+        }
+    }
 
     /* Figure out what kind of nodes we're comparing */
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2145,12 +2145,6 @@ public:
         gtFlags &= ~GTF_MUL_64RSLT;
     }
 
-    void ClearDivFlags()
-    {
-        assert(OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD));
-        gtFlags &= ~(GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW);
-    }
-
     void SetAllEffectsFlags(GenTree* source)
     {
         SetAllEffectsFlags(source->gtFlags & GTF_ALL_EFFECT);

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2145,6 +2145,12 @@ public:
         gtFlags &= ~GTF_MUL_64RSLT;
     }
 
+    void ClearDivFlags()
+    {
+        assert(OperIs(GT_DIV, GT_UDIV, GT_MOD, GT_UMOD));
+        gtFlags &= ~(GTF_DIV_MOD_NO_BY_ZERO | GTF_DIV_MOD_NO_OVERFLOW);
+    }
+
     void SetAllEffectsFlags(GenTree* source)
     {
         SetAllEffectsFlags(source->gtFlags & GTF_ALL_EFFECT);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6492,8 +6492,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             divisorValue -= 1;
         }
 
-        divMod->ClearDivFlags();
-        divMod->SetOper(newOper);
+        divMod->ChangeOper(newOper);
         divisor->AsIntCon()->SetIconValue(divisorValue);
         ContainCheckNode(divMod);
         return true;
@@ -6505,8 +6504,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         if (((type == TYP_INT) && (divisorValue > (UINT32_MAX / 2))) ||
             ((type == TYP_LONG) && (divisorValue > (UINT64_MAX / 2))))
         {
-            divMod->ClearDivFlags();
-            divMod->SetOper(GT_GE);
+            divMod->ChangeOper(GT_GE);
             divMod->gtFlags |= GTF_UNSIGNED;
             ContainCheckNode(divMod);
             return true;
@@ -6641,8 +6639,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
         if (isDiv && !postShift && (type == TYP_I_IMPL))
         {
-            divMod->ClearDivFlags();
-            divMod->SetOper(GT_MULHI);
+            divMod->ChangeOper(GT_MULHI);
             divMod->gtOp1 = adjustedDividend;
             divMod->SetUnsigned();
         }
@@ -6674,8 +6671,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
                 if (isDiv && (type == TYP_I_IMPL))
                 {
-                    divMod->ClearDivFlags();
-                    divMod->SetOper(GT_RSZ);
+                    divMod->ChangeOper(GT_RSZ);
                     divMod->gtOp1 = mulhi;
                     divMod->gtOp2 = shiftBy;
                 }
@@ -6693,8 +6689,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
                 GenTree* mul     = comp->gtNewOperNode(GT_MUL, type, mulhi, divisor);
                 dividend         = comp->gtNewLclvNode(dividend->AsLclVar()->GetLclNum(), dividend->TypeGet());
 
-                divMod->ClearDivFlags();
-                divMod->SetOper(GT_SUB);
+                divMod->ChangeOper(GT_SUB);
                 divMod->gtOp1 = dividend;
                 divMod->gtOp2 = mul;
 
@@ -6702,8 +6697,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             }
             else if (type != TYP_I_IMPL)
             {
-                divMod->ClearDivFlags();
-                divMod->SetOper(GT_CAST);
+                divMod->ChangeOper(GT_CAST);
                 divMod->AsCast()->gtCastType = TYP_INT;
                 divMod->gtOp1                = mulhi;
                 divMod->gtOp2                = nullptr;
@@ -6793,8 +6787,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
         {
             // If the divisor is the minimum representable integer value then we can use a compare,
             // the result is 1 iff the dividend equals divisor.
-            divMod->ClearDivFlags();
-            divMod->SetOper(GT_EQ);
+            divMod->ChangeOper(GT_EQ);
             *nextNode = node;
             return true;
         }
@@ -6889,8 +6882,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
 
         if (isDiv)
         {
-            divMod->ClearDivFlags();
-            divMod->SetOperRaw(GT_ADD);
+            divMod->ChangeOper(GT_ADD);
             divMod->AsOp()->gtOp1 = adjusted;
             divMod->AsOp()->gtOp2 = signBit;
         }
@@ -6905,8 +6897,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
             GenTree* mul     = comp->gtNewOperNode(GT_MUL, type, div, divisor);
             BlockRange().InsertBefore(divMod, dividend, div, divisor, mul);
 
-            divMod->ClearDivFlags();
-            divMod->SetOperRaw(GT_SUB);
+            divMod->ChangeOper(GT_SUB);
             divMod->AsOp()->gtOp1 = dividend;
             divMod->AsOp()->gtOp2 = mul;
         }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6492,6 +6492,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             divisorValue -= 1;
         }
 
+        divMod->ClearDivFlags();
         divMod->SetOper(newOper);
         divisor->AsIntCon()->SetIconValue(divisorValue);
         ContainCheckNode(divMod);
@@ -6504,6 +6505,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         if (((type == TYP_INT) && (divisorValue > (UINT32_MAX / 2))) ||
             ((type == TYP_LONG) && (divisorValue > (UINT64_MAX / 2))))
         {
+            divMod->ClearDivFlags();
             divMod->SetOper(GT_GE);
             divMod->gtFlags |= GTF_UNSIGNED;
             ContainCheckNode(divMod);
@@ -6639,6 +6641,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
         if (isDiv && !postShift && (type == TYP_I_IMPL))
         {
+            divMod->ClearDivFlags();
             divMod->SetOper(GT_MULHI);
             divMod->gtOp1 = adjustedDividend;
             divMod->SetUnsigned();
@@ -6671,6 +6674,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
 
                 if (isDiv && (type == TYP_I_IMPL))
                 {
+                    divMod->ClearDivFlags();
                     divMod->SetOper(GT_RSZ);
                     divMod->gtOp1 = mulhi;
                     divMod->gtOp2 = shiftBy;
@@ -6689,6 +6693,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
                 GenTree* mul     = comp->gtNewOperNode(GT_MUL, type, mulhi, divisor);
                 dividend         = comp->gtNewLclvNode(dividend->AsLclVar()->GetLclNum(), dividend->TypeGet());
 
+                divMod->ClearDivFlags();
                 divMod->SetOper(GT_SUB);
                 divMod->gtOp1 = dividend;
                 divMod->gtOp2 = mul;
@@ -6697,6 +6702,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
             }
             else if (type != TYP_I_IMPL)
             {
+                divMod->ClearDivFlags();
                 divMod->SetOper(GT_CAST);
                 divMod->AsCast()->gtCastType = TYP_INT;
                 divMod->gtOp1                = mulhi;
@@ -6787,6 +6793,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
         {
             // If the divisor is the minimum representable integer value then we can use a compare,
             // the result is 1 iff the dividend equals divisor.
+            divMod->ClearDivFlags();
             divMod->SetOper(GT_EQ);
             *nextNode = node;
             return true;
@@ -6882,6 +6889,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
 
         if (isDiv)
         {
+            divMod->ClearDivFlags();
             divMod->SetOperRaw(GT_ADD);
             divMod->AsOp()->gtOp1 = adjusted;
             divMod->AsOp()->gtOp2 = signBit;
@@ -6897,6 +6905,7 @@ bool Lowering::TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode)
             GenTree* mul     = comp->gtNewOperNode(GT_MUL, type, div, divisor);
             BlockRange().InsertBefore(divMod, dividend, div, divisor, mul);
 
+            divMod->ClearDivFlags();
             divMod->SetOperRaw(GT_SUB);
             divMod->AsOp()->gtOp1 = dividend;
             divMod->AsOp()->gtOp2 = mul;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/98100

```cs
static int Test(int a, int b)
{
    if (b <= 0)  // or other types of similar checks e.g. !=0 or throwing a user exception, etc..
        return 0;

    return a / b;
}
```
Codegen diff:
```diff
; Method Prog:Test(int,int):int (FullOpts)
G_M31864_IG01:
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
G_M31864_IG02:
            cmp     w1, #0
            bgt     G_M31864_IG05
G_M31864_IG03:
            mov     w0, wzr
G_M31864_IG04:
            ldp     fp, lr, [sp], #0x10
            ret     lr
G_M31864_IG05:
-           cmp     w1, #0
-           beq     G_M31864_IG08
-           cmn     w1, #1
-           bne     G_M31864_IG06
-           cmp     w0, #1
-           bvs     G_M31864_IG09
+           sdiv    w0, w0, w1
G_M31864_IG06:
-           sdiv    w0, w0, w1
-G_M31864_IG07:
            ldp     fp, lr, [sp], #0x10
            ret     lr
-G_M31864_IG08:
-           bl      CORINFO_HELP_THROWDIVZERO
-G_M31864_IG09:
-           bl      CORINFO_HELP_OVERFLOW
-           brk_windows #0
-; Total bytes of code: 76
+; Total bytes of code: 40
```

Should slightly improve certain patterns on x64 as well.