### PR TITLE
Ensure the assert in IsEmbMaskOp is correct

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2244,9 +2244,8 @@ public:
 #if defined(TARGET_XARCH) && defined(FEATURE_HW_INTRINSICS)
     bool IsEmbMaskOp()
     {
-        bool result = (gtFlags & GTF_HW_EM_OP) != 0;
-        assert(!result || (gtOper == GT_HWINTRINSIC));
-        return result;
+        assert(OperIsHWIntrinsic());
+        return (gtFlags & GTF_HW_EM_OP) != 0;
     }
 
     void MakeEmbMaskOp()

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -2244,12 +2244,12 @@ public:
 #if defined(TARGET_XARCH) && defined(FEATURE_HW_INTRINSICS)
     bool IsEmbMaskOp()
     {
-        assert(OperIsHWIntrinsic());
-        return (gtFlags & GTF_HW_EM_OP) != 0;
+        return OperIsHWIntrinsic() && ((gtFlags & GTF_HW_EM_OP) != 0);
     }
 
     void MakeEmbMaskOp()
     {
+        assert(OperIsHWIntrinsic());
         assert(!IsEmbMaskOp());
         gtFlags |= GTF_HW_EM_OP;
     }


### PR DESCRIPTION
The `IsEmbMaskOp` API is only expected to be called for `GT_HWINTRINSIC` nodes since it reuses bits valid for specific other node kinds.