### PR TITLE
[RISC-V] Check DivideByZeroException before generating check for unsigned div/mod

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2488,7 +2488,8 @@ void CodeGen::genCodeForDivMod(GenTreeOp* tree)
             // Note that division by the constant 0 was already checked for above by the
             // op2->IsIntegralConst(0) check
 
-            if (!divisorOp->IsCnsIntOrI())
+            if ((exceptions & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None &&
+                !divisorOp->IsCnsIntOrI())
             {
                 // divisorOp is not a constant, so it could be zero
                 genJumpToThrowHlpBlk_la(SCK_DIV_BY_ZERO, INS_beq, divisorReg);

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -309,7 +309,7 @@ int LinearScan::BuildNode(GenTree* tree)
                         needTemp = true;
                 }
 
-                if (!needTemp && (tree->gtOper == GT_DIV || tree->gtOper == GT_MOD))
+                if (!needTemp && tree->OperIs(GT_DIV, GT_MOD))
                 {
                     if ((exceptions & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
                         needTemp = true;


### PR DESCRIPTION
Generate check for unsigned divide by zero only when ExceptionSetFlags::DivideByZeroException is present

Not doing so caused JITting on FullOpts fail on assert(add->acdUsed) in genJumpToThrowHlpBlk_la when the DivByZero check was optimized out as a result of #98113

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @Bajtazar @bartlomiejko @romanzagorowski