### PR TITLE
Remove RuntimeIdentifiers from Microsoft.NETCore.App.Crossgen2.sfxproj

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -10,12 +10,6 @@
     <OverridePackageId>$(SharedFrameworkName)$(PgoSuffix).$(RuntimeIdentifier)</OverridePackageId>
     <ArchiveName>dotnet-crossgen2</ArchiveName>
     <SharedFrameworkHostFileNameOverride>crossgen2</SharedFrameworkHostFileNameOverride>
-    <!-- Build this pack for any RID if building from source. Otherwise, only build select RIDs. -->
-    <RuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true'">linux-x64;linux-musl-x64;linux-arm;linux-musl-arm;linux-arm64;linux-musl-arm64;osx-x64;osx-arm64;win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <!-- runtime/apphost packs of these platforms aren't built in the official build, so only reference the RIDs when we are targetting the community-supported platforms. -->
-    <RuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetOS)' == 'freebsd'">$(RuntimeIdentifiers);freebsd-x64;freebsd-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetsLinuxMusl)' == 'true' and '$(TargetArchitecture)' == 'riscv64'">$(RuntimeIdentifiers);linux-musl-riscv64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="'$(DotNetBuildSourceOnly)' != 'true' and '$(TargetsLinux)' == 'true' and '$(TargetsLinuxMusl)' != 'true' and '$(TargetArchitecture)' == 'riscv64'">$(RuntimeIdentifiers);linux-riscv64</RuntimeIdentifiers>
     <GenerateInstallers>false</GenerateInstallers>
     <HostJsonTargetPath>tools/</HostJsonTargetPath>
     <PermitDllAndExeFilesLackingFileVersion>true</PermitDllAndExeFilesLackingFileVersion>


### PR DESCRIPTION
It shouldn't be needed according to https://github.com/dotnet/runtime/pull/98948#discussion_r1503223785

Running a test official build in https://dev.azure.com/dnceng/internal/_build/results?buildId=2392869&view=results