### PR TITLE
Don't place MSBuild files to target-specific ILCompiler packages

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -24,7 +24,7 @@
       <File Include="$(SharedNativeRoot)libs\Common\*" TargetPath="native/src/libs/Common"/>
     </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
       <File Include="$(CoreCLRBuildIntegrationDir)*" TargetPath="build" />
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
     </ItemGroup>


### PR DESCRIPTION
Fixes #96556.

Cc @dotnet/ilc-contrib 