### PR TITLE
[release/8.0-staging] Fix constant folding for arm64 MultiplyByScalar operations involving Vector2.One

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Numerics;
+using Xunit;
+
+public static class Runtime_93876
+{
+    [Fact]
+    public static void Problem()
+    {
+        Vector4 v = Mul(0, 1);
+        Assert.Equal(Vector4.One, v);
+        Vector64<float> v64 = Mul64(0, 1);
+        Assert.Equal(Vector64<float>.One, v64);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector4 Mul(float a, float b) => Vector4.Multiply(a + b, Vector4.One);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector64<float> Mul64(float a, float b) => Vector64.Multiply(a + b, Vector64<float>.One);
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_93876/Runtime_93876.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #94413 to release/8.0-staging

## Customer Impact

- [x] Customer reported
- [X] Found internally

Expressions involving multiplications of `VectorX.One` with a scalar are constant folded to incorrect values. For example, `Vector2.One * a`, which should be folded to `<a, a>` is folded to `<a, 0>`. Customer reported in #98137; this backports a .NET 9 fix #94413 that noticed and fixed the issue.

## Regression

- [x] Yes
- [ ] No

## Testing
Regression test included.

## Risk

Low. The fix has been in main for several months already.