### PR TITLE
Fix VS debugger compensation for the new EH

### DIFF
--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -1153,14 +1153,14 @@ void DebugStackTrace::GetStackFramesFromException(OBJECTREF * e,
                 DWORD dwNativeOffset;
 
                 UINT_PTR ip = cur.ip;
-#if DACCESS_COMPILE
+#if defined(DACCESS_COMPILE) && defined(TARGET_AMD64)
                 // Compensate for a bug in the old EH that for a frame that faulted
                 // has the ip pointing to an address before the faulting instruction
                 if (g_isNewExceptionHandlingEnabled && (i == 0) && ((cur.flags & STEF_IP_ADJUSTED) == 0))
                 {
                     ip -= 1;
                 }
-#endif // DACCESS_COMPILE
+#endif // DACCESS_COMPILE && TARGET_AMD64
                 if (ip)
                 {
                     EECodeInfo codeInfo(ip);

--- a/src/coreclr/vm/debugdebugger.cpp
+++ b/src/coreclr/vm/debugdebugger.cpp
@@ -1152,9 +1152,18 @@ void DebugStackTrace::GetStackFramesFromException(OBJECTREF * e,
                 // to spot.
                 DWORD dwNativeOffset;
 
-                if (cur.ip)
+                UINT_PTR ip = cur.ip;
+#if DACCESS_COMPILE
+                // Compensate for a bug in the old EH that for a frame that faulted
+                // has the ip pointing to an address before the faulting instruction
+                if (g_isNewExceptionHandlingEnabled && (i == 0) && ((cur.flags & STEF_IP_ADJUSTED) == 0))
                 {
-                    EECodeInfo codeInfo(cur.ip);
+                    ip -= 1;
+                }
+#endif // DACCESS_COMPILE
+                if (ip)
+                {
+                    EECodeInfo codeInfo(ip);
                     dwNativeOffset = codeInfo.GetRelOffset();
                 }
                 else
@@ -1165,7 +1174,7 @@ void DebugStackTrace::GetStackFramesFromException(OBJECTREF * e,
                 pData->pElements[i].InitPass1(
                     dwNativeOffset,
                     pMD,
-                    (PCODE)cur.ip,
+                    (PCODE)ip,
                     cur.flags);
 #ifndef DACCESS_COMPILE
                 pData->pElements[i].InitPass2();

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -7578,15 +7578,8 @@ extern "C" void QCALLTYPE AppendExceptionStackFrame(QCall::ObjectHandleOnStack e
         _ASSERTE(pMD == codeInfo.GetMethodDesc());
 #endif // _DEBUG
 
-        // Compensate for a bug in the old EH that doesn't mark faulting instructions as faulting. The VS expects that behavior.
-        bool hasFaulted = pExInfo->m_frameIter.m_crawl.HasFaulted();
-        if (hasFaulted)
-        {
-            pExInfo->m_frameIter.m_crawl.hasFaulted = false;
-        }
         pExInfo->m_StackTraceInfo.AppendElement(canAllocateMemory, ip, sp, pMD, &pExInfo->m_frameIter.m_crawl);
         pExInfo->m_StackTraceInfo.SaveStackTrace(canAllocateMemory, pExInfo->m_hThrowable, /*bReplaceStack*/FALSE, /*bSkipLastElement*/FALSE);
-        pExInfo->m_frameIter.m_crawl.hasFaulted = hasFaulted;
     }
 
     // Notify the debugger that we are on the first pass for a managed exception.


### PR DESCRIPTION
In a recent fix, I've fixed a problem that VS debugger has with the new exception handling reporting correct address for a hardware exception on a stack trace. However, that has broken the
JIT/opt/Vectorization/UnrollEqualsStartsWith test when it is run with tiered compilation disabled. In that test, the faulting instruction is the first one in a method and the compensation for the old EH issue has moved the address to the previous method. And then a call to PreserveStackTrace that the new EH ends up calling due to the way it propagates exceptions over internal native boundaries ends up asserting down in the DebugStackTrace::GetStackFramesInternal call chain, because the compensated address and the MethodDesc attached to it in the stack frame didn't match.

This change moves the compensation to the
DebugStackTrace::GetStackFramesFromException and only for the DAC code. That way only the debugger gets the compensated value.