### PR TITLE
Set Optimize in ILLink analyzer project

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/ILLink.RoslynAnalyzer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,6 +9,12 @@
     <AnalysisLevel>Latest</AnalysisLevel>
     <NoWarn Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(NoWarn);CS8524</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <!-- The analyzer needs to process deeply nested expressions in corelib.
+         This can blow up the stack if using unoptimized code (due to large
+         stack frames with many temporary locals for debugging support), so we
+         optimize the analyzer even in Debug builds. Note: we still use the
+         Debug configuration to get Debug asserts. -->
+    <Optimize>true</Optimize>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This should unblock https://github.com/dotnet/runtime/pull/91764, which is hitting `InsufficientExecutionStackException` on mac:
```
##[error]CSC(0,0): error AD0001: (NETCORE_ENGINEERING_TELEMETRY=Build) Analyzer 'ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer' threw an exception of type 'System.InsufficientExecutionStackException' with message 'Insufficient stack to continue executing the program safely. This can happen from having too many functions on the call stack or function on the stack using too much stack space.'.
```

while processing this deeply nested binary operation: https://github.com/dotnet/runtime/blob/50c01531acc9a95202b7ec457ff8de592c2555b7/src/libraries/System.Private.CoreLib/src/System/Globalization/IcuLocaleData.cs#L27

I debugged this and found that [`VisitBinaryOperator`](https://github.com/dotnet/runtime/blob/95af2bcf9d84cac3955fe285d22e15e226cc05de/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs#L177-L205) had an unusually large stack frame. The jit dump shows this is due to a bunch of temporary locals created for debugging purposes with unoptimized code:

```
; Final local variable assignments
;
;  V00 this         [V00    ] (  1,  1   )     ref  ->  [rbp+0x10]  do-not-enreg[] this class-hnd <ILLink.RoslynAnalyzer.TrimAnalysis.TrimAnalysisVisitor>
;  V01 arg1         [V01    ] (  1,  1   )     ref  ->  [rbp+0x18]  do-not-enreg[] class-hnd <Microsoft.CodeAnalysis.Operations.IBinaryOperation>
;  V02 arg2         [V02    ] (  1,  1   )     ref  ->  [rbp+0x20]  do-not-enreg[] class-hnd <ILLink.RoslynAnalyzer.DataFlow.LocalDataFlowState`4[ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue],ILLink.RoslynAnalyzer.DataFlow.FeatureContext,ILLink.Shared.DataFlow.ValueSetLattice`1[ILLink.Shared.DataFlow.SingleValue],ILLink.RoslynAnalyzer.DataFlow.FeatureContextLattice]>
;  V03 loc0         [V03    ] (  1,  1   )   ubyte  ->  [rbp-0x04]  do-not-enreg[] must-init
;  V04 loc1         [V04    ] (  1,  1   )  struct (16) [rbp-0x18]  do-not-enreg[XS] must-init addr-exposed ld-addr-op <Microsoft.CodeAnalysis.Optional`1[System.Object]>
;  V05 loc2         [V05    ] (  1,  1   )  struct ( 8) [rbp-0x20]  do-not-enreg[S] must-init <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V06 loc3         [V06    ] (  1,  1   )  struct ( 8) [rbp-0x28]  do-not-enreg[S] must-init <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V07 loc4         [V07    ] (  1,  1   )  struct ( 8) [rbp-0x30]  do-not-enreg[S] must-init <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V08 loc5         [V08    ] (  1,  1   )  struct (24) [rbp-0x48]  do-not-enreg[XS] must-init addr-exposed ld-addr-op <ILLink.Shared.DataFlow.ValueSet`1+Enumerator[ILLink.Shared.DataFlow.SingleValue]>
;  V09 loc6         [V09    ] (  1,  1   )  struct ( 8) [rbp-0x50]  do-not-enreg[XS] must-init addr-exposed ld-addr-op <ILLink.Shared.DataFlow.ValueSet`1+Enumerable[ILLink.Shared.DataFlow.SingleValue]>
;  V10 loc7         [V10    ] (  1,  1   )     ref  ->  [rbp-0x58]  do-not-enreg[] must-init class-hnd <ILLink.Shared.DataFlow.SingleValue>
;  V11 loc8         [V11    ] (  1,  1   )   ubyte  ->  [rbp-0x5C]  do-not-enreg[] must-init
;  V12 loc9         [V12    ] (  1,  1   )     ref  ->  [rbp-0x68]  do-not-enreg[] must-init class-hnd exact <ILLink.Shared.TrimAnalysis.ConstIntValue>
;  V13 loc10        [V13    ] (  1,  1   )   ubyte  ->  [rbp-0x6C]  do-not-enreg[] must-init
;  V14 loc11        [V14    ] (  1,  1   )  struct (24) [rbp-0x88]  do-not-enreg[XS] must-init addr-exposed ld-addr-op <ILLink.Shared.DataFlow.ValueSet`1+Enumerator[ILLink.Shared.DataFlow.SingleValue]>
;  V15 loc12        [V15    ] (  1,  1   )     ref  ->  [rbp-0x90]  do-not-enreg[] must-init class-hnd <ILLink.Shared.DataFlow.SingleValue>
;  V16 loc13        [V16    ] (  1,  1   )   ubyte  ->  [rbp-0x94]  do-not-enreg[] must-init
;  V17 loc14        [V17    ] (  1,  1   )     ref  ->  [rbp-0xA0]  do-not-enreg[] must-init class-hnd exact <ILLink.Shared.TrimAnalysis.ConstIntValue>
;  V18 loc15        [V18    ] (  1,  1   )   ubyte  ->  [rbp-0xA4]  do-not-enreg[] must-init
;  V19 loc16        [V19    ] (  1,  1   )  struct ( 8) [rbp-0xB0]  do-not-enreg[S] must-init <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V20 OutArgs      [V20    ] (  1,  1   )  struct (32) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace"
;  V21 tmp1         [V21    ] (  1,  1   )  struct (16) [rbp-0xC0]  do-not-enreg[HS] must-init hidden-struct-arg "impSpillStackEnsure" <Microsoft.CodeAnalysis.Optional`1[System.Object]>
;  V22 tmp2         [V22    ] (  1,  1   )     int  ->  [rbp-0xC4]  do-not-enreg[] "impSpillStackEnsure"
;  V23 tmp3         [V23    ] (  1,  1   )     int  ->  [rbp-0xC8]  do-not-enreg[] must-init
;  V24 tmp4         [V24    ] (  1,  1   )  struct ( 8) [rbp-0xD0]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V25 tmp5         [V25    ] (  1,  1   )     ref  ->  [rbp-0xD8]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <ILLink.RoslynAnalyzer.TrimAnalysis.TrimAnalysisVisitor>
;  V26 tmp6         [V26    ] (  1,  1   )     ref  ->  [rbp-0xE0]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <Microsoft.CodeAnalysis.IOperation>
;  V27 tmp7         [V27    ] (  1,  1   )  struct ( 8) [rbp-0xE8]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V28 tmp8         [V28    ] (  1,  1   )     ref  ->  [rbp-0xF0]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <ILLink.RoslynAnalyzer.TrimAnalysis.TrimAnalysisVisitor>
;  V29 tmp9         [V29    ] (  1,  1   )     ref  ->  [rbp-0xF8]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <Microsoft.CodeAnalysis.IOperation>
;  V30 tmp10        [V30    ] (  1,  1   )  struct ( 8) [rbp-0x100]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V31 tmp11        [V31    ] (  1,  1   )  struct ( 8) [rbp-0x108]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V32 tmp12        [V32    ] (  1,  1   )  struct ( 8) [rbp-0x110]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1+Enumerable[ILLink.Shared.DataFlow.SingleValue]>
;  V33 tmp13        [V33    ] (  1,  1   )  struct (24) [rbp-0x128]  do-not-enreg[HS] must-init hidden-struct-arg "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1+Enumerator[ILLink.Shared.DataFlow.SingleValue]>
;  V34 tmp14        [V34    ] (  1,  1   )     int  ->  [rbp-0x12C]  do-not-enreg[] "impSpillStackEnsure"
;  V35 tmp15        [V35    ] (  1,  1   )     ref  ->  [rbp-0x138]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <System.__Canon>
;  V36 tmp16        [V36    ] (  1,  1   )  struct ( 8) [rbp-0x140]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1+Enumerable[ILLink.Shared.DataFlow.SingleValue]>
;  V37 tmp17        [V37    ] (  1,  1   )  struct (24) [rbp-0x158]  do-not-enreg[HS] must-init hidden-struct-arg "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1+Enumerator[ILLink.Shared.DataFlow.SingleValue]>
;  V38 tmp18        [V38    ] (  1,  1   )     int  ->  [rbp-0x15C]  do-not-enreg[] "impSpillStackEnsure"
;  V39 tmp19        [V39    ] (  1,  1   )     ref  ->  [rbp-0x168]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <System.__Canon>
;  V40 tmp20        [V40    ] (  1,  1   )     ref  ->  [rbp-0x170]  do-not-enreg[] must-init class-hnd exact "NewObj constructor temp" <ILLink.Shared.TrimAnalysis.ConstIntValue>
;  V41 tmp21        [V41    ] (  1,  1   )   byref  ->  [rbp-0x178]  do-not-enreg[] must-init "impAppendStmt"
;  V42 tmp22        [V42    ] (  1,  1   )  struct ( 8) [rbp-0x180]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V43 tmp23        [V43    ] (  1,  1   )  struct ( 8) [rbp-0x188]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V44 tmp24        [V44    ] (  1,  1   )  struct ( 8) [rbp-0x190]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V45 tmp25        [V45    ] (  1,  1   )   byref  ->  [rbp-0x198]  do-not-enreg[] must-init "non-inline candidate call"
;  V46 tmp26        [V46    ] (  1,  1   )  struct ( 8) [rbp-0x1A0]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V47 tmp27        [V47    ] (  1,  1   )  struct ( 8) [rbp-0x1A8]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V48 tmp28        [V48    ] (  1,  1   )  struct ( 8) [rbp-0x1B0]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V49 tmp29        [V49    ] (  1,  1   )   byref  ->  [rbp-0x1B8]  do-not-enreg[] must-init "non-inline candidate call"
;  V50 tmp30        [V50    ] (  1,  1   )  struct ( 8) [rbp-0x1C0]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V51 tmp31        [V51    ] (  1,  1   )  struct ( 8) [rbp-0x1C8]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V52 tmp32        [V52    ] (  1,  1   )  struct ( 8) [rbp-0x1D0]  do-not-enreg[S] must-init "impSpillStackEnsure" <ILLink.Shared.DataFlow.ValueSet`1[ILLink.Shared.DataFlow.SingleValue]>
;  V53 tmp33        [V53    ] (  1,  1   )     int  ->  [rbp-0x1D4]  do-not-enreg[] "impSpillStackEnsure"
;  V54 tmp34        [V54    ] (  1,  1   )     ref  ->  [rbp-0x1E0]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <Microsoft.CodeAnalysis.IMethodSymbol>
;  V55 tmp35        [V55    ] (  1,  1   )     ref  ->  [rbp-0x1E8]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <Microsoft.CodeAnalysis.ITypeSymbol>
;  V56 tmp36        [V56    ] (  1,  1   )     ref  ->  [rbp-0x1F0]  do-not-enreg[] must-init
;  V57 tmp37        [V57    ] (  1,  1   )     int  ->  [rbp-0x1F4]  do-not-enreg[] "impSpillStackEnsure"
;  V58 tmp38        [V58    ] (  1,  1   )     int  ->  [rbp-0x1F8]  do-not-enreg[] must-init
;  V59 tmp39        [V59    ] (  1,  1   )     int  ->  [rbp-0x1FC]  do-not-enreg[] must-init
;  V60 tmp40        [V60    ] (  1,  1   )     ref  ->  [rbp-0x208]  do-not-enreg[] must-init class-hnd "impSpillStackEnsure" <Microsoft.CodeAnalysis.ITypeSymbol>
;  V61 tmp41        [V61    ] (  1,  1   )     ref  ->  [rbp-0x210]  do-not-enreg[] must-init
;  V62 tmp42        [V62    ] (  1,  1   )     int  ->  [rbp-0x214]  do-not-enreg[] "impSpillStackEnsure"
;  V63 tmp43        [V63    ] (  1,  1   )     int  ->  [rbp-0x218]  do-not-enreg[] must-init
;  V64 PSPSym       [V64    ] (  1,  1   )    long  ->  [rbp-0x220]  do-not-enreg[V] "PSPSym"
```
