### PR TITLE
Add missing "internal use" for register created for LoadAndInsertScalar()

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -11745,8 +11745,7 @@ void LinearScan::verifyFinalAllocation()
             }
         }
 
-        LsraLocation newLocation = currentRefPosition.nodeLocation;
-        currentLocation          = newLocation;
+        currentLocation = currentRefPosition.nodeLocation;
 
         switch (currentRefPosition.refType)
         {

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -2025,7 +2025,7 @@ bool RefPosition::isLiveAtConsecutiveRegistersLoc(LsraLocation consecutiveRegist
         return true;
     }
 
-    bool atConsecutiveRegsLoc = consecutiveRegistersLocation == nodeLocation;
+    bool atConsecutiveRegsLoc          = consecutiveRegistersLocation == nodeLocation;
     bool treeNeedsConsecutiveRegisters = false;
 
     if ((treeNode != nullptr) && treeNode->OperIsHWIntrinsic())

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1684,6 +1684,7 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
 
                 assert(intrinsicTree->OperIsMemoryLoadOrStore());
                 srcCount += BuildAddrUses(intrin.op3);
+                buildInternalRegisterUses();
                 FALLTHROUGH;
             }
 


### PR DESCRIPTION
There was a missing internal use RefPosition creation that was missing causing the register to get allocated throughout the lifetime of the method.

Fixes: #98717 