### PR TITLE
Fix the Syndication Feed RFC822 DateTimeParser

### DIFF
--- a/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -92,28 +92,28 @@ namespace System.ServiceModel.Syndication
             DateTimeOffset theTime;
             string[] parseFormat =
             {
-                "ddd, dd MMMM yyyy HH:mm:ss zzz",
-                "dd MMMM yyyy HH:mm:ss zzz",
-                "ddd, dd MMM yyyy HH:mm:ss zzz",
-                "dd MMM yyyy HH:mm:ss zzz",
-
-                "ddd, dd MMMM yyyy HH:mm zzz",
-                "dd MMMM yyyy HH:mm zzz",
-                "ddd, dd MMM yyyy HH:mm zzz",
-                "dd MMM yyyy HH:mm zzz",
-
+                "ddd, d MMMM yyyy HH:mm:ss zzz",
+                "d MMMM yyyy HH:mm:ss zzz",
+                "ddd, d MMM yyyy HH:mm:ss zzz",
+                "d MMM yyyy HH:mm:ss zzz",
+                
+                "ddd, d MMMM yyyy HH:mm zzz",
+                "d MMMM yyyy HH:mm zzz",
+                "ddd, d MMM yyyy HH:mm zzz",
+                "d MMM yyyy HH:mm zzz",
+                
                 // The original RFC822 spec listed 2 digit years. RFC1123 updated the format to include 4 digit years and states that you should use 4 digits.
                 // Technically RSS2.0 specifies RFC822 but it's presumed that RFC1123 will be used as we're now past Y2K and everyone knows better. The 4 digit
                 // formats are listed first for performance reasons as it's presumed they will be more likely to match first.
-                "ddd, dd MMMM yy HH:mm:ss zzz",
-                "dd MMMM yyyy HH:mm:ss zzz",
-                "ddd, dd MMM yy HH:mm:ss zzz",
-                "dd MMM yyyy HH:mm:ss zzz",
-
-                "ddd, dd MMMM yy HH:mm zzz",
-                "dd MMMM yyyy HH:mm zzz",
-                "ddd, dd MMM yy HH:mm zzz",
-                "dd MMM yyyy HH:mm zzz"
+                "ddd, d MMMM yy HH:mm:ss zzz",
+                "d MMMM yy HH:mm:ss zzz",
+                "ddd, d MMM yy HH:mm:ss zzz",
+                "d MMM yy HH:mm:ss zzz",
+                
+                "ddd, d MMMM yy HH:mm zzz",
+                "d MMMM yy HH:mm zzz",
+                "ddd, d MMM yy HH:mm zzz",
+                "d MMM yy HH:mm zzz"
             };
 
             if (DateTimeOffset.TryParseExact(wellFormattedString, parseFormat,

--- a/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
+++ b/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/Syndication/DateTimeHelper.cs
@@ -96,12 +96,12 @@ namespace System.ServiceModel.Syndication
                 "d MMMM yyyy HH:mm:ss zzz",
                 "ddd, d MMM yyyy HH:mm:ss zzz",
                 "d MMM yyyy HH:mm:ss zzz",
-                
+
                 "ddd, d MMMM yyyy HH:mm zzz",
                 "d MMMM yyyy HH:mm zzz",
                 "ddd, d MMM yyyy HH:mm zzz",
                 "d MMM yyyy HH:mm zzz",
-                
+
                 // The original RFC822 spec listed 2 digit years. RFC1123 updated the format to include 4 digit years and states that you should use 4 digits.
                 // Technically RSS2.0 specifies RFC822 but it's presumed that RFC1123 will be used as we're now past Y2K and everyone knows better. The 4 digit
                 // formats are listed first for performance reasons as it's presumed they will be more likely to match first.
@@ -109,7 +109,7 @@ namespace System.ServiceModel.Syndication
                 "d MMMM yy HH:mm:ss zzz",
                 "ddd, d MMM yy HH:mm:ss zzz",
                 "d MMM yy HH:mm:ss zzz",
-                
+
                 "ddd, d MMMM yy HH:mm zzz",
                 "d MMMM yy HH:mm zzz",
                 "ddd, d MMM yy HH:mm zzz",


### PR DESCRIPTION
[RFC822](https://www.w3.org/Protocols/rfc822/#z28) allows single-digit date values and two-digit year values in the publication date (`pubDate`). The existing `Rfc822DateTimeParser` method in `System.ServiceModel.Syndication.DateTimeHelper` only accepts two-digit dates and (for some formats) four-digit years.

This PR updates the list of date-time formats.

Fixes #99193 