### PR TITLE
Further special-case arrays in Enumerable.Chunk

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Chunk.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Chunk.cs
@@ -45,15 +45,31 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.size);
             }
 
-            if (IsEmptyArray(source))
+            if (source is TSource[] array)
             {
-                return [];
+                // Special-case arrays, which have an immutable length. This enables us to not only do an
+                // empty check and avoid allocating an iterator object when empty, it enables us to have a
+                // much more efficient (and simpler) implementation for chunking up the array.
+                return array.Length != 0 ?
+                    ArrayChunkIterator(array, size) :
+                    [];
             }
 
-            return ChunkIterator(source, size);
+            return EnumerableChunkIterator(source, size);
         }
 
-        private static IEnumerable<TSource[]> ChunkIterator<TSource>(IEnumerable<TSource> source, int size)
+        private static IEnumerable<TSource[]> ArrayChunkIterator<TSource>(TSource[] source, int size)
+        {
+            int index = 0;
+            while (index < source.Length)
+            {
+                TSource[] chunk = new ReadOnlySpan<TSource>(source, index, Math.Min(size, source.Length - index)).ToArray();
+                index += chunk.Length;
+                yield return chunk;
+            }
+        }
+
+        private static IEnumerable<TSource[]> EnumerableChunkIterator<TSource>(IEnumerable<TSource> source, int size)
         {
             using IEnumerator<TSource> e = source.GetEnumerator();
 

--- a/src/libraries/System.Linq/tests/ChunkTests.cs
+++ b/src/libraries/System.Linq/tests/ChunkTests.cs
@@ -38,88 +38,82 @@ namespace System.Linq.Tests
             Assert.True(chunks.MoveNext());
         }
 
-        private static IEnumerable<T> ConvertToType<T>(T[] array, Type type)
+        [Theory]
+        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345})]
+        public void ChunkSourceRepeatCalls(int[] array)
         {
-            return type switch
+            Assert.All(IdentityTransforms<int>(), t =>
             {
-                {} x when x == typeof(TestReadOnlyCollection<T>) => new TestReadOnlyCollection<T>(array),
-                {} x when x == typeof(TestCollection<T>) => new TestCollection<T>(array),
-                {} x when x == typeof(TestEnumerable<T>) => new TestEnumerable<T>(array),
-                _ => throw new Exception()
-            };
+                IEnumerable<int> source = t(array);
+
+                Assert.Equal(source.Chunk(3), source.Chunk(3));
+            });
         }
 
         [Theory]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestReadOnlyCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestEnumerable<int>))]
-        public void ChunkSourceRepeatCalls(int[] array, Type type)
+        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345})]
+        public void ChunkSourceEvenly(int[] array)
         {
-            IEnumerable<int> source = ConvertToType(array, type);
+            Assert.All(IdentityTransforms<int>(), t =>
+            {
+                IEnumerable<int> source = t(array);
 
-            Assert.Equal(source.Chunk(3), source.Chunk(3));
+                using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
+                chunks.MoveNext();
+                Assert.Equal(new[] { 9999, 0, 888 }, chunks.Current);
+                chunks.MoveNext();
+                Assert.Equal(new[] { -1, 66, -777 }, chunks.Current);
+                chunks.MoveNext();
+                Assert.Equal(new[] { 1, 2, -12345 }, chunks.Current);
+                Assert.False(chunks.MoveNext());
+            });
         }
 
         [Theory]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestReadOnlyCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2, -12345}, typeof(TestEnumerable<int>))]
-        public void ChunkSourceEvenly(int[] array, Type type)
+        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2})]
+        public void ChunkSourceUnevenly(int[] array)
         {
-            IEnumerable<int> source = ConvertToType(array, type);
+            Assert.All(IdentityTransforms<int>(), t =>
+            {
+                IEnumerable<int> source = t(array);
 
-            using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
-            chunks.MoveNext();
-            Assert.Equal(new[] {9999, 0, 888}, chunks.Current);
-            chunks.MoveNext();
-            Assert.Equal(new[] {-1, 66, -777}, chunks.Current);
-            chunks.MoveNext();
-            Assert.Equal(new[] {1, 2, -12345}, chunks.Current);
-            Assert.False(chunks.MoveNext());
+                using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
+                chunks.MoveNext();
+                Assert.Equal(new[] { 9999, 0, 888 }, chunks.Current);
+                chunks.MoveNext();
+                Assert.Equal(new[] { -1, 66, -777 }, chunks.Current);
+                chunks.MoveNext();
+                Assert.Equal(new[] { 1, 2 }, chunks.Current);
+                Assert.False(chunks.MoveNext());
+            });
         }
 
         [Theory]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2}, typeof(TestReadOnlyCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2}, typeof(TestCollection<int>))]
-        [InlineData(new[] {9999, 0, 888, -1, 66, -777, 1, 2}, typeof(TestEnumerable<int>))]
-        public void ChunkSourceUnevenly(int[] array, Type type)
+        [InlineData(new[] {9999, 0})]
+        public void ChunkSourceSmallerThanMaxSize(int[] array)
         {
-            IEnumerable<int> source = ConvertToType(array, type);
+            Assert.All(IdentityTransforms<int>(), t =>
+            {
+                IEnumerable<int> source = t(array);
 
-            using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
-            chunks.MoveNext();
-            Assert.Equal(new[] {9999, 0, 888}, chunks.Current);
-            chunks.MoveNext();
-            Assert.Equal(new[] {-1, 66, -777}, chunks.Current);
-            chunks.MoveNext();
-            Assert.Equal(new[] {1, 2}, chunks.Current);
-            Assert.False(chunks.MoveNext());
+                using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
+                chunks.MoveNext();
+                Assert.Equal(new[] { 9999, 0 }, chunks.Current);
+                Assert.False(chunks.MoveNext());
+            });
         }
 
         [Theory]
-        [InlineData(new[] {9999, 0}, typeof(TestReadOnlyCollection<int>))]
-        [InlineData(new[] {9999, 0}, typeof(TestCollection<int>))]
-        [InlineData(new[] {9999, 0}, typeof(TestEnumerable<int>))]
-        public void ChunkSourceSmallerThanMaxSize(int[] array, Type type)
+        [InlineData(new int[0])]
+        public void EmptySourceYieldsNoChunks(int[] array)
         {
-            IEnumerable<int> source = ConvertToType(array, type);
+            Assert.All(IdentityTransforms<int>(), t =>
+            {
+                IEnumerable<int> source = t(array);
 
-            using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
-            chunks.MoveNext();
-            Assert.Equal(new[] {9999, 0}, chunks.Current);
-            Assert.False(chunks.MoveNext());
-        }
-
-        [Theory]
-        [InlineData(new int[] {}, typeof(TestReadOnlyCollection<int>))]
-        [InlineData(new int[] {}, typeof(TestCollection<int>))]
-        [InlineData(new int[] {}, typeof(TestEnumerable<int>))]
-        public void EmptySourceYieldsNoChunks(int[] array, Type type)
-        {
-            IEnumerable<int> source = ConvertToType(array, type);
-
-            using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
-            Assert.False(chunks.MoveNext());
+                using IEnumerator<int[]> chunks = source.Chunk(3).GetEnumerator();
+                Assert.False(chunks.MoveNext());
+            });
         }
 
         [Fact]


### PR DESCRIPTION
Chunk is already testing the input to see if it's an array, in order to special-case empty arrays. We can use that existing check to also make the processing of non-empty arrays faster. The implementation for an array is simple and doesn't contribute a meaningful maintenance burden, so while Enumerable.Chunk already isn't a high-perf API, a dedicated path for arrays is significantly faster than the generic enumerable path.  From perusal of use via grep.app, arrays being the actual underlying type is also reasonably common, that it seems worthwhile to throw a little extra code at it.

Addresses https://github.com/dotnet/runtime/issues/85653#issuecomment-1891125377

| Method | Toolchain         | Mean     | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |---------:|------:|----------:|------------:|
| Count  | \main\corerun.exe | 470.9 ns |  1.00 |   1.26 KB |        1.00 |
| Count  | \pr\corerun.exe   | 180.8 ns |  0.39 |   1.08 KB |        0.86 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public partial class Tests
{
    private double[] _values = Enumerable.Range(0, 100).Select(_ => Random.Shared.NextDouble()).ToArray();

    [Benchmark]
    public int Count()
    {
        int count = 0;
        foreach (var chunk in _values.Chunk(10)) count += chunk.Length;
        return count;
    }
}
```