### PR TITLE
[LoongArch64] Fix the assertion error for DynamicHelpers::CreateDictionaryLookupHelper().

### DIFF
--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1928,7 +1928,7 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
             }
         }
 
-        _ASSERTE(indirectionsDataSize == dataOffset);
+        _ASSERTE((codeSize == dataOffset) || (indirectionsDataSize == dataOffset));
 
         // No null test required
         if (!pLookup->testForNull)

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -1928,7 +1928,7 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
             }
         }
 
-        _ASSERTE((codeSize == dataOffset) || (indirectionsDataSize == dataOffset));
+        _ASSERTE((indirectionsDataSize ? indirectionsDataSize : codeSize) == dataOffset);
 
         // No null test required
         if (!pLookup->testForNull)


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix the assertion error for DynamicHelpers::CreateDictionaryLookupHelper().