### PR TITLE
ObjWriter: Do not generate relocations within .debug_info for DW_AT_type

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using ILCompiler.DependencyAnalysis;
@@ -122,7 +123,7 @@ namespace ILCompiler.ObjectWriter
             }
             else
             {
-                _infoSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_HIGHLOW, ".debug_info", offset);
+                WriteUInt32(offset);
             }
         }
 
@@ -195,17 +196,10 @@ namespace ILCompiler.ObjectWriter
             // Debug.Assert(_dieStack.Count == 0);
 
             // Flush late bound forward references
-            int streamOffset = (int)_infoSectionWriter.Position;
             foreach (var lateBoundReference in _lateBoundReferences)
             {
                 uint offset = _builder.ResolveOffset(lateBoundReference.TypeIndex);
-
-                _infoSectionWriter.EmitRelocation(
-                    - streamOffset + lateBoundReference.Position,
-                    lateBoundReference.Data,
-                    RelocType.IMAGE_REL_BASED_HIGHLOW,
-                    ".debug_info",
-                    (int)offset);
+                BinaryPrimitives.WriteUInt32LittleEndian(lateBoundReference.Data, offset);
             }
 
             // Write abbreviation section

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
@@ -107,7 +107,7 @@ namespace ILCompiler.ObjectWriter
         public void WriteInfoAbsReference(long offset)
         {
             Debug.Assert(offset < uint.MaxValue);
-            _infoSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_HIGHLOW, ".debug_info", offset);
+            WriteUInt32((uint)offset);
         }
 
         public void WriteInfoReference(uint typeIndex)


### PR DESCRIPTION
Fixes #98377.

Neither gcc, nor clang, generate relocations for references within the same `.debug_info` section. The [DWARF 5](https://dwarfstd.org/doc/DWARF5.pdf) specification, section 7.3.1, doesn't list this type of relocation as required. At least some versions of GNU binutils linker seem to apply both the relocation and their own offset in the final file, resulting in the offset being applied twice.