### PR TITLE
JIT: improve throughput of the RLCSE greedy heuristic

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7057,6 +7057,7 @@ protected:
     unsigned optCSEstart;          // The first local variable number that is a CSE
     unsigned optCSEattempt;        // The number of CSEs attempted so far.
     unsigned optCSEcount;          // The total count of CSEs introduced.
+    unsigned optCSEunmarks;        // Number of CSE trees unmarked
     weight_t optCSEweight;         // The weight of the current block when we are doing PerformCSE
     CSE_HeuristicCommon* optCSEheuristic; // CSE Heuristic to use for this method
 

--- a/src/coreclr/jit/optcse.h
+++ b/src/coreclr/jit/optcse.h
@@ -151,12 +151,14 @@ class CSE_HeuristicParameterized : public CSE_HeuristicCommon
 protected:
     struct Choice
     {
-        Choice(CSEdsc* dsc, double preference) : m_dsc(dsc), m_preference(preference), m_softmax(0)
+        Choice(CSEdsc* dsc, double preference) : m_dsc(dsc), m_preference(preference), m_softmax(0), m_performed(false)
         {
         }
+
         CSEdsc* m_dsc;
         double  m_preference;
         double  m_softmax;
+        bool    m_performed;
     };
 
     enum
@@ -185,7 +187,7 @@ public:
     double StoppingPreference();
     void BuildChoices(ArrayStack<Choice>& choices);
 
-    Choice& ChooseGreedy(ArrayStack<Choice>& choices);
+    Choice& ChooseGreedy(ArrayStack<Choice>& choices, bool recompute);
 
     virtual const char* Name() const
     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -34,6 +34,7 @@ void Compiler::optInit()
     optCSECandidateCount = 0;
     optCSEattempt        = 0;
     optCSEheuristic      = nullptr;
+    optCSEunmarks        = 0;
 }
 
 DataFlow::DataFlow(Compiler* pCompiler) : m_pCompiler(pCompiler)


### PR DESCRIPTION
Profiling showed that `GetFeatures` was a major factor in throughput. For the most part the features of CSE candidates don't change as we perform CSEs, so build in some logic to avoid recomputing the feature set unless there is some evidence features have changed.

To avoid having to remove already performed candidates from the candidate vector we now tag them as `m_performed` so they get ignored during subsequent processing, and discarded if we ever recompute features.

This should cut the TP impact roughly in half, the remaining part seems to largely be from doing more CSEs (which we hope will show some perf benefit).

I also took advantage of #98434 so in the symbol table listing the cse temps now show which CSE candidate inspired them.

Contributes to #92915.