### PR TITLE
[browser][MT] Marshal resolved/unresolved tasks separately

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -68,6 +68,7 @@
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'browser' and '$(FeatureWasmManagedThreads)' == 'true'">
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSWebWorker.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\JSSynchronizationContext.cs" />
+    <Compile Include="System\Runtime\InteropServices\JavaScript\JSAsyncTaskScheduler.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(WasmEnableThreads)' == 'true'">
     <ApiCompatSuppressionFile Include="CompatibilitySuppressions.xml;CompatibilitySuppressions.WasmThreads.xml" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSAsyncTaskScheduler.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSAsyncTaskScheduler.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace System.Runtime.InteropServices.JavaScript
+{
+    // executes all tasks thru queue, never inline
+    internal sealed class JSAsyncTaskScheduler : TaskScheduler
+    {
+        private readonly JSSynchronizationContext m_synchronizationContext;
+
+        internal JSAsyncTaskScheduler(JSSynchronizationContext synchronizationContext)
+        {
+            m_synchronizationContext = synchronizationContext;
+        }
+
+        protected override void QueueTask(Task task)
+        {
+            m_synchronizationContext.Post((_) =>
+            {
+                if (!TryExecuteTask(task))
+                {
+                    Environment.FailFast("Unexpected failure in JSAsyncTaskScheduler" + Environment.CurrentManagedThreadId);
+                }
+            }, null);
+        }
+
+        // this is the main difference from the SynchronizationContextTaskScheduler
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued)
+        {
+            return false;
+        }
+
+        protected override IEnumerable<Task>? GetScheduledTasks()
+        {
+            return null;
+        }
+
+        public override int MaximumConcurrencyLevel => 1;
+    }
+}

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using static System.Runtime.InteropServices.JavaScript.JSHostImplementation;
 
 namespace System.Runtime.InteropServices.JavaScript
@@ -40,6 +41,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public int ManagedTID; // current managed thread id
         public bool IsMainThread;
         public JSSynchronizationContext SynchronizationContext;
+        public TaskScheduler? AsyncTaskScheduler;
 
         public static MainThreadingMode MainThreadingMode = MainThreadingMode.DeputyThread;
         public static JSThreadBlockingMode ThreadBlockingMode = JSThreadBlockingMode.NoBlockingWait;
@@ -475,7 +477,7 @@ namespace System.Runtime.InteropServices.JavaScript
                     {
                         if (IsJSVHandle(jsHandle))
                         {
-                            Environment.FailFast("TODO implement blocking ReleaseCSOwnedObjectSend to make sure the order of FreeJSVHandle is correct.");
+                            Environment.FailFast($"TODO implement blocking ReleaseCSOwnedObjectSend to make sure the order of FreeJSVHandle is correct, ManagedThreadId: {Environment.CurrentManagedThreadId}. {Environment.NewLine} {Environment.StackTrace}");
                         }
 
                         // this is async message, we need to call this as the last thing
@@ -493,7 +495,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-#endregion
+        #endregion
 
         #region Dispose
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -40,7 +40,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public int ManagedTID; // current managed thread id
         public bool IsMainThread;
         public JSSynchronizationContext SynchronizationContext;
-        public TaskScheduler? AsyncTaskScheduler;
+        public JSAsyncTaskScheduler? AsyncTaskScheduler;
 
         public static MainThreadingMode MainThreadingMode = MainThreadingMode.DeputyThread;
         public static JSThreadBlockingMode ThreadBlockingMode = JSThreadBlockingMode.NoBlockingWait;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using static System.Runtime.InteropServices.JavaScript.JSHostImplementation;
 
 namespace System.Runtime.InteropServices.JavaScript

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -4,6 +4,7 @@
 #if FEATURE_WASM_MANAGED_THREADS
 
 using System.Threading;
+using System.Threading.Tasks;
 using System.Threading.Channels;
 using System.Runtime.CompilerServices;
 using WorkItemQueueType = System.Threading.Channels.Channel<System.Runtime.InteropServices.JavaScript.JSSynchronizationContext.WorkItem>;
@@ -56,6 +57,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
 
             var proxyContext = ctx.ProxyContext;
+            proxyContext.AsyncTaskScheduler = new JSAsyncTaskScheduler(ctx);
             JSProxyContext.CurrentThreadContext = proxyContext;
             JSProxyContext.ExecutionContext = proxyContext;
             if (isMainThread)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSSynchronizationContext.cs
@@ -4,7 +4,6 @@
 #if FEATURE_WASM_MANAGED_THREADS
 
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Channels;
 using System.Runtime.CompilerServices;
 using WorkItemQueueType = System.Threading.Channels.Channel<System.Runtime.InteropServices.JavaScript.JSSynchronizationContext.WorkItem>;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -142,6 +142,7 @@ namespace System.Runtime.InteropServices.JavaScript
 
             var ctx = ToJSContext;
 
+            // current thread or non-return parameter of JSImport
             var isCurrentThreadOrParameter = ctx.IsCurrentThread() || slot.Type != MarshalerType.TaskPreCreated;
 
             if (task == null)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -196,7 +196,9 @@ namespace System.Runtime.InteropServices.JavaScript
             var taskHolder = ctx.CreateCSOwnedProxy(slot.JSHandle);
 
 #if FEATURE_WASM_MANAGED_THREADS
-            task.ContinueWith(Complete, taskHolder, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.FromCurrentSynchronizationContext());
+            // AsyncTaskScheduler will make sure that the resolve message is always sent after this call is completed
+            // that is: synchronous marshaling and eventually message to the target thread, which need to arrive before the resolve message
+            task.ContinueWith(Complete, taskHolder, ctx.AsyncTaskScheduler!);
 #else
             task.ContinueWith(Complete, taskHolder, TaskScheduler.Current);
 #endif
@@ -280,7 +282,9 @@ namespace System.Runtime.InteropServices.JavaScript
             var taskHolder = ctx.CreateCSOwnedProxy(slot.JSHandle);
 
 #if FEATURE_WASM_MANAGED_THREADS
-            task.ContinueWith(Complete, taskHolder, CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.FromCurrentSynchronizationContext());
+            // AsyncTaskScheduler will make sure that the resolve message is always sent after this call is completed
+            // that is: synchronous marshaling and eventually message to the target thread, which need to arrive before the resolve message
+            task.ContinueWith(Complete, taskHolder, ctx.AsyncTaskScheduler!);
 #else
             task.ContinueWith(Complete, taskHolder, TaskScheduler.Current);
 #endif
@@ -357,7 +361,9 @@ namespace System.Runtime.InteropServices.JavaScript
             var taskHolder = ctx.CreateCSOwnedProxy(slot.JSHandle);
 
 #if FEATURE_WASM_MANAGED_THREADS
-            task.ContinueWith(Complete, new HolderAndMarshaler<T>(taskHolder, marshaler), CancellationToken.None, TaskContinuationOptions.RunContinuationsAsynchronously, TaskScheduler.FromCurrentSynchronizationContext());
+            // AsyncTaskScheduler will make sure that the resolve message is always sent after this call is completed
+            // that is: synchronous marshaling and eventually message to the target thread, which need to arrive before the resolve message
+            task.ContinueWith(Complete, new HolderAndMarshaler<T>(taskHolder, marshaler), ctx.AsyncTaskScheduler!);
 #else
             task.ContinueWith(Complete, new HolderAndMarshaler<T>(taskHolder, marshaler), TaskScheduler.Current);
 #endif

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -140,13 +140,21 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             Task? task = value;
 
+            var ctx = ToJSContext;
+
+            var isCurrentThreadOrParameter = ctx.IsCurrentThread() || slot.Type != MarshalerType.TaskPreCreated;
+
             if (task == null)
             {
+                if (!isCurrentThreadOrParameter)
+                {
+                    Environment.FailFast("Marshalling null return Task to JS is not supported in MT");
+                }
                 slot.Type = MarshalerType.None;
                 return;
             }
 
-            if (task.IsCompleted)
+            if (task.IsCompleted && isCurrentThreadOrParameter)
             {
                 if (task.Exception != null)
                 {
@@ -172,7 +180,6 @@ namespace System.Runtime.InteropServices.JavaScript
                 }
             }
 
-            var ctx = ToJSContext;
 
             if (slot.Type != MarshalerType.TaskPreCreated)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 using System.Threading;
 using static System.Runtime.InteropServices.JavaScript.JSHostImplementation;
+using System.Runtime.CompilerServices;
 
 namespace System.Runtime.InteropServices.JavaScript
 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -382,6 +382,9 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
+#if !DEBUG
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
 #if FEATURE_WASM_MANAGED_THREADS
         // We can't marshal resolved/rejected/null Task.Result directly into current argument when this is marshaling return of JSExport across threads
         private bool CanMarshalTaskResultOnSameCall(JSProxyContext ctx)
@@ -408,11 +411,13 @@ namespace System.Runtime.InteropServices.JavaScript
             return false;
         }
 #else
+#pragma warning disable CA1822 // Mark members as static
         private bool CanMarshalTaskResultOnSameCall(JSProxyContext _)
         {
             // in ST build this is always synchronous and we can marshal the result directly
             return true;
         }
+#pragma warning restore CA1822 // Mark members as static
 #endif
 
         private sealed record HolderAndMarshaler<T>(JSObject TaskHolder, ArgumentToJSCallback<T> Marshaler);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -229,18 +229,18 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             Task? task = value;
             var ctx = ToJSContext;
-            var isCurrentThread = ctx.IsCurrentThread();
+            var isCurrentThreadOrParameter = ctx.IsCurrentThread() || slot.Type != MarshalerType.TaskPreCreated;
 
             if (task == null)
             {
-                if (!isCurrentThread)
+                if (!isCurrentThreadOrParameter)
                 {
-                    Environment.FailFast("Marshalling null task to JS is not supported in MT");
+                    Environment.FailFast("Marshalling null return Task to JS is not supported in MT");
                 }
                 slot.Type = MarshalerType.None;
                 return;
             }
-            if (isCurrentThread && task.IsCompleted)
+            if (isCurrentThreadOrParameter && task.IsCompleted)
             {
                 if (task.Exception != null)
                 {
@@ -303,19 +303,19 @@ namespace System.Runtime.InteropServices.JavaScript
         {
             Task<T>? task = value;
             var ctx = ToJSContext;
-            var isCurrentThread = ctx.IsCurrentThread();
+            var isCurrentThreadOrParameter = ctx.IsCurrentThread() || slot.Type != MarshalerType.TaskPreCreated;
 
             if (task == null)
             {
-                if (!isCurrentThread)
+                if (!isCurrentThreadOrParameter)
                 {
-                    Environment.FailFast("NULL not supported in MT");
+                    Environment.FailFast("Marshalling null return Task to JS is not supported in MT");
                 }
                 slot.Type = MarshalerType.None;
                 return;
             }
 
-            if (isCurrentThread && task.IsCompleted)
+            if (isCurrentThreadOrParameter && task.IsCompleted)
             {
                 if (task.Exception != null)
                 {


### PR DESCRIPTION
This change will avoid sending 2 messages to target thread (UI) and instead will only send one.
- when the target thread is the same as current thread and this is synchronous/blocking return from JSExport
- when this is non-return parameter of JSImport <- this is new here

Otherwise will use new `JSAsyncTaskScheduler` 
- to make sure that the `mono_wasm_resolve_or_reject_promise_post` happens after `mono_wasm_invoke_jsimport_async_post`
- I'm not sure why [#99317](https://github.com/dotnet/runtime/pull/99317) was not enough and didn't help it.

contributes to https://github.com/dotnet/runtime/issues/98406