### PR TITLE
SPMI: Expand PerfScore output

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1782,7 +1782,7 @@ class SuperPMIReplay:
 def html_color(color, text):
     return "<span style=\"color:{}\">{}</span>".format(color, text)
 
-def calculate_improvements_regressions(base_diff_sizes):
+def calculate_size_improvements_regressions(base_diff_sizes):
     num_improvements = sum(1 for (base_size, diff_size) in base_diff_sizes if diff_size < base_size)
     num_regressions = sum(1 for (base_size, diff_size) in base_diff_sizes if diff_size > base_size)
     num_same = sum(1 for (base_size, diff_size) in base_diff_sizes if diff_size == base_size)
@@ -1791,6 +1791,34 @@ def calculate_improvements_regressions(base_diff_sizes):
     byte_regressions = sum(max(0, diff_size - base_size) for (base_size, diff_size) in base_diff_sizes)
 
     return (num_improvements, num_regressions, num_same, byte_improvements, byte_regressions)
+
+def calculate_perfscore_improvements_regressions(base_diff_perfscores):
+    num_ps_improvements = 0
+    num_ps_regressions = 0
+    num_ps_same = 0
+    sum_log_ps_improvements = 0
+    sum_log_ps_regressions = 0
+    for (base_ps, diff_ps) in base_diff_perfscores:
+        log_relative_perfscore = math.log(max(diff_ps, 1.0) / max(base_ps, 1.0))
+
+        if abs(diff_ps - base_ps) < 0.01:
+            num_ps_same += 1
+        elif diff_ps < base_ps:
+            num_ps_improvements += 1
+            sum_log_ps_improvements += log_relative_perfscore
+        elif base_ps < diff_ps:
+            num_ps_regressions += 1
+            sum_log_ps_regressions += log_relative_perfscore
+
+    ps_improvements = None
+    if num_ps_improvements > 0:
+        ps_improvements = math.exp(sum_log_ps_improvements / num_ps_improvements) - 1
+
+    ps_regressions = None
+    if num_ps_regressions > 0:
+        ps_regressions = math.exp(sum_log_ps_regressions / num_ps_regressions) - 1
+
+    return (num_ps_improvements, num_ps_regressions, num_ps_same, ps_improvements, ps_regressions)
 
 def format_delta(base, diff):
     plus_if_positive = "+" if diff >= base else ""
@@ -2375,16 +2403,25 @@ class SuperPMIReplayAsmDiffs:
                     # If we are not specifying custom metrics then print a summary here, otherwise leave the summarization up to jit-analyze.
                     if self.coreclr_args.metrics is None:
                         base_diff_sizes = [(int(r["Base size"]), int(r["Diff size"])) for r in diffs]
+                        (num_size_improvements, num_size_regressions, num_size_same, byte_improvements, byte_regressions) = calculate_size_improvements_regressions(base_diff_sizes)
 
-                        (num_improvements, num_regressions, num_same, byte_improvements, byte_regressions) = calculate_improvements_regressions(base_diff_sizes)
-
-                        logging.info("{:,d} contexts with diffs ({:,d} improvements, {:,d} regressions, {:,d} same size)".format(
-                            len(diffs),
-                            num_improvements,
-                            num_regressions,
-                            num_same,
+                        num_diffs_str = "{:,d} contexts with diffs".format(len(diffs))
+                        logging.info("{} ({:,d} size improvements, {:,d} size regressions, {:,d} same size)".format(
+                            num_diffs_str,
+                            num_size_improvements,
+                            num_size_regressions,
+                            num_size_same,
                             byte_improvements,
                             byte_regressions))
+
+                        base_diff_perfscores = [(float(r["Base PerfScore"]), float(r["Diff PerfScore"])) for r in diffs]
+                        (num_ps_improvements, num_ps_regressions, num_ps_same, ps_improvements, ps_regressions) = calculate_perfscore_improvements_regressions(base_diff_perfscores)
+
+                        logging.info("{} ({:,d} PerfScore improvements, {:,d} PerfScore regressions, {:,d} same PerfScore)".format(
+                            ' ' * len(num_diffs_str),
+                            num_ps_improvements,
+                            num_ps_regressions,
+                            num_ps_same))
 
                         if byte_improvements > 0 and byte_regressions > 0:
                             logging.info("  -{:,d}/+{:,d} bytes".format(byte_improvements, byte_regressions))
@@ -2392,6 +2429,13 @@ class SuperPMIReplayAsmDiffs:
                             logging.info("  -{:,d} bytes".format(byte_improvements))
                         elif byte_regressions > 0:
                             logging.info("  +{:,d} bytes".format(byte_regressions))
+
+                        if ps_improvements is not None and ps_regressions is not None:
+                            logging.info("  {:.2f}%/+{:.2f}% PerfScore".format(ps_improvements * 100, ps_regressions * 100))
+                        elif ps_improvements is not None:
+                            logging.info("  -{:.2f}% PerfScore".format(ps_improvements))
+                        elif ps_regressions is not None:
+                            logging.info("  +{:.2f}% PerfScore".format(ps_regressions))
 
                         logging.info("")
                         logging.info("")
@@ -2568,28 +2612,48 @@ class SuperPMIReplayAsmDiffs:
             # Next write a detailed section
             with DetailsSection(write_fh, "Details"):
                 if any_diffs:
-                    write_fh.write("#### Improvements/regressions per collection\n\n")
-                    write_fh.write("|Collection|Contexts with diffs|Improvements|Regressions|Same size|Improvements (bytes)|Regressions (bytes)|PerfScore Overall (FullOpts)|\n")
-                    write_fh.write("|---|--:|--:|--:|--:|--:|--:|--:|\n")
+                    write_fh.write("#### Size improvements/regressions per collection\n\n")
+                    write_fh.write("|Collection|Contexts with diffs|Improvements|Regressions|Same size|Improvements (bytes)|Regressions (bytes)|\n")
+                    write_fh.write("|---|--:|--:|--:|--:|--:|--:|\n")
 
-                    def write_row(name, diffs, perfscore_geomean):
+                    def write_row(name, diffs):
                         base_diff_sizes = [(int(r["Base size"]), int(r["Diff size"])) for r in diffs]
-                        (num_improvements, num_regressions, num_same, byte_improvements, byte_regressions) = calculate_improvements_regressions(base_diff_sizes)
-                        write_fh.write("|{}|{:,d}|{}|{}|{}|{}|{}|{}|\n".format(
+                        (num_improvements, num_regressions, num_same, byte_improvements, byte_regressions) = calculate_size_improvements_regressions(base_diff_sizes)
+                        write_fh.write("|{}|{:,d}|{}|{}|{}|{}|{}|\n".format(
                             name,
                             len(diffs),
                             html_color("green", "{:,d}".format(num_improvements)),
                             html_color("red", "{:,d}".format(num_regressions)),
                             html_color("blue", "{:,d}".format(num_same)),
                             html_color("green", "-{:,d}".format(byte_improvements)),
-                            html_color("red", "+{:,d}".format(byte_regressions)),
-                            "" if perfscore_geomean is None else format_pct(perfscore_geomean, 4)))
+                            html_color("red", "+{:,d}".format(byte_regressions))))
 
                     for (mch_file, _, diff_metrics, diffs, _, _) in asm_diffs:
-                        write_row(mch_file, diffs, diff_metrics["FullOpts"]["Relative PerfScore Geomean"] * 100 - 100)
+                        write_row(mch_file, diffs)
 
                     if len(asm_diffs) > 1:
-                        write_row("", [r for (_, _, _, diffs, _, _) in asm_diffs for r in diffs], None)
+                        write_row("", [r for (_, _, _, diffs, _, _) in asm_diffs for r in diffs])
+
+                    write_fh.write("\n---\n\n")
+                    write_fh.write("#### PerfScore improvements/regressions per collection\n\n")
+                    write_fh.write("|Collection|Contexts with diffs|Improvements|Regressions|Same PerfScore|Improvements (PerfScore)|Regressions (PerfScore)|PerfScore Overall in FullOpts|\n")
+                    write_fh.write("|---|--:|--:|--:|--:|--:|--:|--:|\n")
+
+                    def write_ps_row(name, diffs, perfscore_geomean):
+                        base_diff_perfscores = [(float(r["Base PerfScore"]), float(r["Diff PerfScore"])) for r in diffs]
+                        (num_improvements, num_regressions, num_same, ps_improvements, ps_regressions) = calculate_perfscore_improvements_regressions(base_diff_perfscores)
+                        write_fh.write("|{}|{:,d}|{}|{}|{}|{}|{}|{}|\n".format(
+                            name,
+                            len(diffs),
+                            html_color("green", "{:,d}".format(num_improvements)),
+                            html_color("red", "{:,d}".format(num_regressions)),
+                            html_color("blue", "{:,d}".format(num_same)),
+                            format_pct(ps_improvements * 100),
+                            format_pct(ps_regressions * 100),
+                            format_pct(perfscore_geomean * 100, 4)))
+
+                    for (mch_file, _, diff_metrics, diffs, _, _) in asm_diffs:
+                        write_ps_row(mch_file, diffs, diff_metrics["FullOpts"]["Relative PerfScore Geomean"] - 1)
 
                     write_fh.write("\n---\n\n")
 


### PR DESCRIPTION
- Output relative perfscore geomean for improvements/regressions separately for the console output
- Output perfscore in its own table in the report and include perfscore improvements/regressions separately

Example output to the console:
```
[13:28:53] 7,259 contexts with diffs (5,422 size improvements, 1,484 size regressions, 353 same size)
[13:28:53]                           (5,570 PerfScore improvements, 1,201 PerfScore regressions, 488 same PerfScore)
[13:28:53]   -278,665/+63,638 bytes
[13:28:53]   -11.35%/+4.20% PerfScore
```

How the table looks in the report:
![image](https://github.com/dotnet/runtime/assets/7887810/a148f3b4-eb4e-454c-b3c3-4133fb4d6c09)

Fix #98799