### PR TITLE
Add missing type name parsing test coverage

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -375,6 +375,63 @@ namespace System.Reflection.Tests
                 Assert.Null(Type.GetType($"System.\\{character}", throwOnError: false));
             }
         }
+
+        public static IEnumerable<object[]> AllWhitespacesArguments()
+        {
+            // leading whitespaces are allowed for type names:
+            yield return new object[]
+            {
+                " \t\r\nSystem.Int32",
+                typeof(int)
+            };
+            yield return new object[]
+            {
+                $"System.Collections.Generic.List`1[\r\n\t [\t\r\n {typeof(int).AssemblyQualifiedName}]], {typeof(List<>).Assembly.FullName}",
+                typeof(List<int>)
+            };
+            yield return new object[]
+            {
+                $"System.Collections.Generic.List`1[\r\n\t{typeof(int).FullName}]",
+                typeof(List<int>)
+            };
+            // leading whitespaces are NOT allowed for modifiers:
+            yield return new object[]
+            {
+                "System.Int32\t\r\n []",
+                null
+            };
+            yield return new object[]
+            {
+                "System.Int32\r\n\t [,]",
+                null
+            };
+            yield return new object[]
+            {
+                "System.Int32 \r\n\t [*]",
+                null
+            };
+            yield return new object[]
+            {
+                "System.Int32 *",
+                null
+            };
+            yield return new object[]
+            {
+                "System.Int32\t&",
+                null
+            };
+            // trailing whitespaces are NOT allowed:
+            yield return new object[]
+            {
+                $"System.Int32 \t\r\n",
+                null
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(AllWhitespacesArguments))]
+        public void AllWhitespaces(string input, Type? expectedType)
+            => Assert.Equal(expectedType, Type.GetType(input));
     }
 
     namespace MyNamespace1

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -355,6 +355,26 @@ namespace System.Reflection.Tests
             Assert.Equal(type, assembly.GetType(type.FullName.ToLower(), throwOnError: true, ignoreCase: true));
             Assert.Equal(type, assembly.GetType(type.FullName.ToUpper(), throwOnError: true, ignoreCase: true));
         }
+
+        [Fact]
+        public void EscapingCharacterThatDoesNotRequireEscapingIsTreatedAsError()
+        {
+            for (char character = (char)0; character <= 255; character++)
+            {
+                Func<Type> testCode = () => Type.GetType($"System.\\{character}", throwOnError: true);
+
+                if (character is '\\' or '[' or ']' or '+' or '*' or '&' or ',')
+                {
+                    Assert.Throws<TypeLoadException>(testCode); // such type does not exist
+                }
+                else
+                {
+                    Assert.Throws<ArgumentException>(testCode); // such name is invalid
+                }
+
+                Assert.Null(Type.GetType($"System.\\{character}", throwOnError: false));
+            }
+        }
     }
 
     namespace MyNamespace1

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -297,6 +297,26 @@ namespace System.Reflection.Tests
             args = new object[1] { Activator.CreateInstance(otherEquivalentValueType) };
             Assert.Equal(42, mi.Invoke(null, args));
         }
+
+        [Fact]
+        public void IgnoreLeadingDotForTypeNamesWithoutNamespace()
+        {
+            Type typeWithNoNamespace = typeof(NoNamespace);
+
+            Assert.Equal(typeWithNoNamespace, Type.GetType($".{typeWithNoNamespace.AssemblyQualifiedName}"));
+            Assert.Equal(typeWithNoNamespace, Type.GetType(typeWithNoNamespace.AssemblyQualifiedName));
+
+            Assert.Equal(typeWithNoNamespace, typeWithNoNamespace.Assembly.GetType($".{typeWithNoNamespace.FullName}"));
+            Assert.Equal(typeWithNoNamespace, typeWithNoNamespace.Assembly.GetType(typeWithNoNamespace.FullName));
+
+            Assert.Equal(typeof(List<NoNamespace>), Type.GetType($"{typeof(List<>).FullName}[[{typeWithNoNamespace.AssemblyQualifiedName}]]"));
+            Assert.Equal(typeof(List<NoNamespace>), Type.GetType($"{typeof(List<>).FullName}[[.{typeWithNoNamespace.AssemblyQualifiedName}]]"));
+
+            Type typeWithNamespace = typeof(int);
+
+            Assert.Equal(typeWithNamespace, Type.GetType(typeWithNamespace.AssemblyQualifiedName));
+            Assert.Null(Type.GetType($".{typeWithNamespace.AssemblyQualifiedName}"));
+        }
     }
 
     namespace MyNamespace1
@@ -351,4 +371,9 @@ namespace System.Reflection.Tests
     public class MyClass1 { }
 
     public class GenericClass<T> { }
+}
+
+public class NoNamespace
+{
+
 }

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/GetTypeTests.cs
@@ -346,6 +346,7 @@ namespace System.Reflection.Tests
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45033", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime))]
         [MemberData(nameof(GetTypesThatRequireEscaping))]
         public void TypeNamesThatRequireEscaping(Type type, Assembly assembly)
         {
@@ -357,6 +358,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45033", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime))]
         public void EscapingCharacterThatDoesNotRequireEscapingIsTreatedAsError()
         {
             for (char character = (char)0; character <= 255; character++)
@@ -429,6 +431,7 @@ namespace System.Reflection.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/45033", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoRuntime))]
         [MemberData(nameof(AllWhitespacesArguments))]
         public void AllWhitespaces(string input, Type? expectedType)
             => Assert.Equal(expectedType, Type.GetType(input));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -525,6 +525,7 @@ namespace System.Tests
             yield return new object[] { "System.Int32&[*]", expectedException, true };
             yield return new object[] { "System.Int32&[,]", expectedException, true };
 
+            // https://github.com/dotnet/runtime/issues/45033
             if (!PlatformDetection.IsMonoRuntime)
             {
                 yield return new object[] { "System.Void[]", expectedException, true };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -513,7 +513,7 @@ namespace System.Tests
             Assert.Equal(expectedType, Type.GetType(typeName.ToLower(), throwOnError: false, ignoreCase: true));
         }
 
-        public static IEnumerable<object[]> GetTypeByName_Invalid_ClrArguments()
+        public static IEnumerable<object[]> GetTypeByName_InvalidElementType()
         {
             Type expectedException = PlatformDetection.IsMonoRuntime
                 ? typeof(ArgumentException) // https://github.com/dotnet/runtime/issues/45033
@@ -524,6 +524,8 @@ namespace System.Tests
             yield return new object[] { "System.Int32&[]", expectedException, true };
             yield return new object[] { "System.Int32&[*]", expectedException, true };
             yield return new object[] { "System.Int32&[,]", expectedException, true };
+            yield return new object[] { "System.Void[]", expectedException, true };
+            yield return new object[] { "System.TypedReference[]", expectedException, true };
         }
 
         [Theory]
@@ -535,7 +537,7 @@ namespace System.Tests
         [InlineData("Outside`1[System.Boolean, System.Int32]", typeof(ArgumentException), true)]
         [InlineData(".System.Int32", typeof(TypeLoadException), false)]
         [InlineData("..Outside`1", typeof(TypeLoadException), false)]
-        [MemberData(nameof(GetTypeByName_Invalid_ClrArguments))]
+        [MemberData(nameof(GetTypeByName_InvalidElementType))]
         public void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)
         {
             if (!alwaysThrowsException)

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -524,8 +524,12 @@ namespace System.Tests
             yield return new object[] { "System.Int32&[]", expectedException, true };
             yield return new object[] { "System.Int32&[*]", expectedException, true };
             yield return new object[] { "System.Int32&[,]", expectedException, true };
-            yield return new object[] { "System.Void[]", expectedException, true };
-            yield return new object[] { "System.TypedReference[]", expectedException, true };
+
+            if (!PlatformDetection.IsMonoRuntime)
+            {
+                yield return new object[] { "System.Void[]", expectedException, true };
+                yield return new object[] { "System.TypedReference[]", expectedException, true };
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -522,6 +522,11 @@ namespace System.Tests
         [InlineData("Outside`1[System.Boolean, System.Int32]", typeof(ArgumentException), true)]
         [InlineData(".System.Int32", typeof(TypeLoadException), false)]
         [InlineData("..Outside`1", typeof(TypeLoadException), false)]
+        [InlineData("System.Int32&&", typeof(TypeLoadException), false)]
+        [InlineData("System.Int32&*", typeof(TypeLoadException), false)]
+        [InlineData("System.Int32&[]", typeof(TypeLoadException), false)]
+        [InlineData("System.Int32&[*]", typeof(TypeLoadException), false)]
+        [InlineData("System.Int32&[,]", typeof(TypeLoadException), false)]
         public void GetTypeByName_Invalid(string typeName, Type expectedException, bool alwaysThrowsException)
         {
             if (!alwaysThrowsException)


### PR DESCRIPTION
While working on the new Type Name Parser API (#97566) I've discovered some testing gaps.

Namely:

1. Reporting parse error for a backslash that was used to escape a character that is not legal to escape inside a type name: https://github.com/dotnet/runtime/blob/7185df8eda6c25d101170a2809094adc9f493b51/src/libraries/Common/src/System/Reflection/TypeNameParser.cs#L326-L331
2. Ignore leading '.' for type names without namespace:
https://github.com/dotnet/runtime/blob/7185df8eda6c25d101170a2809094adc9f493b51/src/libraries/Common/src/System/Reflection/TypeNameParser.cs#L200-L207
3. Supporting all kinds of leading whitespaces (existing test use only ` ` (space character)):
https://github.com/dotnet/runtime/blob/7185df8eda6c25d101170a2809094adc9f493b51/src/libraries/Common/src/System/Reflection/TypeNameParser.cs#L439-L450
4. Type names with escape characters in their name (illegal for C# and F#, but valid for IL)
https://github.com/dotnet/runtime/blob/7185df8eda6c25d101170a2809094adc9f493b51/src/libraries/Common/src/System/Reflection/TypeNameParser.cs#L628-L631
cc @GrabYourPitchforks @jeffhandley 