### PR TITLE
[release/7.0-staging] Define installer-owned directories in dotnet-runtime RPM package

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -53,6 +53,7 @@
   <Target Name="AddLinuxPackageInformation" BeforeTargets="GetDebInstallerJsonProperties;GetRpmInstallerJsonProperties">
     <ItemGroup>
       <LinuxPackageDependency Include="dotnet-hostfxr-$(MajorVersion).$(MinorVersion);dotnet-runtime-deps-$(MajorVersion).$(MinorVersion)" Version="$(InstallerPackageVersion)" />
+      <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet/shared/$(MicrosoftNetCoreAppFrameworkName)&quot; ]" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Backport of #97183 to release/7.0-staging

## Customer Impact

- [ ] Customer reported
- [x] Found internally

`dotner-runtime` RPM package does not define any directories it owns. This causes versioned directory to be left on the machine after uninstall or package upgrade. Presence of the old directory triggers S360 warning about unsecure, stale .NET version.

There are no issues with other .NET packages - `dotnet-hostfxr` and `aspnetcore-runtime` packages contain versioned directories which are properly deleted on package uninstall or upgrade.

## Regression

- [ ] Yes
- [x] No

Not a regression - the issue always existed.

## Testing

Built a private package with the fix and tested on Mariner 2.0.

## Risk

Low. Already tested and present in 9.0.
