### PR TITLE
Cleanup NoWarn in Crossgen2Tasks.csproj

### DIFF
--- a/src/tasks/Crossgen2Tasks/Crossgen2Tasks.csproj
+++ b/src/tasks/Crossgen2Tasks/Crossgen2Tasks.csproj
@@ -4,9 +4,6 @@
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn),CA1050</NoWarn>
-
-    <!-- Ignore nullable warnings on net4* -->
-    <NoWarn Condition="$(TargetFramework.StartsWith('net4'))">$(NoWarn),CS8604,CS8602</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />


### PR DESCRIPTION
The project no longer targets net4x so we don't need the NoWarn anymore.