### PR TITLE
Remove Current interface call in IteratorSelectIterator

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Iterator.cs
@@ -69,7 +69,7 @@ namespace System.Linq
             /// that created this iterator, the result will be this iterator. Otherwise, the result
             /// will be a shallow copy of this iterator.
             /// </remarks>
-            public IEnumerator<TSource> GetEnumerator()
+            public Iterator<TSource> GetEnumerator()
             {
                 Iterator<TSource> enumerator = _state == 0 && _threadId == Environment.CurrentManagedThreadId ? this : Clone();
                 enumerator._state = 1;
@@ -104,6 +104,7 @@ namespace System.Linq
 
             object? IEnumerator.Current => Current;
 
+            IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
             void IEnumerator.Reset() => ThrowHelper.ThrowNotSupportedException();

--- a/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Select.SpeedOpt.cs
@@ -569,7 +569,7 @@ namespace System.Linq
         {
             private readonly Iterator<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
-            private IEnumerator<TSource>? _enumerator;
+            private Iterator<TSource>? _enumerator;
 
             public IteratorSelectIterator(Iterator<TSource> source, Func<TSource, TResult> selector)
             {


### PR DESCRIPTION
By returning `Iterator<>` from GetEnumerator, strongly-typed callers (such as those in IteratorSelectIterator) can bind to the non-virtual Current member, saving an interface/virtual call. The interface dispatch to MoveNext also becomes virtual for such callers.