### PR TITLE
[RISC-V] OSR: Fix initReg usage in genPushCalleeSavedRegisters

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -8093,7 +8093,7 @@ void CodeGen::genPopCalleeSavedRegisters(bool jmpEpilog)
                 unsigned(compiler->lvaOutgoingArgSpaceSize), totalFrameSize, compiler->compCalleeRegsPushed,
                 dspBool(compiler->compLocallocUsed));
 
-        if ((compiler->lvaOutgoingArgSpaceSize + (compiler->compCalleeRegsPushed << 3)) >= 2040)
+        if ((compiler->lvaOutgoingArgSpaceSize + (compiler->compCalleeRegsPushed << 3)) > 2040)
         {
             calleeSaveSPOffset = compiler->lvaOutgoingArgSpaceSize & 0xfffffff0;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -8100,8 +8100,8 @@ void CodeGen::genPopCalleeSavedRegisters(bool jmpEpilog)
             {
                 genStackPointerAdjustment(calleeSaveSPOffset, REG_RA, nullptr, /* reportUnwindData */ true);
             }
+            remainingSPSize    = totalFrameSize - calleeSaveSPOffset;
             calleeSaveSPOffset = compiler->lvaOutgoingArgSpaceSize - calleeSaveSPOffset;
-            remainingSPSize    = remainingSPSize - calleeSaveSPOffset;
         }
         else
         {

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -8012,7 +8012,8 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
         }
         else
         {
-            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, &ignoreInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, &ignoreInitRegZeroed,
+                                      /* reportUnwindData */ true);
         }
     }
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7893,7 +7893,6 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
     // save callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH
     // beforehand. We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
     //
-    bool ignoreInitRegZeroed = false;
 
     // Unlike on x86/x64, we can also push float registers to stack
     regMaskTP rsPushRegs = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;
@@ -8007,13 +8006,11 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
             calleeSaveSPDelta = AlignUp((UINT)offset, STACK_ALIGN);
             offset            = calleeSaveSPDelta - offset;
 
-            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, &ignoreInitRegZeroed,
-                                      /* reportUnwindData */ true);
+            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, nullptr, /* reportUnwindData */ true);
         }
         else
         {
-            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, &ignoreInitRegZeroed,
-                                      /* reportUnwindData */ true);
+            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, nullptr, /* reportUnwindData */ true);
         }
     }
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -8088,7 +8088,7 @@ void CodeGen::genPopCalleeSavedRegisters(bool jmpEpilog)
                 unsigned(compiler->lvaOutgoingArgSpaceSize), totalFrameSize, compiler->compCalleeRegsPushed,
                 dspBool(compiler->compLocallocUsed));
 
-        if ((compiler->lvaOutgoingArgSpaceSize + (compiler->compCalleeRegsPushed << 3)) > 2040)
+        if ((compiler->lvaOutgoingArgSpaceSize + (compiler->compCalleeRegsPushed << 3)) > 2047)
         {
             calleeSaveSPOffset = compiler->lvaOutgoingArgSpaceSize & 0xfffffff0;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7888,10 +7888,10 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
     assert(compiler->compGeneratingProlog);
 
     //
-    // The 'initReg' could have been calculated as one of the callee-saved registers (let's say T0, T1 and T2 are in use,
-    // so the next possible register is S1, which should be callee-save register). This is fine, as long as we save
-    // callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH beforehand.
-    // We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
+    // The 'initReg' could have been calculated as one of the callee-saved registers (let's say T0, T1 and T2 are in
+    // use, so the next possible register is S1, which should be callee-save register). This is fine, as long as we
+    // save callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH
+    // beforehand. We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
     //
     bool ignoreInitRegZeroed = false;
 
@@ -8007,7 +8007,8 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
             calleeSaveSPDelta = AlignUp((UINT)offset, STACK_ALIGN);
             offset            = calleeSaveSPDelta - offset;
 
-            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, &ignoreInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, &ignoreInitRegZeroed,
+                                      /* reportUnwindData */ true);
         }
         else
         {

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7999,11 +7999,11 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
             calleeSaveSPDelta = AlignUp((UINT)offset, STACK_ALIGN);
             offset            = calleeSaveSPDelta - offset;
 
-            genStackPointerAdjustment(-calleeSaveSPDelta, initReg, pInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, pInitRegZeroed, /* reportUnwindData */ true);
         }
         else
         {
-            genStackPointerAdjustment(-totalFrameSize, initReg, pInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, pInitRegZeroed, /* reportUnwindData */ true);
         }
     }
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7887,13 +7887,11 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
 {
     assert(compiler->compGeneratingProlog);
 
-    //
     // The 'initReg' could have been calculated as one of the callee-saved registers (let's say T0, T1 and T2 are in
     // use, so the next possible register is S1, which should be callee-save register). This is fine, as long as we
     // save callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH
     // beforehand. We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
     //
-
     // Unlike on x86/x64, we can also push float registers to stack
     regMaskTP rsPushRegs = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;
 

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7888,10 +7888,10 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
     assert(compiler->compGeneratingProlog);
 
     //
-    // The 'initReg' might have been calculated to be one of the callee-saved registers (say T0, T1 and T2 are in use,
-    // so the next possible register is S1, which should be callee-save register). This is fine as long as we will
-    // save callee-save registers before ferst use of 'initReg'. Instead we can use REG_SCRATCH before that.
-    // We don't care if REG_SCRATCH will be overridden, so wi will skip 'RegZeroed check'.
+    // The 'initReg' could have been calculated as one of the callee-saved registers (let's say T0, T1 and T2 are in use,
+    // so the next possible register is S1, which should be callee-save register). This is fine, as long as we save
+    // callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH beforehand.
+    // We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
     //
     bool ignoreInitRegZeroed = false;
 
@@ -8020,7 +8020,7 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
     genSaveCalleeSavedRegistersHelp(rsPushRegs, offset, 0);
     offset += (int)(genCountBits(rsPushRegs) << 3); // each reg has 8 bytes
 
-    // From now on we can use 'initReg' safely, because all callee-saved registers has been saved.
+    // From now on we can use 'initReg' safely, because all callee-saved registers have been saved.
 
     emit->emitIns_R_R_I(INS_sd, EA_PTRSIZE, REG_RA, REG_SPBASE, offset);
     compiler->unwindSaveReg(REG_RA, offset);


### PR DESCRIPTION
When I've created #96558, I forgot about special case, when `initReg` can be calculated as one of the callee-saved registers. 
This could happen when `T0`, `T1` and `T2` registers have already been used - in that case the next "free" register is `S1`, which is the first callee-saved register. That situation is fine as long as I will save `initReg` first. Instead I could use `REG_SCRATCH`.

This PR fixes issues in following tests:
- `JIT/jit64/hfa/main/testC/hfa_nd2C_d` - calleeSaved register is being used as initReg
- `JIT/jit64/hfa/main/testC/hfa_sd2C_d` - calleeSaved register is being  used as initReg
- `JIT/jit64/gc/regress/vswhidbey/339415` - remainingSPSize is not calculated correctly
- `JIT/Methodical/largeframes/skip6/skippage6` - remainingSPSize is not calculated correctly

Part of #84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov
@viewizard @ashaurtaev @brucehoult @tomeksowi @yurai007 @Bajtazar
@bartlomiejko @rzsc