### PR TITLE
JIT: Discard simple dominated CSEs that will never be defs

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -552,7 +552,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         //
         assert(vnLibNorm == vnStore->VNNormalValue(vnOp2Lib));
     }
-    if (enableSharedConstCSE && tree->IsIntegralConst())
+    else if (enableSharedConstCSE && tree->IsIntegralConst())
     {
         assert(vnStore->IsVNConstant(vnLibNorm));
 

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -636,6 +636,9 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
                         if ((prevExceptionSet != curExceptionSet) &&
                             vnStore->VNExcIsSubset(curExceptionSet, prevExceptionSet))
                         {
+                            JITDUMP("Skipping CSE candidate for tree [%06u]; tree [%06u] is a better candidate with "
+                                    "more exceptions\n",
+                                    prevTree->gtTreeID, tree->gtTreeID);
                             prevTree->gtCSEnum = 0;
                             hashDsc->csdStmt   = stmt;
                             hashDsc->csdTree   = tree;

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -628,12 +628,12 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
                 {
                     GenTree* prevTree  = hashDsc->csdTree;
                     ValueNum prevVnLib = prevTree->GetVN(VNK_Liberal);
-                    assert(vnStore->VNNormalValue(prevVnLib) == vnLibNorm);
                     if (prevVnLib != vnLib)
                     {
                         ValueNum prevExceptionSet = vnStore->VNExceptionSet(prevVnLib);
                         ValueNum curExceptionSet  = vnStore->VNExceptionSet(vnLib);
-                        if (vnStore->VNExcIsSubset(curExceptionSet, prevExceptionSet))
+                        if ((prevExceptionSet != curExceptionSet) &&
+                            vnStore->VNExcIsSubset(curExceptionSet, prevExceptionSet))
                         {
                             prevTree->gtCSEnum = 0;
                             hashDsc->csdStmt   = stmt;

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -618,10 +618,11 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
                 // already prove that the first one is _not_ going to be a
                 // valid def for the second one, due to the second one having
                 // more exceptions. This happens for example in code like
-                // CASTCLASS(x, y) where x was already proven to be of type y.
-                // In those cases it is always better to let the second value
-                // be the def.
-                // This is essentially a less special-casey version of the
+                // CASTCLASS(x, y) where the "CASTCLASS" just adds exceptions
+                // on top of "x". In those cases it is always better to let the
+                // second value be the def.
+                // It also happens for GT_COMMA, but that one is special cased
+                // above; this handling is a less special-casey version of the
                 // GT_COMMA handling above. However, it is quite limited since
                 // it only handles the def/use being in the same block.
                 if (compCurBB == hashDsc->csdBlock)


### PR DESCRIPTION
Be a bit smarter when indexing CSEs if we see the same value twice in the same basic block and the second one has more exceptions than the first one. In that case the first will never be a candidate def for the second, so it is always better to just consider the second one to be the def.

This is particularly relevant with passthrough nodes like `CASTCLASS(x, y)`, where `CASTCLASS` gets the same VN as its first operand, but with more exceptions on it. Previously we would consider `x` to be the def; this naturally considers the full `CASTCLASS(x, y)` to be the def, which promises more exceptions.

One thing to note is that `GT_COMMA` would benefit from this handling too, but it is already special cased such that we create a separate candidate for the `GT_COMMA` (that includes the exception set of `op1`) and its op2 (that doesn't). That would also be a potential way to improve the situation here, but it requires special casing all such cases.

The fix here is very simplistic and doesn't handle many cases. In particular we could have seen `x` previously in another basic block, in which case we run into the same issue again. I think switching CSE to be dominator tree based and generating multiple candidates instead would be a better general solution; hopefully we can work towards that. If not, this at least alleviates some of the problem.

Fix #98413