### PR TITLE
Set the exact initial capacity of a List literal

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CollectionsMarshal.cs
@@ -91,7 +91,11 @@ namespace System.Runtime.InteropServices
 
             list._version++;
 
-            if (count > list.Capacity)
+            if (list.Capacity == 0)
+            {
+                list._items = new T[count];
+            }
+            else if (count > list.Capacity)
             {
                 list.Grow(count);
             }


### PR DESCRIPTION
In .NET 7:

```csharp
List<string> s = ["bonjour"];
Console.WriteLine(s.Capacity);
```

Will print `1`, as it will compile to a call to the `List(int)` constructor which sets the exact initial capacity, then to a `List.Add`.

After .NET 8,

This code prints `4` as `CollectionsMarshal.SetCount(List,int)` calls `List.Grow`.

It seems more optimal to create a List with an exact initial capacity. This PR is not be ready as there's a hundred scenarios I didn't consider and no test at the moment :)

Alternatively, this PR could be scrubbed and the C# compiler could also call the List(int) ctor.