### PR TITLE
[RISC-V] R2RDump to handle System.Private.CoreLib

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcInfo.cs
@@ -267,6 +267,14 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                 }
                 sb.AppendLine($"    Has Tailcalls: {_wantsReportOnlyLeaf}");
             }
+            else if (_machine == Machine.RiscV64)
+            {
+                if (StackBaseRegister != 0xffffffff)
+                {
+                    sb.AppendLine($"    StackBaseRegister: {(RiscV64.Registers)StackBaseRegister}");
+                }
+                sb.AppendLine($"    Has Tailcalls: {_wantsReportOnlyLeaf}");
+            }
 
             sb.AppendLine($"    Size of parameter area: 0x{SizeOfStackOutgoingAndScratchArea:X}");
             if (SizeOfEditAndContinuePreservedArea != 0xffffffff)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -71,6 +71,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     case Machine.LoongArch64:
                         return ((LoongArch64.Registers)registerNumber).ToString();
 
+                    case Machine.RiscV64:
+                        return ((RiscV64.Registers)registerNumber).ToString();
+
                     default:
                         throw new NotImplementedException(machine.ToString());
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
@@ -69,6 +69,10 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         regType = typeof(LoongArch64.Registers);
                         break;
 
+                    case Machine.RiscV64:
+                        regType = typeof(RiscV64.Registers);
+                        break;
+
                     default:
                         throw new NotImplementedException();
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -74,6 +74,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                     return ((Arm64.Registers)regnum).ToString();
                 case Machine.LoongArch64:
                     return ((LoongArch64.Registers)regnum).ToString();
+                case Machine.RiscV64:
+                    return ((RiscV64.Registers)regnum).ToString();
                 default:
                     throw new NotImplementedException($"No implementation for machine type {machine}.");
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -229,6 +229,10 @@ namespace ILCompiler.Reflection.ReadyToRun
             {
                 return (int)loongarch64Info.FunctionLength;
             }
+            else if (UnwindInfo is RiscV64.UnwindInfo riscv64Info)
+            {
+                return (int)riscv64Info.FunctionLength;
+            }
             else if (Method.GcInfo != null)
             {
                 return Method.GcInfo.CodeLength;
@@ -611,6 +615,10 @@ namespace ILCompiler.Reflection.ReadyToRun
                 else if (_readyToRunReader.Machine == Machine.LoongArch64)
                 {
                     unwindInfo = new LoongArch64.UnwindInfo(_readyToRunReader.Image, unwindOffset);
+                }
+                else if (_readyToRunReader.Machine == Machine.RiscV64)
+                {
+                    unwindInfo = new RiscV64.UnwindInfo(_readyToRunReader.Image, unwindOffset);
                 }
 
                 if (i == 0 && unwindInfo != null)

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/Registers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/Registers.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ILCompiler.Reflection.ReadyToRun.RiscV64
+{
+    public enum Registers
+    {
+        Zero,
+        Ra,
+        Sp,
+        Gp,
+        Tp,
+        T0,
+        T1,
+        T2,
+        Fp,
+        S1,
+        A0,
+        A1,
+        A2,
+        A3,
+        A4,
+        A5,
+        A6,
+        A7,
+        S2,
+        S3,
+        S4,
+        S5,
+        S6,
+        S7,
+        S8,
+        S9,
+        S10,
+        S11,
+        T3,
+        T4,
+        T5,
+        T6,
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/UnwindInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/RiscV64/UnwindInfo.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace ILCompiler.Reflection.ReadyToRun.RiscV64
+{
+    public class Epilog
+    {
+        public int Index { get; set; }
+
+        public uint EpilogStartOffset { get; set; }
+        public uint Res { get; set; }
+        public uint Condition { get; set; }
+        public uint EpilogStartIndex { get; set; }
+        public uint EpilogStartOffsetFromMainFunctionBegin { get; set; }
+
+        public Epilog() { }
+
+        public Epilog(int index, int dw, uint startOffset)
+        {
+            Index = index;
+
+            EpilogStartOffset = UnwindInfo.ExtractBits(dw, 0, 18);
+            Res = UnwindInfo.ExtractBits(dw, 18, 4);
+            Condition = UnwindInfo.ExtractBits(dw, 20, 4);
+            EpilogStartIndex = UnwindInfo.ExtractBits(dw, 22, 10);
+
+            // Note that epilogStartOffset for a funclet is the offset from the beginning
+            // of the current funclet, not the offset from the beginning of the main function.
+            // To help find it when looking through JitDump output, also show the offset from
+            // the beginning of the main function.
+            EpilogStartOffsetFromMainFunctionBegin = EpilogStartOffset * 4 + startOffset;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"        Epilog Start Offset: 0x{EpilogStartOffset:X5} Actual offset = 0x{EpilogStartOffset * 4:X5} Offset from main function begin = 0x{EpilogStartOffsetFromMainFunctionBegin:X6}");
+            sb.AppendLine($"        Condition: {Condition} (0x{Condition:X})" + ((Condition == 0xE) ? " (always)" : ""));
+            sb.Append($"        Epilog Start Index: {EpilogStartIndex} (0x{EpilogStartIndex:X})");
+            return sb.ToString();
+        }
+    }
+
+    public class UnwindCode
+    {
+        public int Index { get; set; }
+
+        public UnwindCode() { }
+
+        public UnwindCode(int index)
+        {
+            Index = index;
+
+        }
+    }
+
+    /// <summary>
+    /// based on <a href="https://github.com/dotnet/runtime/src/coreclr/jit/unwindriscv64.cpp">src/jit/unwindriscv64.cpp</a> DumpUnwindInfo
+    /// </summary>
+    public class UnwindInfo : BaseUnwindInfo
+    {
+        public uint CodeWords { get; set; }
+        public uint EpilogCount { get; set; }
+        public uint EBit { get; set; }
+        public uint XBit { get; set; }
+        public uint Vers { get; set; }
+        public uint FunctionLength { get; set; }
+
+        public uint ExtendedCodeWords { get; set; }
+        public uint ExtendedEpilogCount { get; set; }
+
+        public Epilog[] Epilogs { get; set; }
+
+        public UnwindInfo() { }
+
+        public UnwindInfo(byte[] image, int offset)
+        {
+            uint startOffset = (uint)offset;
+
+            int dw = NativeReader.ReadInt32(image, ref offset);
+            CodeWords = ExtractBits(dw, 27, 5);
+            EpilogCount = ExtractBits(dw, 22, 5);
+            EBit = ExtractBits(dw, 21, 1);
+            XBit = ExtractBits(dw, 20, 1);
+            Vers = ExtractBits(dw, 18, 2);
+            FunctionLength = ExtractBits(dw, 0, 18) * 4;
+
+            if (CodeWords == 0 && EpilogCount == 0)
+            {
+                // We have an extension word specifying a larger number of Code Words or Epilog Counts
+                // than can be specified in the header word.
+                dw = NativeReader.ReadInt32(image, ref offset);
+                ExtendedCodeWords = ExtractBits(dw, 16, 8);
+                ExtendedEpilogCount = ExtractBits(dw, 0, 16);
+            }
+
+            bool[] epilogStartAt = new bool[1024]; // One byte per possible epilog start index; initialized to false
+
+            if (EBit == 0)
+            {
+                Epilogs = new Epilog[EpilogCount];
+                if (EpilogCount != 0)
+                {
+                    for (int scope = 0; scope < EpilogCount; scope++)
+                    {
+                        dw = NativeReader.ReadInt32(image, ref offset);
+                        Epilogs[scope] = new Epilog(scope, dw, startOffset);
+                        epilogStartAt[Epilogs[scope].EpilogStartIndex] = true; // an epilog starts at this offset in the unwind codes
+                    }
+                }
+            }
+            else
+            {
+                Epilogs = new Epilog[0];
+                epilogStartAt[EpilogCount] = true; // the one and only epilog starts its unwind codes at this offset
+            }
+
+            Size = offset - (int)startOffset + (int)CodeWords * 4;
+            int alignmentPad = ((Size + sizeof(int) - 1) & ~(sizeof(int) - 1)) - Size;
+            Size += (alignmentPad + sizeof(uint));
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine($"    CodeWords: {CodeWords}");
+            sb.AppendLine($"    EpilogCount: {EpilogCount}");
+            sb.AppendLine($"    EBit: {EBit}");
+            sb.AppendLine($"    XBit: {XBit}");
+            sb.AppendLine($"    Vers: {Vers}");
+            sb.AppendLine($"    FunctionLength: {FunctionLength}");
+            if (CodeWords == 0 && EpilogCount == 0)
+            {
+                sb.AppendLine("    ---- Extension word ----");
+                sb.AppendLine($"    Extended Code Words: {CodeWords}");
+                sb.AppendLine($"    Extended Epilog Count: {EpilogCount}");
+            }
+            if (EpilogCount == 0)
+            {
+                sb.AppendLine("    No epilogs");
+            }
+            else
+            {
+                for (int i = 0; i < Epilogs.Length; i++)
+                {
+                    sb.AppendLine("        -------------------------");
+                    sb.AppendLine(Epilogs[i].ToString());
+                    sb.AppendLine("        -------------------------");
+                }
+            }
+            return sb.ToString();
+        }
+
+        internal static uint ExtractBits(int dw, int start, int length)
+        {
+            return (uint)((dw >> start) & ((1 << length) - 1));
+        }
+    }
+}

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -236,6 +236,11 @@ namespace R2RDump
             }
 
             int instrSize = CoreDisTools.GetInstruction(_disasm, rtf, imageOffset, rtfOffset, _reader.Image, out instruction);
+            if (instrSize == 0)
+            {
+                instruction = "Decode failure, aborting disassembly" + Environment.NewLine;
+                return rtf.Size - rtfOffset;
+            }
 
             // CoreDisTools dumps instructions in the following format:
             //

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -30,9 +30,6 @@ namespace R2RDump
         public static extern IntPtr InitBufferedDisasm(TargetArch Target);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern void DumpCodeBlock(IntPtr Disasm, IntPtr Address, IntPtr Bytes, IntPtr Size);
-
-        [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]
         public static extern int DumpInstruction(IntPtr Disasm, IntPtr Address, IntPtr Bytes, IntPtr Size);
 
         [DllImport(_dll, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Now that we have a crossgen2'ed System.Private.CoreLib.dll, adjust R2RDump to handle it.

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @Bajtazar @bartlomiejko @rzsc