### PR TITLE
[mono][debugger] Send assembly_load events while invoking methods using debugger-libs

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -4124,7 +4124,7 @@ jit_end (MonoProfiler *prof, MonoMethod *method, MonoJitInfo *jinfo)
 		if (assembly) {
 			DebuggerTlsData *tls;
 			tls = (DebuggerTlsData *)mono_native_tls_get_value (debugger_tls_id);
-			if (tls->invoke == NULL) {
+			if (!CHECK_ICORDBG (TRUE) || tls->invoke == NULL) {
 				process_profiler_event (EVENT_KIND_ASSEMBLY_LOAD, assembly);
 			} else {
 				assembly_load(prof, assembly); //send later


### PR DESCRIPTION
Fix side effect of don't sending assembly_load while invoking methods.

This changes make the HotReload XAML stop working because they use debugger-libs to invoke method Assembly.Load on runtime and wait to receive assembly load event for this assembly Xamarin.HotReload.Agent. This change is only allowed when debugging using iCorDebug.

#Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1951670