### PR TITLE
SPMI: Project out fields for diffs information

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -1902,6 +1902,10 @@ def aggregate_diff_metrics(details_file):
     diff_minopts = base_minopts.copy()
     diff_fullopts = base_minopts.copy()
 
+    # Project out these fields for the saved diffs, to use for further
+    # processing. Saving everything into memory is costly on memory when there
+    # are a large number of diffs.
+    diffs_fields = ["Context", "Context size", "Base size", "Diff size", "Base PerfScore", "Diff PerfScore"]
     diffs = []
 
     for row in read_csv(details_file):
@@ -1957,7 +1961,7 @@ def aggregate_diff_metrics(details_file):
             if row["Has diff"] == "True":
                 base_dict["Contexts with diffs"] += 1
                 diff_dict["Contexts with diffs"] += 1
-                diffs.append(row)
+                diffs.append({key: row[key] for key in diffs_fields})
 
     base_overall = base_minopts.copy()
     for k in base_overall.keys():


### PR DESCRIPTION
When there are many diffs we are still loading all of them into memory, and in CI this can cause OOMs in these cases. Every row becomes a dictionary that has an extra copy of all column names, and with the new metrics work there are a lot of columns. Fix the problem by projecting out just what is necessary from each row.

Should fix the superpmi-asmdiffs failures seen in #95565.