### PR TITLE
[LoongArch64] Fix some errors of the struct argument parsing in LoongArch64PassStructInRegister.cs

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/LoongArch64PassStructInRegister.cs
@@ -55,11 +55,7 @@ namespace Internal.JitInterface
             int fieldIndex = 0;
             foreach (FieldDesc field in typeDesc.GetFields())
             {
-                if (fieldIndex > 1)
-                {
-                    return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                }
-                else if (field.IsStatic)
+                if (field.IsStatic)
                 {
                     continue;
                 }
@@ -162,6 +158,11 @@ namespace Internal.JitInterface
 
                     default:
                     {
+                        if ((numIntroducedFields == 2) && (field.FieldType.Category == TypeFlags.Class))
+                        {
+                            return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
+                        }
+
                         if (field.FieldType.GetElementSize().AsInt == 8)
                         {
                             if (numIntroducedFields > 1)


### PR DESCRIPTION
This PR is part of the issue https://github.com/dotnet/runtime/issues/69705 to amend the LA's port.

Fix some errors of the struct argument parsing in LoongArch64PassStructInRegister.cs