### PR TITLE
Delete MemoryHelpers.Memset

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/EETypeCreator.cs
@@ -104,25 +104,14 @@ namespace Internal.Runtime.TypeLoader
             return result;
         }
 
-        public static unsafe void Memset(IntPtr destination, int length, byte value)
+        public static unsafe void* AllocateMemory(int cbBytes)
         {
-            byte* pbDest = (byte*)destination.ToPointer();
-            while (length > 0)
-            {
-                *pbDest = value;
-                pbDest++;
-                length--;
-            }
+            return NativeMemory.Alloc((nuint)cbBytes);
         }
 
-        public static unsafe IntPtr AllocateMemory(int cbBytes)
+        public static unsafe void FreeMemory(void* memoryPtrToFree)
         {
-            return (IntPtr)NativeMemory.Alloc((nuint)cbBytes);
-        }
-
-        public static unsafe void FreeMemory(IntPtr memoryPtrToFree)
-        {
-            NativeMemory.Free((void*)memoryPtrToFree);
+            NativeMemory.Free(memoryPtrToFree);
         }
     }
 
@@ -132,12 +121,12 @@ namespace Internal.Runtime.TypeLoader
             int arity, TypeBuilderState state)
         {
             bool successful = false;
-            IntPtr eeTypePtrPlusGCDesc = IntPtr.Zero;
-            IntPtr writableDataPtr = IntPtr.Zero;
-            IntPtr gcStaticData = IntPtr.Zero;
-            IntPtr nonGcStaticData = IntPtr.Zero;
-            IntPtr genericComposition = IntPtr.Zero;
-            IntPtr threadStaticIndex = IntPtr.Zero;
+            void* eeTypePlusGCDesc = null;
+            void* writableData = null;
+            void* nonGcStaticData = null;
+            void* genericComposition = null;
+            void* threadStaticIndex = null;
+            nint gcStaticData = 0;
 
             try
             {
@@ -266,10 +255,10 @@ namespace Internal.Runtime.TypeLoader
                     int cbGCDescAligned = MemoryHelpers.AlignUp(cbGCDesc, IntPtr.Size);
 
                     // Allocate enough space for the MethodTable + gcDescSize
-                    eeTypePtrPlusGCDesc = MemoryHelpers.AllocateMemory(cbGCDescAligned + cbEEType + cbOptionalFieldsSize);
+                    eeTypePlusGCDesc = MemoryHelpers.AllocateMemory(cbGCDescAligned + cbEEType + cbOptionalFieldsSize);
 
                     // Get the MethodTable pointer, and the template MethodTable pointer
-                    pEEType = (MethodTable*)(eeTypePtrPlusGCDesc + cbGCDescAligned);
+                    pEEType = (MethodTable*)((byte*)eeTypePlusGCDesc + cbGCDescAligned);
                     state.HalfBakedRuntimeTypeHandle = pEEType->ToRuntimeTypeHandle();
 
                     // Set basic MethodTable fields
@@ -319,9 +308,9 @@ namespace Internal.Runtime.TypeLoader
                     *((void**)((byte*)pEEType + cbSealedVirtualSlotsTypeOffset)) = pTemplateEEType->GetSealedVirtualTable();
                 }
 
-                writableDataPtr = MemoryHelpers.AllocateMemory(WritableData.GetSize(IntPtr.Size));
-                MemoryHelpers.Memset(writableDataPtr, WritableData.GetSize(IntPtr.Size), 0);
-                pEEType->WritableData = (void*)writableDataPtr;
+                writableData = MemoryHelpers.AllocateMemory(WritableData.GetSize(IntPtr.Size));
+                NativeMemory.Clear(writableData, (nuint)WritableData.GetSize(IntPtr.Size));
+                pEEType->WritableData = writableData;
 
                 pEEType->DynamicTemplateType = pTemplateEEType;
 
@@ -340,13 +329,13 @@ namespace Internal.Runtime.TypeLoader
                     if (arity > 1)
                     {
                         genericComposition = MemoryHelpers.AllocateMemory(MethodTable.GetGenericCompositionSize(arity));
-                        pEEType->SetGenericComposition(genericComposition);
+                        pEEType->SetGenericComposition((IntPtr)genericComposition);
                     }
 
                     if (allocatedNonGCDataSize > 0)
                     {
                         nonGcStaticData = MemoryHelpers.AllocateMemory(allocatedNonGCDataSize);
-                        MemoryHelpers.Memset(nonGcStaticData, allocatedNonGCDataSize, 0);
+                        NativeMemory.Clear(nonGcStaticData, (nuint)allocatedNonGCDataSize);
                         Debug.Assert(nonGCStaticDataOffset <= allocatedNonGCDataSize);
                         pEEType->DynamicNonGcStaticsData = (IntPtr)((byte*)nonGcStaticData + nonGCStaticDataOffset);
                     }
@@ -359,7 +348,7 @@ namespace Internal.Runtime.TypeLoader
                     threadStaticIndex = MemoryHelpers.AllocateMemory(IntPtr.Size * 2);
                     *(IntPtr*)threadStaticIndex = pEEType->PointerToTypeManager;
                     *(((IntPtr*)threadStaticIndex) + 1) = (IntPtr)state.ThreadStaticOffset;
-                    pEEType->DynamicThreadStaticsIndex = threadStaticIndex;
+                    pEEType->DynamicThreadStaticsIndex = (IntPtr)threadStaticIndex;
                 }
 
                 if (state.GcDataSize != 0)
@@ -368,7 +357,7 @@ namespace Internal.Runtime.TypeLoader
                     object obj = RuntimeAugments.RawNewObject(((MethodTable*)state.GcStaticDesc)->ToRuntimeTypeHandle());
                     gcStaticData = RuntimeAugments.RhHandleAlloc(obj, GCHandleType.Normal);
 
-                    pEEType->DynamicGcStaticsData = gcStaticData;
+                    pEEType->DynamicGcStaticsData = (IntPtr)gcStaticData;
                 }
 
                 if (state.Dictionary != null)
@@ -383,20 +372,16 @@ namespace Internal.Runtime.TypeLoader
             {
                 if (!successful)
                 {
-                    if (eeTypePtrPlusGCDesc != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(eeTypePtrPlusGCDesc);
-                    if (state.HalfBakedDictionary != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(state.HalfBakedDictionary);
-                    if (gcStaticData != IntPtr.Zero)
+                    if (gcStaticData != 0)
                         RuntimeAugments.RhHandleFree(gcStaticData);
-                    if (genericComposition != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(genericComposition);
-                    if (nonGcStaticData != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(nonGcStaticData);
-                    if (writableDataPtr != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(writableDataPtr);
-                    if (threadStaticIndex != IntPtr.Zero)
-                        MemoryHelpers.FreeMemory(threadStaticIndex);
+
+                    MemoryHelpers.FreeMemory((void*)state.HalfBakedDictionary);
+
+                    MemoryHelpers.FreeMemory(threadStaticIndex);
+                    MemoryHelpers.FreeMemory(nonGcStaticData);
+                    MemoryHelpers.FreeMemory(genericComposition);
+                    MemoryHelpers.FreeMemory(writableData);
+                    MemoryHelpers.FreeMemory(eeTypePlusGCDesc);
                 }
             }
         }

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeBuilder.cs
@@ -1080,7 +1080,7 @@ namespace Internal.Runtime.TypeLoader
 
             // The first is a pointer that points to the TypeManager indirection cell.
             // The second is the offset into the native layout info blob in that TypeManager, where the native signature is encoded.
-            IntPtr** lazySignature = (IntPtr**)signature.ToPointer();
+            IntPtr** lazySignature = (IntPtr**)signature;
             typeManager = new TypeManagerHandle(lazySignature[0][0]);
             offset = checked((uint)new IntPtr(lazySignature[1]).ToInt32());
             reader = TypeLoaderEnvironment.GetNativeLayoutInfoReader(typeManager);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.LdTokenResultLookup.cs
@@ -43,7 +43,7 @@ namespace Internal.Runtime.TypeLoader
         #region String conversions
         private static unsafe string GetStringFromMemoryInNativeFormat(IntPtr pointerToDataStream)
         {
-            byte* dataStream = (byte*)pointerToDataStream.ToPointer();
+            byte* dataStream = (byte*)pointerToDataStream;
             uint stringLen = NativePrimitiveDecoder.DecodeUnsigned(ref dataStream);
             return Encoding.UTF8.GetString(dataStream, checked((int)stringLen));
         }
@@ -54,7 +54,7 @@ namespace Internal.Runtime.TypeLoader
         /// </summary>
         /// <param name="str"></param>
         /// <returns></returns>
-        public IntPtr GetNativeFormatStringForString(string str)
+        public unsafe IntPtr GetNativeFormatStringForString(string str)
         {
             using (_typeLoaderLock.EnterScope())
             {
@@ -69,13 +69,13 @@ namespace Internal.Runtime.TypeLoader
                 foreach (byte b in utf8Bytes)
                     stringEncoder.WriteByte(b);
 
-                IntPtr allocatedNativeFormatString = MemoryHelpers.AllocateMemory(stringEncoder.Size);
+                void* allocatedNativeFormatString = MemoryHelpers.AllocateMemory(stringEncoder.Size);
                 unsafe
                 {
-                    stringEncoder.Save((byte*)allocatedNativeFormatString.ToPointer(), stringEncoder.Size);
+                    stringEncoder.Save((byte*)allocatedNativeFormatString, stringEncoder.Size);
                 }
-                _nativeFormatStrings.Add(str, allocatedNativeFormatString);
-                return allocatedNativeFormatString;
+                _nativeFormatStrings.Add(str, (IntPtr)allocatedNativeFormatString);
+                return (IntPtr)allocatedNativeFormatString;
             }
         }
 
@@ -197,16 +197,12 @@ namespace Internal.Runtime.TypeLoader
             {
                 if (!_runtimeFieldHandles.TryGetValue(key, out runtimeFieldHandle))
                 {
-                    IntPtr runtimeFieldHandleValue = MemoryHelpers.AllocateMemory(sizeof(DynamicFieldHandleInfo));
-                    if (runtimeFieldHandleValue == IntPtr.Zero)
-                        throw new OutOfMemoryException();
-
-                    DynamicFieldHandleInfo* fieldData = (DynamicFieldHandleInfo*)runtimeFieldHandleValue.ToPointer();
+                    DynamicFieldHandleInfo* fieldData = (DynamicFieldHandleInfo*)MemoryHelpers.AllocateMemory(sizeof(DynamicFieldHandleInfo));
                     fieldData->DeclaringType = *(IntPtr*)&declaringTypeHandle;
                     fieldData->FieldName = fieldName;
 
                     // Special flag (lowest bit set) in the handle value to indicate it was dynamically allocated
-                    runtimeFieldHandleValue++;
+                    IntPtr runtimeFieldHandleValue = (IntPtr)fieldData + 1;
                     runtimeFieldHandle = *(RuntimeFieldHandle*)&runtimeFieldHandleValue;
 
                     _runtimeFieldHandles.Add(key, runtimeFieldHandle);
@@ -228,10 +224,9 @@ namespace Internal.Runtime.TypeLoader
             IntPtr runtimeFieldHandleValue = *(IntPtr*)&runtimeFieldHandle;
 
             // Special flag in the handle value to indicate it was dynamically allocated
-            Debug.Assert((runtimeFieldHandleValue.ToInt64() & 0x1) == 0x1);
-            runtimeFieldHandleValue--;
+            Debug.Assert((runtimeFieldHandleValue & 0x1) == 0x1);
 
-            DynamicFieldHandleInfo* fieldData = (DynamicFieldHandleInfo*)runtimeFieldHandleValue.ToPointer();
+            DynamicFieldHandleInfo* fieldData = (DynamicFieldHandleInfo*)(runtimeFieldHandleValue - 1);
             declaringTypeHandle = *(RuntimeTypeHandle*)&(fieldData->DeclaringType);
 
             // FieldName points to the field name in NativeLayout format, so we parse it using a NativeParser
@@ -297,11 +292,8 @@ namespace Internal.Runtime.TypeLoader
                     int numGenericMethodArgs = genericMethodArgs == null ? 0 : genericMethodArgs.Length;
                     // Use checked arithmetics to ensure there aren't any overflows/truncations
                     sizeToAllocate = checked(sizeToAllocate + (numGenericMethodArgs > 0 ? sizeof(IntPtr) * (numGenericMethodArgs - 1) : 0));
-                    IntPtr runtimeMethodHandleValue = MemoryHelpers.AllocateMemory(sizeToAllocate);
-                    if (runtimeMethodHandleValue == IntPtr.Zero)
-                        throw new OutOfMemoryException();
 
-                    DynamicMethodHandleInfo* methodData = (DynamicMethodHandleInfo*)runtimeMethodHandleValue.ToPointer();
+                    DynamicMethodHandleInfo* methodData = (DynamicMethodHandleInfo*)MemoryHelpers.AllocateMemory(sizeToAllocate);
                     methodData->DeclaringType = *(IntPtr*)&declaringTypeHandle;
                     methodData->MethodName = methodName;
                     methodData->MethodSignature = methodSignature;
@@ -314,7 +306,7 @@ namespace Internal.Runtime.TypeLoader
                     }
 
                     // Special flag in the handle value to indicate it was dynamically allocated, and doesn't point into the InvokeMap blob
-                    runtimeMethodHandleValue++;
+                    IntPtr runtimeMethodHandleValue = (IntPtr)methodData + 1;
                     runtimeMethodHandle = *(RuntimeMethodHandle*)&runtimeMethodHandleValue;
 
                     _runtimeMethodHandles.Add(key, runtimeMethodHandle);
@@ -346,12 +338,12 @@ namespace Internal.Runtime.TypeLoader
         private unsafe bool TryGetDynamicRuntimeMethodHandleComponents(RuntimeMethodHandle runtimeMethodHandle, out RuntimeTypeHandle declaringTypeHandle, out MethodNameAndSignature nameAndSignature, out RuntimeTypeHandle[] genericMethodArgs)
         {
             IntPtr runtimeMethodHandleValue = *(IntPtr*)&runtimeMethodHandle;
-            Debug.Assert((runtimeMethodHandleValue.ToInt64() & 0x1) == 0x1);
 
             // Special flag in the handle value to indicate it was dynamically allocated, and doesn't point into the InvokeMap blob
-            runtimeMethodHandleValue--;
+            Debug.Assert((runtimeMethodHandleValue & 0x1) == 0x1);
 
-            DynamicMethodHandleInfo* methodData = (DynamicMethodHandleInfo*)runtimeMethodHandleValue.ToPointer();
+            DynamicMethodHandleInfo* methodData = (DynamicMethodHandleInfo*)(runtimeMethodHandleValue - 1);
+
             declaringTypeHandle = *(RuntimeTypeHandle*)&(methodData->DeclaringType);
             genericMethodArgs = null;
 

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/TypeSystemContext.Runtime.cs
@@ -42,7 +42,7 @@ namespace Internal.TypeSystem
             {
                 unsafe
                 {
-                    return ((MethodTable*)pointer.ToPointer())->ToRuntimeTypeHandle();
+                    return ((MethodTable*)pointer)->ToRuntimeTypeHandle();
                 }
             }
 
@@ -104,7 +104,7 @@ namespace Internal.TypeSystem
             {
                 unsafe
                 {
-                    return ((MethodTable*)pointer.ToPointer())->ToRuntimeTypeHandle();
+                    return ((MethodTable*)pointer)->ToRuntimeTypeHandle();
                 }
             }
 


### PR DESCRIPTION
- Replaced MemoryHelpers.Memset with NativeMemory.Clear
- Cleanup up some pointer manipulations in native aot type loader