### PR TITLE
JIT: Remove remaining BBJ_COND fallthrough fixups

### DIFF
--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2103,28 +2103,14 @@ void Compiler::fgTailMergeThrowsFallThroughHelper(BasicBlock* predBlock,
     assert(predBlock->KindIs(BBJ_COND));
     assert(predBlock->FalseTargetIs(nonCanonicalBlock));
 
-    BasicBlock* const newBlock = fgNewBBafter(BBJ_ALWAYS, predBlock, true);
-
-    JITDUMP("*** " FMT_BB " now falling through to empty " FMT_BB " and then to " FMT_BB "\n", predBlock->bbNum,
-            newBlock->bbNum, canonicalBlock->bbNum);
+    JITDUMP("*** " FMT_BB " false target is now " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
 
     // Remove the old flow
     fgRemoveRefPred(predEdge);
 
     // Wire up the new flow
-    FlowEdge* const falseEdge = fgAddRefPred(newBlock, predBlock, predEdge);
+    FlowEdge* const falseEdge = fgAddRefPred(canonicalBlock, predBlock, predEdge);
     predBlock->SetFalseEdge(falseEdge);
-
-    FlowEdge* const newEdge = fgAddRefPred(canonicalBlock, newBlock, predEdge);
-    newBlock->SetTargetEdge(newEdge);
-
-    // If nonCanonicalBlock has only one pred, all its flow transfers.
-    // If it has multiple preds, then we need edge counts or likelihoods
-    // to figure things out.
-    //
-    // For now just do a minimal update.
-    //
-    newBlock->inheritWeight(nonCanonicalBlock);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4995,22 +4995,6 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
                             {
                                 ehUpdateLastBlocks(bNext, bDest);
                             }
-
-                            // Add fall through fixup block, if needed.
-                            //
-                            if (bDest->KindIs(BBJ_COND) && !bDest->NextIs(bDest->GetFalseTarget()))
-                            {
-                                BasicBlock* const bDestFalseTarget = bDest->GetFalseTarget();
-                                BasicBlock* const bFixup           = fgNewBBafter(BBJ_ALWAYS, bDest, true);
-                                bFixup->inheritWeight(bDestFalseTarget);
-
-                                fgRemoveRefPred(bDest->GetFalseEdge());
-                                FlowEdge* const falseEdge = fgAddRefPred(bFixup, bDest);
-                                bDest->SetFalseEdge(falseEdge);
-
-                                FlowEdge* const newEdge = fgAddRefPred(bDestFalseTarget, bFixup);
-                                bFixup->SetTargetEdge(newEdge);
-                            }
                         }
                     }
 


### PR DESCRIPTION
Part of #93020. The diffs from this seem manageable locally -- my hope is the diffs in profile data up to block layout that drive this churn improve as we continue to propagate edge likelihoods to later phases.