### PR TITLE
[NativeAOT] Fix exceptions thrown by LDiv/LMod helpers

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/MathHelpers.cs
@@ -164,6 +164,8 @@ namespace Internal.Runtime.CompilerHelpers
         {
             if (j == 0)
                 return ThrowLngDivByZero();
+            else if (j == -1 && i == long.MinValue)
+                return ThrowLngOvf();
             else
                 return RhpLMod(i, j);
         }
@@ -189,7 +191,7 @@ namespace Internal.Runtime.CompilerHelpers
             if (j == 0)
                 return ThrowLngDivByZero();
             else if (j == -1 && i == long.MinValue)
-                return ThrowLngArithExc();
+                return ThrowLngOvf();
             else
                 return RhpLDiv(i, j);
         }
@@ -204,12 +206,6 @@ namespace Internal.Runtime.CompilerHelpers
         private static ulong ThrowULngDivByZero()
         {
             throw new DivideByZeroException();
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static long ThrowLngArithExc()
-        {
-            throw new ArithmeticException();
         }
 #endif // TARGET_64BIT
 


### PR DESCRIPTION
Fixes the following Pri0 tests:
- JIT/CodeGenBringUpTests/DivConst_d/DivConst_d.dll
- JIT/CodeGenBringUpTests/DivConst_do/DivConst_do.dll
- JIT/CodeGenBringUpTests/DivConst_r/DivConst_r.dll
- JIT/CodeGenBringUpTests/DivConst_ro/DivConst_ro.dll
- JIT/CodeGenBringUpTests/ModConst_d/ModConst_d.dll
- JIT/CodeGenBringUpTests/ModConst_do/ModConst_do.dll
- JIT/CodeGenBringUpTests/ModConst_r/ModConst_r.dll
- JIT/CodeGenBringUpTests/ModConst_ro/ModConst_ro.dll
- JIT/IL_Conformance/Old/Conformance_Base/rem_i8/rem_i8.dll
- JIT/jit64/regress/vsw/543645/test_543645/test_543645.dll

Contributes to #97729
