### PR TITLE
JIT: Handle GT_SWIFT_ERROR in GenTree::Compare

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2906,6 +2906,7 @@ AGAIN:
 
             case GT_NOP:
             case GT_LABEL:
+            case GT_SWIFT_ERROR:
                 return true;
 
             default:


### PR DESCRIPTION
cc @jakobbotsch -- sorry for duplicating PRs, instead of including this in #99236. I didn't want to retrigger CI there.