### PR TITLE
List exact regs killed by ByRefWriteBarrier on AMD64

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -616,12 +616,6 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_CALLEE_TRASH_WRITEBARRIER;
 
         case CORINFO_HELP_ASSIGN_BYREF:
-#ifdef TARGET_AMD64
-            if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
-            {
-                return RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT;
-            }
-#endif
             return RBM_CALLEE_TRASH_WRITEBARRIER_BYREF;
 
         case CORINFO_HELP_PROF_FCN_ENTER:

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -616,6 +616,12 @@ regMaskTP Compiler::compHelperCallKillSet(CorInfoHelpFunc helper)
             return RBM_CALLEE_TRASH_WRITEBARRIER;
 
         case CORINFO_HELP_ASSIGN_BYREF:
+#ifdef TARGET_AMD64
+            if (IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+            {
+                return RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT;
+            }
+#endif
             return RBM_CALLEE_TRASH_WRITEBARRIER_BYREF;
 
         case CORINFO_HELP_PROF_FCN_ENTER:

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10423,6 +10423,12 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
 
         case CORINFO_HELP_ASSIGN_BYREF:
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
+#ifdef TARGET_AMD64
+            if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI))
+            {
+                result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT;
+            }
+#endif
             break;
 
 #if !defined(TARGET_LOONGARCH64) && !defined(TARGET_RISCV64)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10423,12 +10423,6 @@ regMaskTP emitter::emitGetGCRegsKilledByNoGCCall(CorInfoHelpFunc helper)
 
         case CORINFO_HELP_ASSIGN_BYREF:
             result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF;
-#ifdef TARGET_AMD64
-            if (emitComp->IsTargetAbi(CORINFO_NATIVEAOT_ABI))
-            {
-                result = RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT;
-            }
-#endif
             break;
 
 #if !defined(TARGET_LOONGARCH64) && !defined(TARGET_RISCV64)

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -207,10 +207,10 @@
   #define RBM_CALLEE_GCTRASH_WRITEBARRIER       RBM_CALLEE_TRASH_NOGC
 
   // Registers killed by CORINFO_HELP_ASSIGN_BYREF.
-  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_CALLEE_TRASH_NOGC)
+  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
 
   // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF.
-  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF (RBM_CALLEE_TRASH_NOGC & ~(RBM_RDI | RBM_RSI))
+  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF (RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
 
   // We have two register classifications
   // * callee trash: aka     volatile or caller saved

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -206,11 +206,13 @@
   // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_REF and CORINFO_HELP_CHECKED_ASSIGN_REF.
   #define RBM_CALLEE_GCTRASH_WRITEBARRIER       RBM_CALLEE_TRASH_NOGC
 
-  // Registers killed by CORINFO_HELP_ASSIGN_BYREF.
-  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
-
   // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF.
+  // NOTE: CoreCLR-Windows-AMD64 doesn't need R10 and R11, but since Unix and NativeAOT (both nix and Windows) need them,
+  // we conservatively include them here as well (they're callee-trashed on both Windows and Unix anyway).
   #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF (RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
+
+  // Registers killed by CORINFO_HELP_ASSIGN_BYREF.
+  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF)
 
   // We have two register classifications
   // * callee trash: aka     volatile or caller saved

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -207,12 +207,16 @@
   #define RBM_CALLEE_GCTRASH_WRITEBARRIER       RBM_CALLEE_TRASH_NOGC
 
   // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF.
-  // NOTE: CoreCLR-Windows-AMD64 doesn't need R10 and R11, but since Unix and NativeAOT (both nix and Windows) need them,
-  // we conservatively include them here as well (they're callee-trashed on both Windows and Unix anyway).
-  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF (RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
+  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF (RBM_RAX | RBM_RCX)
 
   // Registers killed by CORINFO_HELP_ASSIGN_BYREF.
   #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF)
+
+  // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF on NativeAOT:
+  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT (RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
+
+  // Registers killed by CORINFO_HELP_ASSIGN_BYREF on NativeAOT:
+  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT   (RBM_RSI | RBM_RDI | RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT)
 
   // We have two register classifications
   // * callee trash: aka     volatile or caller saved

--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -212,12 +212,6 @@
   // Registers killed by CORINFO_HELP_ASSIGN_BYREF.
   #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF   (RBM_RSI | RBM_RDI | RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF)
 
-  // Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_BYREF on NativeAOT:
-  #define RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT (RBM_RAX | RBM_RCX | RBM_R10 | RBM_R11)
-
-  // Registers killed by CORINFO_HELP_ASSIGN_BYREF on NativeAOT:
-  #define RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT   (RBM_RSI | RBM_RDI | RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT)
-
   // We have two register classifications
   // * callee trash: aka     volatile or caller saved
   // * callee saved: aka non-volatile

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -260,6 +260,9 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      rdi, rsi are incremented by 8,
 //      rcx, r10, r11: trashed
 //
+// NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+//       if you add more trashed registers.
+//
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 // - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1/2
 // - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -260,7 +260,7 @@ LEAF_END RhpCheckedXchg, _TEXT
 //      rdi, rsi are incremented by 8,
 //      rcx, r10, r11: trashed
 //
-// NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+// NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT
 //       if you add more trashed registers.
 //
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.S
@@ -258,9 +258,9 @@ LEAF_END RhpCheckedXchg, _TEXT
 //
 // On exit:
 //      rdi, rsi are incremented by 8,
-//      rcx, r10, r11: trashed
+//      rcx, rax: trashed
 //
-// NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT
+// NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 //       if you add more trashed registers.
 //
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
@@ -283,16 +283,15 @@ ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
     UPDATE_GC_SHADOW BASENAME, rcx, rdi
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    mov     r11, [C_VAR(g_write_watch_table)]
-    cmp     r11, 0x0
+    cmp     qword ptr [C_VAR(g_write_watch_table)], 0x0
     je      LOCAL_LABEL(RhpByRefAssignRef_CheckCardTable)
 
-    mov     r10, rdi
-    shr     r10, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
-    add     r10, r11
-    cmp     byte ptr [r10], 0x0
+    mov     rax, rdi
+    shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
+    add     rax, [C_VAR(g_write_watch_table)]
+    cmp     byte ptr [rax], 0x0
     jne     LOCAL_LABEL(RhpByRefAssignRef_CheckCardTable)
-    mov     byte ptr [r10], 0xFF
+    mov     byte ptr [rax], 0xFF
 #endif
 
 LOCAL_LABEL(RhpByRefAssignRef_CheckCardTable):
@@ -312,12 +311,12 @@ LOCAL_LABEL(RhpByRefAssignRef_CheckCardTable):
     // an entire byte in the card table since it's quicker than messing around with bitmasks and we only write
     // the byte if it hasn't already been done since writes are expensive and impact scaling.
     shr     rcx, 0x0B
-    mov     r10, [C_VAR(g_card_table)]
-    cmp     byte ptr [rcx + r10], 0x0FF
+    mov     rax, [C_VAR(g_card_table)]
+    cmp     byte ptr [rcx + rax], 0x0FF
     je      LOCAL_LABEL(RhpByRefAssignRef_NoBarrierRequired)
 
 // We get here if it's necessary to update the card table.
-    mov     byte ptr [rcx + r10], 0xFF
+    mov     byte ptr [rcx + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     // Shift rcx by 0x0A more to get the card bundle byte (we shifted by 0x0B already)

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -276,6 +276,9 @@ LEAF_END RhpCheckedXchg, _TEXT
 ;;      rdi, rsi are incremented by 8,
 ;;      rcx, r10, r11: trashed
 ;;
+;; NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;;       if you add more trashed registers.
+;;
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 ;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1/2
 ;; - Function "UnwindSimpleHelperToCaller" assumes the stack contains just the pushed return address

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -276,7 +276,7 @@ LEAF_END RhpCheckedXchg, _TEXT
 ;;      rdi, rsi are incremented by 8,
 ;;      rcx, r10, r11: trashed
 ;;
-;; NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;; NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT
 ;;       if you add more trashed registers.
 ;;
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:

--- a/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/WriteBarriers.asm
@@ -274,9 +274,9 @@ LEAF_END RhpCheckedXchg, _TEXT
 ;;
 ;; On exit:
 ;;      rdi, rsi are incremented by 8,
-;;      rcx, r10, r11: trashed
+;;      rcx, rax: trashed
 ;;
-;; NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF_NAOT and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF_NAOT
+;; NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 ;;       if you add more trashed registers.
 ;;
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
@@ -299,16 +299,15 @@ ALTERNATE_ENTRY RhpByRefAssignRefAVLocation2
     UPDATE_GC_SHADOW BASENAME, rcx, rdi
 
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    mov     r11, [g_write_watch_table]
-    cmp     r11, 0
+    cmp     [g_write_watch_table], 0
     je      RhpByRefAssignRef_CheckCardTable
 
-    mov     r10, rdi
-    shr     r10, 0Ch ;; SoftwareWriteWatch::AddressToTableByteIndexShift
-    add     r10, r11
-    cmp     byte ptr [r10], 0
+    mov     rax, rdi
+    shr     rax, 0Ch ;; SoftwareWriteWatch::AddressToTableByteIndexShift
+    add     rax, [g_write_watch_table]
+    cmp     byte ptr [rax], 0
     jne     RhpByRefAssignRef_CheckCardTable
-    mov     byte ptr [r10], 0FFh
+    mov     byte ptr [rax], 0FFh
 endif
 
 RhpByRefAssignRef_CheckCardTable:
@@ -328,12 +327,12 @@ RhpByRefAssignRef_CheckCardTable:
     ;; an entire byte in the card table since it's quicker than messing around with bitmasks and we only write
     ;; the byte if it hasn't already been done since writes are expensive and impact scaling.
     shr     rcx, 0Bh
-    mov     r10, [g_card_table]
-    cmp     byte ptr [rcx + r10], 0FFh
+    mov     rax, [g_card_table]
+    cmp     byte ptr [rcx + rax], 0FFh
     je      RhpByRefAssignRef_NoBarrierRequired
 
 ;; We get here if it's necessary to update the card table.
-    mov     byte ptr [rcx + r10], 0FFh
+    mov     byte ptr [rcx + rax], 0FFh
 
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
     ;; Shift rcx by 0Ah more to get the card bundle byte (we shifted by 0Bh already)

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.S
@@ -192,6 +192,9 @@
 //   x15  : trashed
 //   x12, x17  : trashed
 //
+//   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+//         if you add more trashed registers.
+//
 // WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 // - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1
 // - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address

--- a/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
+++ b/src/coreclr/nativeaot/Runtime/arm64/WriteBarriers.asm
@@ -206,6 +206,9 @@ INVALIDGCVALUE  EQU 0xCCCCCCCD
 ;;   x15  : trashed
 ;;   x12, x17  : trashed
 ;;
+;;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;;         if you add more trashed registers.
+;;
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 ;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen at RhpByRefAssignRefAVLocation1
 ;; - Function "UnwindSimpleHelperToCaller" assumes no registers were pushed and LR contains the return address

--- a/src/coreclr/pal/inc/unixasmmacrosamd64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosamd64.inc
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#define C_VAR(Name) rip + C_FUNC(Name)
+
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section
         .ifnc \Handler, NoHandler

--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -57,6 +57,7 @@ extern JIT_InternalThrow:proc
 ;   RSI - address of the data  (source)
 ;   RCX is trashed
 ;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+;   R10 and R11 are trashed
 ;
 ;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 ;         if you add more trashed registers.
@@ -84,8 +85,6 @@ endif
 ifdef WRITE_BARRIER_CHECK
         ; we can only trash rcx in this function so in _DEBUG we need to save
         ; some scratch registers.
-        push    r10
-        push    r11
         push    rax
 
         ; **ALSO update the shadow GC heap if that is enabled**
@@ -132,8 +131,6 @@ ifdef WRITE_BARRIER_CHECK
     ; need to replicate the above checks.
     DoneShadow:
         pop     rax
-        pop     r11
-        pop     r10
 endif
 
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP

--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -57,6 +57,10 @@ extern JIT_InternalThrow:proc
 ;   RSI - address of the data  (source)
 ;   RCX is trashed
 ;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+;
+;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;         if you add more trashed registers.
+;
 ; Exit:
 ;   RDI, RSI are incremented by SIZEOF(LPVOID)
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT

--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -56,7 +56,7 @@ extern JIT_InternalThrow:proc
 ;   RDI - address of ref-field (assigned to)
 ;   RSI - address of the data  (source)
 ;   RCX is trashed
-;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+;   RAX is trashed
 ;
 ;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 ;         if you add more trashed registers.
@@ -156,8 +156,6 @@ endif
         cmp     rcx, [g_ephemeral_high]
         jnb     Exit
 
-        ; do the following checks only if we are allowed to trash rax
-        ; otherwise we don't have enough registers
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, rcx
 

--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -57,13 +57,13 @@ extern JIT_InternalThrow:proc
 ;   RSI - address of the data  (source)
 ;   RCX is trashed
 ;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
-;   R10 and R11 are trashed
 ;
 ;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 ;         if you add more trashed registers.
 ;
 ; Exit:
 ;   RDI, RSI are incremented by SIZEOF(LPVOID)
+;
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         mov     rcx, [rsi]
 
@@ -85,6 +85,8 @@ endif
 ifdef WRITE_BARRIER_CHECK
         ; we can only trash rcx in this function so in _DEBUG we need to save
         ; some scratch registers.
+        push    r10
+        push    r11
         push    rax
 
         ; **ALSO update the shadow GC heap if that is enabled**
@@ -131,6 +133,8 @@ ifdef WRITE_BARRIER_CHECK
     ; need to replicate the above checks.
     DoneShadow:
         pop     rax
+        pop     r11
+        pop     r10
 endif
 
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -21,6 +21,10 @@
 //   RAX is trashed
 //   R10 is trashed
 //   R11 is trashed on Debug build
+//
+//   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+//         if you add more trashed registers.
+//
 // Exit:
 //   RDI, RSI are incremented by SIZEOF(LPVOID)
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -5,219 +5,208 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-// JIT_ByRefWriteBarrier has weird semantics, see usage in StubLinkerX86.cpp
-//
-// Entry:
-//   RDI - address of ref-field (assigned to)
-//   RSI - address of the data  (source)
-//
-//   Note: RyuJIT assumes that all volatile registers can be trashed by
-//   the CORINFO_HELP_ASSIGN_BYREF helper (i.e. JIT_ByRefWriteBarrier)
-//   except RDI and RSI. This helper uses and defines RDI and RSI, so
-//   they remain as live GC refs or byrefs, and are not killed.
-//
-//
-//   RCX is trashed
-//   RAX is trashed
-//   R10 is trashed
-//   R11 is trashed on Debug build
-//
-//   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
-//         if you add more trashed registers.
-//
-// Exit:
-//   RDI, RSI are incremented by SIZEOF(LPVOID)
+; JIT_ByRefWriteBarrier has weird semantics, see usage in StubLinkerX86.cpp
+;
+; Entry:
+;   RDI - address of ref-field (assigned to)
+;   RSI - address of the data  (source)
+;   RCX is trashed
+;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+;   R10 and R11 are trashed
+;
+;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;         if you add more trashed registers.
+;
+; Exit:
+;   RDI, RSI are incremented by SIZEOF(LPVOID)
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         mov     rcx, [rsi]
 
-// If !WRITE_BARRIER_CHECK do the write first, otherwise we might have to do some ShadowGC stuff
-#ifndef WRITE_BARRIER_CHECK
-        // rcx is [rsi]
+; If !WRITE_BARRIER_CHECK do the write first, otherwise we might have to do some ShadowGC stuff
+ifndef WRITE_BARRIER_CHECK
+        ; rcx is [rsi]
         mov     [rdi], rcx
-#endif
+endif
 
-        // When WRITE_BARRIER_CHECK is defined _NotInHeap will write the reference
-        // but if it isn't then it will just return.
-        //
-        // See if this is in GCHeap
-        PREPARE_EXTERNAL_VAR g_lowest_address, rax
-        cmp     rdi, [rax]
-        jb      LOCAL_LABEL(NotInHeap_ByRefWriteBarrier)
-        PREPARE_EXTERNAL_VAR g_highest_address, rax
-        cmp     rdi, [rax]
-        jnb     LOCAL_LABEL(NotInHeap_ByRefWriteBarrier)
+        ; When WRITE_BARRIER_CHECK is defined _NotInHeap will write the reference
+        ; but if it isn't then it will just return.
+        ;
+        ; See if this is in GCHeap
+        cmp     rdi, [C_VAR(g_lowest_address)]
+        jb      LOCAL_LABEL(NotInHeap)
+        cmp     rdi, [C_VAR(g_highest_address)]
+        jnb     LOCAL_LABEL(NotInHeap)
 
-#ifdef WRITE_BARRIER_CHECK
-        // **ALSO update the shadow GC heap if that is enabled**
-        // Do not perform the work if g_GCShadow is 0
-        PREPARE_EXTERNAL_VAR g_GCShadow, rax
-        cmp     qword ptr [rax], 0
-        je      LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
+ifdef WRITE_BARRIER_CHECK
+        ; we can only trash rcx in this function so in _DEBUG we need to save
+        ; some scratch registers.
+        push    rax
 
-        // If we end up outside of the heap don't corrupt random memory
+        ; **ALSO update the shadow GC heap if that is enabled**
+        ; Do not perform the work if g_GCShadow is 0
+        cmp     C_VAR(g_GCShadow), 0
+        je      LOCAL_LABEL(NoShadow)
+
+        ; If we end up outside of the heap don't corrupt random memory
         mov     r10, rdi
-        PREPARE_EXTERNAL_VAR g_lowest_address, rax
-        sub     r10, [rax]
-        jb      LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
+        sub     r10, [C_VAR(g_lowest_address)]
+        jb      LOCAL_LABEL(NoShadow)
 
-        // Check that our adjusted destination is somewhere in the shadow gc
-        PREPARE_EXTERNAL_VAR g_GCShadow, rax
-        add     r10, [rax]
-        PREPARE_EXTERNAL_VAR g_GCShadowEnd, rax
-        cmp     r10, [rax]
-        jnb     LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
+        ; Check that our adjusted destination is somewhere in the shadow gc
+        add     r10, [C_VAR(g_GCShadow)]
+        cmp     r10, [C_VAR(g_GCShadowEnd]
+        jnb     LOCAL_LABEL(NoShadow)
 
-        // Write ref into real GC
+        ; Write ref into real GC
         mov     [rdi], rcx
-        // Write ref into shadow GC
+        ; Write ref into shadow GC
         mov     [r10], rcx
 
-        // Ensure that the write to the shadow heap occurs before the read from
-        // the GC heap so that race conditions are caught by INVALIDGCVALUE
+        ; Ensure that the write to the shadow heap occurs before the read from
+        ; the GC heap so that race conditions are caught by INVALIDGCVALUE
         mfence
 
-        // Check that GC/ShadowGC values match
+        ; Check that GC/ShadowGC values match
         mov     r11, [rdi]
         mov     rax, [r10]
         cmp     rax, r11
-        je      LOCAL_LABEL(DoneShadow_ByRefWriteBarrier)
-        movabs  r11, INVALIDGCVALUE
+        je      LOCAL_LABEL(DoneShadow)
+        mov     r11, INVALIDGCVALUE
         mov     [r10], r11
 
-        jmp     LOCAL_LABEL(DoneShadow_ByRefWriteBarrier)
+        jmp     LOCAL_LABEL(DoneShadow)
 
-    // If we don't have a shadow GC we won't have done the write yet
-    LOCAL_LABEL(NoShadow_ByRefWriteBarrier):
+    ; If we don't have a shadow GC we won't have done the write yet
+    LOCAL_LABEL(NoShadow):
         mov     [rdi], rcx
 
-    // If we had a shadow GC then we already wrote to the real GC at the same time
-    // as the shadow GC so we want to jump over the real write immediately above.
-    // Additionally we know for sure that we are inside the heap and therefore don't
-    // need to replicate the above checks.
-    LOCAL_LABEL(DoneShadow_ByRefWriteBarrier):
-#endif
+    ; If we had a shadow GC then we already wrote to the real GC at the same time
+    ; as the shadow GC so we want to jump over the real write immediately above.
+    ; Additionally we know for sure that we are inside the heap and therefore don't
+    ; need to replicate the above checks.
+    LOCAL_LABEL(DoneShadow):
+        pop     rax
+endif
 
-#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-        // Update the write watch table if necessary
-        PREPARE_EXTERNAL_VAR g_sw_ww_enabled_for_gc_heap, rax
-        cmp     byte ptr [rax], 0x0
-        je      LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier)
+ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+        ; Update the write watch table if necessary
+        cmp     byte ptr [C_VAR(g_sw_ww_enabled_for_gc_heap)], 0x0
+        je      LOCAL_LABEL(CheckCardTable)
         mov     rax, rdi
-        shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
-        PREPARE_EXTERNAL_VAR g_sw_ww_table, r10
-        add     rax, qword ptr [r10]
+        shr     rax, 0xC ; SoftwareWriteWatch::AddressToTableByteIndexShift
+        add     rax, qword ptr [C_VAR(g_sw_ww_table)]
         cmp     byte ptr [rax], 0x0
-        jne     LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier)
+        jne     LOCAL_LABEL(CheckCardTable)
         mov     byte ptr [rax], 0xFF
-#endif
+endif
 
-    LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier):
-        // See if we can just quick out
-        PREPARE_EXTERNAL_VAR g_ephemeral_low, rax
-        cmp     rcx, [rax]
-        jb      LOCAL_LABEL(Exit_ByRefWriteBarrier)
-        PREPARE_EXTERNAL_VAR g_ephemeral_high, rax
-        cmp     rcx, [rax]
-        jnb     LOCAL_LABEL(Exit_ByRefWriteBarrier)
+        ; See if we can just quick out
+    LOCAL_LABEL(CheckCardTable):
+        cmp     rcx, [C_VAR(g_ephemeral_low)]
+        jb      LOCAL_LABEL(Exit)
+        cmp     rcx, [C_VAR(g_ephemeral_high)]
+        jnb     LOCAL_LABEL(Exit)
 
+        ; do the following checks only if we are allowed to trash rax
+        ; otherwise we don't have enough registers
+ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, rcx
 
-        PREPARE_EXTERNAL_VAR g_region_shr, rcx
-        mov     cl, [rcx]
+        mov     cl, [C_VAR(g_region_shr)]
         test    cl, cl
-        je      LOCAL_LABEL(SkipCheck_ByRefWriteBarrier)
+        je      LOCAL_LABEL(SkipCheck)
 
-        // check if the source is in gen 2 - then it's not an ephemeral pointer
+        ; check if the source is in gen 2 - then it's not an ephemeral pointer
         shr     rax, cl
-        PREPARE_EXTERNAL_VAR g_region_to_generation_table, r10
-        mov     r10, [r10]
-        cmp     byte ptr [rax + r10], 0x82
-        je      LOCAL_LABEL(Exit_ByRefWriteBarrier)
+        add     rax, [C_VAR(g_region_to_generation_table)]
+        cmp     byte ptr [rax], 0x82
+        je      LOCAL_LABEL(Exit)
 
-        // check if the destination happens to be in gen 0
+        ; check if the destination happens to be in gen 0
         mov     rax, rdi
         shr     rax, cl
-        cmp     byte ptr [rax + r10], 0
-        je      LOCAL_LABEL(Exit_ByRefWriteBarrier)
-    LOCAL_LABEL(SkipCheck_ByRefWriteBarrier):
-
-        PREPARE_EXTERNAL_VAR g_card_table, r10
-        mov     r10, [r10]
-
-        PREPARE_EXTERNAL_VAR g_region_use_bitwise_write_barrier, rax
+        add     rax, [C_VAR(g_region_to_generation_table)]
         cmp     byte ptr [rax], 0
-        je      LOCAL_LABEL(CheckCardTableByte_ByRefWriteBarrier)
+        je      LOCAL_LABEL(Exit)
+    LOCAL_LABEL(SkipCheck):
 
-        // compute card table bit
-        mov     ecx, edi
+        cmp     [C_VAR(g_region_use_bitwise_write_barrier)], 0
+        je      LOCAL_LABEL(CheckCardTableByte)
+
+        ; compute card table bit
+        mov     rcx, rdi
         mov     al, 1
-        shr     ecx, 8
+        shr     rcx, 8
         and     cl, 7
         shl     al, cl
 
-        // move current rdi value into rcx and then increment the pointers
+        ; move current rdi value into rcx and then increment the pointers
         mov     rcx, rdi
         add     rsi, 0x8
         add     rdi, 0x8
 
-        // Check if we need to update the card table
-        // Calc pCardByte
+        ; Check if we need to update the card table
+        ; Calc pCardByte
         shr     rcx, 0xB
-        // Check if this card table bit is already set
-        test    byte ptr [rcx + r10], al
-        je      LOCAL_LABEL(SetCardTableBit_ByRefWriteBarrier)
+        add     rcx, [C_VAR(g_card_table)]
+
+        ; Check if this card table bit is already set
+        test    byte ptr [rcx], al
+        je      LOCAL_LABEL(SetCardTableBit)
         REPRET
 
-    LOCAL_LABEL(SetCardTableBit_ByRefWriteBarrier):
-        lock or byte ptr [rcx + r10], al
+    LOCAL_LABEL(SetCardTableBit):
+        lock or byte ptr [rcx], al
+        jmp     LOCAL_LABEL(CheckCardBundle)
+endif
+LOCAL_LABEL(CheckCardTableByte):
 
-        jmp     LOCAL_LABEL(CheckCardBundle_ByRefWriteBarrier)
-
-    LOCAL_LABEL(CheckCardTableByte_ByRefWriteBarrier):
-        // move current rdi value into rcx and then increment the pointers
+        ; move current rdi value into rcx and then increment the pointers
         mov     rcx, rdi
         add     rsi, 0x8
         add     rdi, 0x8
 
+        ; Check if we need to update the card table
+        ; Calc pCardByte
         shr     rcx, 0xB
-        cmp     byte ptr [rcx + r10], 0xFF
-        jne     LOCAL_LABEL(SetCardTableByte_ByRefWriteBarrier)
-        REPRET
-    LOCAL_LABEL(SetCardTableByte_ByRefWriteBarrier):
-        mov     byte ptr [rcx + r10], 0xFF
+        add     rcx, [C_VAR(g_card_table)]
 
-    LOCAL_LABEL(CheckCardBundle_ByRefWriteBarrier):
-
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        // Shift rcx by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
-        shr     rcx, 0x0A
-
-        PREPARE_EXTERNAL_VAR g_card_bundle_table, rax
-        add     rcx, [rax]
-
-        // Check if this bundle byte is dirty
+        ; Check if this card is dirty
         cmp     byte ptr [rcx], 0xFF
-
-        jne     LOCAL_LABEL(UpdateCardBundle_ByRefWriteBarrier)
+        jne     LOCAL_LABEL(UpdateCardTable)
         REPRET
 
-    LOCAL_LABEL(UpdateCardBundle_ByRefWriteBarrier):
+    LOCAL_LABEL(UpdateCardTable):
         mov     byte ptr [rcx], 0xFF
-#endif
 
+    LOCAL_LABEL(CheckCardBundle):
+
+ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        ; check if we need to update the card bundle table
+        ; restore destination address from rdi - rdi has been incremented by 8 already
+        lea     rcx, [rdi-8]
+        shr     rcx, 0x15
+        add     rcx, [C_VAR(g_card_bundle_table)]
+        cmp     byte ptr [rcx], 0xFF
+        jne     LOCAL_LABEL(UpdateCardBundleTable)
+        REPRET
+
+    LOCAL_LABEL(UpdateCardBundleTable):
+        mov     byte ptr [rcx], 0xFF
+endif
         ret
 
     .balign 16
-    LOCAL_LABEL(NotInHeap_ByRefWriteBarrier):
-// If WRITE_BARRIER_CHECK then we won't have already done the mov and should do it here
-// If !WRITE_BARRIER_CHECK we want _NotInHeap and _Leave to be the same and have both
-// 16 byte aligned.
-#ifdef WRITE_BARRIER_CHECK
-        // rcx is [rsi]
+    LOCAL_LABEL(NotInHeap):
+; If WRITE_BARRIER_CHECK then we won't have already done the mov and should do it here
+; If !WRITE_BARRIER_CHECK we want _NotInHeap and _Leave to be the same and have both
+; 16 byte aligned.
+ifdef WRITE_BARRIER_CHECK
+        ; rcx is [rsi]
         mov     [rdi], rcx
-#endif
-    LOCAL_LABEL(Exit_ByRefWriteBarrier):
-        // Increment the pointers before leaving
+endif
+    LOCAL_LABEL(Exit):
+        ; Increment the pointers before leaving
         add     rdi, 0x8
         add     rsi, 0x8
         ret

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -5,208 +5,212 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-; JIT_ByRefWriteBarrier has weird semantics, see usage in StubLinkerX86.cpp
-;
-; Entry:
-;   RDI - address of ref-field (assigned to)
-;   RSI - address of the data  (source)
-;   RCX is trashed
-;   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
-;   R10 and R11 are trashed
-;
-;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
-;         if you add more trashed registers.
-;
-; Exit:
-;   RDI, RSI are incremented by SIZEOF(LPVOID)
+// JIT_ByRefWriteBarrier has weird semantics, see usage in StubLinkerX86.cpp
+//
+// Entry:
+//   RDI - address of ref-field (assigned to)
+//   RSI - address of the data  (source)
+//   RCX is trashed
+//   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+//
+//   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+//         if you add more trashed registers.
+//
+// Exit:
+//   RDI, RSI are incremented by SIZEOF(LPVOID)
+//
 LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         mov     rcx, [rsi]
 
-; If !WRITE_BARRIER_CHECK do the write first, otherwise we might have to do some ShadowGC stuff
-ifndef WRITE_BARRIER_CHECK
-        ; rcx is [rsi]
+// If !WRITE_BARRIER_CHECK do the write first, otherwise we might have to do some ShadowGC stuff
+#ifndef WRITE_BARRIER_CHECK
+        // rcx is [rsi]
         mov     [rdi], rcx
-endif
+#endif
 
-        ; When WRITE_BARRIER_CHECK is defined _NotInHeap will write the reference
-        ; but if it isn't then it will just return.
-        ;
-        ; See if this is in GCHeap
+        // When WRITE_BARRIER_CHECK is defined _NotInHeap will write the reference
+        // but if it isn't then it will just return.
+        //
+        // See if this is in GCHeap
         cmp     rdi, [C_VAR(g_lowest_address)]
-        jb      LOCAL_LABEL(NotInHeap)
+        jb      LOCAL_LABEL(NotInHeap_ByRefWriteBarrier)
         cmp     rdi, [C_VAR(g_highest_address)]
-        jnb     LOCAL_LABEL(NotInHeap)
+        jnb     LOCAL_LABEL(NotInHeap_ByRefWriteBarrier)
 
-ifdef WRITE_BARRIER_CHECK
-        ; we can only trash rcx in this function so in _DEBUG we need to save
-        ; some scratch registers.
+#ifdef WRITE_BARRIER_CHECK
+        // we can only trash rcx in this function so in _DEBUG we need to save
+        // some scratch registers.
+        push    r10
+        push    r11
         push    rax
 
-        ; **ALSO update the shadow GC heap if that is enabled**
-        ; Do not perform the work if g_GCShadow is 0
-        cmp     C_VAR(g_GCShadow), 0
-        je      LOCAL_LABEL(NoShadow)
+        // **ALSO update the shadow GC heap if that is enabled**
+        // Do not perform the work if g_GCShadow is 0
+        cmp     qword ptr [C_VAR(g_GCShadow)], 0
+        je      LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
 
-        ; If we end up outside of the heap don't corrupt random memory
+        // If we end up outside of the heap don't corrupt random memory
         mov     r10, rdi
         sub     r10, [C_VAR(g_lowest_address)]
-        jb      LOCAL_LABEL(NoShadow)
+        jb      LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
 
-        ; Check that our adjusted destination is somewhere in the shadow gc
+        // Check that our adjusted destination is somewhere in the shadow gc
         add     r10, [C_VAR(g_GCShadow)]
-        cmp     r10, [C_VAR(g_GCShadowEnd]
-        jnb     LOCAL_LABEL(NoShadow)
+        cmp     r10, [C_VAR(g_GCShadowEnd)]
+        jnb     LOCAL_LABEL(NoShadow_ByRefWriteBarrier)
 
-        ; Write ref into real GC
+        // Write ref into real GC
         mov     [rdi], rcx
-        ; Write ref into shadow GC
+        // Write ref into shadow GC
         mov     [r10], rcx
 
-        ; Ensure that the write to the shadow heap occurs before the read from
-        ; the GC heap so that race conditions are caught by INVALIDGCVALUE
+        // Ensure that the write to the shadow heap occurs before the read from
+        // the GC heap so that race conditions are caught by INVALIDGCVALUE
         mfence
 
-        ; Check that GC/ShadowGC values match
+        // Check that GC/ShadowGC values match
         mov     r11, [rdi]
         mov     rax, [r10]
         cmp     rax, r11
-        je      LOCAL_LABEL(DoneShadow)
-        mov     r11, INVALIDGCVALUE
+        je      LOCAL_LABEL(DoneShadow_ByRefWriteBarrier)
+        movabs  r11, INVALIDGCVALUE
         mov     [r10], r11
 
-        jmp     LOCAL_LABEL(DoneShadow)
+        jmp     LOCAL_LABEL(DoneShadow_ByRefWriteBarrier)
 
-    ; If we don't have a shadow GC we won't have done the write yet
-    LOCAL_LABEL(NoShadow):
+    // If we don't have a shadow GC we won't have done the write yet
+    LOCAL_LABEL(NoShadow_ByRefWriteBarrier):
         mov     [rdi], rcx
 
-    ; If we had a shadow GC then we already wrote to the real GC at the same time
-    ; as the shadow GC so we want to jump over the real write immediately above.
-    ; Additionally we know for sure that we are inside the heap and therefore don't
-    ; need to replicate the above checks.
-    LOCAL_LABEL(DoneShadow):
+    // If we had a shadow GC then we already wrote to the real GC at the same time
+    // as the shadow GC so we want to jump over the real write immediately above.
+    // Additionally we know for sure that we are inside the heap and therefore don't
+    // need to replicate the above checks.
+    LOCAL_LABEL(DoneShadow_ByRefWriteBarrier):
         pop     rax
-endif
+        pop     r11
+        pop     r10
+#endif
 
-ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-        ; Update the write watch table if necessary
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+        // Update the write watch table if necessary
         cmp     byte ptr [C_VAR(g_sw_ww_enabled_for_gc_heap)], 0x0
-        je      LOCAL_LABEL(CheckCardTable)
+        je      LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier)
         mov     rax, rdi
-        shr     rax, 0xC ; SoftwareWriteWatch::AddressToTableByteIndexShift
+        shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         add     rax, qword ptr [C_VAR(g_sw_ww_table)]
         cmp     byte ptr [rax], 0x0
-        jne     LOCAL_LABEL(CheckCardTable)
+        jne     LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier)
         mov     byte ptr [rax], 0xFF
-endif
+#endif
 
-        ; See if we can just quick out
-    LOCAL_LABEL(CheckCardTable):
+        // See if we can just quick out
+    LOCAL_LABEL(CheckCardTable_ByRefWriteBarrier):
         cmp     rcx, [C_VAR(g_ephemeral_low)]
-        jb      LOCAL_LABEL(Exit)
+        jb      LOCAL_LABEL(Exit_ByRefWriteBarrier)
         cmp     rcx, [C_VAR(g_ephemeral_high)]
-        jnb     LOCAL_LABEL(Exit)
+        jnb     LOCAL_LABEL(Exit_ByRefWriteBarrier)
 
-        ; do the following checks only if we are allowed to trash rax
-        ; otherwise we don't have enough registers
-ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
+        // do the following checks only if we are allowed to trash rax
+        // otherwise we don't have enough registers
+#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, rcx
 
         mov     cl, [C_VAR(g_region_shr)]
         test    cl, cl
-        je      LOCAL_LABEL(SkipCheck)
+        je      LOCAL_LABEL(SkipCheck_ByRefWriteBarrier)
 
-        ; check if the source is in gen 2 - then it's not an ephemeral pointer
+        // check if the source is in gen 2 - then it's not an ephemeral pointer
         shr     rax, cl
         add     rax, [C_VAR(g_region_to_generation_table)]
         cmp     byte ptr [rax], 0x82
-        je      LOCAL_LABEL(Exit)
+        je      LOCAL_LABEL(Exit_ByRefWriteBarrier)
 
-        ; check if the destination happens to be in gen 0
+        // check if the destination happens to be in gen 0
         mov     rax, rdi
         shr     rax, cl
         add     rax, [C_VAR(g_region_to_generation_table)]
         cmp     byte ptr [rax], 0
-        je      LOCAL_LABEL(Exit)
-    LOCAL_LABEL(SkipCheck):
+        je      LOCAL_LABEL(Exit_ByRefWriteBarrier)
+    LOCAL_LABEL(SkipCheck_ByRefWriteBarrier):
 
-        cmp     [C_VAR(g_region_use_bitwise_write_barrier)], 0
-        je      LOCAL_LABEL(CheckCardTableByte)
+        cmp     byte ptr [C_VAR(g_region_use_bitwise_write_barrier)], 0
+        je      LOCAL_LABEL(CheckCardTableByte_ByRefWriteBarrier)
 
-        ; compute card table bit
+        // compute card table bit
         mov     rcx, rdi
         mov     al, 1
         shr     rcx, 8
         and     cl, 7
         shl     al, cl
 
-        ; move current rdi value into rcx and then increment the pointers
+        // move current rdi value into rcx and then increment the pointers
         mov     rcx, rdi
         add     rsi, 0x8
         add     rdi, 0x8
 
-        ; Check if we need to update the card table
-        ; Calc pCardByte
+        // Check if we need to update the card table
+        // Calc pCardByte
         shr     rcx, 0xB
         add     rcx, [C_VAR(g_card_table)]
 
-        ; Check if this card table bit is already set
+        // Check if this card table bit is already set
         test    byte ptr [rcx], al
-        je      LOCAL_LABEL(SetCardTableBit)
+        je      LOCAL_LABEL(SetCardTableBit_ByRefWriteBarrier)
         REPRET
 
-    LOCAL_LABEL(SetCardTableBit):
+    LOCAL_LABEL(SetCardTableBit_ByRefWriteBarrier):
         lock or byte ptr [rcx], al
-        jmp     LOCAL_LABEL(CheckCardBundle)
-endif
-LOCAL_LABEL(CheckCardTableByte):
+        jmp     LOCAL_LABEL(CheckCardBundle_ByRefWriteBarrier)
+#endif
+LOCAL_LABEL(CheckCardTableByte_ByRefWriteBarrier):
 
-        ; move current rdi value into rcx and then increment the pointers
+        // move current rdi value into rcx and then increment the pointers
         mov     rcx, rdi
         add     rsi, 0x8
         add     rdi, 0x8
 
-        ; Check if we need to update the card table
-        ; Calc pCardByte
+        // Check if we need to update the card table
+        // Calc pCardByte
         shr     rcx, 0xB
         add     rcx, [C_VAR(g_card_table)]
 
-        ; Check if this card is dirty
+        // Check if this card is dirty
         cmp     byte ptr [rcx], 0xFF
-        jne     LOCAL_LABEL(UpdateCardTable)
+        jne     LOCAL_LABEL(UpdateCardTable_ByRefWriteBarrier)
         REPRET
 
-    LOCAL_LABEL(UpdateCardTable):
+    LOCAL_LABEL(UpdateCardTable_ByRefWriteBarrier):
         mov     byte ptr [rcx], 0xFF
 
-    LOCAL_LABEL(CheckCardBundle):
+    LOCAL_LABEL(CheckCardBundle_ByRefWriteBarrier):
 
-ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        ; check if we need to update the card bundle table
-        ; restore destination address from rdi - rdi has been incremented by 8 already
+#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        // check if we need to update the card bundle table
+        // restore destination address from rdi - rdi has been incremented by 8 already
         lea     rcx, [rdi-8]
         shr     rcx, 0x15
         add     rcx, [C_VAR(g_card_bundle_table)]
         cmp     byte ptr [rcx], 0xFF
-        jne     LOCAL_LABEL(UpdateCardBundleTable)
+        jne     LOCAL_LABEL(UpdateCardBundleTable_ByRefWriteBarrier)
         REPRET
 
-    LOCAL_LABEL(UpdateCardBundleTable):
+    LOCAL_LABEL(UpdateCardBundleTable_ByRefWriteBarrier):
         mov     byte ptr [rcx], 0xFF
-endif
+#endif
         ret
 
     .balign 16
-    LOCAL_LABEL(NotInHeap):
-; If WRITE_BARRIER_CHECK then we won't have already done the mov and should do it here
-; If !WRITE_BARRIER_CHECK we want _NotInHeap and _Leave to be the same and have both
-; 16 byte aligned.
-ifdef WRITE_BARRIER_CHECK
-        ; rcx is [rsi]
+    LOCAL_LABEL(NotInHeap_ByRefWriteBarrier):
+// If WRITE_BARRIER_CHECK then we won't have already done the mov and should do it here
+// If !WRITE_BARRIER_CHECK we want _NotInHeap and _Leave to be the same and have both
+// 16 byte aligned.
+#ifdef WRITE_BARRIER_CHECK
+        // rcx is [rsi]
         mov     [rdi], rcx
-endif
-    LOCAL_LABEL(Exit):
-        ; Increment the pointers before leaving
+#endif
+    LOCAL_LABEL(Exit_ByRefWriteBarrier):
+        // Increment the pointers before leaving
         add     rdi, 0x8
         add     rsi, 0x8
         ret

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -11,7 +11,7 @@
 //   RDI - address of ref-field (assigned to)
 //   RSI - address of the data  (source)
 //   RCX is trashed
-//   RAX is trashed when FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP is defined
+//   RAX is trashed
 //
 //   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
 //         if you add more trashed registers.
@@ -111,8 +111,6 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         cmp     rcx, [C_VAR(g_ephemeral_high)]
         jnb     LOCAL_LABEL(Exit_ByRefWriteBarrier)
 
-        // do the following checks only if we are allowed to trash rax
-        // otherwise we don't have enough registers
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, rcx
 

--- a/src/coreclr/vm/amd64/jithelpers_fast.S
+++ b/src/coreclr/vm/amd64/jithelpers_fast.S
@@ -111,7 +111,6 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         cmp     rcx, [C_VAR(g_ephemeral_high)]
         jnb     LOCAL_LABEL(Exit_ByRefWriteBarrier)
 
-#ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, rcx
 
         mov     cl, [C_VAR(g_region_shr)]
@@ -160,7 +159,6 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
     LOCAL_LABEL(SetCardTableBit_ByRefWriteBarrier):
         lock or byte ptr [rcx], al
         jmp     LOCAL_LABEL(CheckCardBundle_ByRefWriteBarrier)
-#endif
 LOCAL_LABEL(CheckCardTableByte_ByRefWriteBarrier):
 
         // move current rdi value into rcx and then increment the pointers

--- a/src/coreclr/vm/arm64/patchedcode.S
+++ b/src/coreclr/vm/arm64/patchedcode.S
@@ -42,6 +42,9 @@ LEAF_END JIT_PatchedCodeStart, _TEXT
 //   x15  : trashed
 //   x17  : trashed (ip1) if FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 //
+//   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+//         if you add more trashed registers.
+//
 WRITE_BARRIER_ENTRY JIT_ByRefWriteBarrier
 
     ldr  x15, [x13], 8

--- a/src/coreclr/vm/arm64/patchedcode.asm
+++ b/src/coreclr/vm/arm64/patchedcode.asm
@@ -76,6 +76,9 @@ wbs_GCShadowEnd
 ;   x15  : trashed
 ;   x17  : trashed (ip1) if FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
 ;
+;   NOTE: Keep in sync with RBM_CALLEE_TRASH_WRITEBARRIER_BYREF and RBM_CALLEE_GCTRASH_WRITEBARRIER_BYREF
+;         if you add more trashed registers.
+;
     WRITE_BARRIER_ENTRY JIT_ByRefWriteBarrier
 
         ldr      x15, [x13], 8


### PR DESCRIPTION
Seems that ARM64 is already fine as is and listing `r12,r15,ip0,ip1 (r17)` as trashed registers.