### PR TITLE
Mark Vector.IsSupported as intrinsic

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
@@ -181,6 +181,7 @@ namespace System.Numerics
         /// <returns><c>true</c> if <typeparamref name="T" /> is supported; otherwise, <c>false</c>.</returns>
         public static bool IsSupported
         {
+            [Intrinsic]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => (typeof(T) == typeof(byte)) ||
                    (typeof(T) == typeof(double)) ||


### PR DESCRIPTION
It's already handled by the runtime and was just missing the attribute.

cc @tannergooding 