### PR TITLE
Derive OrderedEnumerable from Iterator

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
@@ -9,7 +9,7 @@ namespace System.Linq
     {
         private sealed partial class DistinctIterator<TSource> : IIListProvider<TSource>
         {
-            public TSource[] ToArray() => Enumerable.HashSetToArray(new HashSet<TSource>(_source, _comparer));
+            public TSource[] ToArray() => HashSetToArray(new HashSet<TSource>(_source, _comparer));
 
             public List<TSource> ToList() => new List<TSource>(new HashSet<TSource>(_source, _comparer));
 

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -8,405 +8,277 @@ using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
-    internal abstract partial class OrderedEnumerable<TElement> : IPartition<TElement>
+    public static partial class Enumerable
     {
-        public virtual TElement[] ToArray()
+        internal abstract partial class OrderedEnumerable<TElement> : IPartition<TElement>
         {
-            TElement[] buffer = _source.ToArray();
-            if (buffer.Length == 0)
-            {
-                return buffer;
-            }
-
-            TElement[] array = new TElement[buffer.Length];
-            Fill(buffer, array);
-            return array;
-        }
-
-        public virtual List<TElement> ToList()
-        {
-            TElement[] buffer = _source.ToArray();
-
-            List<TElement> list = new();
-            if (buffer.Length > 0)
-            {
-                Fill(buffer, Enumerable.SetCountAndGetSpan(list, buffer.Length));
-            }
-
-            return list;
-        }
-
-        private void Fill(TElement[] buffer, Span<TElement> destination)
-        {
-            int[] map = SortedMap(buffer);
-            for (int i = 0; i < destination.Length; i++)
-            {
-                destination[i] = buffer[map[i]];
-            }
-        }
-
-        public int GetCount(bool onlyIfCheap)
-        {
-            if (_source is IIListProvider<TElement> listProv)
-            {
-                return listProv.GetCount(onlyIfCheap);
-            }
-
-            return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ? _source.Count() : -1;
-        }
-
-        internal TElement[] ToArray(int minIdx, int maxIdx)
-        {
-            TElement[] buffer = _source.ToArray();
-            if (buffer.Length <= minIdx)
-            {
-                return [];
-            }
-
-            if (buffer.Length <= maxIdx)
-            {
-                maxIdx = buffer.Length - 1;
-            }
-
-            if (minIdx == maxIdx)
-            {
-                return [GetEnumerableSorter().ElementAt(buffer, buffer.Length, minIdx)];
-            }
-
-            TElement[] array = new TElement[maxIdx - minIdx + 1];
-
-            Fill(minIdx, maxIdx, buffer, array);
-
-            return array;
-        }
-
-        internal List<TElement> ToList(int minIdx, int maxIdx)
-        {
-            TElement[] buffer = _source.ToArray();
-            if (buffer.Length <= minIdx)
-            {
-                return new List<TElement>();
-            }
-
-            if (buffer.Length <= maxIdx)
-            {
-                maxIdx = buffer.Length - 1;
-            }
-
-            if (minIdx == maxIdx)
-            {
-                return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer, buffer.Length, minIdx) };
-            }
-
-            List<TElement> list = new();
-            Fill(minIdx, maxIdx, buffer, Enumerable.SetCountAndGetSpan(list, maxIdx - minIdx + 1));
-            return list;
-        }
-
-        private void Fill(int minIdx, int maxIdx, TElement[] buffer, Span<TElement> destination)
-        {
-            int[] map = SortedMap(buffer, minIdx, maxIdx);
-            int idx = 0;
-            while (minIdx <= maxIdx)
-            {
-                destination[idx] = buffer[map[minIdx]];
-                ++idx;
-                ++minIdx;
-            }
-        }
-
-        internal int GetCount(int minIdx, int maxIdx, bool onlyIfCheap)
-        {
-            int count = GetCount(onlyIfCheap);
-            if (count <= 0)
-            {
-                return count;
-            }
-
-            if (count <= minIdx)
-            {
-                return 0;
-            }
-
-            return (count <= maxIdx ? count : maxIdx + 1) - minIdx;
-        }
-
-        public IPartition<TElement> Skip(int count) => new OrderedPartition<TElement>(this, count, int.MaxValue);
-
-        public IPartition<TElement> Take(int count) => new OrderedPartition<TElement>(this, 0, count - 1);
-
-        public TElement? TryGetElementAt(int index, out bool found)
-        {
-            if (index == 0)
-            {
-                return TryGetFirst(out found);
-            }
-
-            if (index > 0)
+            public virtual TElement[] ToArray()
             {
                 TElement[] buffer = _source.ToArray();
-                if (index < buffer.Length)
+                if (buffer.Length == 0)
                 {
-                    found = true;
-                    return GetEnumerableSorter().ElementAt(buffer, buffer.Length, index);
+                    return buffer;
+                }
+
+                TElement[] array = new TElement[buffer.Length];
+                Fill(buffer, array);
+                return array;
+            }
+
+            public virtual List<TElement> ToList()
+            {
+                TElement[] buffer = _source.ToArray();
+
+                List<TElement> list = new();
+                if (buffer.Length > 0)
+                {
+                    Fill(buffer, SetCountAndGetSpan(list, buffer.Length));
+                }
+
+                return list;
+            }
+
+            private void Fill(TElement[] buffer, Span<TElement> destination)
+            {
+                int[] map = SortedMap(buffer);
+                for (int i = 0; i < destination.Length; i++)
+                {
+                    destination[i] = buffer[map[i]];
                 }
             }
 
-            found = false;
-            return default;
-        }
-
-        public virtual TElement? TryGetFirst(out bool found)
-        {
-            CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
+            public int GetCount(bool onlyIfCheap)
             {
-                if (!e.MoveNext())
+                if (_source is IIListProvider<TElement> listProv)
                 {
-                    found = false;
-                    return default;
+                    return listProv.GetCount(onlyIfCheap);
                 }
 
-                TElement value = e.Current;
-                comparer.SetElement(value);
-                while (e.MoveNext())
+                return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ? _source.Count() : -1;
+            }
+
+            internal TElement[] ToArray(int minIdx, int maxIdx)
+            {
+                TElement[] buffer = _source.ToArray();
+                if (buffer.Length <= minIdx)
                 {
-                    TElement x = e.Current;
-                    if (comparer.Compare(x, true) < 0)
+                    return [];
+                }
+
+                if (buffer.Length <= maxIdx)
+                {
+                    maxIdx = buffer.Length - 1;
+                }
+
+                if (minIdx == maxIdx)
+                {
+                    return [GetEnumerableSorter().ElementAt(buffer, buffer.Length, minIdx)];
+                }
+
+                TElement[] array = new TElement[maxIdx - minIdx + 1];
+
+                Fill(minIdx, maxIdx, buffer, array);
+
+                return array;
+            }
+
+            internal List<TElement> ToList(int minIdx, int maxIdx)
+            {
+                TElement[] buffer = _source.ToArray();
+                if (buffer.Length <= minIdx)
+                {
+                    return new List<TElement>();
+                }
+
+                if (buffer.Length <= maxIdx)
+                {
+                    maxIdx = buffer.Length - 1;
+                }
+
+                if (minIdx == maxIdx)
+                {
+                    return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer, buffer.Length, minIdx) };
+                }
+
+                List<TElement> list = new();
+                Fill(minIdx, maxIdx, buffer, SetCountAndGetSpan(list, maxIdx - minIdx + 1));
+                return list;
+            }
+
+            private void Fill(int minIdx, int maxIdx, TElement[] buffer, Span<TElement> destination)
+            {
+                int[] map = SortedMap(buffer, minIdx, maxIdx);
+                int idx = 0;
+                while (minIdx <= maxIdx)
+                {
+                    destination[idx] = buffer[map[minIdx]];
+                    ++idx;
+                    ++minIdx;
+                }
+            }
+
+            internal int GetCount(int minIdx, int maxIdx, bool onlyIfCheap)
+            {
+                int count = GetCount(onlyIfCheap);
+                if (count <= 0)
+                {
+                    return count;
+                }
+
+                if (count <= minIdx)
+                {
+                    return 0;
+                }
+
+                return (count <= maxIdx ? count : maxIdx + 1) - minIdx;
+            }
+
+            public IPartition<TElement> Skip(int count) => new OrderedPartition<TElement>(this, count, int.MaxValue);
+
+            public IPartition<TElement> Take(int count) => new OrderedPartition<TElement>(this, 0, count - 1);
+
+            public TElement? TryGetElementAt(int index, out bool found)
+            {
+                if (index == 0)
+                {
+                    return TryGetFirst(out found);
+                }
+
+                if (index > 0)
+                {
+                    TElement[] buffer = _source.ToArray();
+                    if (index < buffer.Length)
+                    {
+                        found = true;
+                        return GetEnumerableSorter().ElementAt(buffer, buffer.Length, index);
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public virtual TElement? TryGetFirst(out bool found)
+            {
+                CachingComparer<TElement> comparer = GetComparer();
+                using (IEnumerator<TElement> e = _source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        found = false;
+                        return default;
+                    }
+
+                    TElement value = e.Current;
+                    comparer.SetElement(value);
+                    while (e.MoveNext())
+                    {
+                        TElement x = e.Current;
+                        if (comparer.Compare(x, true) < 0)
+                        {
+                            value = x;
+                        }
+                    }
+
+                    found = true;
+                    return value;
+                }
+            }
+
+            public virtual TElement? TryGetLast(out bool found)
+            {
+                using (IEnumerator<TElement> e = _source.GetEnumerator())
+                {
+                    if (!e.MoveNext())
+                    {
+                        found = false;
+                        return default;
+                    }
+
+                    CachingComparer<TElement> comparer = GetComparer();
+                    TElement value = e.Current;
+                    comparer.SetElement(value);
+                    while (e.MoveNext())
+                    {
+                        TElement current = e.Current;
+                        if (comparer.Compare(current, false) >= 0)
+                        {
+                            value = current;
+                        }
+                    }
+
+                    found = true;
+                    return value;
+                }
+            }
+
+            public TElement? TryGetLast(int minIdx, int maxIdx, out bool found)
+            {
+                TElement[] buffer = _source.ToArray();
+                if (minIdx < buffer.Length)
+                {
+                    found = true;
+                    return (maxIdx < buffer.Length - 1) ?
+                        GetEnumerableSorter().ElementAt(buffer, buffer.Length, maxIdx) :
+                        Last(buffer);
+                }
+
+                found = false;
+                return default;
+            }
+
+            private TElement Last(TElement[] items)
+            {
+                CachingComparer<TElement> comparer = GetComparer();
+
+                TElement value = items[0];
+                comparer.SetElement(value);
+
+                for (int i = 1; i < items.Length; ++i)
+                {
+                    TElement x = items[i];
+                    if (comparer.Compare(x, cacheLower: false) >= 0)
                     {
                         value = x;
                     }
                 }
 
-                found = true;
                 return value;
             }
         }
 
-        public virtual TElement? TryGetLast(out bool found)
+        internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
         {
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
+            // For complicated cases, rely on the base implementation that's more comprehensive.
+            // For the simple case of OrderBy(...).First() or OrderByDescending(...).First() (i.e. where
+            // there's just a single comparer we need to factor in), we can just do the iteration directly.
+
+            public override TElement? TryGetFirst(out bool found)
             {
-                if (!e.MoveNext())
+                if (_parent is not null)
                 {
-                    found = false;
-                    return default;
+                    return base.TryGetFirst(out found);
                 }
 
-                CachingComparer<TElement> comparer = GetComparer();
-                TElement value = e.Current;
-                comparer.SetElement(value);
-                while (e.MoveNext())
-                {
-                    TElement current = e.Current;
-                    if (comparer.Compare(current, false) >= 0)
-                    {
-                        value = current;
-                    }
-                }
-
-                found = true;
-                return value;
-            }
-        }
-
-        public TElement? TryGetLast(int minIdx, int maxIdx, out bool found)
-        {
-            TElement[] buffer = _source.ToArray();
-            if (minIdx < buffer.Length)
-            {
-                found = true;
-                return (maxIdx < buffer.Length - 1) ?
-                    GetEnumerableSorter().ElementAt(buffer, buffer.Length, maxIdx) :
-                    Last(buffer);
-            }
-
-            found = false;
-            return default;
-        }
-
-        private TElement Last(TElement[] items)
-        {
-            CachingComparer<TElement> comparer = GetComparer();
-
-            TElement value = items[0];
-            comparer.SetElement(value);
-
-            for (int i = 1; i < items.Length; ++i)
-            {
-                TElement x = items[i];
-                if (comparer.Compare(x, cacheLower: false) >= 0)
-                {
-                    value = x;
-                }
-            }
-
-            return value;
-        }
-    }
-
-    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
-    {
-        // For complicated cases, rely on the base implementation that's more comprehensive.
-        // For the simple case of OrderBy(...).First() or OrderByDescending(...).First() (i.e. where
-        // there's just a single comparer we need to factor in), we can just do the iteration directly.
-
-        public override TElement? TryGetFirst(out bool found)
-        {
-            if (_parent is not null)
-            {
-                return base.TryGetFirst(out found);
-            }
-
-            using IEnumerator<TElement> e = _source.GetEnumerator();
-
-            if (e.MoveNext())
-            {
-                IComparer<TKey> comparer = _comparer;
-                Func<TElement, TKey> keySelector = _keySelector;
-
-                TElement resultValue = e.Current;
-                TKey resultKey = keySelector(resultValue);
-
-                if (_descending)
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) > 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-                else
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) < 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-
-                found = true;
-                return resultValue;
-            }
-
-            found = false;
-            return default;
-        }
-
-        public override TElement? TryGetLast(out bool found)
-        {
-            if (_parent is not null)
-            {
-                return base.TryGetLast(out found);
-            }
-
-            using IEnumerator<TElement> e = _source.GetEnumerator();
-
-            if (e.MoveNext())
-            {
-                IComparer<TKey> comparer = _comparer;
-                Func<TElement, TKey> keySelector = _keySelector;
-
-                TElement resultValue = e.Current;
-                TKey resultKey = keySelector(resultValue);
-
-                if (_descending)
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) <= 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-                else
-                {
-                    while (e.MoveNext())
-                    {
-                        TElement nextValue = e.Current;
-                        TKey nextKey = keySelector(nextValue);
-                        if (comparer.Compare(nextKey, resultKey) >= 0)
-                        {
-                            resultKey = nextKey;
-                            resultValue = nextValue;
-                        }
-                    }
-                }
-
-                found = true;
-                return resultValue;
-            }
-
-            found = false;
-            return default;
-        }
-    }
-
-    internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
-    {
-        public override TElement[] ToArray()
-        {
-            TElement[] array = _source.ToArray();
-            Sort(array, _descending);
-            return array;
-        }
-
-        public override List<TElement> ToList()
-        {
-            List<TElement> list = _source.ToList();
-            Sort(CollectionsMarshal.AsSpan(list), _descending);
-            return list;
-        }
-
-        public override TElement? TryGetFirst(out bool found) =>
-            TryGetFirstOrLast(out found, first: !_descending);
-
-        public override TElement? TryGetLast(out bool found) =>
-            TryGetFirstOrLast(out found, first: _descending);
-
-        private TElement? TryGetFirstOrLast(out bool found, bool first)
-        {
-            if (Enumerable.TryGetSpan(_source, out ReadOnlySpan<TElement> span))
-            {
-                if (span.Length != 0)
-                {
-                    Debug.Assert(Enumerable.TypeIsImplicitlyStable<TElement>(), "Using Min/Max has different semantics for floating-point values.");
-
-                    found = true;
-                    return first ?
-                        Enumerable.Min(_source) :
-                        Enumerable.Max(_source);
-                }
-            }
-            else
-            {
                 using IEnumerator<TElement> e = _source.GetEnumerator();
 
                 if (e.MoveNext())
                 {
-                    TElement resultValue = e.Current;
+                    IComparer<TKey> comparer = _comparer;
+                    Func<TElement, TKey> keySelector = _keySelector;
 
-                    if (first)
+                    TElement resultValue = e.Current;
+                    TKey resultKey = keySelector(resultValue);
+
+                    if (_descending)
                     {
                         while (e.MoveNext())
                         {
                             TElement nextValue = e.Current;
-                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) < 0)
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, resultKey) > 0)
                             {
+                                resultKey = nextKey;
                                 resultValue = nextValue;
                             }
                         }
@@ -416,8 +288,10 @@ namespace System.Linq
                         while (e.MoveNext())
                         {
                             TElement nextValue = e.Current;
-                            if (Comparer<TElement>.Default.Compare(nextValue, resultValue) >= 0)
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, resultKey) < 0)
                             {
+                                resultKey = nextKey;
                                 resultValue = nextValue;
                             }
                         }
@@ -426,10 +300,139 @@ namespace System.Linq
                     found = true;
                     return resultValue;
                 }
+
+                found = false;
+                return default;
             }
 
-            found = false;
-            return default;
+            public override TElement? TryGetLast(out bool found)
+            {
+                if (_parent is not null)
+                {
+                    return base.TryGetLast(out found);
+                }
+
+                using IEnumerator<TElement> e = _source.GetEnumerator();
+
+                if (e.MoveNext())
+                {
+                    IComparer<TKey> comparer = _comparer;
+                    Func<TElement, TKey> keySelector = _keySelector;
+
+                    TElement resultValue = e.Current;
+                    TKey resultKey = keySelector(resultValue);
+
+                    if (_descending)
+                    {
+                        while (e.MoveNext())
+                        {
+                            TElement nextValue = e.Current;
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, resultKey) <= 0)
+                            {
+                                resultKey = nextKey;
+                                resultValue = nextValue;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        while (e.MoveNext())
+                        {
+                            TElement nextValue = e.Current;
+                            TKey nextKey = keySelector(nextValue);
+                            if (comparer.Compare(nextKey, resultKey) >= 0)
+                            {
+                                resultKey = nextKey;
+                                resultValue = nextValue;
+                            }
+                        }
+                    }
+
+                    found = true;
+                    return resultValue;
+                }
+
+                found = false;
+                return default;
+            }
+        }
+
+        internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
+        {
+            public override TElement[] ToArray()
+            {
+                TElement[] array = _source.ToArray();
+                Sort(array, _descending);
+                return array;
+            }
+
+            public override List<TElement> ToList()
+            {
+                List<TElement> list = _source.ToList();
+                Sort(CollectionsMarshal.AsSpan(list), _descending);
+                return list;
+            }
+
+            public override TElement? TryGetFirst(out bool found) =>
+                TryGetFirstOrLast(out found, first: !_descending);
+
+            public override TElement? TryGetLast(out bool found) =>
+                TryGetFirstOrLast(out found, first: _descending);
+
+            private TElement? TryGetFirstOrLast(out bool found, bool first)
+            {
+                if (TryGetSpan(_source, out ReadOnlySpan<TElement> span))
+                {
+                    if (span.Length != 0)
+                    {
+                        Debug.Assert(TypeIsImplicitlyStable<TElement>(), "Using Min/Max has different semantics for floating-point values.");
+
+                        found = true;
+                        return first ?
+                            Min(_source) :
+                            Max(_source);
+                    }
+                }
+                else
+                {
+                    using IEnumerator<TElement> e = _source.GetEnumerator();
+
+                    if (e.MoveNext())
+                    {
+                        TElement resultValue = e.Current;
+
+                        if (first)
+                        {
+                            while (e.MoveNext())
+                            {
+                                TElement nextValue = e.Current;
+                                if (Comparer<TElement>.Default.Compare(nextValue, resultValue) < 0)
+                                {
+                                    resultValue = nextValue;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            while (e.MoveNext())
+                            {
+                                TElement nextValue = e.Current;
+                                if (Comparer<TElement>.Default.Compare(nextValue, resultValue) >= 0)
+                                {
+                                    resultValue = nextValue;
+                                }
+                            }
+                        }
+
+                        found = true;
+                        return resultValue;
+                    }
+                }
+
+                found = false;
+                return default;
+            }
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -7,618 +7,621 @@ using System.Diagnostics;
 
 namespace System.Linq
 {
-    internal abstract partial class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>
+    public static partial class Enumerable
     {
-        internal IEnumerable<TElement> _source;
-
-        protected OrderedEnumerable(IEnumerable<TElement> source) => _source = source;
-
-        private int[] SortedMap(TElement[] buffer) => GetEnumerableSorter().Sort(buffer, buffer.Length);
-
-        private int[] SortedMap(TElement[] buffer, int minIdx, int maxIdx) =>
-            GetEnumerableSorter().Sort(buffer, buffer.Length, minIdx, maxIdx);
-
-        public virtual IEnumerator<TElement> GetEnumerator()
+        internal abstract partial class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>
         {
-            TElement[] buffer = _source.ToArray();
-            if (buffer.Length > 0)
+            internal IEnumerable<TElement> _source;
+
+            protected OrderedEnumerable(IEnumerable<TElement> source) => _source = source;
+
+            private int[] SortedMap(TElement[] buffer) => GetEnumerableSorter().Sort(buffer, buffer.Length);
+
+            private int[] SortedMap(TElement[] buffer, int minIdx, int maxIdx) =>
+                GetEnumerableSorter().Sort(buffer, buffer.Length, minIdx, maxIdx);
+
+            public virtual IEnumerator<TElement> GetEnumerator()
             {
-                int[] map = SortedMap(buffer);
-                for (int i = 0; i < buffer.Length; i++)
+                TElement[] buffer = _source.ToArray();
+                if (buffer.Length > 0)
                 {
-                    yield return buffer[map[i]];
+                    int[] map = SortedMap(buffer);
+                    for (int i = 0; i < buffer.Length; i++)
+                    {
+                        yield return buffer[map[i]];
+                    }
+                }
+            }
+
+            internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
+            {
+                TElement[] buffer = _source.ToArray();
+                int count = buffer.Length;
+                if (count > minIdx)
+                {
+                    if (count <= maxIdx)
+                    {
+                        maxIdx = count - 1;
+                    }
+
+                    if (minIdx == maxIdx)
+                    {
+                        yield return GetEnumerableSorter().ElementAt(buffer, count, minIdx);
+                    }
+                    else
+                    {
+                        int[] map = SortedMap(buffer, minIdx, maxIdx);
+                        while (minIdx <= maxIdx)
+                        {
+                            yield return buffer[map[minIdx]];
+                            ++minIdx;
+                        }
+                    }
+                }
+            }
+
+            private EnumerableSorter<TElement> GetEnumerableSorter() => GetEnumerableSorter(null);
+
+            internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next);
+
+            internal abstract CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer = null);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            IOrderedEnumerable<TElement> IOrderedEnumerable<TElement>.CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending) =>
+                new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, @descending, this);
+
+            public TElement? TryGetLast(Func<TElement, bool> predicate, out bool found)
+            {
+                CachingComparer<TElement> comparer = GetComparer();
+                using (IEnumerator<TElement> e = _source.GetEnumerator())
+                {
+                    TElement value;
+                    do
+                    {
+                        if (!e.MoveNext())
+                        {
+                            found = false;
+                            return default;
+                        }
+
+                        value = e.Current;
+                    }
+                    while (!predicate(value));
+
+                    comparer.SetElement(value);
+                    while (e.MoveNext())
+                    {
+                        TElement x = e.Current;
+                        if (predicate(x) && comparer.Compare(x, false) >= 0)
+                        {
+                            value = x;
+                        }
+                    }
+
+                    found = true;
+                    return value;
                 }
             }
         }
 
-        internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
+        internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
         {
-            TElement[] buffer = _source.ToArray();
-            int count = buffer.Length;
-            if (count > minIdx)
+            private readonly OrderedEnumerable<TElement>? _parent;
+            private readonly Func<TElement, TKey> _keySelector;
+            private readonly IComparer<TKey> _comparer;
+            private readonly bool _descending;
+
+            internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending, OrderedEnumerable<TElement>? parent) :
+                base(source)
             {
-                if (count <= maxIdx)
+                if (source is null)
                 {
-                    maxIdx = count - 1;
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                }
+                if (keySelector is null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
                 }
 
-                if (minIdx == maxIdx)
+                _parent = parent;
+                _keySelector = keySelector;
+                _comparer = comparer ?? Comparer<TKey>.Default;
+                _descending = descending;
+            }
+
+            internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next)
+            {
+                // Special case the common use of string with default comparer. Comparer<string>.Default checks the
+                // thread's Culture on each call which is an overhead which is not required, because we are about to
+                // do a sort which remains on the current thread (and EnumerableSorter is not used afterwards).
+                IComparer<TKey> comparer = _comparer;
+                if (typeof(TKey) == typeof(string) && comparer == Comparer<string>.Default)
                 {
-                    yield return GetEnumerableSorter().ElementAt(buffer, count, minIdx);
+                    comparer = (IComparer<TKey>)StringComparer.CurrentCulture;
+                }
+
+                EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
+                if (_parent != null)
+                {
+                    sorter = _parent.GetEnumerableSorter(sorter);
+                }
+
+                return sorter;
+            }
+
+            internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer)
+            {
+                CachingComparer<TElement> cmp = childComparer == null
+                    ? new CachingComparer<TElement, TKey>(_keySelector, _comparer, _descending)
+                    : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
+                return _parent != null ? _parent.GetComparer(cmp) : cmp;
+            }
+        }
+
+        /// <summary>An ordered enumerable used by Order/OrderDescending for Ts that are bitwise indistinguishable for any considered equal.</summary>
+        internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
+        {
+            private readonly bool _descending;
+
+            public OrderedImplicitlyStableEnumerable(IEnumerable<TElement> source, bool descending) : base(source)
+            {
+                Debug.Assert(TypeIsImplicitlyStable<TElement>());
+
+                if (source is null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                }
+
+                _descending = descending;
+            }
+
+            internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer) =>
+                childComparer == null ?
+                    new CachingComparer<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending) :
+                    new CachingComparerWithChild<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending, childComparer);
+
+            internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next) =>
+                new EnumerableSorter<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending, next);
+
+            public override IEnumerator<TElement> GetEnumerator()
+            {
+                TElement[] buffer = _source.ToArray();
+                if (buffer.Length > 0)
+                {
+                    Sort(buffer, _descending);
+                    for (int i = 0; i < buffer.Length; i++)
+                    {
+                        yield return buffer[i];
+                    }
+                }
+            }
+
+            private static void Sort(Span<TElement> span, bool descending)
+            {
+                if (descending)
+                {
+                    span.Sort(static (a, b) => Comparer<TElement>.Default.Compare(b, a));
                 }
                 else
                 {
-                    int[] map = SortedMap(buffer, minIdx, maxIdx);
-                    while (minIdx <= maxIdx)
-                    {
-                        yield return buffer[map[minIdx]];
-                        ++minIdx;
-                    }
+                    span.Sort();
                 }
             }
         }
 
-        private EnumerableSorter<TElement> GetEnumerableSorter() => GetEnumerableSorter(null);
-
-        internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next);
-
-        internal abstract CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer = null);
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        IOrderedEnumerable<TElement> IOrderedEnumerable<TElement>.CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending) =>
-            new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, @descending, this);
-
-        public TElement? TryGetLast(Func<TElement, bool> predicate, out bool found)
+        // A comparer that chains comparisons, and pushes through the last element found to be
+        // lower or higher (depending on use), so as to represent the sort of comparisons
+        // done by OrderBy().ThenBy() combinations.
+        internal abstract class CachingComparer<TElement>
         {
-            CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
+            internal abstract int Compare(TElement element, bool cacheLower);
+
+            internal abstract void SetElement(TElement element);
+        }
+
+        internal class CachingComparer<TElement, TKey> : CachingComparer<TElement>
+        {
+            protected readonly Func<TElement, TKey> _keySelector;
+            protected readonly IComparer<TKey> _comparer;
+            protected readonly bool _descending;
+            protected TKey? _lastKey;
+
+            public CachingComparer(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
             {
-                TElement value;
-                do
+                _keySelector = keySelector;
+                _comparer = comparer;
+                _descending = descending;
+            }
+
+            internal override int Compare(TElement element, bool cacheLower)
+            {
+                TKey newKey = _keySelector(element);
+                int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
+                if (cacheLower == cmp < 0)
                 {
-                    if (!e.MoveNext())
-                    {
-                        found = false;
-                        return default;
-                    }
-
-                    value = e.Current;
+                    _lastKey = newKey;
                 }
-                while (!predicate(value));
 
-                comparer.SetElement(value);
-                while (e.MoveNext())
+                return cmp;
+            }
+
+            internal override void SetElement(TElement element)
+            {
+                _lastKey = _keySelector(element);
+            }
+        }
+
+        internal sealed class CachingComparerWithChild<TElement, TKey> : CachingComparer<TElement, TKey>
+        {
+            private readonly CachingComparer<TElement> _child;
+
+            public CachingComparerWithChild(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, CachingComparer<TElement> child)
+                : base(keySelector, comparer, descending)
+            {
+                _child = child;
+            }
+
+            internal override int Compare(TElement element, bool cacheLower)
+            {
+                TKey newKey = _keySelector(element);
+                int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
+                if (cmp == 0)
                 {
-                    TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, false) >= 0)
-                    {
-                        value = x;
-                    }
+                    return _child.Compare(element, cacheLower);
                 }
 
-                found = true;
-                return value;
-            }
-        }
-    }
-
-    internal sealed partial class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
-    {
-        private readonly OrderedEnumerable<TElement>? _parent;
-        private readonly Func<TElement, TKey> _keySelector;
-        private readonly IComparer<TKey> _comparer;
-        private readonly bool _descending;
-
-        internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey>? comparer, bool descending, OrderedEnumerable<TElement>? parent) :
-            base(source)
-        {
-            if (source is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-            if (keySelector is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
-            }
-
-            _parent = parent;
-            _keySelector = keySelector;
-            _comparer = comparer ?? Comparer<TKey>.Default;
-            _descending = descending;
-        }
-
-        internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next)
-        {
-            // Special case the common use of string with default comparer. Comparer<string>.Default checks the
-            // thread's Culture on each call which is an overhead which is not required, because we are about to
-            // do a sort which remains on the current thread (and EnumerableSorter is not used afterwards).
-            IComparer<TKey> comparer = _comparer;
-            if (typeof(TKey) == typeof(string) && comparer == Comparer<string>.Default)
-            {
-                comparer = (IComparer<TKey>)StringComparer.CurrentCulture;
-            }
-
-            EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
-            if (_parent != null)
-            {
-                sorter = _parent.GetEnumerableSorter(sorter);
-            }
-
-            return sorter;
-        }
-
-        internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer)
-        {
-            CachingComparer<TElement> cmp = childComparer == null
-                ? new CachingComparer<TElement, TKey>(_keySelector, _comparer, _descending)
-                : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
-            return _parent != null ? _parent.GetComparer(cmp) : cmp;
-        }
-    }
-
-    /// <summary>An ordered enumerable used by Order/OrderDescending for Ts that are bitwise indistinguishable for any considered equal.</summary>
-    internal sealed partial class OrderedImplicitlyStableEnumerable<TElement> : OrderedEnumerable<TElement>
-    {
-        private readonly bool _descending;
-
-        public OrderedImplicitlyStableEnumerable(IEnumerable<TElement> source, bool descending) : base(source)
-        {
-            Debug.Assert(Enumerable.TypeIsImplicitlyStable<TElement>());
-
-            if (source is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
-            _descending = descending;
-        }
-
-        internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer) =>
-            childComparer == null ?
-                new CachingComparer<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending) :
-                new CachingComparerWithChild<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending, childComparer);
-
-        internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next) =>
-            new EnumerableSorter<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending, next);
-
-        public override IEnumerator<TElement> GetEnumerator()
-        {
-            TElement[] buffer = _source.ToArray();
-            if (buffer.Length > 0)
-            {
-                Sort(buffer, _descending);
-                for (int i = 0; i < buffer.Length; i++)
+                if (cacheLower == cmp < 0)
                 {
-                    yield return buffer[i];
+                    _lastKey = newKey;
+                    _child.SetElement(element);
                 }
-            }
-        }
 
-        private static void Sort(Span<TElement> span, bool descending)
-        {
-            if (descending)
-            {
-                span.Sort(static (a, b) => Comparer<TElement>.Default.Compare(b, a));
-            }
-            else
-            {
-                span.Sort();
-            }
-        }
-    }
-
-    // A comparer that chains comparisons, and pushes through the last element found to be
-    // lower or higher (depending on use), so as to represent the sort of comparisons
-    // done by OrderBy().ThenBy() combinations.
-    internal abstract class CachingComparer<TElement>
-    {
-        internal abstract int Compare(TElement element, bool cacheLower);
-
-        internal abstract void SetElement(TElement element);
-    }
-
-    internal class CachingComparer<TElement, TKey> : CachingComparer<TElement>
-    {
-        protected readonly Func<TElement, TKey> _keySelector;
-        protected readonly IComparer<TKey> _comparer;
-        protected readonly bool _descending;
-        protected TKey? _lastKey;
-
-        public CachingComparer(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
-        {
-            _keySelector = keySelector;
-            _comparer = comparer;
-            _descending = descending;
-        }
-
-        internal override int Compare(TElement element, bool cacheLower)
-        {
-            TKey newKey = _keySelector(element);
-            int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
-            if (cacheLower == cmp < 0)
-            {
-                _lastKey = newKey;
+                return cmp;
             }
 
-            return cmp;
-        }
-
-        internal override void SetElement(TElement element)
-        {
-            _lastKey = _keySelector(element);
-        }
-    }
-
-    internal sealed class CachingComparerWithChild<TElement, TKey> : CachingComparer<TElement, TKey>
-    {
-        private readonly CachingComparer<TElement> _child;
-
-        public CachingComparerWithChild(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, CachingComparer<TElement> child)
-            : base(keySelector, comparer, descending)
-        {
-            _child = child;
-        }
-
-        internal override int Compare(TElement element, bool cacheLower)
-        {
-            TKey newKey = _keySelector(element);
-            int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
-            if (cmp == 0)
+            internal override void SetElement(TElement element)
             {
-                return _child.Compare(element, cacheLower);
-            }
-
-            if (cacheLower == cmp < 0)
-            {
-                _lastKey = newKey;
+                base.SetElement(element);
                 _child.SetElement(element);
             }
-
-            return cmp;
         }
 
-        internal override void SetElement(TElement element)
+        internal abstract class EnumerableSorter<TElement>
         {
-            base.SetElement(element);
-            _child.SetElement(element);
-        }
-    }
+            /// <summary>Function that returns its input unmodified.</summary>
+            /// <remarks>
+            /// Used for reference equality in order to avoid unnecessary computation when a caller
+            /// can benefit from knowing that the produced value is identical to the input.
+            /// </remarks>
+            internal static readonly Func<TElement, TElement> IdentityFunc = e => e;
 
-    internal abstract class EnumerableSorter<TElement>
-    {
-        /// <summary>Function that returns its input unmodified.</summary>
-        /// <remarks>
-        /// Used for reference equality in order to avoid unnecessary computation when a caller
-        /// can benefit from knowing that the produced value is identical to the input.
-        /// </remarks>
-        internal static readonly Func<TElement, TElement> IdentityFunc = e => e;
+            internal abstract void ComputeKeys(TElement[] elements, int count);
 
-        internal abstract void ComputeKeys(TElement[] elements, int count);
+            internal abstract int CompareAnyKeys(int index1, int index2);
 
-        internal abstract int CompareAnyKeys(int index1, int index2);
-
-        private int[] ComputeMap(TElement[] elements, int count)
-        {
-            ComputeKeys(elements, count);
-            int[] map = new int[count];
-            for (int i = 0; i < map.Length; i++)
+            private int[] ComputeMap(TElement[] elements, int count)
             {
-                map[i] = i;
-            }
-
-            return map;
-        }
-
-        internal int[] Sort(TElement[] elements, int count)
-        {
-            int[] map = ComputeMap(elements, count);
-            QuickSort(map, 0, count - 1);
-            return map;
-        }
-
-        internal int[] Sort(TElement[] elements, int count, int minIdx, int maxIdx)
-        {
-            int[] map = ComputeMap(elements, count);
-            PartialQuickSort(map, 0, count - 1, minIdx, maxIdx);
-            return map;
-        }
-
-        internal TElement ElementAt(TElement[] elements, int count, int idx)
-        {
-            int[] map = ComputeMap(elements, count);
-            return idx == 0 ?
-                elements[Min(map, count)] :
-                elements[QuickSelect(map, count - 1, idx)];
-        }
-
-        protected abstract void QuickSort(int[] map, int left, int right);
-
-        // Sorts the k elements between minIdx and maxIdx without sorting all elements
-        // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
-        protected abstract void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx);
-
-        // Finds the element that would be at idx if the collection was sorted.
-        // Time complexity: O(n) best and average case. O(n^2) worse case.
-        protected abstract int QuickSelect(int[] map, int right, int idx);
-
-        protected abstract int Min(int[] map, int count);
-    }
-
-    internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
-    {
-        private readonly Func<TElement, TKey> _keySelector;
-        private readonly IComparer<TKey> _comparer;
-        private readonly bool _descending;
-        private readonly EnumerableSorter<TElement>? _next;
-        private TKey[]? _keys;
-
-        internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement>? next)
-        {
-            _keySelector = keySelector;
-            _comparer = comparer;
-            _descending = descending;
-            _next = next;
-        }
-
-        internal override void ComputeKeys(TElement[] elements, int count)
-        {
-            Func<TElement, TKey> keySelector = _keySelector;
-            if (!ReferenceEquals(keySelector, IdentityFunc))
-            {
-                var keys = new TKey[count];
-                for (int i = 0; i < keys.Length; i++)
+                ComputeKeys(elements, count);
+                int[] map = new int[count];
+                for (int i = 0; i < map.Length; i++)
                 {
-                    keys[i] = keySelector(elements[i]);
-                }
-                _keys = keys;
-            }
-            else
-            {
-                // The key selector is our known identity function, which means we don't
-                // need to invoke the key selector for every element.  Further, we can just
-                // use the original array as the keys (even if count is smaller, as the additional
-                // values will just be ignored).
-                Debug.Assert(typeof(TKey) == typeof(TElement));
-                _keys = (TKey[])(object)elements;
-            }
-
-            _next?.ComputeKeys(elements, count);
-        }
-
-        internal override int CompareAnyKeys(int index1, int index2)
-        {
-            TKey[]? keys = _keys;
-            Debug.Assert(keys != null);
-
-            int c = _comparer.Compare(keys[index1], keys[index2]);
-            if (c == 0)
-            {
-                if (_next == null)
-                {
-                    return index1 - index2; // ensure stability of sort
+                    map[i] = i;
                 }
 
-                return _next.CompareAnyKeys(index1, index2);
+                return map;
             }
 
-            // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
-            // Flipping keys earlier is more likely to trigger something strange in a comparer,
-            // particularly as it comes to the sort being stable.
-            return (_descending != (c > 0)) ? 1 : -1;
-        }
-
-        private int CompareAnyKeys_DefaultComparer_NoNext_Ascending(int index1, int index2)
-        {
-            Debug.Assert(typeof(TKey).IsValueType);
-            Debug.Assert(_comparer == Comparer<TKey>.Default);
-            Debug.Assert(_next is null);
-            Debug.Assert(!_descending);
-
-            TKey[]? keys = _keys;
-            Debug.Assert(keys != null);
-
-            int c = Comparer<TKey>.Default.Compare(keys[index1], keys[index2]);
-            return
-                c == 0 ? index1 - index2 : // ensure stability of sort
-                c;
-        }
-
-        private int CompareAnyKeys_DefaultComparer_NoNext_Descending(int index1, int index2)
-        {
-            Debug.Assert(typeof(TKey).IsValueType);
-            Debug.Assert(_comparer == Comparer<TKey>.Default);
-            Debug.Assert(_next is null);
-            Debug.Assert(_descending);
-
-            TKey[]? keys = _keys;
-            Debug.Assert(keys != null);
-
-            int c = Comparer<TKey>.Default.Compare(keys[index2], keys[index1]);
-            return
-                c == 0 ? index1 - index2 : // ensure stability of sort
-                c;
-        }
-
-        private int CompareKeys(int index1, int index2) => index1 == index2 ? 0 : CompareAnyKeys(index1, index2);
-
-        protected override void QuickSort(int[] keys, int lo, int hi)
-        {
-            Comparison<int> comparison;
-
-            if (typeof(TKey).IsValueType && _next is null && _comparer == Comparer<TKey>.Default)
+            internal int[] Sort(TElement[] elements, int count)
             {
-                // We can use Comparer<TKey>.Default.Compare and benefit from devirtualization and inlining.
-                // We can also avoid extra steps to check whether we need to deal with a subsequent tie breaker (_next).
-                if (!_descending)
+                int[] map = ComputeMap(elements, count);
+                QuickSort(map, 0, count - 1);
+                return map;
+            }
+
+            internal int[] Sort(TElement[] elements, int count, int minIdx, int maxIdx)
+            {
+                int[] map = ComputeMap(elements, count);
+                PartialQuickSort(map, 0, count - 1, minIdx, maxIdx);
+                return map;
+            }
+
+            internal TElement ElementAt(TElement[] elements, int count, int idx)
+            {
+                int[] map = ComputeMap(elements, count);
+                return idx == 0 ?
+                    elements[Min(map, count)] :
+                    elements[QuickSelect(map, count - 1, idx)];
+            }
+
+            protected abstract void QuickSort(int[] map, int left, int right);
+
+            // Sorts the k elements between minIdx and maxIdx without sorting all elements
+            // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
+            protected abstract void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx);
+
+            // Finds the element that would be at idx if the collection was sorted.
+            // Time complexity: O(n) best and average case. O(n^2) worse case.
+            protected abstract int QuickSelect(int[] map, int right, int idx);
+
+            protected abstract int Min(int[] map, int count);
+        }
+
+        internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
+        {
+            private readonly Func<TElement, TKey> _keySelector;
+            private readonly IComparer<TKey> _comparer;
+            private readonly bool _descending;
+            private readonly EnumerableSorter<TElement>? _next;
+            private TKey[]? _keys;
+
+            internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement>? next)
+            {
+                _keySelector = keySelector;
+                _comparer = comparer;
+                _descending = descending;
+                _next = next;
+            }
+
+            internal override void ComputeKeys(TElement[] elements, int count)
+            {
+                Func<TElement, TKey> keySelector = _keySelector;
+                if (!ReferenceEquals(keySelector, IdentityFunc))
                 {
-                    comparison = CompareAnyKeys_DefaultComparer_NoNext_Ascending;
+                    var keys = new TKey[count];
+                    for (int i = 0; i < keys.Length; i++)
+                    {
+                        keys[i] = keySelector(elements[i]);
+                    }
+                    _keys = keys;
                 }
                 else
                 {
-                    comparison = CompareAnyKeys_DefaultComparer_NoNext_Descending;
+                    // The key selector is our known identity function, which means we don't
+                    // need to invoke the key selector for every element.  Further, we can just
+                    // use the original array as the keys (even if count is smaller, as the additional
+                    // values will just be ignored).
+                    Debug.Assert(typeof(TKey) == typeof(TElement));
+                    _keys = (TKey[])(object)elements;
                 }
-            }
-            else
-            {
-                comparison = CompareAnyKeys;
+
+                _next?.ComputeKeys(elements, count);
             }
 
-            new Span<int>(keys, lo, hi - lo + 1).Sort(comparison);
-        }
-
-        // Sorts the k elements between minIdx and maxIdx without sorting all elements
-        // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
-        protected override void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
-        {
-            do
+            internal override int CompareAnyKeys(int index1, int index2)
             {
-                int i = left;
-                int j = right;
-                int x = map[i + ((j - i) >> 1)];
+                TKey[]? keys = _keys;
+                Debug.Assert(keys != null);
+
+                int c = _comparer.Compare(keys[index1], keys[index2]);
+                if (c == 0)
+                {
+                    if (_next == null)
+                    {
+                        return index1 - index2; // ensure stability of sort
+                    }
+
+                    return _next.CompareAnyKeys(index1, index2);
+                }
+
+                // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
+                // Flipping keys earlier is more likely to trigger something strange in a comparer,
+                // particularly as it comes to the sort being stable.
+                return (_descending != (c > 0)) ? 1 : -1;
+            }
+
+            private int CompareAnyKeys_DefaultComparer_NoNext_Ascending(int index1, int index2)
+            {
+                Debug.Assert(typeof(TKey).IsValueType);
+                Debug.Assert(_comparer == Comparer<TKey>.Default);
+                Debug.Assert(_next is null);
+                Debug.Assert(!_descending);
+
+                TKey[]? keys = _keys;
+                Debug.Assert(keys != null);
+
+                int c = Comparer<TKey>.Default.Compare(keys[index1], keys[index2]);
+                return
+                    c == 0 ? index1 - index2 : // ensure stability of sort
+                    c;
+            }
+
+            private int CompareAnyKeys_DefaultComparer_NoNext_Descending(int index1, int index2)
+            {
+                Debug.Assert(typeof(TKey).IsValueType);
+                Debug.Assert(_comparer == Comparer<TKey>.Default);
+                Debug.Assert(_next is null);
+                Debug.Assert(_descending);
+
+                TKey[]? keys = _keys;
+                Debug.Assert(keys != null);
+
+                int c = Comparer<TKey>.Default.Compare(keys[index2], keys[index1]);
+                return
+                    c == 0 ? index1 - index2 : // ensure stability of sort
+                    c;
+            }
+
+            private int CompareKeys(int index1, int index2) => index1 == index2 ? 0 : CompareAnyKeys(index1, index2);
+
+            protected override void QuickSort(int[] keys, int lo, int hi)
+            {
+                Comparison<int> comparison;
+
+                if (typeof(TKey).IsValueType && _next is null && _comparer == Comparer<TKey>.Default)
+                {
+                    // We can use Comparer<TKey>.Default.Compare and benefit from devirtualization and inlining.
+                    // We can also avoid extra steps to check whether we need to deal with a subsequent tie breaker (_next).
+                    if (!_descending)
+                    {
+                        comparison = CompareAnyKeys_DefaultComparer_NoNext_Ascending;
+                    }
+                    else
+                    {
+                        comparison = CompareAnyKeys_DefaultComparer_NoNext_Descending;
+                    }
+                }
+                else
+                {
+                    comparison = CompareAnyKeys;
+                }
+
+                new Span<int>(keys, lo, hi - lo + 1).Sort(comparison);
+            }
+
+            // Sorts the k elements between minIdx and maxIdx without sorting all elements
+            // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
+            protected override void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
+            {
                 do
                 {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                    int i = left;
+                    int j = right;
+                    int x = map[i + ((j - i) >> 1)];
+                    do
                     {
-                        i++;
-                    }
+                        while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                        {
+                            i++;
+                        }
 
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
-                    {
+                        while (j >= 0 && CompareKeys(x, map[j]) < 0)
+                        {
+                            j--;
+                        }
+
+                        if (i > j)
+                        {
+                            break;
+                        }
+
+                        if (i < j)
+                        {
+                            int temp = map[i];
+                            map[i] = map[j];
+                            map[j] = temp;
+                        }
+
+                        i++;
                         j--;
                     }
+                    while (i <= j);
 
-                    if (i > j)
+                    if (minIdx >= i)
                     {
-                        break;
+                        left = i + 1;
+                    }
+                    else if (maxIdx <= j)
+                    {
+                        right = j - 1;
                     }
 
-                    if (i < j)
+                    if (j - left <= right - i)
                     {
-                        int temp = map[i];
-                        map[i] = map[j];
-                        map[j] = temp;
-                    }
+                        if (left < j)
+                        {
+                            PartialQuickSort(map, left, j, minIdx, maxIdx);
+                        }
 
-                    i++;
-                    j--;
-                }
-                while (i <= j);
-
-                if (minIdx >= i)
-                {
-                    left = i + 1;
-                }
-                else if (maxIdx <= j)
-                {
-                    right = j - 1;
-                }
-
-                if (j - left <= right - i)
-                {
-                    if (left < j)
-                    {
-                        PartialQuickSort(map, left, j, minIdx, maxIdx);
-                    }
-
-                    left = i;
-                }
-                else
-                {
-                    if (i < right)
-                    {
-                        PartialQuickSort(map, i, right, minIdx, maxIdx);
-                    }
-
-                    right = j;
-                }
-            }
-            while (left < right);
-        }
-
-        // Finds the element that would be at idx if the collection was sorted.
-        // Time complexity: O(n) best and average case. O(n^2) worse case.
-        protected override int QuickSelect(int[] map, int right, int idx)
-        {
-            int left = 0;
-            do
-            {
-                int i = left;
-                int j = right;
-                int x = map[i + ((j - i) >> 1)];
-                do
-                {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
-                    {
-                        i++;
-                    }
-
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
-                    {
-                        j--;
-                    }
-
-                    if (i > j)
-                    {
-                        break;
-                    }
-
-                    if (i < j)
-                    {
-                        int temp = map[i];
-                        map[i] = map[j];
-                        map[j] = temp;
-                    }
-
-                    i++;
-                    j--;
-                }
-                while (i <= j);
-
-                if (i <= idx)
-                {
-                    left = i + 1;
-                }
-                else
-                {
-                    right = j - 1;
-                }
-
-                if (j - left <= right - i)
-                {
-                    if (left < j)
-                    {
-                        right = j;
-                    }
-
-                    left = i;
-                }
-                else
-                {
-                    if (i < right)
-                    {
                         left = i;
                     }
+                    else
+                    {
+                        if (i < right)
+                        {
+                            PartialQuickSort(map, i, right, minIdx, maxIdx);
+                        }
 
-                    right = j;
+                        right = j;
+                    }
                 }
+                while (left < right);
             }
-            while (left < right);
 
-            return map[idx];
-        }
-
-        protected override int Min(int[] map, int count)
-        {
-            int index = 0;
-            for (int i = 1; i < count; i++)
+            // Finds the element that would be at idx if the collection was sorted.
+            // Time complexity: O(n) best and average case. O(n^2) worse case.
+            protected override int QuickSelect(int[] map, int right, int idx)
             {
-                if (CompareKeys(map[i], map[index]) < 0)
+                int left = 0;
+                do
                 {
-                    index = i;
+                    int i = left;
+                    int j = right;
+                    int x = map[i + ((j - i) >> 1)];
+                    do
+                    {
+                        while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                        {
+                            i++;
+                        }
+
+                        while (j >= 0 && CompareKeys(x, map[j]) < 0)
+                        {
+                            j--;
+                        }
+
+                        if (i > j)
+                        {
+                            break;
+                        }
+
+                        if (i < j)
+                        {
+                            int temp = map[i];
+                            map[i] = map[j];
+                            map[j] = temp;
+                        }
+
+                        i++;
+                        j--;
+                    }
+                    while (i <= j);
+
+                    if (i <= idx)
+                    {
+                        left = i + 1;
+                    }
+                    else
+                    {
+                        right = j - 1;
+                    }
+
+                    if (j - left <= right - i)
+                    {
+                        if (left < j)
+                        {
+                            right = j;
+                        }
+
+                        left = i;
+                    }
+                    else
+                    {
+                        if (i < right)
+                        {
+                            left = i;
+                        }
+
+                        right = j;
+                    }
                 }
+                while (left < right);
+
+                return map[idx];
             }
-            return map[index];
+
+            protected override int Min(int[] map, int count)
+            {
+                int index = 0;
+                for (int i = 1; i < count; i++)
+                {
+                    if (CompareKeys(map[i], map[index]) < 0)
+                    {
+                        index = i;
+                    }
+                }
+                return map[index];
+            }
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
@@ -7,65 +7,66 @@ using System.Diagnostics;
 
 namespace System.Linq
 {
-    internal sealed class OrderedPartition<TElement> : IPartition<TElement>
-    {
-        private readonly OrderedEnumerable<TElement> _source;
-        private readonly int _minIndexInclusive;
-        private readonly int _maxIndexInclusive;
-
-        public OrderedPartition(OrderedEnumerable<TElement> source, int minIdxInclusive, int maxIdxInclusive)
-        {
-            _source = source;
-            _minIndexInclusive = minIdxInclusive;
-            _maxIndexInclusive = maxIdxInclusive;
-        }
-
-        public IEnumerator<TElement> GetEnumerator() => _source.GetEnumerator(_minIndexInclusive, _maxIndexInclusive);
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-        public IPartition<TElement>? Skip(int count)
-        {
-            int minIndex = _minIndexInclusive + count;
-            return (uint)minIndex > (uint)_maxIndexInclusive ? null : new OrderedPartition<TElement>(_source, minIndex, _maxIndexInclusive);
-        }
-
-        public IPartition<TElement> Take(int count)
-        {
-            int maxIndex = _minIndexInclusive + count - 1;
-            if ((uint)maxIndex >= (uint)_maxIndexInclusive)
-            {
-                return this;
-            }
-
-            return new OrderedPartition<TElement>(_source, _minIndexInclusive, maxIndex);
-        }
-
-        public TElement? TryGetElementAt(int index, out bool found)
-        {
-            if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive))
-            {
-                return _source.TryGetElementAt(index + _minIndexInclusive, out found);
-            }
-
-            found = false;
-            return default;
-        }
-
-        public TElement? TryGetFirst(out bool found) => _source.TryGetElementAt(_minIndexInclusive, out found);
-
-        public TElement? TryGetLast(out bool found) =>
-            _source.TryGetLast(_minIndexInclusive, _maxIndexInclusive, out found);
-
-        public TElement[] ToArray() => _source.ToArray(_minIndexInclusive, _maxIndexInclusive);
-
-        public List<TElement> ToList() => _source.ToList(_minIndexInclusive, _maxIndexInclusive);
-
-        public int GetCount(bool onlyIfCheap) => _source.GetCount(_minIndexInclusive, _maxIndexInclusive, onlyIfCheap);
-    }
-
     public static partial class Enumerable
     {
+        internal sealed class OrderedPartition<TElement> : IPartition<TElement>
+        {
+            private readonly OrderedEnumerable<TElement> _source;
+            private readonly int _minIndexInclusive;
+            private readonly int _maxIndexInclusive;
+
+            public OrderedPartition(OrderedEnumerable<TElement> source, int minIdxInclusive, int maxIdxInclusive)
+            {
+                _source = source;
+                _minIndexInclusive = minIdxInclusive;
+                _maxIndexInclusive = maxIdxInclusive;
+            }
+
+            public IEnumerator<TElement> GetEnumerator() => _source.GetEnumerator(_minIndexInclusive, _maxIndexInclusive);
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public IPartition<TElement>? Skip(int count)
+            {
+                int minIndex = _minIndexInclusive + count;
+                return (uint)minIndex > (uint)_maxIndexInclusive ? null : new OrderedPartition<TElement>(_source, minIndex, _maxIndexInclusive);
+            }
+
+            public IPartition<TElement> Take(int count)
+            {
+                int maxIndex = _minIndexInclusive + count - 1;
+                if ((uint)maxIndex >= (uint)_maxIndexInclusive)
+                {
+                    return this;
+                }
+
+                return new OrderedPartition<TElement>(_source, _minIndexInclusive, maxIndex);
+            }
+
+            public TElement? TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index <= (uint)(_maxIndexInclusive - _minIndexInclusive))
+                {
+                    return _source.TryGetElementAt(index + _minIndexInclusive, out found);
+                }
+
+                found = false;
+                return default;
+            }
+
+            public TElement? TryGetFirst(out bool found) => _source.TryGetElementAt(_minIndexInclusive, out found);
+
+            public TElement? TryGetLast(out bool found) =>
+                _source.TryGetLast(_minIndexInclusive, _maxIndexInclusive, out found);
+
+            public TElement[] ToArray() => _source.ToArray(_minIndexInclusive, _maxIndexInclusive);
+
+            public List<TElement> ToList() => _source.ToList(_minIndexInclusive, _maxIndexInclusive);
+
+            public int GetCount(bool onlyIfCheap) => _source.GetCount(_minIndexInclusive, _maxIndexInclusive, onlyIfCheap);
+        }
+
+
         /// <summary>
         /// An iterator that yields the items of part of an <see cref="IList{TSource}"/>.
         /// </summary>

--- a/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
@@ -24,7 +24,7 @@ namespace System.Linq
                 }
             }
 
-            public TSource[] ToArray() => Enumerable.HashSetToArray(FillSet());
+            public TSource[] ToArray() => HashSetToArray(FillSet());
 
             public List<TSource> ToList() => new List<TSource>(FillSet());
 


### PR DESCRIPTION
The OrderedEnumerable implementation today doesn't derive from Iterator, and it has a GetEnumerator method implemented with yield. That means the optimization that allows the enumerable to be reused as the enumerator doesn't kick in, and we end up allocating a separate enumerator object in order to iterate through an Order{By} enumerable.

| Method  | Toolchain         | Length | Mean        | Ratio | Allocated | Alloc Ratio |
|-------- |------------------ |------- |------------:|------:|----------:|------------:|
| Order   | \main\corerun.exe | 2      |    51.61 ns |  1.00 |     112 B |        1.00 |
| Order   | \pr\corerun.exe   | 2      |    46.16 ns |  0.90 |      88 B |        0.79 |
|         |                   |        |             |       |           |             |
| OrderBy | \main\corerun.exe | 2      |    86.11 ns |  1.00 |     328 B |        1.00 |
| OrderBy | \pr\corerun.exe   | 2      |    87.89 ns |  1.02 |     304 B |        0.93 |
|         |                   |        |             |       |           |             |
| Order   | \main\corerun.exe | 100    |   652.72 ns |  1.00 |     504 B |        1.00 |
| Order   | \pr\corerun.exe   | 100    |   580.34 ns |  0.89 |     480 B |        0.95 |
|         |                   |        |             |       |           |             |
| OrderBy | \main\corerun.exe | 100    | 1,982.54 ns |  1.00 |    1504 B |        1.00 |
| OrderBy | \pr\corerun.exe   | 100    | 1,989.22 ns |  1.00 |    1480 B |        0.98 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public partial class Tests
{
    private int[] _ints;
    private Person[] _people;

    [Params(2, 100)]
    public int Length { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        _ints = Enumerable.Range(0, Length).Reverse().ToArray();
        _people = _ints.Select(i => new Person { Age = i }).ToArray();
    }

    [Benchmark]
    public int Order()
    {
        int sum = 0;
        foreach (int i in _ints.Order()) sum += i;
        return sum;
    }

    [Benchmark]
    public int OrderBy()
    {
        int sum = 0;
        foreach (Person p in _people.OrderBy(p => p.Age)) sum += p.Age;
        return sum;
    }

    public struct Person
    {
        public int Age { get; set; }
    }
}
```

