### PR TITLE
[wasm] pinvoke improvements part 2

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -2272,6 +2272,7 @@ mono_class_layout_fields (MonoClass *klass, int base_instance_size, int packing_
 				}
 
 				size = mono_type_size (field->type, &align);
+				// keep in sync with marshal.c mono_marshal_load_type_info
 				if (m_class_is_inlinearray (klass)) {
 					// Limit the max size of array instance to 1MiB
 					const guint32 struct_max_size = 1024 * 1024;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1877,6 +1877,8 @@ ves_icall_RuntimeMethodHandle_ReboxFromNullable (MonoObjectHandle obj, MonoObjec
 guint32
 ves_icall_RuntimeTypeHandle_GetAttributes (MonoQCallTypeHandle type_handle)
 {
+	g_printf ("RuntimeTypeHandle_GetAttributes: &type_handle.type == %d; type_handle.type == %d\n", &(type_handle.type), type_handle.type);
+
 	MonoType *type = type_handle.type;
 
 	if (m_type_is_byref (type) || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)
@@ -3028,7 +3030,7 @@ ves_icall_RuntimeType_GetNamespace (MonoQCallTypeHandle type_handle, MonoObjectH
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
 	MonoClass *elem;
-	while (!m_class_is_enumtype (klass) && 
+	while (!m_class_is_enumtype (klass) &&
 		!mono_class_is_nullable (klass) &&
 		(klass != (elem = m_class_get_element_class (klass))))
 		klass = elem;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1877,8 +1877,6 @@ ves_icall_RuntimeMethodHandle_ReboxFromNullable (MonoObjectHandle obj, MonoObjec
 guint32
 ves_icall_RuntimeTypeHandle_GetAttributes (MonoQCallTypeHandle type_handle)
 {
-	g_printf ("RuntimeTypeHandle_GetAttributes: &type_handle.type == %d; type_handle.type == %d\n", &(type_handle.type), type_handle.type);
-
 	MonoType *type = type_handle.type;
 
 	if (m_type_is_byref (type) || type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR)

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3577,7 +3577,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 	if (G_UNLIKELY (pinvoke && mono_method_has_unmanaged_callers_only_attribute (method))) {
 		/*
-		 * In AOT mode and embedding scenarios, it is possible that the icall is not registered in the runtime doing the AOT compilation. 
+		 * In AOT mode and embedding scenarios, it is possible that the icall is not registered in the runtime doing the AOT compilation.
 		 * Emit a wrapper that throws a NotSupportedException.
 		 */
 		get_marshal_cb ()->mb_emit_exception (mb, "System", "NotSupportedException", "Method canot be marked with both DllImportAttribute and UnmanagedCallersOnlyAttribute");
@@ -3757,7 +3757,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 	}
 
 	goto leave;
-	
+
 	emit_exception_for_error:
 		mono_error_cleanup (emitted_error);
 		info = mono_wrapper_info_create (mb, WRAPPER_SUBTYPE_NONE);
@@ -5834,7 +5834,6 @@ mono_marshal_load_type_info (MonoClass* klass)
 		if (m_class_is_inlinearray (klass)) {
 			// Limit the max size of array instance to 1MiB
 			const guint32 struct_max_size = 1024 * 1024;
-			guint32 initial_size = size;
 			size *= m_class_inlinearray_value (klass);
 			g_assert ((size > 0) && (size <= struct_max_size));
 		}

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -5833,7 +5833,7 @@ mono_marshal_load_type_info (MonoClass* klass)
 		// Keep in sync with class-init.c mono_class_layout_fields
 		if (m_class_is_inlinearray (klass)) {
 			// Limit the max size of array instance to 1MiB
-			const guint32 struct_max_size = 1024 * 1024;
+			const int struct_max_size = 1024 * 1024;
 			size *= m_class_inlinearray_value (klass);
 			g_assert ((size > 0) && (size <= struct_max_size));
 		}

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -52,7 +52,7 @@ handle_enum:
 		return 'L';
 	case MONO_TYPE_VOID:
 		return 'V';
-	case MONO_TYPE_VALUETYPE:
+	case MONO_TYPE_VALUETYPE: {
 		if (m_class_is_enumtype (t->data.klass)) {
 			t = mono_class_enum_basetype_internal (t->data.klass);
 			goto handle_enum;
@@ -70,8 +70,13 @@ handle_enum:
 			*is_byref_return = 1;
 
 		return 'I';
-	case MONO_TYPE_GENERICINST:
+	}
+	case MONO_TYPE_GENERICINST: {
 		if (m_class_is_valuetype (t->data.klass)) {
+			MonoType *scalar_vtype;
+			if (mini_wasm_is_scalar_vtype (t, &scalar_vtype))
+				return type_to_c (scalar_vtype, NULL);
+
 			if (is_byref_return)
 				*is_byref_return = 1;
 
@@ -79,6 +84,7 @@ handle_enum:
 		}
 
 		return 'I';
+	}
 	default:
 		g_warning ("CANT TRANSLATE %s", mono_type_full_name (t));
 		return 'X';

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -176,9 +176,6 @@ mono_wasm_get_interp_to_native_trampoline (MonoMethodSignature *sig)
 		cookie [offset + i] = type_to_c (sig->params [i], NULL);
 	}
 
-	if (is_byref_return)
-		g_printf("cookie=%s\n", cookie);
-
 	void *p = mono_wasm_interp_to_native_callback (cookie);
 	if (!p)
 		g_error ("CANNOT HANDLE INTERP ICALL SIG %s\n", cookie);

--- a/src/mono/mono/mini/aot-runtime-wasm.c
+++ b/src/mono/mono/mini/aot-runtime-wasm.c
@@ -17,6 +17,10 @@
 static char
 type_to_c (MonoType *t, gboolean *is_byref_return)
 {
+	g_assert (t);
+
+	if (is_byref_return)
+		*is_byref_return = 0;
 	if (m_type_is_byref (t))
 		return 'I';
 
@@ -60,15 +64,20 @@ handle_enum:
 		// FIXME: Handle the scenario where there are fields of struct types that contain no members
 		MonoType *scalar_vtype;
 		if (mini_wasm_is_scalar_vtype (t, &scalar_vtype))
-			return type_to_c (scalar_vtype, is_byref_return);
+			return type_to_c (scalar_vtype, NULL);
 
 		if (is_byref_return)
 			*is_byref_return = 1;
 
 		return 'I';
 	case MONO_TYPE_GENERICINST:
-		if (m_class_is_valuetype (t->data.klass))
+		if (m_class_is_valuetype (t->data.klass)) {
+			if (is_byref_return)
+				*is_byref_return = 1;
+
 			return 'S';
+		}
+
 		return 'I';
 	default:
 		g_warning ("CANT TRANSLATE %s", mono_type_full_name (t));

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1597,10 +1597,11 @@ build_args_from_sig (InterpMethodArguments *margs, MonoMethodSignature *sig, Bui
 	case PINVOKE_ARG_WASM_VALUETYPE_RESULT:
 		// We pass the return value address in arg0 so fill it in, we already
 		//  reserved space for it earlier.
-		g_printf ("wasm valuetype result address == %d\n", frame->retval);
+		g_assert (frame->retval);
 		margs->iargs[0] = (gpointer*)frame->retval;
 		// The return type is void so retval should be NULL
 		margs->retval = NULL;
+		margs->is_float_ret = 0;
 		break;
 	case PINVOKE_ARG_INT:
 		margs->retval = (gpointer*)frame->retval;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1493,6 +1493,7 @@ retry:
 #endif
 		case MONO_TYPE_VALUETYPE:
 		case MONO_TYPE_GENERICINST:
+			info->ret_pinvoke_type = PINVOKE_ARG_INT;
 #ifdef HOST_WASM
 			// This ISSTRUCT check is important, because the type could be an enum
 			if (MONO_TYPE_ISSTRUCT (info->ret_mono_type)) {
@@ -1500,13 +1501,8 @@ retry:
 				//  we're returning a struct byref instead of as a scalar
 				info->ret_pinvoke_type = PINVOKE_ARG_WASM_VALUETYPE_RESULT;
 				info->ilen++;
-			} else {
-
-#else
-			{
-#endif
-				info->ret_pinvoke_type = PINVOKE_ARG_INT;
 			}
+#endif
 			break;
 		case MONO_TYPE_R4:
 		case MONO_TYPE_R8:

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1439,6 +1439,7 @@ retry:
 			ilen++;
 			break;
 		case MONO_TYPE_GENERICINST: {
+			// FIXME: Should mini_wasm_is_scalar_vtype stuff go in here?
 			MonoClass *container_class = type->data.generic_class->container_class;
 			type = m_class_get_byval_arg (container_class);
 			goto retry;
@@ -2269,6 +2270,7 @@ interp_entry (InterpEntryData *data)
 	sp = (stackval*)context->stack_pointer;
 
 	method = rmethod->method;
+	g_printf ("interp entering %s::%s\n", method->klass->name, method->name);
 
 	if (rmethod->is_invoke) {
 		/*
@@ -2496,6 +2498,8 @@ jit_call_cb (gpointer arg)
 	int pindex = cb_data->pindex;
 	gpointer *args = cb_data->args;
 	gpointer ftndesc = cb_data->extra_arg;
+
+	g_printf ("jit_call_cb %x (%d args + ftndesc)\n", jit_wrapper, pindex);
 
 	switch (pindex) {
 	case 0: {
@@ -2841,6 +2845,7 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 
 	interp_push_lmf (&ext, frame);
 
+	g_printf ("do_jit_call entering %s::%s\n", rmethod->method->klass->name, rmethod->method->name);
 	if (mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP) {
 		/* Catch the exception thrown by the native code using a try-catch */
 		mono_llvm_catch_exception (jit_call_cb, &cb_data, &thrown);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1344,7 +1344,6 @@ typedef enum {
 	// This isn't ifdefed so it's easier to write code that handles it without sprinkling
 	//  800 ifdefs in this file
 	PINVOKE_ARG_WASM_VALUETYPE_RESULT = 7,
-	PINVOKE_ARG_I8_RESULT = 8,
 } PInvokeArgType;
 
 typedef struct {
@@ -1488,7 +1487,7 @@ retry:
 #if SIZEOF_VOID_P == 4
 		case MONO_TYPE_I8:
 		case MONO_TYPE_U8:
-			info->ret_pinvoke_type = PINVOKE_ARG_I8_RESULT;
+			info->ret_pinvoke_type = PINVOKE_ARG_INT;
 			break;
 #endif
 		case MONO_TYPE_VALUETYPE:
@@ -1620,10 +1619,6 @@ build_args_from_sig (InterpMethodArguments *margs, MonoMethodSignature *sig, Bui
 		margs->iargs[0] = (gpointer*)frame->retval;
 		// The return type is void so retval should be NULL
 		margs->retval = NULL;
-		margs->is_float_ret = 0;
-		break;
-	case PINVOKE_ARG_I8_RESULT:
-		margs->retval = (gpointer*)frame->retval;
 		margs->is_float_ret = 0;
 		break;
 	case PINVOKE_ARG_INT:

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1810,10 +1810,28 @@ ves_pinvoke_method (
 
 	INTERP_PUSH_LMF_WITH_CTX (&frame, ext, exit_pinvoke);
 
-	g_printf (
-		"ves_pinvoke_method: ret_pinvoke_type=%d retval=%d iargs=%d fargs=%d ilen=%d flen=%d\n",
-		call_info->ret_pinvoke_type, margs.retval, margs.iargs, margs.fargs, margs.ilen, margs.flen
-	);
+	if (FALSE && (call_info->ret_pinvoke_type >= 7)) {
+		g_printf (
+			"ves_pinvoke_method: ret_pinvoke_type=%d retval=%d iargs=%d fargs=%d ilen=%d flen=%d\n",
+			call_info->ret_pinvoke_type, margs.retval, margs.iargs, margs.fargs, margs.ilen, margs.flen
+		);
+
+		if (margs.ilen > 2)
+			g_printf (
+				"  iargs[0] == %d, iargs[1] == %d, iargs[2] == %d\n",
+				margs.iargs[0], margs.iargs[1], margs.iargs[2]
+			);
+		else if (margs.ilen > 1)
+			g_printf (
+				"  iargs[0] == %d, iargs[1] == %d\n",
+				margs.iargs[0], margs.iargs[1]
+			);
+		else if (margs.ilen > 0)
+			g_printf (
+				"  iargs[0] == %d\n",
+				margs.iargs[0]
+			);
+	}
 
 	if (*gc_transitions) {
 		MONO_ENTER_GC_SAFE;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2270,7 +2270,6 @@ interp_entry (InterpEntryData *data)
 	sp = (stackval*)context->stack_pointer;
 
 	method = rmethod->method;
-	g_printf ("interp entering %s::%s\n", method->klass->name, method->name);
 
 	if (rmethod->is_invoke) {
 		/*
@@ -2498,8 +2497,6 @@ jit_call_cb (gpointer arg)
 	int pindex = cb_data->pindex;
 	gpointer *args = cb_data->args;
 	gpointer ftndesc = cb_data->extra_arg;
-
-	g_printf ("jit_call_cb %x (%d args + ftndesc)\n", jit_wrapper, pindex);
 
 	switch (pindex) {
 	case 0: {
@@ -2845,7 +2842,6 @@ do_jit_call (ThreadContext *context, stackval *ret_sp, stackval *sp, InterpFrame
 
 	interp_push_lmf (&ext, frame);
 
-	g_printf ("do_jit_call entering %s::%s\n", rmethod->method->klass->name, rmethod->method->name);
 	if (mono_aot_mode == MONO_AOT_MODE_LLVMONLY_INTERP) {
 		/* Catch the exception thrown by the native code using a try-catch */
 		mono_llvm_catch_exception (jit_call_cb, &cb_data, &thrown);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -1496,7 +1496,6 @@ retry:
 #ifdef HOST_WASM
 			// This ISSTRUCT check is important, because the type could be an enum
 			if (MONO_TYPE_ISSTRUCT (info->ret_mono_type)) {
-				g_printf ("Putting retval in arg0 for type %s\n", mono_type_get_name (info->ret_mono_type));
 				// The return type was already filtered previously, so if we get here
 				//  we're returning a struct byref instead of as a scalar
 				info->ret_pinvoke_type = PINVOKE_ARG_WASM_VALUETYPE_RESULT;
@@ -1809,29 +1808,6 @@ ves_pinvoke_method (
 #endif
 
 	INTERP_PUSH_LMF_WITH_CTX (&frame, ext, exit_pinvoke);
-
-	if (FALSE && (call_info->ret_pinvoke_type >= 7)) {
-		g_printf (
-			"ves_pinvoke_method: ret_pinvoke_type=%d retval=%d iargs=%d fargs=%d ilen=%d flen=%d\n",
-			call_info->ret_pinvoke_type, margs.retval, margs.iargs, margs.fargs, margs.ilen, margs.flen
-		);
-
-		if (margs.ilen > 2)
-			g_printf (
-				"  iargs[0] == %d, iargs[1] == %d, iargs[2] == %d\n",
-				margs.iargs[0], margs.iargs[1], margs.iargs[2]
-			);
-		else if (margs.ilen > 1)
-			g_printf (
-				"  iargs[0] == %d, iargs[1] == %d\n",
-				margs.iargs[0], margs.iargs[1]
-			);
-		else if (margs.ilen > 0)
-			g_printf (
-				"  iargs[0] == %d\n",
-				margs.iargs[0]
-			);
-	}
 
 	if (*gc_transitions) {
 		MONO_ENTER_GC_SAFE;

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -775,6 +775,7 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 		// inlinearray and fixed both work by having a single field that is bigger than its element type.
 		// we also don't want to scalarize a struct that has padding in its metadata, even if it would fit.
 		if (field_size != size) {
+			/*
 			g_printf (
 				"%s (size == %d): %s %s field_size == %d\n",
 				m_class_get_name (klass),
@@ -783,6 +784,7 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 				field->name,
 				field_size
 			);
+			*/
 			return FALSE;
 		} else if (MONO_TYPE_ISSTRUCT (t)) {
 			if (!mini_wasm_is_scalar_vtype (t, etype))

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -757,6 +757,11 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 	klass = mono_class_from_mono_type_internal (type);
 	mono_class_init_internal (klass);
 
+	// A careful reading of the ABI spec suggests that an inlinearray does not count
+	//  as having one scalar member (it either has N scalar members or one array member)
+	if (m_class_is_inlinearray (klass))
+		return FALSE;
+
 	int size = mono_class_value_size (klass, NULL);
 	if (size == 0 || size > 8)
 		return FALSE;

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -775,7 +775,6 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 		// inlinearray and fixed both work by having a single field that is bigger than its element type.
 		// we also don't want to scalarize a struct that has padding in its metadata, even if it would fit.
 		if (field_size != size) {
-			/*
 			g_printf (
 				"%s (size == %d): %s %s field_size == %d\n",
 				m_class_get_name (klass),
@@ -784,7 +783,6 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 				field->name,
 				field_size
 			);
-			*/
 			return FALSE;
 		} else if (MONO_TYPE_ISSTRUCT (t)) {
 			if (!mini_wasm_is_scalar_vtype (t, etype))

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -75,17 +75,23 @@ get_storage (MonoType *type, MonoType **etype, gboolean is_return)
 	case MONO_TYPE_R8:
 		return ArgOnStack;
 
-	case MONO_TYPE_GENERICINST:
+	case MONO_TYPE_GENERICINST: {
 		if (!mono_type_generic_inst_is_valuetype (type))
 			return ArgOnStack;
 
+		if (mini_wasm_is_scalar_vtype (type, etype))
+			return ArgVtypeAsScalar;
+
 		if (mini_is_gsharedvt_variable_type (type))
 			return ArgGsharedVTOnStack;
-		/* fall through */
+
+		return is_return ? ArgValuetypeAddrInIReg : ArgValuetypeAddrOnStack;
+	}
 	case MONO_TYPE_VALUETYPE:
 	case MONO_TYPE_TYPEDBYREF: {
 		if (mini_wasm_is_scalar_vtype (type, etype))
 			return ArgVtypeAsScalar;
+
 		return is_return ? ArgValuetypeAddrInIReg : ArgValuetypeAddrOnStack;
 	}
 	case MONO_TYPE_VAR:

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -775,15 +775,6 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 		// inlinearray and fixed both work by having a single field that is bigger than its element type.
 		// we also don't want to scalarize a struct that has padding in its metadata, even if it would fit.
 		if (field_size != size) {
-			if (FALSE)
-				g_printf (
-					"%s (size == %d): %s %s field_size == %d\n",
-					m_class_get_name (klass),
-					size,
-					m_class_get_name (mono_class_from_mono_type_internal (t)),
-					field->name,
-					field_size
-				);
 			return FALSE;
 		} else if (MONO_TYPE_ISSTRUCT (t)) {
 			if (!mini_wasm_is_scalar_vtype (t, etype))

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -79,11 +79,11 @@ get_storage (MonoType *type, MonoType **etype, gboolean is_return)
 		if (!mono_type_generic_inst_is_valuetype (type))
 			return ArgOnStack;
 
-		if (mini_wasm_is_scalar_vtype (type, etype))
-			return ArgVtypeAsScalar;
-
 		if (mini_is_gsharedvt_variable_type (type))
 			return ArgGsharedVTOnStack;
+
+		if (mini_wasm_is_scalar_vtype (type, etype))
+			return ArgVtypeAsScalar;
 
 		return is_return ? ArgValuetypeAddrInIReg : ArgValuetypeAddrOnStack;
 	}
@@ -777,7 +777,7 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 		if (nfields > 1)
 			return FALSE;
 		MonoType *t = mini_get_underlying_type (field->type);
-		int field_size = mono_class_value_size (mono_class_from_mono_type_internal (t), NULL);
+		int align, field_size = mono_type_size (t, &align);
 		// inlinearray and fixed both work by having a single field that is bigger than its element type.
 		// we also don't want to scalarize a struct that has padding in its metadata, even if it would fit.
 		if (field_size != size) {

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -775,14 +775,15 @@ mini_wasm_is_scalar_vtype (MonoType *type, MonoType **etype)
 		// inlinearray and fixed both work by having a single field that is bigger than its element type.
 		// we also don't want to scalarize a struct that has padding in its metadata, even if it would fit.
 		if (field_size != size) {
-			g_printf (
-				"%s (size == %d): %s %s field_size == %d\n",
-				m_class_get_name (klass),
-				size,
-				m_class_get_name (mono_class_from_mono_type_internal (t)),
-				field->name,
-				field_size
-			);
+			if (FALSE)
+				g_printf (
+					"%s (size == %d): %s %s field_size == %d\n",
+					m_class_get_name (klass),
+					size,
+					m_class_get_name (mono_class_from_mono_type_internal (t)),
+					field->name,
+					field_size
+				);
 			return FALSE;
 		} else if (MONO_TYPE_ISSTRUCT (t)) {
 			if (!mini_wasm_is_scalar_vtype (t, etype))

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -742,6 +742,9 @@ namespace Wasm.Build.Tests
                 public struct PairStruct {
                     public int A, B;
                 }
+                public unsafe struct MyFixedArray {
+                    public fixed int elements[2];
+                }
                 [System.Runtime.CompilerServices.InlineArray(2)]
                 public struct MyInlineArray {
                     public int element0;
@@ -774,13 +777,19 @@ namespace Wasm.Build.Tests
 
                         var pair = new PairStruct { A = 1, B = 2 };
                         var paires = accept_and_return_pair(pair);
-                        Console.WriteLine(""B="" + paires.B);
+                        Console.WriteLine(""paires.B="" + paires.B);
 
                         MyInlineArray ia = new ();
                         for (int i = 0; i < 2; i++)
                             ia[i] = i;
                         var iares = accept_and_return_inlinearray(ia);
-                        Console.WriteLine(""[1]="" + iares[1]);
+                        Console.WriteLine(""iares[1]="" + iares[1]);
+
+                        MyFixedArray fa = new ();
+                        for (int i = 0; i < 2; i++)
+                            fa.elements[i] = i;
+                        var fares = accept_and_return_fixedarray(fa);
+                        Console.WriteLine(""fares.elements[1]="" + fares.elements[1]);
 
                         return (int)res.Value;
                     }
@@ -802,6 +811,9 @@ namespace Wasm.Build.Tests
 
                     [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_pair"")]
                     public static extern PairStruct accept_and_return_pair(PairStruct arg);
+
+                    [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_fixedarray"")]
+                    public static extern MyFixedArray accept_and_return_fixedarray(MyFixedArray arg);
 
                     [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_inlinearray"")]
                     public static extern MyInlineArray accept_and_return_inlinearray(MyInlineArray arg);

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -785,8 +785,7 @@ namespace Wasm.Build.Tests
                             // The return value from the pinvoke appears to be correct, but when ia
                             //  is passed in to the pinvoke, it's all zeroes.
                             var iares = InlineArrayTest2(ia);
-                            Console.WriteLine($""ia[1]={ia[1]} &ia={RefAsAddress(ref ia)} &ia[1]={RefAsAddress(ref ia[1])}"");
-                            Console.WriteLine($""iares[0]={iares[0]} iares[1]={iares[1]} &iares={RefAsAddress(ref iares)} &iares[1]={RefAsAddress(ref iares[1])} *&iares[1]=={ReadThroughAddress(ref iares[1])}"");
+                            Console.WriteLine($""iares[0]={iares[0]} iares[1]={iares[1]}"");
                         }
 
                         MyFixedArray fa = new ();
@@ -886,8 +885,7 @@ namespace Wasm.Build.Tests
             Assert.Contains("s (s)=3.14", runOutput);
             Assert.Contains("paires.B=4", runOutput);
             Assert.Contains("iares[0]=32", runOutput);
-            // FIXME
-            // Assert.Contains("iares[1]=2", runOutput);
+            Assert.Contains("iares[1]=2", runOutput);
             Assert.Contains("fares.elements[1]=2", runOutput);
         }
 

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -782,9 +782,11 @@ namespace Wasm.Build.Tests
                         // Interpreter and AOT implementations of this are broken.
                         if (true) {
                             var ia = InlineArrayTest1();
+                            // The return value from the pinvoke appears to be correct, but when ia
+                            //  is passed in to the pinvoke, it's all zeroes.
                             var iares = InlineArrayTest2(ia);
-                            Console.WriteLine($""ia[1]={ia[1]} &ia={RefAsAddress(ref ia)} &ia[0]={RefAsAddress(ref ia[0])} &ia[1]={RefAsAddress(ref ia[1])} *&ia[1]=={ReadThroughAddress(ref ia[1])}"");
-                            Console.WriteLine($""iares[1]={iares[1]} &iares={RefAsAddress(ref iares)} &iares[0]={RefAsAddress(ref iares[0])} &iares[1]={RefAsAddress(ref iares[1])}"");
+                            Console.WriteLine($""ia[1]={ia[1]} &ia={RefAsAddress(ref ia)} &ia[1]={RefAsAddress(ref ia[1])}"");
+                            Console.WriteLine($""iares[0]={iares[0]} iares[1]={iares[1]} &iares={RefAsAddress(ref iares)} &iares[1]={RefAsAddress(ref iares[1])} *&iares[1]=={ReadThroughAddress(ref iares[1])}"");
                         }
 
                         MyFixedArray fa = new ();
@@ -842,7 +844,7 @@ namespace Wasm.Build.Tests
                     public static extern MyInlineArray accept_and_return_inlinearray(MyInlineArray arg);
                 }";
 
-            var extraProperties = "<AllowUnsafeBlocks>true</AllowUnsafeBlocks><_WasmDevel>true</_WasmDevel><WasmNativeStrip>false</WasmNativeStrip>";
+            var extraProperties = "<AllowUnsafeBlocks>true</AllowUnsafeBlocks><_WasmDevel>false</_WasmDevel><WasmNativeStrip>false</WasmNativeStrip>";
             var extraItems = @"<NativeFileReference Include=""wasm-abi.c"" />";
 
             buildArgs = ExpandBuildArgs(buildArgs,
@@ -882,6 +884,11 @@ namespace Wasm.Build.Tests
             Assert.Contains("f (d)=3.14", runOutput);
             Assert.Contains("f (s)=3.14", runOutput);
             Assert.Contains("s (s)=3.14", runOutput);
+            Assert.Contains("paires.B=4", runOutput);
+            Assert.Contains("iares[0]=32", runOutput);
+            // FIXME
+            // Assert.Contains("iares[1]=2", runOutput);
+            Assert.Contains("fares.elements[1]=2", runOutput);
         }
 
         [Theory]

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -739,6 +739,13 @@ namespace Wasm.Build.Tests
                 public struct SingleI64Struct {
                     public Int64 Value;
                 }
+                public struct PairStruct {
+                    public int A, B;
+                }
+                [System.Runtime.CompilerServices.InlineArray(2)]
+                public struct MyInlineArray {
+                    public int element0;
+                }
 
                 public class Test
                 {
@@ -765,6 +772,16 @@ namespace Wasm.Build.Tests
                         var res = indirect(sds);
                         Console.WriteLine(""s (s)="" + res.Value);
 
+                        var pair = new PairStruct { A = 1, B = 2 };
+                        var paires = accept_and_return_pair(pair);
+                        Console.WriteLine(""B="" + paires.B);
+
+                        MyInlineArray ia = new ();
+                        for (int i = 0; i < 2; i++)
+                            ia[i] = i;
+                        var iares = accept_and_return_inlinearray(ia);
+                        Console.WriteLine(""[1]="" + iares[1]);
+
                         return (int)res.Value;
                     }
 
@@ -782,6 +799,12 @@ namespace Wasm.Build.Tests
 
                     [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_i64_struct"")]
                     public static extern Int64 direct64(Int64 arg);
+
+                    [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_pair"")]
+                    public static extern PairStruct accept_and_return_pair(PairStruct arg);
+
+                    [DllImport(""wasm-abi"", EntryPoint=""accept_and_return_inlinearray"")]
+                    public static extern MyInlineArray accept_and_return_inlinearray(MyInlineArray arg);
                 }";
 
             var extraProperties = "<AllowUnsafeBlocks>true</AllowUnsafeBlocks><_WasmDevel>true</_WasmDevel>";

--- a/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/PInvokeTableGeneratorTests.cs
@@ -779,14 +779,10 @@ namespace Wasm.Build.Tests
                         var paires = accept_and_return_pair(pair);
                         Console.WriteLine(""paires.B="" + paires.B);
 
-                        // Interpreter and AOT implementations of this are broken.
-                        if (true) {
-                            var ia = InlineArrayTest1();
-                            // The return value from the pinvoke appears to be correct, but when ia
-                            //  is passed in to the pinvoke, it's all zeroes.
-                            var iares = InlineArrayTest2(ia);
-                            Console.WriteLine($""iares[0]={iares[0]} iares[1]={iares[1]}"");
-                        }
+                        // This test is split into methods to simplify debugging issues with it
+                        var ia = InlineArrayTest1();
+                        var iares = InlineArrayTest2(ia);
+                        Console.WriteLine($""iares[0]={iares[0]} iares[1]={iares[1]}"");
 
                         MyFixedArray fa = new ();
                         for (int i = 0; i < 2; i++)
@@ -795,16 +791,6 @@ namespace Wasm.Build.Tests
                         Console.WriteLine(""fares.elements[1]="" + fares.elements[1]);
 
                         return (int)res.Value;
-                    }
-
-                    public static unsafe T ReadThroughAddress<T> (ref T r) {
-                        var ptr = RefAsAddress(ref r);
-                        ref T rr = ref Unsafe.AsRef<T>((void *)ptr);
-                        return rr;
-                    }
-
-                    public static unsafe IntPtr RefAsAddress<T> (ref T r) {
-                        return new IntPtr(Unsafe.AsPointer(ref r));
                     }
 
                     public static unsafe MyInlineArray InlineArrayTest1 () {

--- a/src/mono/wasm/testassets/native-libs/wasm-abi.c
+++ b/src/mono/wasm/testassets/native-libs/wasm-abi.c
@@ -33,6 +33,10 @@ typedef struct {
 } PairStruct;
 
 PairStruct accept_and_return_pair (PairStruct arg) {
+    printf (
+        "&arg=%d arg.A=%d arg.B=%d\n",
+        (unsigned int)&arg, arg.A, arg.B
+    );
     arg.A *= 2;
     arg.B *= 2;
     return arg;
@@ -43,7 +47,15 @@ typedef struct {
 } MyInlineArray;
 
 MyInlineArray accept_and_return_inlinearray (MyInlineArray arg) {
+    printf (
+        "&arg=%d arg.elements[0]=%d arg.elements[1]=%d\n",
+        (unsigned int)&arg, arg.elements[0], arg.elements[1]
+    );
     for (int i = 0; i < 2; i++)
         arg.elements[i] *= 2;
     return arg;
+}
+
+MyInlineArray accept_and_return_fixedarray (MyInlineArray arg) {
+    return accept_and_return_inlinearray (arg);
 }

--- a/src/mono/wasm/testassets/native-libs/wasm-abi.c
+++ b/src/mono/wasm/testassets/native-libs/wasm-abi.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+#define TRACING 0
+
 typedef struct {
     float value;
 } TRes;
@@ -7,10 +9,12 @@ typedef struct {
 TRes accept_double_struct_and_return_float_struct (
     struct { struct { double value; } value; } arg
 ) {
+#if TRACING
     printf (
         "&arg=%x (ulonglong)arg=%llx arg.value.value=%lf\n",
         (unsigned int)&arg, *(unsigned long long*)&arg, (double)arg.value.value
     );
+#endif
     TRes result = { arg.value.value };
     return result;
 }
@@ -20,10 +24,12 @@ typedef struct {
 } TResI64;
 
 TResI64 accept_and_return_i64_struct (TResI64 arg) {
+#if TRACING
     printf (
         "&arg=%x (ulonglong)arg=%llx\n",
         (unsigned int)&arg, *(unsigned long long*)&arg
     );
+#endif
     TResI64 result = { ~arg.value };
     return result;
 }
@@ -33,10 +39,12 @@ typedef struct {
 } PairStruct;
 
 PairStruct accept_and_return_pair (PairStruct arg) {
+#if TRACING
     printf (
         "&arg=%d arg.A=%d arg.B=%d\n",
         (unsigned int)&arg, arg.A, arg.B
     );
+#endif
     arg.A = 32;
     arg.B *= 2;
     return arg;
@@ -47,10 +55,12 @@ typedef struct {
 } MyInlineArray;
 
 MyInlineArray accept_and_return_inlinearray (MyInlineArray arg) {
+#if TRACING
     printf (
         "&arg=%d arg.elements[0]=%d arg.elements[1]=%d\n",
         (unsigned int)&arg, arg.elements[0], arg.elements[1]
     );
+#endif
     arg.elements[0] = 32;
     arg.elements[1] *= 2;
     return arg;

--- a/src/mono/wasm/testassets/native-libs/wasm-abi.c
+++ b/src/mono/wasm/testassets/native-libs/wasm-abi.c
@@ -37,7 +37,7 @@ PairStruct accept_and_return_pair (PairStruct arg) {
         "&arg=%d arg.A=%d arg.B=%d\n",
         (unsigned int)&arg, arg.A, arg.B
     );
-    arg.A *= 2;
+    arg.A = 32;
     arg.B *= 2;
     return arg;
 }
@@ -51,8 +51,8 @@ MyInlineArray accept_and_return_inlinearray (MyInlineArray arg) {
         "&arg=%d arg.elements[0]=%d arg.elements[1]=%d\n",
         (unsigned int)&arg, arg.elements[0], arg.elements[1]
     );
-    for (int i = 0; i < 2; i++)
-        arg.elements[i] *= 2;
+    arg.elements[0] = 32;
+    arg.elements[1] *= 2;
     return arg;
 }
 

--- a/src/mono/wasm/testassets/native-libs/wasm-abi.c
+++ b/src/mono/wasm/testassets/native-libs/wasm-abi.c
@@ -27,3 +27,23 @@ TResI64 accept_and_return_i64_struct (TResI64 arg) {
     TResI64 result = { ~arg.value };
     return result;
 }
+
+typedef struct {
+    int A, B;
+} PairStruct;
+
+PairStruct accept_and_return_pair (PairStruct arg) {
+    arg.A *= 2;
+    arg.B *= 2;
+    return arg;
+}
+
+typedef struct {
+    int elements[2];
+} MyInlineArray;
+
+MyInlineArray accept_and_return_inlinearray (MyInlineArray arg) {
+    for (int i = 0; i < 2; i++)
+        arg.elements[i] *= 2;
+    return arg;
+}

--- a/src/tasks/WasmAppBuilder/SignatureMapper.cs
+++ b/src/tasks/WasmAppBuilder/SignatureMapper.cs
@@ -61,12 +61,7 @@ internal static class SignatureMapper
                 c = 'I';
             else if (t.IsEnum) {
                 Type underlyingType = t.GetEnumUnderlyingType();
-                if (underlyingType != t)
-                    c = TypeToChar(underlyingType, log, out _, ++depth);
-                else {
-                    log.Warning("WASM0064", $"Unsupported parameter type '{t.Name}'");
-                    return null;
-                }
+                c = TypeToChar(underlyingType, log, out _, ++depth);
             } else if (t.IsPointer)
                 c = 'I';
             else if (PInvokeTableGenerator.IsFunctionPointer(t))
@@ -76,14 +71,8 @@ internal static class SignatureMapper
                 var fields = t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                 if (fields.Length == 1) {
                     Type fieldType = fields[0].FieldType;
-                    if (fieldType != t)
-                        return TypeToChar(fieldType, log, out isByRefStruct, ++depth);
-                    else {
-                        log.Warning("WASM0064", $"Unsupported parameter type '{t.Name}'");
-                        return null;
-                    }
-                }
-                else if (PInvokeTableGenerator.IsBlittable(t, log))
+                    return TypeToChar(fieldType, log, out isByRefStruct, ++depth);
+                } else if (PInvokeTableGenerator.IsBlittable(t, log))
                     c = 'I';
 
                 isByRefStruct = true;

--- a/src/tasks/WasmAppBuilder/SignatureMapper.cs
+++ b/src/tasks/WasmAppBuilder/SignatureMapper.cs
@@ -27,6 +27,7 @@ internal static class SignatureMapper
                 nameof(String) => 'I',
                 nameof(Boolean) => 'I',
                 nameof(Char) => 'I',
+                nameof(SByte) => 'I',
                 nameof(Byte) => 'I',
                 nameof(Int16) => 'I',
                 nameof(UInt16) => 'I',


### PR DESCRIPTION
Expands WBT test coverage and makes the following improvements:
* InlineArray is supported in wasm pinvokes, and in general works correctly in mono marshaling now (it was broken on all targets)
* fixed arrays are supported in wasm pinvokes
* struct arguments and return values are supported in more wasm pinvoke scenarios (not all, though)
* wasm struct scalarization is more intelligent about noticing padding and size mismatches in structs (without this, some inlinearrays would be scalarized incorrectly)
* Prevent infinite recursion in build task's TypeToChar