### PR TITLE
[RISC-V] Fix initReg usage in genPushCalleeSavedRegisters

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -7887,6 +7887,11 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
 {
     assert(compiler->compGeneratingProlog);
 
+    // The 'initReg' could have been calculated as one of the callee-saved registers (let's say T0, T1 and T2 are in
+    // use, so the next possible register is S1, which should be callee-save register). This is fine, as long as we
+    // save callee-saved registers before using 'initReg' for the first time. Instead, we can use REG_SCRATCH
+    // beforehand. We don't care if REG_SCRATCH will be overwritten, so we'll skip 'RegZeroed check'.
+    //
     // Unlike on x86/x64, we can also push float registers to stack
     regMaskTP rsPushRegs = regSet.rsGetModifiedRegsMask() & RBM_CALLEE_SAVED;
 
@@ -7999,11 +8004,11 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
             calleeSaveSPDelta = AlignUp((UINT)offset, STACK_ALIGN);
             offset            = calleeSaveSPDelta - offset;
 
-            genStackPointerAdjustment(-calleeSaveSPDelta, initReg, pInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-calleeSaveSPDelta, REG_SCRATCH, nullptr, /* reportUnwindData */ true);
         }
         else
         {
-            genStackPointerAdjustment(-totalFrameSize, initReg, pInitRegZeroed, /* reportUnwindData */ true);
+            genStackPointerAdjustment(-totalFrameSize, REG_SCRATCH, nullptr, /* reportUnwindData */ true);
         }
     }
 
@@ -8011,6 +8016,8 @@ void CodeGen::genPushCalleeSavedRegisters(regNumber initReg, bool* pInitRegZeroe
 
     genSaveCalleeSavedRegistersHelp(rsPushRegs, offset, 0);
     offset += (int)(genCountBits(rsPushRegs) << 3); // each reg has 8 bytes
+
+    // From now on, we can safely use initReg.
 
     emit->emitIns_R_R_I(INS_sd, EA_PTRSIZE, REG_RA, REG_SPBASE, offset);
     compiler->unwindSaveReg(REG_RA, offset);


### PR DESCRIPTION
This PR is the result of a discussion in #99156 and #99313

### Tests fixed by this PR:
- `JIT/jit64/hfa/main/testC/hfa_nd2C_d`
- `JIT/jit64/hfa/main/testC/hfa_sd2C_d`

After a brief discussion in #99313, we decided to mimic `arm64` approach:
https://github.com/dotnet/runtime/blob/50d6e5d5ffd05dd4034cffd222ea610baedcc326/src/coreclr/jit/codegenarmarch.cpp#L4883-L4892

### Why there was a problem in the first place?

https://github.com/dotnet/runtime/blob/50d6e5d5ffd05dd4034cffd222ea610baedcc326/src/coreclr/jit/codegencommon.cpp#L5881-L5892

As you can see `initReg` is created from `RBM_ALLINT`, where `RBM_ALLINT` is `RBM_INT_CALLEE_SAVED | RBM_INT_CALLEE_TRASH`, so in fact what matters here is which register have lower `rnum`.
If `T0`, `T1` and `T2` are excluded or reserved for some unknown reason, the next lowest register is `S1`, not `T3`, because `S1` mask is `0x0200` and `T3` is `0x10000000`.

Part of #84834
cc @dotnet/samsung 