### PR TITLE
Use MethodInvoker in ReflectionPropertyFetch

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
@@ -1440,13 +1440,13 @@ namespace System.Diagnostics
                     /// </summary>
                     private sealed class ReflectionPropertyFetch : PropertyFetch
                     {
-                        private readonly PropertyInfo _property;
+                        private readonly MethodInvoker _getterInvoker;
                         public ReflectionPropertyFetch(Type type, PropertyInfo property) : base(type)
                         {
-                            _property = property;
+                            _getterInvoker = MethodInvoker.Create(property.GetMethod!);
                         }
 
-                        public override object? Fetch(object? obj) => _property.GetValue(obj);
+                        public override object? Fetch(object? obj) => _getterInvoker.Invoke(obj);
                     }
 
                     /// <summary>


### PR DESCRIPTION
`ReflectionPropertyFetch` is a fallback used on native AOT only. `MethodInvoker` makes this almost as good as the `RefTypedFetchProperty` that needs to spin up a JIT to work.

| Method | Mean      | Error     | StdDev    | Allocated |
|------- |----------:|----------:|----------:|----------:|
| Old    | 11.977 ns | 0.1585 ns | 0.1405 ns |         - |
| New  |  8.714 ns | 0.0757 ns | 0.0708 ns |         - |
| RefTypedFetchProperty |  5.456 ns | 0.0197 ns | 0.0175 ns |         - |

Cc @dotnet/ilc-contrib 