### PR TITLE
Special case arrays in Enumerable.DefaultIfEmpty

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -18,6 +18,11 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
+            if (source is TSource[] { Length: > 0 })
+            {
+                return source;
+            }
+
             return new DefaultIfEmptyIterator<TSource>(source, defaultValue);
         }
 


### PR DESCRIPTION
Arrays are fixed-length, and DefaultIfEmpty only applies special behaviors on top of the input enumerable if it's empty. Thus, we can special-case arrays, such that if the input is a non-empty array, we just return the original input rather than wrapping it in a new enumerable.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public partial class Tests
{
    private int[] _data = Enumerable.Range(0, 1000).ToArray();

    [Benchmark]
    public double Average() => _data.DefaultIfEmpty().Average();
}
```

| Method | Toolchain         | Mean       | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |-----------:|------:|----------:|------------:|
| Average | \main\corerun.exe | 3,098.3 ns |  1.00 |      80 B |        1.00 |
| Average | \pr\corerun.exe   |   145.0 ns |  0.05 |         - |        0.00 |
