### PR TITLE
[browser][mt] Disable hybrid globalization for multithreaded runtime

### DIFF
--- a/src/mono/browser/build/BrowserWasmApp.targets
+++ b/src/mono/browser/build/BrowserWasmApp.targets
@@ -67,6 +67,7 @@
   </ItemGroup>
 
   <Target Name="_GetWasmGenerateAppBundleDependencies">
+    <Warning Condition="'$(WasmEnableThreads)' == 'true' and '$(HybridGlobalization)' == 'true'" Text="%24(HybridGlobalization) is not supported when %24(WasmEnableThreads) is set to true."  />
     <Warning Condition="'$(InvariantGlobalization)' == 'true' and '$(HybridGlobalization)' == 'true'" Text="%24(HybridGlobalization) has no effect when %24(InvariantGlobalization) is set to true." />
     <Warning Condition="'$(WasmIcuDataFileName)' != '' and '$(HybridGlobalization)' == 'true'" Text="%24(WasmIcuDataFileName) has no effect when %24(HybridGlobalization) is set to true." />
     <Warning Condition="'$(InvariantGlobalization)' != 'true' and '$(WasmIncludeFullIcuData)' == 'true' and '$(WasmIcuDataFileName)' != ''" Text="%24(WasmIcuDataFileName) has no effect when %24(WasmIncludeFullIcuData) is set to true." />
@@ -76,7 +77,7 @@
       <_HasDotnetJsWorker Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.native.worker.js'">true</_HasDotnetJsWorker>
       <_HasDotnetJsSymbols Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.native.js.symbols'">true</_HasDotnetJsSymbols>
       <_HasDotnetNativeJs Condition="'%(WasmNativeAsset.FileName)%(WasmNativeAsset.Extension)' == 'dotnet.native.js'">true</_HasDotnetNativeJs>
-      <HybridGlobalization Condition="'$(InvariantGlobalization)' == 'true'">false</HybridGlobalization>
+      <HybridGlobalization Condition="'$(InvariantGlobalization)' == 'true' or '$(WasmEnableThreads)' == 'true'">false</HybridGlobalization>
       <_WasmIcuDataFileName Condition="'$(HybridGlobalization)' != 'true' and '$(WasmIcuDataFileName)' != '' and Exists('$(WasmIcuDataFileName)')">$(WasmIcuDataFileName)</_WasmIcuDataFileName>
       <_WasmIcuDataFileName Condition="'$(HybridGlobalization)' != 'true' and '$(WasmIcuDataFileName)' != '' and !Exists('$(WasmIcuDataFileName)')">$(MicrosoftNetCoreAppRuntimePackRidNativeDir)$(WasmIcuDataFileName)</_WasmIcuDataFileName>
     </PropertyGroup>

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -51,12 +51,12 @@ void mono_wasm_invoke_js_function_send (pthread_t target_tid, int function_js_ha
 extern void mono_threads_wasm_async_run_in_target_thread_vi (pthread_t target_thread, void (*func) (gpointer), gpointer user_data1);
 extern void mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 extern void mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+
 #else
 extern void mono_wasm_bind_js_import (void *signature, int *is_exception, MonoObject **result);
 extern void mono_wasm_invoke_jsimport_ST (int function_handle, void *args);
-#endif /* DISABLE_THREADS */
 
-// HybridGlobalization
+// HybridGlobalization is supported only in single-threaded runtime
 extern void mono_wasm_change_case_invariant (const uint16_t* src, int32_t srcLength, uint16_t* dst, int32_t dstLength, mono_bool bToUpper, int *is_exception, MonoObject** ex_result);
 extern void mono_wasm_change_case (MonoString **culture, const uint16_t* src, int32_t srcLength, uint16_t* dst, int32_t dstLength, mono_bool bToUpper, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_compare_string (MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options, int *is_exception, MonoObject** ex_result);
@@ -67,6 +67,9 @@ extern int mono_wasm_get_calendar_info (MonoString **culture, int32_t calendarId
 extern int mono_wasm_get_culture_info (MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_day_of_week (MonoString **culture, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_week_of_year (MonoString **culture, int *is_exception, MonoObject** ex_result);
+
+#endif /* DISABLE_THREADS */
+
 
 void bindings_initialize_internals (void)
 {
@@ -98,6 +101,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/Runtime::BindAssemblyExports", mono_wasm_bind_assembly_exports);
 	mono_add_internal_call ("Interop/Runtime::GetAssemblyExport", mono_wasm_get_assembly_export);
 
+#ifdef DISABLE_THREADS
 	mono_add_internal_call ("Interop/JsGlobalization::ChangeCaseInvariant", mono_wasm_change_case_invariant);
 	mono_add_internal_call ("Interop/JsGlobalization::ChangeCase", mono_wasm_change_case);
 	mono_add_internal_call ("Interop/JsGlobalization::CompareString", mono_wasm_compare_string);
@@ -109,6 +113,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstDayOfWeek", mono_wasm_get_first_day_of_week);
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstWeekOfYear", mono_wasm_get_first_week_of_year);
 	mono_add_internal_call ("System.ConsolePal::Clear", mono_wasm_console_clear);
+#endif /* DISABLE_THREADS */
 }
 
 static MonoAssembly* _mono_wasm_assembly_load (char *assembly_name)

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -59,6 +59,18 @@ export const mono_wasm_threads_imports = !WasmEnableThreads ? [] : [
     mono_wasm_invoke_jsimport,
 ];
 
+export const mono_wasm_imports_hybrid_globalization = WasmEnableThreads ? [] : [
+    mono_wasm_get_first_day_of_week,
+    mono_wasm_get_first_week_of_year,
+    mono_wasm_change_case_invariant,
+    mono_wasm_change_case,
+    mono_wasm_compare_string,
+    mono_wasm_starts_with,
+    mono_wasm_ends_with,
+    mono_wasm_index_of,
+    mono_wasm_get_calendar_info,
+]
+
 export const mono_wasm_imports = [
     // mini-wasm.c
     mono_wasm_schedule_timer,
@@ -100,13 +112,6 @@ export const mono_wasm_imports = [
     mono_wasm_invoke_jsimport_ST,
     mono_wasm_resolve_or_reject_promise,
     mono_wasm_cancel_promise,
-    mono_wasm_change_case_invariant,
-    mono_wasm_change_case,
-    mono_wasm_compare_string,
-    mono_wasm_starts_with,
-    mono_wasm_ends_with,
-    mono_wasm_index_of,
-    mono_wasm_get_calendar_info,
     mono_wasm_get_culture_info,
     mono_wasm_get_first_day_of_week,
     mono_wasm_get_first_week_of_year,
@@ -116,6 +121,8 @@ const wasmImports: Function[] = [
     ...mono_wasm_imports,
     // threading exports, if threading is enabled
     ...mono_wasm_threads_imports,
+    // hg exports, if threading is disabled
+    ...mono_wasm_imports_hybrid_globalization.
 ];
 
 export function replace_linker_placeholders(imports: WebAssembly.Imports) {

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -69,7 +69,7 @@ export const mono_wasm_imports_hybrid_globalization = WasmEnableThreads ? [] : [
     mono_wasm_ends_with,
     mono_wasm_index_of,
     mono_wasm_get_calendar_info,
-]
+];
 
 export const mono_wasm_imports = [
     // mini-wasm.c
@@ -122,7 +122,7 @@ const wasmImports: Function[] = [
     // threading exports, if threading is enabled
     ...mono_wasm_threads_imports,
     // hg exports, if threading is disabled
-    ...mono_wasm_imports_hybrid_globalization.
+    ...mono_wasm_imports_hybrid_globalization,
 ];
 
 export function replace_linker_placeholders(imports: WebAssembly.Imports) {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/98483.

ToDo:
- Tests with HG should not run  on mt
- Make sure managed code connected with hg is trimmed
- Do we pass only `process.env` connected with runtime type or also with application variables? If 2nd, then propagate and rely on `HybridGlobalization` variable, not on `wasmEnableThreads` in JS.