### PR TITLE
Replace memmove with Unsafe.CopyBlock in hydration code

### DIFF
--- a/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
+++ b/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs
@@ -290,12 +290,7 @@ namespace Internal.Runtime.CompilerHelpers
                         {
                             // At the time of writing this, 90% of DehydratedDataCommand.Copy cases
                             // would fall into the above specialized cases. 10% fall back to memmove.
-                            memmove(pDest, pCurrent, (nuint)payload);
-
-                            // Not a DllImport - we don't need a GC transition since this is early startup
-                            [MethodImplAttribute(MethodImplOptions.InternalCall)]
-                            [RuntimeImport("*", "memmove")]
-                            static extern unsafe void* memmove(byte* dmem, byte* smem, nuint size);
+                            Unsafe.CopyBlock(pDest, pCurrent, (uint)payload);
                         }
 
                         pDest += payload;

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -119,5 +119,15 @@ namespace System.Runtime.CompilerServices
         {
             throw new PlatformNotSupportedException();
         }
+
+        /// <summary>
+        /// Copies bytes from the source address to the destination address.
+        /// </summary>
+        [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyBlock(void* destination, void* source, uint byteCount)
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 }


### PR DESCRIPTION
The calling convention for `memmove` needs to be `__cdecl` on x86, so avoid hitting the issue.