### PR TITLE
Improve API documentation for Enumerable.Index

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Index.cs
@@ -7,9 +7,9 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        /// <summary>Return index and the associated item.</summary>
+        /// <summary>Returns an enumerable that incorporates the element's index in a tuple.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
-        /// <param name="source">An <see cref="IEnumerable{T}" /> to return an element from.</param>
+        /// <param name="source">The source enumerable providing the elements.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         public static IEnumerable<(int Index, TSource Item)> Index<TSource>(this IEnumerable<TSource> source)
         {

--- a/src/libraries/System.Linq/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Index.cs
@@ -7,7 +7,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
-        /// <summary>Returns an enumerable that incorporates the element's index in a tuple.</summary>
+        /// <summary>Returns an enumerable that incorporates the element's index into a tuple.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
         /// <param name="source">The source enumerable providing the elements.</param>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>


### PR DESCRIPTION
Following feedback from https://github.com/dotnet/runtime/pull/95947/files/77cfd1694e08f0e00bc6d6fd84c7f6944fe563e9#diff-12d771219a25123dfc8964ed48a5e2fad41aa1c6a0e85fe1122fb8197dd57691