### PR TITLE
Prepare the FabricBot config for migration to Policy Service

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1620,17 +1620,6 @@
                   {
                     "name": "activitySenderHasPermissions",
                     "parameters": {
-                      "permissions": "maintain"
-                    }
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "activitySenderHasPermissions",
-                    "parameters": {
                       "permissions": "write"
                     }
                   }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1862,6 +1862,10 @@
             ]
           },
           {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
             "name": "isOpen",
             "parameters": {}
           }
@@ -1917,6 +1921,10 @@
             "parameters": {
               "label": "untriaged"
             }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
           },
           {
             "name": "isOpen",
@@ -2422,6 +2430,10 @@
             "parameters": {
               "label": "no-recent-activity"
             }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
           }
         ]
       }

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -926,6 +926,10 @@
             "parameters": {
               "label": "breaking-change"
             }
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
           }
         ]
       },
@@ -1105,6 +1109,10 @@
             ]
           },
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "name": "isOpen",
             "parameters": {}
           }
@@ -1162,6 +1170,10 @@
                 }
               }
             ]
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
           },
           {
             "name": "isOpen",
@@ -1601,6 +1613,10 @@
             }
           },
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "operator": "and",
             "operands": [
               {
@@ -1764,6 +1780,10 @@
                 }
               }
             ]
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
           },
           {
             "name": "isAction",
@@ -1930,6 +1950,10 @@
         "operator": "and",
         "operands": [
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "name": "isAction",
             "parameters": {
               "action": "synchronize"
@@ -1989,6 +2013,10 @@
             }
           },
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "name": "isOpen",
             "parameters": {}
           }
@@ -2038,6 +2066,10 @@
             "parameters": {
               "action": "submitted"
             }
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
           },
           {
             "name": "isOpen",
@@ -2425,6 +2457,10 @@
         "operator": "and",
         "operands": [
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2485,6 +2521,10 @@
             }
           },
           {
+            "name": "isPr",
+            "parameters": {}
+          },
+          {
             "name": "isOpen",
             "parameters": {}
           }
@@ -2526,6 +2566,10 @@
             "parameters": {
               "label": "no-recent-activity"
             }
+          },
+          {
+            "name": "isPr",
+            "parameters": {}
           },
           {
             "name": "isOpen",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -892,8 +892,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "actions": [
         {
@@ -933,8 +932,7 @@
       "eventType": "pull_request",
       "eventNames": [
         "pull_request",
-        "issues",
-        "project_card"
+        "issues"
       ],
       "actions": [
         {
@@ -1115,8 +1113,7 @@
       "eventType": "pull_request",
       "eventNames": [
         "pull_request",
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Linkable-framework workgroup] Add linkable-framework label to new Prs that touch files with *ILLink* that not have it already",
       "actions": [
@@ -1181,8 +1178,7 @@
       "eventType": "pull_request",
       "eventNames": [
         "pull_request",
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Linkable-framework workgroup] Add linkable-framework label to Prs that get changes pushed where they touch *ILLInk* files",
       "actions": [
@@ -1227,8 +1223,7 @@
       "eventType": "pull_request",
       "eventNames": [
         "pull_request",
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "Auto-approve maestro PRs",
       "actions": [
@@ -1261,8 +1256,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "Manual Issue Cleanup",
       "actions": [

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1194,52 +1194,6 @@
   {
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": "dotnet-maestro[bot]"
-            }
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "opened"
-            }
-          },
-          {
-            "name": "titleContains",
-            "parameters": {
-              "titlePattern": "dotnet-optimization"
-            }
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues"
-      ],
-      "taskName": "Auto-approve maestro PRs",
-      "actions": [
-        {
-          "name": "approvePullRequest",
-          "parameters": {
-            "comment": "Auto-approve dotnet-optimization PR"
-          }
-        }
-      ]
-    },
-    "disabled": true
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
     "subCapability": "IssuesOnlyResponder",
     "version": "1.0",
     "config": {

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1479,10 +1479,6 @@
                 "parameters": {
                   "action": "reopened"
                 }
-              },
-              {
-                "name": "removedFromMilestone",
-                "parameters": {}
               }
             ]
           },
@@ -1547,7 +1543,7 @@
                 }
               },
               {
-                "name": "addedToMilestone",
+                "name": "isInMilestone",
                 "parameters": {}
               }
             ]


### PR DESCRIPTION
This updates our FabricBot configuration to address issues we've seen migrating other repositories to the Policy Service automation. There's only 1 behavioral change included.

* When issues are updated to clear the milestone, they will no longer automatically regain the https://github.com/dotnet/runtime/labels/untriaged label

After this is merged, we'll request the repository's automation be migrated, and a new PR will be created by https://github.com/apps/dotnet-policy-service with a generated YAML-based configuration that will replace fabricbot.json.