### PR TITLE
Use VN instead of GenTree in optGlobalAssertionIsEqualOrNotEqual

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4218,18 +4218,14 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
 
         // Look for matching exact type assertions based on vtable accesses
         if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_EXACT_TYPE) &&
-            op1->OperIs(GT_IND))
+            (curAssertion->op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
         {
-            GenTree* indirAddr = op1->AsIndir()->Addr();
-
-            if (indirAddr->OperIs(GT_LCL_VAR) && (indirAddr->TypeGet() == TYP_REF))
+            ValueNum  op1VN = vnStore->VNConservativeNormalValue(op1->gtVNPair);
+            VNFuncApp funcApp;
+            if (vnStore->GetVNFunc(op1VN, &funcApp) && ((funcApp.m_func == VNF_InvariantLoad)) &&
+                (curAssertion->op1.vn == funcApp.m_args[0]))
             {
-                // op1 is accessing vtable of a ref type local var
-                if ((curAssertion->op1.vn == vnStore->VNConservativeNormalValue(indirAddr->gtVNPair)) &&
-                    (curAssertion->op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
-                {
-                    return assertionIndex;
-                }
+                return assertionIndex;
             }
         }
     }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4216,14 +4216,18 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
             return assertionIndex;
         }
 
-        // Look for matching exact type assertions based on vtable accesses
+        // Look for matching exact type assertions based on vtable accesses. E.g.:
+        //
+        //   op1:       VNF_InvariantLoad(myObj) or in other words: a vtable access
+        //   op2:       'MyType' class handle
+        //   Assertion: 'myObj's type is exactly MyType
+        //
         if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_EXACT_TYPE) &&
-            (curAssertion->op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
+            (curAssertion->op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)) && op1->TypeIs(TYP_I_IMPL))
         {
-            ValueNum  op1VN = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             VNFuncApp funcApp;
-            if (vnStore->GetVNFunc(op1VN, &funcApp) && (funcApp.m_func == VNF_InvariantLoad) &&
-                (curAssertion->op1.vn == funcApp.m_args[0]))
+            if (vnStore->GetVNFunc(vnStore->VNConservativeNormalValue(op1->gtVNPair), &funcApp) &&
+                (funcApp.m_func == VNF_InvariantLoad) && (curAssertion->op1.vn == funcApp.m_args[0]))
             {
                 return assertionIndex;
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4222,7 +4222,7 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
         {
             ValueNum  op1VN = vnStore->VNConservativeNormalValue(op1->gtVNPair);
             VNFuncApp funcApp;
-            if (vnStore->GetVNFunc(op1VN, &funcApp) && ((funcApp.m_func == VNF_InvariantLoad)) &&
+            if (vnStore->GetVNFunc(op1VN, &funcApp) && (funcApp.m_func == VNF_InvariantLoad) &&
                 (curAssertion->op1.vn == funcApp.m_args[0]))
             {
                 return assertionIndex;


### PR DESCRIPTION
Use VN + `VNF_InvariantLoad` instead of expecting plain `GenTreeIndir` in `optGlobalAssertionIsEqualOrNotEqual` because CSE  may convert it to a local.
