### PR TITLE
Disable terminal logger when running from root build script

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -325,6 +325,9 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
   $arguments += " -warnAsError 0"
 }
 
+# disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
+$arguments += " -tl:false"
+
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.
 # The later changes are ignored when using the cache.
 $env:DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -326,7 +326,7 @@ if ($env:TreatWarningsAsErrors -eq 'false') {
 }
 
 # disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
-$arguments += " -tl:false"
+$arguments += " /tl:false"
 
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.
 # The later changes are ignored when using the cache.

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -553,6 +553,9 @@ if [[ "${TreatWarningsAsErrors:-}" == "false" ]]; then
     arguments="$arguments -warnAsError 0"
 fi
 
+# disable terminal logger for now: https://github.com/dotnet/runtime/issues/97211
+arguments="$arguments -tl:false"
+
 initDistroRid "$os" "$arch" "$crossBuild"
 
 # Disable targeting pack caching as we reference a partially constructed targeting pack and update it later.


### PR DESCRIPTION
Since the 9.0-preview1 SDK bump the msbuild terminal logger was used again when using the root build.sh/cmd since the option from Directory.Build.rsp was ignored. The reason is that we're calling msbuild on Build.proj from an arcade nuget package so the file isn't in the directory tree above.

Add the -tl:false option into the build scripts directly. Individual invocations of `dotnet build` for repo projects still work because there the Directory.Build.rsp is in the directory tree above.

See https://github.com/dotnet/runtime/issues/97211