### PR TITLE
[6.0] Fix usage of recycled lists in the thread pool

### DIFF
--- a/src/coreclr/vm/win32threadpool.h
+++ b/src/coreclr/vm/win32threadpool.h
@@ -752,17 +752,23 @@ public:
 
 #ifndef TARGET_UNIX
             if (CPUGroupInfo::CanEnableThreadUseAllCpuGroups())
-                processorNumber = CPUGroupInfo::CalculateCurrentProcessorNumber();
+            {
+                // The current processor number may not be within the total number of active processors determined at
+                // initialization time.
+                processorNumber = CPUGroupInfo::CalculateCurrentProcessorNumber() % CPUGroupInfo::GetNumActiveProcessors();
+            }
             else
+            {
                 // Turns out GetCurrentProcessorNumber can return a value greater than the number of processors reported by
                 // GetSystemInfo, if we're running in WOW64 on a machine with >32 processors.
-        	    processorNumber = GetCurrentProcessorNumber()%NumberOfProcessors;
+                processorNumber = GetCurrentProcessorNumber() % g_SystemInfo.dwNumberOfProcessors;
+            }
 #else // !TARGET_UNIX
             if (PAL_HasGetCurrentProcessorNumber())
             {
                 // On linux, GetCurrentProcessorNumber which uses sched_getcpu() can return a value greater than the number
                 // of processors reported by sysconf(_SC_NPROCESSORS_ONLN) when using OpenVZ kernel.
-                processorNumber = GetCurrentProcessorNumber()%NumberOfProcessors;
+                processorNumber = GetCurrentProcessorNumber() % PAL_GetTotalCpuCount();
             }
 #endif // !TARGET_UNIX
             return pRecycledListPerProcessor[processorNumber][memType];


### PR DESCRIPTION
Fixed the usage of ThreadpoolMgr::RecycledLists to use the same processor count upon access as what is used to allocate the array.

## Customer Impact

The current processor number is used to access the recycled lists array in the thread pool, and the array is allocated using a processor count determined at initialization time. There are some cases where the current processor number may be greater than the predetermined processor count. An out-of-bounds access to the relevant array can lead to a hang, crash, or corruption. A hang was seen on Win11 by a 1p customer, where scheduling changes led to the initializing thread running on a different CPU group from the primary CPU group of the process, the processor count determined using GetSystemInfo returns the number of processors in the CPU group the calling thread is running on, and the primary CPU group had more processors.

## Regression?

No

## Testing

Verified that the issue is resolved on a multi-CPU-group machine.

## Risk

Low, the fix ensures that all accesses into the relevant array are within bounds.