### PR TITLE
[RISC-V] Enable perfmap generation for crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PerfMapWriter.cs
@@ -135,6 +135,7 @@ namespace ILCompiler.Diagnostics
                 TargetArchitecture.ARM64 => PerfMapArchitectureToken.ARM64,
                 TargetArchitecture.X64 => PerfMapArchitectureToken.X64,
                 TargetArchitecture.X86 => PerfMapArchitectureToken.X86,
+                TargetArchitecture.RiscV64 => PerfMapArchitectureToken.RiscV64,
                 _ => throw new NotImplementedException(details.Architecture.ToString())
             };
 

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/ReadyToRunDiagnosticsConstants.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/ReadyToRunDiagnosticsConstants.cs
@@ -19,6 +19,7 @@ public enum PerfMapArchitectureToken : uint
     ARM64 = 2,
     X64 = 3,
     X86 = 4,
+    RiscV64 = 5,
 }
 
 public enum PerfMapOSToken : uint


### PR DESCRIPTION
Fix error in perfmap generation

Part of https://github.com/dotnet/runtime/issues/84834
cc @wscho77 @HJLeee @clamp03 @JongHeonChoi @t-mustafin @gbalykov
@viewizard @ashaurtaev @brucehoult @tomeksowi @yurai007 @Bajtazar
@bartlomiejko @rzsc