### PR TITLE
Skip EventPipe cleanup on mono unless runtime is shutting down

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -852,6 +852,11 @@ ep_rt_mono_init_finish (void)
 void
 ep_rt_mono_fini (void)
 {
+	// Avoid cleaning up resources to prevent cleaning up out from under running
+	// threads.
+	if (!mono_runtime_is_shutting_down ())
+		return;
+
 	ep_rt_mono_runtime_provider_fini ();
 	ep_rt_mono_profiler_provider_fini ();
 


### PR DESCRIPTION
Fixes #97565