### PR TITLE
Switch System.Linq to using `is null` consistently

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Aggregate.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Aggregate.cs
@@ -9,12 +9,12 @@ namespace System.Linq
     {
         public static TSource Aggregate<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (func == null)
+            if (func is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.func);
             }
@@ -38,12 +38,12 @@ namespace System.Linq
 
         public static TAccumulate Aggregate<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (func == null)
+            if (func is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.func);
             }
@@ -59,17 +59,17 @@ namespace System.Linq
 
         public static TResult Aggregate<TSource, TAccumulate, TResult>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (func == null)
+            if (func is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.func);
             }
 
-            if (resultSelector == null)
+            if (resultSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.resultSelector);
             }

--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -22,12 +22,12 @@ namespace System.Linq
 
         public static bool Any<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -45,12 +45,12 @@ namespace System.Linq
 
         public static bool All<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }

--- a/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
@@ -227,7 +227,7 @@ namespace System.Linq
 
                 TSource[] array = new TSource[count];
                 int index = 0;
-                for (SingleLinkedNode<TSource>? node = _prepended; node != null; node = node.Linked)
+                for (SingleLinkedNode<TSource>? node = _prepended; node is not null; node = node.Linked)
                 {
                     array[index] = node.Item;
                     ++index;
@@ -247,7 +247,7 @@ namespace System.Linq
                 }
 
                 index = array.Length;
-                for (SingleLinkedNode<TSource>? node = _appended; node != null; node = node.Linked)
+                for (SingleLinkedNode<TSource>? node = _appended; node is not null; node = node.Linked)
                 {
                     --index;
                     array[index] = node.Item;

--- a/src/libraries/System.Linq/src/System/Linq/AppendPrepend.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AppendPrepend.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource element)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -22,7 +22,7 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource element)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -43,13 +43,13 @@ namespace System.Linq
 
             protected AppendPrependIterator(IEnumerable<TSource> source)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 _source = source;
             }
 
             protected void GetSourceEnumerator()
             {
-                Debug.Assert(_enumerator == null);
+                Debug.Assert(_enumerator is null);
                 _enumerator = _source.GetEnumerator();
             }
 
@@ -59,7 +59,7 @@ namespace System.Linq
 
             protected bool LoadFromEnumerator()
             {
-                Debug.Assert(_enumerator != null);
+                Debug.Assert(_enumerator is not null);
                 if (_enumerator.MoveNext())
                 {
                     _current = _enumerator.Current;
@@ -72,7 +72,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -176,7 +176,7 @@ namespace System.Linq
             public AppendPrependN(IEnumerable<TSource> source, SingleLinkedNode<TSource>? prepended, SingleLinkedNode<TSource>? appended, int prependCount, int appendCount)
                 : base(source)
             {
-                Debug.Assert(prepended != null || appended != null);
+                Debug.Assert(prepended is not null || appended is not null);
                 Debug.Assert(prependCount > 0 || appendCount > 0);
                 Debug.Assert(prependCount + appendCount >= 2);
                 Debug.Assert((prepended?.GetCount() ?? 0) == prependCount);
@@ -199,7 +199,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        if (_node != null)
+                        if (_node is not null)
                         {
                             _current = _node.Item;
                             _node = _node.Linked;
@@ -215,7 +215,7 @@ namespace System.Linq
                             return true;
                         }
 
-                        if (_appended == null)
+                        if (_appended is null)
                         {
                             return false;
                         }
@@ -233,13 +233,13 @@ namespace System.Linq
 
             public override AppendPrependIterator<TSource> Append(TSource item)
             {
-                var appended = _appended != null ? _appended.Add(item) : new SingleLinkedNode<TSource>(item);
+                var appended = _appended is not null ? _appended.Add(item) : new SingleLinkedNode<TSource>(item);
                 return new AppendPrependN<TSource>(_source, _prepended, appended, _prependCount, _appendCount + 1);
             }
 
             public override AppendPrependIterator<TSource> Prepend(TSource item)
             {
-                var prepended = _prepended != null ? _prepended.Add(item) : new SingleLinkedNode<TSource>(item);
+                var prepended = _prepended is not null ? _prepended.Add(item) : new SingleLinkedNode<TSource>(item);
                 return new AppendPrependN<TSource>(_source, prepended, _appended, _prependCount + 1, _appendCount);
             }
         }

--- a/src/libraries/System.Linq/src/System/Linq/Cast.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Cast.cs
@@ -11,7 +11,7 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> OfType<TResult>(this IEnumerable source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -41,7 +41,7 @@ namespace System.Linq
                 return typedSource;
             }
 
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -80,7 +80,7 @@ namespace System.Linq
                         goto case 2;
 
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = (TResult)_enumerator.Current;

--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -35,7 +35,7 @@ namespace System.Linq
         /// </exception>
         public static IEnumerable<TSource[]> Chunk<TSource>(this IEnumerable<TSource> source, int size)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.SpeedOpt.cs
@@ -170,7 +170,7 @@ namespace System.Linq
                     // Enumerable.Count() handles ICollections in O(1) time, but check for them here anyway
                     // to avoid a method call because 1) they're common and 2) this code is run in a loop.
                     var collection = source as ICollection<TSource>;
-                    Debug.Assert(!_hasOnlyCollections || collection != null);
+                    Debug.Assert(!_hasOnlyCollections || collection is not null);
                     int sourceCount = collection?.Count ?? source.Count();
 
                     checked
@@ -178,7 +178,7 @@ namespace System.Linq
                         count += sourceCount;
                     }
                 }
-                while ((previousN = node.PreviousN) != null);
+                while ((previousN = node.PreviousN) is not null);
 
                 Debug.Assert(node._tail is Concat2Iterator<TSource>);
                 return checked(count + node._tail.GetCount(onlyIfCheap));
@@ -202,7 +202,7 @@ namespace System.Linq
                     // On the bright side, the bottleneck will usually be iterating, buffering, and copying
                     // each of the enumerables, so this shouldn't be a noticeable perf hit for most scenarios.
                     IEnumerable<TSource>? source = GetEnumerable(i);
-                    if (source == null)
+                    if (source is null)
                     {
                         break;
                     }
@@ -250,7 +250,7 @@ namespace System.Linq
                         source.CopyTo(array, arrayIndex);
                     }
                 }
-                while ((previousN = node.PreviousN) != null);
+                while ((previousN = node.PreviousN) is not null);
 
                 var previous2 = (Concat2Iterator<TSource>)node._tail;
                 var second = (ICollection<TSource>)previous2._second;
@@ -352,7 +352,7 @@ namespace System.Linq
                 for (int i = 0; ; i++)
                 {
                     IEnumerable<TSource>? source = GetEnumerable(i);
-                    if (source == null)
+                    if (source is null)
                     {
                         break;
                     }

--- a/src/libraries/System.Linq/src/System/Linq/Concat.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Concat.cs
@@ -10,12 +10,12 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Concat<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }
@@ -58,8 +58,8 @@ namespace System.Linq
             /// <param name="second">The second source to concatenate.</param>
             internal Concat2Iterator(IEnumerable<TSource> first, IEnumerable<TSource> second)
             {
-                Debug.Assert(first != null);
-                Debug.Assert(second != null);
+                Debug.Assert(first is not null);
+                Debug.Assert(second is not null);
 
                 _first = first;
                 _second = second;
@@ -139,8 +139,8 @@ namespace System.Linq
             /// </param>
             internal ConcatNIterator(ConcatIterator<TSource> tail, IEnumerable<TSource> head, int headIndex, bool hasOnlyCollections)
             {
-                Debug.Assert(tail != null);
-                Debug.Assert(head != null);
+                Debug.Assert(tail is not null);
+                Debug.Assert(head is not null);
                 Debug.Assert(headIndex >= 2);
 
                 _tail = tail;
@@ -185,7 +185,7 @@ namespace System.Linq
                         return node._head;
                     }
                 }
-                while ((previousN = node.PreviousN) != null);
+                while ((previousN = node.PreviousN) is not null);
 
                 Debug.Assert(index == 0 || index == 1);
                 Debug.Assert(node._tail is Concat2Iterator<TSource>);
@@ -206,7 +206,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -240,7 +240,7 @@ namespace System.Linq
                 {
                     while (true)
                     {
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = _enumerator.Current;
@@ -248,7 +248,7 @@ namespace System.Linq
                         }
 
                         IEnumerable<TSource>? next = GetEnumerable(_state++ - 1);
-                        if (next != null)
+                        if (next is not null)
                         {
                             _enumerator.Dispose();
                             _enumerator = next.GetEnumerator();

--- a/src/libraries/System.Linq/src/System/Linq/Contains.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Contains.cs
@@ -13,12 +13,12 @@ namespace System.Linq
 
         public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value, IEqualityComparer<TSource>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (comparer == null)
+            if (comparer is null)
             {
                 foreach (TSource element in source)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static int Count<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -49,12 +49,12 @@ namespace System.Linq
 
         public static int Count<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -96,7 +96,7 @@ namespace System.Linq
         /// </remarks>
         public static bool TryGetNonEnumeratedCount<TSource>(this IEnumerable<TSource> source, out int count)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -131,7 +131,7 @@ namespace System.Linq
 
         public static long LongCount<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -153,12 +153,12 @@ namespace System.Linq
 
         public static long LongCount<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }

--- a/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/libraries/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -13,7 +13,7 @@ namespace System.Linq
 
         public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -34,7 +34,7 @@ namespace System.Linq
 
             public DefaultIfEmptyIterator(IEnumerable<TSource> source, TSource defaultValue)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 _source = source;
                 _default = defaultValue;
             }
@@ -60,7 +60,7 @@ namespace System.Linq
 
                         return true;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = _enumerator.Current;
@@ -76,7 +76,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;

--- a/src/libraries/System.Linq/src/System/Linq/Distinct.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.cs
@@ -12,7 +12,7 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -101,7 +101,7 @@ namespace System.Linq
 
             public DistinctIterator(IEnumerable<TSource> source, IEqualityComparer<TSource>? comparer)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 _source = source;
                 _comparer = comparer;
             }
@@ -127,8 +127,8 @@ namespace System.Linq
                         _state = 2;
                         return true;
                     case 2:
-                        Debug.Assert(_enumerator != null);
-                        Debug.Assert(_set != null);
+                        Debug.Assert(_enumerator is not null);
+                        Debug.Assert(_set is not null);
                         while (_enumerator.MoveNext())
                         {
                             element = _enumerator.Current;
@@ -148,7 +148,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;

--- a/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ElementAt.cs
@@ -11,7 +11,7 @@ namespace System.Linq
     {
         public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, int index)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -38,7 +38,7 @@ namespace System.Linq
         /// </remarks>
         public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, Index index)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -63,7 +63,7 @@ namespace System.Linq
 
         public static TSource? ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -83,7 +83,7 @@ namespace System.Linq
         /// </remarks>
         public static TSource? ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, Index index)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -110,7 +110,7 @@ namespace System.Linq
 
         private static TSource? TryGetElementAtNonIterator<TSource>(IEnumerable<TSource> source, int index, out bool found, bool guardIListLength = true)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(source is not null);
 
             if (source is IList<TSource> list)
             {
@@ -147,7 +147,7 @@ namespace System.Linq
 
         private static bool TryGetElementFromEnd<TSource>(IEnumerable<TSource> source, int indexFromEnd, [MaybeNullWhen(false)] out TSource element)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(source is not null);
 
             if (indexFromEnd > 0)
             {

--- a/src/libraries/System.Linq/src/System/Linq/Except.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Except.cs
@@ -9,12 +9,12 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }
@@ -24,12 +24,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource>? comparer)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -64,7 +64,7 @@ namespace System.Linq
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, out bool found)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -104,12 +104,12 @@ namespace System.Linq
 
         private static TSource? TryGetFirst<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }

--- a/src/libraries/System.Linq/src/System/Linq/GroupJoin.cs
+++ b/src/libraries/System.Linq/src/System/Linq/GroupJoin.cs
@@ -12,27 +12,27 @@ namespace System.Linq
 
         public static IEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey>? comparer)
         {
-            if (outer == null)
+            if (outer is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.outer);
             }
 
-            if (inner == null)
+            if (inner is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.inner);
             }
 
-            if (outerKeySelector == null)
+            if (outerKeySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.outerKeySelector);
             }
 
-            if (innerKeySelector == null)
+            if (innerKeySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.innerKeySelector);
             }
 
-            if (resultSelector == null)
+            if (resultSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.resultSelector);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Index.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         public static IEnumerable<(int Index, TSource Item)> Index<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Intersect.cs
@@ -11,12 +11,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource>? comparer)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Join.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Join.cs
@@ -12,27 +12,27 @@ namespace System.Linq
 
         public static IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey>? comparer)
         {
-            if (outer == null)
+            if (outer is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.outer);
             }
 
-            if (inner == null)
+            if (inner is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.inner);
             }
 
-            if (outerKeySelector == null)
+            if (outerKeySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.outerKeySelector);
             }
 
-            if (innerKeySelector == null)
+            if (innerKeySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.innerKeySelector);
             }
 
-            if (resultSelector == null)
+            if (resultSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.resultSelector);
             }
@@ -58,7 +58,7 @@ namespace System.Linq
                         {
                             TOuter item = e.Current;
                             Grouping<TKey, TInner>? g = lookup.GetGrouping(outerKeySelector(item), create: false);
-                            if (g != null)
+                            if (g is not null)
                             {
                                 int count = g._count;
                                 TInner[] elements = g._elements;

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -63,7 +63,7 @@ namespace System.Linq
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, out bool found)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -111,12 +111,12 @@ namespace System.Linq
 
         private static TSource? TryGetLast<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Lookup.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Lookup.SpeedOpt.cs
@@ -13,12 +13,12 @@ namespace System.Linq
             TResult[] array = new TResult[_count];
             int index = 0;
             Grouping<TKey, TElement>? g = _lastGrouping;
-            if (g != null)
+            if (g is not null)
             {
                 do
                 {
                     g = g._next;
-                    Debug.Assert(g != null);
+                    Debug.Assert(g is not null);
 
                     g.Trim();
                     array[index] = resultSelector(g._key, g._elements);

--- a/src/libraries/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Lookup.cs
@@ -14,12 +14,12 @@ namespace System.Linq
 
         public static ILookup<TKey, TSource> ToLookup<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (keySelector == null)
+            if (keySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
             }
@@ -37,17 +37,17 @@ namespace System.Linq
 
         public static ILookup<TKey, TElement> ToLookup<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (keySelector == null)
+            if (keySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
             }
 
-            if (elementSelector == null)
+            if (elementSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.elementSelector);
             }
@@ -81,9 +81,9 @@ namespace System.Linq
 
         internal static Lookup<TKey, TElement> Create<TSource>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(keySelector != null);
-            Debug.Assert(elementSelector != null);
+            Debug.Assert(source is not null);
+            Debug.Assert(keySelector is not null);
+            Debug.Assert(elementSelector is not null);
 
             var lookup = new CollectionLookup<TKey, TElement>(comparer);
             foreach (TSource item in source)
@@ -96,8 +96,8 @@ namespace System.Linq
 
         internal static Lookup<TKey, TElement> Create(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IEqualityComparer<TKey>? comparer)
         {
-            Debug.Assert(source != null);
-            Debug.Assert(keySelector != null);
+            Debug.Assert(source is not null);
+            Debug.Assert(keySelector is not null);
 
             var lookup = new CollectionLookup<TKey, TElement>(comparer);
             foreach (TElement item in source)
@@ -114,7 +114,7 @@ namespace System.Linq
             foreach (TElement item in source)
             {
                 TKey key = keySelector(item);
-                if (key != null)
+                if (key is not null)
                 {
                     lookup.GetGrouping(key, create: true)!.Add(item);
                 }
@@ -133,18 +133,18 @@ namespace System.Linq
 
         public IEnumerable<TElement> this[TKey key] => GetGrouping(key, create: false) ?? Enumerable.Empty<TElement>();
 
-        public bool Contains(TKey key) => GetGrouping(key, create: false) != null;
+        public bool Contains(TKey key) => GetGrouping(key, create: false) is not null;
 
         public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator()
         {
             Grouping<TKey, TElement>? g = _lastGrouping;
-            if (g != null)
+            if (g is not null)
             {
                 do
                 {
                     g = g._next;
 
-                    Debug.Assert(g != null);
+                    Debug.Assert(g is not null);
                     yield return g;
                 }
                 while (g != _lastGrouping);
@@ -155,7 +155,7 @@ namespace System.Linq
         {
             List<TResult> list = new List<TResult>(_count);
             Grouping<TKey, TElement>? g = _lastGrouping;
-            if (g != null)
+            if (g is not null)
             {
                 Span<TResult> span = Enumerable.SetCountAndGetSpan(list, _count);
                 int index = 0;
@@ -163,7 +163,7 @@ namespace System.Linq
                 {
                     g = g._next;
 
-                    Debug.Assert(g != null);
+                    Debug.Assert(g is not null);
                     g.Trim();
                     span[index] = resultSelector(g._key, g._elements);
                     ++index;
@@ -179,13 +179,13 @@ namespace System.Linq
         public IEnumerable<TResult> ApplyResultSelector<TResult>(Func<TKey, IEnumerable<TElement>, TResult> resultSelector)
         {
             Grouping<TKey, TElement>? g = _lastGrouping;
-            if (g != null)
+            if (g is not null)
             {
                 do
                 {
                     g = g._next;
 
-                    Debug.Assert(g != null);
+                    Debug.Assert(g is not null);
                     g.Trim();
                     yield return resultSelector(g._key, g._elements);
                 }
@@ -198,13 +198,13 @@ namespace System.Linq
         private int InternalGetHashCode(TKey key)
         {
             // Handle comparer implementations that throw when passed null
-            return (key == null) ? 0 : _comparer.GetHashCode(key) & 0x7FFFFFFF;
+            return (key is null) ? 0 : _comparer.GetHashCode(key) & 0x7FFFFFFF;
         }
 
         internal Grouping<TKey, TElement>? GetGrouping(TKey key, bool create)
         {
             int hashCode = InternalGetHashCode(key);
-            for (Grouping<TKey, TElement>? g = _groupings[(uint)hashCode % _groupings.Length]; g != null; g = g._hashNext)
+            for (Grouping<TKey, TElement>? g = _groupings[(uint)hashCode % _groupings.Length]; g is not null; g = g._hashNext)
             {
                 if (g._hashCode == hashCode && _comparer.Equals(g._key, key))
                 {
@@ -223,7 +223,7 @@ namespace System.Linq
                 Grouping<TKey, TElement> g = new Grouping<TKey, TElement>(key, hashCode);
                 g._hashNext = _groupings[index];
                 _groupings[index] = g;
-                if (_lastGrouping == null)
+                if (_lastGrouping is null)
                 {
                     g._next = g;
                 }
@@ -271,12 +271,12 @@ namespace System.Linq
             ArgumentOutOfRangeException.ThrowIfLessThan(array.Length - arrayIndex, Count, nameof(arrayIndex));
 
             Grouping<TKey, TElement>? g = _lastGrouping;
-            if (g != null)
+            if (g is not null)
             {
                 do
                 {
                     g = g._next;
-                    Debug.Assert(g != null);
+                    Debug.Assert(g is not null);
 
                     array[arrayIndex] = g;
                     ++arrayIndex;

--- a/src/libraries/System.Linq/src/System/Linq/Max.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Max.cs
@@ -27,7 +27,7 @@ namespace System.Linq
 
         private static T? MaxInteger<T>(this IEnumerable<T?> source) where T : struct, IBinaryInteger<T>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -167,7 +167,7 @@ namespace System.Linq
 
         private static T? MaxFloat<T>(this IEnumerable<T?> source) where T : struct, IFloatingPointIeee754<T>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -271,7 +271,7 @@ namespace System.Linq
 
         public static decimal? Max(this IEnumerable<decimal?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -322,7 +322,7 @@ namespace System.Linq
         /// </remarks>
         public static TSource? Max<TSource>(this IEnumerable<TSource> source, IComparer<TSource>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -347,7 +347,7 @@ namespace System.Linq
             TSource? value = default;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (value == null)
+                if (value is null)
                 {
                     do
                     {
@@ -358,12 +358,12 @@ namespace System.Linq
 
                         value = e.Current;
                     }
-                    while (value == null);
+                    while (value is null);
 
                     while (e.MoveNext())
                     {
                         TSource next = e.Current;
-                        if (next != null && comparer.Compare(next, value) > 0)
+                        if (next is not null && comparer.Compare(next, value) > 0)
                         {
                             value = next;
                         }
@@ -432,12 +432,12 @@ namespace System.Linq
         /// </remarks>
         public static TSource? MaxBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (keySelector == null)
+            if (keySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
             }
@@ -463,7 +463,7 @@ namespace System.Linq
 
             if (default(TKey) is null)
             {
-                if (key == null)
+                if (key is null)
                 {
                     TSource firstValue = value;
 
@@ -478,14 +478,14 @@ namespace System.Linq
                         value = e.Current;
                         key = keySelector(value);
                     }
-                    while (key == null);
+                    while (key is null);
                 }
 
                 while (e.MoveNext())
                 {
                     TSource nextValue = e.Current;
                     TKey nextKey = keySelector(nextValue);
-                    if (nextKey != null && comparer.Compare(nextKey, key) > 0)
+                    if (nextKey is not null && comparer.Compare(nextKey, key) > 0)
                     {
                         key = nextKey;
                         value = nextValue;
@@ -535,12 +535,12 @@ namespace System.Linq
 
         private static TResult MaxInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IBinaryInteger<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -569,12 +569,12 @@ namespace System.Linq
 
         private static TResult? MaxInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IBinaryInteger<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -644,12 +644,12 @@ namespace System.Linq
 
         private static TResult MaxFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -688,12 +688,12 @@ namespace System.Linq
 
         private static TResult? MaxFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -747,12 +747,12 @@ namespace System.Linq
 
         public static decimal Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -781,12 +781,12 @@ namespace System.Linq
 
         public static decimal? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -823,12 +823,12 @@ namespace System.Linq
 
         public static TResult? Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -836,7 +836,7 @@ namespace System.Linq
             TResult? value = default;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (value == null)
+                if (value is null)
                 {
                     do
                     {
@@ -847,13 +847,13 @@ namespace System.Linq
 
                         value = selector(e.Current);
                     }
-                    while (value == null);
+                    while (value is null);
 
                     Comparer<TResult> comparer = Comparer<TResult>.Default;
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (x != null && comparer.Compare(x, value) > 0)
+                        if (x is not null && comparer.Compare(x, value) > 0)
                         {
                             value = x;
                         }

--- a/src/libraries/System.Linq/src/System/Linq/Min.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Min.cs
@@ -27,7 +27,7 @@ namespace System.Linq
 
         private static T? MinInteger<T>(this IEnumerable<T?> source) where T : struct, IBinaryInteger<T>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -151,7 +151,7 @@ namespace System.Linq
 
         private static T? MinFloat<T>(this IEnumerable<T?> source) where T : struct, IFloatingPointIeee754<T>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -249,7 +249,7 @@ namespace System.Linq
 
         public static decimal? Min(this IEnumerable<decimal?> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -300,7 +300,7 @@ namespace System.Linq
         /// </remarks>
         public static TSource? Min<TSource>(this IEnumerable<TSource> source, IComparer<TSource>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -325,7 +325,7 @@ namespace System.Linq
             TSource? value = default;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (value == null)
+                if (value is null)
                 {
                     do
                     {
@@ -336,12 +336,12 @@ namespace System.Linq
 
                         value = e.Current;
                     }
-                    while (value == null);
+                    while (value is null);
 
                     while (e.MoveNext())
                     {
                         TSource next = e.Current;
-                        if (next != null && comparer.Compare(next, value) < 0)
+                        if (next is not null && comparer.Compare(next, value) < 0)
                         {
                             value = next;
                         }
@@ -410,12 +410,12 @@ namespace System.Linq
         /// </remarks>
         public static TSource? MinBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (keySelector == null)
+            if (keySelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.keySelector);
             }
@@ -441,7 +441,7 @@ namespace System.Linq
 
             if (default(TKey) is null)
             {
-                if (key == null)
+                if (key is null)
                 {
                     TSource firstValue = value;
 
@@ -456,14 +456,14 @@ namespace System.Linq
                         value = e.Current;
                         key = keySelector(value);
                     }
-                    while (key == null);
+                    while (key is null);
                 }
 
                 while (e.MoveNext())
                 {
                     TSource nextValue = e.Current;
                     TKey nextKey = keySelector(nextValue);
-                    if (nextKey != null && comparer.Compare(nextKey, key) < 0)
+                    if (nextKey is not null && comparer.Compare(nextKey, key) < 0)
                     {
                         key = nextKey;
                         value = nextValue;
@@ -513,12 +513,12 @@ namespace System.Linq
 
         private static TResult MinInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IBinaryInteger<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -547,12 +547,12 @@ namespace System.Linq
 
         private static TResult? MinInteger<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IBinaryInteger<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -604,12 +604,12 @@ namespace System.Linq
 
         private static TResult MinFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -656,12 +656,12 @@ namespace System.Linq
 
         private static TResult? MinFloat<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector) where TResult : struct, IFloatingPointIeee754<TResult>
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -710,12 +710,12 @@ namespace System.Linq
 
         public static decimal Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -744,12 +744,12 @@ namespace System.Linq
 
         public static decimal? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -786,12 +786,12 @@ namespace System.Linq
 
         public static TResult? Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -799,7 +799,7 @@ namespace System.Linq
             TResult? value = default;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (value == null)
+                if (value is null)
                 {
                     do
                     {
@@ -810,13 +810,13 @@ namespace System.Linq
 
                         value = selector(e.Current);
                     }
-                    while (value == null);
+                    while (value is null);
 
                     Comparer<TResult> comparer = Comparer<TResult>.Default;
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (x != null && comparer.Compare(x, value) < 0)
+                        if (x is not null && comparer.Compare(x, value) < 0)
                         {
                             value = x;
                         }

--- a/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderBy.cs
@@ -100,7 +100,7 @@ namespace System.Linq
 
         public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -110,7 +110,7 @@ namespace System.Linq
 
         public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -120,7 +120,7 @@ namespace System.Linq
 
         public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -130,7 +130,7 @@ namespace System.Linq
 
         public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey>? comparer)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -104,7 +104,7 @@ namespace System.Linq
                 }
 
                 EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, comparer, _descending, next);
-                if (_parent != null)
+                if (_parent is not null)
                 {
                     sorter = _parent.GetEnumerableSorter(sorter);
                 }
@@ -114,10 +114,10 @@ namespace System.Linq
 
             internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer)
             {
-                CachingComparer<TElement> cmp = childComparer == null
+                CachingComparer<TElement> cmp = childComparer is null
                     ? new CachingComparer<TElement, TKey>(_keySelector, _comparer, _descending)
                     : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
-                return _parent != null ? _parent.GetComparer(cmp) : cmp;
+                return _parent is not null ? _parent.GetComparer(cmp) : cmp;
             }
 
             public override bool MoveNext()
@@ -185,7 +185,7 @@ namespace System.Linq
             public override Iterator<TElement> Clone() => new ImplicitlyStableOrderedIterator<TElement>(_source, _descending);
 
             internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement>? childComparer) =>
-                childComparer == null ?
+                childComparer is null ?
                     new CachingComparer<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending) :
                     new CachingComparerWithChild<TElement, TElement>(EnumerableSorter<TElement>.IdentityFunc, Comparer<TElement>.Default, _descending, childComparer);
 
@@ -427,12 +427,12 @@ namespace System.Linq
             internal override int CompareAnyKeys(int index1, int index2)
             {
                 TKey[]? keys = _keys;
-                Debug.Assert(keys != null);
+                Debug.Assert(keys is not null);
 
                 int c = _comparer.Compare(keys[index1], keys[index2]);
                 if (c == 0)
                 {
-                    if (_next == null)
+                    if (_next is null)
                     {
                         return index1 - index2; // ensure stability of sort
                     }
@@ -454,7 +454,7 @@ namespace System.Linq
                 Debug.Assert(!_descending);
 
                 TKey[]? keys = _keys;
-                Debug.Assert(keys != null);
+                Debug.Assert(keys is not null);
 
                 int c = Comparer<TKey>.Default.Compare(keys[index1], keys[index2]);
                 return
@@ -470,7 +470,7 @@ namespace System.Linq
                 Debug.Assert(_descending);
 
                 TKey[]? keys = _keys;
-                Debug.Assert(keys != null);
+                Debug.Assert(keys is not null);
 
                 int c = Comparer<TKey>.Default.Compare(keys[index2], keys[index1]);
                 return

--- a/src/libraries/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Repeat.SpeedOpt.cs
@@ -13,7 +13,7 @@ namespace System.Linq
             public override TResult[] ToArray()
             {
                 TResult[] array = new TResult[_count];
-                if (_current != null)
+                if (_current is not null)
                 {
                     Array.Fill(array, _current);
                 }

--- a/src/libraries/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Reverse.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -34,7 +34,7 @@ namespace System.Linq
 
             public ReverseIterator(IEnumerable<TSource> source)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 _source = source;
             }
 
@@ -70,7 +70,7 @@ namespace System.Linq
                         int index = _state - 3;
                         if (index != -1)
                         {
-                            Debug.Assert(_buffer != null);
+                            Debug.Assert(_buffer is not null);
                             _current = _buffer[index];
                             --_state;
                             return true;

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -238,7 +238,7 @@ namespace System.Linq
             {
                 Debug.Assert(start < end);
                 Debug.Assert((uint)(end - start) <= (uint)int.MaxValue);
-                Debug.Assert(selector != null);
+                Debug.Assert(selector is not null);
 
                 _start = start;
                 _end = end;
@@ -573,8 +573,8 @@ namespace System.Linq
 
             public IteratorSelectIterator(Iterator<TSource> source, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _selector = selector;
             }
@@ -591,7 +591,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = _selector(_enumerator.Current);
@@ -607,7 +607,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -771,8 +771,8 @@ namespace System.Linq
 
             public IListSkipTakeSelectIterator(IList<TSource> source, Func<TSource, TResult> selector, int minIndexInclusive, int maxIndexInclusive)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 Debug.Assert(minIndexInclusive >= 0);
                 Debug.Assert(minIndexInclusive <= maxIndexInclusive);
                 _source = source;

--- a/src/libraries/System.Linq/src/System/Linq/Select.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.cs
@@ -13,12 +13,12 @@ namespace System.Linq
         public static IEnumerable<TResult> Select<TSource, TResult>(
             this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -53,12 +53,12 @@ namespace System.Linq
 
         public static IEnumerable<TResult> Select<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, TResult> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -98,8 +98,8 @@ namespace System.Linq
 
             public IEnumerableSelectIterator(IEnumerable<TSource> source, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _selector = selector;
             }
@@ -109,7 +109,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -127,7 +127,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = _selector(_enumerator.Current);
@@ -158,8 +158,8 @@ namespace System.Linq
 
             public ArraySelectIterator(TSource[] source, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 Debug.Assert(source.Length > 0); // Caller should check this beforehand and return a cached result
                 _source = source;
                 _selector = selector;
@@ -202,8 +202,8 @@ namespace System.Linq
 
             public ListSelectIterator(List<TSource> source, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _selector = selector;
             }
@@ -252,8 +252,8 @@ namespace System.Linq
 
             public IListSelectIterator(IList<TSource> source, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _selector = selector;
             }
@@ -271,7 +271,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (_enumerator.MoveNext())
                         {
                             _current = _selector(_enumerator.Current);
@@ -287,7 +287,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;

--- a/src/libraries/System.Linq/src/System/Linq/SelectMany.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SelectMany.cs
@@ -10,12 +10,12 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -30,12 +30,12 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TResult>> selector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (selector == null)
+            if (selector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.selector);
             }
@@ -67,17 +67,17 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (collectionSelector == null)
+            if (collectionSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collectionSelector);
             }
 
-            if (resultSelector == null)
+            if (resultSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.resultSelector);
             }
@@ -109,17 +109,17 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (collectionSelector == null)
+            if (collectionSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.collectionSelector);
             }
 
-            if (resultSelector == null)
+            if (resultSelector is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.resultSelector);
             }
@@ -152,8 +152,8 @@ namespace System.Linq
 
             internal SelectManySingleSelectorIterator(IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(selector is not null);
 
                 _source = source;
                 _selector = selector;
@@ -166,13 +166,13 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_subEnumerator != null)
+                if (_subEnumerator is not null)
                 {
                     _subEnumerator.Dispose();
                     _subEnumerator = null;
                 }
 
-                if (_sourceEnumerator != null)
+                if (_sourceEnumerator is not null)
                 {
                     _sourceEnumerator.Dispose();
                     _sourceEnumerator = null;
@@ -192,7 +192,7 @@ namespace System.Linq
                         goto case 2;
                     case 2:
                         // Take the next element from the source enumerator.
-                        Debug.Assert(_sourceEnumerator != null);
+                        Debug.Assert(_sourceEnumerator is not null);
                         if (!_sourceEnumerator.MoveNext())
                         {
                             break;
@@ -206,7 +206,7 @@ namespace System.Linq
                         goto case 3;
                     case 3:
                         // Take the next element from the sub-collection and yield.
-                        Debug.Assert(_subEnumerator != null);
+                        Debug.Assert(_subEnumerator is not null);
                         if (!_subEnumerator.MoveNext())
                         {
                             _subEnumerator.Dispose();

--- a/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SequenceEqual.cs
@@ -12,12 +12,12 @@ namespace System.Linq
 
         public static bool SequenceEqual<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource>? comparer)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -107,12 +107,12 @@ namespace System.Linq
 
         private static TSource? TryGetSingle<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, out bool found)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }

--- a/src/libraries/System.Linq/src/System/Linq/SingleLinkedNode.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SingleLinkedNode.cs
@@ -27,7 +27,7 @@ namespace System.Linq
         /// <param name="item">The item to place in this node.</param>
         private SingleLinkedNode(SingleLinkedNode<TSource> linked, TSource item)
         {
-            Debug.Assert(linked != null);
+            Debug.Assert(linked is not null);
             Linked = linked;
             Item = item;
         }
@@ -54,7 +54,7 @@ namespace System.Linq
         public int GetCount()
         {
             int count = 0;
-            for (SingleLinkedNode<TSource>? node = this; node != null; node = node.Linked)
+            for (SingleLinkedNode<TSource>? node = this; node is not null; node = node.Linked)
             {
                 count++;
             }
@@ -77,7 +77,7 @@ namespace System.Linq
             for (; index > 0; index--)
             {
                 node = node.Linked!;
-                Debug.Assert(node != null);
+                Debug.Assert(node is not null);
             }
 
             return node;
@@ -103,7 +103,7 @@ namespace System.Linq
         public void Fill(Span<TSource> span)
         {
             int index = 0;
-            for (SingleLinkedNode<TSource>? node = this; node != null; node = node.Linked)
+            for (SingleLinkedNode<TSource>? node = this; node is not null; node = node.Linked)
             {
                 span[index] = node.Item;
                 index++;
@@ -117,7 +117,7 @@ namespace System.Linq
         public void FillReversed(Span<TSource> span)
         {
             int index = span.Length;
-            for (SingleLinkedNode<TSource>? node = this; node != null; node = node.Linked)
+            for (SingleLinkedNode<TSource>? node = this; node is not null; node = node.Linked)
             {
                 --index;
                 span[index] = node.Item;

--- a/src/libraries/System.Linq/src/System/Linq/Skip.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Skip.cs
@@ -9,7 +9,7 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -42,12 +42,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -83,12 +83,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -130,7 +130,7 @@ namespace System.Linq
 
         public static IEnumerable<TSource> SkipLast<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }

--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -21,7 +21,7 @@ namespace System.Linq
 
             public IListSkipTakeIterator(IList<TSource> source, int minIndexInclusive, int maxIndexInclusive)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 Debug.Assert(minIndexInclusive >= 0);
                 Debug.Assert(minIndexInclusive <= maxIndexInclusive);
                 _source = source;
@@ -209,7 +209,7 @@ namespace System.Linq
 
             internal IEnumerableSkipTakeIterator(IEnumerable<TSource> source, int minIndexInclusive, int maxIndexInclusive)
             {
-                Debug.Assert(source != null);
+                Debug.Assert(source is not null);
                 Debug.Assert(!(source is IList<TSource>), $"The caller needs to check for {nameof(IList<TSource>)}.");
                 Debug.Assert(minIndexInclusive >= 0);
                 Debug.Assert(maxIndexInclusive >= -1);
@@ -235,7 +235,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -293,7 +293,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if (!SkipBeforeFirst(_enumerator))
                         {
                             // Reached the end before we finished skipping.
@@ -303,7 +303,7 @@ namespace System.Linq
                         _state = 3;
                         goto default;
                     default:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         if ((!HasLimit || taken < Limit) && _enumerator.MoveNext())
                         {
                             if (HasLimit)
@@ -524,7 +524,7 @@ namespace System.Linq
 
             private static uint SkipAndCount(uint index, IEnumerator<TSource> en)
             {
-                Debug.Assert(en != null);
+                Debug.Assert(en is not null);
 
                 for (uint i = 0; i < index; i++)
                 {

--- a/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SizeOpt.cs
@@ -21,7 +21,7 @@ namespace System.Linq
 
         private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(source is not null);
             Debug.Assert(startIndex >= 0 && startIndex < endIndex);
 
             using IEnumerator<TSource> e = source.GetEnumerator();

--- a/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.SpeedOpt.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         private static IEnumerable<TSource> TakeIterator<TSource>(IEnumerable<TSource> source, int count)
         {
-            Debug.Assert(source != null && !IsEmptyArray(source));
+            Debug.Assert(source is not null && !IsEmptyArray(source));
             Debug.Assert(count > 0);
 
             return
@@ -21,7 +21,7 @@ namespace System.Linq
 
         private static IEnumerable<TSource> TakeRangeIterator<TSource>(IEnumerable<TSource> source, int startIndex, int endIndex)
         {
-            Debug.Assert(source != null && !IsEmptyArray(source));
+            Debug.Assert(source is not null && !IsEmptyArray(source));
             Debug.Assert(startIndex >= 0 && startIndex < endIndex);
 
             return

--- a/src/libraries/System.Linq/src/System/Linq/Take.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Take.cs
@@ -10,7 +10,7 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -32,7 +32,7 @@ namespace System.Linq
         /// </remarks>
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, Range range)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
@@ -70,7 +70,7 @@ namespace System.Linq
 
         private static IEnumerable<TSource> TakeRangeFromEndIterator<TSource>(IEnumerable<TSource> source, bool isStartIndexFromEnd, int startIndex, bool isEndIndexFromEnd, int endIndex)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(source is not null);
             Debug.Assert(isStartIndexFromEnd || isEndIndexFromEnd);
             Debug.Assert(isStartIndexFromEnd
                 ? startIndex > 0 && (!isEndIndexFromEnd || startIndex > endIndex)
@@ -189,12 +189,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -222,12 +222,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -261,7 +261,7 @@ namespace System.Linq
 
         public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
@@ -15,7 +15,7 @@ namespace System.Linq
                 for (int index = 0; ; ++index)
                 {
                     IEnumerable<TSource>? enumerable = GetEnumerable(index);
-                    if (enumerable == null)
+                    if (enumerable is null)
                     {
                         return set;
                     }

--- a/src/libraries/System.Linq/src/System/Linq/Union.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Union.cs
@@ -13,12 +13,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Union<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource>? comparer)
         {
-            if (first == null)
+            if (first is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.first);
             }
 
-            if (second == null)
+            if (second is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.second);
             }
@@ -111,7 +111,7 @@ namespace System.Linq
 
             public sealed override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -134,7 +134,7 @@ namespace System.Linq
 
             private void StoreFirst()
             {
-                Debug.Assert(_enumerator != null);
+                Debug.Assert(_enumerator is not null);
 
                 var set = new HashSet<TSource>(DefaultInternalSetCapacity, _comparer);
                 TSource element = _enumerator.Current;
@@ -145,8 +145,8 @@ namespace System.Linq
 
             private bool GetNext()
             {
-                Debug.Assert(_enumerator != null);
-                Debug.Assert(_set != null);
+                Debug.Assert(_enumerator is not null);
+                Debug.Assert(_set is not null);
 
                 HashSet<TSource> set = _set;
 
@@ -167,7 +167,7 @@ namespace System.Linq
             {
                 if (_state == 1)
                 {
-                    for (IEnumerable<TSource>? enumerable = GetEnumerable(0); enumerable != null; enumerable = GetEnumerable(_state - 1))
+                    for (IEnumerable<TSource>? enumerable = GetEnumerable(0); enumerable is not null; enumerable = GetEnumerable(_state - 1))
                     {
                         IEnumerator<TSource> enumerator = enumerable.GetEnumerator();
                         SetEnumerator(enumerator);
@@ -190,7 +190,7 @@ namespace System.Linq
                         }
 
                         IEnumerable<TSource>? enumerable = GetEnumerable(_state - 1);
-                        if (enumerable == null)
+                        if (enumerable is null)
                         {
                             break;
                         }
@@ -217,8 +217,8 @@ namespace System.Linq
             public UnionIterator2(IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource>? comparer)
                 : base(comparer)
             {
-                Debug.Assert(first != null);
-                Debug.Assert(second != null);
+                Debug.Assert(first is not null);
+                Debug.Assert(second is not null);
                 _first = first;
                 _second = second;
             }

--- a/src/libraries/System.Linq/src/System/Linq/Utilities.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Utilities.cs
@@ -26,7 +26,7 @@ namespace System.Linq
 
             var defaultComparer = EqualityComparer<TSource>.Default;
 
-            if (left == null)
+            if (left is null)
             {
                 // Micro-opt: Typically it's impossible to get a different instance
                 // of the default comparer without reflection/serialization.
@@ -34,7 +34,7 @@ namespace System.Linq
                 return right == defaultComparer || right!.Equals(defaultComparer);
             }
 
-            if (right == null)
+            if (right is null)
             {
                 return left == defaultComparer || left.Equals(defaultComparer);
             }

--- a/src/libraries/System.Linq/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.cs
@@ -11,12 +11,12 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -46,12 +46,12 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null)
+            if (source is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
-            if (predicate == null)
+            if (predicate is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
@@ -93,8 +93,8 @@ namespace System.Linq
 
             public IEnumerableWhereIterator(IEnumerable<TSource> source, Func<TSource, bool> predicate)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(predicate != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(predicate is not null);
                 _source = source;
                 _predicate = predicate;
             }
@@ -103,7 +103,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -121,7 +121,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         while (_enumerator.MoveNext())
                         {
                             TSource item = _enumerator.Current;
@@ -157,8 +157,8 @@ namespace System.Linq
 
             public ArrayWhereIterator(TSource[] source, Func<TSource, bool> predicate)
             {
-                Debug.Assert(source != null && source.Length > 0);
-                Debug.Assert(predicate != null);
+                Debug.Assert(source is not null && source.Length > 0);
+                Debug.Assert(predicate is not null);
                 _source = source;
                 _predicate = predicate;
             }
@@ -205,8 +205,8 @@ namespace System.Linq
 
             public ListWhereIterator(List<TSource> source, Func<TSource, bool> predicate)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(predicate != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(predicate is not null);
                 _source = source;
                 _predicate = predicate;
             }
@@ -260,9 +260,9 @@ namespace System.Linq
 
             public ArrayWhereSelectIterator(TSource[] source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null && source.Length > 0);
-                Debug.Assert(predicate != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null && source.Length > 0);
+                Debug.Assert(predicate is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _predicate = predicate;
                 _selector = selector;
@@ -309,9 +309,9 @@ namespace System.Linq
 
             public ListWhereSelectIterator(List<TSource> source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(predicate != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(predicate is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _predicate = predicate;
                 _selector = selector;
@@ -364,9 +364,9 @@ namespace System.Linq
 
             public IEnumerableWhereSelectIterator(IEnumerable<TSource> source, Func<TSource, bool> predicate, Func<TSource, TResult> selector)
             {
-                Debug.Assert(source != null);
-                Debug.Assert(predicate != null);
-                Debug.Assert(selector != null);
+                Debug.Assert(source is not null);
+                Debug.Assert(predicate is not null);
+                Debug.Assert(selector is not null);
                 _source = source;
                 _predicate = predicate;
                 _selector = selector;
@@ -377,7 +377,7 @@ namespace System.Linq
 
             public override void Dispose()
             {
-                if (_enumerator != null)
+                if (_enumerator is not null)
                 {
                     _enumerator.Dispose();
                     _enumerator = null;
@@ -395,7 +395,7 @@ namespace System.Linq
                         _state = 2;
                         goto case 2;
                     case 2:
-                        Debug.Assert(_enumerator != null);
+                        Debug.Assert(_enumerator is not null);
                         while (_enumerator.MoveNext())
                         {
                             TSource item = _enumerator.Current;

--- a/src/libraries/System.Linq/tests/AnyTests.cs
+++ b/src/libraries/System.Linq/tests/AnyTests.cs
@@ -102,7 +102,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(TestDataWithPredicate))]
         public void Any_Predicate(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.Any());
             }
@@ -115,7 +115,7 @@ namespace System.Linq.Tests
         [Theory, MemberData(nameof(TestDataWithPredicate))]
         public void AnyRunOnce(IEnumerable<int> source, Func<int, bool> predicate, bool expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.RunOnce().Any());
             }

--- a/src/libraries/System.Linq/tests/AppendPrependTests.cs
+++ b/src/libraries/System.Linq/tests/AppendPrependTests.cs
@@ -89,7 +89,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Prepend(4);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -98,7 +98,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Append(4);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Append(4).Append(5).Prepend(-1).Prepend(-2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/CastTests.cs
+++ b/src/libraries/System.Linq/tests/CastTests.cs
@@ -229,10 +229,10 @@ namespace System.Linq.Tests
         [Fact]
         public void ForcedToEnumeratorDoesntEnumerate()
         {
-            var iterator = new object[0].Where(i => i != null).Cast<string>();
+            var iterator = new object[0].Where(i => i is not null).Cast<string>();
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<string>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/ConcatTests.cs
+++ b/src/libraries/System.Linq/tests/ConcatTests.cs
@@ -51,7 +51,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Concat(Enumerable.Range(0, 3));
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/ConsistencyTests.cs
+++ b/src/libraries/System.Linq/tests/ConsistencyTests.cs
@@ -18,7 +18,7 @@ namespace System.Linq.Tests
         {
             MethodInfo enumerableNotInQueryable = GetMissingExtensionMethod(typeof(Enumerable), typeof(Queryable), GetExcludedMethods());
 
-            Assert.True(enumerableNotInQueryable == null, string.Format("Enumerable method {0} not defined by Queryable", enumerableNotInQueryable));
+            Assert.True(enumerableNotInQueryable is null, string.Format("Enumerable method {0} not defined by Queryable", enumerableNotInQueryable));
 
             MethodInfo queryableNotInEnumerable = GetMissingExtensionMethod(
                 typeof(Queryable),
@@ -28,7 +28,7 @@ namespace System.Linq.Tests
                  }
                 );
 
-            Assert.True(queryableNotInEnumerable == null, string.Format("Queryable method {0} not defined by Enumerable", queryableNotInEnumerable));
+            Assert.True(queryableNotInEnumerable is null, string.Format("Queryable method {0} not defined by Enumerable", queryableNotInEnumerable));
         }
 
         // If a change to Enumerable has required a change to the exception list in this test

--- a/src/libraries/System.Linq/tests/ContainsTests.cs
+++ b/src/libraries/System.Linq/tests/ContainsTests.cs
@@ -71,7 +71,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(String_TestData))]
         public void String(IEnumerable<string> source, IEqualityComparer<string> comparer, string value, bool expected)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 Assert.Equal(expected, source.Contains(value));
             }
@@ -81,7 +81,7 @@ namespace System.Linq.Tests
         [Theory, MemberData(nameof(String_TestData))]
         public void StringRunOnce(IEnumerable<string> source, IEqualityComparer<string> comparer, string value, bool expected)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 Assert.Equal(expected, source.RunOnce().Contains(value));
             }

--- a/src/libraries/System.Linq/tests/CountTests.cs
+++ b/src/libraries/System.Linq/tests/CountTests.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(Int_TestData))]
         public void Int(IEnumerable<int> source, Func<int, bool> predicate, int expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.Count());
             }
@@ -61,7 +61,7 @@ namespace System.Linq.Tests
         [Theory, MemberData(nameof(Int_TestData))]
         public void IntRunOnce(IEnumerable<int> source, Func<int, bool> predicate, int expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.RunOnce().Count());
             }

--- a/src/libraries/System.Linq/tests/DefaultIfEmptyTests.cs
+++ b/src/libraries/System.Linq/tests/DefaultIfEmptyTests.cs
@@ -103,7 +103,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).DefaultIfEmpty();
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/DistinctTests.cs
+++ b/src/libraries/System.Linq/tests/DistinctTests.cs
@@ -230,7 +230,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Distinct();
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/EnumerableTests.cs
+++ b/src/libraries/System.Linq/tests/EnumerableTests.cs
@@ -87,7 +87,7 @@ namespace System.Linq.Tests
             public bool Equals(string x, string y)
             {
                 if (ReferenceEquals(x, y)) return true;
-                if (x == null | y == null) return false;
+                if (x is null | y is null) return false;
                 int length = x.Length;
                 if (length != y.Length) return false;
                 using (var en = x.OrderBy(i => i).GetEnumerator())
@@ -103,7 +103,7 @@ namespace System.Linq.Tests
 
             public int GetHashCode(string obj)
             {
-                if (obj == null) return 0;
+                if (obj is null) return 0;
                 int hash = obj.Length;
                 foreach (char c in obj)
                     hash ^= c;

--- a/src/libraries/System.Linq/tests/ExceptTests.cs
+++ b/src/libraries/System.Linq/tests/ExceptTests.cs
@@ -42,7 +42,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(Int_TestData))]
         public void Int(IEnumerable<int> first, IEnumerable<int> second, IEqualityComparer<int> comparer, IEnumerable<int> expected)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 Assert.Equal(expected, first.Except(second));
             }
@@ -64,7 +64,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(String_TestData))]
         public void String(IEnumerable<string> first, IEnumerable<string> second, IEqualityComparer<string> comparer, IEnumerable<string> expected)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 Assert.Equal(expected, first.Except(second));
             }
@@ -119,7 +119,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Except(Enumerable.Range(0, 3));
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/GroupByTests.cs
+++ b/src/libraries/System.Linq/tests/GroupByTests.cs
@@ -16,7 +16,7 @@ namespace System.Linq.Tests
 
         private static void AssertGroupingCorrect<TKey, TElement>(IEnumerable<TKey> keys, IEnumerable<TElement> elements, IEnumerable<IGrouping<TKey, TElement>> grouping, IEqualityComparer<TKey> keyComparer)
         {
-            if (grouping == null)
+            if (grouping is null)
             {
                 Assert.Null(elements);
                 Assert.Null(keys);
@@ -37,7 +37,7 @@ namespace System.Linq.Tests
 
                     TKey key = keyEn.Current;
 
-                    if (key == null)
+                    if (key is null)
                     {
                         groupingForNullKeys.Add(elEn.Current);
                     }
@@ -57,7 +57,7 @@ namespace System.Linq.Tests
                 TKey key = group.Key;
                 List<TElement> list;
 
-                if (key == null)
+                if (key is null)
                 {
                     Assert.Equal(groupingForNullKeys, group);
                     groupingForNullKeys.Clear();

--- a/src/libraries/System.Linq/tests/GroupJoinTests.cs
+++ b/src/libraries/System.Linq/tests/GroupJoinTests.cs
@@ -44,24 +44,24 @@ namespace System.Linq.Tests
             public bool Equals(JoinRec other)
             {
                 if (!string.Equals(name, other.name)) return false;
-                if (orderID == null)
+                if (orderID is null)
                 {
-                    if (other.orderID != null) return false;
+                    if (other.orderID is not null) return false;
                 }
                 else
                 {
-                    if (other.orderID == null) return false;
+                    if (other.orderID is null) return false;
                     if (orderID.Length != other.orderID.Length) return false;
                     for (int i = 0; i != other.orderID.Length; ++i)
                         if (orderID[i] != other.orderID[i]) return false;
                 }
-                if (total == null)
+                if (total is null)
                 {
-                    if (other.total != null) return false;
+                    if (other.total is not null) return false;
                 }
                 else
                 {
-                    if (other.total == null) return false;
+                    if (other.total is null) return false;
                     if (total.Length != other.total.Length) return false;
                     for (int i = 0; i != other.total.Length; ++i)
                         if (total[i] != other.total[i]) return false;
@@ -511,7 +511,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).GroupJoin(Enumerable.Empty<int>(), i => i, i => i, (o, i) => i);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<IEnumerable<int>>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/IntersectTests.cs
+++ b/src/libraries/System.Linq/tests/IntersectTests.cs
@@ -61,7 +61,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(String_TestData))]
         public void String(IEnumerable<string> first, IEnumerable<string> second, IEqualityComparer<string> comparer, string[] expected)
         {
-            if (comparer == null)
+            if (comparer is null)
             {
                 Assert.Equal(expected, first.Intersect(second));
             }
@@ -116,7 +116,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Intersect(Enumerable.Range(0, 3));
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/JoinTests.cs
+++ b/src/libraries/System.Linq/tests/JoinTests.cs
@@ -415,7 +415,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Join(Enumerable.Empty<int>(), i => i, i => i, (o, i) => i);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/LongCountTests.cs
+++ b/src/libraries/System.Linq/tests/LongCountTests.cs
@@ -45,7 +45,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(LongCount_TestData))]
         public static void LongCount(IEnumerable<int> source, Func<int, bool> predicate, long expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.LongCount());
             }
@@ -59,7 +59,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(LongCount_TestData))]
         public static void LongCountRunOnce(IEnumerable<int> source, Func<int, bool> predicate, long expected)
         {
-            if (predicate == null)
+            if (predicate is null)
             {
                 Assert.Equal(expected, source.RunOnce().LongCount());
             }

--- a/src/libraries/System.Linq/tests/OfTypeTests.cs
+++ b/src/libraries/System.Linq/tests/OfTypeTests.cs
@@ -131,7 +131,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).OfType<int>();
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/libraries/System.Linq/tests/OrderedSubsetting.cs
@@ -416,7 +416,7 @@ namespace System.Linq.Tests
             var iterator = Enumerable.Range(-1, 8).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/ReverseTests.cs
+++ b/src/libraries/System.Linq/tests/ReverseTests.cs
@@ -82,7 +82,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Reverse();
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/SelectManyTests.cs
+++ b/src/libraries/System.Linq/tests/SelectManyTests.cs
@@ -345,7 +345,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SelectMany(i => new int[0]);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -353,7 +353,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SelectMany((e, i) => new int[0]);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -361,7 +361,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SelectMany(i => new int[0], (e, i) => e);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -369,7 +369,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SelectMany((e, i) => new int[0], (e, i) => e);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Theory]

--- a/src/libraries/System.Linq/tests/SelectTests.cs
+++ b/src/libraries/System.Linq/tests/SelectTests.cs
@@ -747,7 +747,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Select(i => i);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -756,7 +756,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Select((e, i) => i);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -764,7 +764,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToArray().Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -772,7 +772,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -780,7 +780,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().AsReadOnly().Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -788,7 +788,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().AsReadOnly().Select(i => i).Skip(1);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/SkipTests.cs
+++ b/src/libraries/System.Linq/tests/SkipTests.cs
@@ -210,7 +210,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Skip(2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace System.Linq.Tests
             var iterator = (new[] { 0, 1, 2 }).Skip(2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -497,7 +497,7 @@ namespace System.Linq.Tests
 
             // On platforms that do not have this change, the optimization may not be present
             // and the iterator may not have a field named _state. In that case, nop.
-            if (state != null)
+            if (state is not null)
             {
                 state.SetValue(iterator, int.MaxValue);
 

--- a/src/libraries/System.Linq/tests/SkipWhileTests.cs
+++ b/src/libraries/System.Linq/tests/SkipWhileTests.cs
@@ -166,7 +166,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SkipWhile(e => true);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -175,7 +175,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).SkipWhile((e, i) => true);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/TakeTests.cs
+++ b/src/libraries/System.Linq/tests/TakeTests.cs
@@ -271,23 +271,23 @@ namespace System.Linq.Tests
             var iterator1 = NumberRangeGuaranteedNotCollectionType(0, 3).Take(2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en1 = iterator1 as IEnumerator<int>;
-            Assert.False(en1 != null && en1.MoveNext());
+            Assert.False(en1 is not null && en1.MoveNext());
 
             var iterator2 = NumberRangeGuaranteedNotCollectionType(0, 3).Take(0..2);
             var en2 = iterator2 as IEnumerator<int>;
-            Assert.False(en2 != null && en2.MoveNext());
+            Assert.False(en2 is not null && en2.MoveNext());
 
             var iterator3 = NumberRangeGuaranteedNotCollectionType(0, 3).Take(^3..2);
             var en3 = iterator3 as IEnumerator<int>;
-            Assert.False(en3 != null && en3.MoveNext());
+            Assert.False(en3 is not null && en3.MoveNext());
 
             var iterator4 = NumberRangeGuaranteedNotCollectionType(0, 3).Take(0..^1);
             var en4 = iterator4 as IEnumerator<int>;
-            Assert.False(en4 != null && en4.MoveNext());
+            Assert.False(en4 is not null && en4.MoveNext());
 
             var iterator5 = NumberRangeGuaranteedNotCollectionType(0, 3).Take(^3..^1);
             var en5 = iterator5 as IEnumerator<int>;
-            Assert.False(en5 != null && en5.MoveNext());
+            Assert.False(en5 is not null && en5.MoveNext());
         }
 
         [Fact]
@@ -320,23 +320,23 @@ namespace System.Linq.Tests
             var iterator1 = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(2);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en1 = iterator1 as IEnumerator<int>;
-            Assert.False(en1 != null && en1.MoveNext());
+            Assert.False(en1 is not null && en1.MoveNext());
 
             var iterator2 = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(0..2);
             var en2 = iterator2 as IEnumerator<int>;
-            Assert.False(en2 != null && en2.MoveNext());
+            Assert.False(en2 is not null && en2.MoveNext());
 
             var iterator3 = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(^3..2);
             var en3 = iterator3 as IEnumerator<int>;
-            Assert.False(en3 != null && en3.MoveNext());
+            Assert.False(en3 is not null && en3.MoveNext());
 
             var iterator4 = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(0..^1);
             var en4 = iterator4 as IEnumerator<int>;
-            Assert.False(en4 != null && en4.MoveNext());
+            Assert.False(en4 is not null && en4.MoveNext());
 
             var iterator5 = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(^3..^1);
             var en5 = iterator5 as IEnumerator<int>;
-            Assert.False(en5 != null && en5.MoveNext());
+            Assert.False(en5 is not null && en5.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/TakeWhileTests.cs
+++ b/src/libraries/System.Linq/tests/TakeWhileTests.cs
@@ -174,7 +174,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).TakeWhile(e => true);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).TakeWhile((e, i) => true);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
     }
 }

--- a/src/libraries/System.Linq/tests/TestExtensions.cs
+++ b/src/libraries/System.Linq/tests/TestExtensions.cs
@@ -10,10 +10,10 @@ namespace System.Linq.Tests
     public static class TestExtensions
     {
         public static IEnumerable<T> RunOnce<T>(this IEnumerable<T> source) =>
-            source == null ? null : (source as IList<T>)?.RunOnce() ?? new RunOnceEnumerable<T>(source);
+            source is null ? null : (source as IList<T>)?.RunOnce() ?? new RunOnceEnumerable<T>(source);
 
         public static IEnumerable<T> RunOnce<T>(this IList<T> source)
-            => source == null ? null : new RunOnceList<T>(source);
+            => source is null ? null : new RunOnceList<T>(source);
 
         private class RunOnceEnumerable<T> : IEnumerable<T>
         {

--- a/src/libraries/System.Linq/tests/ToArrayTests.cs
+++ b/src/libraries/System.Linq/tests/ToArrayTests.cs
@@ -152,8 +152,8 @@ namespace System.Linq.Tests
             Assert.Equal(convertedStrings, sourceIntegers.Where(i => true).Select(i => i.ToString()).ToArray());
             Assert.Equal(Array.Empty<string>(), sourceIntegers.Where(i => false).Select(i => i.ToString()).ToArray());
 
-            Assert.Equal(convertedStrings, sourceIntegers.Select(i => i.ToString()).Where(s => s != null).ToArray());
-            Assert.Equal(Array.Empty<string>(), sourceIntegers.Select(i => i.ToString()).Where(s => s == null).ToArray());
+            Assert.Equal(convertedStrings, sourceIntegers.Select(i => i.ToString()).Where(s => s is not null).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceIntegers.Select(i => i.ToString()).Where(s => s is null).ToArray());
         }
 
         [Theory]
@@ -172,8 +172,8 @@ namespace System.Linq.Tests
             Assert.Equal(convertedStrings, sourceList.Where(i => true).Select(i => i.ToString()).ToArray());
             Assert.Equal(Array.Empty<string>(), sourceList.Where(i => false).Select(i => i.ToString()).ToArray());
 
-            Assert.Equal(convertedStrings, sourceList.Select(i => i.ToString()).Where(s => s != null).ToArray());
-            Assert.Equal(Array.Empty<string>(), sourceList.Select(i => i.ToString()).Where(s => s == null).ToArray());
+            Assert.Equal(convertedStrings, sourceList.Select(i => i.ToString()).Where(s => s is not null).ToArray());
+            Assert.Equal(Array.Empty<string>(), sourceList.Select(i => i.ToString()).Where(s => s is null).ToArray());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/ToListTests.cs
+++ b/src/libraries/System.Linq/tests/ToListTests.cs
@@ -121,8 +121,8 @@ namespace System.Linq.Tests
             Assert.Equal(convertedList, sourceIntegers.Where(i => true).Select(i => i.ToString()).ToList());
             Assert.Equal(emptyStringsList, sourceIntegers.Where(i => false).Select(i => i.ToString()).ToList());
 
-            Assert.Equal(convertedList, sourceIntegers.Select(i => i.ToString()).Where(s => s != null).ToList());
-            Assert.Equal(emptyStringsList, sourceIntegers.Select(i => i.ToString()).Where(s => s == null).ToList());
+            Assert.Equal(convertedList, sourceIntegers.Select(i => i.ToString()).Where(s => s is not null).ToList());
+            Assert.Equal(emptyStringsList, sourceIntegers.Select(i => i.ToString()).Where(s => s is null).ToList());
         }
 
         [Theory]
@@ -145,8 +145,8 @@ namespace System.Linq.Tests
             Assert.Equal(convertedList, sourceList.Where(i => true).Select(i => i.ToString()).ToList());
             Assert.Equal(emptyStringsList, sourceList.Where(i => false).Select(i => i.ToString()).ToList());
 
-            Assert.Equal(convertedList, sourceList.Select(i => i.ToString()).Where(s => s != null).ToList());
-            Assert.Equal(emptyStringsList, sourceList.Select(i => i.ToString()).Where(s => s == null).ToList());
+            Assert.Equal(convertedList, sourceList.Select(i => i.ToString()).Where(s => s is not null).ToList());
+            Assert.Equal(emptyStringsList, sourceList.Select(i => i.ToString()).Where(s => s is null).ToList());
         }
 
         [Theory]
@@ -166,8 +166,8 @@ namespace System.Linq.Tests
             Assert.Equal(convertedList, sourceList.Where(i => true).Select(i => i.ToString()).ToList());
             Assert.Equal(ReadOnlyCollection<string>.Empty, sourceList.Where(i => false).Select(i => i.ToString()).ToList());
 
-            Assert.Equal(convertedList, sourceList.Select(i => i.ToString()).Where(s => s != null).ToList());
-            Assert.Equal(ReadOnlyCollection<string>.Empty, sourceList.Select(i => i.ToString()).Where(s => s == null).ToList());
+            Assert.Equal(convertedList, sourceList.Select(i => i.ToString()).Where(s => s is not null).ToList());
+            Assert.Equal(ReadOnlyCollection<string>.Empty, sourceList.Select(i => i.ToString()).Where(s => s is null).ToList());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/ToLookupTests.cs
+++ b/src/libraries/System.Linq/tests/ToLookupTests.cs
@@ -360,7 +360,7 @@ namespace System.Linq.Tests
         {
             public int Id { get; set; }
 
-            public bool Equals(Role other) => other != null && Id == other.Id;
+            public bool Equals(Role other) => other is not null && Id == other.Id;
 
             public override bool Equals(object obj) => Equals(obj as Role);
 
@@ -374,7 +374,7 @@ namespace System.Linq.Tests
             public int CountrB { get; set; }
 
             public bool Equals(RoleMetadata other)
-                => other != null && Role.Equals(other.Role) && CountA == other.CountA && CountrB == other.CountrB;
+                => other is not null && Role.Equals(other.Role) && CountA == other.CountA && CountrB == other.CountrB;
 
             public override bool Equals(object obj) => Equals(obj as RoleMetadata);
 

--- a/src/libraries/System.Linq/tests/UnionTests.cs
+++ b/src/libraries/System.Linq/tests/UnionTests.cs
@@ -302,7 +302,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Union(Enumerable.Range(0, 3));
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -311,7 +311,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Union(Enumerable.Range(0, 3)).Union(Enumerable.Range(2, 4)).Union(new[] { 9, 2, 4 });
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]

--- a/src/libraries/System.Linq/tests/WhereTests.cs
+++ b/src/libraries/System.Linq/tests/WhereTests.cs
@@ -1016,7 +1016,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Where(i => true);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1024,7 +1024,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToArray().Where(i => true);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1032,7 +1032,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Where(i => true);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1040,7 +1040,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Where((e, i) => true);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1048,7 +1048,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Where(i => true).Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1056,7 +1056,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToArray().Where(i => true).Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]
@@ -1064,7 +1064,7 @@ namespace System.Linq.Tests
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Where(i => true).Select(i => i);
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Theory]

--- a/src/libraries/System.Linq/tests/ZipTests.cs
+++ b/src/libraries/System.Linq/tests/ZipTests.cs
@@ -374,7 +374,7 @@ namespace System.Linq.Tests
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Zip(Enumerable.Range(0, 3), (x, y) => x + y);
             // Don't insist on this behaviour, but check it's correct if it happens
             var en = iterator as IEnumerator<int>;
-            Assert.False(en != null && en.MoveNext());
+            Assert.False(en is not null && en.MoveNext());
         }
 
         [Fact]


### PR DESCRIPTION
The project is currently using a mix of `== null` and `is null`. Switch it to consistently use the latter.

This is just about style. Given the uses, this should have zero impact on codegen. The change was entirely mechanical, just search/replace.