### PR TITLE
Expand small value sets to all case permutations in SearchValues<string>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/StringSearchValues.cs
@@ -293,7 +293,7 @@ namespace System.Buffers
             Debug.Assert(values.Length > 1);
             Debug.Assert(n is 2 or 3);
 
-            if (values.Length > 8)
+            if (values.Length > TeddyBucketCount)
             {
                 string[][] buckets = TeddyBucketizer.Bucketize(values, TeddyBucketCount, n);
 


### PR DESCRIPTION
Implements https://github.com/dotnet/runtime/pull/98791#discussion_r1499377478

If we have a set of values like `["ab", "c!"]`, we can expand it to `["ab", "Ab" "aB", "AB", "c!", "C!"]` and switch to case-sensitive searching.
As long as we're making use of buckets that would otherwise have been empty, this is going to be an improvement as the prefix search loop is a bit simpler due to not needing to deal with casing. In the below benchmark, it means eliminating [this step](https://github.com/dotnet/runtime/blob/79dd9bae9bb881eb716b608577c4cedc6c9cba72/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs#L229-L237) from the loop.

This optimization is a bit niche (unlikely to be applicable often), but it's really cheap to check whether it could apply, and can help cases with many non-letter characters in their prefixes.

```c#
public class IgnoreCaseToOrdinal
{
    private static readonly SearchValues<string> s_values = SearchValues.Create(["ab", "c!"], StringComparison.OrdinalIgnoreCase);
    private readonly string _text = new('\n', 1000);

    [Benchmark]
    public int IndexOfAny() => _text.AsSpan().IndexOfAny(s_values);
}
```


| Method     | Toolchain         | Mean     | Error    | Ratio |
|----------- |------------------ |---------:|---------:|------:|
| IndexOfAny | \main\corerun.exe | 82.42 ns | 0.596 ns |  1.00 |
| IndexOfAny | \pr\corerun.exe   | 67.83 ns | 0.369 ns |  0.82 |