### PR TITLE
Increase timeout in profiler multiple test

### DIFF
--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -35,7 +35,7 @@ namespace Profiler.Tests
             }
 
             Console.WriteLine("Waiting for profilers to all detach");
-            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(5)))
+            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(10)))
             {
                 Console.WriteLine("Profiler did not set the callback, test will fail.");
             }

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -37,7 +37,7 @@ namespace Profiler.Tests
             Console.WriteLine("Waiting for profilers to all detach");
             if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(10)))
             {
-                Console.WriteLine("Profiler did not set the callback, test will fail.");
+                Console.WriteLine("Test timed out waiting for the profilers to set the callback, test will fail.");
             }
 
             return 100;


### PR DESCRIPTION
Test is timing out from the event on arm64.