### PR TITLE
[mono] Bump _WIN32_WINNT to align with coreclr

### DIFF
--- a/src/mono/cmake/config.h.in
+++ b/src/mono/cmake/config.h.in
@@ -5,9 +5,9 @@
 
 #include <SDKDDKVer.h>
 
-#if _WIN32_WINNT < 0x0601
-#error "Mono requires Windows 7 or later."
-#endif /* _WIN32_WINNT < 0x0601 */
+#if _WIN32_WINNT < 0x0602
+#error "Mono requires Windows 8 or later."
+#endif /* _WIN32_WINNT < 0x0602 */
 
 #ifndef HAVE_WINAPI_FAMILY_SUPPORT
 

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -385,9 +385,8 @@
       <_MonoCPPFLAGS Include="-D_CRT_NONSTDC_NO_DEPRECATE" />
       <!--<_MonoCPPFLAGS Include="-DGC_NOT_DLL" />--> <!-- only used for Boehm -->
       <_MonoCPPFLAGS Include="-DWIN32_THREADS" />
-      <_MonoCPPFLAGS Include="-DWINVER=0x0601" />
-      <_MonoCPPFLAGS Include="-D_WIN32_WINNT=0x0601" />
-      <_MonoCPPFLAGS Include="-D_WIN32_IE=0x0501" />
+      <_MonoCPPFLAGS Include="-DWINVER=0x0602" />
+      <_MonoCPPFLAGS Include="-D_WIN32_WINNT=0x0602" />
       <_MonoCPPFLAGS Include="-D_UNICODE" />
       <_MonoCPPFLAGS Include="-DUNICODE" />
       <_MonoCPPFLAGS Include="-DFD_SETSIZE=1024" />
@@ -765,9 +764,8 @@
       <_MonoAOTCPPFLAGS Include="-D_CRT_NONSTDC_NO_DEPRECATE" />
       <!--<_MonoAOTCPPFLAGS Include="-DGC_NOT_DLL" />--> <!-- only used for Boehm -->
       <_MonoAOTCPPFLAGS Include="-DWIN32_THREADS" />
-      <_MonoAOTCPPFLAGS Include="-DWINVER=0x0601" />
-      <_MonoAOTCPPFLAGS Include="-D_WIN32_WINNT=0x0601" />
-      <_MonoAOTCPPFLAGS Include="-D_WIN32_IE=0x0501" />
+      <_MonoAOTCPPFLAGS Include="-DWINVER=0x0602" />
+      <_MonoAOTCPPFLAGS Include="-D_WIN32_WINNT=0x0602" />
       <_MonoAOTCPPFLAGS Include="-D_UNICODE" />
       <_MonoAOTCPPFLAGS Include="-DUNICODE" />
       <_MonoAOTCPPFLAGS Include="-DFD_SETSIZE=1024" />


### PR DESCRIPTION
The only code that is affected and enabled now is: https://github.com/dotnet/runtime/blob/50d6e5d5ffd05dd4034cffd222ea610baedcc326/src/mono/mono/utils/mono-threads-windows.c#L476-L497

Also removed setting _WIN32_IE since this makes no sense anymore.