### PR TITLE
x86/funclets: Fix enumerating GC refs in methods with exception handling and localloc

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10790,8 +10790,10 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 
     // TODO We may need EBP restore sequence here if we introduce PSPSym
 
+#ifdef UNIX_X86_ABI
     // Add a padding for 16-byte alignment
     inst_RV_IV(INS_sub, REG_SPBASE, 12, EA_PTRSIZE);
+#endif
 }
 
 /*****************************************************************************
@@ -10810,8 +10812,10 @@ void CodeGen::genFuncletEpilog()
 
     ScopedSetVariable<bool> _setGeneratingEpilog(&compiler->compGeneratingEpilog, true);
 
+#ifdef UNIX_X86_ABI
     // Revert a padding that was added for 16-byte alignment
     inst_RV_IV(INS_add, REG_SPBASE, 12, EA_PTRSIZE);
+#endif
 
     instGen_Return(0);
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10789,6 +10789,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
     compiler->unwindEndProlog();
 
     // TODO We may need EBP restore sequence here if we introduce PSPSym
+    CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef UNIX_X86_ABI
     // Add a padding for 16-byte alignment

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -4072,6 +4072,7 @@ bool UnwindEbpDoubleAlignFrame(
             // Set baseSP as initial SP
             baseSP += GetPushedArgSize(info, table, curOffs);
 
+#ifdef UNIX_X86_ABI
             // 16-byte stack alignment padding (allocated in genFuncletProlog)
             // Current funclet frame layout (see CodeGen::genFuncletProlog() and genFuncletEpilog()):
             //   prolog: sub esp, 12
@@ -4082,6 +4083,7 @@ bool UnwindEbpDoubleAlignFrame(
             const TADDR funcletStart = pCodeInfo->GetJitManager()->GetFuncletStartAddress(pCodeInfo);
             if (funcletStart != pCodeInfo->GetCodeAddress() && methodStart[pCodeInfo->GetRelOffset()] != X86_INSTR_RETN)
                 baseSP += 12;
+#endif
 
             pContext->PCTAddr = baseSP;
             pContext->ControlPC = *PTR_PCODE(pContext->PCTAddr);
@@ -4725,6 +4727,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
                     // Set baseSP as initial SP
                     baseSP += GetPushedArgSize(&info, table, curOffs);
 
+#ifdef UNIX_X86_ABI
                     // 16-byte stack alignment padding (allocated in genFuncletProlog)
                     // Current funclet frame layout (see CodeGen::genFuncletProlog() and genFuncletEpilog()):
                     //   prolog: sub esp, 12
@@ -4735,6 +4738,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
                     const PTR_CBYTE funcletStart = PTR_CBYTE(pCodeInfo->GetJitManager()->GetFuncletStartAddress(pCodeInfo));
                     if (funcletStart != methodStart + curOffs && methodStart[curOffs] != X86_INSTR_RETN)
                         baseSP += 12;
+#endif
 
                     // -sizeof(void*) because we want to point *AT* first parameter
                     pPendingArgFirst = (DWORD *)(size_t)(baseSP - sizeof(void*));

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -4724,6 +4724,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
                     TADDR baseSP = ESP;
                     // Set baseSP as initial SP
                     baseSP += GetPushedArgSize(&info, table, curOffs);
+
                     // 16-byte stack alignment padding (allocated in genFuncletProlog)
                     // Current funclet frame layout (see CodeGen::genFuncletProlog() and genFuncletEpilog()):
                     //   prolog: sub esp, 12
@@ -4731,7 +4732,8 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
                     //           ret
                     // SP alignment padding should be added for all instructions except the first one and the last one.
                     // Epilog may not exist (unreachable), so we need to check the instruction code.
-                    if (curOffs != 0 && methodStart[curOffs] != X86_INSTR_RETN)
+                    const PTR_CBYTE funcletStart = PTR_CBYTE(pCodeInfo->GetJitManager()->GetFuncletStartAddress(pCodeInfo));
+                    if (funcletStart != methodStart + curOffs && methodStart[curOffs] != X86_INSTR_RETN)
                         baseSP += 12;
 
                     // -sizeof(void*) because we want to point *AT* first parameter


### PR DESCRIPTION
The stack layout is different inside funclets. Moreover, in the NativeAOT ABI there's no slot with ESP for localloc methods (https://github.com/dotnet/coreclr/pull/8319), so `GetOutermostBaseFP` would read incorrect information.