### PR TITLE
Use Ubuntu-22.04-based Tizen image

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -101,7 +101,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/x64
 
     - container: tizen_armel
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-armel-tizen
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen
       env:
         ROOTFS_DIR: /crossrootfs/armel
 


### PR DESCRIPTION
This removes the last usage of an image that doesn't support Node16 from the runtime PR pipeline.