### PR TITLE
[Mono][ppc64le] Setting r12 back to function pointer in case of global entry point

### DIFF
--- a/src/mono/mono/mini/exceptions-ppc.c
+++ b/src/mono/mono/mini/exceptions-ppc.c
@@ -838,5 +838,8 @@ mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 	ctx->regs[2] = (gulong)handler_ftnptr->toc;
 #else
 	MONO_CONTEXT_SET_IP(ctx, (unsigned long) func);
+#ifdef TARGET_POWERPC64
+        ctx->regs[12] = (gulong)func;
+#endif
 #endif
 }


### PR DESCRIPTION
In case of global entry point it require to set r12 to the function pointer itself (i.e., the entry point address itself) here in our code this was missing.

https://sourceware.org/bugzilla/show_bug.cgi?id=17638 

In ELFv2, functions may provide both a global and a local entry point.
The global entry point (where the function symbol points to) is intended
to be used for function-pointer or cross-module (PLT) calls, and requires
r12 to be set up to the entry point address itself.