### PR TITLE
Avoid double writes to PDB in NAOT publish

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -24,6 +24,7 @@
     <ItemGroup>
       <_ResolvedCopyLocalPublishAssets Remove="@(_AssembliesToSkipPublish)" />
       <_ResolvedCopyLocalPublishAssets Include="@(_LinkedResolvedAssemblies)" />
+      <_DebugSymbolsIntermediatePath Remove="@(_DebugSymbolsIntermediatePath)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Resolves #89763 (although it will only get fixed once we also update the SDK).

We currently let the publish logic do its things unaware of what PublishAot will do and then copy over native bits. So before this PR, we had to overwrite the PDB that Publish placed there. The fix in this PR fixes things based on the current par for the course.

In general, I wonder if we should switch to the same mechanism that R2R, ILLink, or Single file publishing use - have SDK [be aware of the magic target](https://github.com/dotnet/sdk/blob/95025c62f4e260540c1257627616641e9670501e/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Publish.targets#L453-L460) and then modify ResolvedFileToPublish items as needed in the magic target.

Cc @dotnet/ilc-contrib