### PR TITLE
Fix unhandled exception when dependency is missing

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -8204,18 +8204,6 @@ extern "C" bool QCALLTYPE SfiInit(StackFrameIterator* pThis, CONTEXT* pStackwalk
 
     NotifyExceptionPassStarted(pThis, pThread, pExInfo);
 
-    if (pFrame == FRAME_TOP)
-    {
-        // There are no managed frames on the stack, fail fast and report unhandled exception
-        LONG disposition = InternalUnhandledExceptionFilter_Worker((EXCEPTION_POINTERS *)&pExInfo->m_ptrs);
-#ifdef HOST_WINDOWS
-        CreateCrashDumpIfEnabled(/* fSOException */ FALSE);
-        RaiseFailFastException(pExInfo->m_ptrs.ExceptionRecord, NULL, 0);
-#else
-        CrashDumpAndTerminateProcess(pExInfo->m_ExceptionCode);
-#endif
-    }
-
     REGDISPLAY* pRD = &pExInfo->m_regDisplay;
     pThread->FillRegDisplay(pRD, pStackwalkCtx);
 
@@ -8284,6 +8272,18 @@ extern "C" bool QCALLTYPE SfiInit(StackFrameIterator* pThis, CONTEXT* pStackwalk
         pThis->UpdateIsRuntimeWrappedExceptions();
 
         *pfIsExceptionIntercepted = CheckExceptionInterception(pThis, pExInfo);
+    }
+    else
+    {
+        // There are no managed frames on the stack, fail fast and report unhandled exception
+        LONG disposition = InternalUnhandledExceptionFilter_Worker((EXCEPTION_POINTERS *)&pExInfo->m_ptrs);
+#ifdef HOST_WINDOWS
+        CreateCrashDumpIfEnabled(/* fSOException */ FALSE);
+        GetThread()->SetThreadStateNC(Thread::TSNC_ProcessedUnhandledException);
+        RaiseException(pExInfo->m_ExceptionCode, EXCEPTION_NONCONTINUABLE_EXCEPTION, pExInfo->m_ptrs.ExceptionRecord->NumberParameters, pExInfo->m_ptrs.ExceptionRecord->ExceptionInformation);
+#else
+        CrashDumpAndTerminateProcess(pExInfo->m_ExceptionCode);
+#endif
     }
 
     return result;

--- a/src/tests/baseservices/exceptions/unhandled/dependencytodelete.cs
+++ b/src/tests/baseservices/exceptions/unhandled/dependencytodelete.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dependency
+{
+    public class DependencyClass
+    {
+        public static void Hello()
+        {
+            Console.WriteLine("Hello");
+        }
+    }
+}

--- a/src/tests/baseservices/exceptions/unhandled/dependencytodelete.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/dependencytodelete.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="dependencytodelete.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.cs
@@ -14,14 +14,14 @@ namespace TestUnhandledExceptionTester
 {
     public class Program
     {
-        static void RunExternalProcess(string unhandledType)
+        static void RunExternalProcess(string unhandledType, string assembly)
         {
             List<string> lines = new List<string>();
 
             Process testProcess = new Process();
 
             testProcess.StartInfo.FileName = Path.Combine(Environment.GetEnvironmentVariable("CORE_ROOT"), "corerun");
-            testProcess.StartInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "unhandled.dll") + " " + unhandledType;
+            testProcess.StartInfo.Arguments = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), assembly) + " " + unhandledType;
             testProcess.StartInfo.RedirectStandardError = true;
             // Disable creating dump since the target process is expected to fail with an unhandled exception
             testProcess.StartInfo.Environment.Remove("DOTNET_DbgEnableMiniDump");
@@ -116,8 +116,10 @@ namespace TestUnhandledExceptionTester
         [Fact]
         public static void TestEntryPoint()
         {
-            RunExternalProcess("main");
-            RunExternalProcess("foreign");
+            RunExternalProcess("main", "unhandled.dll");
+            RunExternalProcess("foreign", "unhandled.dll");
+	    File.Delete(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "dependencytodelete.dll"));
+            RunExternalProcess("missingdependency", "unhandledmissingdependency.dll");
         }
     }
 }

--- a/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledTester.csproj
@@ -17,5 +17,10 @@
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </ProjectReference>
+    <ProjectReference Include="unhandledmissingdependency.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/unhandled/unhandledmissingdependency.cs
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledmissingdependency.cs
@@ -1,0 +1,12 @@
+using Dependency;
+
+namespace DependencyTest
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            DependencyClass.Hello();
+        }
+    }
+}

--- a/src/tests/baseservices/exceptions/unhandled/unhandledmissingdependency.csproj
+++ b/src/tests/baseservices/exceptions/unhandled/unhandledmissingdependency.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needs explicit Main to return the proper "unhandled exception" exit code -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="unhandledmissingdependency.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="dependencytodelete.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
ASPNet team has found that the new exception handling doesn't handle unhandled exception caused by a missing dependency assembly correctly. Instead of invoking the unhandled exception machinery in the native code, it actually exited back to the managed exception handler loop with a failure from the the SfiInit.

The reason is that in that specific case, the check if there are still managed frames on the stack that's done by checking if there is any explicit frame doesn't work, since there is a helper method frame.

This change fixes it by moving the unhandled exception check to the end of the SfiInit when we haven't found any managed frame through the stack walker.

It also changes the `RaiseFailFastException` to `RaiseException` so that a native host can catch it, which the ASPNet also needs.

I have added a test case for that to the unhandled exception tests.