### PR TITLE
ILCompiler: support publishing using a non-portable ILCompiler build.

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.DotNet.ILCompiler.SingleEntry.targets
@@ -4,7 +4,11 @@
     <!-- Define the name of the runtime specific compiler package to import -->
     <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
 
+    <_targetsNonPortableSdkRid>false</_targetsNonPortableSdkRid>
+    <_targetsNonPortableSdkRid Condition="'$(RuntimeIdentifier)' == '$(NETCoreSdkRuntimeIdentifier)' and '$(RuntimeIdentifier)' != '$(NETCoreSdkPortableRuntimeIdentifier)'">true</_targetsNonPortableSdkRid>
+
     <_originalTargetOS>$(RuntimeIdentifier.SubString(0, $(RuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
+    <_originalTargetOS Condition="'$(_targetsNonPortableSdkRid)' == 'true'">$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.Contains('.'))">$(_originalTargetOS.SubString(0, $(_originalTargetOS.IndexOf('.'))))</_originalTargetOS>
     <_originalTargetOS Condition="$(_originalTargetOS.StartsWith('win'))">win</_originalTargetOS>
 
@@ -17,7 +21,9 @@
     <_targetArchitecture>$(RuntimeIdentifier.SubString($([MSBuild]::Add($(RuntimeIdentifier.LastIndexOf('-')), 1))))</_targetArchitecture>
 
     <_hostPackageName>runtime.$(_hostOS)-$(_hostArchitecture).Microsoft.DotNet.ILCompiler</_hostPackageName>
+    <_hostPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_hostPackageName>
     <_targetPackageName>runtime.$(_originalTargetOS)-$(_targetArchitecture).Microsoft.DotNet.ILCompiler</_targetPackageName>
+    <_targetPackageName Condition="'$(_targetsNonPortableSdkRid)' == 'true'">runtime.$(RuntimeIdentifier).Microsoft.DotNet.ILCompiler</_targetPackageName>
 
     <!-- Treat linux-musl and linux-bionic etc. as linux -->
     <_targetOS>$(_originalTargetOS)</_targetOS>

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -10,8 +10,6 @@
   <!-- BEGIN: Workaround for https://github.com/dotnet/runtime/issues/67742 -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <PublishDir>$(RuntimeBinDir)ilc-published/</PublishDir>
-    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.EndsWith('-arm')) == 'true'">false</NativeAotSupported>
     <!-- Disable native AOT on FreeBSD when cross building from Linux. -->
@@ -26,7 +24,7 @@
     <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
     <_hostArchitecture Condition="'$(OS)' != 'Windows_NT'">$(NETCoreSdkPortableRuntimeIdentifier.SubString($([MSBuild]::Add($(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-')), 1))))</_hostArchitecture>
     <_hostArchitecture Condition="'$(OS)' == 'Windows_NT'">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</_hostArchitecture>
-    <_hostPackageName>runtime.$(_hostOS)-$(_hostArchitecture).Microsoft.DotNet.ILCompiler</_hostPackageName>
+    <_hostPackageName>runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler</_hostPackageName>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -20,8 +20,7 @@
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
     <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
-    <!-- Compute host OS and architecture (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->
-    <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
+    <!-- Compute host architecture (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->
     <_hostArchitecture Condition="'$(OS)' != 'Windows_NT'">$(NETCoreSdkPortableRuntimeIdentifier.SubString($([MSBuild]::Add($(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-')), 1))))</_hostArchitecture>
     <_hostArchitecture Condition="'$(OS)' == 'Windows_NT'">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</_hostArchitecture>
   </PropertyGroup>
@@ -90,7 +89,7 @@
   </Target>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
-    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(_hostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
+    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(HostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
   </ItemGroup>
 
   <Target Name="PublishCompiler"

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -20,16 +20,15 @@
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
     <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
-    <!-- Compute host package name (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->
+    <!-- Compute host OS and architecture (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->
     <_hostOS>$(NETCoreSdkPortableRuntimeIdentifier.SubString(0, $(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-'))))</_hostOS>
     <_hostArchitecture Condition="'$(OS)' != 'Windows_NT'">$(NETCoreSdkPortableRuntimeIdentifier.SubString($([MSBuild]::Add($(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-')), 1))))</_hostArchitecture>
     <_hostArchitecture Condition="'$(OS)' == 'Windows_NT'">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</_hostArchitecture>
-    <_hostPackageName>runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler</_hostPackageName>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
-    <PackageReference Include="$(_hostPackageName)" Version="$(MicrosoftDotNetILCompilerVersion)" />
+    <PackageReference Include="runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
   </ItemGroup>
 
   <!-- Needed for the amd64 -> amd64 musl cross-build to pass the target flag. -->

--- a/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompiler.csproj
@@ -20,9 +20,6 @@
     <PublishSingleFile Condition="'$(NativeAotSupported)' != 'true'">true</PublishSingleFile>
     <PublishTrimmed Condition="'$(NativeAotSupported)' != 'true'">true</PublishTrimmed>
     <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
-    <!-- Compute host architecture (taken from Microsoft.DotNet.ILCompiler.SingleEntry.targets) -->
-    <_hostArchitecture Condition="'$(OS)' != 'Windows_NT'">$(NETCoreSdkPortableRuntimeIdentifier.SubString($([MSBuild]::Add($(NETCoreSdkPortableRuntimeIdentifier.LastIndexOf('-')), 1))))</_hostArchitecture>
-    <_hostArchitecture Condition="'$(OS)' == 'Windows_NT'">$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant)</_hostArchitecture>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
@@ -89,7 +86,7 @@
   </Target>
 
   <ItemGroup Condition="'$(NativeAotSupported)' == 'true'">
-    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(_hostArchitecture)' == '$(_targetArchitecture)' and '$(HostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
+    <CustomLinkerArg Condition="'$(CrossBuild)' == 'true' and '$(BuildArchitecture)' == '$(_targetArchitecture)' and '$(HostOS)' != 'windows' and '$(_IsApplePlatform)' != 'true'" Include="--gcc-toolchain=$(ROOTFS_DIR)/usr" />
   </ItemGroup>
 
   <Target Name="PublishCompiler"

--- a/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2_publish.csproj
@@ -7,8 +7,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <!-- Can't use NativeAOT in non-portable build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(PortableBuild)' != 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.StartsWith('tizen')) == 'true'">false</NativeAotSupported>
     <NativeAotSupported Condition="$(OutputRID.EndsWith('-arm')) == 'true'">false</NativeAotSupported>
     <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
@@ -14,6 +14,6 @@
     <OfficialBuildRID Include="win-x64" Platform="x64" />
     <OfficialBuildRID Include="freebsd-x64" Platform="x64" />
     <OfficialBuildRID Include="freebsd-arm64" Platform="arm64" />
-    <OfficialBuildRID Include="$(OutputRID)" Platform="$(TargetArchitecture)" Condition="'$(NativeAotSupported)' == 'true'" Exclude="@(OfficialBuildRID)" />
+    <OfficialBuildRID Include="$(OutputRID)" Platform="$(TargetArchitecture)" Exclude="@(OfficialBuildRID)" />
   </ItemGroup>
 </Project>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
@@ -14,5 +14,6 @@
     <OfficialBuildRID Include="win-x64" Platform="x64" />
     <OfficialBuildRID Include="freebsd-x64" Platform="x64" />
     <OfficialBuildRID Include="freebsd-arm64" Platform="arm64" />
+    <OfficialBuildRID Include="$(OutputRID)" Platform="$(TargetArchitecture)" Condition="'$(NativeAotSupported)' == 'true'" Exclude="@(OfficialBuildRID)" />
   </ItemGroup>
 </Project>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -21,8 +21,6 @@
     <ShouldVerifyClosure>false</ShouldVerifyClosure>
     <!-- Publish crossgen2 as a single-file app on native-OS builds. Cross-OS NativeAOT compilation is not supported yet -->
     <NativeAotSupported Condition="'$(CrossBuild)' == 'true' and '$(TargetOS)' != '$(HostOS)'">false</NativeAotSupported>
-    <!-- Can't use NativeAOT in source build yet https://github.com/dotnet/runtime/issues/66859 -->
-    <NativeAotSupported Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</NativeAotSupported>
   </PropertyGroup>
 
   <ItemGroup>
@@ -43,7 +41,7 @@
                              KeepMetadata="REMOVE_ALL" />
     </ItemGroup>
     <ItemGroup Condition="'$(NativeAotSupported)' != 'true'">
-      <FilesToPackage Include="@(_CrossgenPublishFiles)"
+      <FilesToPackage Include="@(_CrossgenPublishFiles->Distinct())"
                       Exclude="*.pdb;*.h;*.lib"
                       TargetPath="tools/" />
     </ItemGroup>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Crossgen2.sfxproj
@@ -41,7 +41,7 @@
                              KeepMetadata="REMOVE_ALL" />
     </ItemGroup>
     <ItemGroup Condition="'$(NativeAotSupported)' != 'true'">
-      <FilesToPackage Include="@(_CrossgenPublishFiles->Distinct())"
+      <FilesToPackage Include="@(_CrossgenPublishFiles)"
                       Exclude="*.pdb;*.h;*.lib"
                       TargetPath="tools/" />
     </ItemGroup>

--- a/src/tasks/Crossgen2Tasks/ResolveReadyToRunCompilers.cs
+++ b/src/tasks/Crossgen2Tasks/ResolveReadyToRunCompilers.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using NuGet.RuntimeModel;
 using NuGet.Versioning;
 
 namespace Microsoft.NET.Build.Tasks
@@ -112,9 +111,8 @@ namespace Microsoft.NET.Build.Tasks
                 return false;
             }
 
-            RuntimeGraph runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-            if (!ExtractTargetPlatformAndArchitecture(runtimeGraph, _targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture) ||
-                !ExtractTargetPlatformAndArchitecture(runtimeGraph, _hostRuntimeIdentifier, out string hostPlatform, out _) ||
+            if (!ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture) ||
+                !ExtractTargetPlatformAndArchitecture(_hostRuntimeIdentifier, out string hostPlatform, out _) ||
                 _targetPlatform != hostPlatform ||
                 !GetCrossgenComponentsPaths())
             {
@@ -144,8 +142,7 @@ namespace Microsoft.NET.Build.Tasks
             }
 
             bool version5 = crossgen2PackVersion.Major < 6;
-            RuntimeGraph runtimeGraph = new RuntimeGraphCache(this).GetRuntimeGraph(RuntimeGraphPath);
-            bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(runtimeGraph, _targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
+            bool isSupportedTarget = ExtractTargetPlatformAndArchitecture(_targetRuntimeIdentifier, out _targetPlatform, out _targetArchitecture);
 
             // Normalize target OS for crossgen invocation
             string targetOS = (_targetPlatform == "win") ? "windows" :
@@ -205,7 +202,7 @@ namespace Microsoft.NET.Build.Tasks
                             .Equals("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase));
         }
 
-        private static bool ExtractTargetPlatformAndArchitecture(RuntimeGraph runtimeGraph, string runtimeIdentifier, out string platform, out Architecture architecture)
+        private static bool ExtractTargetPlatformAndArchitecture(string runtimeIdentifier, out string platform, out Architecture architecture)
         {
             platform = null;
             architecture = default;
@@ -237,30 +234,7 @@ namespace Microsoft.NET.Build.Tasks
                     return false;
             }
 
-            string[] supportedRIDsList = [
-                $"linux-{architectureStr}",
-                $"win-{architectureStr}",
-                $"osx-{architectureStr}",
-                $"freebsd-{architectureStr}",
-                $"maccatalyst-{architectureStr}",
-                $"iossimulator-{architectureStr}",
-                $"ios-{architectureStr}",
-                $"tvossimulator-{architectureStr}",
-                $"tvos-{architectureStr}"
-            ];
-
-            string platformRid = NuGetUtils.GetBestMatchingRid(
-                runtimeGraph,
-                runtimeIdentifier,
-                supportedRIDsList,
-                out _);
-
-            if (platformRid == null)
-            {
-                return false;
-            }
-
-            platform = platformRid.Substring(0, platformRid.LastIndexOf('-')).ToLowerInvariant();
+            platform = runtimeIdentifier.Substring(0, separator).ToLowerInvariant();
             return true;
         }
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/1215.
Closes https://github.com/dotnet/runtime/issues/66859.

@jkotas @hoyosjs @jkoritzinsky @agocke ptal.

cc @MichaelSimons @ashnaga @omajid 