### PR TITLE
JIT: Fix build on GCC

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5250,7 +5250,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 #elif FEATURE_SIMD
         fprintf(compJitFuncInfoFile, " %s\n", eeGetMethodFullName(info.compMethodHnd));
 #endif
-        fprintf(compJitFuncInfoFile, ""); // in our logic this causes a flush
+        fflush(compJitFuncInfoFile);
     }
 #endif // FUNC_INFO_LOGGING
 }


### PR DESCRIPTION
Otherwise, building `compiler.cpp` would trigger a zero-length format string error.

https://github.com/dotnet/runtime/blob/4e86b1c63d9c41c6bfb6f42710be907199ce2671/src/coreclr/jit/compiler.cpp#L5253