### PR TITLE
Disable MsQuicTests.CertificateCallbackThrowPropagates test

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -357,8 +357,10 @@ namespace System.Net.Quic.Tests
             }
         }
 
+        static bool SupportsAsyncCertValidation => QuicTestCollection.MsQuicVersion >= new Version(2, 4);
+
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(SupportsAsyncCertValidation))]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -358,6 +358,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074")]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -13,10 +13,14 @@ using Xunit.Abstractions;
 using Microsoft.Quic;
 using static Microsoft.Quic.MsQuic;
 
+namespace System.Net.Quic.Tests;
+
 [CollectionDefinition(nameof(QuicTestCollection), DisableParallelization = true)]
 public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>, IDisposable
 {
     public static bool IsSupported => QuicListener.IsSupported && QuicConnection.IsSupported;
+
+    public static Version MsQuicVersion { get; } = GetMsQuicVersion();
 
     public QuicTestCollection()
     {
@@ -78,6 +82,13 @@ public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>,
         DumpCounter(QUIC_PERFORMANCE_COUNTERS.CONN_LOAD_REJECT);
 
         System.Console.WriteLine(sb.ToString());
+    }
+
+    private static Version GetMsQuicVersion()
+    {
+        Type msQuicApiType = Type.GetType("System.Net.Quic.MsQuicApi, System.Net.Quic");
+
+        return (Version)msQuicApiType.GetProperty("Version", BindingFlags.NonPublic | BindingFlags.Static).GetGetMethod(true).Invoke(null, Array.Empty<object?>());
     }
 
     private static string? GetMsQuicLibraryVersion()


### PR DESCRIPTION
Contributes to #99074.

Seems like https://github.com/microsoft/msquic/pull/4145 was not enough to fix async certificate rejection.

The test spuriously fails on platforms which have MsQuic built from main, which seems to be the Alpine queues where we don't have MsQuic release feeds for.