### PR TITLE
[mono][sgen] Prevent concurrent sweep from blocking major collections

### DIFF
--- a/src/mono/mono/sgen/sgen-gc.h
+++ b/src/mono/mono/sgen/sgen-gc.h
@@ -716,6 +716,8 @@ struct _SgenMajorCollector {
 	gboolean (*ptr_is_from_pinned_alloc) (char *ptr);
 	void (*report_pinned_memory_usage) (void);
 	size_t (*get_num_major_sections) (void);
+	size_t (*get_min_live_major_sections) (void);
+	size_t (*get_max_last_major_survived_sections) (void);
 	size_t (*get_num_empty_blocks) (void);
 	size_t (*get_bytes_survived_last_sweep) (void);
 	gboolean (*handle_gc_param) (const char *opt);


### PR DESCRIPTION
Sweeping is the final GC stage, that does a final iteration on the memory in order to prepare internal data structures for future allocation, free memory etc. For large objects this is done during GC while for small objects it can be done concurrently with the mutator, after we resume the world. We attempt to trigger the next major collection when the heap grows with another third of its size at the moment of the last collection. This heap limit is the major trigger size and it can only be computed after the sweep job has finished. This is because sweep iterates each major block to determine if they have any marked objects, attempting to free the blocks if possible.

Because there is a dependency for setting the major trigger size on the sweep job completion, before this change we were just blocking any new major collections to happen if concurrent sweep wasn't finished. This means that if the sweep job takes longer than expected and the mutator does excessive allocation in short amount of time, the memory usage can increase aggresively. It is unclear how relevant this scenario is in practice, but it is easy to reproduce in a micro benchmark allocating large objects.

The fix relies on computing estimates for the current heap size and the soon to be computed trigger size. We estimate the current live number of major blocks by adding the number of major blocks allocated since the last collection to the number of blocks already traversed and determined to be live by sweep. This estimate will be a lower limit. We determine the number of major blocks during the previous collection by subtracting the number of major blocks before sweep starts by the number of blocks already traversed and determined to be free. This estimate will be an upper limit. If the lower limit of the current heap size exceeds the upper limit of the trigger size, then there is no point in waiting for sweep to finish. We know we will require a major collection.

Fixes https://github.com/dotnet/runtime/issues/97991