### PR TITLE
Fix profiler evacuation loop logic

### DIFF
--- a/src/coreclr/vm/profdetach.cpp
+++ b/src/coreclr/vm/profdetach.cpp
@@ -326,7 +326,7 @@ void ProfilingAPIDetach::ExecuteEvacuationLoop()
         {
             CRITSEC_Holder csh(ProfilingAPIUtility::GetStatusCrst());
 
-            for (SIZE_T pos = 0; pos < s_profilerDetachInfos.Size(); ++pos)
+            while (s_profilerDetachInfos.Size() > 0)
             {
                 ProfilerDetachInfo current = s_profilerDetachInfos.Pop();
 

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -37,7 +37,7 @@ namespace Profiler.Tests
             Console.WriteLine("Waiting for profilers to all detach");
             if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(10)))
             {
-                Console.WriteLine("Test timed out waiting for the profilers to set the callback, test will fail.");
+                throw new Exception("Test timed out waiting for the profilers to set the callback, test will fail.");
             }
 
             return 100;


### PR DESCRIPTION
This way we get a crash dump when it fails.