### PR TITLE
[mono][aot] Add a 'compile-in-child' AOT argument

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -15625,7 +15625,7 @@ compile_assemblies_in_child (MonoAssembly **assemblies, int nassemblies, GPtrArr
 			/* Already expanded */
 			continue;
 		if (i != aot_index)
-			g_string_append_printf (command, " %s", arg);
+			g_string_append_printf (command, " \"%s\"", arg);
 	}
 
 	/* Pass '_child' instead of 'compile-in-child' */
@@ -15641,10 +15641,10 @@ compile_assemblies_in_child (MonoAssembly **assemblies, int nassemblies, GPtrArr
 			g_string_append_printf (new_aot_args, "%s", aot_arg);
 	}
 
-	g_string_append_printf (command, " --aot=%s", g_string_free (new_aot_args, FALSE));
+	g_string_append_printf (command, " \"--aot=%s\"", g_string_free (new_aot_args, FALSE));
 
 	for (int i = 0; i < nassemblies; ++i)
-		g_string_append_printf (command, " %s", assemblies [i]->image->name);
+		g_string_append_printf (command, " \"%s\"", assemblies [i]->image->name);
 
 	char *cmd = g_string_free (command, FALSE);
 	printf ("Executing: %s\n", cmd);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -258,6 +258,8 @@ typedef struct MonoAotOptions {
 	char *clangxx;
 	char *depfile;
 	char *runtime_init_callback;
+	GPtrArray *runtime_args;
+	const char *aot_options;
 } MonoAotOptions;
 
 typedef enum {
@@ -15528,13 +15530,15 @@ emit_aot_image (MonoAotCompile *acfg)
 }
 
 int
-mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opts, const char *aot_options)
+mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opts, GPtrArray *runtime_args, const char *aot_options)
 {
 	int res = 0;
 	MonoAotOptions aot_opts;
 
 	init_options (&aot_opts);
 	mono_aot_parse_options (aot_options, &aot_opts);
+	aot_opts.runtime_args = runtime_args;
+	aot_opts.aot_options = aot_options;
 	if (aot_opts.direct_extern_calls && !(aot_opts.llvm && aot_opts.static_link)) {
 		fprintf (stderr, "The 'direct-extern-calls' option requires the 'llvm' and 'static' options.\n");
 		res = 1;
@@ -15637,7 +15641,7 @@ mono_aot_get_method_index (MonoMethod *method)
 }
 
 int
-mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 opts, const char *aot_options)
+mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 jit_opts, GPtrArray *runtime_args, const char *aot_options)
 {
 	return 0;
 }

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -15622,7 +15622,7 @@ compile_assemblies_in_child (MonoAotOptions *aot_opts, MonoAssembly **assemblies
 	}
 	g_assert (aot_index != -1);
 
-#ifdef TARGET_WIN32
+#ifdef HOST_WIN32
 	response_fname = g_build_filename (aot_opts->temp_path, "temp.rsp", (const char*)NULL);
 	response = fopen (response_fname, "w");
 	g_assert (response);

--- a/src/mono/mono/mini/aot-compiler.h
+++ b/src/mono/mono/mini/aot-compiler.h
@@ -7,7 +7,7 @@
 
 #include "mini.h"
 
-int mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 opts, const char *aot_options);
+int mono_aot_assemblies (MonoAssembly **assemblies, int nassemblies, guint32 opts, GPtrArray *runtime_args, const char *aot_options);
 void* mono_aot_readonly_field_override (MonoClassField *field);
 gboolean mono_aot_direct_icalls_enabled_for_method (MonoCompile *cfg, MonoMethod *method);
 gboolean mono_aot_is_shared_got_offset (int offset);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -999,7 +999,7 @@ mono_jiterp_parse_option (const char *option)
 
 	const char *arr[2] = { option, NULL };
 	int temp;
-	mono_options_parse_options (arr, 1, &temp, NULL);
+	mono_options_parse_options (arr, 1, &temp, NULL, NULL);
 	return TRUE;
 }
 

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -121,12 +121,13 @@ get_option_hash (void)
  *   Set options based on the command line arguments in ARGV/ARGC.
  * Remove processed arguments from ARGV and set *OUT_ARGC to the
  * number of remaining arguments.
+ * If PROCESSED is != NULL, add the processed arguments to it.
  *
  * NOTE: This only sets the variables, the caller might need to do
  * additional processing based on the new values of the variables.
  */
 void
-mono_options_parse_options (const char **argv, int argc, int *out_argc, MonoError *error)
+mono_options_parse_options (const char **argv, int argc, int *out_argc, GPtrArray *processed, MonoError *error)
 {
 	int aindex = 0;
 	GHashTable *option_hash = NULL;
@@ -187,6 +188,8 @@ mono_options_parse_options (const char **argv, int argc, int *out_argc, MonoErro
 				break;
 			}
 			*(gboolean*)option->addr = negate ? FALSE : TRUE;
+			if (processed)
+				g_ptr_array_add (processed, (gpointer)argv [aindex]);
 			argv [aindex] = NULL;
 			break;
 		}
@@ -202,12 +205,18 @@ mono_options_parse_options (const char **argv, int argc, int *out_argc, MonoErro
 					break;
 				}
 				value = argv [aindex + 1];
+				if (processed) {
+					g_ptr_array_add (processed, (gpointer)argv [aindex]);
+					g_ptr_array_add (processed, (gpointer)argv [aindex + 1]);
+				}
 				argv [aindex] = NULL;
 				argv [aindex + 1] = NULL;
 				aindex ++;
 			} else if (equals_sign_index != -1) {
 				// option=value
 				value = arg + equals_sign_index + 1;
+				if (processed)
+					g_ptr_array_add (processed, (gpointer)argv [aindex]);
 				argv [aindex] = NULL;
 			} else {
 				g_assert_not_reached ();

--- a/src/mono/mono/utils/options.h
+++ b/src/mono/mono/utils/options.h
@@ -26,7 +26,7 @@ extern int mono_options_version;
 
 void mono_options_print_usage (void);
 
-void mono_options_parse_options (const char **args, int argc, int *out_argc, MonoError *error);
+void mono_options_parse_options (const char **args, int argc, int *out_argc, GPtrArray *processed, MonoError *error);
 
 /* returns a json blob representing the current values of all options */
 char * mono_options_get_as_json (void);

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -624,6 +624,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="static" />
       <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
       <MonoAOTCompilerDefaultAotArguments Include="deterministic" />
+      <MonoAOTCompilerDefaultAotArguments Include="compile-in-child" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
       <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="-v" Condition="'$(WasmAOTCompilerVerbose)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmEnableExceptionHandling)' == 'true'" />

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -624,7 +624,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="static" />
       <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
       <MonoAOTCompilerDefaultAotArguments Include="deterministic" />
-      <MonoAOTCompilerDefaultAotArguments Include="compile-in-child" />
+      <MonoAOTCompilerDefaultAotArguments Include="compile-in-child" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
       <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="-v" Condition="'$(WasmAOTCompilerVerbose)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmEnableExceptionHandling)' == 'true'" />

--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -624,7 +624,7 @@
       <MonoAOTCompilerDefaultAotArguments Include="static" />
       <MonoAOTCompilerDefaultAotArguments Include="direct-icalls" />
       <MonoAOTCompilerDefaultAotArguments Include="deterministic" />
-      <MonoAOTCompilerDefaultAotArguments Include="compile-in-child" Condition="!$([MSBuild]::IsOSPlatform('windows'))" />
+      <MonoAOTCompilerDefaultAotArguments Include="compile-in-child" />
       <MonoAOTCompilerDefaultAotArguments Include="mattr=simd" Condition="'$(WasmEnableSIMD)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="-v" Condition="'$(WasmAOTCompilerVerbose)' == 'true'" />
       <MonoAOTCompilerDefaultProcessArguments Include="--wasm-exceptions" Condition="'$(WasmEnableExceptionHandling)' == 'true'" />


### PR DESCRIPTION
When set, the JIT compilation is done in a child process. This helps to reduce overall memory usage since memory used during JITting is no longer going to be reserved when running external tools like opt/llc.