### PR TITLE
New TimeSpan.From overloads which take integers

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/DebugViewTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/DebugViewTests.cs
@@ -316,7 +316,7 @@ namespace System.Linq.Expressions.Tests
             Check(".Call $x.ToString()", Expression.Call(x, typeof(int).GetMethod("ToString", Type.EmptyTypes)));
             Check(".Call $s.Substring($x)", Expression.Call(s, typeof(string).GetMethod("Substring", new[] { typeof(int) }), x));
             Check(".Call $s.Substring(\\r\\n    $x,\\r\\n    $y)", Expression.Call(s, typeof(string).GetMethod("Substring", new[] { typeof(int), typeof(int) }), x, y));
-            Check(".Call System.TimeSpan.FromSeconds($d)", Expression.Call(null, typeof(TimeSpan).GetMethod("FromSeconds", new[] { typeof(int) }), d));
+            Check(".Call System.TimeSpan.FromSeconds($d)", Expression.Call(null, typeof(TimeSpan).GetMethod("FromSeconds", new[] { typeof(double) }), d));
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -235,6 +235,16 @@ namespace System
             return (long)high - ((a >> 63) & b) - ((b >> 63) & a);
         }
 
+        /// <summary>Produces the full product of two 64-bit numbers.</summary>
+        /// <param name="a">The first number to multiply.</param>
+        /// <param name="b">The second number to multiply.</param>
+        /// <returns>The full product of the specified numbers.</returns>
+        internal static Int128 BigMul(long a, long b)
+        {
+            long high = Math.BigMul(a, b, out long low);
+            return new Int128((ulong)high, (ulong)low);
+        }
+
         public static double BitDecrement(double x)
         {
             ulong bits = BitConverter.DoubleToUInt64Bits(x);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -335,19 +335,19 @@ namespace System
         /// </exception>
         public static TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
         {
-            Int128 totalMicroseconds = ((Int128)days * (Int128)MicrosecondsPerDay)
-                                     + ((Int128)hours * (Int128)MicrosecondsPerHour)
-                                     + ((Int128)minutes * (Int128)MicrosecondsPerMinute)
-                                     + ((Int128)seconds * (Int128)MicrosecondsPerSecond)
-                                     + ((Int128)milliseconds * (Int128)MicrosecondsPerMillisecond)
-                                     + (Int128)microseconds;
+            Int128 totalMicroseconds = Math.BigMul(days, MicrosecondsPerDay)
+                                     + Math.BigMul(hours, MicrosecondsPerHour)
+                                     + Math.BigMul(minutes, MicrosecondsPerMinute)
+                                     + Math.BigMul(seconds, MicrosecondsPerSecond)
+                                     + Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
+                                     + microseconds;
 
             if ((totalMicroseconds > MaxMicroseconds) || (totalMicroseconds < MinMicroseconds))
             {
                 ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
             }
             var ticks = (long)totalMicroseconds * TicksPerMicrosecond;
-            return new TimeSpan(ticks);
+            return TimeSpan.FromTicks(ticks);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -313,7 +313,7 @@ namespace System
         /// days.
         /// </summary>
         /// <param name="days">Number of days.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of days.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -329,7 +329,7 @@ namespace System
         /// <param name="seconds">Number of seconds.</param>
         /// <param name="milliseconds">Number of milliseconds.</param>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of days, hours, minutes, seconds, milliseconds, and microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -355,7 +355,7 @@ namespace System
         /// hours.
         /// </summary>
         /// <param name="hours">Number of hours.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of hours.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -370,7 +370,7 @@ namespace System
         /// <param name="seconds">Number of seconds.</param>
         /// <param name="milliseconds">Number of milliseconds.</param>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of hours, minutes, seconds, milliseconds, and microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -382,7 +382,7 @@ namespace System
         /// minutes.
         /// </summary>
         /// <param name="minutes">Number of minutes.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of minutes.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -396,7 +396,7 @@ namespace System
         /// <param name="seconds">Number of seconds.</param>
         /// <param name="milliseconds">Number of milliseconds.</param>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of minutes, seconds, milliseconds, and microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -408,7 +408,7 @@ namespace System
         /// seconds.
         /// </summary>
         /// <param name="seconds">Number of seconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of seconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -421,7 +421,7 @@ namespace System
         /// <param name="seconds">Number of seconds.</param>
         /// <param name="milliseconds">Number of milliseconds.</param>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of seconds, milliseconds, and microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -434,7 +434,7 @@ namespace System
         /// </summary>
         /// <param name="milliseconds">Number of milliseconds.</param>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of milliseconds, and microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
@@ -445,7 +445,7 @@ namespace System
         /// microseconds.
         /// </summary>
         /// <param name="microseconds">Number of microseconds.</param>
-        /// <returns></returns>
+        /// <returns>Returns a <see cref="TimeSpan"/> that represents a specified number of microseconds.</returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -308,6 +308,35 @@ namespace System
 
         public override int GetHashCode() => _ticks.GetHashCode();
 
+        public static TimeSpan FromDays(int days) => FromDays(days, 0);
+        public static TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
+        {
+            long totalMicroseconds = (days * MicrosecondsPerDay)
+                                   + (hours * MicrosecondsPerHour)
+                                   + (minutes * MicrosecondsPerMinute)
+                                   + (seconds * MicrosecondsPerSecond)
+                                   + (milliseconds * MicrosecondsPerMillisecond)
+                                   + microseconds;
+
+            if ((totalMicroseconds > MaxMicroseconds) || (totalMicroseconds < MinMicroseconds))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
+            }
+            var ticks = totalMicroseconds * TicksPerMicrosecond;
+            return new TimeSpan(ticks);
+        }
+        public static TimeSpan FromHours(int hours) => FromDays(0, hours: hours);
+        public static TimeSpan FromHours(int hours, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
+            => FromDays(0, hours: hours, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        public static TimeSpan FromMinutes(long minutes) => FromDays(0, minutes: minutes);
+        public static TimeSpan FromMinutes(long minutes, long seconds = 0, long milliseconds = 0, long microseconds = 0)
+            => FromDays(0, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        public static TimeSpan FromSeconds(long seconds) => FromDays(0, seconds: seconds);
+        public static TimeSpan FromSeconds(long seconds, long milliseconds = 0, long microseconds = 0)
+            => FromDays(0, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0) => FromDays(0, milliseconds: milliseconds, microseconds: microseconds);
+        public static TimeSpan FromMicroseconds(long microseconds) => FromDays(0, microseconds: microseconds);
+
         public static TimeSpan FromHours(double value) => Interval(value, TicksPerHour);
 
         private static TimeSpan Interval(double value, double scale)

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -308,6 +308,19 @@ namespace System
 
         public override int GetHashCode() => _ticks.GetHashCode();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static TimeSpan FromUnits(long units, long ticksPerUnit, long minUnits, long maxUnits)
+        {
+            System.Diagnostics.Debug.Assert(minUnits < 0);
+            System.Diagnostics.Debug.Assert(maxUnits > 0);
+
+            if (units > maxUnits || units < minUnits)
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
+            }
+            return TimeSpan.FromTicks(units * ticksPerUnit);
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
         /// days.
@@ -317,7 +330,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromDays(int days) => FromDays(days, 0);
+        public static TimeSpan FromDays(int days) => FromUnits(days, TicksPerDay, MinDays, MaxDays);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -359,7 +372,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromHours(int hours) => FromDays(0, hours: hours);
+        public static TimeSpan FromHours(int hours) => FromUnits(hours, TicksPerHour, MinHours, MaxHours);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -386,7 +399,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromMinutes(long minutes) => FromDays(0, minutes: minutes);
+        public static TimeSpan FromMinutes(long minutes) => FromUnits(minutes, TicksPerMinute, MinMinutes, MaxMinutes);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -412,7 +425,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromSeconds(long seconds) => FromDays(0, seconds: seconds);
+        public static TimeSpan FromSeconds(long seconds) => FromUnits(seconds, TicksPerSecond, MinSeconds, MaxSeconds);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -449,7 +462,7 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromMicroseconds(long microseconds) => FromDays(0, microseconds: microseconds);
+        public static TimeSpan FromMicroseconds(long microseconds) => FromUnits(microseconds, TicksPerMicrosecond, MinMicroseconds, MaxMicroseconds);
 
         public static TimeSpan FromHours(double value) => Interval(value, TicksPerHour);
 

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -311,18 +311,18 @@ namespace System
         public static TimeSpan FromDays(int days) => FromDays(days, 0);
         public static TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
         {
-            long totalMicroseconds = (days * MicrosecondsPerDay)
-                                   + (hours * MicrosecondsPerHour)
-                                   + (minutes * MicrosecondsPerMinute)
-                                   + (seconds * MicrosecondsPerSecond)
-                                   + (milliseconds * MicrosecondsPerMillisecond)
-                                   + microseconds;
+            Int128 totalMicroseconds = ((Int128)days * (Int128)MicrosecondsPerDay)
+                                     + ((Int128)hours * (Int128)MicrosecondsPerHour)
+                                     + ((Int128)minutes * (Int128)MicrosecondsPerMinute)
+                                     + ((Int128)seconds * (Int128)MicrosecondsPerSecond)
+                                     + ((Int128)milliseconds * (Int128)MicrosecondsPerMillisecond)
+                                     + (Int128)microseconds;
 
             if ((totalMicroseconds > MaxMicroseconds) || (totalMicroseconds < MinMicroseconds))
             {
                 ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
             }
-            var ticks = totalMicroseconds * TicksPerMicrosecond;
+            var ticks = (long)totalMicroseconds * TicksPerMicrosecond;
             return new TimeSpan(ticks);
         }
         public static TimeSpan FromHours(int hours) => FromDays(0, hours: hours);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -308,7 +308,31 @@ namespace System
 
         public override int GetHashCode() => _ticks.GetHashCode();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// days.
+        /// </summary>
+        /// <param name="days">Number of days.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromDays(int days) => FromDays(days, 0);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// days, hours, minutes, seconds, milliseconds, and microseconds.
+        /// </summary>
+        /// <param name="days">Number of days.</param>
+        /// <param name="hours">Number of hours.</param>
+        /// <param name="minutes">Number of minutes.</param>
+        /// <param name="seconds">Number of seconds.</param>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
         {
             Int128 totalMicroseconds = ((Int128)days * (Int128)MicrosecondsPerDay)
@@ -325,16 +349,106 @@ namespace System
             var ticks = (long)totalMicroseconds * TicksPerMicrosecond;
             return new TimeSpan(ticks);
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// hours.
+        /// </summary>
+        /// <param name="hours">Number of hours.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromHours(int hours) => FromDays(0, hours: hours);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// hours, minutes, seconds, milliseconds, and microseconds.
+        /// </summary>
+        /// <param name="hours">Number of hours.</param>
+        /// <param name="minutes">Number of minutes.</param>
+        /// <param name="seconds">Number of seconds.</param>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromHours(int hours, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
             => FromDays(0, hours: hours, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// minutes.
+        /// </summary>
+        /// <param name="minutes">Number of minutes.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromMinutes(long minutes) => FromDays(0, minutes: minutes);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// minutes, seconds, milliseconds, and microseconds.
+        /// </summary>
+        /// <param name="minutes">Number of minutes.</param>
+        /// <param name="seconds">Number of seconds.</param>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromMinutes(long minutes, long seconds = 0, long milliseconds = 0, long microseconds = 0)
             => FromDays(0, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// seconds.
+        /// </summary>
+        /// <param name="seconds">Number of seconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromSeconds(long seconds) => FromDays(0, seconds: seconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// seconds, milliseconds, and microseconds.
+        /// </summary>
+        /// <param name="seconds">Number of seconds.</param>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromSeconds(long seconds, long milliseconds = 0, long microseconds = 0)
             => FromDays(0, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// milliseconds, and microseconds.
+        /// </summary>
+        /// <param name="milliseconds">Number of milliseconds.</param>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0) => FromDays(0, milliseconds: milliseconds, microseconds: microseconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
+        /// microseconds.
+        /// </summary>
+        /// <param name="microseconds">Number of microseconds.</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
+        /// </exception>
         public static TimeSpan FromMicroseconds(long microseconds) => FromDays(0, microseconds: microseconds);
 
         public static TimeSpan FromHours(double value) => Interval(value, TicksPerHour);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -402,7 +402,7 @@ namespace System
         /// </exception>
         public static TimeSpan FromMinutes(long minutes, long seconds = 0, long milliseconds = 0, long microseconds = 0)
             => FromDays(0, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
         /// seconds.

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -355,12 +355,7 @@ namespace System
                                      + Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
                                      + microseconds;
 
-            if ((totalMicroseconds > MaxMicroseconds) || (totalMicroseconds < MinMicroseconds))
-            {
-                ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
-            }
-            var ticks = (long)totalMicroseconds * TicksPerMicrosecond;
-            return TimeSpan.FromTicks(ticks);
+            return FromMicroseconds(totalMicroseconds);
         }
 
         /// <summary>
@@ -451,7 +446,24 @@ namespace System
         /// <exception cref="ArgumentOutOfRangeException">
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
-        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0) => FromDays(0, milliseconds: milliseconds, microseconds: microseconds);
+        public static TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0)
+        {
+            Int128 totalMicroseconds = Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
+                                     + microseconds;
+
+            return FromMicroseconds(totalMicroseconds);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static TimeSpan FromMicroseconds(Int128 microseconds)
+        {
+            if ((microseconds > MaxMicroseconds) || (microseconds < MinMicroseconds))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange_TimeSpanTooLong();
+            }
+            long ticks = (long)microseconds * TicksPerMicrosecond;
+            return TimeSpan.FromTicks(ticks);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of

--- a/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeSpan.cs
@@ -383,7 +383,15 @@ namespace System
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
         public static TimeSpan FromHours(int hours, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0)
-            => FromDays(0, hours: hours, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        {
+            Int128 totalMicroseconds = Math.BigMul(hours, MicrosecondsPerHour)
+                                     + Math.BigMul(minutes, MicrosecondsPerMinute)
+                                     + Math.BigMul(seconds, MicrosecondsPerSecond)
+                                     + Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
+                                     + microseconds;
+
+            return FromMicroseconds(totalMicroseconds);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -409,7 +417,14 @@ namespace System
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
         public static TimeSpan FromMinutes(long minutes, long seconds = 0, long milliseconds = 0, long microseconds = 0)
-            => FromDays(0, minutes: minutes, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        {
+            Int128 totalMicroseconds = Math.BigMul(minutes, MicrosecondsPerMinute)
+                                     + Math.BigMul(seconds, MicrosecondsPerSecond)
+                                     + Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
+                                     + microseconds;
+
+            return FromMicroseconds(totalMicroseconds);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of
@@ -434,7 +449,13 @@ namespace System
         /// The parameters specify a <see cref="TimeSpan"/> value less than <see cref="MinValue"/> or greater than <see cref="MaxValue"/>
         /// </exception>
         public static TimeSpan FromSeconds(long seconds, long milliseconds = 0, long microseconds = 0)
-            => FromDays(0, seconds: seconds, milliseconds: milliseconds, microseconds: microseconds);
+        {
+            Int128 totalMicroseconds = Math.BigMul(seconds, MicrosecondsPerSecond)
+                                     + Math.BigMul(milliseconds, MicrosecondsPerMillisecond)
+                                     + microseconds;
+
+            return FromMicroseconds(totalMicroseconds);
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TimeSpan"/> structure to a specified number of

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5613,6 +5613,16 @@ namespace System
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         public bool Equals(System.TimeSpan obj) { throw null; }
         public static bool Equals(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
+        public static System.TimeSpan FromDays(int days) { throw null; }
+        public static System.TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long  microseconds = 0) { throw null; }
+        public static System.TimeSpan FromHours(int hours) { throw null; }
+        public static System.TimeSpan FromHours(int hours, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0) { throw null; }
+        public static System.TimeSpan FromMinutes(long minutes) { throw null; }
+        public static System.TimeSpan FromMinutes(long minutes, long seconds = 0, long milliseconds = 0, long microseconds = 0) { throw null; }
+        public static System.TimeSpan FromSeconds(long seconds) { throw null; }
+        public static System.TimeSpan FromSeconds(long seconds, long milliseconds = 0, long microseconds = 0) { throw null; }
+        public static System.TimeSpan FromMilliseconds(long milliseconds, long microseconds = 0) { throw null; }
+        public static System.TimeSpan FromMicroseconds(long microseconds) { throw null; }
         public static System.TimeSpan FromDays(double value) { throw null; }
         public static System.TimeSpan FromHours(double value) { throw null; }
         public static System.TimeSpan FromMicroseconds(double value) { throw null; }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5614,7 +5614,7 @@ namespace System
         public bool Equals(System.TimeSpan obj) { throw null; }
         public static bool Equals(System.TimeSpan t1, System.TimeSpan t2) { throw null; }
         public static System.TimeSpan FromDays(int days) { throw null; }
-        public static System.TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long  microseconds = 0) { throw null; }
+        public static System.TimeSpan FromDays(int days, int hours = 0, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0) { throw null; }
         public static System.TimeSpan FromHours(int hours) { throw null; }
         public static System.TimeSpan FromHours(int hours, long minutes = 0, long seconds = 0, long milliseconds = 0, long microseconds = 0) { throw null; }
         public static System.TimeSpan FromMinutes(long minutes) { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -369,33 +369,19 @@ namespace System.Tests
             var actual = TimeSpan.FromDays(0, 0, 0, 0, 0, 0);
             Assert.Equal(expectedaaa, actual);
         }
-        [Fact]
-        public static void FromHours_Int_Overload2()
-        {
-            var expecteda = new TimeSpan(0, 1, 2, 3, 4, 5);
-            var actual = TimeSpan.FromHours(1, 2, 3, 4, 5);
-            Assert.Equal(expecteda, actual);
-        }
-        [Fact]
-        public static void FromMinutes_Int_Overload2()
-        {
-            var expected = new TimeSpan(0, 0, 1, 2, 3, 4);
-            var actual = TimeSpan.FromMinutes(1, 2, 3, 4);
-            Assert.Equal(expected, actual);
-        }
-        [Fact]
-        public static void FromSeconds_Int_Overload2()
-        {
-            var expected = new TimeSpan(0, 0, 0, 1, 2, 3);
-            var actualaaa = TimeSpan.FromSeconds(1, 2, 3);
-            Assert.Equal(expected, actualaaa);
-        }
 
         [Fact]
         public static void FromSeconds_Int_ShouldGiveResultWithPrecision()
         {
             // Given example of problem with double in: https://github.com/dotnet/runtime/issues/93890#issue-1957706751
             Assert.Equal(new TimeSpan(0, 0, 0, 101, 832), TimeSpan.FromSeconds(101, 832));
+        }
+
+        [Fact]
+        public static void FromDays_Int_ShouldOverflow_WhenIntermediateCalculationCouldOverflowBackIntoValidRange()
+        {
+            // Given example of problematic day count in comment in abandoned pr https://github.com/dotnet/runtime/pull/95779/files#r1439772903
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(1067519900));
         }
 
         [Fact]
@@ -495,56 +481,26 @@ namespace System.Tests
             Assert.True(actual > TimeSpan.FromDays(-1));
             Assert.True(actual < TimeSpan.FromDays(1));
         }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenAllParamsIsMaxValidValue()
+        [Theory]
+        [InlineData(maxDays, maxHours, maxMinutes, maxSeconds, maxMilliseconds, maxMicroseconds)]
+        [InlineData(-maxDays, -maxHours, -maxMinutes, -maxSeconds, -maxMilliseconds, -maxMicroseconds)]
+        [InlineData(int.MaxValue, int.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue)]
+        [InlineData(int.MinValue, int.MinValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue)]
+        [InlineData(int.MaxValue, 0, 0, 0, 0, 0)]
+        [InlineData(int.MinValue, 0, 0, 0, 0, 0)]
+        [InlineData(0, int.MaxValue, 0, 0, 0, 0)]
+        [InlineData(0, int.MinValue, 0, 0, 0, 0)]
+        [InlineData(0, 0, long.MaxValue, 0, 0, 0)]
+        [InlineData(0, 0, long.MinValue, 0, 0, 0)]
+        [InlineData(0, 0, 0, long.MaxValue, 0, 0)]
+        [InlineData(0, 0, 0, long.MinValue, 0, 0)]
+        [InlineData(0, 0, 0, 0, long.MaxValue, 0)]
+        [InlineData(0, 0, 0, 0, long.MinValue, 0)]
+        [InlineData(0, 0, 0, 0, 0, long.MaxValue)]
+        [InlineData(0, 0, 0, 0, 0, long.MinValue)]
+        public static void FromDays_Int_ShouldOverflow(int days, int hours, long minutes, long seconds, long milliseconds, long microseconds)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(maxDays, maxHours, maxMinutes, maxSeconds, maxMilliseconds, maxMicroseconds));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldUnderflow_WhenAllParamsIsMinValidValue()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(-maxDays, -maxHours, -maxMinutes, -maxSeconds, -maxMilliseconds, -maxMicroseconds));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenIntermediateCalculationCouldOverflowBackIntoValidRange()
-        {
-            // Given example of problematic day count in comment in abandoned pr https://github.com/dotnet/runtime/pull/95779/files#r1439772903
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(1067519900));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_All()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(int.MaxValue, int.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Days()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(int.MaxValue, 0, 0, 0, 0, 0));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Hours()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, int.MaxValue, 0, 0, 0, 0));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Minutes()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, 0, long.MaxValue, 0, 0, 0));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Seconds()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, 0, 0, long.MaxValue, 0, 0));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Milliseconds()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, 0, 0, 0, long.MaxValue, 0));
-        }
-        [Fact]
-        public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Microseconds()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, 0, 0, 0, 0, long.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(days, hours, minutes, seconds, milliseconds, microseconds));
         }
 
         [Theory]
@@ -588,6 +544,46 @@ namespace System.Tests
         }
 
         [Theory]
+        [InlineData(0, 0, 0, 0, 0)]
+        [InlineData(1, 1, 1, 1, 1)]
+        [InlineData(-1, -1, -1, -1, -1)]
+        [InlineData(maxHours, 0, 0, 0, 0)]
+        [InlineData(-maxHours, 0, 0, 0, 0)]
+        [InlineData(0, maxMinutes, 0, 0, 0)]
+        [InlineData(0, -maxMinutes, 0, 0, 0)]
+        [InlineData(0, 0, maxSeconds, 0, 0)]
+        [InlineData(0, 0, -maxSeconds, 0, 0)]
+        [InlineData(0, 0, 0, maxMilliseconds, 0)]
+        [InlineData(0, 0, 0, -maxMilliseconds, 0)]
+        [InlineData(0, 0, 0, 0, maxMicroseconds)]
+        [InlineData(0, 0, 0, 0, -maxMicroseconds)]
+        public static void FromHours_Int_ShouldCreate(int hours, long minutes, long seconds, long milliseconds, long microseconds)
+        {
+            var ticksFromHours = hours * TimeSpan.TicksPerHour;
+            var ticksFromMinutes = minutes * TimeSpan.TicksPerMinute;
+            var ticksFromSeconds = seconds * TimeSpan.TicksPerSecond;
+            var ticksFromMilliseconds = milliseconds * TimeSpan.TicksPerMillisecond;
+            var ticksFromMicroseconds = microseconds * TimeSpan.TicksPerMicrosecond;
+            var expected = TimeSpan.FromTicks(ticksFromHours + ticksFromMinutes + ticksFromSeconds + ticksFromMilliseconds + ticksFromMicroseconds);
+            Assert.Equal(expected, TimeSpan.FromHours(hours, minutes, seconds, milliseconds, microseconds));
+        }
+        [Theory]
+        [InlineData(maxHours + 1, 0, 0, 0, 0)]
+        [InlineData(-(maxHours + 1), 0, 0, 0, 0)]
+        [InlineData(0, maxMinutes + 1, 0, 0, 0)]
+        [InlineData(0, -(maxMinutes + 1), 0, 0, 0)]
+        [InlineData(0, 0, maxSeconds + 1, 0, 0)]
+        [InlineData(0, 0, -(maxSeconds + 1), 0, 0)]
+        [InlineData(0, 0, 0, maxMilliseconds + 1, 0)]
+        [InlineData(0, 0, 0, -(maxMilliseconds + 1), 0)]
+        [InlineData(0, 0, 0, 0, maxMicroseconds + 1)]
+        [InlineData(0, 0, 0, 0, -(maxMicroseconds + 1))]
+        public static void FromHours_Int_ShouldOverflow(int hours, long minutes, long seconds, long milliseconds, long microseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromHours(hours, minutes, seconds, milliseconds, microseconds));
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(-1)]
@@ -608,6 +604,41 @@ namespace System.Tests
         }
 
         [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(1, 1, 1, 1)]
+        [InlineData(-1, -1, -1, -1)]
+        [InlineData(maxMinutes, 0, 0, 0)]
+        [InlineData(-maxMinutes, 0, 0, 0)]
+        [InlineData(0, maxSeconds, 0, 0)]
+        [InlineData(0, -maxSeconds, 0, 0)]
+        [InlineData(0, 0, maxMilliseconds, 0)]
+        [InlineData(0, 0, -maxMilliseconds, 0)]
+        [InlineData(0, 0, 0, maxMicroseconds)]
+        [InlineData(0, 0, 0, -maxMicroseconds)]
+        public static void FromMinutes_Int_ShouldCreate(long minutes, long seconds, long milliseconds, long microseconds)
+        {
+            var ticksFromMinutes = minutes * TimeSpan.TicksPerMinute;
+            var ticksFromSeconds = seconds * TimeSpan.TicksPerSecond;
+            var ticksFromMilliseconds = milliseconds * TimeSpan.TicksPerMillisecond;
+            var ticksFromMicroseconds = microseconds * TimeSpan.TicksPerMicrosecond;
+            var expected = TimeSpan.FromTicks(ticksFromMinutes + ticksFromSeconds + ticksFromMilliseconds + ticksFromMicroseconds);
+            Assert.Equal(expected, TimeSpan.FromMinutes(minutes, seconds, milliseconds, microseconds));
+        }
+        [Theory]
+        [InlineData(maxMinutes + 1, 0, 0, 0)]
+        [InlineData(-(maxMinutes + 1), 0, 0, 0)]
+        [InlineData(0, maxSeconds + 1, 0, 0)]
+        [InlineData(0, -(maxSeconds + 1), 0, 0)]
+        [InlineData(0, 0, maxMilliseconds + 1, 0)]
+        [InlineData(0, 0, -(maxMilliseconds + 1), 0)]
+        [InlineData(0, 0, 0, maxMicroseconds + 1)]        
+        [InlineData(0, 0, 0, -(maxMicroseconds + 1))]
+        public static void FromMinutes_Int_ShouldOverflow(long minutes, long seconds, long milliseconds, long microseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMinutes(minutes, seconds, milliseconds, microseconds));
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(-1)]
@@ -625,6 +656,45 @@ namespace System.Tests
         public static void FromSeconds_Int_Single_ShouldOverflow(long seconds)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromSeconds(seconds));
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(1, 1, 1)]
+        [InlineData(-1, -1, -1)]
+        [InlineData(maxSeconds, 0, 0)]
+        [InlineData(-maxSeconds, 0, 0)]
+        [InlineData(0, maxMilliseconds, 0)]
+        [InlineData(0, -maxMilliseconds, 0)]
+        [InlineData(0, 0, maxMicroseconds)]
+        [InlineData(0, 0, -maxMicroseconds)]
+        public static void FromSeconds_Int_ShouldCreate(long seconds, long milliseconds, long microseconds)
+        {
+            var ticksFromSeconds = seconds * TimeSpan.TicksPerSecond;
+            var ticksFromMilliseconds = milliseconds * TimeSpan.TicksPerMillisecond;
+            var ticksFromMicroseconds = microseconds * TimeSpan.TicksPerMicrosecond;
+            var expected = TimeSpan.FromTicks(ticksFromSeconds + ticksFromMilliseconds + ticksFromMicroseconds);
+            Assert.Equal(expected, TimeSpan.FromSeconds(seconds, milliseconds, microseconds));
+        }
+        [Theory]
+        [InlineData(maxSeconds + 1, 0, 0)]
+        [InlineData(-(maxSeconds + 1), 0, 0)]
+        [InlineData(0, maxMilliseconds + 1, 0)]
+        [InlineData(0, -(maxMilliseconds + 1), 0)]
+        [InlineData(0, 0, maxMicroseconds + 1)]
+        [InlineData(0, 0, -(maxMicroseconds + 1))]
+        [InlineData(long.MaxValue, 0, 0)]
+        [InlineData(long.MinValue, 0, 0)]
+        [InlineData(0, long.MaxValue, 0)]
+        [InlineData(0, long.MinValue, 0)]
+        [InlineData(0, 0, long.MaxValue)]
+        [InlineData(0, 0, long.MinValue)]
+        [InlineData(maxSeconds, maxMilliseconds, 0)]
+        [InlineData(0, maxMilliseconds, maxMicroseconds)]
+        [InlineData(maxSeconds, 0, maxMicroseconds)]
+        public static void FromSeconds_Int_ShouldOverflow(long seconds, long milliseconds, long microseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromSeconds(seconds, milliseconds, microseconds));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -410,7 +410,7 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void FromSeconds_Int_ProblematicWhenUsingDouble()
+        public static void FromSeconds_Int_ShouldGiveResultWithPrecision()
         {
             // Given example of problem with double in: https://github.com/dotnet/runtime/issues/93890#issue-1957706751
             Assert.Equal(new TimeSpan(0, 0, 0, 101, 832), TimeSpan.FromSeconds(101, 832));
@@ -422,8 +422,8 @@ namespace System.Tests
             var expected = TimeSpan.MaxValue;
             var actual = TimeSpan.FromDays(expected.Days, expected.Hours, expected.Minutes, expected.Seconds, expected.Milliseconds, expected.Microseconds);
             // Should be within TicksPerMicrosecond (10) ticks of expected
-            var diffTicks = (expected-actual).Ticks;
-            Assert.True(diffTicks < 10, $"Diff ticks was {diffTicks}");
+            var diffTicks = (expected - actual).Ticks;
+            Assert.True(Math.Abs(diffTicks) < 10, $"Diff ticks was {diffTicks}");
         }
         [Fact]
         public static void FromDays_Int_ShouldConstructMinValueAproximation()
@@ -431,8 +431,8 @@ namespace System.Tests
             var expected = TimeSpan.MinValue;
             var actual = TimeSpan.FromDays(expected.Days, expected.Hours, expected.Minutes, expected.Seconds, expected.Milliseconds, expected.Microseconds);
             // Should be within TicksPerMicrosecond (10) ticks of expected
-            var diffTicks = (actual-expected).Ticks;
-            Assert.True(diffTicks < 10, $"Diff ticks was {diffTicks}");
+            var diffTicks = (actual - expected).Ticks;
+            Assert.True(Math.Abs(diffTicks) < 10, $"Diff ticks was {diffTicks}");
         }
 
         // Consts copied from internal const in TimeSpan
@@ -481,7 +481,7 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(days, hours, minutes, seconds, milliseconds, microseconds));
         }
 
-        public static IEnumerable<object[]> FromDays_Int_ShouldNotOverflow_WhenOverflowParamIsCounteredByOppositeSignParam_Data()
+        public static IEnumerable<object[]> FromDays_Int_ShouldNotOverflow_WhenOverflowingParamIsCounteredByOppositeSignParam_Data()
         {
             long[] individualMaxValues = [ maxDays, maxHours, maxMinutes, maxSeconds, maxMilliseconds, maxMicroseconds ];
             for (var i = 0; i < individualMaxValues.Length; i++)
@@ -502,11 +502,12 @@ namespace System.Tests
             }
         }
         [Theory]
-        [MemberData(nameof(FromDays_Int_ShouldNotOverflow_WhenOverflowParamIsCounteredByOppositeSignParam_Data))]
-        public static void FromDays_Int_ShouldNotOverflow_WhenOverflowParamIsCounteredByOppositeSignParam(int days, int hours, long minutes, long seconds, long milliseconds, long microseconds)
+        [MemberData(nameof(FromDays_Int_ShouldNotOverflow_WhenOverflowingParamIsCounteredByOppositeSignParam_Data))]
+        public static void FromDays_Int_ShouldNotOverflow_WhenOverflowingParamIsCounteredByOppositeSignParam(int days, int hours, long minutes, long seconds, long milliseconds, long microseconds)
         {
             var actual = TimeSpan.FromDays(days, hours, minutes, seconds, milliseconds, microseconds);
             // 2 individually overflowing or underflowing params with opposite sign should end up close to TimeSpan.FromDays(0)
+            // This is an implementation detail of the chosen test data, but a nice sanity check of expected result
             Assert.True(actual > TimeSpan.FromDays(-1));
             Assert.True(actual < TimeSpan.FromDays(1));
         }
@@ -521,7 +522,7 @@ namespace System.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(-maxDays, -maxHours, -maxMinutes, -maxSeconds, -maxMilliseconds, -maxMicroseconds));
         }
         [Fact]
-        public static void FromDays_Int_WhenIntermediateCalculationOverflows()
+        public static void FromDays_Int_ShouldOverflow_WhenIntermediateCalculationCouldOverflowBackIntoValidRange()
         {
             // Given example of problematic day count in comment in abandoned pr https://github.com/dotnet/runtime/pull/95779/files#r1439772903
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(1067519900));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -449,12 +449,13 @@ namespace System.Tests
             // Each possibility for individual property to overflow or underflow
             for (var i = 0; i < individualMaxValues.Length; i++)
             {
-               object[] result = [ 0, 0, 0, 0, 0, 0 ];
-               var iVal = individualMaxValues[i] + 1;
-               result[i] = iVal;
-               yield return result;
-               result[i] = -iVal;
-               yield return result;
+                var iVal = individualMaxValues[i] + 1;
+               object[] resultPos = [ 0, 0, 0, 0, 0, 0 ];
+               resultPos[i] = iVal;
+               yield return resultPos;
+               object[] resultNeg = [ 0, 0, 0, 0, 0, 0 ];
+               resultNeg[i] = -iVal;
+               yield return resultNeg;
             }
             // Each possibility for 2 properties to overflow or underflow
             // while neither of them individually overflow or underflow
@@ -464,13 +465,14 @@ namespace System.Tests
                 {
                     var iVal = individualMaxValues[i];
                     var jVal = individualMaxValues[j];
-                    object[] result = [ 0, 0, 0, 0, 0, 0 ];
-                    result[i] = iVal;
-                    result[j] = jVal;
-                    yield return result;
-                    result[i] = -iVal;
-                    result[j] = -jVal;
-                    yield return result;
+                    object[] resultPos = [ 0, 0, 0, 0, 0, 0 ];
+                    resultPos[i] = iVal;
+                    resultPos[j] = jVal;
+                    yield return resultPos;
+                    object[] resultNeg = [ 0, 0, 0, 0, 0, 0 ];
+                    resultNeg[i] = -iVal;
+                    resultNeg[j] = -jVal;
+                    yield return resultNeg;
                 }
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -460,12 +460,8 @@ namespace System.Tests
             // while neither of them individually overflow or underflow
             for (var i = 0; i < individualMaxValues.Length; i++)
             {
-                for (var j = 0; j < individualMaxValues.Length; j++)
+                for (var j = i + 1; j < individualMaxValues.Length; j++)
                 {
-                    if (i == j)
-                    {
-                        continue;
-                    }
                     var iVal = individualMaxValues[i];
                     var jVal = individualMaxValues[j];
                     object[] result = [ 0, 0, 0, 0, 0, 0 ];

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -349,21 +349,25 @@ namespace System.Tests
 
 #region FromX_int_overloads
         [Fact]
-        public static void FromDays_Int_Overload1()
-        {
-            Assert.Equal(new TimeSpan(1, 0, 0, 0), TimeSpan.FromDays(1));
-        }
-        [Fact]
-        public static void FromDays_Int_Overload2()
+        public static void FromDays_Int_Positive()
         {
             var expectedaaa = new TimeSpan(1, 2, 3, 4, 5, 6);
             var actual = TimeSpan.FromDays(1, 2, 3, 4, 5, 6);
             Assert.Equal(expectedaaa, actual);
         }
         [Fact]
-        public static void FromHours_Int_Overload1()
+        public static void FromDays_Int_Negative()
         {
-            Assert.Equal(new TimeSpan(1, 0, 0), TimeSpan.FromHours(1));
+            var expectedaaa = new TimeSpan(-1, -2, -3, -4, -5, -6);
+            var actual = TimeSpan.FromDays(-1, -2, -3, -4, -5, -6);
+            Assert.Equal(expectedaaa, actual);
+        }
+        [Fact]
+        public static void FromDays_Int_Zero()
+        {
+            var expectedaaa = new TimeSpan(0, 0, 0, 0, 0, 0);
+            var actual = TimeSpan.FromDays(0, 0, 0, 0, 0, 0);
+            Assert.Equal(expectedaaa, actual);
         }
         [Fact]
         public static void FromHours_Int_Overload2()
@@ -373,21 +377,11 @@ namespace System.Tests
             Assert.Equal(expecteda, actual);
         }
         [Fact]
-        public static void FromMinutes_Int_Overload1()
-        {
-            Assert.Equal(new TimeSpan(0, 1, 0), TimeSpan.FromMinutes(1));
-        }
-        [Fact]
         public static void FromMinutes_Int_Overload2()
         {
             var expected = new TimeSpan(0, 0, 1, 2, 3, 4);
             var actual = TimeSpan.FromMinutes(1, 2, 3, 4);
             Assert.Equal(expected, actual);
-        }
-        [Fact]
-        public static void FromSeconds_Int_Overload1()
-        {
-            Assert.Equal(new TimeSpan(0, 0, 1), TimeSpan.FromSeconds(1));
         }
         [Fact]
         public static void FromSeconds_Int_Overload2()
@@ -402,11 +396,6 @@ namespace System.Tests
             var expected = new TimeSpan(0, 0, 0, 0, 1, 2);
             var actuala = TimeSpan.FromMilliseconds(1, 2);
             Assert.Equal(expected, actuala);
-        }
-        [Fact]
-        public static void FromMicroseconds_Int_Overload()
-        {
-            Assert.Equal(new TimeSpan(0, 0, 0, 0, 0, 1), TimeSpan.FromMicroseconds(1));
         }
 
         [Fact]
@@ -563,6 +552,126 @@ namespace System.Tests
         public static void FromDays_Int_ShouldOverflow_WhenParamIsTypeMaxValue_Microseconds()
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(0, 0, 0, 0, 0, long.MaxValue));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxDays)]
+        [InlineData(-maxDays)]
+        public static void FromDays_Int_Single_ShouldCreate(int days)
+        {
+            Assert.Equal(new TimeSpan(days, 0, 0, 0), TimeSpan.FromDays(days));
+        }
+        [Theory]
+        [InlineData(maxDays + 1)]
+        [InlineData(-(maxDays + 1))]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        public static void FromDays_Int_Single_ShouldOverflow(int days)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromDays(days));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxHours)]
+        [InlineData(-maxHours)]
+        public static void FromHours_Int_Single_ShouldCreate(int hours)
+        {
+            Assert.Equal(new TimeSpan(0, hours, 0, 0), TimeSpan.FromHours(hours));
+        }
+        [Theory]
+        [InlineData(maxHours + 1)]
+        [InlineData(-(maxHours + 1))]
+        [InlineData(int.MaxValue)]
+        [InlineData(int.MinValue)]
+        public static void FromHours_Int_Single_ShouldOverflow(int hours)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromHours(hours));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxMinutes)]
+        [InlineData(-maxMinutes)]
+        public static void FromMinutes_Int_Single_ShouldCreate(long minutes)
+        {
+            Assert.Equal(TimeSpan.FromDays(0, minutes: minutes), TimeSpan.FromMinutes(minutes));
+        }
+        [Theory]
+        [InlineData(maxMinutes + 1)]
+        [InlineData(-(maxMinutes + 1))]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public static void FromMinutes_Int_Single_ShouldOverflow(long minutes)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMinutes(minutes));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxSeconds)]
+        [InlineData(-maxSeconds)]
+        public static void FromSeconds_Int_Single_ShouldCreate(long seconds)
+        {
+            Assert.Equal(TimeSpan.FromDays(0, seconds: seconds), TimeSpan.FromSeconds(seconds));
+        }
+        [Theory]
+        [InlineData(maxSeconds + 1)]
+        [InlineData(-(maxSeconds + 1))]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public static void FromSeconds_Int_Single_ShouldOverflow(long seconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromSeconds(seconds));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxMilliseconds)]
+        [InlineData(-maxMilliseconds)]
+        public static void FromMilliseconds_Int_Single_ShouldCreate(long milliseconds)
+        {
+            Assert.Equal(TimeSpan.FromDays(0, milliseconds: milliseconds), TimeSpan.FromMilliseconds(milliseconds));
+        }
+        [Theory]
+        [InlineData(maxMilliseconds + 1)]
+        [InlineData(-(maxMilliseconds + 1))]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public static void FromMilliseconds_Int_Single_ShouldOverflow(long milliseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMilliseconds(milliseconds));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(-1)]
+        [InlineData(maxMicroseconds)]
+        [InlineData(-maxMicroseconds)]
+        public static void FromMicroseconds_Int_Single_ShouldCreate(long microseconds)
+        {
+            Assert.Equal(TimeSpan.FromDays(0, microseconds: microseconds), TimeSpan.FromMicroseconds(microseconds));
+        }
+        [Theory]
+        [InlineData(maxMicroseconds + 1)]
+        [InlineData(-(maxMicroseconds + 1))]
+        [InlineData(long.MaxValue)]
+        [InlineData(long.MinValue)]
+        public static void FromMicroseconds_Int_Single_ShouldOverflow(long microseconds)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMicroseconds(microseconds));
         }
 #endregion
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -390,13 +390,6 @@ namespace System.Tests
             var actualaaa = TimeSpan.FromSeconds(1, 2, 3);
             Assert.Equal(expected, actualaaa);
         }
-        [Fact]
-        public static void FromMilliseconds_Int_Overload()
-        {
-            var expected = new TimeSpan(0, 0, 0, 0, 1, 2);
-            var actuala = TimeSpan.FromMilliseconds(1, 2);
-            Assert.Equal(expected, actuala);
-        }
 
         [Fact]
         public static void FromSeconds_Int_ShouldGiveResultWithPrecision()
@@ -635,23 +628,38 @@ namespace System.Tests
         }
 
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(-1)]
-        [InlineData(maxMilliseconds)]
-        [InlineData(-maxMilliseconds)]
-        public static void FromMilliseconds_Int_Single_ShouldCreate(long milliseconds)
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(0, 1)]
+        [InlineData(-1, 0)]
+        [InlineData(0, -1)]
+        [InlineData(maxMilliseconds, 0)]
+        [InlineData(-maxMilliseconds, 0)]
+        [InlineData(0, maxMicroseconds)]
+        [InlineData(0, -maxMicroseconds)]
+        public static void FromMilliseconds_Int_ShouldCreate(long milliseconds, long microseconds)
         {
-            Assert.Equal(TimeSpan.FromDays(0, milliseconds: milliseconds), TimeSpan.FromMilliseconds(milliseconds));
+            long ticksFromMilliseconds = milliseconds * TimeSpan.TicksPerMillisecond;
+            long ticksFromMicroseconds = microseconds * TimeSpan.TicksPerMicrosecond;
+            var expected = TimeSpan.FromTicks(ticksFromMilliseconds + ticksFromMicroseconds);
+            Assert.Equal(expected, TimeSpan.FromMilliseconds(milliseconds, microseconds));
         }
         [Theory]
-        [InlineData(maxMilliseconds + 1)]
-        [InlineData(-(maxMilliseconds + 1))]
-        [InlineData(long.MaxValue)]
-        [InlineData(long.MinValue)]
-        public static void FromMilliseconds_Int_Single_ShouldOverflow(long milliseconds)
+        [InlineData(maxMilliseconds + 1, 0)]
+        [InlineData(-(maxMilliseconds + 1), 0)]
+        [InlineData(long.MaxValue, 0)]
+        [InlineData(long.MinValue, 0)]
+        [InlineData(0, maxMicroseconds + 1)]
+        [InlineData(0, -(maxMicroseconds + 1))]
+        [InlineData(0, long.MaxValue)]
+        [InlineData(0, long.MinValue)]
+        [InlineData(maxMilliseconds, 1000)]
+        [InlineData(-maxMilliseconds, -1000)]
+        [InlineData(1, maxMicroseconds)]
+        [InlineData(-1, -maxMicroseconds)]
+        public static void FromMilliseconds_Int_ShouldOverflow(long milliseconds, long microseconds)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMilliseconds(milliseconds));
+            Assert.Throws<ArgumentOutOfRangeException>(() => TimeSpan.FromMilliseconds(milliseconds, microseconds));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeSpanTests.cs
@@ -347,6 +347,76 @@ namespace System.Tests
             Assert.Equal(expected, timeSpan1.Equals(obj));
         }
 
+#region FromX_int_overloads
+        [Fact]
+        public static void FromDays_Int_Overload1()
+        {
+            Assert.Equal(new TimeSpan(1, 0, 0, 0), TimeSpan.FromDays(1));
+        }
+        [Fact]
+        public static void FromDays_Int_Overload2()
+        {
+            var expectedaaa = new TimeSpan(1, 2, 3, 4, 5, 6);
+            var actual = TimeSpan.FromDays(1, 2, 3, 4, 5, 6);
+            Assert.Equal(expectedaaa, actual);
+        }
+        [Fact]
+        public static void FromHours_Int_Overload1()
+        {
+            Assert.Equal(new TimeSpan(1, 0, 0), TimeSpan.FromHours(1));
+        }
+        [Fact]
+        public static void FromHours_Int_Overload2()
+        {
+            var expecteda = new TimeSpan(0, 1, 2, 3, 4, 5);
+            var actual = TimeSpan.FromHours(1, 2, 3, 4, 5);
+            Assert.Equal(expecteda, actual);
+        }
+        [Fact]
+        public static void FromMinutes_Int_Overload1()
+        {
+            Assert.Equal(new TimeSpan(0, 1, 0), TimeSpan.FromMinutes(1));
+        }
+        [Fact]
+        public static void FromMinutes_Int_Overload2()
+        {
+            var expected = new TimeSpan(0, 0, 1, 2, 3, 4);
+            var actual = TimeSpan.FromMinutes(1, 2, 3, 4);
+            Assert.Equal(expected, actual);
+        }
+        [Fact]
+        public static void FromSeconds_Int_Overload1()
+        {
+            Assert.Equal(new TimeSpan(0, 0, 1), TimeSpan.FromSeconds(1));
+        }
+        [Fact]
+        public static void FromSeconds_Int_Overload2()
+        {
+            var expected = new TimeSpan(0, 0, 0, 1, 2, 3);
+            var actualaaa = TimeSpan.FromSeconds(1, 2, 3);
+            Assert.Equal(expected, actualaaa);
+        }
+        [Fact]
+        public static void FromMilliseconds_Int_Overload()
+        {
+            var expected = new TimeSpan(0, 0, 0, 0, 1, 2);
+            var actuala = TimeSpan.FromMilliseconds(1, 2);
+            Assert.Equal(expected, actuala);
+        }
+        [Fact]
+        public static void FromMicroseconds_Int_Overload()
+        {
+            Assert.Equal(new TimeSpan(0, 0, 0, 0, 0, 1), TimeSpan.FromMicroseconds(1));
+        }
+
+        [Fact]
+        public static void FromSeconds_Int_ProblematicWhenUsingDouble()
+        {
+            // Given example of problem with double in: https://github.com/dotnet/runtime/issues/93890#issue-1957706751
+            Assert.Equal(new TimeSpan(0, 0, 0, 101, 832), TimeSpan.FromSeconds(101, 832));
+        }
+#endregion
+
         public static IEnumerable<object[]> FromDays_TestData()
         {
             yield return new object[] { 100.5, new TimeSpan(100, 12, 0, 0) };


### PR DESCRIPTION
Add new TimeSpan.From overloads as approved in #93890

The implementation is slightly inconsistent with existing methods.
This implementation will not overflow on intermediate calculations, and only throw if the final result is out of range.
I believe this inconsistency to be desirable based on comments on an earlier attempt (#95779)
> For example, using 1067519900 days will result -1008547758080 microseconds which is going to be considered as a valid value while it is really overflowed.

> Personally I think that we should only throw if the final tick count is out of range.
It's always annoying when x + y + z fails but x + z + y would succeed

fix #93890