### PR TITLE
Fix a bug in PAL version of _vsnprint_f

### DIFF
--- a/src/coreclr/pal/src/safecrt/vsprintf.cpp
+++ b/src/coreclr/pal/src/safecrt/vsprintf.cpp
@@ -95,7 +95,7 @@ DLLEXPORT int __cdecl _vsnprintf_s (
         retvalue = vsnprintf(string, sizeInBytes, format, ap);
         string[sizeInBytes - 1] = '\0';
         /* we allow truncation if count == _TRUNCATE */
-        if (retvalue > (int)sizeInBytes && count == _TRUNCATE)
+        if (retvalue >= (int)sizeInBytes && count == _TRUNCATE)
         {
             if (errno == ERANGE)
             {

--- a/src/coreclr/pal/tests/palsuite/c_runtime/_vsnprintf_s/test1/test1.cpp
+++ b/src/coreclr/pal/tests/palsuite/c_runtime/_vsnprintf_s/test1/test1.cpp
@@ -49,6 +49,18 @@ PALTEST(c_runtime__vsnprintf_s_test1_paltest_vsnprintf_test1, "c_runtime/_vsnpri
         Fail("ERROR: expected %s (up to %d chars), got %s\n", checkstr, 8, buf);
     }
 
+    char buf8[8] = {0};
+
+    ret = Testvsnprintf(buf8, 8, "abcdefgh");
+    if (ret >= 0)
+    {
+        Fail("ERROR: expected negative return value, got %d", ret);
+    }
+    if (memcmp(buf8, "abcdefg\0", 8) != 0)
+    {
+        Fail("ERROR: Expected 7 chars + null terminator");
+    }
+
     PAL_Terminate();
     return PASS;
 }


### PR DESCRIPTION
When the formatted string cannot fully fit in the buffer (including its null terminator) `_vsnprint_f` should return -1. However, in the case where the number of chars was the same as the buffer size it was returning the buffer size.