### PR TITLE
Add ca-certificates to Mariner 2.0 deps

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-cm.2.proj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LinuxPackageDependency Include="openssl-libs;icu;krb5" />
+    <LinuxPackageDependency Include="openssl-libs;icu;krb5;ca-certificates" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/96874

Adds `ca-certificates` package as dependency, to runtime deps package.

Fixing for Mariner 2.0 only, as 1.0 is out of support.

@leecow 