### PR TITLE
[NativeAOT] Fix shift math helpers to mask the shift operand

### DIFF
--- a/src/coreclr/nativeaot/Runtime/MathHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MathHelpers.cpp
@@ -139,17 +139,17 @@ EXTERN_C NATIVEAOT_API uint64_t REDHAWK_CALLCONV RhpULMul(uint64_t i, uint64_t j
 
 EXTERN_C NATIVEAOT_API uint64_t REDHAWK_CALLCONV RhpLRsz(uint64_t i, int32_t j)
 {
-    return i >> j;
+    return i >> (j & 0x3f);
 }
 
 EXTERN_C NATIVEAOT_API int64_t REDHAWK_CALLCONV RhpLRsh(int64_t i, int32_t j)
 {
-    return i >> j;
+    return i >> (j & 0x3f);
 }
 
 EXTERN_C NATIVEAOT_API int64_t REDHAWK_CALLCONV RhpLLsh(int64_t i, int32_t j)
 {
-    return i << j;
+    return i << (j & 0x3f);
 }
 
 EXTERN_C NATIVEAOT_API int64_t REDHAWK_CALLCONV RhpDbl2Lng(double val)


### PR DESCRIPTION
Match the JIT code:
https://github.com/dotnet/runtime/blob/988958fec561240b665b28913dfadd8c14f5fb43/src/coreclr/vm/jithelpers.cpp#L455-L475

Fixes following Pri0 tests on arm32:
- JIT/Regression/JitBlue/GitHub_15291
- JIT/Regression/JitBlue/GitHub_15949