### PR TITLE
JIT: Set naive likelihoods when initializing preds

### DIFF
--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -246,7 +246,20 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
 
         const unsigned numSucc = blockPred->NumSucc();
         assert(numSucc > 0);
-        flow->setLikelihood(1.0 / numSucc);
+
+        // NumSucc() returns 1 for BBJ_CONDs with the same true/false target;
+        // for such cases, don't factor in the edge dup count to avoid overflowing the likelihood
+        //
+        if (blockPred->KindIs(BBJ_COND) && (numSucc == 1))
+        {
+            flow->setLikelihood(1.0);
+        }
+        else
+        {
+            // Else, account for duplicate successors so the edge likelihood isn't too small
+            //
+            flow->setLikelihood((1.0 / numSucc) * flow->getDupCount());
+        }
     }
 
     return flow;

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -235,6 +235,20 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
     //
     assert(block->checkPredListOrder());
 
+    // When initializing preds, ensure edge likelihood is set,
+    // such that this edge is as likely as any other successor edge
+    //
+    if (initializingPreds)
+    {
+        // Shouldn't be copying edge likelihoods/weights from an existing edge
+        //
+        assert(oldEdge == nullptr);
+
+        const unsigned numSucc = blockPred->NumSucc();
+        assert(numSucc > 0);
+        flow->setLikelihood(1.0 / numSucc);
+    }
+
     return flow;
 }
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3916,7 +3916,10 @@ void EfficientEdgeCountReconstructor::PropagateOSREntryEdges(BasicBlock* block, 
         FlowEdge* const flowEdge = m_comp->fgGetPredForBlock(edge->m_targetBlock, block);
 
         assert(flowEdge != nullptr);
-        assert(!flowEdge->hasLikelihood());
+
+        // Naive likelihood should have been set during pred initialization in fgAddRefPred
+        //
+        assert(flowEdge->hasLikelihood());
         weight_t likelihood = 0;
 
         if (nEdges == 1)

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -12280,7 +12280,7 @@ void Compiler::impFixPredLists()
 
                         BasicBlock* const continuation = predBlock->Next();
                         FlowEdge* const   newEdge      = fgAddRefPred(continuation, finallyBlock);
-                        newEdge->setLikelihood(1.0);
+                        newEdge->setLikelihood(1.0 / predCount);
 
                         jumpEhf->bbeSuccs[predNum] = continuation;
                         ++predNum;


### PR DESCRIPTION
Part of #93020. Per discussion on #98054, set "naive" edge likelihoods (in other words, assume every successor edge is equally likely to be taken) in `fgAddRefPred` when initializing preds.

cc @dotnet/jit-contrib