### PR TITLE
Shrink `.eh_frame` section in naot executables

### DIFF
--- a/src/coreclr/nativeaot/CMakeLists.txt
+++ b/src/coreclr/nativeaot/CMakeLists.txt
@@ -15,6 +15,7 @@ endif (MSVC)
 
 if(CLR_CMAKE_HOST_UNIX)
   add_compile_options(-fno-exceptions)    # Native AOT runtime doesn't use C++ exception handling
+  add_compile_options(-fno-asynchronous-unwind-tables)
   add_compile_options(-nostdlib)
 
   if(CLR_CMAKE_TARGET_APPLE)


### PR DESCRIPTION
`-fno-exceptions` is not enough to stop generating `.eh_frames`. We need to also pass `-fno-asynchronous-unwind-tables`.

Saves 50 kB on an app using WKS gc. Possibly more on SRV GC since that has two copies of the GC and most of our native runtime is the GC.

Note that we still get unwinding information for the debugger because `-g` is going to force generation of `.debug_frame` instead. But `.debug_frame` is part of debugging symbols and not part of the app.