### PR TITLE
Add more RuntimeTestMode options for the XUnitWrapperGenerator

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
@@ -35,7 +35,7 @@ public static class CoreClrConfigurationDetection
 
     public static bool IsStressTest =>
         IsGCStress ||
-        IsZapDisable ||
+        IsDisableR2R ||
         IsAnyJitStress ||
         IsHeapVerify;
 

--- a/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
@@ -20,8 +20,14 @@ public static class CoreClrConfigurationDetection
     public static bool IsDisableR2R => string.Equals(GetEnvironmentVariableValue("ReadyToRun"), "0", StringComparison.InvariantCulture);
     public static bool IsGCStress3 => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0x3", "3");
     public static bool IsGCStressC => CompareGCStressModeAsLower(GetEnvironmentVariableValue("GCStress"), "0xC", "C");
+    public static bool IsTieredCompilation => string.Equals(GetEnvironmentVariableValue("TieredCompilation", "1"), "1", StringComparison.InvariantCulture);
+    public static bool IsHeapVerify => string.Equals(GetEnvironmentVariableValue("HeapVerify"), "1", StringComparison.InvariantCulture);
 
     public static bool IsGCStress => !string.Equals(GetEnvironmentVariableValue("GCStress"), "0", StringComparison.InvariantCulture);
+    
+    public static bool IsAnyJitStress => IsJitStress || IsJitStressRegs || IsJitMinOpts || IsTailCallStress;
+
+    public static bool IsAnyJitOptimizationStress => IsAnyJitStress || IsTieredCompilation;
 
     public static bool IsCheckedRuntime => AssemblyConfigurationEquals("Checked");
     public static bool IsReleaseRuntime => AssemblyConfigurationEquals("Release");
@@ -29,14 +35,12 @@ public static class CoreClrConfigurationDetection
 
     public static bool IsStressTest =>
         IsGCStress ||
-        IsDisableR2R ||
-        IsTailCallStress ||
-        IsJitStressRegs ||
-        IsJitStress ||
-        IsJitMinOpts;
+        IsZapDisable ||
+        IsAnyJitStress ||
+        IsHeapVerify;
 
-    private static string GetEnvironmentVariableValue(string name) =>
-        Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? "0";
+    private static string GetEnvironmentVariableValue(string name, string defaultValue = "0") =>
+        Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? defaultValue;
 
     private static bool AssemblyConfigurationEquals(string configuration)
     {

--- a/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
@@ -33,7 +33,7 @@ namespace Xunit
         // GCStressC forces a GC at every JIT-generated code instruction,
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 7, // DOTNET_GCStress includes mode 0xC.
-        AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
+        AnyGCStress = GCStress3 | GCStressC, // Disable when any GCStress is exercised.
         // TieredCompilation is on by default, but can cause some tests to fail
         // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.
         TieredCompilation = 1 << 8, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.

--- a/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/RuntimeTestModes.cs
@@ -34,5 +34,14 @@ namespace Xunit
         // including in NGEN/ReadyToRun code.
         GCStressC = 1 << 7, // DOTNET_GCStress includes mode 0xC.
         AnyGCStress = GCStress3 | GCStressC // Disable when any GCStress is exercised.
+        // TieredCompilation is on by default, but can cause some tests to fail
+        // As TieredCompilation is on by default, it does not count as a stress mode for RegularRun.
+        TieredCompilation = 1 << 8, // DOTNET_TieredCompilation (or COMPlus_TieredCompilation) is not set to 0.
+
+        AnyJitStress = JitStress | JitStressRegs | JitMinOpts | TailcallStress, // Disable when any JIT stress mode is exercised.
+
+        AnyJitOptimizationStress = AnyJitStress | TieredCompilation, // Disable when any JIT non-full optimization stress mode is exercised.
+
+        HeapVerify = 1 << 9, // DOTNET_HeapVerify (or COMPlus_HeapVerify) is set.
     }
 }

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -892,6 +892,10 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         {
             conditions.Add($"{ConditionClass}.IsStressTest");
         }
+        if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.DisableR2R))
+        {
+            conditions.Add($"!{ConditionClass}.IsDisableR2R");
+        }
         if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.JitStress))
         {
             conditions.Add($"!{ConditionClass}.IsJitStress");
@@ -908,9 +912,13 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         {
             conditions.Add($"!{ConditionClass}.IsTailcallStress");
         }
-        if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.DisableR2R))
+        if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.TieredCompilation))
         {
-            conditions.Add($"!{ConditionClass}.IsDisableR2R");
+            conditions.Add($"!{ConditionClass}.IsTieredCompilation");
+        }
+        if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.HeapVerify))
+        {
+            conditions.Add($"!{ConditionClass}.IsHeapVerify");
         }
 
         if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.AnyGCStress))


### PR DESCRIPTION
Adds runtime-based checks for options that make the same checks as JitOptimizationSensitive and HeapVerifyIncompatible.

dotnet/runtime counterpart to dotnet/arcade#14538
