### PR TITLE
Fix more bugs found with ILVerify

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInstantiation.cs
@@ -58,7 +58,7 @@ namespace System.Reflection.Emit
         public override CallingConventions CallingConvention => _ctor.CallingConvention;
         public override Type[] GetGenericArguments() { return _ctor.GetGenericArguments(); }
         public override bool IsGenericMethodDefinition => false;
-        public override bool ContainsGenericParameters => _ctor.ContainsGenericParameters;
+        public override bool ContainsGenericParameters => _type.ContainsGenericParameters;
 
         public override bool IsGenericMethod => false;
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorOnTypeBuilderInstantiation.cs
@@ -58,7 +58,7 @@ namespace System.Reflection.Emit
         public override CallingConventions CallingConvention => _ctor.CallingConvention;
         public override Type[] GetGenericArguments() { return _ctor.GetGenericArguments(); }
         public override bool IsGenericMethodDefinition => false;
-        public override bool ContainsGenericParameters => _type.ContainsGenericParameters;
+        public override bool ContainsGenericParameters => _ctor.ContainsGenericParameters;
 
         public override bool IsGenericMethod => false;
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
@@ -68,13 +68,6 @@ namespace System.Reflection.Emit
             throw new NotSupportedException();
         }
         public override CallingConventions CallingConvention => _method.CallingConvention;
-#if !MONO
-        public override MethodInfo GetGenericMethodDefinition() { return _method; }
-        public override bool IsGenericMethodDefinition => _method.IsGenericMethodDefinition;
-        public override Type[] GetGenericArguments()
-        {
-            return _method.GetGenericArguments();
-        }
         public override bool ContainsGenericParameters
         {
             get
@@ -101,6 +94,14 @@ namespace System.Reflection.Emit
                 return false;
             }
         }
+#if !MONO
+        public override MethodInfo GetGenericMethodDefinition() { return _method; }
+        public override bool IsGenericMethodDefinition => _method.IsGenericMethodDefinition;
+        public override Type[] GetGenericArguments()
+        {
+            return _method.GetGenericArguments();
+        }
+
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
         public override MethodInfo MakeGenericMethod(params Type[] typeArgs)
         {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/MethodBuilderImpl.cs
@@ -252,7 +252,21 @@ namespace System.Reflection.Emit
         public override int MetadataToken => _handle == default ? 0 : MetadataTokens.GetToken(_handle);
         public override RuntimeMethodHandle MethodHandle => throw new NotSupportedException(SR.NotSupported_DynamicModule);
         public override Type? ReflectedType => DeclaringType;
-        public override ParameterInfo ReturnParameter { get => throw new NotImplementedException(); }
+        public override ParameterInfo ReturnParameter
+        {
+            get
+            {
+                if (_parameterBuilders == null || _parameterBuilders[0] == null)
+                {
+                    return new ParameterInfoWrapper(new ParameterBuilderImpl(this, 0, ParameterAttributes.Retval, null), _returnType);
+                }
+                else
+                {
+                    return new ParameterInfoWrapper(_parameterBuilders[0], _returnType);
+                }
+            }
+        }
+
         public override Type ReturnType => _returnType;
         public override ICustomAttributeProvider ReturnTypeCustomAttributes { get => throw new NotImplementedException(); }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -607,8 +607,9 @@ namespace System.Reflection.Emit
         private static MemberInfo GetOriginalMemberIfConstructedType(MethodBase methodBase)
         {
             Type declaringType = methodBase.DeclaringType!;
-            if (declaringType.IsConstructedGenericType && !methodBase.ContainsGenericParameters &&
-                declaringType.GetGenericTypeDefinition() is not TypeBuilderImpl)
+            if (declaringType.IsConstructedGenericType &&
+                declaringType.GetGenericTypeDefinition() is not TypeBuilderImpl &&
+                !ContainsNotBakedTypeBuilder(declaringType.GetGenericArguments()))
             {
                 return declaringType.GetGenericTypeDefinition().GetMemberWithSameMetadataDefinitionAs(methodBase);
             }
@@ -891,14 +892,14 @@ namespace System.Reflection.Emit
         }
 
         private static bool IsConstructedFromNotBakedTypeBuilder(Type type) => type.IsConstructedGenericType &&
-            (type.GetGenericTypeDefinition() is TypeBuilderImpl tb && tb._handle == default ||
+            (type.GetGenericTypeDefinition() is TypeBuilderImpl ||
              ContainsNotBakedTypeBuilder(type.GetGenericArguments()));
 
         private static bool ContainsNotBakedTypeBuilder(Type[] genericArguments)
         {
             foreach (Type type in genericArguments)
             {
-                if (type is TypeBuilderImpl tb && tb._handle == default)
+                if (type is TypeBuilderImpl || type is GenericTypeParameterBuilderImpl)
                 {
                     return true;
                 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -538,6 +538,7 @@ namespace System.Reflection.Emit
                             MetadataSignatureHelper.GetFieldSignature(field.FieldType, field.GetRequiredCustomModifiers(), field.GetOptionalCustomModifiers(), this));
                         break;
                     case ConstructorInfo ctor:
+                        ctor = (ConstructorInfo)GetOriginalMemberIfConstructedType(ctor);
                         memberHandle = AddMemberReference(ctor.Name, GetTypeHandle(memberInfo.DeclaringType!), MetadataSignatureHelper.GetConstructorSignature(ctor.GetParameters(), this));
                         break;
                     case MethodInfo method:
@@ -964,8 +965,8 @@ namespace System.Reflection.Emit
         private static bool IsArrayMethodFromNotBakedTypeBuilder(MethodInfo method) => method is ArrayMethod arrayMethod &&
             arrayMethod.DeclaringType!.GetElementType() is TypeBuilderImpl tb && tb._handle == default;
 
-        private static bool IsConstructedMethodFromNotBakedMethodBuilder(MethodInfo method) =>
-            method.IsConstructedGenericMethod && method.GetGenericMethodDefinition() is MethodBuilderImpl mb && mb._handle == default;
+        private static bool IsConstructedMethodFromNotBakedMethodBuilder(MethodInfo method) => method.IsConstructedGenericMethod &&
+            (method.GetGenericMethodDefinition() is MethodBuilderImpl mb && mb._handle == default || ContainsNotBakedTypeBuilder(method.GetGenericArguments()));
 
         internal EntityHandle TryGetMethodHandle(MethodInfo method, Type[] optionalParameterTypes)
         {

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -892,5 +892,22 @@ namespace System.Reflection.Emit.Tests
                 Assert.IsType(typeFromDisk, obj);
             }
         }
+
+        [Fact]
+        public void TestContainsGenericParametersOnMethodCtorOfConstructedGenericType()
+        {
+            AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder tb);
+            GenericTypeParameterBuilder[] typeParameters = tb.DefineGenericParameters("T");
+            ConstructorBuilder constructorBuilder = tb.DefineDefaultConstructor(MethodAttributes.Public);
+            MethodBuilder methodBuilder = tb.DefineMethod("Method", MethodAttributes.Public);
+
+            Type instantiatedTypeBuilder1 = tb.MakeGenericType(typeof(List<>).GetGenericArguments()[0]);
+            Assert.True(TypeBuilder.GetConstructor(instantiatedTypeBuilder1, constructorBuilder).ContainsGenericParameters);
+            Assert.True(TypeBuilder.GetMethod(instantiatedTypeBuilder1, methodBuilder).ContainsGenericParameters);
+
+            Type instantiatedTypeBuilder2 = tb.MakeGenericType(typeof(int));
+            Assert.False(TypeBuilder.GetConstructor(instantiatedTypeBuilder2, constructorBuilder).ContainsGenericParameters);
+            Assert.False(TypeBuilder.GetMethod(instantiatedTypeBuilder2, methodBuilder).ContainsGenericParameters);
+        }
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistableAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -606,6 +606,49 @@ namespace System.Reflection.Emit.Tests
                 }
             }
         }
+
+        [Fact]
+        public void MethodBuilderGetParametersReturnParameterTest()
+        {
+            AssemblyBuilder assemblyBuilder = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder type);
+            MethodBuilder method1 = type.DefineMethod("Method1", MethodAttributes.Public, typeof(long), [typeof(int), typeof(string)]);
+            MethodBuilder method2 = type.DefineMethod("Method2", MethodAttributes.Static);
+            MethodBuilder method3 = type.DefineMethod("Method1", MethodAttributes.Public, typeof(int), [typeof(string)]);
+            method1.DefineParameter(0, ParameterAttributes.Retval, null);
+            method1.DefineParameter(1, ParameterAttributes.None, "index");
+            method1.DefineParameter(2, ParameterAttributes.Out, "outParam");
+            ParameterBuilder pb = method3.DefineParameter(1, ParameterAttributes.Optional, "name");
+            pb.SetConstant("defaultName");
+            //type.CreateType();
+
+            ParameterInfo[] params1 = method1.GetParameters();
+            Assert.Equal(2, params1.Length);
+            Assert.Equal("index", params1[0].Name);
+            Assert.Equal(typeof(int), params1[0].ParameterType);
+            Assert.Equal("outParam", params1[1].Name);
+            Assert.Equal(typeof(string), params1[1].ParameterType);
+            Assert.Equal(ParameterAttributes.Out, params1[1].Attributes);
+            Assert.True(params1[1].IsOut);
+            Assert.Equal(typeof(long), method1.ReturnParameter.ParameterType);
+            Assert.Null(method1.ReturnParameter.Name);
+            Assert.True(method1.ReturnParameter.IsRetval);
+
+            Assert.Empty(method2.GetParameters());
+            Assert.Equal(typeof(void), method2.ReturnParameter.ParameterType);
+            Assert.Null(method2.ReturnParameter.Name);
+            Assert.True(method2.ReturnParameter.IsRetval);
+
+            ParameterInfo[] params3 = method3.GetParameters();
+            Assert.Equal(1, params3.Length);
+            Assert.Equal("name", params3[0].Name);
+            Assert.Equal(typeof(string), params3[0].ParameterType);
+            Assert.True(params3[0].HasDefaultValue);
+            Assert.Equal("defaultName", params3[0].DefaultValue);
+
+            Assert.Equal(typeof(int), method3.ReturnParameter.ParameterType);
+            Assert.Null(method3.ReturnParameter.Name);
+            Assert.True(method3.ReturnParameter.IsRetval);
+        }
     }
 
     // Test Types

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.Mono.cs
@@ -66,25 +66,6 @@ namespace System.Reflection.Emit
             return result;
         }
 
-        public override bool ContainsGenericParameters
-        {
-            get
-            {
-                if (_method.ContainsGenericParameters)
-                    return true;
-                if (!_method.IsGenericMethodDefinition)
-                    throw new NotSupportedException();
-                if (_typeArguments == null)
-                    return true;
-                foreach (Type t in _typeArguments)
-                {
-                    if (t.ContainsGenericParameters)
-                        return true;
-                }
-                return false;
-            }
-        }
-
         public override bool IsGenericMethodDefinition => _method.IsGenericMethodDefinition && _typeArguments == null;
 
         public override MethodInfo GetGenericMethodDefinition() { return _genericMethodDefinition ?? _method; }


### PR DESCRIPTION
- For constructors populated from constructed generic type also need to load original ctor version
- Incorrect token when unbaked `TypeBuilder` used as generic argument for generic method
- Add  `MethodBuilderImpl.ReturnParameter` implementation

Contributes to https://github.com/dotnet/runtime/issues/92975