### PR TITLE
[mono] Fix msvc warning

### DIFF
--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -11634,7 +11634,7 @@ MONO_RESTORE_WARNING
 			lhs = LLVMBuildLoad2 (builder, ret_t, addresses [ins->sreg1]->value, "");
 
 			LLVMValueRef *args = g_new0(LLVMValueRef, n_elem_tuple + 2);
-			int idx = 0;
+			unsigned int idx = 0;
 			for ( ; idx < n_elem_tuple; idx++) {
 				args [idx] = LLVMBuildExtractValue (builder, lhs, idx, "extract_elem");
 			}

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -11650,7 +11650,7 @@ MONO_RESTORE_WARNING
 				LLVMValueRef retval = LLVMGetUndef (ret_t);
 				args [idx - 1] = const_int64 (i);
 				LLVMValueRef result_loaded = call_overloaded_intrins (ctx, iid, ovr_tag, args, "");
-				for (int j = 0; j < n_elem_tuple; j++) {
+				for (unsigned int j = 0; j < n_elem_tuple; j++) {
 					LLVMValueRef elem = LLVMBuildExtractValue (builder, result_loaded,  j, "extract_elem");
 					retval = LLVMBuildInsertValue (builder, retval, elem, j, "insert_val");
 				}


### PR DESCRIPTION
Fix this msvc warning introduced by https://github.com/dotnet/runtime/pull/98532

```
D:\a\_work\1\s\src\mono\mono\mini\mini-llvm.c(11638): error C2220: the following warning is treated as an error
  D:\a\_work\1\s\src\mono\mono\mini\mini-llvm.c(11638): warning C4018: '<': signed/unsigned mismatch
  D:\a\_work\1\s\src\mono\mono\mini\mini-llvm.c(11653): warning C4018: '<': signed/unsigned mismatch
```