### PR TITLE
Check if AttributeData for InterfaceTypeAttribute is not null in ConvertComImportToGeneratedComInterfaceAnalyzer

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/ComInterfaceGenerator/Analyzers/ConvertComImportToGeneratedComInterfaceAnalyzer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Interop.Analyzers
                     INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
                     AttributeData? interfaceTypeAttributeData = type.GetAttributes().FirstOrDefault(a => a.AttributeClass.Equals(interfaceTypeAttribute, SymbolEqualityComparer.Default));
                     if (type is not { TypeKind: TypeKind.Interface, IsComImport: true }
-                        || interfaceTypeAttributeData.ConstructorArguments.Length == 1 && (int)interfaceTypeAttributeData.ConstructorArguments[0].Value != (int)ComInterfaceType.InterfaceIsIUnknown)
+                        || interfaceTypeAttributeData is not { ConstructorArguments: [{ Value: (int)ComInterfaceType.InterfaceIsIUnknown }] })
                     {
                         return;
                     }

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ConvertToGeneratedComInterfaceTests.cs
@@ -370,5 +370,43 @@ namespace ComInterfaceGenerator.Unit.Tests
 
             await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
         }
+
+        [Fact]
+        public async Task UnsupportedInterfaceTypes_DoesNotReportDiagnostic()
+        {
+            // This also tests the case where InterfaceType is missing (defaulting to ComInterfaceType.InterfaceIsDual).
+            string source = """
+                 using System.Runtime.InteropServices;
+
+                 [ComImport]
+                 [Guid("73EB4AF8-BE9C-4b49-B3A4-24F4FF657B26")]
+                 public interface IInterfaceIsDualMissingAttribute
+                 {
+                 }
+
+                 [ComImport]
+                 [Guid("5DA39CDF-DCAD-447A-836E-EA80DB34D81B")]
+                 [InterfaceType(ComInterfaceType.InterfaceIsDual)]
+                 public interface IInterfaceIsDual
+                 {
+                 }
+
+                 [ComImport]
+                 [Guid("F59AB2FE-523D-4B28-911C-21363808C51E")]
+                 [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
+                 public interface IInterfaceIsIDispatch
+                 {
+                 }
+
+                 [ComImport]
+                 [Guid("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7")]
+                 [InterfaceType(ComInterfaceType.InterfaceIsIInspectable)]
+                 public interface IInterfaceIsIInspectable
+                 {
+                 }
+                 """;
+
+            await VerifyCS.VerifyCodeFixAsync(source, source);
+        }
     }
 }


### PR DESCRIPTION
`ConvertComImportToGeneratedComInterfaceAnalyzer` always assumed that an `InterfaceTypeAttribute` was present on interface types with `ComImportAttribute`, throwing a `NullReferenceException` if it was missing.
This PR also adds tests for each unsupported `ComInterfaceType`.

Not sure why there was no nullability warning in the original code.

Fixes #94968.