### PR TITLE
Remove test exclusion for dotnet/runtimelab#164

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -772,9 +772,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Interop/LayoutClass/LayoutClassTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/81673</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/MarshalAPI/FunctionPointer/FunctionPtrTest/*">
-            <Issue>https://github.com/dotnet/runtimelab/issues/164</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/NativeLibrary/AssemblyLoadContext/ResolveUnmanagedDllTests/*">
             <Issue>https://github.com/dotnet/runtimelab/issues/165</Issue>
         </ExcludeList>


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtimelab/issues/164

The path no longer exists in the repository.