### PR TITLE
JIT: Improve isinst expansion

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -5524,7 +5524,7 @@ GenTree* Compiler::impCastClassOrIsInstToTree(
     GenTreeOp*    condMT    = gtNewOperNode(GT_NE, TYP_INT, gtNewMethodTableLookup(op1Clone), op2);
     GenTreeOp*    condNull  = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewNull());
     GenTreeQmark* qmarkMT   = gtNewQmarkNode(TYP_REF, condMT, gtNewColonNode(TYP_REF, gtNewNull(), gtClone(op1)));
-    GenTreeQmark* qmarkNull = gtNewQmarkNode(TYP_REF, condNull, gtNewColonNode(TYP_REF, gtClone(op1), qmarkMT));
+    GenTreeQmark* qmarkNull = gtNewQmarkNode(TYP_REF, condNull, gtNewColonNode(TYP_REF, gtNewNull(), qmarkMT));
 
     // Make QMark node a top level node by spilling it.
     const unsigned result = lvaGrabTemp(true DEBUGARG("spilling qmarkNull"));


### PR DESCRIPTION
Small change - big (-400kb) diffs.


What it does, for `op1 isinst ExactCls` it changes the resulting shape like this:
```diff
      tmp = op1;
      if (tmp != null) // qmarkNull
      {
          if (tmp->pMT == ExactCls) // qmarkMT
              result = tmp;
          else
              result = null;
      }
      else
-        result = tmp; // tmp is always null here anyway
+        result = null;
```