### PR TITLE
JIT: Use faster unchecked write-barrier for boxed statics

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4904,6 +4904,11 @@ static GCInfo::WriteBarrierForm GetWriteBarrierForm(ValueNumStore* vnStore, Valu
             // Pointer to a local
             return GCInfo::WriteBarrierForm::WBF_NoBarrier;
         }
+        if ((funcApp.m_func == VNF_PtrToStatic) && vnStore->IsVNHandle(funcApp.m_args[0], GTF_ICON_STATIC_BOX_PTR))
+        {
+            // Boxed static - always on the heap
+            return GCInfo::WriteBarrierForm::WBF_BarrierUnchecked;
+        }
         if (funcApp.m_func == VNFunc(GT_ADD))
         {
             // Check arguments of the GT_ADD

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2411,7 +2411,7 @@ ValueNum ValueNumStore::VNForFunc(var_types typ, VNFunc func, ValueNum arg0VN)
             if ((resultVN == NoVN) && GetVNFunc(addressVN, &funcApp) && (funcApp.m_func == VNF_InvariantNonNullLoad))
             {
                 ValueNum fieldSeqVN = VNNormalValue(funcApp.m_args[0]);
-                if (IsVNHandle(fieldSeqVN) && (GetHandleFlags(fieldSeqVN) == GTF_ICON_FIELD_SEQ))
+                if (IsVNHandle(fieldSeqVN, GTF_ICON_FIELD_SEQ))
                 {
                     FieldSeq* fieldSeq = FieldSeqVNToFieldSeq(fieldSeqVN);
                     if (fieldSeq != nullptr)
@@ -5474,7 +5474,7 @@ ValueNum ValueNumStore::VNForFieldSeq(FieldSeq* fieldSeq)
 //
 FieldSeq* ValueNumStore::FieldSeqVNToFieldSeq(ValueNum vn)
 {
-    assert(IsVNHandle(vn) && (GetHandleFlags(vn) == GTF_ICON_FIELD_SEQ));
+    assert(IsVNHandle(vn, GTF_ICON_FIELD_SEQ));
 
     return reinterpret_cast<FieldSeq*>(ConstantValue<ssize_t>(vn));
 }
@@ -6113,14 +6113,19 @@ bool ValueNumStore::IsVNHandle(ValueNum vn)
     return c->m_attribs == CEA_Handle;
 }
 
+bool ValueNumStore::IsVNHandle(ValueNum vn, GenTreeFlags flag)
+{
+    return IsVNHandle(vn) && (GetHandleFlags(vn) == flag);
+}
+
 bool ValueNumStore::IsVNObjHandle(ValueNum vn)
 {
-    return IsVNHandle(vn) && (GetHandleFlags(vn) == GTF_ICON_OBJ_HDL);
+    return IsVNHandle(vn, GTF_ICON_OBJ_HDL);
 }
 
 bool ValueNumStore::IsVNTypeHandle(ValueNum vn)
 {
-    return IsVNHandle(vn) && (GetHandleFlags(vn) == GTF_ICON_CLASS_HDL);
+    return IsVNHandle(vn, GTF_ICON_CLASS_HDL);
 }
 
 //------------------------------------------------------------------------
@@ -8989,7 +8994,7 @@ void ValueNumStore::vnDump(Compiler* comp, ValueNum vn, bool isPtr)
     {
         printf("NoVN");
     }
-    else if (IsVNHandle(vn) && (GetHandleFlags(vn) == GTF_ICON_FIELD_SEQ))
+    else if (IsVNHandle(vn, GTF_ICON_FIELD_SEQ))
     {
         comp->gtDispFieldSeq(FieldSeqVNToFieldSeq(vn), 0);
         printf(" ");

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1025,6 +1025,9 @@ public:
     // Returns true iff the VN represents a handle constant.
     bool IsVNHandle(ValueNum vn);
 
+    // Returns true iff the VN represents a specific handle constant.
+    bool IsVNHandle(ValueNum vn, GenTreeFlags flag);
+
     // Returns true iff the VN represents an object handle constant.
     bool IsVNObjHandle(ValueNum vn);
 


### PR DESCRIPTION
And a small clean up.

Example:
```cs
struct MyStruct
{
    public object Obj;
}

static MyStruct boxedStatic;

[MethodImpl(MethodImplOptions.NoInlining)]
static void Test(string str1, string str2)
{
    // simple way to trigger CSE:
    boxedStatic.Obj = str1;
    boxedStatic.Obj = str2;
}
```
Codegen diff for `Test`:
```diff
; Method Prog:Test(System.String,System.String) (FullOpts)
G_M57713_IG01:  
       push     rdi
       push     rsi
       push     rbx
       sub      rsp, 32
       mov      rbx, rcx
       mov      rsi, rdx
G_M57713_IG02:  
       test     byte  ptr [(reloc 0x7ff8e243b942)], 1      ; global ptr
       je       SHORT G_M57713_IG05
G_M57713_IG03:  
       mov      rcx, 0x21A0D401E10      ; box for Prog:boxedStatic
       mov      rdi, gword ptr [rcx]
       add      rdi, 8
       mov      rcx, rdi
       mov      rdx, rbx
-      call     CORINFO_HELP_CHECKED_ASSIGN_REF
+      call     CORINFO_HELP_ASSIGN_REF
       mov      rcx, rdi
       mov      rdx, rsi
-      call     CORINFO_HELP_CHECKED_ASSIGN_REF
+      call     CORINFO_HELP_ASSIGN_REF
       nop      
G_M57713_IG04:  
       add      rsp, 32
       pop      rbx
       pop      rsi
       pop      rdi
       ret      
G_M57713_IG05:  
       mov      rcx, 0x7FF8E243B910
       mov      edx, 2
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       jmp      SHORT G_M57713_IG03
; Total bytes of code: 92
```