### PR TITLE
Fix exception in BitArray.CopyTo  when destination array is too small

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Collections/src/System/Collections/BitArray.cs
@@ -756,6 +756,11 @@ namespace System.Collections
 
             if (array is int[] intArray)
             {
+                if (array.Length - index < GetInt32ArrayLengthFromBitLength(m_length))
+                {
+                    throw new ArgumentException(SR.Argument_InvalidOffLen);
+                }
+
                 Div32Rem(m_length, out int extraBits);
 
                 if (extraBits == 0)

--- a/src/libraries/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
+++ b/src/libraries/System.Collections/tests/BitArray/BitArray_GetSetTests.cs
@@ -452,19 +452,13 @@ namespace System.Collections.Tests
         [InlineData(default(int), BitsPerInt32, 1, 1)]
         [InlineData(default(int), BitsPerInt32 * 4, 4 - 1, 0)]
         [InlineData(default(int), BitsPerInt32 * 4, 4, 1)]
-        public static void CopyTo_Size_Invalid<T>(T def, int bits, int arraySize, int index)
+        [InlineData(default(int), BitsPerInt32 + 1, 1, 0)]
+        public static void CopyTo_Size_Invalid<T>(T _, int bits, int arraySize, int index)
         {
             ICollection bitArray = new BitArray(bits);
             T[] array = (T[])Array.CreateInstance(typeof(T), arraySize);
             AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => bitArray.CopyTo(array, -1));
-            if (def is int)
-            {
-                AssertExtensions.Throws<ArgumentException>("destinationArray", string.Empty, () => bitArray.CopyTo(array, index));
-            }
-            else
-            {
-                AssertExtensions.Throws<ArgumentException>(null, () => bitArray.CopyTo(array, index));
-            }
+            AssertExtensions.Throws<ArgumentException>(null, () => bitArray.CopyTo(array, index));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #98859