### PR TITLE
#98441 - Ignore invalid handle/access when setting console cp

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Windows/Interop.Errors.cs
@@ -13,6 +13,7 @@ internal static partial class Interop
         internal const int ERROR_ACCESS_DENIED = 0x5;
         internal const int ERROR_INVALID_HANDLE = 0x6;
         internal const int ERROR_NOT_ENOUGH_MEMORY = 0x8;
+        internal const int ERROR_INVALID_ACCESS = 0xC;
         internal const int ERROR_INVALID_DATA = 0xD;
         internal const int ERROR_OUTOFMEMORY = 0xE;
         internal const int ERROR_INVALID_DRIVE = 0xF;

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -132,7 +132,7 @@ namespace System
 
         private static void HandleSetConsoleEncodingError()
         {
-            var lastError = Marshal.GetLastPInvokeError();
+            int lastError = Marshal.GetLastPInvokeError();
             if (lastError == Interop.Errors.ERROR_INVALID_HANDLE
                 || lastError == Interop.Errors.ERROR_INVALID_ACCESS)
             {

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -108,7 +108,9 @@ namespace System
             if (enc.CodePage != UnicodeCodePage)
             {
                 if (!Interop.Kernel32.SetConsoleCP(enc.CodePage))
-                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastPInvokeError());
+                {
+                    HandleSetConsoleEncodingError();
+                }
             }
         }
 
@@ -122,8 +124,23 @@ namespace System
             if (enc.CodePage != UnicodeCodePage)
             {
                 if (!Interop.Kernel32.SetConsoleOutputCP(enc.CodePage))
-                    throw Win32Marshal.GetExceptionForWin32Error(Marshal.GetLastPInvokeError());
+                {
+                    HandleSetConsoleEncodingError();
+                }
             }
+        }
+
+        private static void HandleSetConsoleEncodingError()
+        {
+            var lastError = Marshal.GetLastPInvokeError();
+            if (lastError == Interop.Errors.ERROR_INVALID_HANDLE
+                || lastError == Interop.Errors.ERROR_INVALID_ACCESS)
+            {
+                // no console, or not a valid handle, so fail silently
+                return;
+            }
+
+            throw Win32Marshal.GetExceptionForWin32Error(lastError);
         }
 
         /// <summary>Gets whether Console.In is targeting a terminal display.</summary>

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -109,7 +109,7 @@ namespace System
             {
                 if (!Interop.Kernel32.SetConsoleCP(enc.CodePage))
                 {
-                    HandleSetConsoleEncodingError();
+                    HandleSetConsoleEncodingError(Marshal.GetLastPInvokeError());
                 }
             }
         }
@@ -125,14 +125,13 @@ namespace System
             {
                 if (!Interop.Kernel32.SetConsoleOutputCP(enc.CodePage))
                 {
-                    HandleSetConsoleEncodingError();
+                    HandleSetConsoleEncodingError(Marshal.GetLastPInvokeError());
                 }
             }
         }
 
-        private static void HandleSetConsoleEncodingError()
+        private static void HandleSetConsoleEncodingError(int lastError)
         {
-            int lastError = Marshal.GetLastPInvokeError();
             if (lastError == Interop.Errors.ERROR_INVALID_HANDLE
                 || lastError == Interop.Errors.ERROR_INVALID_ACCESS)
             {

--- a/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
+++ b/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Text;
 using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -40,6 +40,27 @@ public partial class ConsoleEncoding
 
     [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
     [PlatformSpecific(TestPlatforms.Windows)]
+    public void InputEncoding_SetEncodingWhenDetached_ErrorIsSilentlyIgnored()
+    {
+        RemoteExecutor.Invoke(() =>
+        {
+            Encoding encoding = Encoding.GetEncoding(0);
+            Assert.NotEqual(encoding.CodePage, Console.InputEncoding.CodePage);
+
+            // use FreeConsole to detach the current console - simulating a process started with the "DETACHED_PROCESS" flag
+            FreeConsole();
+
+            // Setting the input encoding should not throw an exception
+            Console.InputEncoding = encoding;
+            // The internal state of Console should have updated, despite the failure to change the console's input encoding
+            Assert.Equal(encoding, Console.InputEncoding);
+            // Operations on the console are no longer valid - GetConsoleCP fails.
+            Assert.Equal(0u, GetConsoleCP());
+        }).Dispose();
+    }
+
+    [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+    [PlatformSpecific(TestPlatforms.Windows)]
     public void OutputEncoding_SetDefaultEncoding_Success()
     {
         RemoteExecutor.Invoke(() =>
@@ -67,9 +88,33 @@ public partial class ConsoleEncoding
         }).Dispose();
     }
 
+    [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void OutputEncoding_SetEncodingWhenDetached_ErrorIsSilentlyIgnored()
+    {
+        RemoteExecutor.Invoke(() =>
+        {
+            Encoding encoding = Encoding.GetEncoding(0);
+            Assert.NotEqual(encoding.CodePage, Console.OutputEncoding.CodePage);
+
+            // use FreeConsole to detach the current console - simulating a process started with the "DETACHED_PROCESS" flag
+            FreeConsole();
+
+            // Setting the output encoding should not throw an exception
+            Console.OutputEncoding = encoding;
+            // The internal state of Console should have updated, despite the failure to change the console's output encoding
+            Assert.Equal(encoding, Console.OutputEncoding);
+            // Operations on the console are no longer valid - GetConsoleOutputCP fails.
+            Assert.Equal(0u, GetConsoleOutputCP());
+        }).Dispose();
+    }
+
     [LibraryImport("kernel32.dll")]
     public static partial uint GetConsoleCP();
 
     [LibraryImport("kernel32.dll")]
     public static partial uint GetConsoleOutputCP();
+
+    [LibraryImport("kernel32.dll")]
+    public static partial int FreeConsole();
 }

--- a/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
+++ b/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
@@ -15,7 +15,10 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Encoding.GetEncoding(0);
+            Encoding encoding = Console.InputEncoding.CodePage != Encoding.ASCII.CodePage
+                ? Encoding.ASCII
+                : Encoding.Latin1;
+
             Console.InputEncoding = encoding;
             Assert.Equal(encoding, Console.InputEncoding);
             Assert.Equal((uint)encoding.CodePage, GetConsoleCP());
@@ -44,8 +47,9 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Encoding.GetEncoding(0);
-            Assert.NotEqual(encoding.CodePage, Console.InputEncoding.CodePage);
+            Encoding encoding = Console.InputEncoding.CodePage != Encoding.ASCII.CodePage
+                ? Encoding.ASCII
+                : Encoding.Latin1;
 
             // use FreeConsole to detach the current console - simulating a process started with the "DETACHED_PROCESS" flag
             FreeConsole();
@@ -65,7 +69,10 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Encoding.GetEncoding(0);
+            Encoding encoding = Console.OutputEncoding.CodePage != Encoding.ASCII.CodePage
+                ? Encoding.ASCII
+                : Encoding.Latin1;
+
             Console.OutputEncoding = encoding;
             Assert.Equal(encoding, Console.OutputEncoding);
             Assert.Equal((uint)encoding.CodePage, GetConsoleOutputCP());
@@ -94,8 +101,9 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Encoding.GetEncoding(0);
-            Assert.NotEqual(encoding.CodePage, Console.OutputEncoding.CodePage);
+            Encoding encoding = Console.OutputEncoding.CodePage != Encoding.ASCII.CodePage
+                ? Encoding.ASCII
+                : Encoding.Latin1;
 
             // use FreeConsole to detach the current console - simulating a process started with the "DETACHED_PROCESS" flag
             FreeConsole();

--- a/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
+++ b/src/libraries/System.Console/tests/ConsoleEncoding.Windows.cs
@@ -15,10 +15,7 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Console.InputEncoding.CodePage != Encoding.ASCII.CodePage
-                ? Encoding.ASCII
-                : Encoding.Latin1;
-
+            Encoding encoding = Encoding.GetEncoding(0);
             Console.InputEncoding = encoding;
             Assert.Equal(encoding, Console.InputEncoding);
             Assert.Equal((uint)encoding.CodePage, GetConsoleCP());
@@ -69,10 +66,7 @@ public partial class ConsoleEncoding
     {
         RemoteExecutor.Invoke(() =>
         {
-            Encoding encoding = Console.OutputEncoding.CodePage != Encoding.ASCII.CodePage
-                ? Encoding.ASCII
-                : Encoding.Latin1;
-
+            Encoding encoding = Encoding.GetEncoding(0);
             Console.OutputEncoding = encoding;
             Assert.Equal(encoding, Console.OutputEncoding);
             Assert.Equal((uint)encoding.CodePage, GetConsoleOutputCP());


### PR DESCRIPTION
There are situations where setting the console code page is expected to fail. For instance, if the application was started with DETACHED_PROCESS, the attempting to set the code page will fail with ERROR_INVALID_HANDLE. In these cases, ignore the returned error.

Fixes #98441