### PR TITLE
[browser][MT] Log ManagedThreadId and NativeThreadId for known test failures

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
@@ -81,9 +81,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 await Assert.ThrowsAsync<TaskCanceledException>(async () =>
                 {
                     CancellationTokenSource cts = new CancellationTokenSource();
-                    var promise = response.Content.ReadAsStringAsync(cts.Token);
                     try
                     {
+                        var promise = response.Content.ReadAsStringAsync(cts.Token);
                         Console.WriteLine("HttpClient_CancelInDifferentThread: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                         cts.Cancel();
                         await promise;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
@@ -82,6 +82,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 {
                     CancellationTokenSource cts = new CancellationTokenSource();
                     var promise = response.Content.ReadAsStringAsync(cts.Token);
+                    Console.WriteLine("HttpClient_CancelInDifferentThread: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                     cts.Cancel();
                     await promise;
                 });

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.Http.cs
@@ -82,9 +82,22 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 {
                     CancellationTokenSource cts = new CancellationTokenSource();
                     var promise = response.Content.ReadAsStringAsync(cts.Token);
-                    Console.WriteLine("HttpClient_CancelInDifferentThread: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
-                    cts.Cancel();
-                    await promise;
+                    try
+                    {
+                        Console.WriteLine("HttpClient_CancelInDifferentThread: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
+                        cts.Cancel();
+                        await promise;
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        Console.WriteLine("HttpClient_CancelInDifferentThread: TaskCanceledException is thrown with message: " + ex.ToString());
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        Console.WriteLine("HttpClient_CancelInDifferentThread: OperationCanceledException is thrown with message: " + ex.ToString());
+                        throw;
+                    }
                 });
             });
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
@@ -364,20 +364,20 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             await executor.Execute(async () =>
             {
                 TaskCompletionSource tcs = new TaskCompletionSource();
+                Console.WriteLine("ThreadingTimer: Start Time: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + " ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
 
                 using var timer = new Timer(_ =>
                 {
                     Assert.NotEqual(1, Environment.CurrentManagedThreadId);
-                    Console.WriteLine("ThreadingTimer: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                     Assert.True(Thread.CurrentThread.IsThreadPoolThread);
-                    tcs.SetResult();
                     hit = true;
+                    tcs.SetResult();
                 }, null, 100, Timeout.Infinite);
 
                 await tcs.Task;
             }, cts.Token);
 
-            Console.WriteLine("ThreadingTimer: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
+            Console.WriteLine("ThreadingTimer: End Time: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + " ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
             Assert.True(hit);
         }
 
@@ -453,7 +453,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 {
                     exception = ex;
                 }
-                Console.WriteLine("WaitAssertsOnJSInteropThreads: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
+                Console.WriteLine("WaitAssertsOnJSInteropThreads: ExecuterType: " + executor.Type + " ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                 executor.AssertBlockingWait(exception);
 
                 return Task.CompletedTask;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTest.cs
@@ -368,6 +368,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 using var timer = new Timer(_ =>
                 {
                     Assert.NotEqual(1, Environment.CurrentManagedThreadId);
+                    Console.WriteLine("ThreadingTimer: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                     Assert.True(Thread.CurrentThread.IsThreadPoolThread);
                     tcs.SetResult();
                     hit = true;
@@ -376,6 +377,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 await tcs.Task;
             }, cts.Token);
 
+            Console.WriteLine("ThreadingTimer: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
             Assert.True(hit);
         }
 
@@ -451,7 +453,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 {
                     exception = ex;
                 }
-
+                Console.WriteLine("WaitAssertsOnJSInteropThreads: ManagedThreadId: " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
                 executor.AssertBlockingWait(exception);
 
                 return Task.CompletedTask;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -156,24 +156,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     using var cts = new CancellationTokenSource(8);
                     try {
                         mr.Wait(cts.Token);
-                    } catch (Exception ex) {
-                        if (ex is OperationCanceledException)
-                        {
-                            throw;
-                        }
-                    }
+                    } catch (OperationCanceledException) { /* ignore */ }
                 }},
                 new NamedCall { Name = "SemaphoreSlim.Wait", Call = delegate (CancellationToken ct) {
                     using var sem = new SemaphoreSlim(2);
                     var cts = new CancellationTokenSource(8);
                     try {
                         sem.Wait(cts.Token);
-                    } catch (Exception ex) {
-                        if (ex is OperationCanceledException)
-                        {
-                            throw;
-                        }
-                    }
+                    } catch (OperationCanceledException) { /* ignore */ }
                 }},
         };
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -156,14 +156,20 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     using var cts = new CancellationTokenSource(8);
                     try {
                         mr.Wait(cts.Token);
-                    } catch (OperationCanceledException) { /* ignore */ }
+                    } catch (OperationCanceledException) { 
+                        Console.WriteLine("ManualResetEventSlim.Wait: OperationCanceledException is ignored " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
+                        /* ignore */
+                 }
                 }},
                 new NamedCall { Name = "SemaphoreSlim.Wait", Call = delegate (CancellationToken ct) {
                     using var sem = new SemaphoreSlim(2);
                     var cts = new CancellationTokenSource(8);
                     try {
                         sem.Wait(cts.Token);
-                    } catch (OperationCanceledException) { /* ignore */ }
+                    } catch (OperationCanceledException) { 
+                        Console.WriteLine("SemaphoreSlim.Wait: OperationCanceledException is ignored " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
+                        /* ignore */ 
+                    }
                 }},
         };
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -156,19 +156,23 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     using var cts = new CancellationTokenSource(8);
                     try {
                         mr.Wait(cts.Token);
-                    } catch (OperationCanceledException) { 
-                        Console.WriteLine("ManualResetEventSlim.Wait: OperationCanceledException is ignored " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
-                        /* ignore */
-                 }
+                    } catch (Exception ex) {
+                        if (ex is OperationCanceledException)
+                        {
+                            throw;
+                        }
+                    }
                 }},
                 new NamedCall { Name = "SemaphoreSlim.Wait", Call = delegate (CancellationToken ct) {
                     using var sem = new SemaphoreSlim(2);
                     var cts = new CancellationTokenSource(8);
                     try {
                         sem.Wait(cts.Token);
-                    } catch (OperationCanceledException) { 
-                        Console.WriteLine("SemaphoreSlim.Wait: OperationCanceledException is ignored " + Environment.CurrentManagedThreadId + " NativeThreadId: " + WebWorkerTestHelper.NativeThreadId);
-                        /* ignore */ 
+                    } catch (Exception ex) {
+                        if (ex is OperationCanceledException)
+                        {
+                            throw;
+                        }
                     }
                 }},
         };


### PR DESCRIPTION
Log ManagedThreadId and NativeThreadId for following test failures
https://github.com/dotnet/runtime/issues/98101, https://github.com/dotnet/runtime/issues/98216, https://github.com/dotnet/runtime/issues/97914

Once test failures will be fixed, we will remove these logs.