### PR TITLE
Pass --target in preprocess_file()

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -228,9 +228,12 @@ function(preprocess_file inputFilename outputFilename)
         COMMENT "Preprocessing ${inputFilename}. Outputting to ${outputFilename}"
     )
   else()
+    if (CMAKE_CXX_COMPILER_TARGET AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set(_LOCAL_CROSS_TARGET "--target=${CMAKE_CXX_COMPILER_TARGET}")
+    endif()
     add_custom_command(
         OUTPUT ${outputFilename}
-        COMMAND ${CMAKE_CXX_COMPILER} -E -P ${PREPROCESS_DEFINITIONS} ${PREPROCESS_INCLUDE_DIRECTORIES} -o ${outputFilename} -x c ${inputFilename}
+        COMMAND ${CMAKE_CXX_COMPILER} ${_LOCAL_CROSS_TARGET} -E -P ${PREPROCESS_DEFINITIONS} ${PREPROCESS_INCLUDE_DIRECTORIES} -o ${outputFilename} -x c ${inputFilename}
         DEPENDS ${inputFilename}
         COMMENT "Preprocessing ${inputFilename}. Outputting to ${outputFilename}"
     )


### PR DESCRIPTION
Without this patch, cross-compilation for linux-riscv64 from linux-arm64 fails like this:

```sh
$ uname -m
aarch64

$ ROOTFS_DIR=/crossrootfs/riscv64 src/coreclr/build-runtime.sh --cross --arch riscv64

[ 11%] Building CXX object md/runtime/CMakeFiles/mdruntime_wks.dir/recordpool.cpp.o
In file included from /runtime/src/coreclr/dlls/mscorrc/include.rc:4:
In file included from /runtime/src/coreclr/dlls/mscorrc/mscorrc.rc:7:
In file included from /runtime/src/coreclr/pal/prebuilt/inc/corerror.h:7:
In file included from /runtime/src/coreclr/pal/inc/rt/winerror.h:12:
In file included from /runtime/src/coreclr/pal/inc/rt/palrt.h:136:
/runtime/src/coreclr/pal/inc/pal.h:2764:2: error: PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 2764 | #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
      |  ^
1 error generated.
```

and with the patch, coreclr build succeeds.