### PR TITLE
[mono] Block SIMD types in Swift interop

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3713,7 +3713,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 						swift_self_args++;
 					} else if (!m_class_is_blittable (param_klass) || m_class_is_simd_type (param_klass)) {
 						swift_error_args = swift_self_args = 0;
-						mono_error_set_generic_error (emitted_error, "System", "InvalidProgramException", "Passing non-primitive value types to a P/Invoke with the Swift calling convention is unsupported.");
+						mono_error_set_generic_error (emitted_error, "System", "InvalidProgramException", "Passing non-blittable types to a P/Invoke with the Swift calling convention is unsupported.");
 						break;
 					}
 				}

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3711,7 +3711,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 						swift_error_args++;
 					} else if (param_klass == swift_self) {
 						swift_self_args++;
-					} else if (!m_class_is_blittable (param_klass) && m_class_get_this_arg (param_klass)->type != MONO_TYPE_FNPTR) {
+					} else if (!m_class_is_blittable (param_klass) || m_class_is_simd_type (param_klass)) {
 						swift_error_args = swift_self_args = 0;
 						mono_error_set_generic_error (emitted_error, "System", "InvalidProgramException", "Passing non-primitive value types to a P/Invoke with the Swift calling convention is unsupported.");
 						break;

--- a/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
+++ b/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Swift;
+using System.Numerics;
 using Xunit;
 
 public class InvalidCallingConvTests
@@ -35,6 +36,10 @@ public class InvalidCallingConvTests
     [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
     [DllImport(SwiftLib, EntryPoint = "$s20SwiftInvalidCallConv10simpleFuncyyF")]
     public static extern void FuncWithNonPrimitiveArg(StringClass arg1);
+
+    [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvSwift) })]
+    [DllImport(SwiftLib, EntryPoint = "$s20SwiftInvalidCallConv10simpleFuncyyF")]
+    public static extern void FuncWithSIMDArg(Vector4 vec);
 
     [Fact]
     public static void TestFuncWithTwoSelfParameters()
@@ -76,5 +81,13 @@ public class InvalidCallingConvTests
         StringClass arg1 = new StringClass();
         arg1.value = "fail";
         Assert.Throws<InvalidProgramException>(() => FuncWithNonPrimitiveArg(arg1));
+    }
+
+    [Fact]
+    public static void TestFuncWithSIMDArg()
+    {
+        // Invalid due to a SIMD argument.
+        Vector4 vec = new Vector4(); // Using Vector4 as it is a SIMD type across all architectures for Mono
+        Assert.Throws<InvalidProgramException>(() => FuncWithSIMDArg(vec));
     }
 }


### PR DESCRIPTION
Restricting SIMD types in Swift Interop for Mono.

---

Contributes to https://github.com/dotnet/runtime/issues/94081