### PR TITLE
Handle large imm values in ARMEmitter.EmitLDR

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM/ARMEmitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM/ARMEmitter.cs
@@ -121,9 +121,41 @@ namespace ILCompiler.DependencyAnalysis.ARM
         // ldr.w reg, [reg, #offset]
         // reg range: [0..PC]
         // offset range: [-255..4095]
+        //
+        // for offset >= 4096 we do an expansion into:
+        // add.w destination, source, #const
+        // ldr.w destination, [destination, #offset]
         public void EmitLDR(Register destination, Register source, int offset)
         {
             Debug.Assert(IsValidReg(destination) && IsValidReg(source));
+
+            if (offset >= 0x1000)
+            {
+                uint constVal = (uint)offset & ~0xfffu;
+                uint mask32 = 0xff;
+                uint imm8 = 0;
+                int encode = 31; // 11111
+
+                do
+                {
+                    mask32 <<= 1;
+                    if ((constVal & ~mask32) == 0)
+                    {
+                        imm8 = (constVal & mask32) >> (32 - encode);
+                        break;
+                    }
+                    encode--;
+                } while (encode >= 8);
+
+                Debug.Assert(encode >= 8);
+                Debug.Assert((imm8 & 0x80) > 0);
+                Builder.EmitShort((short)(0xF100 + (byte)source + (((byte)encode & 0x10) << 6)));
+                Builder.EmitShort((short)((((byte)encode & 0xE) << 11) + ((byte)destination << 8) + (((byte)encode & 1) << 7) + (imm8 & 0x7f)));
+
+                offset = (int)(offset & 0xfffu);
+                source = destination;
+            }
+
             Debug.Assert(offset >= -255 && offset <= 4095);
             if (offset >= 0)
             {


### PR DESCRIPTION
Fixes [pri0 test failure](https://github.com/dotnet/runtime/pull/98022#issuecomment-1943598123):
```
2024-02-14T08:23:44.0403671Z     Process terminated. Assertion failed.
2024-02-14T08:23:44.0405627Z        at ILCompiler.DependencyAnalysis.ARM.ARMEmitter.EmitLDR(Register destination, Register source, Int32 offset) in /_/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_ARM/ARMEmitter.cs:line 127
2024-02-14T08:23:44.0406283Z        at ILCompiler.DependencyAnalysis.ReadyToRunHelperNode.EmitCode(NodeFactory factory, ARMEmitter& encoder, Boolean relocsOnly) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_ARM/ARMReadyToRunHelperNode.cs:line 36
2024-02-14T08:23:44.0406921Z        at ILCompiler.DependencyAnalysis.AssemblyStubNode.GetData(NodeFactory factory, Boolean relocsOnly) in /_/src/coreclr/tools/Common/Compiler/DependencyAnalysis/AssemblyStubNode.cs:line 59
2024-02-14T08:23:44.0407567Z        at ILCompiler.ObjectWriter.ObjectWriter.EmitObject(String objectFilePath, IReadOnlyCollection`1 nodes, IObjectDumper dumper, Logger logger) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs:line 391
2024-02-14T08:23:44.0420336Z        at ILCompiler.ObjectWriter.ObjectWriter.EmitObject(String objectFilePath, IReadOnlyCollection`1 nodes, NodeFactory factory, ObjectWritingOptions options, IObjectDumper dumper, Logger logger) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.cs:line 542
2024-02-14T08:23:44.0421003Z        at ILCompiler.Compilation.ILCompiler.ICompilation.Compile(String outputFile, ObjectDumper dumper) in /_/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs:line 525
2024-02-14T08:23:44.0421421Z        at ILCompiler.Program.Run() in /_/src/coreclr/tools/aot/ILCompiler/Program.cs:line 585
2024-02-14T08:23:44.0421751Z        at ILCompiler.ILCompilerRootCommand.<>c__DisplayClass236_0.<.ctor>b__0(ParseResult result) in /_/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs:line 292
2024-02-14T08:23:44.0422100Z        at System.CommandLine.Invocation.InvocationPipeline.Invoke(ParseResult parseResult)
2024-02-14T08:23:44.0422354Z        at System.CommandLine.ParseResult.Invoke()
2024-02-14T08:23:44.0422610Z        at ILCompiler.Program.Main(String[] args) in /_/src/coreclr/tools/aot/ILCompiler/Program.cs:line 753
2024-02-14T08:23:44.4226529Z /__w/1/s/artifacts/bin/coreclr/linux.arm.Checked/build/Microsoft.NETCore.Native.targets(310,5): error MSB3073: The command ""/__w/1/s/artifacts/bin/coreclr/linux.arm.Checked/x64/ilc/ilc" @"/__w/1/s/artifacts/tests/coreclr/obj/linux.arm.Checked/Managed/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r/native/bigvtbl_cs_r.ilc.rsp"" exited with code 134.
```

Contributes to https://github.com/dotnet/runtime/issues/97729