### PR TITLE
Reduce tolerances for floating point types in TP tests.

### DIFF
--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -12,11 +12,14 @@ namespace System.Numerics.Tensors.Tests
 
         public static IEnumerable<int> TensorLengths => Enumerable.Range(1, 256);
 
-        private const float DefaultFloatTolerance = 1e-6f;
-#if NETCOREAPP
-        private const double DefaultDoubleTolerance = 1e-15;
-        private const float DefaultHalfTolerance = 1e-4f;
+        // Tolerances taken from testing in the scalar math routines:
+        // cf. https://github.com/dotnet/runtime/blob/89f7ad3b276fb0b48f20cb4e8408bdce85c2b415/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Math.cs
+        public const double DefaultDoubleTolerance = 8.8817841970012523e-16;
+        public const float DefaultFloatTolerance = 4.76837158e-07f;
+        public const float DefaultHalfTolerance = 1e-4f;
+        public const double DefaultToleranceForEstimates = 1.171875e-02;
 
+#if NETCOREAPP
         private static class DefaultTolerance<T> where T : unmanaged, INumber<T>
         {
             public static readonly T Value = DetermineTolerance<T>(DefaultDoubleTolerance, DefaultFloatTolerance, Half.CreateTruncating(DefaultHalfTolerance)) ?? T.CreateTruncating(0);

--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -11,5 +11,56 @@ namespace System.Numerics.Tensors.Tests
         public static IEnumerable<int> TensorLengthsIncluding0 => Enumerable.Range(0, 257);
 
         public static IEnumerable<int> TensorLengths => Enumerable.Range(1, 256);
+
+        private const float DefaultFloatTolerance = 1e-6f;
+#if NETCOREAPP
+        private const double DefaultDoubleTolerance = 1e-15;
+        private const float DefaultHalfTolerance = 1e-4f;
+
+        private static class DefaultTolerance<T> where T : unmanaged, INumber<T>
+        {
+            public static readonly T Value = DetermineTolerance<T>(DefaultDoubleTolerance, DefaultFloatTolerance, Half.CreateTruncating(DefaultHalfTolerance)) ?? T.CreateTruncating(0);
+        }
+
+        public static bool IsEqualWithTolerance<T>(T expected, T actual, T? tolerance = null) where T : unmanaged, INumber<T>
+        {
+            tolerance = tolerance ?? DefaultTolerance<T>.Value;
+            T diff = T.Abs(expected - actual);
+            return !(diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance);
+        }
+#else
+        public static bool IsEqualWithTolerance(float expected, float actual, float? tolerance = null)
+        {
+            tolerance ??= DefaultFloatTolerance;
+            float diff = MathF.Abs(expected - actual);
+            return !(diff > tolerance && diff > MathF.Max(MathF.Abs(expected), MathF.Abs(actual)) * tolerance);
+        }
+#endif
+
+        public static T? DetermineTolerance<T>(
+            double? doubleTolerance = null,
+            float? floatTolerance = null
+#if NETCOREAPP
+            , Half? halfTolerance = null
+#endif
+            ) where T : struct
+        {
+            if (typeof(T) == typeof(double) && doubleTolerance != null)
+            {
+                return (T?)(object)doubleTolerance;
+            }
+            else if (typeof(T) == typeof(float) && floatTolerance != null)
+            {
+                return (T?)(object)floatTolerance;
+            }
+#if NETCOREAPP
+            else if (typeof(T) == typeof(Half) && halfTolerance != null)
+            {
+                return (T?)(object)halfTolerance;
+            }
+#endif
+
+            return null;
+        }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -14,9 +14,10 @@ namespace System.Numerics.Tensors.Tests
 
         // Tolerances taken from testing in the scalar math routines:
         // cf. https://github.com/dotnet/runtime/blob/89f7ad3b276fb0b48f20cb4e8408bdce85c2b415/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Math.cs
+        // and https://github.com/dotnet/runtime/blob/fd48b6f5d1ff81a81d09e9d72982cc9e8d139852/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
         public const double DefaultDoubleTolerance = 8.8817841970012523e-16;
         public const float DefaultFloatTolerance = 4.76837158e-07f;
-        public const float DefaultHalfTolerance = 1e-4f;
+        public const float DefaultHalfTolerance = 3.90625e-03f;
         public const double DefaultToleranceForEstimates = 1.171875e-02;
 
 #if NETCOREAPP

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -366,7 +366,7 @@ namespace System.Numerics.Tensors.Tests
             // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cosh), new Func<T, T>(T.Cosh), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14) };
             // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.CosPi), new Func<T, T>(T.CosPi), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.CosPi), new Func<T, T>(T.CosPi), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4, floatTolerance: 1e-4f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.DegreesToRadians), new Func<T, T>(T.DegreesToRadians) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp), new Func<T, T>(T.Exp) };
             // TODO https://github.com/dotnet/runtime/issues/98861
@@ -388,11 +388,9 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Log10P1), new Func<T, T>(T.Log10P1) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.RadiansToDegrees), new Func<T, T>(T.RadiansToDegrees) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Reciprocal), new Func<T, T>(f => T.One / f) };
-            // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalEstimate), new Func<T, T>(T.ReciprocalEstimate), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-3, floatTolerance: 1e-3f) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalEstimate), new Func<T, T>(T.ReciprocalEstimate), T.CreateTruncating(Helpers.DefaultToleranceForEstimates) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrt), new Func<T, T>(f => T.One / T.Sqrt(f)) };
-            // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrtEstimate), new Func<T, T>(T.ReciprocalSqrtEstimate), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-3, floatTolerance: 1e-3f) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrtEstimate), new Func<T, T>(T.ReciprocalSqrtEstimate), T.CreateTruncating(Helpers.DefaultToleranceForEstimates) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Round), new Func<T, T>(T.Round) };
             // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sin), new Func<T, T>(T.Sin), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
@@ -518,6 +516,7 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Hypot), new Func<T, T, T>(T.Hypot) };
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Ieee754Remainder), new Func<T, T, T>(T.Ieee754Remainder) };
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Log), new Func<T, T, T>(T.Log) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
         }
 
@@ -581,7 +580,7 @@ namespace System.Numerics.Tensors.Tests
                     tensorPrimitivesMethod(x.Span, y.Span, destination.Span);
                     for (int i = 0; i < tensorLength; i++)
                     {
-                        AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i]);
+                        AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i], tolerance);
                     }
                 }, y);
             });
@@ -746,13 +745,14 @@ namespace System.Numerics.Tensors.Tests
         {
             yield return new object[] { new ScalarSpanDestinationDelegate(TensorPrimitives.Atan2), new Func<T, T, T>(T.Atan2) };
             yield return new object[] { new ScalarSpanDestinationDelegate(TensorPrimitives.Atan2Pi), new Func<T, T, T>(T.Atan2Pi) };
-            yield return new object[] { new ScalarSpanDestinationDelegate(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new ScalarSpanDestinationDelegate(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow), Helpers.DetermineTolerance<T>(floatTolerance: 1e-4f)};
             yield return new object[] { new ScalarSpanDestinationDelegate(TensorPrimitives.Ieee754Remainder), new Func<T, T, T>(T.Ieee754Remainder) };
         }
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void SpanScalarFloatDestination_AllLengths(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanScalarFloatDestination_AllLengths(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -763,14 +763,14 @@ namespace System.Numerics.Tensors.Tests
                 tensorPrimitivesMethod(x, y, destination);
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(x, y[i]), destination[i]);
+                    AssertEqualTolerance(expectedMethod(x, y[i]), destination[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void SpanScalarFloatDestination_InPlace(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanScalarFloatDestination_InPlace(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -782,14 +782,14 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(x, yOrig[i]), y[i]);
+                    AssertEqualTolerance(expectedMethod(x, yOrig[i]), y[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void ScalarSpanDestination_SpecialValues(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void ScalarSpanDestination_SpecialValues(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
@@ -802,7 +802,7 @@ namespace System.Numerics.Tensors.Tests
                     tensorPrimitivesMethod(x, y.Span, destination.Span);
                     for (int i = 0; i < tensorLength; i++)
                     {
-                        AssertEqualTolerance(expectedMethod(x, y[i]), destination[i]);
+                        AssertEqualTolerance(expectedMethod(x, y[i]), destination[i], tolerance);
                     }
                 }, y);
             });
@@ -810,8 +810,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void SpanScalarFloatDestination_ThrowsForTooShortDestination(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanScalarFloatDestination_ThrowsForTooShortDestination(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 T x = NextRandom();
@@ -824,8 +827,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(ScalarSpanFloatDestinationFunctionsToTest))]
-        public void SpanScalarFloatDestination_ThrowsForOverlapppingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanScalarFloatDestination_ThrowsForOverlapppingInputsWithOutputs(ScalarSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(default, array.AsSpan(1, 2), array.AsSpan(0, 2)));
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(default, array.AsSpan(1, 2), array.AsSpan(2, 2)));

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -362,7 +362,7 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cbrt), new Func<T, T>(T.Cbrt), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Ceiling), new Func<T, T>(T.Ceiling) };
             // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cos), new Func<T, T>(T.Cos), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cos), new Func<T, T>(T.Cos), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4, floatTolerance: 1e-4f) };
             // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cosh), new Func<T, T>(T.Cosh), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14) };
             // TODO https://github.com/dotnet/runtime/issues/98861
@@ -393,14 +393,14 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrtEstimate), new Func<T, T>(T.ReciprocalSqrtEstimate), T.CreateTruncating(Helpers.DefaultToleranceForEstimates) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Round), new Func<T, T>(T.Round) };
             // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sin), new Func<T, T>(T.Sin), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sin), new Func<T, T>(T.Sin), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
             // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sinh), new Func<T, T>(T.Sinh), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14) };
             // TODO https://github.com/dotnet/runtime/issues/98861
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.SinPi), new Func<T, T>(T.SinPi), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sqrt), new Func<T, T>(T.Sqrt) };
             // TODO https://github.com/dotnet/runtime/issues/98861
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tan), new Func<T, T>(T.Tan), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-10) };
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tan), new Func<T, T>(T.Tan), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-10, floatTolerance: 1e-4f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tanh), new Func<T, T>(T.Tanh) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.TanPi), new Func<T, T>(T.TanPi) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Truncate), new Func<T, T>(T.Truncate) };

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -113,7 +113,7 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    if (!IsEqualWithTolerance(TTo.CreateTruncating(source.Span[i]), destination.Span[i]))
+                    if (!Helpers.IsEqualWithTolerance(TTo.CreateTruncating(source.Span[i]), destination.Span[i]))
                     {
                         throw new XunitException($"{typeof(TFrom).Name} => {typeof(TTo).Name}. Input: {source.Span[i]}. Actual: {destination.Span[i]}. Expected: {TTo.CreateTruncating(source.Span[i])}.");
                     }
@@ -145,7 +145,7 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    if (!IsEqualWithTolerance(TTo.CreateSaturating(source.Span[i]), destination.Span[i]))
+                    if (!Helpers.IsEqualWithTolerance(TTo.CreateSaturating(source.Span[i]), destination.Span[i]))
                     {
                         throw new XunitException($"{typeof(TFrom).Name} => {typeof(TTo).Name}. Input: {source.Span[i]}. Actual: {destination.Span[i]}. Expected: {TTo.CreateSaturating(source.Span[i])}.");
                     }
@@ -177,7 +177,7 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    if (!IsEqualWithTolerance(TTo.CreateChecked(source.Span[i]), destination.Span[i]))
+                    if (!Helpers.IsEqualWithTolerance(TTo.CreateChecked(source.Span[i]), destination.Span[i]))
                     {
                         throw new XunitException($"{typeof(TFrom).Name} => {typeof(TTo).Name}. Input: {source.Span[i]}. Actual: {destination.Span[i]}. Expected: {TTo.CreateChecked(source.Span[i])}.");
                     }
@@ -199,7 +199,7 @@ namespace System.Numerics.Tensors.Tests
                 TensorPrimitives.ConvertChecked<TFrom, TTo>(source.Span, destination.Span);
                 foreach (TTo result in destination.Span)
                 {
-                    Assert.True(IsEqualWithTolerance(TTo.CreateChecked(valid), result));
+                    Assert.True(Helpers.IsEqualWithTolerance(TTo.CreateChecked(valid), result));
                 }
 
                 // Test with at least one invalid
@@ -210,19 +210,6 @@ namespace System.Numerics.Tensors.Tests
                     Assert.Throws<OverflowException>(() => TensorPrimitives.ConvertChecked<TFrom, TTo>(source.Span, destination.Span));
                 }
             };
-        }
-
-        private static bool IsEqualWithTolerance<T>(T expected, T actual, T? tolerance = null) where T : unmanaged, INumber<T>
-        {
-            tolerance ??= T.CreateTruncating(0.0001);
-
-            T diff = T.Abs(expected - actual);
-            if (diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance)
-            {
-                return false;
-            }
-
-            return true;
         }
     }
 
@@ -371,18 +358,27 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Atanh), new Func<T, T>(T.Atanh) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.AtanPi), new Func<T, T>(T.AtanPi) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Atan), new Func<T, T>(T.Atan) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cbrt), new Func<T, T>(T.Cbrt) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cbrt), new Func<T, T>(T.Cbrt), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Ceiling), new Func<T, T>(T.Ceiling) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cos), new Func<T, T>(T.Cos) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cosh), new Func<T, T>(T.Cosh) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.CosPi), new Func<T, T>(T.CosPi) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cos), new Func<T, T>(T.Cos), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Cosh), new Func<T, T>(T.Cosh), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.CosPi), new Func<T, T>(T.CosPi), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-4) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.DegreesToRadians), new Func<T, T>(T.DegreesToRadians) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp), new Func<T, T>(T.Exp) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp2), new Func<T, T>(T.Exp2) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp10), new Func<T, T>(T.Exp10) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ExpM1), new Func<T, T>(T.ExpM1) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp2M1), new Func<T, T>(T.Exp2M1) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp10M1), new Func<T, T>(T.Exp10M1) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp2), new Func<T, T>(T.Exp2), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-6, floatTolerance: 1e-5f) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp10), new Func<T, T>(T.Exp10), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-6, floatTolerance: 1e-5f) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ExpM1), new Func<T, T>(T.ExpM1), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-6) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp2M1), new Func<T, T>(T.Exp2M1), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-6, floatTolerance: 1e-5f) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Exp10M1), new Func<T, T>(T.Exp10M1), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-6, floatTolerance: 1e-5f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Floor), new Func<T, T>(T.Floor) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Log), new Func<T, T>(T.Log) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Log2), new Func<T, T>(T.Log2) };
@@ -392,15 +388,21 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Log10P1), new Func<T, T>(T.Log10P1) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.RadiansToDegrees), new Func<T, T>(T.RadiansToDegrees) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Reciprocal), new Func<T, T>(f => T.One / f) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalEstimate), new Func<T, T>(T.ReciprocalEstimate), T.CreateTruncating(1.171875e-02) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalEstimate), new Func<T, T>(T.ReciprocalEstimate), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-3, floatTolerance: 1e-3f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrt), new Func<T, T>(f => T.One / T.Sqrt(f)) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrtEstimate), new Func<T, T>(T.ReciprocalSqrtEstimate), T.CreateTruncating(1.171875e-02) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.ReciprocalSqrtEstimate), new Func<T, T>(T.ReciprocalSqrtEstimate), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-3, floatTolerance: 1e-3f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Round), new Func<T, T>(T.Round) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sin), new Func<T, T>(T.Sin) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sinh), new Func<T, T>(T.Sinh) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.SinPi), new Func<T, T>(T.SinPi) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sin), new Func<T, T>(T.Sin), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sinh), new Func<T, T>(T.Sinh), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.SinPi), new Func<T, T>(T.SinPi), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Sqrt), new Func<T, T>(T.Sqrt) };
-            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tan), new Func<T, T>(T.Tan) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tan), new Func<T, T>(T.Tan), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-10) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Tanh), new Func<T, T>(T.Tanh) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.TanPi), new Func<T, T>(T.TanPi) };
             yield return new object[] { new SpanDestinationDelegate(TensorPrimitives.Truncate), new Func<T, T>(T.Truncate) };
@@ -516,12 +518,12 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Hypot), new Func<T, T, T>(T.Hypot) };
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Ieee754Remainder), new Func<T, T, T>(T.Ieee754Remainder) };
             yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Log), new Func<T, T, T>(T.Log) };
-            yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow) };
+            yield return new object[] { new SpanSpanDestinationDelegate(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
         }
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_AllLengths(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanSpanDestination_AllLengths(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -532,14 +534,14 @@ namespace System.Numerics.Tensors.Tests
                 tensorPrimitivesMethod(x, y, destination);
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i]);
+                    AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_InPlace(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanSpanDestination_InPlace(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -550,14 +552,14 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(xOrig[i], xOrig[i]), x[i]);
+                    AssertEqualTolerance(expectedMethod(xOrig[i], xOrig[i]), x[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_SpecialValues(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanSpanDestination_SpecialValues(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
@@ -570,7 +572,7 @@ namespace System.Numerics.Tensors.Tests
                     tensorPrimitivesMethod(x.Span, y.Span, destination.Span);
                     for (int i = 0; i < tensorLength; i++)
                     {
-                        AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i]);
+                        AssertEqualTolerance(expectedMethod(x[i], y[i]), destination[i], tolerance);
                     }
                 }, x);
 
@@ -587,8 +589,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_ThrowsForMismatchedLengths(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanSpanDestination_ThrowsForMismatchedLengths(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -602,8 +607,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_ThrowsForTooShortDestination(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanSpanDestination_ThrowsForTooShortDestination(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -616,8 +624,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanSpanDestinationFunctionsToTest))]
-        public void SpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanSpanDestination_ThrowsForOverlapppingInputsWithOutputs(SpanSpanDestinationDelegate tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), array.AsSpan(5, 2), array.AsSpan(0, 2)));
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), array.AsSpan(5, 2), array.AsSpan(2, 2)));
@@ -633,7 +644,8 @@ namespace System.Numerics.Tensors.Tests
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Atan2Pi), new Func<T, T, T>(T.Atan2Pi) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.CopySign), new Func<T, T, T>(T.CopySign) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Ieee754Remainder), new Func<T, T, T>(T.Ieee754Remainder) };
-            yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Pow), new Func<T, T, T>(T.Pow), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-4f) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Log), new Func<T, T, T>(T.Log) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.Max), new Func<T, T, T>(T.Max) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, T, T>(TensorPrimitives.MaxMagnitude), new Func<T, T, T>(T.MaxMagnitude) };
@@ -643,7 +655,7 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_AllLengths(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanScalarDestination_AllLengths(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -654,14 +666,14 @@ namespace System.Numerics.Tensors.Tests
                 tensorPrimitivesMethod(x, y, destination);
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(x[i], y), destination[i]);
+                    AssertEqualTolerance(expectedMethod(x[i], y), destination[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_InPlace(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanScalarDestination_InPlace(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -673,14 +685,14 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(xOrig[i], y), x[i]);
+                    AssertEqualTolerance(expectedMethod(xOrig[i], y), x[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_SpecialValues(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod)
+        public void SpanScalarDestination_SpecialValues(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
@@ -693,7 +705,7 @@ namespace System.Numerics.Tensors.Tests
                     tensorPrimitivesMethod(x.Span, y, destination.Span);
                     for (int i = 0; i < tensorLength; i++)
                     {
-                        AssertEqualTolerance(expectedMethod(x[i], y), destination[i]);
+                        AssertEqualTolerance(expectedMethod(x[i], y), destination[i], tolerance);
                     }
                 }, x);
             });
@@ -701,8 +713,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_ThrowsForTooShortDestination(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanScalarDestination_ThrowsForTooShortDestination(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -715,8 +730,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanScalarDestinationFunctionsToTest))]
-        public void SpanScalarDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> _)
+        public void SpanScalarDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, T, T> tensorPrimitivesMethod, Func<T, T, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), default, array.AsSpan(0, 2)));
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), default, array.AsSpan(2, 2)));
@@ -817,13 +835,14 @@ namespace System.Numerics.Tensors.Tests
         #region Span,Int,Span -> Destination
         public static IEnumerable<object[]> SpanIntDestinationFunctionsToTest()
         {
-            yield return new object[] { new SpanScalarDestinationDelegate<T, int, T>(TensorPrimitives.RootN), new Func<T, int, T>(T.RootN) };
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            yield return new object[] { new SpanScalarDestinationDelegate<T, int, T>(TensorPrimitives.RootN), new Func<T, int, T>(T.RootN), Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13) };
             yield return new object[] { new SpanScalarDestinationDelegate<T, int, T>(TensorPrimitives.ScaleB), new Func<T, int, T>(T.ScaleB) };
         }
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_AllLengths(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod)
+        public void SpanIntDestination_AllLengths(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -834,14 +853,14 @@ namespace System.Numerics.Tensors.Tests
                 tensorPrimitivesMethod(x, y, destination);
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(x[i], y), destination[i]);
+                    AssertEqualTolerance(expectedMethod(x[i], y), destination[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_InPlace(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod)
+        public void SpanIntDestination_InPlace(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
@@ -853,14 +872,14 @@ namespace System.Numerics.Tensors.Tests
 
                 for (int i = 0; i < tensorLength; i++)
                 {
-                    AssertEqualTolerance(expectedMethod(xOrig[i], y), x[i]);
+                    AssertEqualTolerance(expectedMethod(xOrig[i], y), x[i], tolerance);
                 }
             });
         }
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_SpecialValues(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod)
+        public void SpanIntDestination_SpecialValues(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
@@ -873,7 +892,7 @@ namespace System.Numerics.Tensors.Tests
                     tensorPrimitivesMethod(x.Span, y, destination.Span);
                     for (int i = 0; i < tensorLength; i++)
                     {
-                        AssertEqualTolerance(expectedMethod(x[i], y), destination[i]);
+                        AssertEqualTolerance(expectedMethod(x[i], y), destination[i], tolerance);
                     }
                 }, x);
             });
@@ -881,8 +900,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_ThrowsForTooShortDestination(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> _)
+        public void SpanIntDestination_ThrowsForTooShortDestination(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -895,8 +917,11 @@ namespace System.Numerics.Tensors.Tests
 
         [Theory]
         [MemberData(nameof(SpanIntDestinationFunctionsToTest))]
-        public void SpanIntDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> _)
+        public void SpanIntDestination_ThrowsForOverlapppingInputsWithOutputs(SpanScalarDestinationDelegate<T, int, T> tensorPrimitivesMethod, Func<T, int, T> expectedMethod, T? tolerance = null)
         {
+            _ = expectedMethod;
+            _ = tolerance;
+
             T[] array = new T[10];
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), 2, array.AsSpan(0, 2)));
             AssertExtensions.Throws<ArgumentException>("destination", () => tensorPrimitivesMethod(array.AsSpan(1, 2), 2, array.AsSpan(2, 2)));
@@ -2071,10 +2096,7 @@ namespace System.Numerics.Tensors.Tests
 
         protected override void AssertEqualTolerance(T expected, T actual, T? tolerance = null)
         {
-            tolerance ??= T.CreateTruncating(0.0001);
-
-            T diff = T.Abs(expected - actual);
-            if (diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance)
+            if (!Helpers.IsEqualWithTolerance(expected, actual, tolerance))
             {
                 throw EqualException.ForMismatchedValues(expected, actual);
             }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.NonGeneric.Single.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.NonGeneric.Single.cs
@@ -106,10 +106,7 @@ namespace System.Numerics.Tensors.Tests
 
         protected override void AssertEqualTolerance(float expected, float actual, float? tolerance = null)
         {
-            tolerance ??= 0.0001f;
-
-            double diff = Math.Abs((double)expected - (double)actual);
-            if (diff > tolerance && diff > Math.Max(Math.Abs(expected), Math.Abs(actual)) * tolerance)
+            if (!Helpers.IsEqualWithTolerance(expected, actual, tolerance))
             {
                 throw EqualException.ForMismatchedValues(expected, actual);
             }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -3170,7 +3170,7 @@ namespace System.Numerics.Tensors.Tests
         public void SumOfMagnitudes_AllLengths()
         {
             // TODO https://github.com/dotnet/runtime/issues/98861
-            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12);
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12, floatTolerance: 1e-6f);
 
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
@@ -3192,7 +3192,7 @@ namespace System.Numerics.Tensors.Tests
         public void SumOfSquares_AllLengths()
         {
             // TODO https://github.com/dotnet/runtime/issues/98861
-            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12);
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12, floatTolerance: 1e-6f);
 
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -3149,7 +3149,7 @@ namespace System.Numerics.Tensors.Tests
         public void Sum_AllLengths()
         {
             // TODO https://github.com/dotnet/runtime/issues/98861
-            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14, floatTolerance: 1e-5f);
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13, floatTolerance: 1e-5f);
 
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitivesTests.cs
@@ -663,6 +663,9 @@ namespace System.Numerics.Tensors.Tests
         {
             if (!IsFloatingPoint) return;
 
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14);
+
             Assert.All(VectorLengthAndIteratedRange(ConvertFromSingle(-100f), ConvertFromSingle(100f), ConvertFromSingle(3f)), arg =>
             {
                 T[] x = new T[arg.Length];
@@ -674,7 +677,7 @@ namespace System.Numerics.Tensors.Tests
                 T expected = Cosh(arg.Element);
                 foreach (T actual in dest)
                 {
-                    AssertEqualTolerance(expected, actual);
+                    AssertEqualTolerance(expected, actual, tolerance);
                 }
             });
         }
@@ -952,6 +955,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void Dot_AllLengths()
         {
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14f, floatTolerance: 1e-3f);
+
             Assert.All(Helpers.TensorLengthsIncluding0, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -963,7 +969,7 @@ namespace System.Numerics.Tensors.Tests
                     dot = Add(dot, Multiply(x[i], y[i]));
                 }
 
-                AssertEqualTolerance(dot, Dot(x, y));
+                AssertEqualTolerance(dot, Dot(x, y), tolerance);
             });
         }
         #endregion
@@ -2879,6 +2885,9 @@ namespace System.Numerics.Tensors.Tests
         {
             if (!IsFloatingPoint) return;
 
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14);
+
             Assert.All(VectorLengthAndIteratedRange(ConvertFromSingle(-100f), ConvertFromSingle(100f), ConvertFromSingle(3f)), args =>
             {
                 T[] x = new T[args.Length];
@@ -2890,7 +2899,7 @@ namespace System.Numerics.Tensors.Tests
                 T expected = Sinh(args.Element);
                 foreach (T actual in dest)
                 {
-                    AssertEqualTolerance(expected, actual);
+                    AssertEqualTolerance(expected, actual, tolerance);
                 }
             });
         }
@@ -3139,6 +3148,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void Sum_AllLengths()
         {
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14, floatTolerance: 1e-5f);
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -3148,7 +3160,7 @@ namespace System.Numerics.Tensors.Tests
                 {
                     sum = Add(sum, value);
                 }
-                AssertEqualTolerance(sum, Sum(x));
+                AssertEqualTolerance(sum, Sum(x), tolerance);
             });
         }
         #endregion
@@ -3157,6 +3169,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void SumOfMagnitudes_AllLengths()
         {
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12);
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateTensor(tensorLength);
@@ -3167,7 +3182,7 @@ namespace System.Numerics.Tensors.Tests
                 {
                     sum = Add(sum, Abs(value));
                 }
-                AssertEqualTolerance(sum, SumOfMagnitudes(x));
+                AssertEqualTolerance(sum, SumOfMagnitudes(x), tolerance);
             });
         }
         #endregion
@@ -3176,6 +3191,9 @@ namespace System.Numerics.Tensors.Tests
         [Fact]
         public void SumOfSquares_AllLengths()
         {
+            // TODO https://github.com/dotnet/runtime/issues/98861
+            T? tolerance = Helpers.DetermineTolerance<T>(doubleTolerance: 1e-12);
+
             Assert.All(Helpers.TensorLengths, tensorLength =>
             {
                 using BoundedMemory<T> x = CreateAndFillTensor(tensorLength);
@@ -3185,7 +3203,7 @@ namespace System.Numerics.Tensors.Tests
                 {
                     sum = Add(sum, Multiply(value, value));
                 }
-                AssertEqualTolerance(sum, SumOfSquares(x));
+                AssertEqualTolerance(sum, SumOfSquares(x), tolerance);
             });
         }
         #endregion


### PR DESCRIPTION
Reduces the default tolerances to 15 digits for `double`, 6 digits for `float` and 4 digits for `Half`. Reworks the test cases such that tolerances can be overridden individually for each floating point type. The goal of this PR is to better quantify which TP methods deviate from the scalar implementations precision-wise.

Contributes to #98861.