### PR TITLE
Restore erroneously removed encoding of the argument count in a generic method instantiation

### DIFF
--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -1341,6 +1341,9 @@ BOOL ZapSig::EncodeMethod(
         else
         {
             Instantiation inst = pMethod->GetMethodInstantiation();
+
+            pSigBuilder->AppendData(inst.GetNumArgs());
+
             for (DWORD i = 0; i < inst.GetNumArgs(); i++)
             {
                 TypeHandle t = inst[i];


### PR DESCRIPTION
When IBC was removed, we accidentally removed the argument count from the encoding of generic method instantiations (it was previously being conditionally *omitted* when IBC was active, so it should have stayed.)

This can cause crashes in multicore jit scenarios and generally makes it not work for generic methods.

Adding this back will ensure that profiles recorded in the future will be valid, though we can't fix existing ones.

Still looking into where & how I could add regression coverage for this, but I'm not sure it's necessary.