### PR TITLE
Workaround arm32 remote unwind assert in createdump

### DIFF
--- a/src/coreclr/pal/src/exception/remote-unwind.cpp
+++ b/src/coreclr/pal/src/exception/remote-unwind.cpp
@@ -2219,8 +2219,7 @@ resume(unw_addr_space_t as, unw_cursor_t *cp, void *arg)
 static int
 get_proc_name(unw_addr_space_t as, unw_word_t addr, char *bufp, size_t buf_len, unw_word_t *offp, void *arg)
 {
-    ASSERT("Not supposed to be ever called\n");
-    return -UNW_EINVAL;
+    return -UNW_ENOINFO;
 }
 
 static int


### PR DESCRIPTION
Createdump was hitting the assert in get_proc_name in the remote unwinder on arm32.  The newer libunwind is calling this now. Working around the call by returning that there is no proc name for the address (return -ENW_ENOINFO).