### PR TITLE
Keep stack trace while passing through native

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -2889,7 +2889,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrow(Object *exceptionObj)
     CONTRACTL_END;
 
     OBJECTREF throwable = ObjectToOBJECTREF(exceptionObj);
-    RealCOMPlusThrow(throwable, FALSE);
+    RealCOMPlusThrowWorker(throwable, FALSE);
 }
 #endif // USE_CHECKED_OBJECTREFS
 
@@ -7830,7 +7830,7 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
         }
         else
         {
-            DispatchManagedException(orThrowable);
+            DispatchManagedException(orThrowable, /* preserveStackTrace */ false);
         }
     }
     else

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -939,7 +939,7 @@ ProcessCLRExceptionNew(IN     PEXCEPTION_RECORD   pExceptionRecord,
         else
         {
             OBJECTREF oref = ExceptionTracker::CreateThrowable(pExceptionRecord, FALSE);
-            DispatchManagedException(oref, pContextRecord);
+            DispatchManagedException(oref, pContextRecord, /* preserveStackTrace */ false);
         }
     }
 #endif // !HOST_UNIX


### PR DESCRIPTION
In the new EH, when an exception is propagated over native runtime
frames, the stack trace is cleared and saved into the
_remoteStackTraceString member. This is different from the old EH.

This change makes the new EH behave as the old one, the frames being
kept on the exception stack trace.