### PR TITLE
[RISC-V] Remove unnecessary assertion from emitOutputInstr

### DIFF
--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2118,8 +2118,8 @@ AGAIN:
 unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code) const
 {
     assert(dst != nullptr);
-    assert(sizeof(code_t) == 4);
-    memcpy(dst + writeableOffset, &code, sizeof(code_t));
+    static_assert(sizeof(code_t) == 4, "code_t must be 4 bytes");
+    *(code_t*)(dst + writeableOffset) = code;
     return sizeof(code_t);
 }
 
@@ -3157,7 +3157,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     instruction       ins;
     size_t            sz = 0;
 
-    assert(REG_NA == static_cast<int>(REG_NA));
+    static_assert(REG_NA == static_cast<int>(REG_NA), "REG_NA must fit in an int");
 
     insOpts insOp = id->idInsOpt();
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -3158,7 +3158,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     size_t            sz = 0;
 
     assert(REG_NA == static_cast<int>(REG_NA));
-    assert(writeableOffset == 0);
 
     insOpts insOp = id->idInsOpt();
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2119,7 +2119,7 @@ unsigned emitter::emitOutput_Instr(BYTE* dst, code_t code) const
 {
     assert(dst != nullptr);
     static_assert(sizeof(code_t) == 4, "code_t must be 4 bytes");
-    *(code_t*)(dst + writeableOffset) = code;
+    memcpy(dst + writeableOffset, &code, sizeof(code));
     return sizeof(code_t);
 }
 


### PR DESCRIPTION
Remove unnecessary assertion introduced in #98226. It fired a false positive when W^X was enabled.

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @Bajtazar @bartlomiejko