### PR TITLE
Get Count of IReadOnlyCollection object in TryGetNonEnumeratedCount method

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -15,8 +15,7 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            int count = 0;
-            if (source.TryGetNonEnumeratedCount(out count))
+            if (source.TryGetNonEnumeratedCount(out int count))
             {
                 return count;
             }

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -15,22 +15,12 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (source is ICollection<TSource> collectionoft)
-            {
-                return collectionoft.Count;
-            }
-
-            if (source is IIListProvider<TSource> listProv)
-            {
-                return listProv.GetCount(onlyIfCheap: false);
-            }
-
-            if (source is ICollection collection)
-            {
-                return collection.Count;
-            }
-
             int count = 0;
+            if (source.TryGetNonEnumeratedCount(out count))
+            {
+                return count;
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 checked

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -99,6 +99,12 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
+            if (source is IReadOnlyCollection<TSource> readonlyCollection)
+            {
+                count = readonlyCollection.Count;
+                return true;
+            }
+
             if (source is ICollection<TSource> collectionoft)
             {
                 count = collectionoft.Count;

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
@@ -173,7 +174,7 @@ namespace System.Linq.Tests
 
             IEnumerator IEnumerable.GetEnumerator()
             {
-                return GetEnumerator();
+                return GetEnumerator<T>();
             }
 
             public int Count => 1;

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -164,6 +164,29 @@ namespace System.Linq.Tests
             }
         }
 
+        private class MockReadOnlyCollection<T> : IReadOnlyCollection<T>
+        {
+            public IEnumerator<T> GetEnumerator()
+            {
+                throw new InvalidOperationException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+
+            public int Count => 1;
+        }
+
+        [Fact]
+        public void NonEnumeratedCount_ShouldNotEnumerateReadOnlyCollection()
+        {
+            var readOnlyCollection = new MockReadOnlyCollection<int>();
+            Assert.True(readOnlyCollection.TryGetNonEnumeratedCount(out var count));
+            Assert.Equal(1, count);
+        }
+
         public static IEnumerable<object[]> NonEnumeratedCount_SupportedEnumerables()
         {
             yield return WrapArgs(4, new int[]{ 1, 2, 3, 4 });
@@ -199,7 +222,7 @@ namespace System.Linq.Tests
                 yield return WrapArgs(Enumerable.Range(1, 100));
                 yield return WrapArgs(Enumerable.Repeat(1, 80));
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
-                yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));            
+                yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
                 yield return WrapArgs(Enumerable.Range(1, 20).Reverse());
                 yield return WrapArgs(Enumerable.Range(1, 20).OrderBy(x => -x));


### PR DESCRIPTION
## What

This PR allows [TryGetNonEnumeratedCount](https://github.com/dotnet/runtime/blob/463869be4569c9557cb1545c5e5850fecd5f9cd0/src/libraries/System.Linq/src/System/Linq/Count.cs#L95) to use `IReadOnlyCollection.Count` which avoids unnecessary enumeration.