### PR TITLE
JIT: Add a simple `Counter` dumpable

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -294,6 +294,19 @@ public:
     virtual void dump(FILE* output) = 0;
 };
 
+// Helper class record and display a simple single value.
+class Counter : public Dumpable
+{
+public:
+    int64_t Value;
+
+    Counter(int64_t initialValue = 0) : Value(initialValue)
+    {
+    }
+
+    void dump(FILE* output);
+};
+
 // Helper class to record and display a histogram of different values.
 // Usage like:
 // static unsigned s_buckets[] = { 1, 2, 5, 10, 0 }; // Must have terminating 0

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1098,6 +1098,11 @@ void ConfigDoubleArray::Dump()
 
 #if CALL_ARG_STATS || COUNT_BASIC_BLOCKS || COUNT_LOOPS || EMITTER_STATS || MEASURE_NODE_SIZE || MEASURE_MEM_ALLOC
 
+void Counter::dump(FILE* output)
+{
+    fprintf(output, "%lld\n", (long long)Value);
+}
+
 /*****************************************************************************
  *  Histogram class.
  */


### PR DESCRIPTION
This allows easily measuring and outputting a single value at the end of all JIT compilations.

Example use:
```diff
@@ -1137,6 +1137,9 @@ void Compiler::optReplaceWidenedIV(unsigned lclNum, unsigned newLclNum, Statemen
     }
 }
 
+static Counter s_widened;
+static DumpOnShutdown d("Widened IVs", &s_widened);
+
 //------------------------------------------------------------------------
 // optInductionVariables: Try and optimize induction variables in the method.
 //
@@ -1275,6 +1278,7 @@ PhaseStatus Compiler::optInductionVariables()
             });
 
             changed |= optSinkWidenedIV(lcl->GetLclNum(), newLclNum, loop);
+            s_widened.Value++;
         }
     }
 ```