### PR TITLE
[RISC-V] Fix bug in crossgen2

### DIFF
--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -1932,7 +1932,7 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
             p += 4;
         }
 
-        BYTE* pBLTCall = NULL;
+        BYTE* pBLECall = NULL;
 
         for (WORD i = 0; i < pLookup->indirections; i++)
         {
@@ -1962,8 +1962,8 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
                 p += 4;
                 *(DWORD*)p = ITypeInstr(0x13, 0, RegT4, RegT4, slotOffset & 0xfff);// addi  t4, t4, (slotOffset&0xfff)
                 p += 4;
-                // blt  t4, t5, CALL HELPER
-                pBLTCall = p;       // Offset filled later
+                // bge  t4, t5, CALL HELPER
+                pBLECall = p;       // Offset filled later
                 p += 4;
             }
 
@@ -2005,8 +2005,8 @@ PCODE DynamicHelpers::CreateDictionaryLookupHelper(LoaderAllocator * pAllocator,
             p += 4;
 
             // CALL HELPER:
-            if (pBLTCall != NULL)
-                *(DWORD*)pBLTCall = BTypeInstr(0x63, 0x4, RegT4, RegT5, (UINT32)(p - pBLTCall));
+            if (pBLECall != NULL)
+                *(DWORD*)pBLECall = BTypeInstr(0x63, 0x5, RegT4, RegT5, (UINT32)(p - pBLECall));
 
             *(DWORD*)p = ITypeInstr(0x13, 0, RegA0, RegT2, 0);// addi  a0, t2, 0
             p += 4;


### PR DESCRIPTION
Fix failures for coreclr tests with crossgened SPC.dll
I checked these tests pass now.
```
./JIT/Directed/debugging/debuginfo/tester/tester.sh
./JIT/Methodical/refany/format_d/format_d.sh
./JIT/Methodical/refany/format/format.sh
./JIT/Methodical/refany/format_r/format_r.sh
./JIT/Methodical/refany/longsig_d/longsig_d.sh
./JIT/Methodical/refany/longsig_r/longsig_r.sh
./JIT/Methodical/refany/shortsig_d/shortsig_d.sh
./JIT/Methodical/refany/shortsig_r/shortsig_r.sh
./JIT/Performance/CodeQuality/BenchmarksGame/k-nucleotide/k-nucleotide-9/k-nucleotide-9.sh
./JIT/Performance/CodeQuality/Roslyn/CscBench/CscBench.sh
./JIT/Performance/CodeQuality/Serialization/Deserialize/Deserialize.sh
./JIT/Performance/CodeQuality/Serialization/Serialize/Serialize.sh
./JIT/superpmi/superpmicollect/CscBench/CscBench.sh
./JIT/superpmi/superpmicollect/superpmicollect.sh
./Loader/binding/tracing/BinderTracingTest.Basic/BinderTracingTest.Basic.sh
./Loader/binding/tracing/BinderTracingTest.ResolutionFlow/BinderTracingTest.ResolutionFlow.sh
./profiler/eventpipe/reverse_startup/reverse_startup.sh
./readytorun/crossgen2/crossgen2smoke/crossgen2smoke.sh
./readytorun/crossgen2/crossgen2smoke_donotalwaysusecrossgen2/crossgen2smoke_donotalwaysusecrossgen2.sh
./reflection/GenericAttribute/GenericAttributeTests/GenericAttributeTests.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung