### PR TITLE
[release/8.0-staging] Fix NativeAOT publish failure on fi_FI culture (#98552)

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -5,8 +5,7 @@
     <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
 
     <_targetOS>$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.LastIndexOf('-'))))</_targetOS>
-    <_indexOfPeriod>$(_targetOS.IndexOf('.'))</_indexOfPeriod>
-    <_targetOS Condition="'$(_indexOfPeriod)' &gt; -1">$(_targetOS.SubString(0, $(_indexOfPeriod)))</_targetOS>
+    <_targetOS Condition="$(_targetOS.Contains('.'))">$(_targetOS.SubString(0, $(_targetOS.IndexOf('.'))))</_targetOS>
     <_targetOS Condition="$(_targetOS.StartsWith('win'))">win</_targetOS>
 
     <!-- On non-Windows, determine _hostArchitecture from NETCoreSdkPortableRuntimeIdentifier -->


### PR DESCRIPTION
Backport of #98552 to release/8.0-staging

/cc @MichalStrehovsky 

## Customer Impact

- [x] Customer reported: https://github.com/dotnet/runtime/issues/98550
- [ ] Found internally

The fi_FI culture uses `U+2212 : MINUS SIGN` instead of `-` for negative numbers which trips up msbuild when comparing a property in NativeAOT targets. This means that using PublishAot doesn't work in that culture.

## Regression

- [x] Yes
- [ ] No

This was introduced in .NET 8 in https://github.com/dotnet/runtime/commit/b96927124c9910e16cc46495953f4a19a1af2cbf.

## Testing

Tested manually by running `LANG=fi_FI dotnet publish /p:PublishAot=true` and observing that the msbuild error no longer happens.

## Risk

Low. This is replacing one way of doing string manipulation with a different one.
