### PR TITLE
SPMI: Handle PerfScore=0 edge case

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1917,10 +1917,9 @@ def aggregate_diff_metrics(details):
             base_dict["Diffed PerfScore"] += base_perfscore
             diff_dict["Diffed PerfScore"] += diff_perfscore
 
-            if base_perfscore > 0:
-                log_relative_perfscore = math.log(diff_perfscore / base_perfscore)
-                base_dict["Relative PerfScore Geomean"] += log_relative_perfscore
-                diff_dict["Relative PerfScore Geomean"] += log_relative_perfscore
+            log_relative_perfscore = math.log(max(diff_perfscore, 1.0) / max(base_perfscore, 1.0))
+            base_dict["Relative PerfScore Geomean"] += log_relative_perfscore
+            diff_dict["Relative PerfScore Geomean"] += log_relative_perfscore
 
             base_dict["Diffed contexts"] += 1
             diff_dict["Diffed contexts"] += 1


### PR DESCRIPTION
If the weight of all IGs are 0 we end up with 0 perfscore. If this happened just in the diff it would lead to computing `math.log(0)` which throws an exception.

cc @dotnet/jit-contrib 