### PR TITLE
Handle MakeGeneric APIs in dataflow

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ConstructedTypeRewritingHelpers.cs
@@ -78,7 +78,6 @@ namespace Internal.TypeSystem
             if (type.HasInstantiation)
             {
                 TypeDesc[] newInstantiation = null;
-                Debug.Assert(type is InstantiatedType);
                 int instantiationIndex = 0;
                 for (; instantiationIndex < type.Instantiation.Length; instantiationIndex++)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
@@ -30,6 +30,7 @@ namespace ILCompiler.Dataflow
         public NodeFactory Factory { get; }
         public FlowAnnotations Annotations { get; }
         public DependencyList Dependencies { get => _dependencies; }
+        public List<INodeWithRuntimeDeterminedDependencies> RuntimeDeterminedDependencies { get; } = new List<INodeWithRuntimeDeterminedDependencies>();
 
         internal enum AccessKind
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -1062,7 +1062,7 @@ namespace ILCompiler.Dataflow
             return aotUnsafeDelegate || comDangerousMethod;
         }
 
-        private class MakeGenericMethodSite : INodeWithRuntimeDeterminedDependencies
+        private sealed class MakeGenericMethodSite : INodeWithRuntimeDeterminedDependencies
         {
             private readonly MethodDesc _method;
 
@@ -1076,7 +1076,7 @@ namespace ILCompiler.Dataflow
             }
         }
 
-        private class MakeGenericTypeSite : INodeWithRuntimeDeterminedDependencies
+        private sealed class MakeGenericTypeSite : INodeWithRuntimeDeterminedDependencies
         {
             private readonly TypeDesc _type;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -380,11 +380,7 @@ namespace ILCompiler.Dataflow
                     {
                         bool triggersWarning = false;
 
-                        if (instanceValue.IsEmpty() || argumentValues[0].IsEmpty())
-                        {
-                            triggersWarning = true;
-                        }
-                        else
+                        if (!instanceValue.IsEmpty() && !argumentValues[0].IsEmpty())
                         {
                             foreach (var value in instanceValue.AsEnumerable())
                             {
@@ -423,7 +419,7 @@ namespace ILCompiler.Dataflow
                                 }
                                 else
                                 {
-                                    // We don't know what type the `MakeGenericMethod` was called on
+                                    // We don't know what type the `MakeGenericType` was called on
                                     triggersWarning = true;
                                 }
                             }
@@ -442,11 +438,7 @@ namespace ILCompiler.Dataflow
                     {
                         bool triggersWarning = false;
 
-                        if (instanceValue.IsEmpty())
-                        {
-                            triggersWarning = true;
-                        }
-                        else
+                        if (!instanceValue.IsEmpty())
                         {
                             foreach (var methodValue in instanceValue.AsEnumerable())
                             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DataflowAnalyzedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/DataflowAnalyzedMethodNode.cs
@@ -19,6 +19,7 @@ namespace ILCompiler.DependencyAnalysis
     public class DataflowAnalyzedMethodNode : DependencyNodeCore<NodeFactory>
     {
         private readonly MethodIL _methodIL;
+        private List<INodeWithRuntimeDeterminedDependencies> _runtimeDependencies;
 
         public DataflowAnalyzedMethodNode(MethodIL methodIL)
         {
@@ -32,13 +33,39 @@ namespace ILCompiler.DependencyAnalysis
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
             try
             {
-                return Dataflow.ReflectionMethodBodyScanner.ScanAndProcessReturnValue(factory, mdManager.FlowAnnotations, mdManager.Logger, _methodIL);
+                return Dataflow.ReflectionMethodBodyScanner.ScanAndProcessReturnValue(factory, mdManager.FlowAnnotations, mdManager.Logger, _methodIL, out _runtimeDependencies);
             }
             catch (TypeSystemException)
             {
                 // Something wrong with the input - missing references, etc.
                 // The method body likely won't compile either, so we don't care.
+                _runtimeDependencies = new List<INodeWithRuntimeDeterminedDependencies>();
                 return Array.Empty<DependencyListEntry>();
+            }
+        }
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
+        {
+            MethodDesc analyzedMethod = _methodIL.OwningMethod;
+
+            // Look for any generic specialization of this method. If any are found, specialize any dataflow dependencies.
+            for (int i = firstNode; i < markedNodes.Count; i++)
+            {
+                if (markedNodes[i] is not IMethodBodyNode methodBody)
+                    continue;
+
+                MethodDesc method = methodBody.Method;
+                if (method.GetTypicalMethodDefinition() != analyzedMethod)
+                    continue;
+
+                // Instantiate all runtime dependencies for the found generic specialization
+                foreach (var n in _runtimeDependencies)
+                {
+                    foreach (var d in n.InstantiateDependencies(factory, method.OwningType.Instantiation, method.Instantiation))
+                    {
+                        yield return new CombinedDependencyListEntry(d.Node, null, d.Reason);
+                    }
+                }
             }
         }
 
@@ -48,10 +75,9 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public override bool InterestingForDynamicDependencyAnalysis => false;
-        public override bool HasDynamicDependencies => false;
+        public override bool HasDynamicDependencies => _runtimeDependencies.Count > 0;
         public override bool HasConditionalStaticDependencies => false;
         public override bool StaticDependenciesAreComputed => true;
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
-        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ScannedMethodNode.cs
@@ -82,7 +82,7 @@ namespace ILCompiler.DependencyAnalysis
         }
 
         public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory) => null;
-        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool InterestingForDynamicDependencyAnalysis => _method.HasInstantiation || _method.OwningType.HasInstantiation;
         public override bool HasDynamicDependencies => false;
         public override bool HasConditionalStaticDependencies => CodeBasedDependencyAlgorithm.HasConditionalDependenciesDueToMethodCodePresence(_method);
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -58,6 +58,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => _methodCode != null;
 
+        public override bool InterestingForDynamicDependencyAnalysis => _method.HasInstantiation || _method.OwningType.HasInstantiation;
+
         public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append(nameMangler.GetMangledMethodName(_method));

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -1051,11 +1051,13 @@ class TestSharedCode
             int val = AccessCookie<C1>();
             Assert.AreEqual(42, val);
 
-            val = (int)typeof(ClassWithTemplate<>).MakeGenericType(typeof(C2)).GetField("Cookie").GetValue(null);
+            val = (int)typeof(ClassWithTemplate<>).MakeGenericType(GetC2()).GetField("Cookie").GetValue(null);
             Assert.AreEqual(42, val);
+            static Type GetC2() => typeof(C2);
 
-            val = (int)typeof(TestSharedCode).GetMethod(nameof(AccessCookie)).MakeGenericMethod(typeof(C3)).Invoke(null, Array.Empty<object>());
+            val = (int)typeof(TestSharedCode).GetMethod(nameof(AccessCookie)).MakeGenericMethod(GetC3()).Invoke(null, Array.Empty<object>());
             Assert.AreEqual(42, val);
+            static Type GetC3() => typeof(C3);
         }
 
         {
@@ -1063,13 +1065,15 @@ class TestSharedCode
             object val = AccessArray<C1>();
             Assert.AreEqual(int.MaxValue, GC.GetGeneration(val));
 
-            val = typeof(ClassWithTemplate<>).MakeGenericType(typeof(C4)).GetField("Array").GetValue(null);
+            val = typeof(ClassWithTemplate<>).MakeGenericType(GetC4()).GetField("Array").GetValue(null);
             Assert.AreEqual(0, GC.GetGeneration(val));
             Assert.AreEqual(nameof(C4), val.GetType().GetElementType().Name);
+            static Type GetC4() => typeof(C4);
 
-            val = typeof(TestSharedCode).GetMethod(nameof(AccessArray)).MakeGenericMethod(typeof(C5)).Invoke(null, Array.Empty<object>());
+            val = typeof(TestSharedCode).GetMethod(nameof(AccessArray)).MakeGenericMethod(GetC5()).Invoke(null, Array.Empty<object>());
             Assert.AreEqual(0, GC.GetGeneration(val));
             Assert.AreEqual(nameof(C5), val.GetType().GetElementType().Name);
+            static Type GetC5() => typeof(C5);
         }
     }
 }

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -187,13 +187,6 @@ internal static class ReflectionTest
         {
             Console.WriteLine(nameof(TestReflectionInvoke));
 
-            // Ensure things we reflect on are in the static callgraph
-            if (string.Empty.Length > 0)
-            {
-                InvokeTests.GetHelloGeneric<int>(0);
-                new InvokeTestsGeneric<int>().GetHelloGeneric<double>(0);
-            }
-
             {
                 object? arg = "world";
                 MethodInfo helloMethod = typeof(InvokeTests).GetTypeInfo().GetDeclaredMethod("GetHello");
@@ -1824,9 +1817,10 @@ internal static class ReflectionTest
                 typeof(GenericType<>).MakeGenericType(typeof(object)).GetMethod("Gimme");
             }
 
-            var t = (Type)s_type.MakeGenericType(typeof(double)).GetMethod("Gimme").Invoke(null, Array.Empty<object>());
+            var t = (Type)s_type.MakeGenericType(GetDouble()).GetMethod("Gimme").Invoke(null, Array.Empty<object>());
             if (t != typeof(double))
                 throw new Exception();
+            static Type GetDouble() => typeof(double);
         }
     }
 
@@ -2432,9 +2426,10 @@ internal static class ReflectionTest
 
         public static void Run()
         {
-            var mi = typeof(TestMdArrayLoad).GetMethod(nameof(MakeMdArray)).MakeGenericMethod(typeof(Atom));
+            var mi = typeof(TestMdArrayLoad).GetMethod(nameof(MakeMdArray)).MakeGenericMethod(GetAtom());
             if ((Type)mi.Invoke(null, Array.Empty<object>()) != typeof(Atom[,,]))
                 throw new Exception();
+            static Type GetAtom() => typeof(Atom);
         }
     }
 
@@ -2446,9 +2441,10 @@ internal static class ReflectionTest
 
         public static void Run()
         {
-            var mi = typeof(TestByRefTypeLoad).GetMethod(nameof(MakeFnPtrType)).MakeGenericMethod(typeof(Atom));
+            var mi = typeof(TestByRefTypeLoad).GetMethod(nameof(MakeFnPtrType)).MakeGenericMethod(GetAtom());
             if ((Type)mi.Invoke(null, Array.Empty<object>()) != typeof(delegate*<ref Atom>))
                 throw new Exception();
+            static Type GetAtom() => typeof(Atom);
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -187,6 +187,13 @@ internal static class ReflectionTest
         {
             Console.WriteLine(nameof(TestReflectionInvoke));
 
+            // Ensure things we reflect on are in the static callgraph
+            if (string.Empty.Length > 0)
+            {
+                InvokeTests.GetHelloGeneric<int>(0);
+                new InvokeTestsGeneric<int>().GetHelloGeneric<double>(0);
+            }
+
             {
                 object? arg = "world";
                 MethodInfo helloMethod = typeof(InvokeTests).GetTypeInfo().GetDeclaredMethod("GetHello");

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Dataflow.cs
@@ -26,6 +26,8 @@ class Dataflow
         TestDynamicDependency.Run();
         TestDynamicDependencyWithGenerics.Run();
         TestObjectGetTypeDataflow.Run();
+        TestMakeGenericDataflow.Run();
+        TestMakeGenericDataflowInvalid.Run();
         TestMarshalIntrinsics.Run();
         Regression97758.Run();
 
@@ -585,6 +587,117 @@ class Dataflow
             Assert.Equal(1, s_baseWithMixKept.GetType().CountPublicMethods());
             Assert.Equal(2, s_baseWithMixKept.GetType().CountPublicConstructors());
             Assert.Equal(2, s_baseWithMixKept.GetType().CountConstructors());
+        }
+    }
+
+    class TestMakeGenericDataflow
+    {
+        class Gen1<T, U>
+        {
+            public static void Bridge() { }
+        }
+
+        class Gen1
+        {
+            public static void Bridge<T, U>() { }
+        }
+
+
+        class Gen2<T>
+        {
+            public static void Bridge() { }
+        }
+
+        class Gen2
+        {
+            public static void Bridge<T>() { }
+        }
+
+        struct MyStruct<T> { }
+
+        static void DoBridgeT1<T, U>() => typeof(Gen1<,>).MakeGenericType([typeof(T), typeof(U)]).GetMethod(nameof(Gen1<T, U>.Bridge)).Invoke(null, []);
+
+        static void DoBridgeT2<T>() => typeof(Gen2<>).MakeGenericType([typeof(MyStruct<T>)]).GetMethod(nameof(Gen2<T>.Bridge)).Invoke(null, []);
+
+        static void DoBridgeM1<T, U>() => typeof(Gen1).GetMethod(nameof(Gen1.Bridge)).MakeGenericMethod([typeof(T), typeof(U)]).Invoke(null, []);
+
+        static void DoBridgeM2<T>() => typeof(Gen2).GetMethod(nameof(Gen2.Bridge)).MakeGenericMethod([typeof(MyStruct<T>)]).Invoke(null, []);
+
+        public static void Run()
+        {
+            DoBridgeT1<string, string>();
+            DoBridgeT1<string, int>();
+            DoBridgeT1<int, int>();
+
+            DoBridgeT2<string>();
+            DoBridgeT2<int>();
+
+            DoBridgeM1<string, string>();
+            DoBridgeM1<string, int>();
+            DoBridgeM1<int, int>();
+
+            DoBridgeM2<string>();
+            DoBridgeM2<int>();
+
+            typeof(Gen1<,>).MakeGenericType([typeof(float), typeof(string)]).GetMethod(nameof(Gen1<float, string>.Bridge)).Invoke(null, []);
+            typeof(Gen2<>).MakeGenericType([typeof(MyStruct<float>)]).GetMethod(nameof(Gen2<float>.Bridge)).Invoke(null, []);
+            typeof(Gen1).GetMethod(nameof(Gen1.Bridge)).MakeGenericMethod([typeof(float), typeof(string)]).Invoke(null, []);
+            typeof(Gen2).GetMethod(nameof(Gen2.Bridge)).MakeGenericMethod([typeof(MyStruct<float>)]).Invoke(null, []);
+        }
+    }
+
+    class TestMakeGenericDataflowInvalid
+    {
+        class Gen<T> { }
+
+        class Gen
+        {
+            public static void Bridge<T>() { }
+        }
+
+        public static void Run()
+        {
+            try
+            {
+                typeof(Gen<>).MakeGenericType(null);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen<>).MakeGenericType([]);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen<>).MakeGenericType([typeof(float), typeof(double)]);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen<>).MakeGenericType([typeof(Gen<>)]);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen).GetMethod("Bridge").MakeGenericMethod(null);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen).GetMethod("Bridge").MakeGenericMethod([]);
+            }
+            catch (ArgumentException) { }
+
+            try
+            {
+                typeof(Gen).GetMethod("Bridge").MakeGenericMethod([typeof(float), typeof(double)]);
+            }
+            catch (ArgumentException) { }
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Devirtualization.cs
@@ -111,7 +111,8 @@ class Devirtualization
             TestIntf1((IIntf1)new Intf1CastableImpl(), 456);
 
             TestIntf2(new Intf2Impl1(), 123);
-            TestIntf2((IIntf2)Activator.CreateInstance(typeof(Intf2Impl2<>).MakeGenericType(typeof(object))), 456);
+            TestIntf2((IIntf2)Activator.CreateInstance(typeof(Intf2Impl2<>).MakeGenericType(GetObject())), 456);
+            static Type GetObject() => typeof(object);
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -1976,8 +1976,10 @@ class Generics
             Foo<object>.s_floatField = 12.34f;
             Foo<object>.s_longField1 = 0x1111;
 
-            var fooDynamicOfClassType = typeof(Foo<>).MakeGenericType(typeof(ClassType)).GetTypeInfo();
-            var fooDynamicOfClassType2 = typeof(Foo<>).MakeGenericType(typeof(ClassType2)).GetTypeInfo();
+            var fooDynamicOfClassType = typeof(Foo<>).MakeGenericType(GetClassType()).GetTypeInfo();
+            static Type GetClassType() => typeof(ClassType);
+            var fooDynamicOfClassType2 = typeof(Foo<>).MakeGenericType(GetClassType2()).GetTypeInfo();
+            static Type GetClassType2() => typeof(ClassType2);
 
             FieldInfo fi = fooDynamicOfClassType.GetDeclaredField("s_intField");
             FieldInfo fi2 = fooDynamicOfClassType2.GetDeclaredField("s_intField");
@@ -2031,7 +2033,8 @@ class Generics
             heh2.GenericVirtualMethod(new Program(), "ayy");
 
             // Simple method invocation
-            var dynamicBaseOfString = typeof(DynamicBase<>).MakeGenericType(typeof(string));
+            var dynamicBaseOfString = typeof(DynamicBase<>).MakeGenericType(GetString());
+            static Type GetString() => typeof(string);
             object obj = Activator.CreateInstance(dynamicBaseOfString);
             {
                 var simpleMethod = dynamicBaseOfString.GetTypeInfo().GetDeclaredMethod("SimpleMethod");
@@ -2054,7 +2057,7 @@ class Generics
             }
 
             {
-                var dynamicDerivedOfString = typeof(DynamicDerived<>).MakeGenericType(typeof(string));
+                var dynamicDerivedOfString = typeof(DynamicDerived<>).MakeGenericType(GetString());
                 object dynamicDerivedObj = Activator.CreateInstance(dynamicDerivedOfString);
                 var virtualMethodDynamicDerived = dynamicDerivedOfString.GetTypeInfo().GetDeclaredMethod("VirtualMethod");
                 string result = (string)virtualMethodDynamicDerived.Invoke(dynamicDerivedObj, new[] { "fad" });
@@ -2063,7 +2066,7 @@ class Generics
 
             // Test generic method invocation
             {
-                var genericMethod = dynamicBaseOfString.GetTypeInfo().GetDeclaredMethod("GenericMethod").MakeGenericMethod(new[] { typeof(string) });
+                var genericMethod = dynamicBaseOfString.GetTypeInfo().GetDeclaredMethod("GenericMethod").MakeGenericMethod(new[] { GetString() });
                 string result = (string)genericMethod.Invoke(obj, new[] { "hey", "hello" });
 
                 Verify("System.Stringhello", result);
@@ -2072,15 +2075,15 @@ class Generics
             // Test GVM invocation
             {
                 var genericMethod = dynamicBaseOfString.GetTypeInfo().GetDeclaredMethod("GenericVirtualMethod");
-                genericMethod = genericMethod.MakeGenericMethod(new[] { typeof(string) });
+                genericMethod = genericMethod.MakeGenericMethod(new[] { GetString() });
                 string result = (string)genericMethod.Invoke(obj, new[] { "hey", "hello" });
                 Verify("DynamicBaseSystem.Stringhello", result);
             }
 
             {
-                var dynamicDerivedOfString = typeof(DynamicDerived<>).MakeGenericType(typeof(string));
+                var dynamicDerivedOfString = typeof(DynamicDerived<>).MakeGenericType(GetString());
                 object dynamicDerivedObj = Activator.CreateInstance(dynamicDerivedOfString);
-                var virtualMethodDynamicDerived = dynamicDerivedOfString.GetTypeInfo().GetDeclaredMethod("GenericVirtualMethod").MakeGenericMethod(new[] { typeof(string) });
+                var virtualMethodDynamicDerived = dynamicDerivedOfString.GetTypeInfo().GetDeclaredMethod("GenericVirtualMethod").MakeGenericMethod(new[] { GetString() });
                 string result = (string)virtualMethodDynamicDerived.Invoke(dynamicDerivedObj, new[] { "hey", "fad" });
                 Verify("DynamicDerivedSystem.Stringfad", result);
             }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -1583,11 +1583,13 @@ public class Interfaces
         [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
-            var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz)).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            var r = (string)typeof(Gen<>).MakeGenericType(GetBaz()).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            static Type GetBaz() => typeof(Baz);
             if (r != "IBar")
                 throw new Exception(r);
 
-            r = (string)typeof(Gen<>).MakeGenericType(typeof(IBar)).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            r = (string)typeof(Gen<>).MakeGenericType(GetIBar()).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            static Type GetIBar() => typeof(IBar);
             if (r != "IBar")
                 throw new Exception(r);
         }
@@ -1620,15 +1622,18 @@ public class Interfaces
         [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "MakeGenericType - Intentional")]
         public static void Run()
         {
-            Activator.CreateInstance(typeof(Baz<>).MakeGenericType(typeof(Atom1)));
+            Activator.CreateInstance(typeof(Baz<>).MakeGenericType(GetAtom1()));
 
-            var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz<>).MakeGenericType(typeof(Atom1))).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            var r = (string)typeof(Gen<>).MakeGenericType(typeof(Baz<>).MakeGenericType(GetAtom1())).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
             if (r != "IBar<Atom1>")
                 throw new Exception(r);
 
-            r = (string)typeof(Gen<>).MakeGenericType(typeof(IBar<>).MakeGenericType(typeof(Atom2))).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
+            r = (string)typeof(Gen<>).MakeGenericType(typeof(IBar<>).MakeGenericType(GetAtom2())).GetMethod("GrabCookie").Invoke(null, Array.Empty<object>());
             if (r != "IBar<Atom2>")
                 throw new Exception(r);
+
+            static Type GetAtom1() => typeof(Atom1);
+            static Type GetAtom2() => typeof(Atom2);
         }
     }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ExponentialDataFlow.cs
@@ -58,7 +58,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[ExpectedWarning ("IL3050", ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			[ExpectedWarning ("IL3050", ProducedBy = Tool.Analyzer)]
 			[ExpectedWarning ("IL2090", "'T'")]
 			public static void Test<T> ()
 			{


### PR DESCRIPTION
Contributes to #81204.

With this, we can handle `typeof(Foo<>).MakeGenericType(typeof(T))` (and `MakeGenericMethod`), including in shared generic code.

The dataflow analysis change should be straightforward (we just look if it's a known array, with all known elements). I scoped this down to "exactly one array" and "exactly one possible value in the element" because the objective is constraint bridging code. We could extend to supporting multiple values, but I don't see a need.

If we know what the values are, we elide generating a warning.

The support for this in the rest of the compiler is a bit annoying due to generics. We only run dataflow on uninstantiated code. So we have a dependency node representing the dataflow analysis. This node obviously cannot know what are all the possible instantiations we saw, so it cannot directly report things about instantiated generic code. Three possible options to solve this:

* Re-run dataflow analysis on instantiated code. I didn't feel great about doing that.
* Introduce a new node `SpecializedDataflowAnalyzedMethodNode` that would be injected as a conditional dependency of all scanned/compiled method bodies, conditioned on `DataflowAnalyzedMethodNode` being present. This would work, but to obtain a `DataflowAnalyzedMethod` we need the `MethodIL` of the definition (not the `MethodDesc`) and that started to look sketchy.
* Use dynamic dependencies. We only use these for GVM analysis right now. They give a node the ability to receive callbacks when new nodes are added to the graph. These nodes need to declare they are "interesting" to dynamic dependency analysis. It's not great, but it works.

I went with option 3.

I'm not making this resolve the above issue. We'd ideally want to implement this in the analyzer too. I had a quick look at that and it looks like we need to write a brand new `DiagnosticAnalyzer` similar to the `DynamicallyAccessedMembersAnalyzer`.

Cc @dotnet/ilc-contrib 