### PR TITLE
[browser][MT] Fix Promise cancelation

### DIFF
--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -447,6 +447,13 @@ type APIType = {
      */
     runMainAndExit: (mainAssemblyName?: string, args?: string[]) => Promise<number>;
     /**
+     * Exits the runtime.
+     * Note: after the runtime exits, it would reject all further calls to the API.
+     * @param code "process" exit code.
+     * @param reason could be a string or an Error object.
+     */
+    exit: (code: number, reason?: any) => void;
+    /**
      * Sets the environment variable for the "process"
      * @param name
      * @param value

--- a/src/mono/browser/runtime/export-api.ts
+++ b/src/mono/browser/runtime/export-api.ts
@@ -9,13 +9,12 @@ import { getB32, getF32, getF64, getI16, getI32, getI52, getI64Big, getI8, getU1
 import { mono_run_main, mono_run_main_and_exit } from "./run";
 import { mono_wasm_setenv } from "./startup";
 import { loaderHelpers, runtimeHelpers } from "./globals";
-import { mono_exit } from "./loader/exit";
 
 export function export_api(): any {
     const api: APIType = {
         runMain: mono_run_main,
         runMainAndExit: mono_run_main_and_exit,
-        exit: mono_exit,
+        exit: loaderHelpers.mono_exit,
         setEnvironmentVariable: mono_wasm_setenv,
         getAssemblyExports: mono_wasm_get_assembly_exports,
         setModuleImports: mono_wasm_set_module_imports,

--- a/src/mono/browser/runtime/export-api.ts
+++ b/src/mono/browser/runtime/export-api.ts
@@ -9,11 +9,13 @@ import { getB32, getF32, getF64, getI16, getI32, getI52, getI64Big, getI8, getU1
 import { mono_run_main, mono_run_main_and_exit } from "./run";
 import { mono_wasm_setenv } from "./startup";
 import { loaderHelpers, runtimeHelpers } from "./globals";
+import { mono_exit } from "./loader/exit";
 
 export function export_api(): any {
     const api: APIType = {
         runMain: mono_run_main,
         runMainAndExit: mono_run_main_and_exit,
+        exit: mono_exit,
         setEnvironmentVariable: mono_wasm_setenv,
         getAssemblyExports: mono_wasm_get_assembly_exports,
         setModuleImports: mono_wasm_set_module_imports,

--- a/src/mono/browser/runtime/gc-handles.ts
+++ b/src/mono/browser/runtime/gc-handles.ts
@@ -139,6 +139,9 @@ export function setup_managed_proxy(owner: any, gc_handle: GCHandle): void {
 
 export function upgrade_managed_proxy_to_strong_ref(owner: any, gc_handle: GCHandle): void {
     const sr = create_strong_ref(owner);
+    if (_use_finalization_registry) {
+        _js_owned_object_registry.unregister(owner);
+    }
     _js_owned_object_table.set(gc_handle, sr);
 }
 

--- a/src/mono/browser/runtime/interp-pgo.ts
+++ b/src/mono/browser/runtime/interp-pgo.ts
@@ -193,7 +193,6 @@ export async function getCacheKey(prefix: string): Promise<string | null> {
     delete inputs.forwardConsoleLogsToWS;
     delete inputs.diagnosticTracing;
     delete inputs.appendElementOnExit;
-    delete inputs.assertAfterExit;
     delete inputs.interopCleanupOnExit;
     delete inputs.dumpThreadsOnNonZeroExit;
     delete inputs.logExitCode;

--- a/src/mono/browser/runtime/invoke-js.ts
+++ b/src/mono/browser/runtime/invoke-js.ts
@@ -53,6 +53,7 @@ export function mono_wasm_invoke_jsimport(signature: JSFunctionSignature, args: 
 
 export function mono_wasm_invoke_jsimport_ST(function_handle: JSFnHandle, args: JSMarshalerArguments): void {
     if (WasmEnableThreads) return;
+    loaderHelpers.assert_runtime_running();
     const bound_fn = js_import_wrapper_by_fn_handle[<any>function_handle];
     mono_assert(bound_fn, () => `Imported function handle expected ${function_handle}`);
     bound_fn(args);
@@ -336,6 +337,7 @@ type BindingClosure = {
 }
 
 export function mono_wasm_invoke_js_function(bound_function_js_handle: JSHandle, args: JSMarshalerArguments): void {
+    loaderHelpers.assert_runtime_running();
     const bound_fn = mono_wasm_get_jsobj_from_js_handle(bound_function_js_handle);
     mono_assert(bound_fn && typeof (bound_fn) === "function" && bound_fn[bound_js_function_symbol], () => `Bound function handle expected ${bound_function_js_handle}`);
     bound_fn(args);

--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -6,7 +6,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { MainThreadingMode, type DotnetModuleInternal, type MonoConfigInternal, JSThreadBlockingMode, JSThreadInteropMode } from "../types/internal";
 import type { DotnetModuleConfig, MonoConfig, ResourceGroups, ResourceList } from "../types";
-import { ENVIRONMENT_IS_WEB, exportedRuntimeAPI, loaderHelpers, runtimeHelpers } from "./globals";
+import { exportedRuntimeAPI, loaderHelpers, runtimeHelpers } from "./globals";
 import { mono_log_error, mono_log_debug } from "./logging";
 import { importLibraryInitializers, invokeLibraryInitializers } from "./libraryInitializers";
 import { mono_exit } from "./exit";
@@ -177,8 +177,6 @@ export function normalizeConfig() {
             deep_merge_resources(config.resources, toMerge);
         }
     }
-
-    loaderHelpers.assertAfterExit = config.assertAfterExit = config.assertAfterExit || !ENVIRONMENT_IS_WEB;
 
     if (config.debugLevel === undefined && BuildConfiguration === "Debug") {
         config.debugLevel = -1;

--- a/src/mono/browser/runtime/loader/exit.ts
+++ b/src/mono/browser/runtime/loader/exit.ts
@@ -15,19 +15,11 @@ export function is_runtime_running() {
 }
 
 export function assert_runtime_running() {
-    if (!is_exited()) {
-        if (WasmEnableThreads && ENVIRONMENT_IS_WORKER) {
-            mono_assert(runtimeHelpers.runtimeReady, "The WebWorker is not attached to the runtime. See https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#JS-interop-on-dedicated-threads");
-        } else {
-            mono_assert(runtimeHelpers.runtimeReady, ".NET runtime didn't start yet. Please call dotnet.create() first.");
-        }
+    mono_assert(!is_exited(), () => `.NET runtime already exited with ${loaderHelpers.exitCode} ${loaderHelpers.exitReason}. You can use runtime.runMain() which doesn't exit the runtime.`);
+    if (WasmEnableThreads && ENVIRONMENT_IS_WORKER) {
+        mono_assert(runtimeHelpers.runtimeReady, "The WebWorker is not attached to the runtime. See https://github.com/dotnet/runtime/blob/main/src/mono/wasm/threads.md#JS-interop-on-dedicated-threads");
     } else {
-        const message = `.NET runtime already exited with ${loaderHelpers.exitCode} ${loaderHelpers.exitReason}. You can use runtime.runMain() which doesn't exit the runtime.`;
-        if (loaderHelpers.assertAfterExit) {
-            mono_assert(false, message);
-        } else {
-            mono_log_warn(message);
-        }
+        mono_assert(runtimeHelpers.runtimeReady, ".NET runtime didn't start yet. Please call dotnet.create() first.");
     }
 }
 

--- a/src/mono/browser/runtime/loader/globals.ts
+++ b/src/mono/browser/runtime/loader/globals.ts
@@ -86,7 +86,6 @@ export function setLoaderGlobals(
 
         maxParallelDownloads: 16,
         enableDownloadRetry: true,
-        assertAfterExit: !ENVIRONMENT_IS_WEB,
 
         _loaded_files: [],
         loadedFiles: [],

--- a/src/mono/browser/runtime/loader/run.ts
+++ b/src/mono/browser/runtime/loader/run.ts
@@ -139,19 +139,6 @@ export class HostBuilder implements DotnetHostBuilder {
     }
 
     // internal
-    withAssertAfterExit(): DotnetHostBuilder {
-        try {
-            deep_merge_config(monoConfig, {
-                assertAfterExit: true
-            });
-            return this;
-        } catch (err) {
-            mono_exit(1, err);
-            throw err;
-        }
-    }
-
-    // internal
     //  todo fallback later by debugLevel
     withWaitingForDebugger(level: number): DotnetHostBuilder {
         try {

--- a/src/mono/browser/runtime/managed-exports.ts
+++ b/src/mono/browser/runtime/managed-exports.ts
@@ -80,6 +80,7 @@ export function call_entry_point(main_assembly_name: string, program_args: strin
 
 // the marshaled signature is: void LoadSatelliteAssembly(byte[] dll)
 export function load_satellite_assembly(dll: Uint8Array): void {
+    loaderHelpers.assert_runtime_running();
     const sp = Module.stackSave();
     try {
         const size = 3;
@@ -95,6 +96,7 @@ export function load_satellite_assembly(dll: Uint8Array): void {
 
 // the marshaled signature is: void LoadLazyAssembly(byte[] dll, byte[] pdb)
 export function load_lazy_assembly(dll: Uint8Array, pdb: Uint8Array | null): void {
+    loaderHelpers.assert_runtime_running();
     const sp = Module.stackSave();
     try {
         const size = 4;

--- a/src/mono/browser/runtime/marshal-to-js.ts
+++ b/src/mono/browser/runtime/marshal-to-js.ts
@@ -23,6 +23,7 @@ import { get_marshaler_to_cs_by_type, jsinteropDoc, marshal_exception_to_cs } fr
 import { localHeapViewF64, localHeapViewI32, localHeapViewU8 } from "./memory";
 import { call_delegate } from "./managed-exports";
 import { gc_locked } from "./gc-lock";
+import { mono_log_debug } from "./logging";
 
 export function initialize_marshalers_to_js(): void {
     if (cs_to_js_marshalers.size == 0) {
@@ -337,6 +338,10 @@ function create_task_holder(res_converter?: MarshalerToJs) {
 }
 
 export function mono_wasm_resolve_or_reject_promise(args: JSMarshalerArguments): void {
+    if (!loaderHelpers.is_runtime_running()) {
+        mono_log_debug("This promise resolution/rejection can't be propagated to managed code, mono runtime already exited.");
+        return;
+    }
     const exc = get_arg(args, 0);
     const receiver_should_free = WasmEnableThreads && is_receiver_should_free(args);
     try {

--- a/src/mono/browser/runtime/memory.ts
+++ b/src/mono/browser/runtime/memory.ts
@@ -331,7 +331,7 @@ export function compareExchangeI32(offset: MemOffset, value: number, expected: n
         }
         return actual;
     }
-    return globalThis.Atomics.compareExchange(localHeapViewI32(), <any>offset >>> 2, value, expected);
+    return globalThis.Atomics.compareExchange(localHeapViewI32(), <any>offset >>> 2, expected, value);
 }
 
 export function storeI32(offset: MemOffset, value: number): void {

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -416,6 +416,13 @@ export type APIType = {
      */
     runMainAndExit: (mainAssemblyName?: string, args?: string[]) => Promise<number>;
     /**
+     * Exits the runtime.
+     * Note: after the runtime exits, it would reject all further calls to the API.
+     * @param code "process" exit code.
+     * @param reason could be a string or an Error object.
+     */
+    exit: (code: number, reason?: any) => void;
+    /**
      * Sets the environment variable for the "process"
      * @param name
      * @param value

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -80,7 +80,6 @@ export type MonoConfigInternal = MonoConfig & {
     browserProfilerOptions?: BrowserProfilerOptions, // dictionary-style Object. If omitted, browser profiler will not be initialized.
     waitForDebugger?: number,
     appendElementOnExit?: boolean
-    assertAfterExit?: boolean // default true for shell/nodeJS
     interopCleanupOnExit?: boolean
     dumpThreadsOnNonZeroExit?: boolean
     logExitCode?: boolean
@@ -123,7 +122,6 @@ export type LoaderHelpers = {
 
     maxParallelDownloads: number;
     enableDownloadRetry: boolean;
-    assertAfterExit: boolean;
 
     exitCode: number | undefined;
     exitReason: any;

--- a/src/mono/browser/test-main.js
+++ b/src/mono/browser/test-main.js
@@ -250,7 +250,6 @@ function configureRuntime(dotnet, runArgs) {
         .withExitCodeLogging()
         .withElementOnExit()
         .withInteropCleanupOnExit()
-        .withAssertAfterExit()
         .withDumpThreadsOnNonZeroExit()
         .withConfig({
             loadAllSatelliteResources: true

--- a/src/mono/sample/wasm/browser-shutdown/main.js
+++ b/src/mono/sample/wasm/browser-shutdown/main.js
@@ -14,7 +14,6 @@ try {
         .withExitOnUnhandledError()
         .withExitCodeLogging()
         .withElementOnExit()
-        .withAssertAfterExit()
         .withOnConfigLoaded(() => {
             // you can test abort of the startup by opening http://localhost:8000/?throwError=true
             const params = new URLSearchParams(location.search);

--- a/src/mono/wasm/features.md
+++ b/src/mono/wasm/features.md
@@ -402,8 +402,8 @@ In Blazor, you can customize the startup in your index.html
 <script src="_framework/blazor.webassembly.js" autostart="false"></script>
 <script>
 Blazor.start({
-    configureRuntime: function (builder) {
-        builder.withConfig({
+    configureRuntime: function (dotnet) {
+        dotnet.withConfig({
             browserProfilerOptions: {}
         });
     }

--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
@@ -86,7 +86,8 @@
     {
         await DisposeHubConnection();
         // exit the client
-        Environment.Exit(0);
+        Helper.TestOutputWriteLine($"SendExitSignal by CurrentManagedThreadId={Environment.CurrentManagedThreadId}");
+        await JSRuntime.InvokeVoidAsync("eval", "setTimeout(() => { getDotnetRuntime(0).exit(0); }, 50);");
     }
 
     private async Task DisposeHubConnection()

--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
@@ -86,7 +86,7 @@
     {
         await DisposeHubConnection();
         // exit the client
-        await JSRuntime.InvokeVoidAsync("eval", "import('./dotnet.js').then(module => { module.dotnet; module.exit(0); });");
+        await JSRuntime.InvokeVoidAsync("eval", "getDotnetRuntime(0).exit(0);");
     }
 
     private async Task DisposeHubConnection()

--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Pages/Chat.razor
@@ -86,7 +86,7 @@
     {
         await DisposeHubConnection();
         // exit the client
-        await JSRuntime.InvokeVoidAsync("eval", "getDotnetRuntime(0).exit(0);");
+        Environment.Exit(0);
     }
 
     private async Task DisposeHubConnection()

--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/wwwroot/index.html
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/wwwroot/index.html
@@ -16,7 +16,14 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+    <script>
+        Blazor.start({
+            configureRuntime: function (dotnet) {
+                dotnet.withExitCodeLogging();
+            }
+        });
+    </script>
 </body>
 
 </html>

--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Server/appsettings.json
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Server/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+        "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
- fixed `compareExchangeI32` 🤦‍♂️
- unregister from `FinalizationRegistry` in `upgrade_managed_proxy_to_strong_ref`
- more testing if the runtime is still running
- testing if the promise holder is already disposed
- added `exit` to `RuntimeAPI`
- improve `BlazorHosted` WBT exit
- make `assert_runtime_running` always throw, in order to really protect the code after it.
   - make it not configurable by dropping `withAssertAfterExit`

Contributes to https://github.com/dotnet/runtime/issues/98721