### PR TITLE
Remove exclusion for a fixed test

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1012,9 +1012,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/ContextualReflection/ContextualReflection/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/Modifiers/modifiers/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/201</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/200</Issue>
         </ExcludeList>


### PR DESCRIPTION
I think I fixed this.

Fixes dotnet/runtimelab#201.

Cc @dotnet/ilc-contrib 