### PR TITLE
Fix unwound stack range check for the new EH

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -6624,6 +6624,13 @@ bool ExceptionTracker::IsInStackRegionUnwoundBySpecifiedException(CrawlFrame * p
 
     // Remember that sfLowerBound and sfUpperBound are in the "OS format".
     // Refer to the comment for CallerStackFrame for more information.
+
+    if (g_isNewExceptionHandlingEnabled)
+    {
+        // The new exception handling sets the ranges always to the SP of the unwound frame
+        return (sfLowerBound < csfToCheck) && (csfToCheck <= sfUpperBound);
+    }
+
 #ifndef STACK_RANGE_BOUNDS_ARE_CALLER_SP
     if ((sfLowerBound < csfToCheck) && (csfToCheck <= sfUpperBound))
 #else // !STACK_RANGE_BOUNDS_ARE_CALLER_SP


### PR DESCRIPTION
With the old EH, the unwound stack range limits are using SP for each frame on x64 and a caller SP on arm64, arm, riscv64 and longsoon. The `ExceptionTracker::IsInStackRegionUnwoundBySpecifiedException` takes that into consideration when detecting whether a frame with a specific SP was already unwound or not.
With the new EH though, the range is always based on the actual SP of the frame, so the check was being done incorrectly on non-x64 architectures.
That lead to a crash in a test that has dynamic method code on stack and its frame was unwound. The bug has caused that method to not to be reported to GC, so the dynamic method was destroyed by GC. And later on, another GC stack walk has crashed while trying to get info on the method.
This change fixes it by making the check with new EH enabled the same for all architectures, the same as it was for x64 in the old EH.

Close #98914