### PR TITLE
Expand ignoreCase to case-sensitive optimization to non-ASCII SearchValues

### DIFF
--- a/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/StringSearchValues.cs
@@ -279,7 +279,7 @@ namespace System.Memory.Tests.Span
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.LinuxBionic, "Remote executor has problems with exit codes")]
-        [ActiveIssue("Manual execution only. Worth running any time SearchValues<string> logic is modified.")]
+        //[ActiveIssue("Manual execution only. Worth running any time SearchValues<string> logic is modified.")]
         public static void TestIndexOfAny_RandomInputs_Stress()
         {
             RunStress();

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs
@@ -188,6 +188,7 @@ namespace System.Buffers
                 where TValueLength : struct, IValueLength
             {
                 Debug.Assert(candidate.Length > 1);
+                Debug.Assert(Ascii.IsValid(candidate));
                 Debug.Assert(candidate.ToUpperInvariant() == candidate);
 
                 if (TValueLength.AtLeast8CharsOrUnknown)
@@ -262,6 +263,10 @@ namespace System.Buffers
             public static bool Equals<TValueLength>(ref char matchStart, string candidate)
                 where TValueLength : struct, IValueLength
             {
+                Debug.Assert(candidate.Length > 1);
+                Debug.Assert(Ascii.IsValid(candidate));
+                Debug.Assert(candidate.ToUpperInvariant() == candidate);
+
                 if (TValueLength.AtLeast8CharsOrUnknown)
                 {
                     return Ascii.EqualsIgnoreCase(ref matchStart, ref candidate.GetRawStringData(), (uint)candidate.Length);


### PR DESCRIPTION
If all characters in all `SearchValues<string>` values can only match against themselves, we can treat searching to be case-sensitive.
This PR extends this optimization to also apply to non-ASCII characters.