### PR TITLE
Add Read/Write Async test

### DIFF
--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1240,6 +1240,7 @@ namespace System.Threading.ThreadPools.Tests
                     ManualResetEvent[] waitEvents = [eventListener.TPWaitIOEnqueueEvent, eventListener.TPWaitIODequeueEvent];
                     WaitHandle.WaitAll(waitEvents, TimeSpan.FromSeconds(15));
                     Assert.True(eventListener.TPIOEnqueue > 0);
+                    Assert.True(eventListener.TPIODequeue > 0);
                 }
             }).Dispose();
         }

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1180,7 +1180,7 @@ namespace System.Threading.ThreadPools.Tests
         }
 
         [ConditionalFact(nameof(IsThreadingAndRemoteExecutorSupported))]
-        public void ReadAsyncTest()
+        public void ReadWriteAsyncTest()
         {
             RemoteExecutor.Invoke(async () =>
             {

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -1170,6 +1170,7 @@ namespace System.Threading.ThreadPools.Tests
 
             public volatile int TPIOEnqueue = 0;
             public ManualResetEvent TPWaitIOEnqueueEvent = new ManualResetEvent(false);
+
             protected override void OnEventSourceCreated(EventSource eventSource)
             {
                 if (eventSource.Name.Equals(ClrProviderName))
@@ -1179,6 +1180,7 @@ namespace System.Threading.ThreadPools.Tests
 
                 base.OnEventSourceCreated(eventSource);
             }
+
             protected override void OnEventWritten(EventWrittenEventArgs eventData)
             {
                 if (eventData.EventName.Equals("ThreadPoolIOEnqueue"))

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net.Sockets;
 using System.Net;
 using System.Reflection;
-using System.Text;
 using System.Threading.Tasks;
 using System.Threading.Tests;
 using Microsoft.DotNet.RemoteExecutor;


### PR DESCRIPTION
Adding a read/write async test that runs with the Windows thread pool enabled. 

It also checks that the thread pool IO events are fired correctly, verifying the changes made in https://github.com/dotnet/runtime/pull/97365. 