### PR TITLE
Disable optimize ThreadStaticAccess for FreeBSD/arm64

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -1580,6 +1580,8 @@ void CEEInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
                 // Optimization is disabled for linux/x86
 #elif defined(TARGET_LINUX_MUSL) && defined(TARGET_ARM64)
                 // Optimization is disabled for linux musl arm64
+#elif defined(TARGET_FREEBSD) && defined(TARGET_ARM64)
+                // Optimization is disabled for FreeBSD/arm64
 #else
                 bool optimizeThreadStaticAccess = true;
 #if !defined(TARGET_OSX) && defined(TARGET_UNIX) && defined(TARGET_AMD64)


### PR DESCRIPTION
Quick fix to disable TLS inline access, as it crash on FreeBSD/arm64 (more details [here](https://github.com/dotnet/runtime/issues/71338#issuecomment-1684009823)).

Maybe someone with more expierence in this field will know how/where to fix it, if not - I'm fine with this disabled, as working build is better than non-working one :)