### PR TITLE
Interface maps' TargetMethods array should only contain generic method definitions, not instances

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2757,7 +2757,7 @@ namespace System
                 MethodBase? rtTypeMethodBase = GetMethodBase(reflectedType, classRtMethodHandle);
                 // a class may not implement all the methods of an interface (abstract class) so null is a valid value
                 Debug.Assert(rtTypeMethodBase is null || rtTypeMethodBase is RuntimeMethodInfo);
-                RuntimeMethodInfo? targetMethod = (RuntimeMethodInfo)rtTypeMethodBase;
+                RuntimeMethodInfo? targetMethod = (RuntimeMethodInfo?)rtTypeMethodBase;
                 // the TargetMethod provided to us by runtime internals may be a generic method instance,
                 //  potentially with invalid arguments. TargetMethods in the InterfaceMap should never be
                 //  instances, only definitions.

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2757,14 +2757,12 @@ namespace System
                 MethodBase? rtTypeMethodBase = GetMethodBase(reflectedType, classRtMethodHandle);
                 // a class may not implement all the methods of an interface (abstract class) so null is a valid value
                 Debug.Assert(rtTypeMethodBase is null || rtTypeMethodBase is RuntimeMethodInfo);
-                RuntimeMethodInfo? targetMethod = rtTypeMethodBase as RuntimeMethodInfo;
+                RuntimeMethodInfo? targetMethod = (RuntimeMethodInfo)rtTypeMethodBase;
                 // the TargetMethod provided to us by runtime internals may be a generic method instance,
                 //  potentially with invalid arguments. TargetMethods in the InterfaceMap should never be
                 //  instances, only definitions.
-                if ((targetMethod?.IsGenericMethod == true) && !targetMethod.IsGenericMethodDefinition)
-                    targetMethod = (RuntimeMethodInfo)targetMethod.GetGenericMethodDefinition();
-
-                im.TargetMethods[i] = targetMethod!;
+                im.TargetMethods[i] = (targetMethod is { IsGenericMethod: true, IsGenericMethodDefinition: false })
+                    ? targetMethod.GetGenericMethodDefinition() : targetMethod!;
             }
 
             return im;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2757,7 +2757,12 @@ namespace System
                 MethodBase? rtTypeMethodBase = GetMethodBase(reflectedType, classRtMethodHandle);
                 // a class may not implement all the methods of an interface (abstract class) so null is a valid value
                 Debug.Assert(rtTypeMethodBase is null || rtTypeMethodBase is RuntimeMethodInfo);
-                im.TargetMethods[i] = (MethodInfo)rtTypeMethodBase!;
+                MethodInfo targetMethod = (MethodInfo)rtTypeMethodBase!;
+                // https://github.com/dotnet/runtime/issues/90863
+                if (targetMethod.IsGenericMethod && !targetMethod.IsGenericMethodDefinition)
+                    targetMethod = targetMethod.GetGenericMethodDefinition();
+
+                im.TargetMethods[i] = targetMethod;
             }
 
             return im;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2757,12 +2757,14 @@ namespace System
                 MethodBase? rtTypeMethodBase = GetMethodBase(reflectedType, classRtMethodHandle);
                 // a class may not implement all the methods of an interface (abstract class) so null is a valid value
                 Debug.Assert(rtTypeMethodBase is null || rtTypeMethodBase is RuntimeMethodInfo);
-                MethodInfo targetMethod = (MethodInfo)rtTypeMethodBase!;
-                // https://github.com/dotnet/runtime/issues/90863
-                if (targetMethod.IsGenericMethod && !targetMethod.IsGenericMethodDefinition)
-                    targetMethod = targetMethod.GetGenericMethodDefinition();
+                RuntimeMethodInfo? targetMethod = rtTypeMethodBase as RuntimeMethodInfo;
+                // the TargetMethod provided to us by runtime internals may be a generic method instance,
+                //  potentially with invalid arguments. TargetMethods in the InterfaceMap should never be
+                //  instances, only definitions.
+                if ((targetMethod?.IsGenericMethod == true) && !targetMethod.IsGenericMethodDefinition)
+                    targetMethod = (RuntimeMethodInfo)targetMethod.GetGenericMethodDefinition();
 
-                im.TargetMethods[i] = targetMethod;
+                im.TargetMethods[i] = targetMethod!;
             }
 
             return im;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/TypeTests.cs
@@ -1188,9 +1188,6 @@ namespace System.Tests
                     }
                     else
                     {
-                        // [ActiveIssue("https://github.com/dotnet/runtime/issues/90863")]
-                        if (classType.Type == typeof(SIMs.C2Implicit<string>) && interfaceType.Type == typeof(SIMs.I1<string>)) continue;
-
                         // It's implemented implicitly by the level 2 interface
                         MTarget = interfaceType.Level2InterfaceType.GetMethod(interfaceType.MethodNamePrefix + "M", bindingFlags);
                         GTarget = interfaceType.Level2InterfaceType.GetMethod(interfaceType.MethodNamePrefix + "G", bindingFlags);
@@ -1315,7 +1312,7 @@ namespace System.Tests
 
         static class DIMs
         {
-            
+
             internal interface I1
             {
                 void M() { throw new Exception("e"); }


### PR DESCRIPTION
Should fix https://github.com/dotnet/runtime/issues/90863.

Under some circumstances, an interface map can end up containing invalid generic method *instances* where a generic method *definition* should be. The runtime internals do not thoroughly validate generic method instances at construction time, and it's not straightforward (or necessarily possible at all) to tighten the validation to prevent these instances from making it into the runtime representation or prevent them from being constructed.

So this PR adds a simple validation check to the C# layer that exposes the interface map, and if it sees a generic method instance, it grabs the definition for that instance instead and puts it in the interface map.

Re-enables a disabled test data item that covers this scenario.