### PR TITLE
make Socket useable after cancellation

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3754,7 +3754,7 @@ namespace System.Net.Sockets
 
             if (disconnectOnFailure && _isConnected && (_handle.IsInvalid || (errorCode != SocketError.WouldBlock &&
                     errorCode != SocketError.IOPending && errorCode != SocketError.NoBufferSpaceAvailable &&
-                    errorCode != SocketError.TimedOut)))
+                    errorCode != SocketError.TimedOut && errorCode != SocketError.OperationAborted)))
             {
                 // The socket is no longer a valid socket.
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Invalidating socket.");


### PR DESCRIPTION
contributes to #69397

We already have logic to don't disconnect coket after sync `Read`. This change makes it consistent for `ReadAsync`. 
I personally don't see reason why the cancellation (or timeout) should change status of the socket since they are really independent. And I don't see any risk that we would loose data.  

I added test for both sync & async versions. 