### PR TITLE
Revert "Add an internal mode to `Lock` to have it use non-alertable w…

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/WaitHandle.CoreCLR.cs
@@ -9,7 +9,7 @@ namespace System.Threading
     public abstract partial class WaitHandle
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout, bool useTrivialWaits);
+        private static extern int WaitOneCore(IntPtr waitHandle, int millisecondsTimeout);
 
         private static unsafe int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> waitHandles, bool waitAll, int millisecondsTimeout)
         {

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifier.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifier()
         {
-            _lock = new Lock(useTrivialWaits: true);
+            _lock = new Lock();
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierW.cs
@@ -75,7 +75,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierW()
         {
-            _lock = new Lock(useTrivialWaits: true);
+            _lock = new Lock();
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
+++ b/src/coreclr/nativeaot/Common/src/System/Collections/Concurrent/ConcurrentUnifierWKeyed.cs
@@ -84,7 +84,7 @@ namespace System.Collections.Concurrent
     {
         protected ConcurrentUnifierWKeyed()
         {
-            _lock = new Lock(useTrivialWaits: true);
+            _lock = new Lock();
             _container = new Container(this);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/CompatibilitySuppressions.xml
@@ -834,10 +834,6 @@
     <Target>M:System.Reflection.MethodBase.GetParametersAsSpan</Target>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:System.Threading.Lock.#ctor(System.Boolean)</Target>
-  </Suppression>
-  <Suppression>
     <DiagnosticId>CP0015</DiagnosticId>
     <Target>M:System.Diagnostics.Tracing.EventSource.Write``1(System.String,``0):[T:System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute]</Target>
   </Suppression>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/Internal/Runtime/FrozenObjectHeapManager.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
     {
         public static readonly FrozenObjectHeapManager Instance = new FrozenObjectHeapManager();
 
-        private readonly Lock m_Crst = new Lock(useTrivialWaits: true);
+        private readonly LowLevelLock m_Crst = new LowLevelLock();
         private FrozenObjectSegment m_CurrentSegment;
 
         // Default size to reserve for a frozen segment
@@ -34,7 +34,9 @@ namespace Internal.Runtime
         {
             HalfBakedObject* obj = null;
 
-            using (m_Crst.EnterScope())
+            m_Crst.Acquire();
+
+            try
             {
                 Debug.Assert(type != null);
                 // _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
@@ -82,6 +84,10 @@ namespace Internal.Runtime
                     Debug.Assert(obj != null);
                 }
             } // end of m_Crst lock
+            finally
+            {
+                m_Crst.Release();
+            }
 
             IntPtr result = (IntPtr)obj;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/ClassConstructorRunner.cs
@@ -275,7 +275,7 @@ namespace System.Runtime.CompilerServices
 #if TARGET_WASM
                 if (s_cctorGlobalLock == null)
                 {
-                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(useTrivialWaits: true), null);
+                    Interlocked.CompareExchange(ref s_cctorGlobalLock, new Lock(), null);
                 }
                 if (s_cctorArrays == null)
                 {
@@ -342,7 +342,7 @@ namespace System.Runtime.CompilerServices
 
                         Debug.Assert(resultArray[resultIndex]._pContext == default(StaticClassConstructionContext*));
                         resultArray[resultIndex]._pContext = pContext;
-                        resultArray[resultIndex].Lock = new Lock(useTrivialWaits: true);
+                        resultArray[resultIndex].Lock = new Lock();
                         s_count++;
                     }
 
@@ -489,7 +489,7 @@ namespace System.Runtime.CompilerServices
         internal static void Initialize()
         {
             s_cctorArrays = new Cctor[10][];
-            s_cctorGlobalLock = new Lock(useTrivialWaits: true);
+            s_cctorGlobalLock = new Lock();
         }
 
         [Conditional("ENABLE_NOISY_CCTOR_LOG")]

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.NativeAot.cs
@@ -44,7 +44,7 @@ namespace System.Runtime.InteropServices
         private static readonly List<GCHandle> s_referenceTrackerNativeObjectWrapperCache = new List<GCHandle>();
 
         private readonly ConditionalWeakTable<object, ManagedObjectWrapperHolder> _ccwTable = new ConditionalWeakTable<object, ManagedObjectWrapperHolder>();
-        private readonly Lock _lock = new Lock(useTrivialWaits: true);
+        private readonly Lock _lock = new Lock();
         private readonly Dictionary<IntPtr, GCHandle> _rcwCache = new Dictionary<IntPtr, GCHandle>();
 
         internal static bool TryGetComInstanceForIID(object obj, Guid iid, out IntPtr unknown, out long wrapperId)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -114,7 +114,6 @@ namespace System.Threading
                 success =
                     waiter.ev.WaitOneNoCheck(
                         millisecondsTimeout,
-                        false, // useTrivialWaits
                         associatedObjectForMonitorWait,
                         associatedObjectForMonitorWait != null
                             ? NativeRuntimeEventSource.WaitHandleWaitSourceMap.MonitorWait

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -92,18 +92,6 @@ namespace System.Threading
             _recursionCount = previousRecursionCount;
         }
 
-        private static bool IsFullyInitialized
-        {
-            get
-            {
-                // If NativeRuntimeEventSource is already being class-constructed by this thread earlier in the stack, Log can
-                // be null. This property is used to avoid going down the wait path in that case to avoid null checks in several
-                // other places.
-                Debug.Assert((StaticsInitializationStage)s_staticsInitializationStage == StaticsInitializationStage.Complete);
-                return NativeRuntimeEventSource.Log != null;
-            }
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private TryLockResult LazyInitializeOrEnter()
         {
@@ -113,10 +101,6 @@ namespace System.Threading
                 case StaticsInitializationStage.Complete:
                     if (_spinCount == SpinCountNotInitialized)
                     {
-                        if (!IsFullyInitialized)
-                        {
-                            goto case StaticsInitializationStage.Started;
-                        }
                         _spinCount = s_maxSpinCount;
                     }
                     return TryLockResult.Spin;
@@ -137,7 +121,7 @@ namespace System.Threading
                         }
 
                         stage = (StaticsInitializationStage)Volatile.Read(ref s_staticsInitializationStage);
-                        if (stage == StaticsInitializationStage.Complete && IsFullyInitialized)
+                        if (stage == StaticsInitializationStage.Complete)
                         {
                             goto case StaticsInitializationStage.Complete;
                         }
@@ -182,17 +166,14 @@ namespace System.Threading
                     return true;
             }
 
-            bool isFullyInitialized;
             try
             {
                 s_isSingleProcessor = Environment.IsSingleProcessor;
                 s_maxSpinCount = DetermineMaxSpinCount();
                 s_minSpinCount = DetermineMinSpinCount();
 
-                // Also initialize some types that are used later to prevent potential class construction cycles. If
-                // NativeRuntimeEventSource is already being class-constructed by this thread earlier in the stack, Log can be
-                // null. Avoid going down the wait path in that case to avoid null checks in several other places.
-                isFullyInitialized = NativeRuntimeEventSource.Log != null;
+                // Also initialize some types that are used later to prevent potential class construction cycles
+                _ = NativeRuntimeEventSource.Log;
             }
             catch
             {
@@ -201,7 +182,7 @@ namespace System.Threading
             }
 
             Volatile.Write(ref s_staticsInitializationStage, (int)StaticsInitializationStage.Complete);
-            return isFullyInitialized;
+            return true;
         }
 
         // Returns false until the static variable is lazy-initialized

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
@@ -65,7 +65,7 @@ namespace System.Threading
         /// <summary>
         /// Protects all mutable operations on s_entries, s_freeEntryList, s_unusedEntryIndex. Also protects growing the table.
         /// </summary>
-        internal static readonly Lock s_lock = new Lock(useTrivialWaits: true);
+        internal static readonly Lock s_lock = new Lock();
 
         /// <summary>
         /// The dynamically growing array of sync entries.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Windows.cs
@@ -167,7 +167,7 @@ namespace System.Threading
                 }
                 else
                 {
-                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout, useTrivialWaits: false);
+                    result = WaitHandle.WaitOneCore(waitHandle.DangerousGetHandle(), millisecondsTimeout);
                 }
 
                 return result == (int)Interop.Kernel32.WAIT_OBJECT_0;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs
@@ -31,7 +31,7 @@ namespace System.Threading
         private Exception? _startException;
 
         // Protects starting the thread and setting its priority
-        private Lock _lock = new Lock(useTrivialWaits: true);
+        private Lock _lock = new Lock();
 
         // This is used for a quick check on thread pool threads after running a work item to determine if the name, background
         // state, or priority were changed by the work item, and if so to reset it. Other threads may also change some of those,

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.ConstructedGenericsRegistration.cs
@@ -24,7 +24,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all dynamic generic type registration/lookups under a global lock
-        private Lock _dynamicGenericsLock = new Lock(useTrivialWaits: true);
+        private Lock _dynamicGenericsLock = new Lock();
 
         internal void RegisterDynamicGenericTypesAndMethods(DynamicGenericsRegistrationData registrationData)
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.StaticsLookup.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime.TypeLoader
     public sealed partial class TypeLoaderEnvironment
     {
         // To keep the synchronization simple, we execute all TLS registration/lookups under a global lock
-        private Lock _threadStaticsLock = new Lock(useTrivialWaits: true);
+        private Lock _threadStaticsLock = new Lock();
 
         // Counter to keep track of generated offsets for TLS cells of dynamic types;
         private LowLevelDictionary<IntPtr, uint> _maxThreadLocalIndex = new LowLevelDictionary<IntPtr, uint>();

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeLoaderEnvironment.cs
@@ -145,7 +145,7 @@ namespace Internal.Runtime.TypeLoader
         }
 
         // To keep the synchronization simple, we execute all type loading under a global lock
-        private Lock _typeLoaderLock = new Lock(useTrivialWaits: true);
+        private Lock _typeLoaderLock = new Lock();
 
         public void VerifyTypeLoaderLockHeld()
         {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/TypeSystemContextFactory.cs
@@ -18,7 +18,7 @@ namespace Internal.Runtime.TypeLoader
         // This allows us to avoid recreating the type resolution context again and again, but still allows it to go away once the types are no longer being built
         private static GCHandle s_cachedContext = GCHandle.Alloc(null, GCHandleType.Weak);
 
-        private static Lock s_lock = new Lock(useTrivialWaits: true);
+        private static Lock s_lock = new Lock();
 
         public static TypeSystemContext Create()
         {

--- a/src/coreclr/vm/comwaithandle.cpp
+++ b/src/coreclr/vm/comwaithandle.cpp
@@ -16,7 +16,7 @@
 #include "excep.h"
 #include "comwaithandle.h"
 
-FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL useTrivialWaits)
+FCIMPL2(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout)
 {
     FCALL_CONTRACT;
 
@@ -28,8 +28,7 @@ FCIMPL3(INT32, WaitHandleNative::CorWaitOneNative, HANDLE handle, INT32 timeout,
 
     Thread* pThread = GET_THREAD();
 
-    WaitMode waitMode = (WaitMode)((!useTrivialWaits ? WaitMode_Alertable : WaitMode_None) | WaitMode_IgnoreSyncCtx);
-    retVal = pThread->DoAppropriateWait(1, &handle, TRUE, timeout, waitMode);
+    retVal = pThread->DoAppropriateWait(1, &handle, TRUE, timeout, (WaitMode)(WaitMode_Alertable | WaitMode_IgnoreSyncCtx));
 
     HELPER_METHOD_FRAME_END();
     return retVal;

--- a/src/coreclr/vm/comwaithandle.h
+++ b/src/coreclr/vm/comwaithandle.h
@@ -18,7 +18,7 @@
 class WaitHandleNative
 {
 public:
-    static FCDECL3(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout, CLR_BOOL useTrivialWaits);
+    static FCDECL2(INT32, CorWaitOneNative, HANDLE handle, INT32 timeout);
     static FCDECL4(INT32, CorWaitMultipleNative, HANDLE *handleArray, INT32 numHandles, CLR_BOOL waitForAll, INT32 timeout);
     static FCDECL3(INT32, CorSignalAndWaitOneNative, HANDLE waitHandleSignalUNSAFE, HANDLE waitHandleWaitUNSAFE, INT32 timeout);
 };

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
@@ -7,8 +7,8 @@ namespace System.Threading
 {
     public abstract partial class WaitHandle
     {
-        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits) =>
-            WaitSubsystem.Wait(handle, millisecondsTimeout, interruptible: !useTrivialWaits);
+        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout) =>
+            WaitSubsystem.Wait(handle, millisecondsTimeout, true);
 
         private static int WaitMultipleIgnoringSyncContextCore(Span<IntPtr> handles, bool waitAll, int millisecondsTimeout) =>
             WaitSubsystem.Wait(handles, waitAll, millisecondsTimeout);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Windows.cs
@@ -14,11 +14,11 @@ namespace System.Threading
         {
             fixed (IntPtr* pHandles = &MemoryMarshal.GetReference(handles))
             {
-                return WaitForMultipleObjectsIgnoringSyncContext(pHandles, handles.Length, waitAll, millisecondsTimeout, useTrivialWaits: false);
+                return WaitForMultipleObjectsIgnoringSyncContext(pHandles, handles.Length, waitAll, millisecondsTimeout);
             }
         }
 
-        private static unsafe int WaitForMultipleObjectsIgnoringSyncContext(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout, bool useTrivialWaits)
+        private static unsafe int WaitForMultipleObjectsIgnoringSyncContext(IntPtr* pHandles, int numHandles, bool waitAll, int millisecondsTimeout)
         {
             Debug.Assert(millisecondsTimeout >= -1);
 
@@ -27,8 +27,7 @@ namespace System.Threading
                 waitAll = false;
 
 #if NATIVEAOT // TODO: reentrant wait support https://github.com/dotnet/runtime/issues/49518
-            // Trivial waits don't allow reentrance
-            bool reentrantWait = !useTrivialWaits && Thread.ReentrantWaitsEnabled;
+            bool reentrantWait = Thread.ReentrantWaitsEnabled;
 
             if (reentrantWait)
             {
@@ -93,9 +92,9 @@ namespace System.Threading
             return result;
         }
 
-        internal static unsafe int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits)
+        internal static unsafe int WaitOneCore(IntPtr handle, int millisecondsTimeout)
         {
-            return WaitForMultipleObjectsIgnoringSyncContext(&handle, 1, false, millisecondsTimeout, useTrivialWaits);
+            return WaitForMultipleObjectsIgnoringSyncContext(&handle, 1, false, millisecondsTimeout);
         }
 
         private static int SignalAndWaitCore(IntPtr handleToSignal, IntPtr handleToWaitOn, int millisecondsTimeout)


### PR DESCRIPTION
…aits (#97227)"

This reverts commit e568f7576fce63d5a41af18b530c9613a83c0ee8.

This change caused a significant perf regression in ASP.NET GRPC and WebAPI scenarios as detailed in https://github.com/dotnet/runtime/issues/98021

 @kouvel Feel free to bring this change back after the cause of the regression has been fixed.