### PR TITLE
Fix missing relocations in NativeAOT x86 output

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -15330,13 +15330,10 @@ BYTE* emitter::emitOutputRI(BYTE* dst, instrDesc* id)
 
         if (id->idIsCnsReloc())
         {
-            if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+            if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI) && id->idAddr()->iiaSecRel)
             {
-                if (id->idAddr()->iiaSecRel)
-                {
-                    // For section relative, the immediate offset is relocatable and hence need IMAGE_REL_SECREL
-                    emitRecordRelocation((void*)(dst - (unsigned)EA_SIZE(size)), (void*)(size_t)val, IMAGE_REL_SECREL);
-                }
+                // For section relative, the immediate offset is relocatable and hence need IMAGE_REL_SECREL
+                emitRecordRelocation((void*)(dst - (unsigned)EA_SIZE(size)), (void*)(size_t)val, IMAGE_REL_SECREL);
             }
             else
             {


### PR DESCRIPTION
This bug was introduced in #97413.

Output without the fix:
```
IN0011: 000047 mov      edx, dword ptr [ebp+0x10]
IN0012: 00004A mov      ecx, (reloc 0x40420290)
recordRelocation: 10A4E138 (rw: 10A4E138) => 40420310, type 16 (IMAGE_REL_BASED_REL32), delta 0
IN0013: 00004F call     CORINFO_HELP_NEWARR_1_VC
```

Output with the fix:
```
IN0011: 000047 mov      edx, dword ptr [ebp+0x10]
recordRelocation: 12241DAB (rw: 12241DAB) => 40420290, type 3 (IMAGE_REL_BASED_MOFFSET), delta 0
IN0012: 00004A mov      ecx, (reloc 0x40420290)
recordRelocation: 12241DB0 (rw: 12241DB0) => 40420310, type 16 (IMAGE_REL_BASED_REL32), delta 0
IN0013: 00004F call     CORINFO_HELP_NEWARR_1_VC
```