### PR TITLE
[release/6.0-staging] Bump Pkcs servicing version to 4

### DIFF
--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>3</ServicingVersion>
+    <ServicingVersion>4</ServicingVersion>
     <PackageDescription>Provides support for PKCS and CMS algorithms.
 
 Commonly Used Types:


### PR DESCRIPTION
The last version we published [was 6.0.4](https://www.nuget.org/packages/System.Security.Cryptography.Pkcs/6.0.4), but wasn't carried automatically by the internal->public merge PR, so I'm updating it manually.