### PR TITLE
[release/8.0-staging] Update diasymreader to 17.8.7-beta1.24113.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
     <optimizationlinuxarm64MIBCRuntimeVersion>1.0.0-prerelease.23566.3</optimizationlinuxarm64MIBCRuntimeVersion>
     <optimizationPGOCoreCLRVersion>1.0.0-prerelease.23566.3</optimizationPGOCoreCLRVersion>
     <!-- Not auto-updated. -->
-    <MicrosoftDiaSymReaderNativeVersion>16.11.29-beta1.23404.4</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>17.8.7-beta1.24113.1</MicrosoftDiaSymReaderNativeVersion>
     <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
     <TraceEventVersion>3.0.3</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>


### PR DESCRIPTION
Update version of diasymreader to 17.8.7-beta1.24113.1

## Customer Impact

This comes from a request of the Roslyn team as newer reader is needed to emit toolset information into debug streams. This aligns the toolset with best practices for supply chain and is needed for LTS use of the toolchain. 

## Regression

- [ ] Yes
- [x] No

## Testing

- The scenarios called out in the risks section have limited test in automation. Some scenarios are currently being manually tested.

## Risk

Moderate. The following areas use this library:

- NativeAOT classic PDB generation. R2R ni PDB generation.
- Roslyn generation of portable PDBs. 
- Uncommon JIT path where explicit sequence points are requested explicitly from the PDB.
- Exception.ToString.