### PR TITLE
Ensure file-opening exceptions emerge asynchronously from File.Append/WriteAllLinesAsync

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/ReadWriteAllLinesAsync.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/ReadWriteAllLinesAsync.cs
@@ -98,8 +98,11 @@ namespace System.IO.Tests
 
             using (File.Create(path))
             {
-                await Assert.ThrowsAsync<IOException>(async () => await WriteAsync(path, lines));
-                await Assert.ThrowsAsync<IOException>(async () => await ReadAsync(path));
+                Task t = WriteAsync(path, lines);
+                await Assert.ThrowsAsync<IOException>(async () => await t);
+
+                t = ReadAsync(path);
+                await Assert.ThrowsAsync<IOException>(async () => await t);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/98564