### PR TITLE
Reduce overheads of enumerating Grouping from Enumerable.GroupBy

### DIFF
--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -73,6 +73,7 @@
     <Compile Include="System\Linq\OfType.cs" />
     <Compile Include="System\Linq\OrderBy.cs" />
     <Compile Include="System\Linq\OrderedEnumerable.cs" />
+    <Compile Include="System\Linq\PartialArrayEnumerator.cs" />
     <Compile Include="System\Linq\Range.cs" />
     <Compile Include="System\Linq\Repeat.cs" />
     <Compile Include="System\Linq\Reverse.cs" />

--- a/src/libraries/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Grouping.cs
@@ -388,10 +388,8 @@ namespace System.Linq
 
         public IEnumerator<TElement> GetEnumerator()
         {
-            for (int i = 0; i < _count; i++)
-            {
-                yield return _elements[i];
-            }
+            Debug.Assert(_count > 0, "A grouping should only have been created if an element was being added to it.");
+            return new PartialArrayEnumerator<TElement>(_elements, _count);
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -411,11 +409,7 @@ namespace System.Linq
         void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex) =>
             Array.Copy(_elements, 0, array, arrayIndex, _count);
 
-        bool ICollection<TElement>.Remove(TElement item)
-        {
-            ThrowHelper.ThrowNotSupportedException();
-            return false;
-        }
+        bool ICollection<TElement>.Remove(TElement item) => ThrowHelper.ThrowNotSupportedException_Boolean();
 
         int IList<TElement>.IndexOf(TElement item) => Array.IndexOf(_elements, item, 0, _count);
 
@@ -427,7 +421,7 @@ namespace System.Linq
         {
             get
             {
-                if (index < 0 || index >= _count)
+                if ((uint)index >= (uint)_count)
                 {
                     ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index);
                 }
@@ -435,10 +429,7 @@ namespace System.Linq
                 return _elements[index];
             }
 
-            set
-            {
-                ThrowHelper.ThrowNotSupportedException();
-            }
+            set => ThrowHelper.ThrowNotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/PartialArrayEnumerator.cs
+++ b/src/libraries/System.Linq/src/System/Linq/PartialArrayEnumerator.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Linq
+{
+    /// <summary>Enumerator for iterating through part of an array.</summary>
+    internal sealed class PartialArrayEnumerator<T> : IEnumerator<T>
+    {
+        private readonly T[] _array;
+        private readonly int _count;
+        private int _index = -1;
+
+        public PartialArrayEnumerator(T[] array, int count)
+        {
+            Debug.Assert(array is not null);
+            _array = array;
+            _count = count;
+        }
+
+        public bool MoveNext()
+        {
+            if (_index + 1 < _count)
+            {
+                _index++;
+                return true;
+            }
+
+            return false;
+        }
+
+        public T Current => _array[_index];
+        object? IEnumerator.Current => Current;
+
+        public void Dispose() { }
+
+        public void Reset() => _index = -1;
+    }
+}

--- a/src/libraries/System.Linq/tests/GroupByTests.cs
+++ b/src/libraries/System.Linq/tests/GroupByTests.cs
@@ -887,5 +887,32 @@ namespace System.Linq.Tests
                 }
             }
         }
+
+        [Fact]
+        public void EnumerateGrouping()
+        {
+            IGrouping<string, int> g = Enumerable.Range(0, 42).GroupBy(i => "onegroup").First();
+            Assert.Equal("onegroup", g.Key);
+            Assert.Equal(42, g.Count());
+
+            using IEnumerator<int> e = g.GetEnumerator();
+
+            var values = new HashSet<int>();
+
+            for (int trial = 0; trial < 3; trial++)
+            {
+                values.Clear();
+
+                while (e.MoveNext())
+                {
+                    Assert.True(values.Add(e.Current));
+                }
+
+                Assert.Equal(42, values.Count);
+                Assert.Equal(Enumerable.Range(0, 42), values.Order());
+
+                e.Reset();
+            }
+        }
     }
 }


### PR DESCRIPTION
Use a custom enumerator for Grouping.GetEnumerator. Today it's just implemented with an iterator, but while simple:
- The resulting class is generic on TKey even thought it doesn't need to be (possibly resulting in extra generic instantiations).
- The generated type is larger than it needs to be, with a field for _current, even though at this point the array is observably immutable and we don't need separate storage for the current item.
- There's more overhead in MoveNext than is necessary, because we only need to track the current index and not also a separate state.

| Method | Toolchain         | ItemsPerGroup | Mean     | Ratio | Allocated | Alloc Ratio |
|------- |------------------ |-------------- |---------:|------:|----------:|------------:|
| Sum    | \main\corerun.exe | 1             | 167.5 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 1             | 137.3 ns |  0.82 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 2             | 195.4 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 2             | 155.0 ns |  0.79 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 3             | 225.3 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 3             | 171.9 ns |  0.76 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 4             | 260.1 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 4             | 190.7 ns |  0.73 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 5             | 291.3 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 5             | 208.2 ns |  0.71 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 6             | 331.1 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 6             | 225.6 ns |  0.68 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 7             | 367.2 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 7             | 246.7 ns |  0.67 |     368 B |        0.82 |
|        |                   |               |          |       |           |             |
| Sum    | \main\corerun.exe | 8             | 388.1 ns |  1.00 |     448 B |        1.00 |
| Sum    | \pr\corerun.exe   | 8             | 265.5 ns |  0.68 |     368 B |        0.82 |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class Tests
{
    private ILookup<int, string> _stringsByLength;

    [Params(1, 2, 3, 4, 5, 6, 7, 8)]
    public int ItemsPerGroup { get; set; }

    [GlobalSetup]
    public void Setup()
    {
        const int NumGroups = 10;

        var list = new List<string>();
        for (int i = 0; i < NumGroups; i++)
        {
            for (int item = 0; item < ItemsPerGroup; item++)
            {
                list.Add(new string((char)('a' + item), i + 1));
            }
        }

        _stringsByLength = list.ToLookup(s => s.Length);
    }

    [Benchmark]
    public int Sum()
    {
        int sum = 0;
        foreach (IGrouping<int, string> group in _stringsByLength)
        {
            foreach (string item in group)
            {
                sum += item.Length;
            }
        }
        return sum;
    }
}
```