### PR TITLE
[mono][jit] Fix the alignment of stack slots used to pass HFA argumen…

### DIFF
--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -1662,6 +1662,8 @@ add_valuetype (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t, gboolean is_return)
 
 	nregs = align_size / 8;
 	if (is_hfa (t, &nfields, &esize, field_offsets)) {
+		/* Use pinvoke size/alignment */
+		size = mini_type_stack_size_full (t, &align, TRUE);
 		/*
 		 * The struct might include nested float structs aligned at 8,
 		 * so need to keep track of the offsets of the individual fields.
@@ -1678,7 +1680,7 @@ add_valuetype (CallInfo *cinfo, ArgInfo *ainfo, MonoType *t, gboolean is_return)
 		} else {
 			ainfo->nfregs_to_skip = FP_PARAM_REGS > cinfo->fr ? FP_PARAM_REGS - cinfo->fr : 0;
 			cinfo->fr = FP_PARAM_REGS;
-			if (!(ios_abi && cinfo->pinvoke))
+			if (!ios_abi)
 				size = ALIGN_TO (size, 8);
 			ainfo->storage = ArgVtypeOnStack;
 			cinfo->stack_usage = ALIGN_TO (cinfo->stack_usage, align);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2749,16 +2749,6 @@
         </ExcludeList>
     </ItemGroup>
 
-    <!-- These are known failures on mono-arm64 on OSX -->
-    <ItemGroup Condition=" '$(RuntimeFlavor)' == 'mono' and '$(TargetArchitecture)' == 'arm64' and '$(TargetsOSX)' == 'true' and '$(RuntimeVariant)' == 'monointerpreter'" >
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_r/**">
-            <Issue>https://github.com/dotnet/runtime/issues/96051</Issue>
-        </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/**">
-            <Issue>https://github.com/dotnet/runtime/issues/96051</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <ItemGroup Condition="'$(TargetArchitecture)' == 'wasm' or '$(TargetsAppleMobile)' == 'true'">
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/finalization/CriticalFinalizer/**">
             <Issue>https://github.com/dotnet/runtime/issues/75756</Issue>


### PR DESCRIPTION
…ts on arm64.

Vector3 was assumed to have size 16 and alignment 8, which caused problems when calling llvm compiled methods which assumed it was 12/8.

Fixes https://github.com/dotnet/runtime/issues/96051.

Previously, different sizes/alignment where used in the pinvoke/non-pinvoke cases, causing problems with calling llvm compiled methods which always