### PR TITLE
Do not crash on a never true `typeof(T) == typeof(Gen<>)`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -885,6 +885,10 @@ namespace ILCompiler
             if (!ReadGetTypeFromHandle(ref reader, methodIL, flags))
                 return false;
 
+            // No value in making this work for definitions
+            if (type1.IsGenericDefinition || type2.IsGenericDefinition)
+                return false;
+
             // Dataflow runs on top of uninstantiated IL and we can't answer some questions there.
             // Unfortunately this means dataflow will still see code that the rest of the system
             // might have optimized away. It should not be a problem in practice.

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -340,6 +340,8 @@ class DeadCodeElimination
 
     class TestTypeEquals
     {
+        sealed class Gen<T> { }
+
         sealed class Never { }
 
         static Type s_type = null;
@@ -349,6 +351,9 @@ class DeadCodeElimination
             // This was asserting the BCL because Never would not have reflection metadata
             // despite the typeof
             Console.WriteLine(s_type == typeof(Never));
+
+            // This was a compiler crash
+            Console.WriteLine(typeof(object) == typeof(Gen<>));
 
 #if !DEBUG
             ThrowIfPresent(typeof(TestTypeEquals), nameof(Never));


### PR DESCRIPTION
Fixes #98821.

Cc @dotnet/ilc-contrib 