### PR TITLE
workload-testing: Fix building the targeting pack

### DIFF
--- a/eng/testing/workloads-browser.targets
+++ b/eng/testing/workloads-browser.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GetWorkloadInputsDependsOn>_GetWorkloadsToInstall;$(GetWorkloadInputsDependsOn)</GetWorkloadInputsDependsOn>
-    <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
+    <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;_GetNuGetToBuildForTargetingPack;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
   </PropertyGroup>
 
   <Target Name="_GetWorkloadsToInstall" DependsOnTargets="_SetPackageVersionForWorkloadsTesting" Returns="@(WorkloadIdForTesting);@(WorkloadCombinationsToInstall)">
@@ -44,7 +44,7 @@
   <!-- For local builds, only one of the 2 required runtime packs might be available. In that case,
        build the other nugets with the *same runtime* but different names.
   -->
-  <Target Name="_GetRuntimePackNuGetsToBuild" Condition="'$(WasmSkipMissingRuntimePackBuild)' != 'true'" Returns="@(_NuGetsToBuild)">
+  <Target Name="_GetRuntimePackNuGetsToBuild" Condition="'$(WasmSkipMissingRuntimePackBuild)' != 'true'" Returns="@(NuGetsToBuildForWorkloadTesting)">
     <Error Condition="'$(RIDForWorkload)' == ''" Text="$(RIDForWorkload) is unset" />
     <PropertyGroup>
       <_IsMTNugetMissing Condition="'$(WasmEnableThreads)' != 'true'">true</_IsMTNugetMissing>
@@ -68,9 +68,9 @@
            Text="Expected to find either one or two in $(LibrariesShippingPackagesDir): @(_RuntimePackNugetAvailable->'%(FileName)%(Extension)')" />
 
     <ItemGroup>
-      <!-- We need nugets for all wasm runtime flavors. The one corresponding the current 
-      property values is already built, the others need to be added to _NuGetsToBuild -->
-      <_NuGetsToBuild Include="$(_DefaultRuntimePackNuGetPath)"
+      <!-- We need nugets for all wasm runtime flavors. The one corresponding the current
+      property values is already built, the others need to be added to NuGetsToBuildForWorkloadTesting -->
+      <NuGetsToBuildForWorkloadTesting Include="$(_DefaultRuntimePackNuGetPath)"
                       Project="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj"
                       Dependencies="$(_DefaultRuntimePackNuGetPath)"
                       Properties="@(_DefaultPropsForNuGetBuild, ';');WasmEnableThreads=$(_IsMTNugetMissing)"

--- a/eng/testing/workloads-browser.targets
+++ b/eng/testing/workloads-browser.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GetWorkloadInputsDependsOn>_GetWorkloadsToInstall;$(GetWorkloadInputsDependsOn)</GetWorkloadInputsDependsOn>
-    <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;_GetNuGetToBuildForTargetingPack;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
+    <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetRuntimePackNuGetsToBuild;_GetNugetsForAOT;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
   </PropertyGroup>
 
   <Target Name="_GetWorkloadsToInstall" DependsOnTargets="_SetPackageVersionForWorkloadsTesting" Returns="@(WorkloadIdForTesting);@(WorkloadCombinationsToInstall)">

--- a/eng/testing/workloads-testing.targets
+++ b/eng/testing/workloads-testing.targets
@@ -24,9 +24,9 @@
     <DefaultPropertiesForNuGetBuild Include="TargetArchitecture=$(TargetArchitectureForWorkload)" />
   </ItemGroup>
 
-  <Target Name="GetNuGetsToBuildForWorkloadTesting_Mobile" Returns="@(_NuGetsToBuild)" Condition="'$(PreparePackagesForWorkloadInstall)' == 'true'">
+  <Target Name="_GetNuGetToBuildForTargetingPack" Returns="@(NuGetsToBuildForWorkloadTesting)" Condition="'$(PreparePackagesForWorkloadInstall)' == 'true'">
     <ItemGroup>
-      <_NuGetsToBuild Include="$(BuiltNuGetsDir)Microsoft.NETCore.App.Ref.$(PackageVersionForWorkloadManifests).nupkg"
+      <NuGetsToBuildForWorkloadTesting Include="$(BuiltNuGetsDir)Microsoft.NETCore.App.Ref.$(PackageVersionForWorkloadManifests).nupkg"
                       Project="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App\Microsoft.NETCore.App.Ref.sfxproj"
                       Properties="@(DefaultPropertiesForNuGetBuild, ';')"
                       Descriptor="Ref pack"/>

--- a/eng/testing/workloads-wasm.targets
+++ b/eng/testing/workloads-wasm.targets
@@ -2,6 +2,7 @@
   <Target Name="_GetNugetsForAOT" Returns="@(NuGetsToBuildForWorkloadTesting)">
     <Error Condition="'$(RIDForWorkload)' == ''" Text="$(RIDForWorkload) is unset" />
     <PropertyGroup>
+      <GetNuGetsToBuildForWorkloadTestingDependsOn>_GetNuGetToBuildForTargetingPack;$(GetNuGetsToBuildForWorkloadTestingDependsOn)</GetNuGetsToBuildForWorkloadTestingDependsOn>
       <!-- Eg. Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm.6.0.0-dev.nupkg -->
       <_AOTCrossNuGetPath>$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Runtime.AOT.$(NETCoreSdkRuntimeIdentifier).Cross.$(RIDForWorkload).$(PackageVersionForWorkloadManifests).nupkg</_AOTCrossNuGetPath>
     </PropertyGroup>

--- a/eng/testing/workloads-wasm.targets
+++ b/eng/testing/workloads-wasm.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Target Name="_GetNugetsForAOT" Returns="@(_NuGetsToBuild)">
+  <Target Name="_GetNugetsForAOT" Returns="@(NuGetsToBuildForWorkloadTesting)">
     <Error Condition="'$(RIDForWorkload)' == ''" Text="$(RIDForWorkload) is unset" />
     <PropertyGroup>
       <!-- Eg. Microsoft.NETCore.App.Runtime.AOT.osx-x64.Cross.browser-wasm.6.0.0-dev.nupkg -->
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_NuGetsToBuild Include="$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Ref.$(PackageVersionForWorkloadManifests).nupkg"
+      <NuGetsToBuildForWorkloadTesting Include="$(LibrariesShippingPackagesDir)Microsoft.NETCore.App.Ref.$(PackageVersionForWorkloadManifests).nupkg"
                       Project="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App\Microsoft.NETCore.App.Ref.sfxproj"
                       Properties="@(_DefaultPropsForNuGetBuild, ';')"
                       Descriptor="Ref pack"/>
@@ -19,7 +19,7 @@
       <_PropsForAOTCrossBuild Include="TargetCrossRid=$(RIDForWorkload)" />
       <_PropsForAOTCrossBuild Include="DisableSourceLink=true" />
 
-      <_NuGetsToBuild Include="$(_AOTCrossNuGetPath)"
+      <NuGetsToBuildForWorkloadTesting Include="$(_AOTCrossNuGetPath)"
                       Project="$(InstallerProjectRoot)pkg/sfx/Microsoft.NETCore.App\Microsoft.NETCore.App.MonoCrossAOT.sfxproj"
                       Properties="@(_PropsForAOTCrossBuild,';')"
                       Descriptor="AOT Cross compiler"/>

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -165,20 +165,20 @@
           Condition="'$(InstallWorkloadForTesting)' == 'true'" />
 
   <Target Name="GetNuGetsToBuildForWorkloadTesting"
-          Returns="@(_NuGetsToBuild)"
+          Returns="@(NuGetsToBuildForWorkloadTesting)"
           DependsOnTargets="$(GetNuGetsToBuildForWorkloadTestingDependsOn)"
           Condition="'$(PreparePackagesForWorkloadInstall)' == 'true'" />
 
-  <Target Name="_PreparePackagesForWorkloadInstall" Inputs="%(_NuGetsToBuild.Project);%(_NuGetsToBuild.Dependencies)" Outputs="%(_NuGetsToBuild.Identity)" Condition="'$(PreparePackagesForWorkloadInstall)' == 'true'">
+  <Target Name="_PreparePackagesForWorkloadInstall" Inputs="%(NuGetsToBuildForWorkloadTesting.Project);%(NuGetsToBuildForWorkloadTesting.Dependencies)" Outputs="%(NuGetsToBuildForWorkloadTesting.Identity)" Condition="'$(PreparePackagesForWorkloadInstall)' == 'true'">
     <Message Importance="High" Text="
-** Building %(_NuGetsToBuild.Descriptor) **
+** Building %(NuGetsToBuildForWorkloadTesting.Descriptor) **
       " />
 
-    <MSBuild Projects="%(_NuGetsToBuild.Project)"
-             Properties="%(_NuGetsToBuild.Properties);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
+    <MSBuild Projects="%(NuGetsToBuildForWorkloadTesting.Project)"
+             Properties="%(NuGetsToBuildForWorkloadTesting.Properties);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
              Targets="Restore" />
-    <MSBuild Projects="%(_NuGetsToBuild.Project)"
-             Properties="%(_NuGetsToBuild.Properties)"
+    <MSBuild Projects="%(NuGetsToBuildForWorkloadTesting.Project)"
+             Properties="%(NuGetsToBuildForWorkloadTesting.Properties)"
              Targets="Pack" />
   </Target>
 


### PR DESCRIPTION
- Rename `_NuGetsToBuild` to `NuGetsToBuildForWorkloadTesting`
- And connect back the target to build the targeting pack
