### PR TITLE
Harden UnixPkcs12Reader AllocHGlobal

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -118,8 +118,9 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static AndroidCertificatePal ReadPkcs12(ReadOnlySpan<byte> rawData, SafePasswordHandle password, bool ephemeralSpecified)
         {
-            using (var reader = new AndroidPkcs12Reader(rawData))
+            using (var reader = new AndroidPkcs12Reader())
             {
+                reader.ParsePkcs12(rawData);
                 reader.Decrypt(password, ephemeralSpecified);
 
                 UnixPkcs12Reader.CertAndKey certAndKey = reader.GetSingleCert();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidPkcs12Reader.cs
@@ -11,17 +11,17 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed class AndroidPkcs12Reader : UnixPkcs12Reader
     {
-        internal AndroidPkcs12Reader(ReadOnlySpan<byte> data)
+        internal AndroidPkcs12Reader()
         {
-            ParsePkcs12(data);
         }
 
         public static bool IsPkcs12(ReadOnlySpan<byte> data)
         {
             try
             {
-                using (var reader = new AndroidPkcs12Reader(data))
+                using (var reader = new AndroidPkcs12Reader())
                 {
+                    reader.ParsePkcs12(data);
                     return true;
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Pkcs12.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Pkcs12.iOS.cs
@@ -14,8 +14,9 @@ namespace System.Security.Cryptography.X509Certificates
             SafePasswordHandle password,
             bool ephemeralSpecified)
         {
-            using (ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData))
+            using (ApplePkcs12Reader reader = new ApplePkcs12Reader())
             {
+                reader.ParsePkcs12(rawData);
                 reader.Decrypt(password, ephemeralSpecified);
                 return ImportPkcs12(reader.GetSingleCert());
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Pkcs12.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.Pkcs12.macOS.cs
@@ -15,8 +15,9 @@ namespace System.Security.Cryptography.X509Certificates
             bool exportable,
             SafeKeychainHandle keychain)
         {
-            using (ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData))
+            using (ApplePkcs12Reader reader = new ApplePkcs12Reader())
             {
+                reader.ParsePkcs12(rawData);
                 reader.Decrypt(password, ephemeralSpecified: false);
 
                 UnixPkcs12Reader.CertAndKey certAndKey = reader.GetSingleCert();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.iOS.cs
@@ -10,9 +10,8 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed class ApplePkcs12Reader : UnixPkcs12Reader
     {
-        internal ApplePkcs12Reader(ReadOnlySpan<byte> data)
+        internal ApplePkcs12Reader()
         {
-            ParsePkcs12(data);
         }
 
         protected override ICertificatePalCore ReadX509Der(ReadOnlyMemory<byte> data)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ApplePkcs12Reader.macOS.cs
@@ -11,9 +11,8 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed class ApplePkcs12Reader : UnixPkcs12Reader
     {
-        internal ApplePkcs12Reader(ReadOnlySpan<byte> data)
+        internal ApplePkcs12Reader()
         {
-            ParsePkcs12(data);
         }
 
         protected override ICertificatePalCore ReadX509Der(ReadOnlyMemory<byte> data)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslPkcs12Reader.cs
@@ -9,9 +9,8 @@ namespace System.Security.Cryptography.X509Certificates
 {
     internal sealed class OpenSslPkcs12Reader : UnixPkcs12Reader
     {
-        private OpenSslPkcs12Reader(ReadOnlySpan<byte> data)
+        private OpenSslPkcs12Reader()
         {
-            ParsePkcs12(data);
         }
 
         protected override ICertificatePalCore ReadX509Der(ReadOnlyMemory<byte> data)
@@ -89,7 +88,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                pkcs12Reader = new OpenSslPkcs12Reader(data);
+                pkcs12Reader = new OpenSslPkcs12Reader();
+                pkcs12Reader.ParsePkcs12(data);
                 return true;
             }
             catch (CryptographicException e)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.Android.cs
@@ -118,8 +118,9 @@ namespace System.Security.Cryptography.X509Certificates
             SafePasswordHandle password,
             bool ephemeralSpecified)
         {
-            using (var reader = new AndroidPkcs12Reader(rawData))
+            using (var reader = new AndroidPkcs12Reader())
             {
+                reader.ParsePkcs12(rawData);
                 reader.Decrypt(password, ephemeralSpecified);
 
                 ICertificatePal[] certs = new ICertificatePal[reader.GetCertCount()];

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.iOS.cs
@@ -46,10 +46,11 @@ namespace System.Security.Cryptography.X509Certificates
             if (contentType == X509ContentType.Pkcs12)
             {
                 X509Certificate.EnforceIterationCountLimit(ref rawData, readingFromFile, password.PasswordProvided);
-                ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData);
+                ApplePkcs12Reader reader = new ApplePkcs12Reader();
 
                 try
                 {
+                    reader.ParsePkcs12(rawData);
                     reader.Decrypt(password, ephemeralSpecified);
                     return new ApplePkcs12CertLoader(reader, password);
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/StorePal.macOS.cs
@@ -72,10 +72,11 @@ namespace System.Security.Cryptography.X509Certificates
             bool ephemeralSpecified,
             SafeKeychainHandle keychain)
         {
-            ApplePkcs12Reader reader = new ApplePkcs12Reader(rawData);
+            ApplePkcs12Reader reader = new ApplePkcs12Reader();
 
             try
             {
+                reader.ParsePkcs12(rawData);
                 reader.Decrypt(password, ephemeralSpecified);
                 return new ApplePkcs12CertLoader(reader, keychain, password, exportable);
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/UnixPkcs12Reader.cs
@@ -42,22 +42,17 @@ namespace System.Security.Cryptography.X509Certificates
 
                 unsafe
                 {
-                    IntPtr tmpPtr = IntPtr.Zero;
+                    void* tmpPtr = NativeMemory.Alloc((uint)encodedData.Length);
 
                     try
                     {
-                        tmpPtr = Marshal.AllocHGlobal(encodedData.Length);
                         Span<byte> tmpSpan = new Span<byte>((byte*)tmpPtr, encodedData.Length);
                         encodedData.CopyTo(tmpSpan);
-                        _tmpManager = new PointerMemoryManager<byte>((void*)tmpPtr, encodedData.Length);
+                        _tmpManager = new PointerMemoryManager<byte>(tmpPtr, encodedData.Length);
                     }
                     catch
                     {
-                        if (tmpPtr != IntPtr.Zero)
-                        {
-                            Marshal.FreeHGlobal(tmpPtr);
-                        }
-
+                        NativeMemory.Free(tmpPtr);
                         throw;
                     }
                 }
@@ -139,7 +134,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     fixed (byte* ptr = tmp)
                     {
-                        Marshal.FreeHGlobal((IntPtr)ptr);
+                        NativeMemory.Free(ptr);
                     }
                 }
 


### PR DESCRIPTION
* Do not do the allocation and parsing in the constructor, since throwing there prevents Dispose from running
* If something goes wrong between AllocHGlobal and moving the pointer into a PointerMemoryManager, call FreeHGlobal.
  * Past that point it will be correctly freed by Dispose.

Replaces PRs #93647 and #97447