### PR TITLE
Fix PAL tests - remove non-existent tests from the list

### DIFF
--- a/src/coreclr/pal/tests/palsuite/paltestlist.txt
+++ b/src/coreclr/pal/tests/palsuite/paltestlist.txt
@@ -2,9 +2,6 @@ c_runtime/atof/test1/paltest_atof_test1
 c_runtime/atoi/test1/paltest_atoi_test1
 c_runtime/bsearch/test1/paltest_bsearch_test1
 c_runtime/bsearch/test2/paltest_bsearch_test2
-c_runtime/errno/test1/paltest_errno_test1
-c_runtime/errno/test2/paltest_errno_test2
-c_runtime/exit/test1/paltest_exit_test1
 c_runtime/free/test1/paltest_free_test1
 c_runtime/isalnum/test1/paltest_isalnum_test1
 c_runtime/isalpha/test1/paltest_isalpha_test1


### PR DESCRIPTION
Recent refactoring of the PAL has forgotten to remove three tests from the paltestlist.txt file, which has broken the PAL test execution.

Close #98574