### PR TITLE
Block things needing align8 from preinitializing

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ArrayOfFrozenObjectsNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
 
 using Internal.Text;
 using Internal.TypeSystem;
@@ -33,6 +34,7 @@ namespace ILCompiler.DependencyAnalysis
             builder.AddSymbol(this);
             foreach (FrozenObjectNode node in factory.MetadataManager.GetFrozenObjects())
             {
+                Debug.Assert(node is not FrozenObjectNode frozenObj || !frozenObj.ObjectType.RequiresAlign8());
                 AlignNextObject(ref builder, factory);
 
                 node.InitializeOffsetFromBeginningOfArray(builder.CountBytes);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1633,6 +1633,9 @@ namespace ILCompiler
                                 if (type.IsNullable)
                                     return Status.Fail(methodIL.OwningMethod, opcode);
 
+                                if (type.RequiresAlign8())
+                                    return Status.Fail(methodIL.OwningMethod, opcode, "Align8");
+
                                 Value value = stack.PopIntoLocation(type);
                                 AllocationSite allocSite = new AllocationSite(_type, instructionCounter);
                                 if (!ObjectInstance.TryBox((DefType)type, value, allocSite, out ObjectInstance boxedResult))

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -247,6 +247,11 @@ namespace ILCompiler
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Array out of bounds");
                             }
 
+                            if (elementType.RequiresAlign8())
+                            {
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Align8");
+                            }
+
                             AllocationSite allocSite = new AllocationSite(_type, instructionCounter);
                             stack.Push(new ArrayInstance(elementType.MakeArrayType(), elementCount, allocSite));
                         }
@@ -535,6 +540,11 @@ namespace ILCompiler
                             if (_flowAnnotations.RequiresDataflowAnalysisDueToSignature(ctor))
                             {
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Needs dataflow analysis");
+                            }
+
+                            if (owningType.RequiresAlign8())
+                            {
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Align8");
                             }
 
                             Value[] ctorParameters = new Value[ctorSig.Length + 1];

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -404,7 +404,15 @@ class TestReferenceTypeAllocation
 
     public static void Run()
     {
-        Assert.IsPreinitialized(typeof(TestReferenceTypeAllocation));
+        if (RuntimeInformation.ProcessArchitecture is Architecture.Arm or Architecture.Wasm)
+        {
+            // Because of the double field, this is not preinitialized
+            Assert.IsLazyInitialized(typeof(TestReferenceTypeAllocation));
+        }
+        else
+        {
+            Assert.IsPreinitialized(typeof(TestReferenceTypeAllocation));
+        }
         Assert.AreEqual(12345, s_referenceType.IntValue);
         Assert.AreEqual(3.14159, s_referenceType.DoubleValue);
     }


### PR DESCRIPTION
We don't align these correctly on the frozen heap.

Correctness first, perf second (it's questionable how important this is anyway).