### PR TITLE
Disable Swift interop tests on macOS with Native AOT

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1158,6 +1158,10 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/CustomAttributes/**">
             <Issue>Dynamic code generation is not supported on this platform</Issue>
         </ExcludeList>
+
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/Swift/**">
+            <Issue>https://github.com/dotnet/runtime/issues/93631</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- run.proj finds all the *.cmd/*.sh scripts in a test folder and creates corresponding test methods.


### PR DESCRIPTION
## Description

This PR disables failing Swift interop tests on macOS with Native AOT. The runtime support will be introduced in subsequent PRs.

Fixes https://github.com/dotnet/runtime/issues/98611