### PR TITLE
[RISC-V] Add missing jumpTable increment

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2867,6 +2867,7 @@ void CodeGen::genJumpTable(GenTree* treeNode)
     for (unsigned i = 0; i < jumpCount; i++)
     {
         BasicBlock* target = (*jumpTable)->getDestinationBlock();
+        jumpTable++;
         noway_assert(target->HasFlag(BBF_HAS_LABEL));
 
         JITDUMP("            DD      L_M%03u_" FMT_BB "\n", compiler->compMethodID, target->bbNum);


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/98671 we noticed that some of coreclr tests started crashing because of infinite recursion seen like:
```
root@3b821d4a686a:/runtime/artifacts/tests/coreclr/linux.riscv64.Checked/CoreMangLib/system/buffer/ASURT_99893# $CORE_ROOT/corerun -p System.Reflection.Metadata.MetadataUpdater.IsSupported=false -p System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization=true ASURT_99893.dll '' Process terminated. Encountered infinite recursion while looking up resource 'Arg_ResourceFileUnsupportedVersion' in System.Private.CoreLib. Verify the installation of .NET is complete and does not need repairing, and that the state of the process has not become corrupted.
   at System.Environment.FailFast(System.String)
   at System.SR.InternalGetResourceString(System.String)
   at System.SR.GetResourceString(System.String)
   at System.SR.get_Arg_ResourceFileUnsupportedVersion()
   at System.Resources.ResourceReader._ReadResources()
   at System.Resources.ResourceReader.ReadResources()
   at System.Resources.ResourceReader..ctor(System.IO.Stream, System.Collections.Generic.Dictionary`2<System.String,System.Resources.ResourceLocator>, Boolean)
   at System.Resources.RuntimeResourceSet..ctor(System.IO.Stream, Boolean)
   at System.Resources.ManifestBasedResourceGroveler.CreateResourceSet(System.IO.Stream, System.Reflection.Assembly)
   at System.Resources.ManifestBasedResourceGroveler.GrovelForResourceSet(System.Globalization.CultureInfo, System.Collections.Generic.Dictionary`2<System.String,System.Resources.ResourceSet>, Boolean, Boolean)
   at System.Resources.ResourceManager.InternalGetResourceSet(System.Globalization.CultureInfo, Boolean, Boolean)
   at System.Resources.ResourceManager.GetString(System.String, System.Globalization.CultureInfo)
   at System.SR.InternalGetResourceString(System.String)
   at System.SR.GetResourceString(System.String)
   at System.SR.get_Arg_ResourceFileUnsupportedVersion()
   at System.Resources.ResourceReader._ReadResources()
   at System.Resources.ResourceReader.ReadResources()
   at System.Resources.ResourceReader..ctor(System.IO.Stream, System.Collections.Generic.Dictionary`2<System.String,System.Resources.ResourceLocator>, Boolean)
   at System.Resources.RuntimeResourceSet..ctor(System.IO.Stream, Boolean)
   at System.Resources.ManifestBasedResourceGroveler.CreateResourceSet(System.IO.Stream, System.Reflection.Assembly)
   at System.Resources.ManifestBasedResourceGroveler.GrovelForResourceSet(System.Globalization.CultureInfo, System.Collections.Generic.Dictionary`2<System.String,System.Resources.ResourceSet>, Boolean, Boolean)
```
This change fixes issue by adding missing jumpTable increment.

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov @viewizard @ashaurtaev @brucehoult @sirntar @yurai007 @Bajtazar @bartlomiejko @rzsc @tomeksowi @amanasifkhalid 