### PR TITLE
WorkloadBuildTasks: fix sourcebuild

### DIFF
--- a/src/mono/nuget/mono-packages.proj
+++ b/src/mono/nuget/mono-packages.proj
@@ -9,6 +9,8 @@
     <ProjectReference Include="Microsoft.NET.Runtime.WebAssembly.Sdk\Microsoft.NET.Runtime.WebAssembly.Sdk.pkgproj" />
     <ProjectReference Include="..\wasm\templates\Microsoft.NET.Runtime.WebAssembly.Templates.csproj" />
     <ProjectReference Include="Microsoft.NET.Sdk.WebAssembly.Pack\Microsoft.NET.Sdk.WebAssembly.Pack.pkgproj" />
+
+    <ProjectReference Include="Microsoft.NET.Runtime.WorkloadTesting.Internal\Microsoft.NET.Runtime.WorkloadTesting.Internal.pkgproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsWasi)' == 'true'">
@@ -30,9 +32,5 @@
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <ProjectReference Include="Microsoft.NET.Runtime.MonoTargets.Sdk\Microsoft.NET.Runtime.MonoTargets.Sdk.pkgproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="Microsoft.NET.Runtime.WorkloadTesting.Internal\Microsoft.NET.Runtime.WorkloadTesting.Internal.pkgproj" />
   </ItemGroup>
 </Project>

--- a/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
+++ b/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppToolCurrent);net8.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppToolCurrent)</TargetFrameworks>
+    <!-- net8.0 is only need for the internal nuget produced which isn't required for source builds -->
+    <TargetFrameworks Condition="'$(DotNetBuildFromSource)' != 'true'">$(TargetFrameworks);net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn),CA1050,CA1850</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
`WorkloadBuildTasks` project uses source generated regex, which requires
the corresponding analyzer to be used. But for net8.0, in source build
the prebuilt package does not have the analyzers which causes the build
to fail like:

`/__w/1/s/artifacts/sb/src/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs(61,38): error CS8795: Partial method 'InstallWorkloadFromArtifacts.bandVersionRegex()' must have an implementation part because it has accessibility modifiers. [/__w/1/s/artifacts/sb/src/src/tasks/WorkloadBuildTasks/WorkloadBuildTasks.csproj::TargetFramework=net8.0]`

Since the net8.0 build for the task is needed only for the internal
nuget being produced, we can skip the net8.0 build for source builds.

Also, build WorkloadTest.Internal nuget only when building wasm.

Fixes https://github.com/dotnet/runtime/issues/98130 .