### PR TITLE
Fix single-file debugging; missing g_dacTable export

### DIFF
--- a/src/native/corehost/apphost/static/singlefilehost.def
+++ b/src/native/corehost/apphost/static/singlefilehost.def
@@ -13,5 +13,8 @@ CLRJitAttachState                                   @3 data
 ; needed by SOS, WinDBG, and Watson. This must remain ordinal 4.
 DotNetRuntimeInfo                                   @4 data
 
+; DAC table export
+g_dacTable = s_dacGlobals
+
 ; Used by profilers
 MetaDataGetDispenser


### PR DESCRIPTION
The linker pragma [here](https://github.com/dotnet/runtime/blob/15ff723dfe6b0fc90797c8b3117b29e51bcddab0/src/coreclr/debug/ee/dactable.cpp#L78) doesn't work for single-file apps anymore.