### PR TITLE
Set the wasRelocHandled flag

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
@@ -878,7 +878,6 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
                 break;
 
                 case IMAGE_REL_ARM64_PAGEOFFSET_12A: // ADD 12 bit page offset
-                case IMAGE_REL_AARCH64_TLSDESC_ADD_LO12: // TLSDESC ADD for corresponding ADRP
                 {
                     if ((section_begin <= address) && (address < section_end)) // A reloc for our section?
                     {
@@ -889,25 +888,13 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
                 }
                 break;
 
-                case IMAGE_REL_AARCH64_TLSDESC_CALL:
-                case IMAGE_REL_TLSGD:
-                {
-                    DWORDLONG fixupLocation = tmp.location;
-
-                    size_t address = section_begin + (size_t)fixupLocation - (size_t)originalAddr;
-                    if ((section_begin <= address) && (address < section_end)) // A reloc for our section?
-                    {
-                        LogDebug("    fixupLoc-%016" PRIX64 " (@%p) : %08X => %08X", fixupLocation, address,
-                                 *(DWORD*)address, (DWORD)tmp.target);
-                        *(DWORD*)address = (DWORD)tmp.target;
-                    }
-                    wasRelocHandled = true;
-                }
-                break;
-
                 case IMAGE_REL_AARCH64_TLSDESC_LD64_LO12:
+                case IMAGE_REL_AARCH64_TLSDESC_ADD_LO12: // TLSDESC ADD for corresponding ADRP
+                case IMAGE_REL_AARCH64_TLSDESC_CALL:
                 {
-                    // not needed
+                    // These are patched later by linker during actual execution
+                    // and do not need relocation.
+                    wasRelocHandled = true;
                 }
                 break;
 
@@ -936,6 +923,12 @@ void CompileResult::applyRelocs(RelocContext* rc, unsigned char* block1, ULONG b
                     *(DWORDLONG*)address = tmp.target;
                 }
 
+                wasRelocHandled = true;
+            }
+            else if (relocType == IMAGE_REL_TLSGD)
+            {
+                // These are patched later by linker during actual execution
+                // and do not need relocation.
                 wasRelocHandled = true;
             }
         }


### PR DESCRIPTION
In my earlier fix in https://github.com/dotnet/runtime/pull/98840, I forgot to set the flag `wasRelocHandled ` to indicate the the relocation was handled.


 Fixes# https://github.com/dotnet/runtime/issues/98996