### PR TITLE
Skip long values when building Rabin-Karp buckets in SearchValues

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/RabinKarp.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/RabinKarp.cs
@@ -64,6 +64,12 @@ namespace System.Buffers
 
             foreach (string value in values)
             {
+                if (value.Length > MaxInputLength)
+                {
+                    // This value can never match. There's no point in including it in the buckets.
+                    continue;
+                }
+
                 nuint hash = 0;
                 for (int i = 0; i < minimumLength; i++)
                 {


### PR DESCRIPTION
We already have an optimization that skips building the buckets altogether if all the values are longer than `MaxInputLength`.
This change excludes such long values that can never match if we do end up building the buckets, slightly reducing memory consumption, as well as potentially reducing the amount of wasted confirmations we have to do when searching.