### PR TITLE
Prevent incorrect constant folding

### DIFF
--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4421,6 +4421,11 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_RSZ:
             case GT_ROL:
             case GT_ROR:
+               if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                {
+                    return false;
+                }
+                break;
 
             case GT_GT:
             case GT_GE:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4421,17 +4421,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_RSZ:
             case GT_ROL:
             case GT_ROR:
-                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
-                {
-                    return false;
-                }
-                break;
-
-            case GT_GT:
-            case GT_GE:
-            case GT_LT:
-            case GT_LE:
-                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) || (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
+                if (m_pComp->opts.compReloc && (IsVNHandle(arg0VN) || IsVNHandle(arg1VN)))
                 {
                     return false;
                 }
@@ -4439,10 +4429,10 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
 
             case GT_EQ:
             case GT_NE:
-                if ((IsVNHandle(arg0VN) || arg0VN == VNForNull()) != (IsVNHandle(arg1VN) || arg1VN == VNForNull()))
-                {
-                    return false;
-                }
+            case GT_GT:
+            case GT_GE:
+            case GT_LT:
+            case GT_LE:
                 break;
 
             default:
@@ -4457,11 +4447,6 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case VNF_GE_UN:
             case VNF_LT_UN:
             case VNF_LE_UN:
-                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) || (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
-                {
-                    return false;
-                }
-                break;
 
             case VNF_ADD_OVF:
             case VNF_SUB_OVF:
@@ -4469,7 +4454,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case VNF_ADD_UN_OVF:
             case VNF_SUB_UN_OVF:
             case VNF_MUL_UN_OVF:
-                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                if (m_pComp->opts.compReloc && (IsVNHandle(arg0VN) || IsVNHandle(arg1VN)))
                 {
                     return false;
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4422,12 +4422,22 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_ROL:
             case GT_ROR:
 
-            case GT_EQ:
-            case GT_NE:
             case GT_GT:
             case GT_GE:
             case GT_LT:
             case GT_LE:
+                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                {
+                    return false;
+                }
+                break;
+
+            case GT_EQ:
+            case GT_NE:
+                if (IsVNHandle(arg0VN) != IsVNHandle(arg1VN))
+                {
+                    return false;
+                }
                 break;
 
             default:
@@ -4449,6 +4459,11 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case VNF_ADD_UN_OVF:
             case VNF_SUB_UN_OVF:
             case VNF_MUL_UN_OVF:
+                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                {
+                    return false;
+                }
+                break;
 
             case VNF_Cast:
             case VNF_CastOvf:

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4421,7 +4421,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_RSZ:
             case GT_ROL:
             case GT_ROR:
-               if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
                 {
                     return false;
                 }
@@ -4431,8 +4431,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_GE:
             case GT_LT:
             case GT_LE:
-                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) ||
-                    (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
+                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) || (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
                 {
                     return false;
                 }
@@ -4440,8 +4439,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
 
             case GT_EQ:
             case GT_NE:
-                if ((IsVNHandle(arg0VN) || arg0VN == VNForNull()) !=
-                    (IsVNHandle(arg1VN) || arg1VN == VNForNull()))
+                if ((IsVNHandle(arg0VN) || arg0VN == VNForNull()) != (IsVNHandle(arg1VN) || arg1VN == VNForNull()))
                 {
                     return false;
                 }
@@ -4459,8 +4457,7 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case VNF_GE_UN:
             case VNF_LT_UN:
             case VNF_LE_UN:
-                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) ||
-                    (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
+                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) || (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
                 {
                     return false;
                 }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -4426,7 +4426,8 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case GT_GE:
             case GT_LT:
             case GT_LE:
-                if (IsVNHandle(arg0VN) || IsVNHandle(arg1VN))
+                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) ||
+                    (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
                 {
                     return false;
                 }
@@ -4434,7 +4435,8 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
 
             case GT_EQ:
             case GT_NE:
-                if (IsVNHandle(arg0VN) != IsVNHandle(arg1VN))
+                if ((IsVNHandle(arg0VN) || arg0VN == VNForNull()) !=
+                    (IsVNHandle(arg1VN) || arg1VN == VNForNull()))
                 {
                     return false;
                 }
@@ -4452,6 +4454,12 @@ bool ValueNumStore::VNEvalCanFoldBinaryFunc(var_types type, VNFunc func, ValueNu
             case VNF_GE_UN:
             case VNF_LT_UN:
             case VNF_LE_UN:
+                if ((IsVNHandle(arg0VN) && arg1VN != VNForNull()) ||
+                    (IsVNHandle(arg1VN) && arg0VN != VNForNull()))
+                {
+                    return false;
+                }
+                break;
 
             case VNF_ADD_OVF:
             case VNF_SUB_OVF:


### PR DESCRIPTION
Prevent incorrect constant folding of arithmetic operations involving handle in relocatable code.

Fixes #98493