### PR TITLE
Guarantee that initReg won't be a callee-saved register

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4934,7 +4934,7 @@ void CodeGen::genPushCalleeSavedRegisters()
 #ifdef TARGET_ARM64
     // Probe large frames now, if necessary, since genPushCalleeSavedRegisters() will allocate the frame. Note that
     // for arm64, genAllocLclFrame only probes the frame; it does not actually allocate it (it does not change SP).
-    genAllocLclFrame(compiler->compLclFrameSize, intReg, pInitRegZeroed, intRegState.rsCalleeRegArgMaskLiveIn);
+    genAllocLclFrame(compiler->compLclFrameSize, initReg, pInitRegZeroed, intRegState.rsCalleeRegArgMaskLiveIn);
 #endif
 
     regMaskTP rsPushRegs = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4934,14 +4934,7 @@ void CodeGen::genPushCalleeSavedRegisters()
 #ifdef TARGET_ARM64
     // Probe large frames now, if necessary, since genPushCalleeSavedRegisters() will allocate the frame. Note that
     // for arm64, genAllocLclFrame only probes the frame; it does not actually allocate it (it does not change SP).
-    // For arm64, we are probing the frame before the callee-saved registers are saved. The 'initReg' might have
-    // been calculated to be one of the callee-saved registers (say, if all the integer argument registers are
-    // in use, and perhaps with other conditions being satisfied). This is ok in other cases, after the callee-saved
-    // registers have been saved. So instead of letting genAllocLclFrame use initReg as a temporary register,
-    // always use REG_SCRATCH. We don't care if it trashes it, so ignore the initRegZeroed output argument.
-    bool ignoreInitRegZeroed = false;
-    genAllocLclFrame(compiler->compLclFrameSize, REG_SCRATCH, &ignoreInitRegZeroed,
-                     intRegState.rsCalleeRegArgMaskLiveIn);
+    genAllocLclFrame(compiler->compLclFrameSize, intReg, pInitRegZeroed, intRegState.rsCalleeRegArgMaskLiveIn);
 #endif
 
     regMaskTP rsPushRegs = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5884,7 +5884,7 @@ void CodeGen::genFnProlog()
     // If they aren't available we use one of the caller-saved integer registers.
     else
     {
-        tempMask = regSet.rsGetModifiedRegsMask() & RBM_ALLINT & ~excludeMask & ~regSet.rsMaskResvd;
+        tempMask = regSet.rsGetModifiedRegsMask() & RBM_INT_CALLEE_TRASH & ~excludeMask & ~regSet.rsMaskResvd;
         if (tempMask != RBM_NONE)
         {
             // We pick the lowest register number

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5887,7 +5887,7 @@ void CodeGen::genFnProlog()
 #if !defined(TARGET_AMD64) && !defined(TARGET_ARM)
         tempMask = regSet.rsGetModifiedRegsMask() & RBM_INT_CALLEE_TRASH & ~excludeMask & ~regSet.rsMaskResvd;
 #else
-        tempMask = regSet.rsGetModifiedRegsMask() & RBM_ALLINT & ~excludeMask & ~regSet.rsMaskResvd;
+        tempMask            = regSet.rsGetModifiedRegsMask() & RBM_ALLINT & ~excludeMask & ~regSet.rsMaskResvd;
 #endif
         if (tempMask != RBM_NONE)
         {

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5884,7 +5884,11 @@ void CodeGen::genFnProlog()
     // If they aren't available we use one of the caller-saved integer registers.
     else
     {
+#if !defined(TARGET_AMD64) && !defined(TARGET_ARM)
         tempMask = regSet.rsGetModifiedRegsMask() & RBM_INT_CALLEE_TRASH & ~excludeMask & ~regSet.rsMaskResvd;
+#else
+        tempMask = regSet.rsGetModifiedRegsMask() & RBM_ALLINT & ~excludeMask & ~regSet.rsMaskResvd;
+#endif
         if (tempMask != RBM_NONE)
         {
             // We pick the lowest register number


### PR DESCRIPTION
This PR is the result of a discussion in #99156

Tests fixed by this PR:
- `JIT/jit64/hfa/main/testC/hfa_nd2C_d`
- `JIT/jit64/hfa/main/testC/hfa_sd2C_d`

Part of #84834
cc @dotnet/samsung 