### PR TITLE
Skip EventSource tests if process is not elevated

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EtwListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EtwListener.cs
@@ -39,7 +39,7 @@ namespace BasicEventSourceTests
             // Today you have to be Admin to turn on ETW events (anyone can write ETW events).
             if (TraceEventSession.IsElevated() != true)
             {
-                throw new Exception("Need to be elevated to run. ");
+                throw new SkipTestException("Need to be elevated to run. ");
             }
 
             if (dataFileName == null)

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EtwListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/Harness/EtwListener.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Diagnostics.Tracing;
 using Microsoft.Diagnostics.Tracing.Session;
+using Microsoft.DotNet.XUnitExtensions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Fixes #88305

No reason to fail the test if the issue is in the machine setup.