### PR TITLE
Include namespace in the reflection error message

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/MethodBaseInvoker.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Reflection/Core/Execution/MethodBaseInvoker.cs
@@ -57,7 +57,7 @@ namespace Internal.Reflection.Core.Execution
                 throw new TargetException(SR.RFLCT_Targ_StatMethReqTarg);
 
             if (!RuntimeAugments.IsAssignable(thisObject, declaringTypeHandle))
-                throw new TargetException(SR.Format(SR.RFLCT_Targ_ITargMismatch_WithType, declaringTypeHandle.GetRuntimeTypeInfoForRuntimeTypeHandle().Name, thisObject.GetType().Name));
+                throw new TargetException(SR.Format(SR.RFLCT_Targ_ITargMismatch_WithType, declaringTypeHandle.GetRuntimeTypeInfoForRuntimeTypeHandle(), thisObject.GetType()));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/FieldAccessor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/FieldAccessor.cs
@@ -381,7 +381,7 @@ namespace System.Reflection
             if ((_fieldInfo.Attributes & FieldAttributes.InitOnly) == FieldAttributes.InitOnly &&
                 _fieldAccessType != FieldAccessorType.SlowPathUntilClassInitialized)
             {
-                ThrowHelperFieldAccessException(_fieldInfo.Name, _fieldInfo.DeclaringType?.FullName);
+                ThrowHelperFieldAccessException(_fieldInfo);
             }
         }
 
@@ -480,8 +480,8 @@ namespace System.Reflection
         private static void ThrowHelperArgumentException(object target, FieldInfo fieldInfo) =>
             throw new ArgumentException(SR.Format(SR.Arg_FieldDeclTarget, fieldInfo.Name, fieldInfo.DeclaringType, target.GetType()));
 
-        private static void ThrowHelperFieldAccessException(string fieldName, string? declaringTypeName) =>
-            throw new FieldAccessException(SR.Format(SR.RFLCT_CannotSetInitonlyStaticField, fieldName, declaringTypeName));
+        private static void ThrowHelperFieldAccessException(FieldInfo fieldInfo) =>
+            throw new FieldAccessException(SR.Format(SR.RFLCT_CannotSetInitonlyStaticField, fieldInfo.Name, fieldInfo.DeclaringType));
 
         private enum FieldAccessorType
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
@@ -96,7 +96,7 @@ namespace System.Reflection
 
             if (!method.DeclaringType!.IsInstanceOfType(target))
             {
-                throw new TargetException(SR.Format(SR.RFLCT_Targ_ITargMismatch_WithType, method.DeclaringType.Name, target.GetType().Name));
+                throw new TargetException(SR.Format(SR.RFLCT_Targ_ITargMismatch_WithType, method.DeclaringType, target.GetType()));
             }
         }
 


### PR DESCRIPTION
Reflection error messages typically include full type name (namespace + name) computed via `ToString`.

Update recently added error messages for consistency.