### PR TITLE
Mention NetFx40_LegacySecurityPolicy for PublicSign

### DIFF
--- a/docs/project/public-signing.md
+++ b/docs/project/public-signing.md
@@ -17,7 +17,7 @@ Known issues when debugging and testing public signed assemblies on .NET Framewo
 - You will not be able to load the assembly in an AppDomain where shadow copying is turned on.
 - You will not be able to load the assembly in a partially trusted AppDomain
 - You will not be able to pre-compile ASP.NET applications
-- You may not be able to load the assembly if the `app.config` file specifies `<configuration`/`<runtime>`/`<NetFx40_LegacySecurityPolicy enabled="true" />`
+- You may not be able to load the assembly if the `app.config` file specifies `<configuration>`/`<runtime>`/`<NetFx40_LegacySecurityPolicy enabled="true" />`
 
 The `corflags.exe` tool that ships with the .NET Framework SDK can show whether a binary is delay-signed or strong-named. For a delay-signed assembly it may show:
 

--- a/docs/project/public-signing.md
+++ b/docs/project/public-signing.md
@@ -17,6 +17,7 @@ Known issues when debugging and testing public signed assemblies on .NET Framewo
 - You will not be able to load the assembly in an AppDomain where shadow copying is turned on.
 - You will not be able to load the assembly in a partially trusted AppDomain
 - You will not be able to pre-compile ASP.NET applications
+- You will not be able to load the assembly if the `app.config` file specifies `<configuration`/`<runtime>`/`<NetFx40_LegacySecurityPolicy enabled="true" />`
 
 The `corflags.exe` tool that ships with the .NET Framework SDK can show whether a binary is delay-signed or strong-named. For a delay-signed assembly it may show:
 

--- a/docs/project/public-signing.md
+++ b/docs/project/public-signing.md
@@ -17,7 +17,7 @@ Known issues when debugging and testing public signed assemblies on .NET Framewo
 - You will not be able to load the assembly in an AppDomain where shadow copying is turned on.
 - You will not be able to load the assembly in a partially trusted AppDomain
 - You will not be able to pre-compile ASP.NET applications
-- You will not be able to load the assembly if the `app.config` file specifies `<configuration`/`<runtime>`/`<NetFx40_LegacySecurityPolicy enabled="true" />`
+- You may not be able to load the assembly if the `app.config` file specifies `<configuration`/`<runtime>`/`<NetFx40_LegacySecurityPolicy enabled="true" />`
 
 The `corflags.exe` tool that ships with the .NET Framework SDK can show whether a binary is delay-signed or strong-named. For a delay-signed assembly it may show:
 


### PR DESCRIPTION
Mention that PublicSign doesn't work if the app.config specifies `<NetFx40_LegacySecurityPolicy enabled="true" />`