### PR TITLE
Remove call to InflateInterfaces that does nothing

### DIFF
--- a/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
+++ b/src/tools/illink/src/linker/Linker/TypeMapInfo.cs
@@ -32,6 +32,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Mono.Cecil;
 
 namespace Mono.Linker
@@ -148,7 +149,7 @@ namespace Mono.Linker
 
 			// Foreach interface and for each newslot virtual method on the interface, try
 			// to find the method implementation and record it.
-			foreach (var interfaceImpl in type.GetInflatedInterfaces (context)) {
+			foreach (var interfaceImpl in type.Interfaces.Select(i => (InflatedInterface: i.InterfaceType, OriginalImpl: i))) {
 				foreach (MethodReference interfaceMethod in interfaceImpl.InflatedInterface.GetMethods (context)) {
 					MethodDefinition? resolvedInterfaceMethod = context.TryResolve (interfaceMethod);
 					if (resolvedInterfaceMethod == null)

--- a/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
+++ b/src/tools/illink/src/linker/Linker/TypeReferenceExtensions.cs
@@ -151,25 +151,6 @@ namespace Mono.Linker
 			return null;
 		}
 
-		public static IEnumerable<(TypeReference InflatedInterface, InterfaceImplementation OriginalImpl)> GetInflatedInterfaces (this TypeReference typeRef, ITryResolveMetadata resolver)
-		{
-			var typeDef = resolver.TryResolve (typeRef);
-
-			if (typeDef?.HasInterfaces != true)
-				yield break;
-
-			if (typeRef is GenericInstanceType genericInstance) {
-				foreach (var interfaceImpl in typeDef.Interfaces) {
-					// InflateGenericType only returns null when inflating generic parameters (and the generic instance type doesn't resolve).
-					// Here we are not inflating a generic parameter but an interface type reference.
-					yield return (InflateGenericType (genericInstance, interfaceImpl.InterfaceType, resolver), interfaceImpl)!;
-				}
-			} else {
-				foreach (var interfaceImpl in typeDef.Interfaces)
-					yield return (interfaceImpl.InterfaceType, interfaceImpl);
-			}
-		}
-
 		public static TypeReference? InflateGenericType (GenericInstanceType genericInstanceProvider, TypeReference typeToInflate, ITryResolveMetadata resolver)
 		{
 			if (typeToInflate is ArrayType arrayType) {


### PR DESCRIPTION
The call to `TypeReferenceExtensions.GetInflatedInterfaces` is always called on a `TypeDefinition`, so `typeRef` is never a `GenericInstanceType` and the method will always return the uninflated `InterfaceImplementation.InterfaceType` property.

We should remove the Linq enumerable before we merge, but wanted to bring this up for a discussion.