### PR TITLE
Stop overbuilding runtime-prereqs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -313,6 +313,8 @@
                                   '$(OfficialBuildId)' == ''">true</DisableSourceLink>
     <!-- Runtime doesn't support Arcade-driven target framework filtering. -->
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
+
+    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
   </PropertyGroup>
 
   <!-- RepositoryEngineeringDir isn't set when Installer tests import this file. -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -255,7 +255,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.nativeprereqs+'))">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime-prereqs.proj" Category="clr" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime-prereqs.proj" Category="clr" GlobalPropertiesToRemove="CMakeArgs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -255,7 +255,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != '' or $(_subset.Contains('+clr.nativeprereqs+'))">
-    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime-prereqs.proj" Category="clr" GlobalPropertiesToRemove="CMakeArgs" />
+    <ProjectToBuild Include="$(CoreClrProjectRoot)runtime-prereqs.proj" Category="clr" GlobalPropertiesToRemove="$(NativeBuildPartitionPropertiesToRemove)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">

--- a/src/coreclr/Directory.Build.props
+++ b/src/coreclr/Directory.Build.props
@@ -1,5 +1,4 @@
 <Project>
-
   <PropertyGroup>
     <InferPlatformFromTargetArchitecture>true</InferPlatformFromTargetArchitecture>
 
@@ -27,9 +26,4 @@
     <SignAssembly Condition="'$(UsingMicrosoftNETSdk)' != 'true'">false</SignAssembly>
     <CL_MPCount>$(NumberOfCores)</CL_MPCount>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
-  </PropertyGroup>
-
 </Project>

--- a/src/coreclr/Directory.Build.props
+++ b/src/coreclr/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project>
+
   <PropertyGroup>
     <InferPlatformFromTargetArchitecture>true</InferPlatformFromTargetArchitecture>
 
@@ -26,4 +27,9 @@
     <SignAssembly Condition="'$(UsingMicrosoftNETSdk)' != 'true'">false</SignAssembly>
     <CL_MPCount>$(NumberOfCores)</CL_MPCount>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
+  </PropertyGroup>
+
 </Project>

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="runtime-prereqs.proj" GlobalPropertiesToRemove="$(NativeBuildPartitionPropertiesToRemove);CMakeArgs" />
+    <ProjectReference Include="runtime-prereqs.proj" GlobalPropertiesToRemove="$(NativeBuildPartitionPropertiesToRemove)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true'">

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="runtime-prereqs.proj" GlobalPropertiesToRemove="$(NativeBuildPartitionPropertiesToRemove)" />
+    <ProjectReference Include="runtime-prereqs.proj" GlobalPropertiesToRemove="$(NativeBuildPartitionPropertiesToRemove);CMakeArgs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true'">

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
     <_IcuDir Condition="'$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)' != ''">$(PkgMicrosoft_NETCore_Runtime_ICU_Transport)/runtimes/$(TargetOS)-$(TargetArchitecture)$(_RuntimeVariant)/native</_IcuDir>
 
     <_BuildNativeTargetOS>$(TargetOS)</_BuildNativeTargetOS>


### PR DESCRIPTION
runtime-preqreqs is built twice with different global properties. Here's the global property diff: https://www.diffchecker.com/EN5CN7vm/

I noticed that runtime.proj is invoked with different global properties than runtime-prereqs.proj and those global properties weren't removed.