### PR TITLE
[browser][MT] silence "keeping the worker alive for asynchronous operation"

### DIFF
--- a/src/mono/browser/runtime/run.ts
+++ b/src/mono/browser/runtime/run.ts
@@ -75,8 +75,6 @@ export async function mono_run_main(main_assembly_name?: string, args?: string[]
     }
 }
 
-
-
 export function nativeExit(code: number) {
     if (WasmEnableThreads) {
         cancelThreads();


### PR DESCRIPTION
The version of emscripten we have will print following to console any time we try to create thread with external/browser event loop.

```
err('Pthread 0x' + Module['_pthread_self']().toString(16) + ' completed its main entry point with an `unwind`, keeping the worker alive for asynchronous operation.');
```

![image](https://github.com/dotnet/runtime/assets/271576/9ee07595-9880-4cf9-9ec4-2cc98cc9fd0f)

