### PR TITLE
JIT: a bunch of peepholes for AND and OR operations

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6463,6 +6463,7 @@ private:
     GenTree* fgOptimizeAddition(GenTreeOp* add);
     GenTree* fgOptimizeMultiply(GenTreeOp* mul);
     GenTree* fgOptimizeBitwiseAnd(GenTreeOp* andOp);
+    GenTree* fgOptimizeBitwiseOr(GenTreeOp* orOp);
     GenTree* fgOptimizeBitwiseXor(GenTreeOp* xorOp);
     GenTree* fgPropagateCommaThrow(GenTree* parent, GenTreeOp* commaThrow, GenTreeFlags precedingSideEffects);
     GenTree* fgMorphRetInd(GenTreeUnOp* tree);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -11328,12 +11328,44 @@ GenTree* Compiler::fgOptimizeBitwiseAnd(GenTreeOp* andOp)
     GenTree* op1 = andOp->gtGetOp1();
     GenTree* op2 = andOp->gtGetOp2();
 
+    // "X & X" -> "X"
+    if (((op2->IsLocal() || op2->IsInvariant()) && GenTree::Compare(op1->gtEffectiveVal(), op2)))
+    {
+        return op1;
+    }
+
     // Fold "cmp & 1" to just "cmp".
     if (andOp->TypeIs(TYP_INT) && op1->OperIsCompare() && op2->IsIntegralConst(1))
     {
         DEBUG_DESTROY_NODE(op2);
         DEBUG_DESTROY_NODE(andOp);
 
+        return op1;
+    }
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
+// fgOptimizeBitwiseOr: optimizes the "or" operation.
+//
+// Arguments:
+//   andOp - the GT_OR tree to optimize.
+//
+// Return Value:
+//   The optimized tree. Otherwise, "nullptr", guaranteeing no state change.
+//
+GenTree* Compiler::fgOptimizeBitwiseOr(GenTreeOp* andOp)
+{
+    assert(andOp->OperIs(GT_OR));
+    assert(!optValnumCSE_phase);
+
+    GenTree* op1 = andOp->gtGetOp1();
+    GenTree* op2 = andOp->gtGetOp2();
+
+    // "X | X" -> "X"
+    if (((op2->IsLocal() || op2->IsInvariant()) && GenTree::Compare(op1->gtEffectiveVal(), op2)))
+    {
         return op1;
     }
 


### PR DESCRIPTION
A bunch of simple peepholes for GT_AND and GT_OR + a small clean up.
```
// X & X          -> X
// X & 0          -> 0
// X & 1          -> X if X is [0..1]
// X & 0xFF       -> X if X is [0..0xFF]
// X & 0xFFFF     -> X if X is [0..0xFFFF]
// X & 0xFFFFFFFF -> X if X is [0..0xFFFFFFFF]
// X | 0          -> X
// X | X          -> X
// X | 1          -> 1          if X is [0..1]
// X | 0xFF       -> 0xFF       if X is [0..0xFF]
// X | 0xFFFF     -> 0xFFFF     if X is [0..0xFFFF]
// X | 0xFFFFFFFF -> 0xFFFFFFFF if X is [0..0xFFFFFFFF]
```