### PR TITLE
More precise writebarrier for regions

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
@@ -400,6 +400,9 @@ EXTERN g_highest_address    : QWORD
 EXTERN g_ephemeral_low      : QWORD
 EXTERN g_ephemeral_high     : QWORD
 EXTERN g_card_table         : QWORD
+EXTERN g_region_shr         : BYTE
+EXTERN g_region_use_bitwise_write_barrier : BYTE
+EXTERN g_region_to_generation_table       : QWORD
 
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
 EXTERN g_card_bundle_table  : QWORD

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -415,6 +415,9 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
         assert(args->ephemeral_high != nullptr);
         g_ephemeral_low = args->ephemeral_low;
         g_ephemeral_high = args->ephemeral_high;
+        g_region_to_generation_table = args->region_to_generation_table;
+        g_region_shr = args->region_shr;
+        g_region_use_bitwise_write_barrier = args->region_use_bitwise_write_barrier;
         return;
     case WriteBarrierOp::Initialize:
         // This operation should only be invoked once, upon initialization.
@@ -442,6 +445,9 @@ void GCToEEInterface::StompWriteBarrier(WriteBarrierParameters* args)
 
         g_lowest_address = args->lowest_address;
         g_highest_address = args->highest_address;
+        g_region_to_generation_table = args->region_to_generation_table;
+        g_region_shr = args->region_shr;
+        g_region_use_bitwise_write_barrier = args->region_use_bitwise_write_barrier;
         g_ephemeral_low = args->ephemeral_low;
         g_ephemeral_high = args->ephemeral_high;
         return;

--- a/src/coreclr/nativeaot/Runtime/gcheaputilities.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcheaputilities.cpp
@@ -21,6 +21,9 @@ GPTR_IMPL_INIT(uint8_t,  g_highest_address, nullptr);
 GVAL_IMPL_INIT(GCHeapType, g_heap_type,     GC_HEAP_INVALID);
 uint8_t* g_ephemeral_low  = (uint8_t*)1;
 uint8_t* g_ephemeral_high = (uint8_t*)~0;
+uint8_t* g_region_to_generation_table = nullptr;
+uint8_t  g_region_shr = 0;
+bool g_region_use_bitwise_write_barrier = false;
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
 uint32_t* g_card_bundle_table = nullptr;

--- a/src/coreclr/nativeaot/Runtime/gcheaputilities.h
+++ b/src/coreclr/nativeaot/Runtime/gcheaputilities.h
@@ -27,6 +27,9 @@ extern "C" uint32_t* g_card_bundle_table;
 
 extern "C" uint8_t* g_ephemeral_low;
 extern "C" uint8_t* g_ephemeral_high;
+extern "C" uint8_t* g_region_to_generation_table;
+extern "C" uint8_t  g_region_shr;
+extern "C" bool     g_region_use_bitwise_write_barrier;
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 extern "C" bool g_sw_ww_enabled_for_gc_heap;


### PR DESCRIPTION
Port of #67389 to Native AOT.

Adds additional checks to write barriers so that the GC can do less work. Write barriers get slower with the expectation that we'll recoup the time during garbage collections.

Was hoping to see similar gains as https://github.com/dotnet/runtime/pull/67389#issuecomment-1240955293 for our self-hosted ILC, but wallclock time got maybe 1% worse instead. However GC stats in Perfview look much better:

Before:

* Total CPU Time: 33,478 msec
* Total GC CPU Time: 585 msec
* Total Allocs : 776.721 MB
* Number of Heaps: 16
* GC CPU MSec/MB Alloc : 0.753 MSec/MB
* Total GC Pause: 207.7 msec
* % Time paused for Garbage Collection: 2.4%
* % CPU Time spent Garbage Collecting: 1.7%

After:

* Total CPU Time: 33,348 msec
* Total GC CPU Time: 179 msec
* Total Allocs : 771.313 MB
* Number of Heaps: 16
* GC CPU MSec/MB Alloc : 0.232 MSec/MB
* Total GC Pause: 195.8 msec
* % Time paused for Garbage Collection: 2.3%
* % CPU Time spent Garbage Collecting: 0.5%

Opening as a draft because maybe we can do something to make these not as expensive (CoreCLR seems to have lots of tricks up its sleeve). We also need the Linux version.

Cc @dotnet/ilc-contrib 