### PR TITLE
Detect CPUs with throttled 512-bit width instructions

### DIFF
--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -10,6 +10,12 @@ using Internal.JitInterface;
 
 namespace ILCompiler
 {
+    [Flags]
+    public enum InstructionSetSupportFlags
+    {
+        Vector512Throttling = 0x1,
+    }
+
     public class InstructionSetSupport
     {
         private readonly TargetArchitecture _targetArchitecture;
@@ -17,19 +23,21 @@ namespace ILCompiler
         private readonly InstructionSetFlags _supportedInstructionSets;
         private readonly InstructionSetFlags _unsupportedInstructionSets;
         private readonly InstructionSetFlags _nonSpecifiableInstructionSets;
+        private readonly InstructionSetSupportFlags _flags;
 
         public InstructionSetSupport(InstructionSetFlags supportedInstructionSets, InstructionSetFlags unsupportedInstructionSets, TargetArchitecture architecture) :
             this(supportedInstructionSets, unsupportedInstructionSets, supportedInstructionSets, default(InstructionSetFlags), architecture)
         {
         }
 
-        public InstructionSetSupport(InstructionSetFlags supportedInstructionSets, InstructionSetFlags unsupportedInstructionSets, InstructionSetFlags optimisticInstructionSets, InstructionSetFlags nonSpecifiableInstructionSets, TargetArchitecture architecture)
+        public InstructionSetSupport(InstructionSetFlags supportedInstructionSets, InstructionSetFlags unsupportedInstructionSets, InstructionSetFlags optimisticInstructionSets, InstructionSetFlags nonSpecifiableInstructionSets, TargetArchitecture architecture, InstructionSetSupportFlags flags = 0)
         {
             _supportedInstructionSets = supportedInstructionSets;
             _unsupportedInstructionSets = unsupportedInstructionSets;
             _optimisticInstructionSets = optimisticInstructionSets;
             _targetArchitecture = architecture;
             _nonSpecifiableInstructionSets = nonSpecifiableInstructionSets;
+            _flags = flags;
         }
 
         public bool IsInstructionSetSupported(InstructionSet instructionSet)
@@ -53,6 +61,8 @@ namespace ILCompiler
         public InstructionSetFlags NonSpecifiableFlags => _nonSpecifiableInstructionSets;
 
         public TargetArchitecture Architecture => _targetArchitecture;
+
+        public InstructionSetSupportFlags Flags => _flags;
 
         public static string GetHardwareIntrinsicId(TargetArchitecture architecture, TypeDesc potentialTypeDesc)
         {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -4112,6 +4112,9 @@ namespace Internal.JitInterface
                 case TargetArchitecture.X86:
                     Debug.Assert(InstructionSet.X86_SSE2 == InstructionSet.X64_SSE2);
                     Debug.Assert(_compilation.InstructionSetSupport.IsInstructionSetSupported(InstructionSet.X86_SSE2));
+
+                    if ((_compilation.InstructionSetSupport.Flags & InstructionSetSupportFlags.Vector512Throttling) != 0)
+                        flags.Set(CorJitFlag.CORJIT_FLAG_VECTOR512_THROTTLING);
                     break;
 
                 case TargetArchitecture.ARM64:


### PR DESCRIPTION
When compiling with `--instruction-set:native` detect the CPUs that implemented AVX-512 in a way where it's better not to use it much.

This replicates the check in codeman.cpp and passes the same flag to JIT that the VM would pass.

I noticed this because passing `--instruction-set:native` to our ASP.NET benchmark machines murders the performance (minus 10+% in RPS) instead of helping it in any way. Passing `--application.environmentVariables DOTNET_PreferredVectorBitWidth=512` kills it in similar way with CoreCLR-JIT, so this detection will likely fix it.

Cc @dotnet/ilc-contrib 