### PR TITLE
Fix bug in arm64 LazyMachState unwind

### DIFF
--- a/src/coreclr/vm/arm64/asmconstants.h
+++ b/src/coreclr/vm/arm64/asmconstants.h
@@ -96,7 +96,11 @@ ASMCONSTANTS_C_ASSERT(MachState__isValid == offsetof(MachState, _isValid))
 #define LazyMachState_captureX19_X29 MachState__captureX19_X29
 ASMCONSTANTS_C_ASSERT(LazyMachState_captureX19_X29 == offsetof(LazyMachState, captureX19_X29))
 
+#ifdef __APPLE__
+#define LazyMachState_captureSp     (MachState__isValid+8+88) // padding for alignment
+#else // __APPLE__
 #define LazyMachState_captureSp     (MachState__isValid+8) // padding for alignment
+#endif // __APPLE
 ASMCONSTANTS_C_ASSERT(LazyMachState_captureSp == offsetof(LazyMachState, captureSp))
 
 #define LazyMachState_captureIp     (LazyMachState_captureSp+8)

--- a/src/coreclr/vm/arm64/gmscpu.h
+++ b/src/coreclr/vm/arm64/gmscpu.h
@@ -25,6 +25,9 @@ struct MachState {
     TADDR          _pc; // program counter after the function returns
     TADDR          _sp; // stack pointer after the function returns
     BOOL           _isValid;
+#ifdef __APPLE__
+    ULONG64        unwoundX19_X29[NUM_NONVOLATILE_CONTEXT_POINTERS]; // preserved registers
+#endif // __APPLE__
 
     BOOL   isValid()    { LIMITED_METHOD_DAC_CONTRACT; return _isValid; }
     TADDR  GetRetAddr() { LIMITED_METHOD_DAC_CONTRACT; return _pc; }
@@ -54,6 +57,10 @@ inline void LazyMachState::setLazyStateFromUnwind(MachState* copy)
 
     _sp = copy->_sp;
     _pc = copy->_pc;
+
+#ifdef __APPLE__
+    memcpy(unwoundX19_X29, copy->unwoundX19_X29, sizeof(unwoundX19_X29));
+#endif // __APPLE__
 
     // Capture* has already been set, so there is no need to touch it
 

--- a/src/coreclr/vm/arm64/gmscpu.h
+++ b/src/coreclr/vm/arm64/gmscpu.h
@@ -26,6 +26,8 @@ struct MachState {
     TADDR          _sp; // stack pointer after the function returns
     BOOL           _isValid;
 #ifdef __APPLE__
+    // libunwind on macOS doesn't support context pointers and we cannot modify the captureX19_X29,
+    // so we store the unwound values in a separate array.
     ULONG64        unwoundX19_X29[NUM_NONVOLATILE_CONTEXT_POINTERS]; // preserved registers
 #endif // __APPLE__
 

--- a/src/coreclr/vm/arm64/gmscpu.h
+++ b/src/coreclr/vm/arm64/gmscpu.h
@@ -80,7 +80,6 @@ inline void LazyMachState::setLazyStateFromUnwind(MachState* copy)
         }
 
         *pDst++ = valueSrc;
-        captureX19_X29[i] = copy->captureX19_X29[i];
     }
 
 

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -378,19 +378,19 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
         }
     } while (true);
 
-#ifdef TARGET_UNIX
-    unwoundstate->captureX19_X29[0] = context.X19;
-    unwoundstate->captureX19_X29[1] = context.X20;
-    unwoundstate->captureX19_X29[2] = context.X21;
-    unwoundstate->captureX19_X29[3] = context.X22;
-    unwoundstate->captureX19_X29[4] = context.X23;
-    unwoundstate->captureX19_X29[5] = context.X24;
-    unwoundstate->captureX19_X29[6] = context.X25;
-    unwoundstate->captureX19_X29[7] = context.X26;
-    unwoundstate->captureX19_X29[8] = context.X27;
-    unwoundstate->captureX19_X29[9] = context.X28;
-    unwoundstate->captureX19_X29[10] = context.Fp;
-#endif
+#ifdef __APPLE__
+    unwoundstate->unwoundX19_X29[0] = context.X19;
+    unwoundstate->unwoundX19_X29[1] = context.X20;
+    unwoundstate->unwoundX19_X29[2] = context.X21;
+    unwoundstate->unwoundX19_X29[3] = context.X22;
+    unwoundstate->unwoundX19_X29[4] = context.X23;
+    unwoundstate->unwoundX19_X29[5] = context.X24;
+    unwoundstate->unwoundX19_X29[6] = context.X25;
+    unwoundstate->unwoundX19_X29[7] = context.X26;
+    unwoundstate->unwoundX19_X29[8] = context.X27;
+    unwoundstate->unwoundX19_X29[9] = context.X28;
+    unwoundstate->unwoundX19_X29[10] = context.Fp;
+#endif // __APPLE__
 
 #ifdef DACCESS_COMPILE
     // For DAC builds, we update the registers directly since we dont have context pointers
@@ -506,6 +506,20 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloat
     pRD->pCurrentContext->Sp = pRD->SP;
 
 #ifdef TARGET_UNIX
+#ifdef __APPLE__
+    pRD->pCurrentContext->X19 = (DWORD64)(m_MachState.unwoundX19_X29[0]);
+    pRD->pCurrentContext->X20 = (DWORD64)(m_MachState.unwoundX19_X29[1]);
+    pRD->pCurrentContext->X21 = (DWORD64)(m_MachState.unwoundX19_X29[2]);
+    pRD->pCurrentContext->X22 = (DWORD64)(m_MachState.unwoundX19_X29[3]);
+    pRD->pCurrentContext->X23 = (DWORD64)(m_MachState.unwoundX19_X29[4]);
+    pRD->pCurrentContext->X24 = (DWORD64)(m_MachState.unwoundX19_X29[5]);
+    pRD->pCurrentContext->X25 = (DWORD64)(m_MachState.unwoundX19_X29[6]);
+    pRD->pCurrentContext->X26 = (DWORD64)(m_MachState.unwoundX19_X29[7]);
+    pRD->pCurrentContext->X27 = (DWORD64)(m_MachState.unwoundX19_X29[8]);
+    pRD->pCurrentContext->X28 = (DWORD64)(m_MachState.unwoundX19_X29[9]);
+    pRD->pCurrentContext->Fp = (DWORD64)(m_MachState.unwoundX19_X29[10]);
+    pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
+#else // __APPLE__
     pRD->pCurrentContext->X19 = m_MachState.ptrX19_X29[0] ? *m_MachState.ptrX19_X29[0] : m_MachState.captureX19_X29[0];
     pRD->pCurrentContext->X20 = m_MachState.ptrX19_X29[1] ? *m_MachState.ptrX19_X29[1] : m_MachState.captureX19_X29[1];
     pRD->pCurrentContext->X21 = m_MachState.ptrX19_X29[2] ? *m_MachState.ptrX19_X29[2] : m_MachState.captureX19_X29[2];
@@ -518,6 +532,8 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloat
     pRD->pCurrentContext->X28 = m_MachState.ptrX19_X29[9] ? *m_MachState.ptrX19_X29[9] : m_MachState.captureX19_X29[9];
     pRD->pCurrentContext->Fp = m_MachState.ptrX19_X29[10] ? *m_MachState.ptrX19_X29[10] : m_MachState.captureX19_X29[10];
     pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
+#endif // __APPLE__
+
 #else // TARGET_UNIX
     pRD->pCurrentContext->X19 = *m_MachState.ptrX19_X29[0];
     pRD->pCurrentContext->X20 = *m_MachState.ptrX19_X29[1];

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -505,7 +505,6 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloat
     pRD->pCurrentContext->Pc = pRD->ControlPC;
     pRD->pCurrentContext->Sp = pRD->SP;
 
-#ifdef TARGET_UNIX
 #ifdef __APPLE__
     pRD->pCurrentContext->X19 = (DWORD64)(m_MachState.unwoundX19_X29[0]);
     pRD->pCurrentContext->X20 = (DWORD64)(m_MachState.unwoundX19_X29[1]);
@@ -520,21 +519,6 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloat
     pRD->pCurrentContext->Fp = (DWORD64)(m_MachState.unwoundX19_X29[10]);
     pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
 #else // __APPLE__
-    pRD->pCurrentContext->X19 = m_MachState.ptrX19_X29[0] ? *m_MachState.ptrX19_X29[0] : m_MachState.captureX19_X29[0];
-    pRD->pCurrentContext->X20 = m_MachState.ptrX19_X29[1] ? *m_MachState.ptrX19_X29[1] : m_MachState.captureX19_X29[1];
-    pRD->pCurrentContext->X21 = m_MachState.ptrX19_X29[2] ? *m_MachState.ptrX19_X29[2] : m_MachState.captureX19_X29[2];
-    pRD->pCurrentContext->X22 = m_MachState.ptrX19_X29[3] ? *m_MachState.ptrX19_X29[3] : m_MachState.captureX19_X29[3];
-    pRD->pCurrentContext->X23 = m_MachState.ptrX19_X29[4] ? *m_MachState.ptrX19_X29[4] : m_MachState.captureX19_X29[4];
-    pRD->pCurrentContext->X24 = m_MachState.ptrX19_X29[5] ? *m_MachState.ptrX19_X29[5] : m_MachState.captureX19_X29[5];
-    pRD->pCurrentContext->X25 = m_MachState.ptrX19_X29[6] ? *m_MachState.ptrX19_X29[6] : m_MachState.captureX19_X29[6];
-    pRD->pCurrentContext->X26 = m_MachState.ptrX19_X29[7] ? *m_MachState.ptrX19_X29[7] : m_MachState.captureX19_X29[7];
-    pRD->pCurrentContext->X27 = m_MachState.ptrX19_X29[8] ? *m_MachState.ptrX19_X29[8] : m_MachState.captureX19_X29[8];
-    pRD->pCurrentContext->X28 = m_MachState.ptrX19_X29[9] ? *m_MachState.ptrX19_X29[9] : m_MachState.captureX19_X29[9];
-    pRD->pCurrentContext->Fp = m_MachState.ptrX19_X29[10] ? *m_MachState.ptrX19_X29[10] : m_MachState.captureX19_X29[10];
-    pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
-#endif // __APPLE__
-
-#else // TARGET_UNIX
     pRD->pCurrentContext->X19 = *m_MachState.ptrX19_X29[0];
     pRD->pCurrentContext->X20 = *m_MachState.ptrX19_X29[1];
     pRD->pCurrentContext->X21 = *m_MachState.ptrX19_X29[2];
@@ -547,7 +531,7 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD, bool updateFloat
     pRD->pCurrentContext->X28 = *m_MachState.ptrX19_X29[9];
     pRD->pCurrentContext->Fp  = *m_MachState.ptrX19_X29[10];
     pRD->pCurrentContext->Lr = NULL; // Unwind again to get Caller's PC
-#endif
+#endif // __APPLE__
 
 #if !defined(DACCESS_COMPILE)
     pRD->pCurrentContextPointers->X19 = m_MachState.ptrX19_X29[0];


### PR DESCRIPTION
When we were enabling the mac M1 couple of years ago, a bug has creeped in that causes a race in lazy machine state unwinding. The LazyMachState::setLazyStateFromUnwind was incorrectly modifying the captured state, so in case multiple threads were racing for the unwind, a thread that came at a time when part of the captured state was modified and before the `_isValid` was set would start unwinding from a wrong state (the partial unwound one), effectively unwinding twice.

I've hit this in CI for enabling the new exception handling, as it results in an assert when comparing the resulting address of the floating point registers unwind with the mach state.