### PR TITLE
Fix macOS checked build of NativeAOT

### DIFF
--- a/src/coreclr/nativeaot/Runtime/interoplibinterface_objc.cpp
+++ b/src/coreclr/nativeaot/Runtime/interoplibinterface_objc.cpp
@@ -24,6 +24,7 @@
 #include "thread.h"
 #include "threadstore.h"
 #include "threadstore.inl"
+#include "thread.inl"
 
 #include "interoplibinterface.h"
 


### PR DESCRIPTION
Fixes the following build error:
```
  Generating native code
  ld: Undefined symbols:
    Thread::IsCurrentThreadInCooperativeMode(), referenced from:
        ObjCMarshalNative::RegisterBeginEndCallback(void*) in libRuntime.ServerGC.a[56](interoplibinterface_objc.cpp.o)
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```