### PR TITLE
JIT: Handle GT_SWIFT_ERROR in gtCloneExpr

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -9421,6 +9421,7 @@ GenTree* Compiler::gtCloneExpr(GenTree* tree)
             case GT_NO_OP:
             case GT_NOP:
             case GT_LABEL:
+            case GT_SWIFT_ERROR:
                 copy = new (this, oper) GenTree(oper, tree->gtType);
                 goto DONE;
 


### PR DESCRIPTION
Fixes #99214 by handling `GT_SWIFT_ERROR` in `Compiler::gtCloneExpr`.

cc @jakobbotsch. Since this isn't the first time an outerloop pipeline has failed due to a missing `GT_SWIFT_ERROR` switch case, I tried to look for other missing cases by searching for similarly-handled `GenTree` nodes. It's not the most precise method, but I did notice we aren't explicitly handling `GT_SWIFT_ERROR` in `GenTree::Compare` -- we return false if we encounter it. Just to check, is this the correct behavior, since `GT_SWIFT_ERROR` represents a value unknown at compile time?