### PR TITLE
Disable IPV6 cases of QuicConnectionTests.TestConnect on non-ipv6 systems

### DIFF
--- a/src/libraries/Common/tests/System/Net/Configuration.Sockets.cs
+++ b/src/libraries/Common/tests/System/Net/Configuration.Sockets.cs
@@ -29,7 +29,7 @@ namespace System.Net.Test.Common
                 {
                     yield return new[] { IPAddress.Loopback };
                 }
-                if (Socket.OSSupportsIPv6)
+                if (Socket.OSSupportsIPv6 && IsIPv6LoopbackAvailable)
                 {
                     yield return new[] { IPAddress.IPv6Loopback };
                 }
@@ -46,6 +46,23 @@ namespace System.Net.Test.Common
                     .Select(a => a.Address)
                     .Where(a => a.IsIPv6LinkLocal)
                     .FirstOrDefault();
+
+            private static readonly Lazy<bool> _isIPv6LoopbackAvailable = new Lazy<bool>(GetIsIPv6LoopbackAvailable);
+            public static bool IsIPv6LoopbackAvailable => _isIPv6LoopbackAvailable.Value;
+
+            private static bool GetIsIPv6LoopbackAvailable()
+            {
+                try
+                {
+                    using Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
+                    s.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+                    return true;
+                }
+                catch (SocketException)
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,10 +23,15 @@ namespace System.Net.Quic.Tests
 
         public QuicConnectionTests(ITestOutputHelper output) : base(output) { }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(LocalAddresses))]
         public async Task TestConnect(IPAddress address)
         {
+            if (address.AddressFamily == AddressFamily.InterNetworkV6 && !IsIPv6Available)
+            {
+                throw new SkipTestException("IPv6 is not available on this platform");
+            }
+
             await using QuicListener listener = await CreateQuicListener(address);
             Assert.Equal(address, listener.LocalEndPoint.Address);
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -27,11 +27,6 @@ namespace System.Net.Quic.Tests
         [MemberData(nameof(LocalAddresses))]
         public async Task TestConnect(IPAddress address)
         {
-            if (address.AddressFamily == AddressFamily.InterNetworkV6 && !IsIPv6Available)
-            {
-                throw new SkipTestException("IPv6 is not available on this platform");
-            }
-
             await using QuicListener listener = await CreateQuicListener(address);
             Assert.Equal(address, listener.LocalEndPoint.Address);
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestBase.cs
@@ -18,6 +18,8 @@ using Microsoft.Quic;
 
 namespace System.Net.Quic.Tests
 {
+    using Configuration = System.Net.Test.Common.Configuration;
+
     public abstract class QuicTestBase : IDisposable
     {
         public const long DefaultStreamErrorCodeClient = 123456;
@@ -31,8 +33,7 @@ namespace System.Net.Quic.Tests
         public static bool IsSupported => QuicListener.IsSupported && QuicConnection.IsSupported;
         public static bool IsNotArm32CoreClrStressTest => !(CoreClrConfigurationDetection.IsStressTest && PlatformDetection.IsArmProcess);
 
-        private static readonly Lazy<bool> _isIPv6Available = new Lazy<bool>(GetIsIPv6Available);
-        public static bool IsIPv6Available => _isIPv6Available.Value;
+        public static bool IsIPv6Available => Configuration.Sockets.IsIPv6LoopbackAvailable;
 
         public static SslApplicationProtocol ApplicationProtocol { get; } = new SslApplicationProtocol("quictest");
 
@@ -373,20 +374,6 @@ namespace System.Net.Quic.Tests
             finally
             {
                 ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-
-        internal static bool GetIsIPv6Available()
-        {
-            try
-            {
-                using Socket s = new Socket(AddressFamily.InterNetworkV6, SocketType.Dgram, ProtocolType.Udp);
-                s.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
-                return true;
-            }
-            catch (SocketException)
-            {
-                return false;
             }
         }
     }


### PR DESCRIPTION
I am not sure why the ::1 address is included in `LocalAddresses` if system does not support IPv6, but we do similar filtering of IPv6 addresses in other tests.