### PR TITLE
Enable building tests with UseLocalAppHostPack=true

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -543,6 +543,7 @@
   <Target Name="RestorePackage">
     <PropertyGroup>
       <_ConfigurationProperties>/p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:Configuration=$(Configuration) /p:CrossBuild=$(CrossBuild)</_ConfigurationProperties>
+      <_ConfigurationProperties Condition="'$(UseLocalAppHostPack)' == 'true'">$(_ConfigurationProperties) -p:EnableAppHostPackDownload=false -p:EnableTargetingPackDownload=false -p:EnableRuntimePackDownload=false</_ConfigurationProperties>
       <DotnetRestoreCommand>"$(DotNetTool)" restore $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true $(_ConfigurationProperties)</DotnetRestoreCommand>
     </PropertyGroup>
     <Exec Command="$(DotnetRestoreCommand)"/>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/97791
This is to enable building clr tests with -p:UseLocalAppHostPack=true (once the host subset is already built). This option is useful for community-supported platforms, which are listed in KnownFrameworkReference, KnownRuntimePack etc. in the dotnet/installer repo and we don't expect the official SDK to provide packs for these platforms.