### PR TITLE
Fix ValueType.GetHashCode not calling overriden method on nested field

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -95,21 +95,17 @@ namespace System
 
         public override unsafe int GetHashCode()
         {
-            int hashCode = (int)this.GetMethodTable()->HashCode;
+            HashCode hashCode = default;
+            hashCode.Add(this.GetMethodTable()->HashCode);
 
-            hashCode ^= GetHashCodeImpl();
-
-            return hashCode;
-        }
-
-        private unsafe int GetHashCodeImpl()
-        {
             int numFields = __GetFieldHelper(GetNumFields, out _);
 
             if (numFields == UseFastHelper)
-                return FastGetValueTypeHashCodeHelper(this.GetMethodTable(), ref this.GetRawData());
+                hashCode.Add(FastGetValueTypeHashCodeHelper(this.GetMethodTable(), ref this.GetRawData()));
 
-            return RegularGetValueTypeHashCode(ref this.GetRawData(), numFields);
+            hashCode.Add(RegularGetValueTypeHashCode(ref this.GetRawData(), numFields));
+
+            return hashCode.ToHashCode();
         }
 
         private static unsafe int FastGetValueTypeHashCodeHelper(MethodTable* type, ref byte data)
@@ -164,7 +160,6 @@ namespace System
                     var fieldValue = (ValueType)RuntimeImports.RhBox(fieldType, ref fieldData);
                     if (fieldValue != null)
                     {
-                        // call virtual method to handle overriden case
                         hashCode = fieldValue.GetHashCode();
                     }
                     else

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -101,18 +101,18 @@ namespace System
             int numFields = __GetFieldHelper(GetNumFields, out _);
 
             if (numFields == UseFastHelper)
-                AddHashCodeForField(ref hashCode, this.GetMethodTable(), ref this.GetRawData());
+                hashCode.AddBytes(GetSpanForField(this.GetMethodTable(), ref this.GetRawData()));
             else
                 RegularGetValueTypeHashCode(ref hashCode, ref this.GetRawData(), numFields);
 
             return hashCode.ToHashCode();
         }
 
-        private static unsafe void AddHashCodeForField(ref HashCode hashCode, MethodTable* type, ref byte data)
+        private static unsafe ReadOnlySpan<byte> GetSpanForField(MethodTable* type, ref byte data)
         {
             // Sanity check - if there are GC references, we should not be hashing bytes
             Debug.Assert(!type->ContainsGCPointers);
-            hashCode.AddBytes(new ReadOnlySpan<byte>(ref data, (int)type->ValueTypeSize));
+            return new ReadOnlySpan<byte>(ref data, (int)type->ValueTypeSize);
         }
 
         private unsafe void RegularGetValueTypeHashCode(ref HashCode hashCode, ref byte data, int numFields)
@@ -135,7 +135,7 @@ namespace System
                 }
                 else if (fieldType->IsPrimitive)
                 {
-                    AddHashCodeForField(ref hashCode, fieldType, ref fieldData);
+                    hashCode.AddBytes(GetSpanForField(fieldType, ref fieldData));
                 }
                 else if (fieldType->IsValueType)
                 {

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -101,18 +101,18 @@ namespace System
             int numFields = __GetFieldHelper(GetNumFields, out _);
 
             if (numFields == UseFastHelper)
-                hashCode.AddBytes(GetSpanForField(this.GetMethodTable(), ref this.GetRawData()));
+                AddHashCodeForField(ref hashCode, this.GetMethodTable(), ref this.GetRawData());
             else
                 hashCode.Add(RegularGetValueTypeHashCode(ref this.GetRawData(), numFields));
 
             return hashCode.ToHashCode();
         }
 
-        private static unsafe ReadOnlySpan<byte> GetSpanForField(MethodTable* type, ref byte data)
+        private static unsafe void AddHashCodeForField(ref HashCode hashCode, MethodTable* type, ref byte data)
         {
             // Sanity check - if there are GC references, we should not be hashing bytes
             Debug.Assert(!type->ContainsGCPointers);
-            return new ReadOnlySpan<byte>(ref data, (int)type->ValueTypeSize);
+            hashCode.AddBytes(new ReadOnlySpan<byte>(ref data, (int)type->ValueTypeSize));
         }
 
         private unsafe int RegularGetValueTypeHashCode(ref byte data, int numFields)
@@ -138,7 +138,7 @@ namespace System
                 else if (fieldType->IsPrimitive)
                 {
                     HashCode hash = default;
-                    hash.AddBytes(GetSpanForField(fieldType, ref fieldData));
+                    AddHashCodeForField(ref hash, fieldType, ref fieldData);
                     hashCode = hash.ToHashCode();
                 }
                 else if (fieldType->IsValueType)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ValueType.cs
@@ -164,7 +164,8 @@ namespace System
                     var fieldValue = (ValueType)RuntimeImports.RhBox(fieldType, ref fieldData);
                     if (fieldValue != null)
                     {
-                        hashCode = fieldValue.GetHashCodeImpl();
+                        // call virtual method to handle overriden case
+                        hashCode = fieldValue.GetHashCode();
                     }
                     else
                     {

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -252,7 +252,7 @@ public:
 
 extern "C" BOOL QCALLTYPE MethodTable_AreTypesEquivalent(MethodTable* mta, MethodTable* mtb);
 extern "C" BOOL QCALLTYPE MethodTable_CanCompareBitsOrUseFastGetHashCode(MethodTable* mt);
-extern "C" INT32 QCALLTYPE ValueType_GetHashCodeStrategy(MethodTable* mt, QCall::ObjectHandleOnStack objHandle, UINT32* fieldOffset, UINT32* fieldSize, PCODE * method);
+extern "C" INT32 QCALLTYPE ValueType_GetHashCodeStrategy(MethodTable* mt, QCall::ObjectHandleOnStack objHandle, UINT32* fieldOffset, UINT32* fieldSize, MethodTable** fieldMT);
 
 class StreamNative {
 public:

--- a/src/coreclr/vm/comutilnative.h
+++ b/src/coreclr/vm/comutilnative.h
@@ -252,7 +252,7 @@ public:
 
 extern "C" BOOL QCALLTYPE MethodTable_AreTypesEquivalent(MethodTable* mta, MethodTable* mtb);
 extern "C" BOOL QCALLTYPE MethodTable_CanCompareBitsOrUseFastGetHashCode(MethodTable* mt);
-extern "C" INT32 QCALLTYPE ValueType_GetHashCodeStrategy(MethodTable* mt, QCall::ObjectHandleOnStack objHandle, UINT32* fieldOffset, UINT32* fieldSize);
+extern "C" INT32 QCALLTYPE ValueType_GetHashCodeStrategy(MethodTable* mt, QCall::ObjectHandleOnStack objHandle, UINT32* fieldOffset, UINT32* fieldSize, PCODE * method);
 
 class StreamNative {
 public:

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
@@ -315,6 +315,21 @@ namespace System.Tests
             Assert.Equal(obj1.GetHashCode(), obj2.GetHashCode());
         }
 
+        [Fact]
+        public static void StructWithNestedOverriddenNotBitwiseComparableNext()
+        {
+            StructWithNestedOverriddenNotBitwiseComparable obj1 = new StructWithNestedOverriddenNotBitwiseComparable();
+            obj1.value1.value = 0.0;
+            obj1.value2.value = 1.0;
+
+            StructWithNestedOverriddenNotBitwiseComparable obj2 = new StructWithNestedOverriddenNotBitwiseComparable();
+            obj1.value1.value = -0.0;
+            obj1.value2.value = 1.0;
+
+            Assert.True(obj1.Equals(obj2));
+            Assert.Equal(obj1.GetHashCode(), obj2.GetHashCode());
+        }
+
         public struct S
         {
             public int x;
@@ -412,6 +427,21 @@ namespace System.Tests
         {
             public object o;
             public StructNonOverriddenEqualsOrGetHasCode value;
+        }
+
+        public struct StructOverriddenNotBitwiseComparable
+        {
+            public double value;
+
+            public override bool Equals(object obj) => obj is StructOverriddenNotBitwiseComparable other && value.Equals(other.value);
+
+            public override int GetHashCode() => value.GetHashCode();
+        }
+
+        public struct StructWithNestedOverriddenNotBitwiseComparable
+        {
+            public StructOverriddenNotBitwiseComparable value1;
+            public StructOverriddenNotBitwiseComparable value2;
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
@@ -316,15 +316,15 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void StructWithNestedOverriddenNotBitwiseComparableNext()
+        public static void StructWithNestedOverriddenNotBitwiseComparableTest()
         {
             StructWithNestedOverriddenNotBitwiseComparable obj1 = new StructWithNestedOverriddenNotBitwiseComparable();
             obj1.value1.value = 0.0;
             obj1.value2.value = 1.0;
 
             StructWithNestedOverriddenNotBitwiseComparable obj2 = new StructWithNestedOverriddenNotBitwiseComparable();
-            obj1.value1.value = -0.0;
-            obj1.value2.value = 1.0;
+            obj2.value1.value = -0.0;
+            obj2.value2.value = 1.0;
 
             Assert.True(obj1.Equals(obj2));
             Assert.Equal(obj1.GetHashCode(), obj2.GetHashCode());

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ValueTypeTests.cs
@@ -319,12 +319,12 @@ namespace System.Tests
         public static void StructWithNestedOverriddenNotBitwiseComparableTest()
         {
             StructWithNestedOverriddenNotBitwiseComparable obj1 = new StructWithNestedOverriddenNotBitwiseComparable();
-            obj1.value1.value = 0.0;
-            obj1.value2.value = 1.0;
+            obj1.value1.value = 1;
+            obj1.value2.value = 0;
 
             StructWithNestedOverriddenNotBitwiseComparable obj2 = new StructWithNestedOverriddenNotBitwiseComparable();
-            obj2.value1.value = -0.0;
-            obj2.value2.value = 1.0;
+            obj2.value1.value = -1;
+            obj2.value2.value = 0;
 
             Assert.True(obj1.Equals(obj2));
             Assert.Equal(obj1.GetHashCode(), obj2.GetHashCode());
@@ -431,11 +431,11 @@ namespace System.Tests
 
         public struct StructOverriddenNotBitwiseComparable
         {
-            public double value;
+            public int value;
 
-            public override bool Equals(object obj) => obj is StructOverriddenNotBitwiseComparable other && value.Equals(other.value);
+            public override bool Equals(object obj) => obj is StructOverriddenNotBitwiseComparable other && (value == other.value || value == -other.value);
 
-            public override int GetHashCode() => value.GetHashCode();
+            public override int GetHashCode() => value < 0 ? -value : value;
         }
 
         public struct StructWithNestedOverriddenNotBitwiseComparable


### PR DESCRIPTION
Follow up for https://github.com/dotnet/runtime/pull/97590#issuecomment-1913554974

This is indeed a bug, since `GetHashCode` can return different result when `Equals` is returning `true`.