### PR TITLE
[debugproxy] Invoke CDP endpoint to report error to telemetry

### DIFF
--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -917,14 +917,13 @@ namespace Microsoft.WebAssembly.Diagnostics
                 logger.LogDebug($"Unable to evaluate breakpoint condition '{condition}': {ree}");
                 SendLog(sessionId, $"Unable to evaluate breakpoint condition '{condition}': {ree.Message}", token, type: "error");
                 bp.ConditionAlreadyEvaluatedWithError = true;
-                SendExceptionToTelemetry(ree, sessionId, token);
+                SendExceptionToTelemetry(ree.Message, sessionId, token);
             }
             catch (Exception e)
             {
                 Log("info", $"Unable to evaluate breakpoint condition '{condition}': {e}");
                 bp.ConditionAlreadyEvaluatedWithError = true;
-                var ree = new ReturnAsErrorException(e.Message, e.GetType().Name);
-                SendExceptionToTelemetry(ree, sessionId, token);
+                SendExceptionToTelemetry(e.Message, sessionId, token);
             }
             return false;
         }
@@ -1523,22 +1522,22 @@ namespace Microsoft.WebAssembly.Diagnostics
             catch (ReturnAsErrorException ree)
             {
                 SendResponse(msg_id, AddCallStackInfoToException(ree.Error, context, scopeId), token);
-                SendExceptionToTelemetry(ree, msg_id, token);
+                SendExceptionToTelemetry(ree.Message, msg_id, token);
             }
             catch (Exception e)
             {
                 logger.LogDebug($"Error in EvaluateOnCallFrame for expression '{expression}' with '{e}.");
                 var ree = new ReturnAsErrorException(e.Message, e.GetType().Name);
                 SendResponse(msg_id, AddCallStackInfoToException(ree.Error, context, scopeId), token);
-                SendExceptionToTelemetry(ree, msg_id, token);
+                SendExceptionToTelemetry(e.Message, msg_id, token);
             }
 
             return true;
         }
 
-        private void SendExceptionToTelemetry(ReturnAsErrorException ree, SessionId msg_id, CancellationToken token)
+        private void SendExceptionToTelemetry(string message, SessionId msg_id, CancellationToken token)
         {
-            var exceptionWithCallStackInfo = $"{ree.Error}\n{new StackTrace(1, true)}";
+            var exceptionWithCallStackInfo = $"{message}\n{new StackTrace(1, true)}";
             JObject reportBlazorDebugError = JObject.FromObject(new
             {
                 exceptionType = "uncaughtException",

--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -912,16 +912,19 @@ namespace Microsoft.WebAssembly.Diagnostics
                     return true;
                 }
             }
-            catch (ReturnAsErrorException raee)
+            catch (ReturnAsErrorException ree)
             {
-                logger.LogDebug($"Unable to evaluate breakpoint condition '{condition}': {raee}");
-                SendLog(sessionId, $"Unable to evaluate breakpoint condition '{condition}': {raee.Message}", token, type: "error");
+                logger.LogDebug($"Unable to evaluate breakpoint condition '{condition}': {ree}");
+                SendLog(sessionId, $"Unable to evaluate breakpoint condition '{condition}': {ree.Message}", token, type: "error");
                 bp.ConditionAlreadyEvaluatedWithError = true;
+                SendExceptionToTelemetry(ree, sessionId, token);
             }
             catch (Exception e)
             {
                 Log("info", $"Unable to evaluate breakpoint condition '{condition}': {e}");
                 bp.ConditionAlreadyEvaluatedWithError = true;
+                var ree = new ReturnAsErrorException(e.Message, e.GetType().Name);
+                SendExceptionToTelemetry(ree, sessionId, token);
             }
             return false;
         }


### PR DESCRIPTION
Associated with https://github.com/microsoft/vscode-js-debug/pull/1961

When debugging blazorwasm applications using the BlazorDebugProxy, there are instances where the debugger itself hits an exception, such as attempting to evaluate an expression in the watch window when the debugger is paused. To capture how often users encounter such debugger exceptions, it would be helpful to send telemetry information for such events.

This PR looks to invoke the new CDP DotnetDebugger event API endpoint being added in https://github.com/microsoft/vscode-js-debug/pull/1961 when expression evaluation throws an exception in the debug proxy.

[example exception message send to telemetry](https://gist.github.com/mdh1418/571b826dd66348102f00f7df7a38ba5a) 