### PR TITLE
JIT: Add helper method for updating bbTargetEdge

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5902,6 +5902,10 @@ public:
     template <bool initializingPreds = false>
     FlowEdge* fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowEdge* oldEdge = nullptr);
 
+    void fgUpdateEdgeTarget(FlowEdge* edge, BasicBlock* newTarget);
+
+    void fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget);
+
     void fgFindBasicBlocks();
 
     bool fgCheckEHCanInsertAfterBlock(BasicBlock* blk, unsigned regionIndex, bool putInTryRegion);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5903,7 +5903,7 @@ public:
     FlowEdge* fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowEdge* oldEdge = nullptr);
 
 private:
-    FlowEdge** fgGetPredInsertPoint(FlowEdge* edge, BasicBlock* newTarget);
+    FlowEdge** fgGetPredInsertPoint(BasicBlock* blockPred, BasicBlock* newTarget);
 
 public:
     void fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5902,8 +5902,10 @@ public:
     template <bool initializingPreds = false>
     FlowEdge* fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowEdge* oldEdge = nullptr);
 
-    void fgUpdateEdgeTarget(FlowEdge* edge, BasicBlock* newTarget);
+private:
+    FlowEdge** fgGetPredInsertPoint(FlowEdge* edge, BasicBlock* newTarget);
 
+public:
     void fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget);
 
     void fgFindBasicBlocks();

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -646,6 +646,7 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
         case BBJ_EHFILTERRET:
         case BBJ_LEAVE: // This function can be called before import, so we still have BBJ_LEAVE
         {
+            // TODO: Use fgRedirectTargetEdge once pred edge iterators are resilient to bbPreds being modified.
             assert(block->TargetIs(oldTarget));
             fgRemoveRefPred(block->GetTargetEdge());
             FlowEdge* const newEdge = fgAddRefPred(newTarget, block, block->GetTargetEdge());

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4192,9 +4192,7 @@ void Compiler::fgFixEntryFlowForOSR()
     //
     fgEnsureFirstBBisScratch();
     assert(fgFirstBB->KindIs(BBJ_ALWAYS) && fgFirstBB->JumpsToNext());
-    fgRemoveRefPred(fgFirstBB->GetTargetEdge());
-    FlowEdge* const newEdge = fgAddRefPred(fgOSREntryBB, fgFirstBB);
-    fgFirstBB->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
+    fgRedirectTargetEdge(fgFirstBB, fgOSREntryBB);
 
     // We don't know the right weight for this block, since
     // execution of the method was interrupted within the

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2127,7 +2127,6 @@ void Compiler::fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
 {
     JITDUMP("*** " FMT_BB " now branching to " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
 
-
     if (predBlock->KindIs(BBJ_ALWAYS))
     {
         // Update flow to new target

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -117,7 +117,7 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
     // dependency on this order. Note also that we don't allow duplicates in the list; we maintain a DupCount
     // count of duplication. This also necessitates walking the flow list for every edge we add.
     //
-    FlowEdge*  flow  = nullptr;
+    FlowEdge*  flow = nullptr;
     FlowEdge** listp;
 
     if (initializingPreds)
@@ -126,7 +126,7 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
         // increasing blockPred->bbNum order. The only possible
         // dup list entry is the last one.
         //
-        listp = &block->bbPreds;
+        listp              = &block->bbPreds;
         FlowEdge* flowLast = block->bbLastPred;
         if (flowLast != nullptr)
         {
@@ -395,7 +395,7 @@ FlowEdge** Compiler::fgGetPredInsertPoint(BasicBlock* blockPred, BasicBlock* new
     assert(blockPred != nullptr);
     assert(newTarget != nullptr);
     assert(fgPredsComputed);
-    
+
     FlowEdge** listp = &newTarget->bbPreds;
 
     // Search pred list for insertion point
@@ -424,14 +424,14 @@ void Compiler::fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget)
 
     FlowEdge* edge = block->GetTargetEdge();
     assert(edge->getDupCount() == 1);
-    
+
     // Update oldTarget's pred list.
     // We could call fgRemoveRefPred, but since we're removing the one and only ref from block to oldTarget,
     // fgRemoveAllRefPreds is slightly more efficient (one fewer branch, doesn't update edge's dup count, etc).
     //
     BasicBlock* oldTarget = edge->getDestinationBlock();
     fgRemoveAllRefPreds(oldTarget, block);
-    
+
     // Splice edge into new target block's pred list
     //
     FlowEdge** predListPtr = fgGetPredInsertPoint(block, newTarget);

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -443,7 +443,9 @@ void Compiler::fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget)
     //
     assert(newTarget->checkPredListOrder());
 
-    newTarget->bbRefs += edge->getDupCount();
+    // Edge should still have only one ref
+    assert(edge->getDupCount() == 1);
+    newTarget->bbRefs++;
 }
 
 Compiler::SwitchUniqueSuccSet Compiler::GetDescriptorForSwitch(BasicBlock* switchBlk)

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -439,7 +439,7 @@ void Compiler::fgRedirectTargetEdge(BasicBlock* block, BasicBlock* newTarget)
     edge->setDestinationBlock(newTarget);
     *predListPtr = edge;
 
-    // Pred list of target should (stilL) be ordered
+    // Pred list of target should (still) be ordered
     //
     assert(newTarget->checkPredListOrder());
 

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -1550,11 +1550,9 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
         // Insert inlinee's blocks into inliner's block list.
         assert(topBlock->KindIs(BBJ_ALWAYS));
         assert(topBlock->TargetIs(bottomBlock));
-        fgRemoveRefPred(topBlock->GetTargetEdge());
-        FlowEdge* const newEdge = fgAddRefPred(InlineeCompiler->fgFirstBB, topBlock, topBlock->GetTargetEdge());
+        fgRedirectTargetEdge(topBlock, InlineeCompiler->fgFirstBB);
 
         topBlock->SetNext(InlineeCompiler->fgFirstBB);
-        topBlock->SetTargetEdge(newEdge);
         topBlock->SetFlags(BBF_NONE_QUIRK);
         InlineeCompiler->fgLastBB->SetNext(bottomBlock);
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -834,9 +834,7 @@ PhaseStatus Compiler::fgPostImportationCleanup()
 
                 if (entryJumpTarget != osrEntry)
                 {
-                    fgRemoveRefPred(fgFirstBB->GetTargetEdge());
-                    FlowEdge* const newEdge = fgAddRefPred(entryJumpTarget, fgFirstBB, fgFirstBB->GetTargetEdge());
-                    fgFirstBB->SetTargetEdge(newEdge);
+                    fgRedirectTargetEdge(fgFirstBB, entryJumpTarget);
 
                     JITDUMP("OSR: redirecting flow from method entry " FMT_BB " to OSR entry " FMT_BB
                             " via step blocks.\n",
@@ -1570,9 +1568,7 @@ bool Compiler::fgOptimizeBranchToEmptyUnconditional(BasicBlock* block, BasicBloc
             case BBJ_ALWAYS:
             case BBJ_CALLFINALLYRET:
             {
-                fgRemoveRefPred(block->GetTargetEdge());
-                FlowEdge* const newEdge = fgAddRefPred(bDest->GetTarget(), block, block->GetTargetEdge());
-                block->SetTargetEdge(newEdge);
+                fgRedirectTargetEdge(block, bDest->GetTarget());
                 break;
             }
 

--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -372,7 +372,6 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     // Update preds in all new blocks
     //
     assert(prevBb->KindIs(BBJ_ALWAYS));
-    fgRemoveRefPred(prevBb->GetTargetEdge());
 
     {
         FlowEdge* const newEdge = fgAddRefPred(block, fastPathBb);
@@ -389,8 +388,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     if (needsSizeCheck)
     {
         // sizeCheckBb is the first block after prevBb
-        FlowEdge* const newEdge = fgAddRefPred(sizeCheckBb, prevBb);
-        prevBb->SetTargetEdge(newEdge);
+        fgRedirectTargetEdge(prevBb, sizeCheckBb);
 
         // sizeCheckBb flows into nullcheckBb in case if the size check passes
         {
@@ -406,8 +404,7 @@ bool Compiler::fgExpandRuntimeLookupsForCall(BasicBlock** pBlock, Statement* stm
     else
     {
         // nullcheckBb is the first block after prevBb
-        FlowEdge* const newEdge = fgAddRefPred(nullcheckBb, prevBb);
-        prevBb->SetTargetEdge(newEdge);
+        fgRedirectTargetEdge(prevBb, nullcheckBb);
 
         // No size check, nullcheckBb jumps to fast path
         // fallbackBb is only reachable from nullcheckBb (jump destination)
@@ -742,9 +739,7 @@ bool Compiler::fgExpandThreadLocalAccessForCallNativeAOT(BasicBlock** pBlock, St
     // fallback will just execute first time
     fallbackBb->bbSetRunRarely();
 
-    fgRemoveRefPred(prevBb->GetTargetEdge());
-    FlowEdge* const newEdge = fgAddRefPred(tlsRootNullCondBB, prevBb);
-    prevBb->SetTargetEdge(newEdge);
+    fgRedirectTargetEdge(prevBb, tlsRootNullCondBB);
 
     // All blocks are expected to be in the same EH region
     assert(BasicBlock::sameEHRegion(prevBb, block));
@@ -1089,12 +1084,7 @@ bool Compiler::fgExpandThreadLocalAccessForCall(BasicBlock** pBlock, Statement* 
     // Update preds in all new blocks
     //
     assert(prevBb->KindIs(BBJ_ALWAYS));
-    fgRemoveRefPred(prevBb->GetTargetEdge());
-
-    {
-        FlowEdge* const newEdge = fgAddRefPred(maxThreadStaticBlocksCondBB, prevBb);
-        prevBb->SetTargetEdge(newEdge);
-    }
+    fgRedirectTargetEdge(prevBb, maxThreadStaticBlocksCondBB);
 
     {
         FlowEdge* const trueEdge  = fgAddRefPred(fallbackBb, maxThreadStaticBlocksCondBB);
@@ -1462,8 +1452,10 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     // Update preds in all new blocks
     //
 
-    // Unlink block and prevBb
-    fgRemoveRefPred(prevBb->GetTargetEdge());
+    // Redirect prevBb from block to isInitedBb
+    fgRedirectTargetEdge(prevBb, isInitedBb);
+    prevBb->SetFlags(BBF_NONE_QUIRK);
+    assert(prevBb->JumpsToNext());
 
     {
         // Block has two preds now: either isInitedBb or helperCallBb
@@ -1471,15 +1463,6 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
         helperCallBb->SetTargetEdge(newEdge);
         assert(helperCallBb->JumpsToNext());
         helperCallBb->SetFlags(BBF_NONE_QUIRK);
-    }
-
-    {
-        // prevBb always flows into isInitedBb
-        assert(prevBb->KindIs(BBJ_ALWAYS));
-        FlowEdge* const newEdge = fgAddRefPred(isInitedBb, prevBb);
-        prevBb->SetTargetEdge(newEdge);
-        prevBb->SetFlags(BBF_NONE_QUIRK);
-        assert(prevBb->JumpsToNext());
     }
 
     {
@@ -1792,17 +1775,10 @@ bool Compiler::fgVNBasedIntrinsicExpansionForCall_ReadUtf8(BasicBlock** pBlock, 
     //
     // Update preds in all new blocks
     //
-    // block is no longer a predecessor of prevBb
-    fgRemoveRefPred(prevBb->GetTargetEdge());
-
-    {
-        // prevBb flows into lengthCheckBb
-        assert(prevBb->KindIs(BBJ_ALWAYS));
-        FlowEdge* const newEdge = fgAddRefPred(lengthCheckBb, prevBb);
-        prevBb->SetTargetEdge(newEdge);
-        prevBb->SetFlags(BBF_NONE_QUIRK);
-        assert(prevBb->JumpsToNext());
-    }
+    // Redirect prevBb to lengthCheckBb
+    fgRedirectTargetEdge(prevBb, lengthCheckBb);
+    prevBb->SetFlags(BBF_NONE_QUIRK);
+    assert(prevBb->JumpsToNext());
 
     {
         // lengthCheckBb has two successors: block and fastpathBb
@@ -2511,12 +2487,7 @@ bool Compiler::fgLateCastExpansionForCall(BasicBlock** pBlock, Statement* stmt, 
         }
     }
 
-    fgRemoveRefPred(firstBb->GetTargetEdge());
-
-    {
-        FlowEdge* const newEdge = fgAddRefPred(nullcheckBb, firstBb);
-        firstBb->SetTargetEdge(newEdge);
-    }
+    fgRedirectTargetEdge(firstBb, nullcheckBb);
 
     {
         FlowEdge* const trueEdge = fgAddRefPred(lastBb, nullcheckBb);

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -4688,10 +4688,10 @@ void Compiler::impImportLeave(BasicBlock* block)
                 else
                 {
                     FlowEdge* const newEdge = fgAddRefPred(exitBlock, step);
-                    step->SetTargetEdge(newEdge); // the previous step (maybe a call to a nested finally, or a nested catch
+                    step->SetTargetEdge(newEdge); // the previous step (maybe a call to a nested finally, or a nested
+                                                  // catch
                                                   // exit) returns to this block
                 }
-
 
                 // The new block will inherit this block's weight.
                 exitBlock->inheritWeight(block);

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -1219,9 +1219,7 @@ private:
             // Finally, rewire the cold block to jump to the else block,
             // not fall through to the check block.
             //
-            compiler->fgRemoveRefPred(coldBlock->GetTargetEdge());
-            FlowEdge* const newEdge = compiler->fgAddRefPred(elseBlock, coldBlock, coldBlock->GetTargetEdge());
-            coldBlock->SetKindAndTargetEdge(BBJ_ALWAYS, newEdge);
+            compiler->fgRedirectTargetEdge(coldBlock, elseBlock);
         }
 
         // When the current candidate has sufficiently high likelihood, scan

--- a/src/coreclr/jit/jiteh.cpp
+++ b/src/coreclr/jit/jiteh.cpp
@@ -4342,9 +4342,7 @@ void Compiler::fgExtendEHRegionBefore(BasicBlock* block)
                 }
 #endif // DEBUG
                 // Change the target for bFilterLast from the old first 'block' to the new first 'bPrev'
-                fgRemoveRefPred(bFilterLast->GetTargetEdge());
-                FlowEdge* const newEdge = fgAddRefPred(bPrev, bFilterLast);
-                bFilterLast->SetTargetEdge(newEdge);
+                fgRedirectTargetEdge(bFilterLast, bPrev);
             }
         }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14613,7 +14613,6 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     // Conservatively propagate BBF_COPY_PROPAGATE flags to all blocks
     BasicBlockFlags propagateFlagsToAll = block->GetFlagsRaw() & BBF_COPY_PROPAGATE;
     BasicBlock*     remainderBlock      = fgSplitBlockAfterStatement(block, stmt);
-    fgRemoveRefPred(block->GetTargetEdge()); // We're going to put more blocks between block and remainderBlock.
 
     BasicBlock* condBlock = fgNewBBafter(BBJ_ALWAYS, block, true);
     BasicBlock* elseBlock = fgNewBBafter(BBJ_ALWAYS, condBlock, true);
@@ -14637,10 +14636,7 @@ bool Compiler::fgExpandQmarkStmt(BasicBlock* block, Statement* stmt)
     assert(condBlock->bbWeight == remainderBlock->bbWeight);
 
     assert(block->KindIs(BBJ_ALWAYS));
-    {
-        FlowEdge* const newEdge = fgAddRefPred(condBlock, block);
-        block->SetTargetEdge(newEdge);
-    }
+    fgRedirectTargetEdge(block, condBlock);
 
     {
         FlowEdge* const newEdge = fgAddRefPred(elseBlock, condBlock);

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2206,10 +2206,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     bNewCond->SetTrueEdge(trueEdge);
     bNewCond->SetFalseEdge(falseEdge);
 
-    fgRemoveRefPred(block->GetTargetEdge());
-    FlowEdge* const newEdge = fgAddRefPred(bNewCond, block);
-
-    block->SetTargetEdge(newEdge);
+    fgRedirectTargetEdge(block, bNewCond);
     block->SetFlags(BBF_NONE_QUIRK);
     assert(block->JumpsToNext());
 


### PR DESCRIPTION
Part of #93020. Adds `fgRedirectTargetEdge`, which updates bbTargetEdge's block target while maintaining the rest of the edge's state to simplify edge profile maintenance (and avoid additional allocations). My goal is to eventually have some generalized version of this that can replace any block's successor edges without having to consider the block's kind, such as by updating the edge via a `FlowEdge**`. I tried this locally, and there are some quirks around duplicate edges that complicate this approach, and it might make sense to have a fast path for updating blocks with only one successor anyway, so I'm starting here.

Note that I didn't update `fgReplaceJumpTarget` to use this yet, as the method is frequently called while iterating a block's predecessors, and `fgRedirectTargetEdge` modifies `bbPreds`, breaking the iterator. This can be easily fixed through multiple approaches, though I'm not sure which one is preferable:
* We could convert problematic iterator usages to raw loops that cache the next pred edge pointer before calling `fgReplaceJumpTarget`, though this isn't as elegant.
* We already have a `m_next` pointer in pred iterators in Debug builds for consistency checking. We can make this available all the time, and then update the iterator to it instead of using `m_pred->getNextPredEdge`, as that will traverse the pred list of the new target. This will impact TP, so perhaps this should be tried in a separate PR.
* To lessen the TP impact of the above approach, we could add a new iterator type that caches the next pred edge specifically for these situations, though it might be confusing having multiple pred iterator types.