### PR TITLE
Fix Random.Shuffle covariance

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -321,8 +321,8 @@ namespace System
 
                 if (j != i)
                 {
-                    ref T first = Unsafe.Add(ref values, (uint)i);
-                    ref T second = Unsafe.Add(ref values, (uint)j);
+                    ref T first = ref Unsafe.Add(ref values, (uint)i);
+                    ref T second = ref Unsafe.Add(ref values, (uint)j);
                     T temp = first;
                     first = second;
                     second = temp;

--- a/src/libraries/System.Private.CoreLib/src/System/Random.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Random.cs
@@ -294,7 +294,7 @@ namespace System
         public void Shuffle<T>(T[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
-            Shuffle(values.AsSpan());
+            Shuffle(ref MemoryMarshal.GetArrayDataReference(values), values.Length);
         }
 
         /// <summary>
@@ -308,17 +308,24 @@ namespace System
         /// </remarks>
         public void Shuffle<T>(Span<T> values)
         {
-            int n = values.Length;
+            Shuffle(ref MemoryMarshal.GetReference(values), values.Length);
+        }
 
+        private void Shuffle<T>(ref T values, int n)
+        {
             for (int i = 0; i < n - 1; i++)
             {
                 int j = Next(i, n);
+                Debug.Assert((uint)i < (uint)n, $"Shuffle first index {i} out of range (max {n - 1})!");
+                Debug.Assert((uint)j < (uint)n, $"Shuffle second index {j} out of range (max {n - 1})!");
 
                 if (j != i)
                 {
-                    T temp = values[i];
-                    values[i] = values[j];
-                    values[j] = temp;
+                    ref T first = Unsafe.Add(ref values, (uint)i);
+                    ref T second = Unsafe.Add(ref values, (uint)j);
+                    T temp = first;
+                    first = second;
+                    second = temp;
                 }
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
@@ -734,7 +734,7 @@ namespace System.Tests
 			string[] items = ["", ""];
 			object[] array = items;
             random.Shuffle(array);
-            AssertExtensions.SequenceEqual((ReadOnlySpan<T>)["", ""], items);
+            AssertExtensions.SequenceEqual((ReadOnlySpan<string>)["", ""], items);
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
@@ -728,6 +728,16 @@ namespace System.Tests
         }
 
         [Fact]
+        public static void Shuffle_Array_Covariance()
+        {
+            Random random = new Random(0x70636A61);
+			string[] items = ["", ""];
+			object[] array = items;
+            random.Shuffle(array);
+            AssertExtensions.SequenceEqual(["", ""], items);
+        }
+
+        [Fact]
         public static void Shuffle_Array_ArgValidation()
         {
             Random random = new Random(0x70636A61);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Random.cs
@@ -734,7 +734,7 @@ namespace System.Tests
 			string[] items = ["", ""];
 			object[] array = items;
             random.Shuffle(array);
-            AssertExtensions.SequenceEqual(["", ""], items);
+            AssertExtensions.SequenceEqual((ReadOnlySpan<T>)["", ""], items);
         }
 
         [Fact]


### PR DESCRIPTION
Made both overloads use an internal version that works on refs without checking covariance.

Fixes #98470.