### PR TITLE
[browser] Fix switching between single and multi threaded runtimes without clean

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -256,8 +256,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ComputeWasmBuildAssets>
 
     <PropertyGroup>
-      <_WasmBuildWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil'))</_WasmBuildWebCilPath>
-      <_WasmBuildTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil'))</_WasmBuildTmpWebCilPath>
+      <_WasmWebcilFolderName>webcil</_WasmWebcilFolderName>
+      <_WasmWebcilFolderName Condition="'$(WasmEnableThreads)' == 'true'">$(_WasmWebcilFolderName)-threads</_WasmWebcilFolderName>
+      <_WasmBuildWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), '$(_WasmWebcilFolderName)'))</_WasmBuildWebCilPath>
+      <_WasmBuildTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-$(_WasmWebcilFolderName)'))</_WasmBuildTmpWebCilPath>
     </PropertyGroup>
 
     <ConvertDllsToWebCil Candidates="@(_BuildAssetsCandidates)" IntermediateOutputPath="$(_WasmBuildTmpWebCilPath)" OutputPath="$(_WasmBuildWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">
@@ -445,8 +447,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     </ComputeWasmPublishAssets>
 
     <PropertyGroup>
-      <_WasmPublishWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil', 'publish'))</_WasmPublishWebCilPath>
-      <_WasmPublishTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil', 'publish'))</_WasmPublishTmpWebCilPath>
+      <_WasmPublishWebcilFolderName>webcil</_WasmPublishWebcilFolderName>
+      <_WasmPublishWebcilFolderName Condition="'$(WasmEnableThreads)' == 'true'">$(_WasmPublishWebcilFolderName)-threads</_WasmPublishWebcilFolderName>
+      <_WasmPublishWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), '$(_WasmPublishWebcilFolderName)', 'publish'))</_WasmPublishWebCilPath>
+      <_WasmPublishTmpWebCilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-$(_WasmPublishWebcilFolderName)', 'publish'))</_WasmPublishTmpWebCilPath>
     </PropertyGroup>
 
     <ConvertDllsToWebCil Candidates="@(_NewWasmPublishStaticWebAssets)" IntermediateOutputPath="$(_WasmPublishTmpWebCilPath)" OutputPath="$(_WasmPublishWebCilPath)" IsEnabled="$(_WasmEnableWebcil)">

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorBuildOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorBuildOptions.cs
@@ -20,5 +20,6 @@ public record BlazorBuildOptions
     GlobalizationMode GlobalizationMode = GlobalizationMode.Sharded,
     string PredefinedIcudt = "",
     bool AssertAppBundle = true,
-    string? BinFrameworkDir = null
+    string? BinFrameworkDir = null,
+    string? Label = null
 );

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -60,7 +60,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         if (options.WarnAsError)
             extraArgs = extraArgs.Append("/warnaserror").ToArray();
 
-        (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: false, setWasmDevel: false, expectSuccess: options.ExpectSuccess, extraArgs);
+        (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: false, setWasmDevel: false, expectSuccess: options.ExpectSuccess, label: options.Label, extraArgs);
 
         if (options.ExpectSuccess && options.AssertAppBundle)
         {
@@ -75,7 +75,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         if (options.WarnAsError)
             extraArgs = extraArgs.Append("/warnaserror").ToArray();
 
-        (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: true, setWasmDevel: false, expectSuccess: options.ExpectSuccess, extraArgs);
+        (CommandResult res, string logPath) = BlazorBuildInternal(options.Id, options.Config, publish: true, setWasmDevel: false, expectSuccess: options.ExpectSuccess, label: options.Label, extraArgs);
 
         if (options.ExpectSuccess && options.AssertAppBundle)
         {
@@ -95,6 +95,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
         bool publish = false,
         bool setWasmDevel = true,
         bool expectSuccess = true,
+        string? label = null,
         params string[] extraArgs)
     {
         try
@@ -102,7 +103,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
             return BuildProjectWithoutAssert(
                         id,
                         config,
-                        new BuildProjectOptions(CreateProject: false, UseCache: false, Publish: publish, ExpectSuccess: expectSuccess),
+                        new BuildProjectOptions(CreateProject: false, UseCache: false, Publish: publish, ExpectSuccess: expectSuccess, Label: label),
                         extraArgs.Concat(new[]
                         {
                             "-p:BlazorEnableCompression=false",

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Text;
+using System.Linq;
 using System.Threading.Tasks;
 using Wasm.Build.Tests.Blazor;
 using Xunit;
@@ -103,7 +104,11 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
         // Build and run multithreaded
         await PublishAndRunAsync(id, config, true);
 
-        Directory.EnumerateFiles(_provider.FindBinFrameworkDir(config, true, DefaultTargetFramework), "dotnet.native.worker.*");
+        File.Delete(
+            Directory
+                .EnumerateFiles(_provider.FindBinFrameworkDir(config, true, DefaultTargetFramework), "dotnet.native.worker.*")
+                .First()
+        );
 
         // Build and run singlethreaded without clean
         await PublishAndRunAsync(id, config, false);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -103,7 +103,12 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
         // Build and run multithreaded
         await PublishAndRunAsync(id, config, true);
 
+        Directory.EnumerateFiles(_provider.FindBinFrameworkDir(config, true, DefaultTargetFramework), "dotnet.native.worker.*");
+
         // Build and run singlethreaded without clean
+        await PublishAndRunAsync(id, config, false);
+
+        // Build and run multithreaded again
         await PublishAndRunAsync(id, config, false);
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -102,7 +102,8 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
         string projectFile = CreateWasmTemplateProject(id, "blazorwasm");
 
         // Build and run multithreaded
-        await PublishAndRunAsync(id, config, true);
+        _testOutput.WriteLine("Publish and run MT");
+        await PublishAndRunAsync(id, config, true, "First MT");
 
         File.Delete(
             Directory
@@ -111,20 +112,23 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
         );
 
         // Build and run singlethreaded without clean
-        await PublishAndRunAsync(id, config, false);
+        _testOutput.WriteLine("Publish and run ST");
+        await PublishAndRunAsync(id, config, false, "ST after MT");
 
         // Build and run multithreaded again
-        await PublishAndRunAsync(id, config, false);
+        _testOutput.WriteLine("Publish and run MT");
+        await PublishAndRunAsync(id, config, false, "MT after ST");
     }
 
-    private async Task PublishAndRunAsync(string id, string config, bool isMultiThreaded) 
+    private async Task PublishAndRunAsync(string id, string config, bool isMultiThreaded, string label) 
     {
         BlazorPublish(
             new BlazorBuildOptions(
                 id,
                 config,
                 NativeFilesType.FromRuntimePack,
-                RuntimeType: isMultiThreaded ? RuntimeVariant.MultiThreaded : RuntimeVariant.SingleThreaded
+                RuntimeType: isMultiThreaded ? RuntimeVariant.MultiThreaded : RuntimeVariant.SingleThreaded,
+                Label: label
             ), 
             isMultiThreaded ? new string[] { "-p:WasmEnableThreads=true"} : new string[0]
         );

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/SimpleMultiThreadedTests.cs
@@ -95,7 +95,7 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
     }
 
     [ConditionalTheory(typeof(BuildTestBase), nameof(IsWorkloadWithMultiThreadingForDefaultFramework))]
-    [InlineData("Debug")]
+    [InlineData("Release")]
     public async Task SwitchSingleAndMultiThreaded(string config)
     {
         string id = $"blazor_mt_{config}_{GetRandomId()}";
@@ -126,7 +126,7 @@ public class SimpleMultiThreadedTests : BlazorWasmTestBase
             new BlazorBuildOptions(
                 id,
                 config,
-                NativeFilesType.FromRuntimePack,
+                NativeFilesType.Relinked,
                 RuntimeType: isMultiThreaded ? RuntimeVariant.MultiThreaded : RuntimeVariant.SingleThreaded,
                 Label: label
             ), 


### PR DESCRIPTION
_TBD_

This is more of a hotfix. I would like to find a better solution with inputs and outputs, but didn't succeeded yet

When build is fixed, publish works without changes needed

Fixes https://github.com/dotnet/runtime/issues/98502