### PR TITLE
Fix initial context for HW exceptions in the new EH

### DIFF
--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -333,8 +333,9 @@ ExInfo::ExInfo(Thread *pThread, EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pEx
     if (exceptionKind == ExKind::HardwareFault)
     {
         // Hardware exception handling needs to start on the FaultingExceptionFrame, so we are
-        // passing in a context with zeroed out IP.
+        // passing in a context with zeroed out IP and SP.
         SetIP(&m_exContext, 0);
+        SetSP(&m_exContext, 0);
         m_exContext.ContextFlags = CONTEXT_FULL;
     }
     else


### PR DESCRIPTION
I have made a last minute change before creating the PR for the final fixes for the new EH that turned out to fire an assert in REGDISPLAY initialization. I was originally zeroing the whole context, but then figured out that just zeroing IP is sufficient to make the stack walker start at an explicit frame. However, there is one assert that also checks SP for validity (or 0) that started to fire with that change.

This PR fixes it.