### PR TITLE
Add timezone data to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -25,4 +25,5 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         libssl-dev \
         libkrb5-dev \
         zlib1g-dev \
-        ninja-build
+        ninja-build \
+        tzdata


### PR DESCRIPTION
This change is to allow running of tests for `System.Runtime` in newly created codespace.

Current behavior when creating new codespace with configuration `Libraries/Runtime development (prebuilt)`
```bash
cd /workspaces/runtime/src/libraries/System.Runtime/tests/System.Runtime.Tests
# /workspaces/runtime/docs/workflow/building/libraries/README.md (Quick Start ; Iterating on System.Private.CoreLib changes)
/workspaces/runtime/build.sh clr+libs -rc Release
/workspaces/runtime/build.sh clr.corelib+clr.nativecorelib+libs.pretest -rc Release
dotnet build /t:test
```
Gives test result with 100 failures similar to
```xml
<test name="System.Tests.TimeZoneInfoTests.TimeZoneDisplayNames_Unix" type="System.Tests.TimeZoneInfoTests" method="TimeZoneDisplayNames_Unix" time="0" result="Fail">
  <failure exception-type="System.TypeInitializationException">
    <message><![CDATA[System.TypeInitializationException : The type initializer for 'System.Tests.TimeZoneInfoTests' threw an exception.\n---- System.TimeZoneNotFoundException : The time zone ID 'Europe/London' was not found on the local computer.\n-------- System.IO.DirectoryNotFoundException : Could not find a part of the path '/usr/share/zoneinfo/Europe/London'.]]></message>
```

Workaround
```bash
sudo apt-get update; sudo DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata
```