### PR TITLE
Disable failing outerloop regex test

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
@@ -1409,6 +1409,7 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/98962")]
         [Theory]
         [MemberData(nameof(RecreationalRegex_Rectangle_MemberData))]
         [OuterLoop("May take several seconds")]


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/98962