### PR TITLE
JIT: profiled SpanHelpers.Fill

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1309,6 +1309,7 @@ DONE_CALL:
                         call->AsCall()->gtHandleHistogramProfileCandidateInfo = pInfo;
                         compCurBB->SetFlags(BBF_HAS_VALUE_PROFILE);
                     }
+                    break;
                 default:
                     break;
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2053,16 +2053,9 @@ bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
             BlockRange().InsertBefore(call, srcBlk);
             BlockRange().InsertBefore(call, storeBlk);
             BlockRange().Remove(lengthArg);
-            BlockRange().Remove(call);
-
-            // Remove all non-user args (e.g. r2r cell)
-            for (CallArg& arg : call->gtArgs.Args())
-            {
-                if (arg.IsArgAddedLate())
-                {
-                    arg.GetNode()->SetUnusedValue();
-                }
-            }
+            BlockRange().Remove(call, true);
+            dstAddr->ClearUnusedValue();
+            srcAddr->ClearUnusedValue();
 
             JITDUMP("\nNew tree:\n")
             DISPTREE(storeBlk);
@@ -2070,10 +2063,7 @@ bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
             *next = storeBlk->gtNext;
             return true;
         }
-        else
-        {
-            JITDUMP("Size is either 0 or too big to unroll.\n")
-        }
+        JITDUMP("Size is either 0 or too big to unroll.\n")
     }
     else
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -306,7 +306,8 @@ namespace System
                 // The runtime eventually calls memset, which can efficiently support large buffers.
                 // We don't need to check IsReferenceOrContainsReferences because no references
                 // can ever be stored in types this small.
-                Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _reference), *(byte*)&value, (uint)_length);
+                T tmp = value; // avoid address exposure of value
+                Unsafe.InitBlockUnaligned(ref Unsafe.As<T, byte>(ref _reference), *(byte*)&tmp, (uint)_length);
             }
             else
             {


### PR DESCRIPTION
Extend value-probing on SpanHelpers.Fill which now supports unrolling. Again, this opt is only applicable with R2R=0, I have some ideas how to fix it for R2R=1..

Benchmark:
```cs
public IEnumerable<int[]> TestData()
{
    yield return new int[16];
}

[Benchmark]
[ArgumentsSource(nameof(TestData))]
public void FillBench(int[] array)
{
    array.AsSpan().Fill(0);
}
```

```diff
; Assembly listing for method Prog:FillBench(int[]):this (Tier1)
       push     rbx
       sub      rsp, 32
       test     rdx, rdx
-      je       SHORT G_M000_IG06
+      je       SHORT G_M000_IG09
       lea      rcx, bword ptr [rdx+0x10]
       mov      ebx, dword ptr [rdx+0x08]
G_M000_IG04:
       mov      edx, ebx
+      cmp      rdx, 16
+      jne      SHORT G_M000_IG06
+      vxorps   ymm0, ymm0, ymm0
+      vmovdqu32 zmmword ptr [rcx], zmm0
+      jmp      SHORT G_M000_IG07
+G_M000_IG06:
       xor      r8d, r8d
       call     [System.SpanHelpers:Fill[int](byref,ulong,int)]
+G_M000_IG07:
       nop
       add      rsp, 32
       pop      rbx
       ret
-G_M000_IG06:
+G_M000_IG09:
       xor      rcx, rcx
       xor      ebx, ebx
       jmp      SHORT G_M000_IG04
-; Total bytes of code 41
+; Total bytes of code 59
```

| Method    | Toolchain         | array     | Mean      | Ratio |
|---------- |-------------------|---------- |----------:|------:|
| FillBench | \base\corerun.exe | Int32[16] | 1.1679 ns |  5.76 |
| FillBench | \pr\corerun.exe   | Int32[16] | 0.2028 ns |  1.00 |