### PR TITLE
[browser][MT] JSType.OneWay fire and forget

### DIFF
--- a/docs/workflow/debugging/mono/wasm-debugging.md
+++ b/docs/workflow/debugging/mono/wasm-debugging.md
@@ -180,8 +180,8 @@ $func166 @ dotnet.wasm:0xba0a
 $func2810 @ dotnet.wasm:0xabacf
 $func1615 @ dotnet.wasm:0x6f8eb
 $func1619 @ dotnet.wasm:0x6ff58
-$mono_wasm_invoke_method @ dotnet.wasm:0x96c9
-Module._mono_wasm_invoke_method @ dotnet.6.0.1.hopd7ipo8x.js:1
+$mono_wasm_invoke_jsexport @ dotnet.wasm:0x96c9
+Module.mono_wasm_invoke_jsexport @ dotnet.6.0.1.hopd7ipo8x.js:1
 managed__Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_BeginInvokeDotNet @ managed__Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_BeginInvokeDotNet:19
 beginInvokeDotNetFromJS @ blazor.webassembly.js:1
 b @ blazor.webassembly.js:1
@@ -244,8 +244,8 @@ $mono_jit_runtime_invoke @ dotnet.wasm:0x1dec32
 $do_runtime_invoke @ dotnet.wasm:0x95fca
 $mono_runtime_try_invoke @ dotnet.wasm:0x966fe
 $mono_runtime_invoke @ dotnet.wasm:0x98982
-$mono_wasm_invoke_method @ dotnet.wasm:0x227de2
-Module._mono_wasm_invoke_method @ dotnet..y6ggkhlo8e.js:9927
+$mono_wasm_invoke_jsexport @ dotnet.wasm:0x227de2
+Module.mono_wasm_invoke_jsexport @ dotnet..y6ggkhlo8e.js:9927
 managed__Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_BeginInvokeDotNet @ managed__Microsoft_AspNetCore_Components_WebAssembly__Microsoft_AspNetCore_Components_WebAssembly_Services_DefaultWebAssemblyJSRuntime_BeginInvokeDotNet:19
 beginInvokeDotNetFromJS @ blazor.webassembly.js:1
 b @ blazor.webassembly.js:1

--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -47,11 +47,11 @@ internal static partial class Interop
         public static extern void UninstallWebWorkerInterop();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void InvokeJSImportSync(nint data, nint signature);
+        public static extern void InvokeJSImportSync(nint signature, nint args);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void InvokeJSImportSyncSend(nint targetNativeTID, nint data, nint signature);
+        public static extern void InvokeJSImportSyncSend(nint targetNativeTID, nint signature, nint args);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void InvokeJSImportAsyncPost(nint targetNativeTID, nint data, nint signature);
+        public static extern void InvokeJSImportAsyncPost(nint targetNativeTID, nint signature, nint args);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void CancelPromise(nint taskHolderGCHandle);
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -60,7 +60,7 @@ internal static partial class Interop
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern unsafe void BindJSImport(void* signature, out int is_exception, out object result);
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern void InvokeJSImport(int importHandle, nint data);
+        public static extern void InvokeJSImportST(int importHandle, nint args);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void CancelPromise(nint gcHandle);
 #endif

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSGeneratorFactory.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSGeneratorFactory.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Interop.JavaScript
                     return ResolvedGenerator.NotSupported(new(info, context));
 
                 // void
+                case { TypeInfo: JSSimpleTypeInfo(KnownManagedType.Void), JSType: JSTypeFlags.OneWay }:
+                    return ResolvedGenerator.Resolved(new VoidGenerator(MarshalerType.OneWay));
                 case { TypeInfo: JSSimpleTypeInfo(KnownManagedType.Void), JSType: JSTypeFlags.Discard }:
                 case { TypeInfo: JSSimpleTypeInfo(KnownManagedType.Void), JSType: JSTypeFlags.Void }:
                 case { TypeInfo: JSSimpleTypeInfo(KnownManagedType.Void), JSType: JSTypeFlags.None }:
@@ -51,6 +53,10 @@ namespace Microsoft.Interop.JavaScript
                 // discard no void
                 case { JSType: JSTypeFlags.Discard }:
                     return fail(SR.DiscardOnlyVoid);
+
+                // oneway no void
+                case { JSType: JSTypeFlags.OneWay }:
+                    return fail(SR.OneWayOnlyVoid);
 
                 // primitive
                 case { TypeInfo: JSSimpleTypeInfo simple }:

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSTypeFlags.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/JSTypeFlags.cs
@@ -22,6 +22,7 @@ namespace System.Runtime.InteropServices.JavaScript
         MemoryView = 0x800,
         Any = 0x1000,
         Discard = 0x2000,
+        OneWay = 0x4000,
         Missing = 0x4000_0000,
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Resources/Strings.resx
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/gen/JSImportGenerator/Resources/Strings.resx
@@ -184,6 +184,9 @@
   <data name="DiscardOnlyVoid" xml:space="preserve">
     <value>'JSType.Discard' could be only used with void return argument.</value>
   </data>
+  <data name="OneWayOnlyVoid" xml:space="preserve">
+    <value>'JSType.OneWay' could be only used with void returning method.</value>
+  </data>
   <data name="FuncArgumentNotSupported" xml:space="preserve">
     <value>Type {0} is not supported as argument of marshaled function.</value>
     <comment>{0} is a type of the argument</comment>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/CompatibilitySuppressions.xml
@@ -12,4 +12,16 @@
     <Left>ref/net9.0/System.Runtime.InteropServices.JavaScript.dll</Left>
     <Right>runtimes/browser/lib/net9.0/System.Runtime.InteropServices.JavaScript.dll</Right>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:System.Runtime.InteropServices.JavaScript.JSType.OneWay</Target>
+    <Left>ref/net9.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net9.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:System.Runtime.InteropServices.JavaScript.JSMarshalerType.get_OneWay</Target>
+    <Left>ref/net9.0/System.Runtime.InteropServices.JavaScript.dll</Left>
+    <Right>runtimes/browser/lib/net9.0/System.Runtime.InteropServices.JavaScript.dll</Right>
+  </Suppression>
 </Suppressions>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -28,6 +30,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if FEATURE_WASM_MANAGED_THREADS
                 // when we arrive here, we are on the thread which owns the proxies
                 arg_exc.AssertCurrentThreadContext();
+                Debug.Assert(arg_result.slot.Type == MarshalerType.TaskPreCreated);
 #endif
 
                 arg_1.ToManaged(out IntPtr assemblyNamePtr);
@@ -47,6 +50,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
+        // the marshaled signature is: void LoadLazyAssembly(byte[] dll, byte[] pdb)
         public static void LoadLazyAssembly(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0];
@@ -70,6 +74,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
+        // the marshaled signature is: void LoadSatelliteAssembly(byte[] dll)
         public static void LoadSatelliteAssembly(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0];
@@ -91,10 +96,8 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        // The JS layer invokes this method when the JS wrapper for a JS owned object
-        //  has been collected by the JS garbage collector
-        // the marshaled signature is:
-        // void ReleaseJSOwnedObjectByGCHandle(GCHandle gcHandle)
+        // The JS layer invokes this method when the JS wrapper for a JS owned object has been collected by the JS garbage collector
+        // the marshaled signature is: void ReleaseJSOwnedObjectByGCHandle(GCHandle gcHandle)
         public static void ReleaseJSOwnedObjectByGCHandle(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -16,12 +16,11 @@ namespace System.Runtime.InteropServices.JavaScript
     // TODO: all the calls here should be running on deputy or TP in MT, not in UI thread
     internal static unsafe partial class JavaScriptExports
     {
-        // the marshaled signature is:
-        // Task<int>? CallEntrypoint(char* assemblyNamePtr, string[] args)
+        // the marshaled signature is: Task<int>? CallEntrypoint(char* assemblyNamePtr, string[] args)
         public static void CallEntrypoint(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
-            ref JSMarshalerArgument arg_result = ref arguments_buffer[1]; // initialized by caller in alloc_stack_frame()
+            ref JSMarshalerArgument arg_res = ref arguments_buffer[1]; // initialized by caller in alloc_stack_frame()
             ref JSMarshalerArgument arg_1 = ref arguments_buffer[2]; // initialized and set by caller
             ref JSMarshalerArgument arg_2 = ref arguments_buffer[3]; // initialized and set by caller
             ref JSMarshalerArgument arg_3 = ref arguments_buffer[4]; // initialized and set by caller
@@ -30,7 +29,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if FEATURE_WASM_MANAGED_THREADS
                 // when we arrive here, we are on the thread which owns the proxies
                 arg_exc.AssertCurrentThreadContext();
-                Debug.Assert(arg_result.slot.Type == MarshalerType.TaskPreCreated);
+                Debug.Assert(arg_res.slot.Type == MarshalerType.TaskPreCreated);
 #endif
 
                 arg_1.ToManaged(out IntPtr assemblyNamePtr);
@@ -39,7 +38,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
                 Task<int>? result = JSHostImplementation.CallEntrypoint(assemblyNamePtr, args, waitForDebugger);
 
-                arg_result.ToJS(result, (ref JSMarshalerArgument arg, int value) =>
+                arg_res.ToJS(result, (ref JSMarshalerArgument arg, int value) =>
                 {
                     arg.ToJS(value);
                 });
@@ -115,8 +114,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        // the marshaled signature is:
-        // TRes? CallDelegate<T1,T2,T3TRes>(GCHandle callback, T1? arg1, T2? arg2, T3? arg3)
+        // the marshaled signature is: TRes? CallDelegate<T1,T2,T3TRes>(GCHandle callback, T1? arg1, T2? arg2, T3? arg3)
         public static void CallDelegate(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by JS caller in alloc_stack_frame()
@@ -152,8 +150,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        // the marshaled signature is:
-        // void CompleteTask<T>(GCHandle holder, Exception? exceptionResult, T? result)
+        // the marshaled signature is: void CompleteTask<T>(GCHandle holder, Exception? exceptionResult, T? result)
         public static void CompleteTask(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
@@ -212,12 +209,11 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        // the marshaled signature is:
-        // string GetManagedStackTrace(GCHandle exception)
+        // the marshaled signature is: string GetManagedStackTrace(GCHandle exception)
         public static void GetManagedStackTrace(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
-            ref JSMarshalerArgument arg_return = ref arguments_buffer[1]; // used as return value
+            ref JSMarshalerArgument arg_res = ref arguments_buffer[1]; // used as return value
             ref JSMarshalerArgument arg_1 = ref arguments_buffer[2];// initialized and set by caller
             try
             {
@@ -227,7 +223,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 GCHandle exception_gc_handle = (GCHandle)arg_1.slot.GCHandle;
                 if (exception_gc_handle.Target is Exception exception)
                 {
-                    arg_return.ToJS(exception.StackTrace);
+                    arg_res.ToJS(exception.StackTrace);
                 }
                 else
                 {
@@ -244,19 +240,18 @@ namespace System.Runtime.InteropServices.JavaScript
 
         // this is here temporarily, until JSWebWorker becomes public API
         [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicMethods, "System.Runtime.InteropServices.JavaScript.JSWebWorker", "System.Runtime.InteropServices.JavaScript")]
-        // the marshaled signature is:
-        // void InstallMainSynchronizationContext(nint jsNativeTID, out GCHandle contextHandle)
+        // the marshaled signature is: GCHandle InstallMainSynchronizationContext(nint jsNativeTID)
         public static void InstallMainSynchronizationContext(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
+            ref JSMarshalerArgument arg_res = ref arguments_buffer[1];// initialized and set by caller
             ref JSMarshalerArgument arg_1 = ref arguments_buffer[2];// initialized and set by caller
-            ref JSMarshalerArgument arg_2 = ref arguments_buffer[3];// initialized and set by caller
 
             try
             {
                 var jsSynchronizationContext = JSSynchronizationContext.InstallWebWorkerInterop(true, CancellationToken.None);
                 jsSynchronizationContext.ProxyContext.JSNativeTID = arg_1.slot.IntPtrValue;
-                arg_2.slot.GCHandle = jsSynchronizationContext.ProxyContext.ContextHandle;
+                arg_res.slot.GCHandle = jsSynchronizationContext.ProxyContext.ContextHandle;
             }
             catch (Exception ex)
             {
@@ -266,12 +261,11 @@ namespace System.Runtime.InteropServices.JavaScript
 
 #endif
 
-        // the marshaled signature is:
-        // Task BindAssemblyExports(string assemblyName)
+        // the marshaled signature is: Task BindAssemblyExports(string assemblyName)
         public static void BindAssemblyExports(JSMarshalerArgument* arguments_buffer)
         {
             ref JSMarshalerArgument arg_exc = ref arguments_buffer[0]; // initialized by caller in alloc_stack_frame()
-            ref JSMarshalerArgument arg_result = ref arguments_buffer[1]; // used as return value
+            ref JSMarshalerArgument arg_res = ref arguments_buffer[1]; // used as return value
             ref JSMarshalerArgument arg_1 = ref arguments_buffer[2];// initialized and set by caller
             try
             {
@@ -282,7 +276,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
                 var result = JSHostImplementation.BindAssemblyExports(assemblyName);
 
-                arg_result.ToJS(result);
+                arg_res.ToJS(result);
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptImports.Generated.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptImports.Generated.cs
@@ -57,6 +57,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
 #if DEBUG
         [JSImport("globalThis.console.log")]
+        [return: JSMarshalAs<JSType.OneWay>]
         public static partial void Log([JSMarshalAs<JSType.String>] string message);
 #endif
     }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -30,6 +30,7 @@ namespace System.Runtime.InteropServices.JavaScript
         internal static volatile uint nextImportHandle = 1;
         internal int ImportHandle;
         internal bool IsAsync;
+        internal bool IsOneWay;
 #if DEBUG
         internal string? FunctionName;
 #endif
@@ -285,6 +286,11 @@ namespace System.Runtime.InteropServices.JavaScript
                 arguments[1].slot.GCHandle = holder.GCHandle;
             }
 
+            if (signature.IsOneWay)
+            {
+                arguments[1].slot.Type = MarshalerType.OneWay;
+            }
+
 #if FEATURE_WASM_MANAGED_THREADS
             // if we are on correct thread already or this is synchronous call, just call it
             if (targetContext.IsCurrentThread())
@@ -299,15 +305,15 @@ namespace System.Runtime.InteropServices.JavaScript
 #endif
 
             }
-            else if (!signature.IsAsync)
-            {
-                //sync
-                DispatchJSImportSyncSend(signature, targetContext, arguments);
-            }
-            else
+            else if (signature.IsAsync || signature.IsOneWay)
             {
                 //async
                 DispatchJSImportAsyncPost(signature, targetContext, arguments);
+            }
+            else
+            {
+                //sync
+                DispatchJSImportSyncSend(signature, targetContext, arguments);
             }
 #else
             InvokeJSImportCurrent(signature, arguments);
@@ -332,9 +338,9 @@ namespace System.Runtime.InteropServices.JavaScript
             fixed (JSMarshalerArgument* args = arguments)
             {
 #if FEATURE_WASM_MANAGED_THREADS
-                Interop.Runtime.InvokeJSImportSync((nint)args, (nint)signature.Header);
+                Interop.Runtime.InvokeJSImportSync((nint)signature.Header, (nint)args);
 #else
-                Interop.Runtime.InvokeJSImport(signature.ImportHandle, (nint)args);
+                Interop.Runtime.InvokeJSImportST(signature.ImportHandle, (nint)args);
 #endif
             }
 
@@ -361,7 +367,7 @@ namespace System.Runtime.InteropServices.JavaScript
             // we also don't throw PNSE here, because we know that the target has JS interop installed and that it could not block
             // so it could take some time, while target is CPU busy, but not forever
             // see also https://github.com/dotnet/runtime/issues/76958#issuecomment-1921418290
-            Interop.Runtime.InvokeJSImportSyncSend(targetContext.JSNativeTID, args, sig);
+            Interop.Runtime.InvokeJSImportSyncSend(targetContext.JSNativeTID, sig, args);
 
             ref JSMarshalerArgument exceptionArg = ref arguments[0];
             if (exceptionArg.slot.Type != MarshalerType.None)
@@ -375,7 +381,10 @@ namespace System.Runtime.InteropServices.JavaScript
 #endif
         internal static unsafe void DispatchJSImportAsyncPost(JSFunctionBinding signature, JSProxyContext targetContext, Span<JSMarshalerArgument> arguments)
         {
-            // this copy is freed in mono_wasm_invoke_import_async
+            // meaning JS side needs to dispose it
+            ref JSMarshalerArgument exc = ref arguments[0];
+            exc.slot.ReceiverShouldFree = true;
+
             var bytes = sizeof(JSMarshalerArgument) * arguments.Length;
             void* cpy = (void*)Marshal.AllocHGlobal(bytes);
             void* src = Unsafe.AsPointer(ref arguments[0]);
@@ -385,7 +394,7 @@ namespace System.Runtime.InteropServices.JavaScript
             // we already know that we are not on the right thread
             // this will return quickly after sending the message
             // async
-            Interop.Runtime.InvokeJSImportAsyncPost(targetContext.JSNativeTID, (nint)cpy, sig);
+            Interop.Runtime.InvokeJSImportAsyncPost(targetContext.JSNativeTID, sig, (nint)cpy);
 
         }
 
@@ -431,8 +440,8 @@ namespace System.Runtime.InteropServices.JavaScript
             else
             {
                 // meaning JS side needs to dispose it
-                ref JSMarshalerArgument res = ref arguments[1];
-                res.slot.BooleanValue = true;
+                ref JSMarshalerArgument exc = ref arguments[0];
+                exc.slot.ReceiverShouldFree = true;
 
                 // this copy is freed in mono_wasm_resolve_or_reject_promise
                 var bytes = sizeof(JSMarshalerArgument) * arguments.Length;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -153,6 +153,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 var type = signature.Sigs[i] = types[i + 1]._signatureType;
             }
             signature.IsAsync = types[0]._signatureType.Type == MarshalerType.Task;
+            signature.IsOneWay = types[0]._signatureType.Type == MarshalerType.OneWay;
 
             signature.Header[0].ImportHandle = signature.ImportHandle;
             signature.Header[0].FunctionNameLength = functionNameBytes;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
@@ -79,6 +79,7 @@ namespace System.Runtime.InteropServices.JavaScript
             // also this is called multiple times
             JSProxyContext.JSImportWithUnknownContext();
             slot.ContextHandle = IntPtr.Zero;
+            slot.ReceiverShouldFree = false;
 #endif
         }
 
@@ -88,6 +89,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             slot.Type = MarshalerType.None;
             slot.ContextHandle = knownProxyContext.ContextHandle;
+            slot.ReceiverShouldFree = false;
         }
 #endif
         // this is always called from ToManaged() marshaler

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
@@ -58,11 +58,13 @@ namespace System.Runtime.InteropServices.JavaScript
             [FieldOffset(13)]
             internal MarshalerType ElementType;
 
+#if FEATURE_WASM_MANAGED_THREADS
             [FieldOffset(16)]
             internal IntPtr ContextHandle;
 
             [FieldOffset(20)]
             internal bool ReceiverShouldFree;
+#endif
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
@@ -60,6 +60,9 @@ namespace System.Runtime.InteropServices.JavaScript
 
             [FieldOffset(16)]
             internal IntPtr ContextHandle;
+
+            [FieldOffset(20)]
+            internal bool ReceiverShouldFree;
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerType.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerType.cs
@@ -45,6 +45,15 @@ namespace System.Runtime.InteropServices.JavaScript
         });
 
         /// <summary>
+        /// Dispatches the call asynchronously and doesn't wait for result.
+        /// </summary>
+        /// <returns>The marshaler metadata.</returns>
+        public static JSMarshalerType OneWay { get; } = new JSMarshalerType(new JSFunctionBinding.JSBindingType
+        {
+            Type = MarshalerType.OneWay
+        });
+
+        /// <summary>
         /// Marshal as JavaScript <see href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</see> type.
         /// </summary>
         /// <returns>The marshaler metadata.</returns>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -36,7 +36,8 @@ namespace System.Runtime.InteropServices.JavaScript
 #else
         public nint ContextHandle;
         public nint JSNativeTID; // target thread where JavaScript is running
-        public int ManagedTID;
+        public nint NativeTID; // current pthread id
+        public int ManagedTID; // current managed thread id
         public bool IsMainThread;
         public JSSynchronizationContext SynchronizationContext;
 
@@ -58,7 +59,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public JSProxyContext(bool isMainThread, JSSynchronizationContext synchronizationContext)
         {
             SynchronizationContext = synchronizationContext;
-            JSNativeTID = GetNativeThreadId();
+            NativeTID = JSNativeTID = GetNativeThreadId();
             ManagedTID = Environment.CurrentManagedThreadId;
             IsMainThread = isMainThread;
             ContextHandle = (nint)GCHandle.Alloc(this, GCHandleType.Normal);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -179,7 +179,7 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             // While we COULD pump here, we don't want to. We want the pump to happen on the next event loop turn.
             // Otherwise we could get a chain where a pump generates a new work item and that makes us pump again, forever.
-            TargetThreadScheduleBackgroundJob(ProxyContext.JSNativeTID, (delegate* unmanaged[Cdecl]<void>)&BackgroundJobHandler);
+            TargetThreadScheduleBackgroundJob(ProxyContext.NativeTID, (delegate* unmanaged[Cdecl]<void>)&BackgroundJobHandler);
         }
 
         public override void Post(SendOrPostCallback d, object? state)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSType.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSType.cs
@@ -29,6 +29,15 @@ namespace System.Runtime.InteropServices.JavaScript
         }
 
         /// <summary>
+        /// Could return immediately without waiting for the execution to finish, when dispatching the call to another thread.
+        /// Suppresses marshaling of the JavaScript function's return value.
+        /// </summary>
+        public sealed class OneWay : JSType
+        {
+            internal OneWay() { }
+        }
+
+        /// <summary>
         /// Marshal as JavaScript <see href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean">Boolean</see> type.
         /// </summary>
         public sealed class Boolean : JSType

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/MarshalerType.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/MarshalerType.cs
@@ -34,6 +34,7 @@ namespace System.Runtime.InteropServices.JavaScript
         Span,
         Action,
         Function,
+        OneWay,
 
 #if !JSIMPORTGENERATOR
         // only on runtime

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
@@ -24,6 +24,17 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 "boolean");
         }
 
+        [Theory]
+        [MemberData(nameof(MarshalInt32Cases))]
+        public async Task JsExportInt32OneWay(int value)
+        {
+            JavaScriptTestHelper.optimizedReached=0;
+            
+            JavaScriptTestHelper.invoke1O(value);
+            await Task.Yield();
+            Assert.Equal(value, JavaScriptTestHelper.optimizedReached);
+        }
+
         private async Task JsExportTestAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] T>(T value
         , Func<T, string, Task<T>> invoke, string echoName, string jsType, string? jsClass = null)
         {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -529,6 +529,15 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         #region Int32
         [Theory]
         [MemberData(nameof(MarshalInt32Cases))]
+        public async Task JsImportInt32OneWay(int value)
+        {
+            JavaScriptTestHelper.store1OneWay_Int32(value);
+            await Task.Yield();
+            Assert.Equal(value, JavaScriptTestHelper.retrieve1_Int32());
+        }
+
+        [Theory]
+        [MemberData(nameof(MarshalInt32Cases))]
         public void JsImportInt32(int value)
         {
             JsImportTest(value,

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -15,6 +15,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
     public partial class JavaScriptTestHelper
     {
         [JSImport("globalThis.console.log")]
+        [return: JSMarshalAs<JSType.OneWay>]
         public static partial void Log([JSMarshalAs<JSType.String>] string message);
 
         [JSImport("globalThis.window.location.toString")]
@@ -27,6 +28,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static partial string ReboundMemberEcho(string message);
 
         [JSExport]
+        [return: JSMarshalAs<JSType.OneWay>]
         public static void ConsoleWriteLine([JSMarshalAs<JSType.String>] string message)
         {
             Console.WriteLine(message);
@@ -72,6 +74,15 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
         [JSImport("invoke1V", "JavaScriptTestHelper")]
         public static partial void invoke1V(int a1);
+
+        [JSExport]
+        [return: JSMarshalAs<JSType.OneWay>]
+        public static void Optimized1O(int a1)
+        {
+            optimizedReached += a1;
+        }
+        [JSImport("invoke1O", "JavaScriptTestHelper")]
+        public static partial void invoke1O(int a1);
 
         [JSExport]
         public static int Optimized1R(int a1)
@@ -261,6 +272,11 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("store1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Void>]
         internal static partial void store1_Int32([JSMarshalAs<JSType.Number>] int value);
+
+        [JSImport("store1", "JavaScriptTestHelper")]
+        [return: JSMarshalAs<JSType.OneWay>]
+        internal static partial void store1OneWay_Int32([JSMarshalAs<JSType.Number>] int value);
+
         [JSImport("retrieve1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Number>]
         internal static partial int retrieve1_Int32();
@@ -1022,7 +1038,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
         public static Task DisposeAsync()
         {
-            _module?.Dispose();
+            // TODO _module?.Dispose();
             _module = null;
             return Task.CompletedTask;
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -1038,7 +1038,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
         public static Task DisposeAsync()
         {
-            // TODO _module?.Dispose();
+            _module?.Dispose();
             _module = null;
             return Task.CompletedTask;
         }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -186,6 +186,12 @@ export function invoke1V(arg1) {
     fn(arg1);
 }
 
+export function invoke1O(arg1) {
+    const JavaScriptTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper;
+    const fn = JavaScriptTestHelper['Optimized1O'];
+    fn(arg1);
+}
+
 export function invoke1R(arg1) {
     const JavaScriptTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.JavaScriptTestHelper;
     const fn = JavaScriptTestHelper['Optimized1R'];

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.cs
@@ -325,6 +325,10 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
         public static Task RunOnNewThread(Func<Task> job, CancellationToken cancellationToken)
         {
+            if( Environment.CurrentManagedThreadId == 1)
+            {
+                throw new Exception("This unit test should be executed with -backgroundExec otherwise it's prone to consume all threads too quickly");
+            }
             TaskCompletionSource tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var thread = new Thread(() =>
             {

--- a/src/mono/browser/debugger/tests/debugger-test/debugger-main.js
+++ b/src/mono/browser/debugger/tests/debugger-test/debugger-main.js
@@ -36,15 +36,15 @@ try {
         }
     }
 
-    // this is fake implementation of legacy `bind_static_method` which uses `mono_wasm_invoke_method`
+    // this is fake implementation of legacy `bind_static_method` which uses `mono_wasm_invoke_jsexport`
     // We have unit tests that stop on unhandled managed exceptions.
-    // as opposed to [JSExport], the `mono_wasm_invoke_method` doesn't handle managed exceptions.
+    // as opposed to [JSExport], the `mono_wasm_invoke_jsexport` doesn't handle managed exceptions.
     // Same way as old `bind_static_method` didn't
     App.bind_static_method_native = (method_name) => {
         try {
             const monoMethodPtr = App.exports.DebuggerTests.BindStaticMethod.GetMonoMethodPtr(method_name);
             // this is only implemented for void methods with no arguments
-            const invoker = runtime.Module.cwrap("mono_wasm_invoke_method", "void", ["number", "number"]);
+            const invoker = runtime.Module.cwrap("mono_wasm_invoke_jsexport", "void", ["number", "number"]);
             return function () {
                 try {
                     return invoker(monoMethodPtr, 0, 0);

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -21,11 +21,12 @@
 
 //JS funcs
 extern void mono_wasm_release_cs_owned_object (int js_handle);
-extern void mono_wasm_resolve_or_reject_promise (void *data);
+extern void mono_wasm_resolve_or_reject_promise (void *args);
 extern void mono_wasm_cancel_promise (int task_holder_gc_handle);
 extern void mono_wasm_console_clear ();
 extern void mono_wasm_set_entrypoint_breakpoint (int entry_point_metadata_token);
 extern void mono_wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
+extern void mono_wasm_invoke_js_function (int function_js_handle, void *args);
 
 extern int mono_runtime_run_module_cctor (MonoImage *image, MonoError *error);
 
@@ -37,24 +38,21 @@ void mono_wasm_get_assembly_export (char *assembly_name, char *namespace, char *
 
 #ifndef DISABLE_THREADS
 void mono_wasm_release_cs_owned_object_post (pthread_t target_tid, int js_handle);
-void mono_wasm_resolve_or_reject_promise_post (pthread_t target_tid, void *data);
+void mono_wasm_resolve_or_reject_promise_post (pthread_t target_tid, void *args);
 void mono_wasm_cancel_promise_post (pthread_t target_tid, int task_holder_gc_handle);
 
 extern void mono_wasm_install_js_worker_interop (int context_gc_handle);
 extern void mono_wasm_uninstall_js_worker_interop ();
-extern void mono_wasm_invoke_import_async (void* args, void* signature);
-void mono_wasm_invoke_import_async_post (pthread_t target_tid, void* args, void* signature);
-extern void mono_wasm_invoke_import_sync (void* args, void* signature);
-void mono_wasm_invoke_import_sync_send (pthread_t target_tid, void* args, void* signature);
-extern void mono_wasm_invoke_js_function (int function_js_handle, void *args);
+extern void mono_wasm_invoke_jsimport (void* signature, void* args);
+void mono_wasm_invoke_jsimport_async_post (pthread_t target_tid, void* signature, void* args);
+void mono_wasm_invoke_jsimport_sync_send (pthread_t target_tid, void* signature, void* args);
 void mono_wasm_invoke_js_function_send (pthread_t target_tid, int function_js_handle, void *args);
 extern void mono_threads_wasm_async_run_in_target_thread_vi (pthread_t target_thread, void (*func) (gpointer), gpointer user_data1);
 extern void mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 extern void mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 #else
 extern void mono_wasm_bind_js_import (void *signature, int *is_exception, MonoObject **result);
-extern void mono_wasm_invoke_js_import (int function_handle, void *args);
-extern void mono_wasm_invoke_js_function (int function_js_handle, void *args);
+extern void mono_wasm_invoke_jsimport_ST (int function_handle, void *args);
 #endif /* DISABLE_THREADS */
 
 // HybridGlobalization
@@ -77,33 +75,27 @@ void bindings_initialize_internals (void)
 #endif /* ENABLE_JS_INTEROP_BY_VALUE */
 
 #ifndef DISABLE_THREADS
-	mono_add_internal_call ("Interop/Runtime::ReleaseCSOwnedObject", mono_wasm_release_cs_owned_object);
 	mono_add_internal_call ("Interop/Runtime::ReleaseCSOwnedObjectPost", mono_wasm_release_cs_owned_object_post);
-	mono_add_internal_call ("Interop/Runtime::ResolveOrRejectPromise", mono_wasm_resolve_or_reject_promise);
 	mono_add_internal_call ("Interop/Runtime::ResolveOrRejectPromisePost", mono_wasm_resolve_or_reject_promise_post);
 	mono_add_internal_call ("Interop/Runtime::InstallWebWorkerInterop", mono_wasm_install_js_worker_interop);
 	mono_add_internal_call ("Interop/Runtime::UninstallWebWorkerInterop", mono_wasm_uninstall_js_worker_interop);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSync", mono_wasm_invoke_import_sync);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSyncSend", mono_wasm_invoke_import_sync_send);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSImportAsyncPost", mono_wasm_invoke_import_async_post);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSFunction", mono_wasm_invoke_js_function);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSync", mono_wasm_invoke_jsimport);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSyncSend", mono_wasm_invoke_jsimport_sync_send);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSImportAsyncPost", mono_wasm_invoke_jsimport_async_post);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSFunctionSend", mono_wasm_invoke_js_function_send);
-	mono_add_internal_call ("Interop/Runtime::CancelPromise", mono_wasm_cancel_promise);
 	mono_add_internal_call ("Interop/Runtime::CancelPromisePost", mono_wasm_cancel_promise_post);
-	mono_add_internal_call ("Interop/Runtime::AssemblyGetEntryPoint", mono_wasm_assembly_get_entry_point);
-	mono_add_internal_call ("Interop/Runtime::BindAssemblyExports", mono_wasm_bind_assembly_exports);
-	mono_add_internal_call ("Interop/Runtime::GetAssemblyExport", mono_wasm_get_assembly_export);
 #else
+	mono_add_internal_call ("Interop/Runtime::BindJSImport", mono_wasm_bind_js_import);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSImportST", mono_wasm_invoke_jsimport_ST);
+#endif /* DISABLE_THREADS */
+
 	mono_add_internal_call ("Interop/Runtime::ReleaseCSOwnedObject", mono_wasm_release_cs_owned_object);
 	mono_add_internal_call ("Interop/Runtime::ResolveOrRejectPromise", mono_wasm_resolve_or_reject_promise);
-	mono_add_internal_call ("Interop/Runtime::BindJSImport", mono_wasm_bind_js_import);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSImport", mono_wasm_invoke_js_import);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSFunction", mono_wasm_invoke_js_function);
 	mono_add_internal_call ("Interop/Runtime::CancelPromise", mono_wasm_cancel_promise);
 	mono_add_internal_call ("Interop/Runtime::AssemblyGetEntryPoint", mono_wasm_assembly_get_entry_point);
 	mono_add_internal_call ("Interop/Runtime::BindAssemblyExports", mono_wasm_bind_assembly_exports);
 	mono_add_internal_call ("Interop/Runtime::GetAssemblyExport", mono_wasm_get_assembly_export);
-#endif /* DISABLE_THREADS */
 
 	mono_add_internal_call ("Interop/JsGlobalization::ChangeCaseInvariant", mono_wasm_change_case_invariant);
 	mono_add_internal_call ("Interop/JsGlobalization::ChangeCase", mono_wasm_change_case);
@@ -276,14 +268,14 @@ void mono_wasm_cancel_promise_post (pthread_t target_tid, int task_holder_gc_han
 	mono_threads_wasm_async_run_in_target_thread_vi (target_tid, (void (*) (gpointer))mono_wasm_cancel_promise, (gpointer)task_holder_gc_handle);
 }
 
-void mono_wasm_invoke_import_async_post (pthread_t target_tid, void* args, void* signature)
+void mono_wasm_invoke_jsimport_async_post (pthread_t target_tid, void* signature, void* args)
 {
-	mono_threads_wasm_async_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_import_async, (gpointer)args, (gpointer)signature);
+	mono_threads_wasm_async_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport, (gpointer)signature, (gpointer)args);
 }
 
-void mono_wasm_invoke_import_sync_send (pthread_t target_tid, void* args, void* signature)
+void mono_wasm_invoke_jsimport_sync_send (pthread_t target_tid, void* signature, void* args)
 {
-	mono_threads_wasm_sync_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_import_sync, (gpointer)args, (gpointer)signature);
+	mono_threads_wasm_sync_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport, (gpointer)signature, (gpointer)args);
 }
 
 void mono_wasm_invoke_js_function_send (pthread_t target_tid, int function_js_handle, void *args)

--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -12,6 +12,7 @@ import type { VoidPtr, CharPtrPtr, Int32Ptr, CharPtr, ManagedPointer } from "./t
 import { Module, runtimeHelpers } from "./globals";
 import { mono_log_error } from "./logging";
 import { mono_assert } from "./globals";
+import { PThreadPtr } from "./pthreads/shared/types";
 
 type SigLine = [lazyOrSkip: boolean | (() => boolean), name: string, returnType: string | null, argTypes?: string[], opts?: any];
 
@@ -25,6 +26,8 @@ const threading_cwraps: SigLine[] = WasmEnableThreads ? [
     [true, "mono_wasm_diagnostic_server_post_resume_runtime", "void", []],
     [true, "mono_wasm_diagnostic_server_create_stream", "number", []],
     [false, "mono_wasm_init_finalizer_thread", null, []],
+    [false, "mono_wasm_invoke_jsexport_async_post", "void", ["number", "number", "number"]],
+    [false, "mono_wasm_invoke_jsexport_async_send", "void", ["number", "number", "number"]],
 ] : [];
 
 // when the method is assigned/cached at usage, instead of being invoked directly from cwraps, it can't be marked lazy, because it would be re-bound on each call
@@ -61,7 +64,7 @@ const fn_signatures: SigLine[] = [
     [() => !runtimeHelpers.emscriptenBuildOptions.enableBrowserProfiler, "mono_wasm_profiler_init_aot", "void", ["string"]],
     [true, "mono_wasm_profiler_init_browser", "void", ["number"]],
     [false, "mono_wasm_exec_regression", "number", ["number", "string"]],
-    [false, "mono_wasm_invoke_method", "void", ["number", "number"]],
+    [false, "mono_wasm_invoke_jsexport", "void", ["number", "number"]],
     [true, "mono_wasm_write_managed_pointer_unsafe", "void", ["number", "number"]],
     [true, "mono_wasm_copy_managed_pointer", "void", ["number", "number"]],
     [true, "mono_wasm_i52_to_f64", "number", ["number", "number"]],
@@ -140,6 +143,8 @@ export interface t_ThreadingCwraps {
     mono_wasm_diagnostic_server_post_resume_runtime(): void;
     mono_wasm_diagnostic_server_create_stream(): VoidPtr;
     mono_wasm_init_finalizer_thread(): void;
+    mono_wasm_invoke_jsexport_async_post(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
+    mono_wasm_invoke_jsexport_async_send(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
 }
 
 export interface t_ProfilerCwraps {
@@ -176,7 +181,7 @@ export interface t_Cwraps {
     mono_wasm_getenv(name: string): CharPtr;
     mono_wasm_set_main_args(argc: number, argv: VoidPtr): void;
     mono_wasm_exec_regression(verbose_level: number, image: string): number;
-    mono_wasm_invoke_method(method: MonoMethod, args: JSMarshalerArguments): void;
+    mono_wasm_invoke_jsexport(method: MonoMethod, args: JSMarshalerArguments): void;
     mono_wasm_write_managed_pointer_unsafe(destination: VoidPtr | MonoObjectRef, pointer: ManagedPointer): void;
     mono_wasm_copy_managed_pointer(destination: VoidPtr | MonoObjectRef, source: VoidPtr | MonoObjectRef): void;
     mono_wasm_i52_to_f64(source: VoidPtr, error: Int32Ptr): number;

--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -27,7 +27,7 @@ const threading_cwraps: SigLine[] = WasmEnableThreads ? [
     [true, "mono_wasm_diagnostic_server_create_stream", "number", []],
     [false, "mono_wasm_init_finalizer_thread", null, []],
     [false, "mono_wasm_invoke_jsexport_async_post", "void", ["number", "number", "number"]],
-    [false, "mono_wasm_invoke_jsexport_async_send", "void", ["number", "number", "number"]],
+    [false, "mono_wasm_invoke_jsexport_sync_send", "void", ["number", "number", "number"]],
 ] : [];
 
 // when the method is assigned/cached at usage, instead of being invoked directly from cwraps, it can't be marked lazy, because it would be re-bound on each call
@@ -144,7 +144,7 @@ export interface t_ThreadingCwraps {
     mono_wasm_diagnostic_server_create_stream(): VoidPtr;
     mono_wasm_init_finalizer_thread(): void;
     mono_wasm_invoke_jsexport_async_post(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
-    mono_wasm_invoke_jsexport_async_send(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
+    mono_wasm_invoke_jsexport_sync_send(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
 }
 
 export interface t_ProfilerCwraps {

--- a/src/mono/browser/runtime/debug.ts
+++ b/src/mono/browser/runtime/debug.ts
@@ -82,7 +82,7 @@ export function mono_wasm_send_dbg_command_with_parms(id: number, command_set: n
 
     const { res_ok, res } = commands_received.remove(id);
     if (!res_ok)
-        throw new Error("Failed on mono_wasm_invoke_method_debugger_agent_with_parms");
+        throw new Error("Failed on mono_wasm_send_dbg_command_with_parms");
     return res;
 }
 

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -275,7 +275,7 @@ mono_wasm_invoke_jsexport_async_post (void* target_thread, MonoMethod *method, v
 
 // sync
 EMSCRIPTEN_KEEPALIVE void
-mono_wasm_invoke_jsexport_async_send (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
+mono_wasm_invoke_jsexport_sync_send (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
 {
 	mono_threads_wasm_sync_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport, method, args);
 }

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -228,7 +228,7 @@ mono_wasm_load_runtime (int debug_level)
 }
 
 EMSCRIPTEN_KEEPALIVE void
-mono_wasm_invoke_method (MonoMethod *method, void* args)
+mono_wasm_invoke_jsexport (MonoMethod *method, void* args)
 {
 	PVOLATILE(MonoObject) temp_exc = NULL;
 
@@ -244,7 +244,7 @@ mono_wasm_invoke_method (MonoMethod *method, void* args)
 		PVOLATILE(MonoObject) exc2 = NULL;
 		store_volatile((MonoObject**)&temp_exc, (MonoObject*)mono_object_to_string ((MonoObject*)temp_exc, (MonoObject **)&exc2));
 		if (exc2) {
-			mono_wasm_trace_logger ("jsinterop", "critical", "mono_wasm_invoke_method unexpected double fault", 1, NULL);
+			mono_wasm_trace_logger ("jsinterop", "critical", "mono_wasm_invoke_jsexport unexpected double fault", 1, NULL);
 		} else {
 			mono_wasm_trace_logger ("jsinterop", "critical", mono_string_to_utf8((MonoString*)temp_exc), 1, NULL);
 		}
@@ -252,6 +252,35 @@ mono_wasm_invoke_method (MonoMethod *method, void* args)
 	}
 	MONO_EXIT_GC_UNSAFE;
 }
+
+#ifndef DISABLE_THREADS
+
+extern void mono_threads_wasm_async_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+extern void mono_threads_wasm_sync_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+
+static void
+mono_wasm_invoke_jsexport_async_post_cb (MonoMethod *method, void* args)
+{
+	mono_wasm_invoke_jsexport (method, args);
+	// TODO assert receiver_should_free ?
+	free (args);
+}
+
+// async
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_invoke_jsexport_async_post (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
+{
+	mono_threads_wasm_async_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport_async_post_cb, method, args);
+}
+
+// sync
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_invoke_jsexport_async_send (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
+{
+	mono_threads_wasm_sync_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport, method, args);
+}
+
+#endif /* DISABLE_THREADS */
 
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_string_from_utf16_ref (const mono_unichar2 * chars, int length, MonoString **result)

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -5,7 +5,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { mono_wasm_debugger_log, mono_wasm_add_dbg_command_received, mono_wasm_set_entrypoint_breakpoint, mono_wasm_fire_debugger_agent_message_with_data, mono_wasm_fire_debugger_agent_message_with_data_to_pause } from "./debug";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
-import { mono_wasm_bind_js_import, mono_wasm_invoke_js_function, mono_wasm_invoke_import_async, mono_wasm_invoke_import_sync, mono_wasm_invoke_js_import } from "./invoke-js";
+import { mono_wasm_bind_js_import, mono_wasm_invoke_js_function, mono_wasm_invoke_jsimport, mono_wasm_invoke_jsimport_ST } from "./invoke-js";
 import { mono_interp_tier_prepare_jiterpreter, mono_jiterp_free_method_data_js } from "./jiterpreter";
 import { mono_interp_jit_wasm_entry_trampoline, mono_interp_record_interp_entry } from "./jiterpreter-interp-entry";
 import { mono_interp_jit_wasm_jit_call_trampoline, mono_interp_invoke_wasm_jit_call_trampoline, mono_interp_flush_jitcall_queue } from "./jiterpreter-jit-call";
@@ -48,8 +48,7 @@ export const mono_wasm_threads_imports = !WasmEnableThreads ? [] : [
     // corebindings.c
     mono_wasm_install_js_worker_interop,
     mono_wasm_uninstall_js_worker_interop,
-    mono_wasm_invoke_import_async,
-    mono_wasm_invoke_import_sync,
+    mono_wasm_invoke_jsimport,
 ];
 
 export const mono_wasm_imports = [
@@ -90,7 +89,7 @@ export const mono_wasm_imports = [
     mono_wasm_release_cs_owned_object,
     mono_wasm_bind_js_import,
     mono_wasm_invoke_js_function,
-    mono_wasm_invoke_js_import,
+    mono_wasm_invoke_jsimport_ST,
     mono_wasm_resolve_or_reject_promise,
     mono_wasm_cancel_promise,
     mono_wasm_change_case_invariant,

--- a/src/mono/browser/runtime/invoke-cs.ts
+++ b/src/mono/browser/runtime/invoke-cs.ts
@@ -38,6 +38,14 @@ export function mono_wasm_bind_cs_function(method: MonoMethod, assemblyName: str
 
     const res_sig = get_sig(signature, 1);
     let res_marshaler_type = get_signature_type(res_sig);
+
+    // hack until we have public API for JSType.OneWay
+    if (WasmEnableThreads && shortClassName === "DefaultWebAssemblyJSRuntime"
+        && namespaceName === "Microsoft.AspNetCore.Components.WebAssembly.Services"
+        && (methodName === "BeginInvokeDotNet" || methodName === "EndInvokeJS")) {
+        res_marshaler_type = MarshalerType.OneWay;
+    }
+
     const is_async = res_marshaler_type == MarshalerType.Task;
     const is_oneway = res_marshaler_type == MarshalerType.OneWay;
     if (is_async) {

--- a/src/mono/browser/runtime/invoke-cs.ts
+++ b/src/mono/browser/runtime/invoke-cs.ts
@@ -14,7 +14,7 @@ import {
 import { MonoMethod, JSFunctionSignature, BoundMarshalerToCs, BoundMarshalerToJs, MarshalerType } from "./types/internal";
 import { assert_js_interop } from "./invoke-js";
 import { startMeasure, MeasuredBlock, endMeasure } from "./profiler";
-import { bind_assembly_exports, invoke_sync_method } from "./managed-exports";
+import { bind_assembly_exports, invoke_async_jsexport, invoke_sync_jsexport } from "./managed-exports";
 import { mono_log_debug } from "./logging";
 
 export function mono_wasm_bind_cs_function(method: MonoMethod, assemblyName: string, namespaceName: string, shortClassName: string, methodName: string, signatureHash: number, signature: JSFunctionSignature): void {
@@ -39,6 +39,7 @@ export function mono_wasm_bind_cs_function(method: MonoMethod, assemblyName: str
     const res_sig = get_sig(signature, 1);
     let res_marshaler_type = get_signature_type(res_sig);
     const is_async = res_marshaler_type == MarshalerType.Task;
+    const is_oneway = res_marshaler_type == MarshalerType.OneWay;
     if (is_async) {
         res_marshaler_type = MarshalerType.TaskPreCreated;
     }
@@ -51,30 +52,39 @@ export function mono_wasm_bind_cs_function(method: MonoMethod, assemblyName: str
         arg_marshalers,
         res_converter,
         is_async,
+        is_oneway,
         isDisposed: false,
     };
     let bound_fn: Function;
-    // void
-    if (args_count == 0 && !res_converter) {
-        bound_fn = bind_fn_0V(closure);
-    }
-    else if (args_count == 1 && !res_converter) {
-        bound_fn = bind_fn_1V(closure);
-    }
-    else if (is_async && args_count == 1 && res_converter) {
-        bound_fn = bind_fn_1RA(closure);
-    }
-    else if (is_async && args_count == 2 && res_converter) {
-        bound_fn = bind_fn_2RA(closure);
-    }
-    else if (args_count == 1 && res_converter) {
-        bound_fn = bind_fn_1R(closure);
-    }
-    else if (args_count == 2 && res_converter) {
-        bound_fn = bind_fn_2R(closure);
-    }
-    else {
+
+    if (is_async) {
+        if (args_count == 1 && res_converter) {
+            bound_fn = bind_fn_1RA(closure);
+        }
+        else if (args_count == 2 && res_converter) {
+            bound_fn = bind_fn_2RA(closure);
+        }
+        else {
+            bound_fn = bind_fn(closure);
+        }
+    } else if (is_oneway) {
         bound_fn = bind_fn(closure);
+    } else {
+        if (args_count == 0 && !res_converter) {
+            bound_fn = bind_fn_0V(closure);
+        }
+        else if (args_count == 1 && !res_converter) {
+            bound_fn = bind_fn_1V(closure);
+        }
+        else if (args_count == 1 && res_converter) {
+            bound_fn = bind_fn_1R(closure);
+        }
+        else if (args_count == 2 && res_converter) {
+            bound_fn = bind_fn_2R(closure);
+        }
+        else {
+            bound_fn = bind_fn(closure);
+        }
     }
 
     // this is just to make debugging easier. 
@@ -107,7 +117,7 @@ function bind_fn_0V(closure: BindingClosure) {
         try {
             const args = alloc_stack_frame(2);
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_sync_jsexport(method, args);
         } finally {
             Module.stackRestore(sp);
             endMeasure(mark, MeasuredBlock.callCsFunction, fqn);
@@ -130,7 +140,7 @@ function bind_fn_1V(closure: BindingClosure) {
             marshaler1(args, arg1);
 
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_sync_jsexport(method, args);
         } finally {
             Module.stackRestore(sp);
             endMeasure(mark, MeasuredBlock.callCsFunction, fqn);
@@ -154,7 +164,7 @@ function bind_fn_1R(closure: BindingClosure) {
             marshaler1(args, arg1);
 
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_sync_jsexport(method, args);
 
             const js_result = res_converter(args);
             return js_result;
@@ -171,7 +181,7 @@ function bind_fn_1RA(closure: BindingClosure) {
     const res_converter = closure.res_converter!;
     const fqn = closure.fullyQualifiedName;
     if (!WasmEnableThreads) (<any>closure) = null;
-    return function bound_fn_1R(arg1: any) {
+    return function bind_fn_1RA(arg1: any) {
         const mark = startMeasure();
         loaderHelpers.assert_runtime_running();
         mono_assert(!WasmEnableThreads || !closure.isDisposed, "The function was already disposed");
@@ -184,7 +194,7 @@ function bind_fn_1RA(closure: BindingClosure) {
             let promise = res_converter(args);
 
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_async_jsexport(method, args, 3);
 
             // in case the C# side returned synchronously
             promise = end_marshal_task_to_js(args, undefined, promise);
@@ -215,7 +225,7 @@ function bind_fn_2R(closure: BindingClosure) {
             marshaler2(args, arg2);
 
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_sync_jsexport(method, args);
 
             const js_result = res_converter(args);
             return js_result;
@@ -233,7 +243,7 @@ function bind_fn_2RA(closure: BindingClosure) {
     const res_converter = closure.res_converter!;
     const fqn = closure.fullyQualifiedName;
     if (!WasmEnableThreads) (<any>closure) = null;
-    return function bound_fn_2R(arg1: any, arg2: any) {
+    return function bind_fn_2RA(arg1: any, arg2: any) {
         const mark = startMeasure();
         loaderHelpers.assert_runtime_running();
         mono_assert(!WasmEnableThreads || !closure.isDisposed, "The function was already disposed");
@@ -247,7 +257,7 @@ function bind_fn_2RA(closure: BindingClosure) {
             let promise = res_converter(args);
 
             // call C# side
-            invoke_sync_method(method, args);
+            invoke_async_jsexport(method, args, 4);
 
             // in case the C# side returned synchronously
             promise = end_marshal_task_to_js(args, undefined, promise);
@@ -267,6 +277,7 @@ function bind_fn(closure: BindingClosure) {
     const method = closure.method;
     const fqn = closure.fullyQualifiedName;
     const is_async = closure.is_async;
+    const is_oneway = closure.is_oneway;
     if (!WasmEnableThreads) (<any>closure) = null;
     return function bound_fn(...js_args: any[]) {
         const mark = startMeasure();
@@ -289,13 +300,20 @@ function bind_fn(closure: BindingClosure) {
             }
 
             // call C# side
-            invoke_sync_method(method, args);
             if (is_async) {
+                invoke_async_jsexport(method, args, 2 + args_count);
                 // in case the C# side returned synchronously
                 js_result = end_marshal_task_to_js(args, undefined, js_result);
             }
-            else if (res_converter) {
-                js_result = res_converter(args);
+            else if (is_oneway) {
+                // call C# side, fire and forget
+                invoke_async_jsexport(method, args, 2 + args_count);
+            }
+            else {
+                invoke_sync_jsexport(method, args);
+                if (res_converter) {
+                    js_result = res_converter(args);
+                }
             }
             return js_result;
         } finally {
@@ -312,6 +330,7 @@ type BindingClosure = {
     arg_marshalers: (BoundMarshalerToCs)[],
     res_converter: BoundMarshalerToJs | undefined,
     is_async: boolean,
+    is_oneway: boolean,
     isDisposed: boolean,
 }
 

--- a/src/mono/browser/runtime/invoke-js.ts
+++ b/src/mono/browser/runtime/invoke-js.ts
@@ -279,6 +279,7 @@ function bind_fn(closure: BindingClosure) {
     const fqn = closure.fqn;
     if (!WasmEnableThreads) (<any>closure) = null;
     return function bound_fn(args: JSMarshalerArguments) {
+        const is_async = WasmEnableThreads && is_receiver_should_free(args);
         const mark = startMeasure();
         try {
             mono_assert(!WasmEnableThreads || !closure.isDisposed, "The function was already disposed");
@@ -308,7 +309,7 @@ function bind_fn(closure: BindingClosure) {
             marshal_exception_to_cs(<any>args, ex);
         }
         finally {
-            if (is_receiver_should_free(args)) {
+            if (is_async) {
                 Module._free(args as any);
             }
             endMeasure(mark, MeasuredBlock.callCsFunction, fqn);

--- a/src/mono/browser/runtime/managed-exports.ts
+++ b/src/mono/browser/runtime/managed-exports.ts
@@ -60,7 +60,7 @@ export function call_entry_point(main_assembly_name: string, program_args: strin
         // because this is async, we could pre-allocate the promise
         let promise = begin_marshal_task_to_js(res, MarshalerType.TaskPreCreated, marshal_int32_to_js);
 
-        invoke_sync_method(managedExports.CallEntrypoint, args);
+        invoke_async_jsexport(managedExports.CallEntrypoint, args, 5);
 
         // in case the C# side returned synchronously
         promise = end_marshal_task_to_js(args, marshal_int32_to_js, promise);
@@ -84,7 +84,7 @@ export function load_satellite_assembly(dll: Uint8Array): void {
         const arg1 = get_arg(args, 2);
         set_arg_type(arg1, MarshalerType.Array);
         marshal_array_to_cs(arg1, dll, MarshalerType.Byte);
-        invoke_sync_method(managedExports.LoadSatelliteAssembly, args);
+        invoke_sync_jsexport(managedExports.LoadSatelliteAssembly, args);
     } finally {
         Module.stackRestore(sp);
     }
@@ -101,7 +101,7 @@ export function load_lazy_assembly(dll: Uint8Array, pdb: Uint8Array | null): voi
         set_arg_type(arg2, MarshalerType.Array);
         marshal_array_to_cs(arg1, dll, MarshalerType.Byte);
         marshal_array_to_cs(arg2, pdb, MarshalerType.Byte);
-        invoke_sync_method(managedExports.LoadLazyAssembly, args);
+        invoke_sync_jsexport(managedExports.LoadLazyAssembly, args);
     } finally {
         Module.stackRestore(sp);
     }
@@ -117,7 +117,8 @@ export function release_js_owned_object_by_gc_handle(gc_handle: GCHandle) {
         const arg1 = get_arg(args, 2);
         set_arg_type(arg1, MarshalerType.Object);
         set_gc_handle(arg1, gc_handle);
-        invoke_sync_method(managedExports.ReleaseJSOwnedObjectByGCHandle, args);
+        // this must stay synchronous for free_gcv_handle sake
+        invoke_sync_jsexport(managedExports.ReleaseJSOwnedObjectByGCHandle, args);
     } finally {
         Module.stackRestore(sp);
     }
@@ -145,7 +146,7 @@ export function complete_task(holder_gc_handle: GCHandle, isCanceling: boolean, 
             mono_assert(res_converter, "res_converter missing");
             res_converter(arg3, data);
         }
-        invoke_sync_method(managedExports.CompleteTask, args);
+        invoke_async_jsexport(managedExports.CompleteTask, args, 4);
     } finally {
         Module.stackRestore(sp);
     }
@@ -176,7 +177,7 @@ export function call_delegate(callback_gc_handle: GCHandle, arg1_js: any, arg2_j
             arg3_converter(arg4, arg3_js);
         }
 
-        invoke_sync_method(managedExports.CallDelegate, args);
+        invoke_sync_jsexport(managedExports.CallDelegate, args);
 
         if (res_converter) {
             const res = get_arg(args, 1);
@@ -198,7 +199,7 @@ export function get_managed_stack_trace(exception_gc_handle: GCHandle) {
         set_arg_type(arg1, MarshalerType.Exception);
         set_gc_handle(arg1, exception_gc_handle);
 
-        invoke_sync_method(managedExports.GetManagedStackTrace, args);
+        invoke_sync_jsexport(managedExports.GetManagedStackTrace, args);
         const res = get_arg(args, 1);
         return marshal_string_to_js(res);
     } finally {
@@ -220,7 +221,7 @@ export function install_main_synchronization_context(): GCHandle {
         const arg1 = get_arg(args, 2);
         const arg2 = get_arg(args, 3);
         set_arg_intptr(arg1, mono_wasm_main_thread_ptr() as any);
-        cwraps.mono_wasm_invoke_method(managedExports.InstallMainSynchronizationContext!, args);
+        cwraps.mono_wasm_invoke_jsexport(managedExports.InstallMainSynchronizationContext!, args);
         if (is_args_exception(args)) {
             const exc = get_arg(args, 0);
             throw marshal_exception_to_js(exc);
@@ -231,9 +232,40 @@ export function install_main_synchronization_context(): GCHandle {
     }
 }
 
-export function invoke_sync_method(method: MonoMethod, args: JSMarshalerArguments): void {
+export function invoke_async_jsexport(method: MonoMethod, args: JSMarshalerArguments, size: number): void {
     assert_js_interop();
-    cwraps.mono_wasm_invoke_method(method, args as any);
+    if (!WasmEnableThreads || runtimeHelpers.isCurrentThread) {
+        cwraps.mono_wasm_invoke_jsexport(method, args as any);
+        if (is_args_exception(args)) {
+            const exc = get_arg(args, 0);
+            throw marshal_exception_to_js(exc);
+        }
+    } else {
+        throw new Error("Should be unreachable until we implement deputy." + size);
+        /*
+        set_receiver_should_free(args);
+        const bytes = JavaScriptMarshalerArgSize * size;
+        const cpy = Module._malloc(bytes) as any;
+        copyBytes(args as any, cpy, bytes);
+        twraps.mono_wasm_invoke_jsexport_async_post(runtimeHelpers.managedThreadTID, method, cpy);
+        */
+    }
+}
+
+export function invoke_sync_jsexport(method: MonoMethod, args: JSMarshalerArguments): void {
+    assert_js_interop();
+    if (!WasmEnableThreads || runtimeHelpers.isCurrentThread) {
+        cwraps.mono_wasm_invoke_jsexport(method, args as any);
+    } else {
+        throw new Error("Should be unreachable until we implement deputy.");
+        /*
+        if (!runtimeHelpers.isCurrentThread && runtimeHelpers.isPendingSynchronousCall) {
+            throw new Error("Cannot call synchronous C# method from inside a synchronous call to a JS method.");
+        }
+        // this is blocking too
+        twraps.mono_wasm_invoke_jsexport_async_send(runtimeHelpers.managedThreadTID, method, args as any);
+        */
+    }
     if (is_args_exception(args)) {
         const exc = get_arg(args, 0);
         throw marshal_exception_to_js(exc);
@@ -253,7 +285,7 @@ export function bind_assembly_exports(assemblyName: string): Promise<void> {
         // because this is async, we could pre-allocate the promise
         let promise = begin_marshal_task_to_js(res, MarshalerType.TaskPreCreated);
 
-        invoke_sync_method(managedExports.BindAssemblyExports, args);
+        invoke_async_jsexport(managedExports.BindAssemblyExports, args, 3);
 
         // in case the C# side returned synchronously
         promise = end_marshal_task_to_js(args, marshal_int32_to_js, promise);

--- a/src/mono/browser/runtime/managed-exports.ts
+++ b/src/mono/browser/runtime/managed-exports.ts
@@ -263,7 +263,7 @@ export function invoke_sync_jsexport(method: MonoMethod, args: JSMarshalerArgume
             throw new Error("Cannot call synchronous C# method from inside a synchronous call to a JS method.");
         }
         // this is blocking too
-        twraps.mono_wasm_invoke_jsexport_async_send(runtimeHelpers.managedThreadTID, method, args as any);
+        twraps.mono_wasm_invoke_jsexport_sync_send(runtimeHelpers.managedThreadTID, method, args as any);
         */
     }
     if (is_args_exception(args)) {

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -279,12 +279,6 @@ export function set_arg_proxy_context(arg: JSMarshalerArgument): void {
     setI32(<any>arg + 16, <any>runtimeHelpers.proxyGCHandle);
 }
 
-export function get_arg_proxy_context(arg: JSMarshalerArgument): GCHandle {
-    if (!WasmEnableThreads) return GCHandleNull;
-    mono_assert(arg, "Null arg");
-    return getI32(<any>arg + 16) as any;
-}
-
 export function set_js_handle(arg: JSMarshalerArgument, jsHandle: JSHandle): void {
     mono_assert(arg, "Null arg");
     setI32(<any>arg + 4, <any>jsHandle);

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -5,7 +5,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles";
 import { Module, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
-import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8, localHeapViewF64, localHeapViewI32, localHeapViewU8, _zero_region } from "./memory";
+import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8, localHeapViewF64, localHeapViewI32, localHeapViewU8, _zero_region, getB32, setB32 } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
 import { GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot, MarshalerType } from "./types/internal";
 import { TypedArray, VoidPtr } from "./types/emscripten";
@@ -40,6 +40,16 @@ export function is_args_exception(args: JSMarshalerArguments): boolean {
     mono_assert(args, "Null args");
     const exceptionType = get_arg_type(<any>args);
     return exceptionType !== MarshalerType.None;
+}
+
+export function is_receiver_should_free(args: JSMarshalerArguments): boolean {
+    mono_assert(args, "Null args");
+    return getB32(<any>args + 20);
+}
+
+export function set_receiver_should_free(args: JSMarshalerArguments): void {
+    mono_assert(args, "Null args");
+    setB32(<any>args + 20, true);
 }
 
 export function set_args_context(args: JSMarshalerArguments): void {
@@ -267,6 +277,12 @@ export function set_arg_proxy_context(arg: JSMarshalerArgument): void {
     if (!WasmEnableThreads) return;
     mono_assert(arg, "Null arg");
     setI32(<any>arg + 16, <any>runtimeHelpers.proxyGCHandle);
+}
+
+export function get_arg_proxy_context(arg: JSMarshalerArgument): GCHandle {
+    if (!WasmEnableThreads) return GCHandleNull;
+    mono_assert(arg, "Null arg");
+    return getI32(<any>arg + 16) as any;
 }
 
 export function set_js_handle(arg: JSMarshalerArgument, jsHandle: JSHandle): void {

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -43,6 +43,7 @@ export function is_args_exception(args: JSMarshalerArguments): boolean {
 }
 
 export function is_receiver_should_free(args: JSMarshalerArguments): boolean {
+    if (WasmEnableThreads) return false;
     mono_assert(args, "Null args");
     return getB32(<any>args + 20);
 }

--- a/src/mono/browser/runtime/memory.ts
+++ b/src/mono/browser/runtime/memory.ts
@@ -390,6 +390,13 @@ export function localHeapViewF64(): Float64Array {
     return Module.HEAPF64;
 }
 
+export function copyBytes(srcPtr: VoidPtr, dstPtr: VoidPtr, bytes: number): void {
+    const heap = localHeapViewU8();
+    const src = heap.subarray(srcPtr as any, srcPtr as any + bytes);
+    const dst = heap.subarray(dstPtr as any, dstPtr as any + bytes);
+    dst.set(src);
+}
+
 // when we run with multithreading enabled, we need to make sure that the memory views are updated on each worker
 // on non-MT build, this will be a no-op trimmed by rollup
 export function receiveWorkerHeapViews() {

--- a/src/mono/browser/runtime/pthreads/shared/emscripten-replacements.ts
+++ b/src/mono/browser/runtime/pthreads/shared/emscripten-replacements.ts
@@ -80,6 +80,7 @@ export function replaceEmscriptenPThreadLibrary(modulePThread: PThreadLibrary): 
 
 let availableThreadCount = 0;
 export function is_thread_available() {
+    if (!WasmEnableThreads) return true;
     return availableThreadCount > 0;
 }
 

--- a/src/mono/browser/runtime/startup.ts
+++ b/src/mono/browser/runtime/startup.ts
@@ -25,7 +25,7 @@ import { mono_log_debug, mono_log_error, mono_log_warn } from "./logging";
 // threads
 import { preAllocatePThreadWorkerPool, mono_wasm_init_threads } from "./pthreads/browser";
 import { currentWorkerThreadEvents, dotnetPthreadCreated, initWorkerThreadEvents, monoThreadInfo } from "./pthreads/worker";
-import { update_thread_info } from "./pthreads/shared";
+import { mono_wasm_pthread_ptr, update_thread_info } from "./pthreads/shared";
 import { jiterpreter_allocate_tables } from "./jiterpreter-support";
 import { localHeapViewU8 } from "./memory";
 import { assertNoProxies } from "./gc-handles";
@@ -516,6 +516,8 @@ export function start_runtime() {
             monoThreadInfo.isRegistered = true;
             update_thread_info();
             runtimeHelpers.proxyGCHandle = install_main_synchronization_context();
+            runtimeHelpers.managedThreadTID = mono_wasm_pthread_ptr();
+            runtimeHelpers.isCurrentThread = true;
         }
 
         // get GCHandle of the ctx

--- a/src/mono/browser/runtime/strings.ts
+++ b/src/mono/browser/runtime/strings.ts
@@ -171,7 +171,7 @@ export function stringToMonoStringRoot(string: string, result: WasmRoot<MonoStri
     }
 }
 
-export function stringToInternedMonoStringRoot(string: string | symbol, result: WasmRoot<MonoString>): void {
+function stringToInternedMonoStringRoot(string: string | symbol, result: WasmRoot<MonoString>): void {
     let text: string | undefined;
     if (typeof (string) === "symbol") {
         text = string.description;
@@ -244,6 +244,7 @@ function storeStringInInternTable(string: string, root: WasmRoot<MonoString>, in
 
 function stringToMonoStringNewRoot(string: string, result: WasmRoot<MonoString>): void {
     const bufferLen = (string.length + 1) * 2;
+    // TODO this could be stack allocated
     const buffer = Module._malloc(bufferLen);
     stringToUTF16(buffer as any, buffer as any + bufferLen, string);
     cwraps.mono_wasm_string_from_utf16_ref(<any>buffer, string.length, result.address);

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -3,6 +3,7 @@
 
 import type { AssetEntry, DotnetModuleConfig, LoadBootResourceCallback, LoadingResource, MonoConfig, RuntimeAPI, SingleAssetBehaviors } from ".";
 import type { PThreadLibrary } from "../pthreads/shared/emscripten-internals";
+import { PThreadPtr } from "../pthreads/shared/types";
 import type { CharPtr, EmscriptenModule, ManagedPointer, NativePointer, VoidPtr, Int32Ptr } from "./emscripten";
 
 export type GCHandle = {
@@ -200,6 +201,9 @@ export type RuntimeHelpers = {
     getWasmIndirectFunctionTable(): WebAssembly.Table,
     runtimeReady: boolean,
     proxyGCHandle: GCHandle | undefined,
+    managedThreadTID: PThreadPtr,
+    isCurrentThread: boolean,
+    isPendingSynchronousCall: boolean, // true when we are in the middle of a synchronous call from managed code with the same JSProxyContext
     cspPolicy: boolean,
 
     allAssetsInMemory: PromiseAndController<void>,
@@ -333,6 +337,7 @@ export enum MarshalerType {
     Span,
     Action,
     Function,
+    OneWay,
 
     // only on runtime
     JSException,

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -45,7 +45,7 @@ wasm_get_stack_size (void)
 	return (guint8*)emscripten_stack_get_base () - (guint8*)emscripten_stack_get_end ();
 }
 
-#else /* WASI */
+#else /* HOST_BROWSER -> WASI */
 
 // TODO after https://github.com/llvm/llvm-project/commit/1532be98f99384990544bd5289ba339bca61e15b
 // use __stack_low && __stack_high
@@ -79,7 +79,7 @@ wasm_get_stack_base (void)
 	// this will need further change for multithreading as the stack will allocated be per thread at different addresses
 }
 
-#endif
+#endif /* HOST_BROWSER */
 
 int
 mono_thread_info_get_system_max_stack_size (void)
@@ -176,6 +176,7 @@ mono_native_thread_set_name (MonoNativeThreadId tid, const char *name)
 {
 #ifndef DISABLE_THREADS
 	// note there is also emscripten_set_thread_name, but it only changes the name for emscripten profiler
+	// this only sets the name for the current thread
 	mono_wasm_pthread_set_name (name);
 #endif
 }
@@ -540,23 +541,6 @@ mono_threads_wasm_on_thread_registered (void)
 }
 
 #ifndef DISABLE_THREADS
-void
-mono_threads_wasm_async_run_in_ui_thread (void (*func) (void))
-{
-	emscripten_async_run_in_main_runtime_thread (EM_FUNC_SIG_V, func);
-}
-
-void
-mono_threads_wasm_async_run_in_ui_thread_vi (void (*func) (gpointer), gpointer user_data)
-{
-	emscripten_async_run_in_main_runtime_thread (EM_FUNC_SIG_VI, func, user_data);
-}
-
-void
-mono_threads_wasm_async_run_in_ui_thread_vii (void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2)
-{
-	emscripten_async_run_in_main_runtime_thread (EM_FUNC_SIG_VII, func, user_data1, user_data2);
-}
 
 void
 mono_threads_wasm_async_run_in_target_thread (pthread_t target_thread, void (*func) (void))

--- a/src/mono/mono/utils/mono-threads-wasm.h
+++ b/src/mono/mono/utils/mono-threads-wasm.h
@@ -27,21 +27,6 @@ MonoNativeThreadId
 mono_threads_wasm_ui_thread_tid (void);
 
 #ifndef DISABLE_THREADS
-/**
- * Runs the given function asynchronously on the main thread.
- * See emscripten/threading.h emscripten_async_run_in_main_runtime_thread
- */
-void
-mono_threads_wasm_async_run_in_ui_thread (void (*func) (void));
-
-/*
- * Variant that takes an argument. Add more variants as needed.
- */
-void
-mono_threads_wasm_async_run_in_ui_thread_vi (void (*func)(gpointer), gpointer user_data);
-
-void
-mono_threads_wasm_async_run_in_ui_thread_vii (void (*func)(gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 
 void
 mono_threads_wasm_async_run_in_target_thread (pthread_t target_thread, void (*func) (void));


### PR DESCRIPTION
This will be useful for `beginInvokeDotNetFromJS` and `endInvokeJSFromDotNet` which could be fire & forget across threads.

There is new API `JSType.OneWay` which will need API review later.

Other changes
- unified order of `signature` and `args` on all `InvokeJSImport` variations.
- added `ReceiverShouldFree` to make reasoning easier about who should `free` the `args` on heap.
- renamed `mono_wasm_invoke_method` to `mono_wasm_invoke_jsexport` and variations
- renamed `mono_wasm_invoke_import` to `mono_wasm_invoke_jsimport` and variations
- unified sync and async `mono_wasm_invoke_jsimport`
- dropped `mono_threads_wasm_async_run_in_ui_thread` and variations

Prep for deputy
- added `JSProxyContext.NativeTID` which will be different than current thread when we have deputy thread.
- `mono_wasm_invoke_jsexport_async_post` and `mono_wasm_invoke_jsexport_async_send` unused for now
- split `invoke_async_jsexport` and `invoke_sync_jsexport`, both are synchronous until deputy
