### PR TITLE
JIT: Generalize strategy for finding addrecs

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -9717,6 +9717,7 @@ JITDBGAPI void __cdecl cScev(Compiler* comp, Scev* scev)
     else
     {
         scev->Dump(comp);
+        printf("\n");
     }
 }
 

--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -654,7 +654,7 @@ PhaseStatus Compiler::optInductionVariables()
                                                  initStmt->GetNextStmt());
             }
 
-            JITDUMP("    Replacing in the loop; %d statements with appearences\n", ivUses.Height());
+            JITDUMP("    Replacing in the loop; %d statements with appearances\n", ivUses.Height());
             for (int i = 0; i < ivUses.Height(); i++)
             {
                 Statement* stmt = ivUses.Bottom(i);

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -682,7 +682,7 @@ Scev* ScalarEvolutionContext::MakeAddRecFromRecursiveScev(Scev* startScev, Scev*
                 }
 
                 return ScevVisit::Continue;
-                });
+            });
 
             if (result == ScevVisit::Abort)
             {
@@ -703,7 +703,7 @@ Scev* ScalarEvolutionContext::MakeAddRecFromRecursiveScev(Scev* startScev, Scev*
         // These cases can arise due to "dup".
         // In this case we see that i = <L, [i from outside loop], -1>, but for
         // j we will see <L, [i from outside loop], -1> + (-1) in this function.
-        // 
+        //
         return nullptr;
     }
 

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -486,7 +486,7 @@ Scev* ScalarEvolutionContext::AnalyzeNew(BasicBlock* block, GenTree* tree, int d
             else
             {
                 m_usingEphemeralCache = true;
-                result             = Analyze(ssaDsc->GetBlock(), ssaDsc->GetDefNode()->Data(), depth + 1);
+                result                = Analyze(ssaDsc->GetBlock(), ssaDsc->GetDefNode()->Data(), depth + 1);
                 m_usingEphemeralCache = false;
                 m_ephemeralCache.RemoveAll();
             }

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -491,6 +491,11 @@ Scev* ScalarEvolutionContext::AnalyzeNew(BasicBlock* block, GenTree* tree, int d
                 m_ephemeralCache.RemoveAll();
             }
 
+            if (result == nullptr)
+            {
+                return nullptr;
+            }
+
             return MakeAddRecFromRecursiveScev(enterScev, result, symbolicAddRec);
         }
         case GT_CAST:

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -475,7 +475,7 @@ Scev* ScalarEvolutionContext::AnalyzeNew(BasicBlock* block, GenTree* tree, int d
                 return simpleAddRec;
             }
 
-            ScevConstant* symbolicAddRec = NewConstant(TYP_INT, 0xdeadbeef);
+            ScevConstant* symbolicAddRec = NewConstant(data->TypeGet(), 0xdeadbeef);
             m_ephemeralCache.Emplace(store, symbolicAddRec);
 
             Scev* result;

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -192,8 +192,8 @@ class ScalarEvolutionContext
     // During analysis of PHIs we insert a symbolic node representing the
     // "recurrence"; we use this cache to be able to invalidate things that end
     // up depending on the symbolic node quickly.
-    ScalarEvolutionMap    m_ephemeralCache;
-    bool                  m_usingEphemeralCache = false;
+    ScalarEvolutionMap m_ephemeralCache;
+    bool               m_usingEphemeralCache = false;
 
     Scev* Analyze(BasicBlock* block, GenTree* tree, int depth);
     Scev* AnalyzeNew(BasicBlock* block, GenTree* tree, int depth);

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -188,8 +188,12 @@ class ScalarEvolutionContext
     Compiler*             m_comp;
     FlowGraphNaturalLoop* m_loop = nullptr;
     ScalarEvolutionMap    m_cache;
-    ScalarEvolutionMap    m_cyclicCache;
-    bool                  m_usingCyclicCache = false;
+
+    // During analysis of PHIs we insert a symbolic node representing the
+    // "recurrence"; we use this cache to be able to invalidate things that end
+    // up depending on the symbolic node quickly.
+    ScalarEvolutionMap    m_ephemeralCache;
+    bool                  m_usingEphemeralCache = false;
 
     Scev* Analyze(BasicBlock* block, GenTree* tree, int depth);
     Scev* AnalyzeNew(BasicBlock* block, GenTree* tree, int depth);

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -68,7 +68,7 @@ struct Scev
 #ifdef DEBUG
     void Dump(Compiler* comp);
 #endif
-    template<typename TVisitor>
+    template <typename TVisitor>
     ScevVisit Visit(TVisitor visitor);
 };
 
@@ -139,7 +139,7 @@ struct ScevAddRec : Scev
 // Remarks:
 //   The visit is done in preorder.
 //
-template<typename TVisitor>
+template <typename TVisitor>
 ScevVisit Scev::Visit(TVisitor visitor)
 {
     if (visitor(this) == ScevVisit::Abort)

--- a/src/coreclr/jit/scev.h
+++ b/src/coreclr/jit/scev.h
@@ -37,6 +37,12 @@ static bool ScevOperIs(ScevOper oper, ScevOper operFirst, Args... operTail)
     return oper == operFirst || ScevOperIs(oper, operTail...);
 }
 
+enum class ScevVisit
+{
+    Abort,
+    Continue,
+};
+
 struct Scev
 {
     const ScevOper  Oper;
@@ -62,6 +68,8 @@ struct Scev
 #ifdef DEBUG
     void Dump(Compiler* comp);
 #endif
+    template<typename TVisitor>
+    ScevVisit Visit(TVisitor visitor);
 };
 
 struct ScevConstant : Scev
@@ -119,6 +127,57 @@ struct ScevAddRec : Scev
     INDEBUG(FlowGraphNaturalLoop* const Loop);
 };
 
+//------------------------------------------------------------------------
+// Scev::Visit: Recursively visit all SCEV nodes in the SCEV tree.
+//
+// Parameters:
+//   visitor - Callback with signature Scev* -> ScevVisit.
+//
+// Returns:
+//   ScevVisit::Abort if "visitor" aborted, otherwise ScevVisit::Continue.
+//
+// Remarks:
+//   The visit is done in preorder.
+//
+template<typename TVisitor>
+ScevVisit Scev::Visit(TVisitor visitor)
+{
+    if (visitor(this) == ScevVisit::Abort)
+        return ScevVisit::Abort;
+
+    switch (Oper)
+    {
+        case ScevOper::Constant:
+        case ScevOper::Local:
+            break;
+        case ScevOper::ZeroExtend:
+        case ScevOper::SignExtend:
+            return static_cast<ScevUnop*>(this)->Op1->Visit(visitor);
+        case ScevOper::Add:
+        case ScevOper::Mul:
+        case ScevOper::Lsh:
+        {
+            ScevBinop* binop = static_cast<ScevBinop*>(this);
+            if (binop->Op1->Visit(visitor) == ScevVisit::Abort)
+                return ScevVisit::Abort;
+
+            return binop->Op2->Visit(visitor);
+        }
+        case ScevOper::AddRec:
+        {
+            ScevAddRec* addrec = static_cast<ScevAddRec*>(this);
+            if (addrec->Start->Visit(visitor) == ScevVisit::Abort)
+                return ScevVisit::Abort;
+
+            return addrec->Step->Visit(visitor);
+        }
+        default:
+            unreached();
+    }
+
+    return ScevVisit::Continue;
+}
+
 typedef JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, Scev*> ScalarEvolutionMap;
 
 // Scalar evolution is analyzed in the context of a single loop, and are
@@ -129,6 +188,8 @@ class ScalarEvolutionContext
     Compiler*             m_comp;
     FlowGraphNaturalLoop* m_loop = nullptr;
     ScalarEvolutionMap    m_cache;
+    ScalarEvolutionMap    m_cyclicCache;
+    bool                  m_usingCyclicCache = false;
 
     Scev* Analyze(BasicBlock* block, GenTree* tree, int depth);
     Scev* AnalyzeNew(BasicBlock* block, GenTree* tree, int depth);
@@ -136,8 +197,10 @@ class ScalarEvolutionContext
                              ScevLocal*           start,
                              BasicBlock*          stepDefBlock,
                              GenTree*             stepDefData);
+    Scev* MakeAddRecFromRecursiveScev(Scev* start, Scev* scev, Scev* recursiveScev);
     Scev* CreateSimpleInvariantScev(GenTree* tree);
     Scev* CreateScevForConstant(GenTreeIntConCommon* tree);
+    void ExtractAddOperands(ScevBinop* add, ArrayStack<Scev*>& operands);
 
 public:
     ScalarEvolutionContext(Compiler* comp);


### PR DESCRIPTION
When looking at a PHI, utilize a strategy where a symbolic node representing the recurrence is inserted in the cache, after which the analysis is invoked recursively. The created SCEV can afterwards be turned into a recurrence by considering the symbolic node to be a recursive occurrence.