### PR TITLE
JIT: More CSE heuristics adjustments

### DIFF
--- a/src/coreclr/jit/optcse.h
+++ b/src/coreclr/jit/optcse.h
@@ -162,7 +162,7 @@ private:
 
     enum
     {
-        numParameters = 19,
+        numParameters = 25,
         booleanScale  = 5,
         maxSteps      = 65, // MAX_CSE_CNT + 1 (for stopping)
     };


### PR DESCRIPTION
Based on analysis of cases where the machine learning is struggling, add some more observations and tweak some of the existing ones:
* where we use `log` for dynamic compresson, bias results to they are always non-negative
* only consider integral vars for pressure estimate
* note if a CSE has a call
* note weighted tree costs
* note weighted local occurrences (approx pressure relief)
* note spread of occurrences (as fraction of BBs)
* note if CSE is something that can be contained (guess)
* note if CSE is cheap (cost 2 or 3) and is something that can be contained
* note if CSE might be "live across" a call in LSRA block ordering

The block spread and LSRA live across are using the RPO artifacts that may no longer be up to date. Not clear it matters as LSRA does not use RPO for block ordering.

Contributes to #92915.