### PR TITLE
Fix regression in jiterpreter trace generation

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -1148,7 +1148,7 @@ class Cfg {
     blockStack: Array<MintOpcodePtr> = [];
     backDispatchOffsets: Array<MintOpcodePtr> = [];
     dispatchTable = new Map<MintOpcodePtr, number>();
-    observedBranchTargets = new Set<MintOpcodePtr>();
+    observedBackBranchTargets = new Set<MintOpcodePtr>();
     trace = 0;
 
     constructor(builder: WasmBuilder) {
@@ -1165,7 +1165,7 @@ class Cfg {
         this.lastSegmentEnd = 0;
         this.overheadBytes = 10; // epilogue
         this.dispatchTable.clear();
-        this.observedBranchTargets.clear();
+        this.observedBackBranchTargets.clear();
         this.trace = trace;
         this.backDispatchOffsets.length = 0;
     }
@@ -1212,7 +1212,9 @@ class Cfg {
     }
 
     branch(target: MintOpcodePtr, isBackward: boolean, branchType: CfgBranchType) {
-        this.observedBranchTargets.add(target);
+        if (isBackward)
+            this.observedBackBranchTargets.add(target);
+
         this.appendBlob();
         this.segments.push({
             type: "branch",
@@ -1224,7 +1226,10 @@ class Cfg {
         // some branches will generate bailouts instead so we allocate 4 bytes per branch
         //  to try and balance this out and avoid underestimating too much
         this.overheadBytes += 4; // forward branches are a constant br + depth (optimally 2 bytes)
+
         if (isBackward) {
+            // TODO: Make this smaller by setting the flag inside the dispatcher when disp != 0,
+            //  this will save space for any trace with more than one back-branch
             // get_local <cinfo>
             // i32_const 1
             // i32_store 0 0
@@ -1298,7 +1303,7 @@ class Cfg {
                 const breakDepth = this.blockStack.indexOf(offset);
                 if (breakDepth < 0)
                     continue;
-                if (!this.observedBranchTargets.has(offset))
+                if (!this.observedBackBranchTargets.has(offset))
                     continue;
 
                 this.dispatchTable.set(offset, this.backDispatchOffsets.length + 1);


### PR DESCRIPTION
Should fix some or all of https://github.com/dotnet/perf-autofiling-issues/issues/29881

When I migrated the jiterpreter to a new branch target scanning pass I failed to filter the branch target tables it generates properly. This combined with an existing bug in the cfg code meant that traces in large methods ended up having big branch dispatch tables at the top where most of the branch targets were never hit, eating up a valuable chunk of the trace's 4KB limit.

This PR adds appropriate filtering in both the scanning pass and the cfg so that the dispatch table is as small as possible.