### PR TITLE
Remove use of POH for cryptographic primitives

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -403,6 +403,7 @@
     <Compile Include="System\Security\Cryptography\ECKeyXmlFormat.cs" />
     <Compile Include="System\Security\Cryptography\ECParameters.cs" />
     <Compile Include="System\Security\Cryptography\ECPoint.cs" />
+    <Compile Include="System\Security\Cryptography\FixedMemoryKeyBox.cs" />
     <Compile Include="System\Security\Cryptography\HashAlgorithm.cs" />
     <Compile Include="System\Security\Cryptography\HashAlgorithmName.cs" />
     <Compile Include="System\Security\Cryptography\HashAlgorithmNames.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCcm.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesCcm.Android.cs
@@ -9,16 +9,16 @@ namespace System.Security.Cryptography
 {
     public sealed partial class AesCcm
     {
-        private byte[]? _key;
+        private FixedMemoryKeyBox _keyBox;
 
         public static bool IsSupported => true;
 
-        [MemberNotNull(nameof(_key))]
+        [MemberNotNull(nameof(_keyBox))]
         private void ImportKey(ReadOnlySpan<byte> key)
         {
-            // Pin the array on the POH so that the GC doesn't move it around to allow zeroing to be more effective.
-            _key = GC.AllocateArray<byte>(key.Length, pinned: true);
-            key.CopyTo(_key);
+            // We should only be calling this in the constructor, so there shouldn't be a previous key.
+            Debug.Assert(_keyBox is null);
+            _keyBox = new FixedMemoryKeyBox(key);
         }
 
         private void EncryptCore(
@@ -28,80 +28,93 @@ namespace System.Security.Cryptography
             Span<byte> tag,
             ReadOnlySpan<byte> associatedData = default)
         {
-            CheckDisposed();
+            bool acquired = false;
 
-            // Convert key length to bits.
-            using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(_key.Length * 8)))
+            try
             {
-                if (ctx.IsInvalid)
+                _keyBox.DangerousAddRef(ref acquired);
+                ReadOnlySpan<byte> key = _keyBox.DangerousKeySpan;
+
+                // Convert key length to bits.
+                using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(key.Length * 8)))
                 {
-                    throw new CryptographicException();
-                }
-
-                if (!Interop.Crypto.CipherSetTagLength(ctx, tag.Length))
-                {
-                    throw new CryptographicException();
-                }
-
-                Interop.Crypto.CipherSetNonceLength(ctx, nonce.Length);
-                Interop.Crypto.EvpCipherSetKeyAndIV(ctx, _key, nonce, Interop.Crypto.EvpCipherDirection.Encrypt);
-
-                if (associatedData.Length != 0)
-                {
-                    Interop.Crypto.CipherUpdateAAD(ctx, associatedData);
-                }
-
-                byte[]? rented = null;
-                try
-                {
-                    scoped Span<byte> ciphertextAndTag;
-
-                    // Arbitrary limit.
-                    const int StackAllocMax = 128;
-                    if (checked(ciphertext.Length + tag.Length) <= StackAllocMax)
-                    {
-                        ciphertextAndTag = stackalloc byte[ciphertext.Length + tag.Length];
-                    }
-                    else
-                    {
-                        rented = CryptoPool.Rent(ciphertext.Length + tag.Length);
-                        ciphertextAndTag = new Span<byte>(rented, 0, ciphertext.Length + tag.Length);
-                    }
-
-                    if (!Interop.Crypto.EvpCipherUpdate(ctx, ciphertextAndTag, out int ciphertextBytesWritten, plaintext))
+                    if (ctx.IsInvalid)
                     {
                         throw new CryptographicException();
                     }
 
-                    if (!Interop.Crypto.EvpAeadCipherFinalEx(
-                        ctx,
-                        ciphertextAndTag.Slice(ciphertextBytesWritten),
-                        out int bytesWritten,
-                        out bool authTagMismatch))
+                    if (!Interop.Crypto.CipherSetTagLength(ctx, tag.Length))
                     {
-                        Debug.Assert(!authTagMismatch);
                         throw new CryptographicException();
                     }
 
-                    ciphertextBytesWritten += bytesWritten;
+                    Interop.Crypto.CipherSetNonceLength(ctx, nonce.Length);
+                    Interop.Crypto.EvpCipherSetKeyAndIV(ctx, key, nonce, Interop.Crypto.EvpCipherDirection.Encrypt);
 
-                    // NOTE: Android appends tag to the end of the ciphertext in case of CCM/GCM and "encryption" mode
-
-                    if (ciphertextBytesWritten != ciphertextAndTag.Length)
+                    if (associatedData.Length != 0)
                     {
-                        Debug.Fail($"CCM encrypt wrote {ciphertextBytesWritten} of {ciphertextAndTag.Length} bytes.");
-                        throw new CryptographicException();
+                        Interop.Crypto.CipherUpdateAAD(ctx, associatedData);
                     }
 
-                    ciphertextAndTag[..ciphertext.Length].CopyTo(ciphertext);
-                    ciphertextAndTag[ciphertext.Length..].CopyTo(tag);
+                    byte[]? rented = null;
+                    try
+                    {
+                        scoped Span<byte> ciphertextAndTag;
+
+                        // Arbitrary limit.
+                        const int StackAllocMax = 128;
+                        if (checked(ciphertext.Length + tag.Length) <= StackAllocMax)
+                        {
+                            ciphertextAndTag = stackalloc byte[ciphertext.Length + tag.Length];
+                        }
+                        else
+                        {
+                            rented = CryptoPool.Rent(ciphertext.Length + tag.Length);
+                            ciphertextAndTag = new Span<byte>(rented, 0, ciphertext.Length + tag.Length);
+                        }
+
+                        if (!Interop.Crypto.EvpCipherUpdate(ctx, ciphertextAndTag, out int ciphertextBytesWritten, plaintext))
+                        {
+                            throw new CryptographicException();
+                        }
+
+                        if (!Interop.Crypto.EvpAeadCipherFinalEx(
+                            ctx,
+                            ciphertextAndTag.Slice(ciphertextBytesWritten),
+                            out int bytesWritten,
+                            out bool authTagMismatch))
+                        {
+                            Debug.Assert(!authTagMismatch);
+                            throw new CryptographicException();
+                        }
+
+                        ciphertextBytesWritten += bytesWritten;
+
+                        // NOTE: Android appends tag to the end of the ciphertext in case of CCM/GCM and "encryption" mode
+
+                        if (ciphertextBytesWritten != ciphertextAndTag.Length)
+                        {
+                            Debug.Fail($"CCM encrypt wrote {ciphertextBytesWritten} of {ciphertextAndTag.Length} bytes.");
+                            throw new CryptographicException();
+                        }
+
+                        ciphertextAndTag[..ciphertext.Length].CopyTo(ciphertext);
+                        ciphertextAndTag[ciphertext.Length..].CopyTo(tag);
+                    }
+                    finally
+                    {
+                        if (rented != null)
+                        {
+                            CryptoPool.Return(rented, ciphertext.Length + tag.Length);
+                        }
+                    }
                 }
-                finally
+            }
+            finally
+            {
+                if (acquired)
                 {
-                    if (rented != null)
-                    {
-                        CryptoPool.Return(rented, ciphertext.Length + tag.Length);
-                    }
+                    _keyBox.DangerousRelease();
                 }
             }
         }
@@ -113,64 +126,77 @@ namespace System.Security.Cryptography
             Span<byte> plaintext,
             ReadOnlySpan<byte> associatedData)
         {
-            CheckDisposed();
+            bool acquired = false;
 
-            using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(_key.Length * 8)))
+            try
             {
-                if (ctx.IsInvalid)
+                _keyBox.DangerousAddRef(ref acquired);
+                ReadOnlySpan<byte> key = _keyBox.DangerousKeySpan;
+
+                using (SafeEvpCipherCtxHandle ctx = Interop.Crypto.EvpCipherCreatePartial(GetCipher(key.Length * 8)))
                 {
-                    throw new CryptographicException();
-                }
-                Interop.Crypto.CipherSetNonceLength(ctx, nonce.Length);
-
-                if (!Interop.Crypto.CipherSetTagLength(ctx, tag.Length))
-                {
-                    throw new CryptographicException();
-                }
-
-                Interop.Crypto.EvpCipherSetKeyAndIV(ctx, _key, nonce, Interop.Crypto.EvpCipherDirection.Decrypt);
-
-                if (associatedData.Length != 0)
-                {
-                    Interop.Crypto.CipherUpdateAAD(ctx, associatedData);
-                }
-
-                if (!Interop.Crypto.EvpCipherUpdate(ctx, plaintext, out int plaintextBytesWritten, ciphertext))
-                {
-                    CryptographicOperations.ZeroMemory(plaintext);
-                    throw new CryptographicException();
-                }
-
-                if (!Interop.Crypto.EvpCipherUpdate(ctx, plaintext.Slice(plaintextBytesWritten), out int bytesWritten, tag))
-                {
-                    CryptographicOperations.ZeroMemory(plaintext);
-                    throw new CryptographicException();
-                }
-
-                plaintextBytesWritten += bytesWritten;
-
-                if (!Interop.Crypto.EvpAeadCipherFinalEx(
-                    ctx,
-                    plaintext.Slice(plaintextBytesWritten),
-                    out bytesWritten,
-                    out bool authTagMismatch))
-                {
-                    CryptographicOperations.ZeroMemory(plaintext);
-
-                    if (authTagMismatch)
+                    if (ctx.IsInvalid)
                     {
-                        throw new AuthenticationTagMismatchException();
+                        throw new CryptographicException();
+                    }
+                    Interop.Crypto.CipherSetNonceLength(ctx, nonce.Length);
+
+                    if (!Interop.Crypto.CipherSetTagLength(ctx, tag.Length))
+                    {
+                        throw new CryptographicException();
                     }
 
-                    throw new CryptographicException(SR.Arg_CryptographyException);
+                    Interop.Crypto.EvpCipherSetKeyAndIV(ctx, key, nonce, Interop.Crypto.EvpCipherDirection.Decrypt);
+
+                    if (associatedData.Length != 0)
+                    {
+                        Interop.Crypto.CipherUpdateAAD(ctx, associatedData);
+                    }
+
+                    if (!Interop.Crypto.EvpCipherUpdate(ctx, plaintext, out int plaintextBytesWritten, ciphertext))
+                    {
+                        CryptographicOperations.ZeroMemory(plaintext);
+                        throw new CryptographicException();
+                    }
+
+                    if (!Interop.Crypto.EvpCipherUpdate(ctx, plaintext.Slice(plaintextBytesWritten), out int bytesWritten, tag))
+                    {
+                        CryptographicOperations.ZeroMemory(plaintext);
+                        throw new CryptographicException();
+                    }
+
+                    plaintextBytesWritten += bytesWritten;
+
+                    if (!Interop.Crypto.EvpAeadCipherFinalEx(
+                        ctx,
+                        plaintext.Slice(plaintextBytesWritten),
+                        out bytesWritten,
+                        out bool authTagMismatch))
+                    {
+                        CryptographicOperations.ZeroMemory(plaintext);
+
+                        if (authTagMismatch)
+                        {
+                            throw new AuthenticationTagMismatchException();
+                        }
+
+                        throw new CryptographicException(SR.Arg_CryptographyException);
+                    }
+
+                    plaintextBytesWritten += bytesWritten;
+
+                    if (plaintextBytesWritten != plaintext.Length)
+                    {
+                        Debug.Fail($"CCM decrypt wrote {plaintextBytesWritten} of {plaintext.Length} bytes.");
+                        throw new CryptographicException();
+                    }
                 }
-
-                plaintextBytesWritten += bytesWritten;
-
-                if (plaintextBytesWritten != plaintext.Length)
+            }
+            finally
+            {
+                if (acquired)
                 {
-                    Debug.Fail($"CCM decrypt wrote {plaintextBytesWritten} of {plaintext.Length} bytes.");
-                    throw new CryptographicException();
+                    _keyBox.DangerousRelease();
                 }
             }
         }
@@ -186,16 +212,6 @@ namespace System.Security.Cryptography
             };
         }
 
-        [MemberNotNull(nameof(_key))]
-        private void CheckDisposed()
-        {
-            ObjectDisposedException.ThrowIf(_key is null, this);
-        }
-
-        public void Dispose()
-        {
-            CryptographicOperations.ZeroMemory(_key);
-            _key = null;
-        }
+        public void Dispose() => _keyBox.Dispose();
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AesGcm.macOS.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography
 {
     public sealed partial class AesGcm
     {
-        private byte[]? _key;
+        private FixedMemoryKeyBox _keyBox;
 
         // CryptoKit added AES.GCM in macOS 10.15, which is our minimum target for macOS.
         public static bool IsSupported => true;
@@ -17,15 +17,12 @@ namespace System.Security.Cryptography
         // CryptoKit only supports 16 byte tags.
         public static KeySizes TagByteSizes { get; } = new KeySizes(16, 16, 1);
 
-        [MemberNotNull(nameof(_key))]
+        [MemberNotNull(nameof(_keyBox))]
         private void ImportKey(ReadOnlySpan<byte> key)
         {
             // We should only be calling this in the constructor, so there shouldn't be a previous key.
-            Debug.Assert(_key is null);
-
-            // Pin the array on the POH so that the GC doesn't move it around to allow zeroing to be more effective.
-            _key = GC.AllocateArray<byte>(key.Length, pinned: true);
-            key.CopyTo(_key);
+            Debug.Assert(_keyBox is null);
+            _keyBox = new FixedMemoryKeyBox(key);
         }
 
         private void EncryptCore(
@@ -35,14 +32,26 @@ namespace System.Security.Cryptography
             Span<byte> tag,
             ReadOnlySpan<byte> associatedData)
         {
-            CheckDisposed();
-            Interop.AppleCrypto.AesGcmEncrypt(
-                _key,
-                nonce,
-                plaintext,
-                ciphertext,
-                tag,
-                associatedData);
+            bool acquired = false;
+
+            try
+            {
+                _keyBox.DangerousAddRef(ref acquired);
+                Interop.AppleCrypto.AesGcmEncrypt(
+                    _keyBox.DangerousKeySpan,
+                    nonce,
+                    plaintext,
+                    ciphertext,
+                    tag,
+                    associatedData);
+            }
+            finally
+            {
+                if (acquired)
+                {
+                    _keyBox.DangerousRelease();
+                }
+            }
         }
 
         private void DecryptCore(
@@ -52,26 +61,28 @@ namespace System.Security.Cryptography
             Span<byte> plaintext,
             ReadOnlySpan<byte> associatedData)
         {
-            CheckDisposed();
-            Interop.AppleCrypto.AesGcmDecrypt(
-                _key,
-                nonce,
-                ciphertext,
-                tag,
-                plaintext,
-                associatedData);
+            bool acquired = false;
+
+            try
+            {
+                _keyBox.DangerousAddRef(ref acquired);
+                Interop.AppleCrypto.AesGcmDecrypt(
+                    _keyBox.DangerousKeySpan,
+                    nonce,
+                    ciphertext,
+                    tag,
+                    plaintext,
+                    associatedData);
+            }
+            finally
+            {
+                if (acquired)
+                {
+                    _keyBox.DangerousRelease();
+                }
+            }
         }
 
-        public void Dispose()
-        {
-            CryptographicOperations.ZeroMemory(_key);
-            _key = null;
-        }
-
-        [MemberNotNull(nameof(_key))]
-        private void CheckDisposed()
-        {
-            ObjectDisposedException.ThrowIf(_key is null, this);
-        }
+        public void Dispose() => _keyBox.Dispose();
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/FixedMemoryKeyBox.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/FixedMemoryKeyBox.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System.Security.Cryptography
+{
+    internal sealed unsafe class FixedMemoryKeyBox : SafeHandle
+    {
+        private readonly int _length;
+
+        internal FixedMemoryKeyBox(ReadOnlySpan<byte> key) : base(IntPtr.Zero, ownsHandle: true)
+        {
+            void* memory = NativeMemory.Alloc((nuint)key.Length);
+            key.CopyTo(new Span<byte>(memory, key.Length));
+            SetHandle((IntPtr)memory);
+            _length = key.Length;
+        }
+
+        internal ReadOnlySpan<byte> DangerousKeySpan => new ReadOnlySpan<byte>((void*)handle, _length);
+
+        protected override bool ReleaseHandle()
+        {
+            CryptographicOperations.ZeroMemory(new Span<byte>((void*)handle, _length));
+            NativeMemory.Free((void*)handle);
+            return true;
+        }
+
+        public override bool IsInvalid => handle == IntPtr.Zero;
+    }
+}


### PR DESCRIPTION
In some cryptographic primitives, we used the POH to pin arrays so that the underlying key material would not get moved around by the GC, which would allow for more effective zeroing of key material.

Based on feedback in https://github.com/dotnet/runtime/pull/97447, this pattern turned out to be undesirable. This replaces the uses of the POH with native memory.