### PR TITLE
Fix System.Runtime.InteropServices.UnitTests on Windows set to UTF8 encoding

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SecureStringToCoTaskMemAnsiTests.cs
@@ -33,9 +33,9 @@ namespace System.Runtime.InteropServices.Tests
                 {
                     Assert.NotEqual(IntPtr.Zero, ptr);
 
-                    // Unix is incorrect with unicode chars.
+                    // The check is incorrect for UTF8 encoding of non-Ansi chars. Detect UTF8 encoding via SystemMaxDBCSCharSize.
                     bool containsNonAnsiChars = s.Any(c => c > 0xFF);
-                    if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                    if (!containsNonAnsiChars || Marshal.SystemMaxDBCSCharSize < 3)
                     {
                         // Make sure the native memory is correctly laid out.
                         for (int i = 0; i < s.Length; i++)

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SecureStringToGlobalAllocAnsiTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/SecureStringToGlobalAllocAnsiTests.cs
@@ -33,9 +33,9 @@ namespace System.Runtime.InteropServices.Tests
                 {
                     Assert.NotEqual(IntPtr.Zero, ptr);
 
-                    // Unix uses UTF8 for Ansi marshalling.
+                    // The check is incorrect for UTF8 encoding of non-Ansi chars. Detect UTF8 encoding via SystemMaxDBCSCharSize.
                     bool containsNonAnsiChars = s.Any(c => c > 0xFF);
-                    if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                    if (!containsNonAnsiChars || Marshal.SystemMaxDBCSCharSize < 3)
                     {
                         // Make sure the native memory is correctly laid out.
                         for (int i = 0; i < s.Length; i++)

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StringToCoTaskMemAnsiTests.cs
@@ -30,9 +30,9 @@ namespace System.Runtime.InteropServices.Tests
             {
                 Assert.NotEqual(IntPtr.Zero, ptr);
 
-                // Unix uses UTF8 for Ansi marshalling.
+                // The check is incorrect for UTF8 encoding of non-Ansi chars. Detect UTF8 encoding via SystemMaxDBCSCharSize.
                 bool containsNonAnsiChars = s.Any(c => c > 0xFF);
-                if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                if (!containsNonAnsiChars || Marshal.SystemMaxDBCSCharSize < 3)
                 {
                     // Make sure the native memory is correctly laid out.
                     for (int i = 0; i < s.Length; i++)

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StringToHGlobalAnsiTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/StringToHGlobalAnsiTests.cs
@@ -30,9 +30,9 @@ namespace System.Runtime.InteropServices.Tests
             {
                 Assert.NotEqual(IntPtr.Zero, ptr);
 
-                // Unix uses UTF8 for Ansi marshalling.
+                // The check is incorrect for UTF8 encoding of non-Ansi chars. Detect UTF8 encoding via SystemMaxDBCSCharSize.
                 bool containsNonAnsiChars = s.Any(c => c > 0xFF);
-                if (!containsNonAnsiChars || PlatformDetection.IsWindows)
+                if (!containsNonAnsiChars || Marshal.SystemMaxDBCSCharSize < 3)
                 {
                     // Make sure the native memory is correctly laid out.
                     for (int i = 0; i < s.Length; i++)


### PR DESCRIPTION
Windows 11 provide "Beta: Use Unicode UTF-8 for worldwide language support." setting. Fix failures in InteropServices UnitTests with this option enabled.