### PR TITLE
JIT: Fix rich debug info reporting with failed inline contexts

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7480,7 +7480,7 @@ void CodeGen::genReportRichDebugInfo()
         for (size_t i = 0; i < mappingIndex; i++)
         {
             printf("  [%zu] 0x%x <-> IL %d in #%d\n", i, mappings[i].NativeOffset, mappings[i].ILOffset,
-                   mappings->Inlinee);
+                   mappings[i].Inlinee);
         }
 
         printf("\n");


### PR DESCRIPTION
The child/sibling link ordinals would be reported as 0 in cases where the immediate child/sibling was a failed one. This would break the reported tree structure.

Also add some JITDUMP logging of the reported info.