### PR TITLE
[release/6.0] Bump Microsoft.Windows.Compatibility to servicing version 8

### DIFF
--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -6,7 +6,7 @@
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ServicingVersion>7</ServicingVersion>
+    <ServicingVersion>8</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET Core as well as .NET Standard.</PackageDescription>


### PR DESCRIPTION
We recently enabled it for building and [bumped it to 7](https://github.com/dotnet/runtime/pull/97884/files) but we had already published [that version in nuget](https://www.nuget.org/packages/Microsoft.Windows.Compatibility/6.0.7). We needed to bump it to 8.

Since PR #97884 has already been approved by Tactics and this is only fixing the version issue, I'll mark this as approved for servicing too.