### PR TITLE
[mt][browser] Disable `SignalRClientTests` - timing out on Windows

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SignalRClientTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/SignalRClientTests.cs
@@ -24,6 +24,7 @@ public class SignalRClientTests : AppTestBase
     }
 
     [ConditionalTheory(typeof(BuildTestBase), nameof(IsWorkloadWithMultiThreadingForDefaultFramework))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/99268", TestPlatforms.Windows)]
     [InlineData("Debug", "LongPolling")]
     [InlineData("Release", "LongPolling")]
     [InlineData("Debug", "WebSockets")]


### PR DESCRIPTION
Disables failures: https://github.com/dotnet/runtime/issues/99268.