### PR TITLE
Set assets manifest metadata for assets that get shipped with .NET release

### DIFF
--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -58,6 +58,16 @@
     <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
   </ItemGroup>
 
+  <!-- 
+    Set metadata for all assets that will get pushed to the Azure DevOps artifacts.
+    It will get overwritten for nonshipping assets.
+  -->
+  <ItemDefinitionGroup>
+    <ItemsToPush>
+      <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+    </ItemsToPush>
+  </ItemDefinitionGroup>
+
   <!--
     Run Arcade's signing project directly. The 'eng/Signing.props' extensibility props file checks
     if '$(<StageName>)' == 'true' and points Arcade to the correct files.

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -59,8 +59,8 @@
   </ItemGroup>
 
   <!-- 
-    Set metadata for all assets that will get pushed to the Azure DevOps artifacts.
-    It will get overwritten for nonshipping assets.
+    Set metadata for assets that are not marked as NonShipping. 
+    This is used to determine if the asset should be shipped as part of .NET release.
   -->
   <ItemDefinitionGroup>
     <ItemsToPush>

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -114,47 +114,36 @@
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
 
-      <ItemsToPush Include="@(ShippingNupkgToPublishFile)">
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
-      </ItemsToPush>
-
+      <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
       <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
-
-      <ItemsToPush Include="@(SymbolNupkgToPublishFile)">
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
-      </ItemsToPush>
+      <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
 
       <ItemsToPush
         Include="@(UploadToBlobStorageFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="@(GeneratedChecksumFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)runtime-productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)runtime-productVersion.txt</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="@(WorkloadsVSInsertionFile)">
         <RelativeBlobPath>$(InstallersRelativePath)workloads/%(Filename)%(Extension)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
-        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <!-- Source build intermediated packages will be pushed and signed by the sourcebuild leg. -->

--- a/src/installer/prepare-artifacts.proj
+++ b/src/installer/prepare-artifacts.proj
@@ -23,6 +23,8 @@
   </PropertyGroup>
   <Import Project="../tools/Sign.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
+  <Import Project="$(RepositoryEngineeringDir)Publishing.props" Condition="Exists('$(RepositoryEngineeringDir)Publishing.props')" />
+
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(InstallerTasksAssemblyPath)" />
 
   <PropertyGroup>
@@ -102,36 +104,47 @@
     <ItemGroup>
       <ItemsToPush Remove="@(ItemsToPush)" />
 
-      <ItemsToPush Include="@(ShippingNupkgToPublishFile)" />
+      <ItemsToPush Include="@(ShippingNupkgToPublishFile)">
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+      </ItemsToPush>
+
       <ItemsToPush Include="@(NonShippingNupkgToPublishFile)" ManifestArtifactData="NonShipping=true" />
-      <ItemsToPush Include="@(SymbolNupkgToPublishFile)" />
+
+      <ItemsToPush Include="@(SymbolNupkgToPublishFile)">
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
+      </ItemsToPush>
 
       <ItemsToPush
         Include="@(UploadToBlobStorageFile)"
         Exclude="@(NupkgToPublishFile);@(SymbolNupkgToPublishFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="@(GeneratedChecksumFile)">
         <RelativeBlobPath>$(InstallersRelativePath)%(Filename)%(Extension)</RelativeBlobPath>
         <Category>Checksum</Category>
         <PublishFlatContainer>true</PublishFlatContainer>
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)productVersion.txt</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="$(ArtifactsShippingPackagesDir)runtime-productVersion.txt">
         <RelativeBlobPath>$(InstallersRelativePath)runtime-productVersion.txt</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <ItemsToPush Include="@(WorkloadsVSInsertionFile)">
         <RelativeBlobPath>$(InstallersRelativePath)workloads/%(Filename)%(Extension)</RelativeBlobPath>
         <PublishFlatContainer>true</PublishFlatContainer>
+        <ManifestArtifactData Condition="'$(ProducesDotNetReleaseShippingAssets)' == 'true'">DotNetReleaseShipping=true</ManifestArtifactData>
       </ItemsToPush>
 
       <!-- Source build intermediated packages will be pushed and signed by the sourcebuild leg. -->


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/release/issues/822

Setting metadata for assets that will get shipped as part of .NET release in the assets manifest file. 
I added the `ProducesDotNetReleaseShippingAssets` property in https://github.com/dotnet/runtime/pull/98665
Since runtime doesn't use arcade's default publishing, this is editing `prepare-artifacts.proj` where the metadata is getting added to the manifest