### PR TITLE
Add most x86 ReadyToRunHelperNode/ReadyToRunGenericHelperNode helpers

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
@@ -17,6 +17,24 @@ namespace ILCompiler.DependencyAnalysis.X86
         public ObjectDataBuilder Builder;
         public TargetRegisterMap TargetRegister;
 
+        public void EmitMOV(ref AddrMode addrMode, Register reg)
+        {
+            Debug.Assert(addrMode.Size != AddrModeSize.Int8 && addrMode.Size != AddrModeSize.Int16);
+            EmitIndirInstruction(0x89, (byte)reg, ref addrMode);
+        }
+
+        public void EmitMOV(Register reg, ref AddrMode addrMode)
+        {
+            Debug.Assert(addrMode.Size != AddrModeSize.Int8 && addrMode.Size != AddrModeSize.Int16);
+            EmitIndirInstruction(0x8B, (byte)reg, ref addrMode);
+        }
+
+        public void EmitLEA(Register reg, ref AddrMode addrMode)
+        {
+            Debug.Assert(addrMode.Size != AddrModeSize.Int8 && addrMode.Size != AddrModeSize.Int16);
+            EmitIndirInstruction(0x8D, (byte)reg, ref addrMode);
+        }
+
         public void EmitCMP(ref AddrMode addrMode, sbyte immediate)
         {
             if (addrMode.Size == AddrModeSize.Int16)
@@ -48,16 +66,53 @@ namespace ILCompiler.DependencyAnalysis.X86
             }
         }
 
+        public void EmitJE(ISymbolNode symbol)
+        {
+            if (symbol.RepresentsIndirectionCell)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                Builder.EmitByte(0x0f);
+                Builder.EmitByte(0x84);
+                Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_REL32);
+            }
+        }
+
         public void EmitXOR(Register register1, Register register2)
         {
             Builder.EmitByte(0x33);
             Builder.EmitByte((byte)(0xC0 | ((byte)register1 << 3) | (byte)register2));
         }
 
+        public void EmitZeroReg(Register reg)
+        {
+            EmitXOR(reg, reg);
+        }
+
+        public void EmitPOP(Register reg)
+        {
+            Builder.EmitByte((byte)(0x58 + (byte)reg));
+        }
+
+        public void EmitStackDup()
+        {
+            // PUSH [ESP]
+            Builder.EmitByte(0xff);
+            Builder.EmitByte(0x34);
+            Builder.EmitByte(0x24);
+        }
+
         public void EmitPUSH(sbyte imm8)
         {
             Builder.EmitByte(0x6A);
             Builder.EmitByte(unchecked((byte)imm8));
+        }
+
+        public void EmitPUSH(Register reg)
+        {
+            Builder.EmitByte((byte)(0x50 + (byte)reg));
         }
 
         public void EmitPUSH(ISymbolNode node)
@@ -101,6 +156,11 @@ namespace ILCompiler.DependencyAnalysis.X86
         public void EmitINT3()
         {
             Builder.EmitByte(0xCC);
+        }
+
+        public void EmitJmpToAddrMode(ref AddrMode addrMode)
+        {
+            EmitIndirInstruction(0xFF, 0x4, ref addrMode);
         }
 
         public void EmitRET()

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_X86/X86Emitter.cs
@@ -29,6 +29,19 @@ namespace ILCompiler.DependencyAnalysis.X86
             EmitIndirInstruction(0x8B, (byte)reg, ref addrMode);
         }
 
+        public void EmitMOV(ref AddrMode addrMode, ISymbolNode symbol)
+        {
+            if (symbol.RepresentsIndirectionCell)
+            {
+                throw new NotImplementedException();
+            }
+            else
+            {
+                EmitIndirInstruction(0xC7, (byte)0, ref addrMode);
+                Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_HIGHLOW);
+            }
+        }
+
         public void EmitLEA(Register reg, ref AddrMode addrMode)
         {
             Debug.Assert(addrMode.Size != AddrModeSize.Int8 && addrMode.Size != AddrModeSize.Int16);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunGenericHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunGenericHelperNode.cs
@@ -1,15 +1,254 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 using ILCompiler.DependencyAnalysis.X86;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace ILCompiler.DependencyAnalysis
 {
     public partial class ReadyToRunGenericHelperNode
     {
+        protected void EmitDictionaryLookup(NodeFactory factory, ref X86Emitter encoder, Register context, Register result, GenericLookupResult lookup, bool relocsOnly)
+        {
+            // INVARIANT: must not trash context register
+
+            // Find the generic dictionary slot
+            int dictionarySlot = 0;
+            if (!relocsOnly)
+            {
+                // The concrete slot won't be known until we're emitting data - don't ask for it in relocsOnly.
+                if (!factory.GenericDictionaryLayout(_dictionaryOwner).TryGetSlotForEntry(lookup, out dictionarySlot))
+                {
+                    encoder.EmitZeroReg(result);
+                    return;
+                }
+            }
+
+            // Load the generic dictionary cell
+            AddrMode loadEntry = new AddrMode(
+                context, null, dictionarySlot * factory.Target.PointerSize, 0, AddrModeSize.Int32);
+            encoder.EmitMOV(result, ref loadEntry);
+
+            // If there's any invalid entries, we need to test for them
+            //
+            // Skip this in relocsOnly to make it easier to weed out bugs - the _hasInvalidEntries
+            // flag can change over the course of compilation and the bad slot helper dependency
+            // should be reported by someone else - the system should not rely on it coming from here.
+            if (!relocsOnly && _hasInvalidEntries)
+            {
+                AddrMode resultAddr = new AddrMode(Register.RegDirect | result, null, 0, 0, AddrModeSize.Int32);
+                encoder.EmitCMP(ref resultAddr, 0);
+                encoder.EmitJE(GetBadSlotHelper(factory));
+            }
+        }
+
         protected sealed override void EmitCode(NodeFactory factory, ref X86Emitter encoder, bool relocsOnly)
         {
-            encoder.EmitINT3();
+            // First load the generic context into the context register.
+            EmitLoadGenericContext(factory, ref encoder, relocsOnly);
+
+            switch (_id)
+            {
+                case ReadyToRunHelperId.GetNonGCStaticBase:
+                    {
+                        if (!TriggersLazyStaticConstructor(factory))
+                        {
+                            EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
+                            encoder.EmitRET();
+                        }
+                        else
+                        {
+                            EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg0, _lookupSignature, relocsOnly);
+                            encoder.EmitMOV(encoder.TargetRegister.Result, encoder.TargetRegister.Arg0);
+
+                            // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
+                            int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int32);
+                            encoder.EmitCMP(ref initialized, 0);
+                            encoder.EmitRETIfEqual();
+
+                            AddrMode loadCctor = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int32);
+                            encoder.EmitLEA(encoder.TargetRegister.Arg0, ref loadCctor);
+                            encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
+                            encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnNonGCStaticBase));
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetGCStaticBase:
+                    {
+                        MetadataType target = (MetadataType)_target;
+
+                        EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
+
+                        AddrMode loadFromResult = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int32);
+                        encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromResult);
+
+                        if (!TriggersLazyStaticConstructor(factory))
+                        {
+                            encoder.EmitRET();
+                        }
+                        else
+                        {
+                            // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
+                            GenericLookupResult nonGcRegionLookup = factory.GenericLookup.TypeNonGCStaticBase(target);
+                            EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg0, nonGcRegionLookup, relocsOnly);
+
+                            int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int32);
+                            encoder.EmitCMP(ref initialized, 0);
+                            encoder.EmitRETIfEqual();
+
+                            encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
+                            AddrMode loadCctor = new AddrMode(encoder.TargetRegister.Arg0, null, -cctorContextSize, 0, AddrModeSize.Int32);
+                            encoder.EmitLEA(encoder.TargetRegister.Arg0, ref loadCctor);
+
+                            encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase));
+                        }
+                    }
+                    break;
+
+                case ReadyToRunHelperId.GetThreadStaticBase:
+                    {
+                        MetadataType target = (MetadataType)_target;
+
+                        // Look up the index cell
+                        EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Arg1, _lookupSignature, relocsOnly);
+
+                        ISymbolNode helperEntrypoint;
+                        if (TriggersLazyStaticConstructor(factory))
+                        {
+                            // There is a lazy class constructor. We need the non-GC static base because that's where the
+                            // class constructor context lives.
+                            GenericLookupResult nonGcRegionLookup = factory.GenericLookup.TypeNonGCStaticBase(target);
+                            EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, nonGcRegionLookup, relocsOnly);
+                            int cctorContextSize = NonGCStaticsNode.GetClassConstructorContextSize(factory.Target);
+                            AddrMode loadCctor = new AddrMode(encoder.TargetRegister.Result, null, -cctorContextSize, 0, AddrModeSize.Int32);
+                            encoder.EmitLEA(encoder.TargetRegister.Result, ref loadCctor);
+
+                            AddrMode storeAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                            encoder.EmitStackDup();
+                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+
+                            helperEntrypoint = factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase);
+                        }
+                        else
+                        {
+                            helperEntrypoint = factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType);
+                        }
+
+                        // First arg: address of the TypeManager slot that provides the helper with
+                        // information about module index and the type manager instance (which is used
+                        // for initialization on first access).
+                        AddrMode loadFromArg1 = new AddrMode(encoder.TargetRegister.Arg1, null, 0, 0, AddrModeSize.Int32);
+                        encoder.EmitMOV(encoder.TargetRegister.Arg0, ref loadFromArg1);
+
+                        // Second arg: index of the type in the ThreadStatic section of the modules
+                        AddrMode loadFromArg1AndDelta = new AddrMode(encoder.TargetRegister.Arg1, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
+                        encoder.EmitMOV(encoder.TargetRegister.Arg1, ref loadFromArg1AndDelta);
+
+                        encoder.EmitJMP(helperEntrypoint);
+                    }
+                    break;
+
+                case ReadyToRunHelperId.DelegateCtor:
+                    {
+                        // This is a weird helper. Codegen populated Arg0 and Arg1 with the values that the constructor
+                        // method expects. Codegen also passed us the generic context on stack.
+                        // We now need to load the delegate target method on the stack (using a dictionary lookup)
+                        // and the optional 4th parameter, and call the ctor.
+
+                        var target = (DelegateCreationInfo)_target;
+
+                        // EmitLoadGenericContext loaded the context from stack into Result
+                        EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Result, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
+
+                        AddrMode storeAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                        if (target.Thunk != null)
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 3);
+                            AddrMode storeAtEspPlus8 = new AddrMode(Register.ESP, null, 8, 0, AddrModeSize.Int32);
+                            encoder.EmitStackDup();
+                            encoder.EmitMOV(ref storeAtEspPlus8, encoder.TargetRegister.Result);
+                            encoder.EmitMOV(encoder.TargetRegister.Result, target.Thunk);
+                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+                        }
+                        else
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 2);
+                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+                        }
+
+                        encoder.EmitJMP(target.Constructor);
+                    }
+                    break;
+
+                // These are all simple: just get the thing from the dictionary and we're done
+                case ReadyToRunHelperId.TypeHandle:
+                case ReadyToRunHelperId.MethodHandle:
+                case ReadyToRunHelperId.FieldHandle:
+                case ReadyToRunHelperId.MethodDictionary:
+                case ReadyToRunHelperId.MethodEntry:
+                case ReadyToRunHelperId.VirtualDispatchCell:
+                case ReadyToRunHelperId.DefaultConstructor:
+                case ReadyToRunHelperId.ObjectAllocator:
+                case ReadyToRunHelperId.TypeHandleForCasting:
+                case ReadyToRunHelperId.ConstrainedDirectCall:
+                    {
+                        EmitDictionaryLookup(factory, ref encoder, encoder.TargetRegister.Arg0, encoder.TargetRegister.Result, _lookupSignature, relocsOnly);
+                        encoder.EmitRET();
+                    }
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+        protected virtual void EmitLoadGenericContext(NodeFactory factory, ref X86Emitter encoder, bool relocsOnly)
+        {
+            // Assume generic context is already loaded in the context register.
+            if (Id == ReadyToRunHelperId.DelegateCtor)
+            {
+                AddrMode loadAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                encoder.EmitMOV(encoder.TargetRegister.Result, ref loadAtEspPlus4);
+            }
+        }
+    }
+
+    public partial class ReadyToRunGenericLookupFromTypeNode
+    {
+        protected override void EmitLoadGenericContext(NodeFactory factory, ref X86Emitter encoder, bool relocsOnly)
+        {
+            // We start with context register pointing to the MethodTable
+            Register contextRegister = encoder.TargetRegister.Arg0;
+
+            // Locate the VTable slot that points to the dictionary
+            int vtableSlot = 0;
+            if (!relocsOnly)
+            {
+                // The concrete slot won't be known until we're emitting data - don't ask for it in relocsOnly.
+                vtableSlot = VirtualMethodSlotHelper.GetGenericDictionarySlot(factory, (TypeDesc)_dictionaryOwner);
+            }
+
+            int pointerSize = factory.Target.PointerSize;
+            int slotOffset = EETypeNode.GetVTableOffset(pointerSize) + (vtableSlot * pointerSize);
+
+            // DelegateCtor is special, the context is on stack
+            if (Id == ReadyToRunHelperId.DelegateCtor)
+            {
+                AddrMode loadAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                encoder.EmitMOV(encoder.TargetRegister.Result, ref loadAtEspPlus4);
+                contextRegister = encoder.TargetRegister.Result;
+            }
+
+            // Load the dictionary pointer from the VTable
+            AddrMode loadDictionary = new AddrMode(contextRegister, null, slotOffset, 0, AddrModeSize.Int32);
+            encoder.EmitMOV(contextRegister, ref loadDictionary);
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 
 using ILCompiler.DependencyAnalysis.X86;
 
@@ -20,7 +21,25 @@ namespace ILCompiler.DependencyAnalysis
             {
                 case ReadyToRunHelperId.VirtualCall:
                     {
-                        encoder.EmitINT3();
+                        MethodDesc targetMethod = (MethodDesc)Target;
+
+                        Debug.Assert(!targetMethod.OwningType.IsInterface);
+                        Debug.Assert(!targetMethod.CanMethodBeInSealedVTable(factory));
+
+                        AddrMode loadFromThisPtr = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int32);
+                        encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromThisPtr);
+
+                        int pointerSize = factory.Target.PointerSize;
+
+                        int slot = 0;
+                        if (!relocsOnly)
+                        {
+                            slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, targetMethod, targetMethod.OwningType);
+                            Debug.Assert(slot != -1);
+                        }
+
+                        AddrMode jmpAddrMode = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(pointerSize) + (slot * pointerSize), 0, AddrModeSize.Int32);
+                        encoder.EmitJmpToAddrMode(ref jmpAddrMode);
                     }
                     break;
 
@@ -51,19 +70,121 @@ namespace ILCompiler.DependencyAnalysis
 
                 case ReadyToRunHelperId.GetThreadStaticBase:
                     {
-                        encoder.EmitINT3();
+                        MetadataType target = (MetadataType)Target;
+                        ISortableSymbolNode index = factory.TypeThreadStaticIndex(target);
+                        if (index is TypeThreadStaticIndexNode ti && ti.IsInlined)
+                        {
+                            throw new NotImplementedException();
+                        }
+                        else
+                        {
+                            encoder.EmitMOV(encoder.TargetRegister.Result, index);
+
+                            // First arg: address of the TypeManager slot that provides the helper with
+                            // information about module index and the type manager instance (which is used
+                            // for initialization on first access).
+                            AddrMode loadFromEax = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int32);
+                            encoder.EmitMOV(encoder.TargetRegister.Arg0, ref loadFromEax);
+
+                            // Second arg: index of the type in the ThreadStatic section of the modules
+                            AddrMode loadFromEaxAndDelta = new AddrMode(encoder.TargetRegister.Result, null, factory.Target.PointerSize, 0, AddrModeSize.Int32);
+                            encoder.EmitMOV(encoder.TargetRegister.Arg1, ref loadFromEaxAndDelta);
+
+                            ISymbolNode helper = factory.HelperEntrypoint(HelperEntrypoint.GetThreadStaticBaseForType);
+                            if (!factory.PreinitializationManager.HasLazyStaticConstructor(target))
+                            {
+                                encoder.EmitJMP(helper);
+                            }
+                            else
+                            {
+                                encoder.EmitMOV(encoder.TargetRegister.Result, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
+
+                                AddrMode initialized = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int32);
+                                encoder.EmitCMP(ref initialized, 0);
+                                encoder.EmitJE(helper);
+
+                                // Add extra parameter and tail call
+                                encoder.EmitStackDup();
+                                AddrMode storeAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                                encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+
+                                encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnThreadStaticBase));
+                            }
+                        }
                     }
                     break;
 
                 case ReadyToRunHelperId.GetGCStaticBase:
                     {
-                        encoder.EmitINT3();
+                        MetadataType target = (MetadataType)Target;
+                        bool hasLazyStaticConstructor = factory.PreinitializationManager.HasLazyStaticConstructor(target);
+                        encoder.EmitMOV(encoder.TargetRegister.Result, factory.TypeGCStaticsSymbol(target));
+                        AddrMode loadFromEax = new AddrMode(encoder.TargetRegister.Result, null, 0, 0, AddrModeSize.Int32);
+                        encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromEax);
+
+                        if (!hasLazyStaticConstructor)
+                        {
+                            encoder.EmitRET();
+                        }
+                        else
+                        {
+                            // We need to trigger the cctor before returning the base. It is stored at the beginning of the non-GC statics region.
+                            encoder.EmitMOV(encoder.TargetRegister.Arg0, factory.TypeNonGCStaticsSymbol(target), -NonGCStaticsNode.GetClassConstructorContextSize(factory.Target));
+
+                            AddrMode initialized = new AddrMode(encoder.TargetRegister.Arg0, null, 0, 0, AddrModeSize.Int32);
+                            encoder.EmitCMP(ref initialized, 0);
+                            encoder.EmitRETIfEqual();
+
+                            encoder.EmitMOV(encoder.TargetRegister.Arg1, encoder.TargetRegister.Result);
+                            encoder.EmitJMP(factory.HelperEntrypoint(HelperEntrypoint.EnsureClassConstructorRunAndReturnGCStaticBase));
+                        }
                     }
                     break;
 
                 case ReadyToRunHelperId.DelegateCtor:
                     {
-                        encoder.EmitINT3();
+                        DelegateCreationInfo target = (DelegateCreationInfo)Target;
+
+                        encoder.EmitStackDup();
+
+                        if (target.TargetNeedsVTableLookup)
+                        {
+                            Debug.Assert(!target.TargetMethod.CanMethodBeInSealedVTable(factory));
+
+                            AddrMode loadFromThisPtr = new AddrMode(encoder.TargetRegister.Arg1, null, 0, 0, AddrModeSize.Int32);
+                            encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromThisPtr);
+
+                            int slot = 0;
+                            if (!relocsOnly)
+                                slot = VirtualMethodSlotHelper.GetVirtualMethodSlot(factory, target.TargetMethod, target.TargetMethod.OwningType);
+
+                            Debug.Assert(slot != -1);
+                            AddrMode loadFromSlot = new AddrMode(encoder.TargetRegister.Result, null, EETypeNode.GetVTableOffset(factory.Target.PointerSize) + (slot * factory.Target.PointerSize), 0, AddrModeSize.Int32);
+                            encoder.EmitMOV(encoder.TargetRegister.Result, ref loadFromSlot);
+                        }
+                        else
+                        {
+                            encoder.EmitMOV(encoder.TargetRegister.Result, target.GetTargetNode(factory));
+                        }
+
+                        AddrMode storeAtEspPlus4 = new AddrMode(Register.ESP, null, 4, 0, AddrModeSize.Int32);
+                        if (target.Thunk != null)
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 3);
+                            AddrMode storeAtEspPlus8 = new AddrMode(Register.ESP, null, 8, 0, AddrModeSize.Int32);
+                            encoder.EmitStackDup();
+                            encoder.EmitMOV(ref storeAtEspPlus8, encoder.TargetRegister.Result);
+                            // TODO: Is it possible to fold this into one MOV?
+                            encoder.EmitMOV(encoder.TargetRegister.Result, target.Thunk);
+                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+                        }
+                        else
+                        {
+                            Debug.Assert(target.Constructor.Method.Signature.Length == 2);
+                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+                        }
+
+                        encoder.EmitJMP(target.Constructor);
                     }
                     break;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/Target_X86/X86ReadyToRunHelperNode.cs
@@ -174,9 +174,7 @@ namespace ILCompiler.DependencyAnalysis
                             AddrMode storeAtEspPlus8 = new AddrMode(Register.ESP, null, 8, 0, AddrModeSize.Int32);
                             encoder.EmitStackDup();
                             encoder.EmitMOV(ref storeAtEspPlus8, encoder.TargetRegister.Result);
-                            // TODO: Is it possible to fold this into one MOV?
-                            encoder.EmitMOV(encoder.TargetRegister.Result, target.Thunk);
-                            encoder.EmitMOV(ref storeAtEspPlus4, encoder.TargetRegister.Result);
+                            encoder.EmitMOV(ref storeAtEspPlus4, target.Thunk);
                         }
                         else
                         {


### PR DESCRIPTION
- The implementation is not always the most efficient possible but it's good enough that it passed all the NativeAOT smoke tests.
- We convert everything into tailcalls which is necessary to have the stack unwinding working and unaware of these helpers. Since x86 heavily relies on argument passing on stack we sometimes need to pop the return address, push more arguments on the stack, and then push the return address back. At the same time we don't have any registers to spare. To solve the issue I added the `EmitStackDup` helper that duplicates last DWORD on the stack (ie. the return address) and allows the previous slot to be overridden with the injected parameter.