### PR TITLE
[WIP] Use `ISimdVector` for `TensorPrimitives` in .NET 9+

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IAggregationOperator.cs
@@ -15,9 +15,7 @@ namespace System.Numerics.Tensors
         /// <summary><see cref="IBinaryOperator{T}"/> that specializes horizontal aggregation of all elements in a vector.</summary>
         private interface IAggregationOperator<T> : IBinaryOperator<T>
         {
-            static abstract T Invoke(Vector128<T> x);
-            static abstract T Invoke(Vector256<T> x);
-            static abstract T Invoke(Vector512<T> x);
+            static abstract T Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T>;
 
             static virtual T IdentityValue => throw new NotSupportedException();
         }
@@ -31,7 +29,7 @@ namespace System.Numerics.Tensors
         /// </typeparam>
         private static T Aggregate<T, TTransformOperator, TAggregationOperator>(
             ReadOnlySpan<T> x)
-            where TTransformOperator : struct, IUnaryOperator<T, T>
+            where TTransformOperator : struct, IUnaryOperator<T>
             where TAggregationOperator : struct, IAggregationOperator<T>
         {
             // Since every branch has a cost and since that cost is

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IStatefulUnaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IStatefulUnaryOperator.cs
@@ -17,9 +17,7 @@ namespace System.Numerics.Tensors
         {
             static abstract bool Vectorizable { get; }
             T Invoke(T x);
-            Vector128<T> Invoke(Vector128<T> x);
-            Vector256<T> Invoke(Vector256<T> x);
-            Vector512<T> Invoke(Vector512<T> x);
+            TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T>;
         }
 
         /// <summary>Performs an element-wise operation on <paramref name="x"/> and writes the results to <paramref name="destination"/>.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.ITernaryOperator.cs
@@ -16,9 +16,27 @@ namespace System.Numerics.Tensors
         private interface ITernaryOperator<T>
         {
             static abstract T Invoke(T x, T y, T z);
-            static abstract Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z);
-            static abstract Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z);
-            static abstract Vector512<T> Invoke(Vector512<T> x, Vector512<T> y, Vector512<T> z);
+            static abstract TVector Invoke<TVector>(TVector x, TVector y, TVector z) where TVector : struct, ISimdVector<TVector, T>;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static TVector TernaryOperatorAutoImpl<T, TTernaryOperator, TVector>(TVector x, TVector y, TVector z) where TTernaryOperator : struct, ITernaryOperator<T> where TVector : struct, ISimdVector<TVector, T>
+        {
+            if (sizeof(TVector) == sizeof(Vector128<T>))
+            {
+                Debug.Fail("TernaryOperatorAutoImpl not supported for Vector128");
+            }
+            if (sizeof(TVector) == sizeof(Vector256<T>))
+            {
+                return (TVector)(object)Vector256.Create(TTernaryOperator.Invoke(((Vector256<T>)(object)x).GetLower(), ((Vector256<T>)(object)y).GetLower()((Vector256<T>)(object)z).GetLower(), ), TTernaryOperator.Invoke(((Vector256<T>)(object)x).GetUpper(), ((Vector256<T>)(object)y).GetUpper(), ((Vector256<T>)(object)z).GetUpper()));
+            }
+            if (sizeof(TVector) == sizeof(Vector512<T>))
+            {
+                return (TVector)(object)Vector512.Create(TTernaryOperator.Invoke(((Vector512<T>)(object)x).GetLower(), ((Vector512<T>)(object)y).GetLower(), ((Vector512<T>)(object)z).GetLower()), TTernaryOperator.Invoke(((Vector512<T>)(object)x).GetUpper(), ((Vector512<T>)(object)y).GetUpper(), ((Vector512<T>)(object)z).GetUpper()));
+            }
+
+            Debug.Fail("Unsupported vector type.");
+            retuen default;
         }
 
         /// <summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryInputBinaryOutput.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/Common/TensorPrimitives.IUnaryInputBinaryOutput.cs
@@ -14,9 +14,7 @@ namespace System.Numerics.Tensors
         {
             static abstract bool Vectorizable { get; }
             static abstract (T, T) Invoke(T x);
-            static abstract (Vector128<T> First, Vector128<T> Second) Invoke(Vector128<T> x);
-            static abstract (Vector256<T> First, Vector256<T> Second) Invoke(Vector256<T> x);
-            static abstract (Vector512<T> First, Vector512<T> Second) Invoke(Vector512<T> x);
+            static abstract (TVector First, TVector Second) Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T>;
         }
 
         /// <summary>Performs an element-wise operation on <paramref name="x"/> and writes the results to <paramref name="destination1"/> and <paramref name="destination2"/>.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Abs.cs
@@ -31,14 +31,14 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AbsoluteOperator<T>>(x, destination);
 
         /// <summary>T.Abs(x)</summary>
-        internal readonly struct AbsoluteOperator<T> : IUnaryOperator<T, T> where T : INumberBase<T>
+        internal readonly struct AbsoluteOperator<T> : IUnaryOperator<T> where T : INumberBase<T>
         {
             public static bool Vectorizable => true;
 
             public static T Invoke(T x) => T.Abs(x);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static Vector128<T> Invoke(Vector128<T> x)
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T>
             {
                 if (typeof(T) == typeof(sbyte) ||
                     typeof(T) == typeof(short) ||
@@ -49,58 +49,14 @@ namespace System.Numerics.Tensors
                     // Handle signed integers specially, in order to throw if any attempt is made to
                     // take the absolute value of the minimum value of the type, which doesn't have
                     // a positive absolute value representation.
-                    Vector128<T> abs = Vector128.ConditionalSelect(Vector128.LessThan(x, Vector128<T>.Zero), -x, x);
-                    if (Vector128.LessThan(abs, Vector128<T>.Zero) != Vector128<T>.Zero)
+                    TVector abs = TVector.ConditionalSelect(TVector.LessThan(x, TVector.Zero), -x, x);
+                    if (TVector.LessThan(abs, TVector.Zero) != TVector.Zero)
                     {
                         ThrowNegateTwosCompOverflow();
                     }
                 }
 
-                return Vector128.Abs(x);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static Vector256<T> Invoke(Vector256<T> x)
-            {
-                if (typeof(T) == typeof(sbyte) ||
-                    typeof(T) == typeof(short) ||
-                    typeof(T) == typeof(int) ||
-                    typeof(T) == typeof(long) ||
-                    typeof(T) == typeof(nint))
-                {
-                    // Handle signed integers specially, in order to throw if any attempt is made to
-                    // take the absolute value of the minimum value of the type, which doesn't have
-                    // a positive absolute value representation.
-                    Vector256<T> abs = Vector256.ConditionalSelect(Vector256.LessThan(x, Vector256<T>.Zero), -x, x);
-                    if (Vector256.LessThan(abs, Vector256<T>.Zero) != Vector256<T>.Zero)
-                    {
-                        ThrowNegateTwosCompOverflow();
-                    }
-                }
-
-                return Vector256.Abs(x);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static Vector512<T> Invoke(Vector512<T> x)
-            {
-                if (typeof(T) == typeof(sbyte) ||
-                    typeof(T) == typeof(short) ||
-                    typeof(T) == typeof(int) ||
-                    typeof(T) == typeof(long) ||
-                    typeof(T) == typeof(nint))
-                {
-                    // Handle signed integers specially, in order to throw if any attempt is made to
-                    // take the absolute value of the minimum value of the type, which doesn't have
-                    // a positive absolute value representation.
-                    Vector512<T> abs = Vector512.ConditionalSelect(Vector512.LessThan(x, Vector512<T>.Zero), -x, x);
-                    if (Vector512.LessThan(abs, Vector512<T>.Zero) != Vector512<T>.Zero)
-                    {
-                        ThrowNegateTwosCompOverflow();
-                    }
-                }
-
-                return Vector512.Abs(x);
+                return TVector.Abs(x);
             }
         }
     }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Acos.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Acos.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AcosOperator<T>>(x, destination);
 
         /// <summary>T.Acos(x)</summary>
-        private readonly struct AcosOperator<T> : IUnaryOperator<T, T>
+        private readonly struct AcosOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Acos(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AcosPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AcosPi.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AcosPiOperator<T>>(x, destination);
 
         /// <summary>T.AcosPi(x)</summary>
-        private readonly struct AcosPiOperator<T> : IUnaryOperator<T, T>
+        private readonly struct AcosPiOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => AcosOperator<T>.Vectorizable;
             public static T Invoke(T x) => T.AcosPi(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => AcosOperator<T>.Invoke(x) / Vector128.Create(T.Pi);
-            public static Vector256<T> Invoke(Vector256<T> x) => AcosOperator<T>.Invoke(x) / Vector256.Create(T.Pi);
-            public static Vector512<T> Invoke(Vector512<T> x) => AcosOperator<T>.Invoke(x) / Vector512.Create(T.Pi);
+            public static TVector Invoke(TVector x) where TVector : struct, ISimdVector<TVector, T> => AcosOperator<T>.Invoke(x) / TVector.Create(T.Pi);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Acosh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Acosh.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AcoshOperator<T>>(x, destination);
 
         /// <summary>T.Acosh(x)</summary>
-        private readonly struct AcoshOperator<T> : IUnaryOperator<T, T>
+        private readonly struct AcoshOperator<T> : IUnaryOperator<T>
             where T : IHyperbolicFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Acosh(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Add.cs
@@ -51,13 +51,8 @@ namespace System.Numerics.Tensors
             public static bool Vectorizable => true;
 
             public static T Invoke(T x, T y) => x + y;
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => x + y;
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => x + y;
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => x + y;
-
-            public static T Invoke(Vector128<T> x) => Vector128.Sum(x);
-            public static T Invoke(Vector256<T> x) => Vector256.Sum(x);
-            public static T Invoke(Vector512<T> x) => Vector512.Sum(x);
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T> => x + y;
+            public static T Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => TVector.Sum(x);
 
             public static T IdentityValue => T.AdditiveIdentity;
         }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AddMultiply.cs
@@ -75,9 +75,7 @@ namespace System.Numerics.Tensors
         internal readonly struct AddMultiplyOperator<T> : ITernaryOperator<T> where T : IAdditionOperators<T, T, T>, IMultiplyOperators<T, T, T>
         {
             public static T Invoke(T x, T y, T z) => (x + y) * z;
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> z) => (x + y) * z;
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> z) => (x + y) * z;
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y, Vector512<T> z) => (x + y) * z;
+            public static TVector Invoke<TVector>(TVector x, TVector y, TVector z) where TVector : struct, ISimdVector<TVector, T> => (x + y) * z;
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Asin.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Asin.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AsinOperator<T>>(x, destination);
 
         /// <summary>T.Asin(x)</summary>
-        private readonly struct AsinOperator<T> : IUnaryOperator<T, T>
+        private readonly struct AsinOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Asin(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AsinPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AsinPi.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AsinPiOperator<T>>(x, destination);
 
         /// <summary>T.AsinPi(x)</summary>
-        private readonly struct AsinPiOperator<T> : IUnaryOperator<T, T>
+        private readonly struct AsinPiOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => AsinOperator<T>.Vectorizable;
             public static T Invoke(T x) => T.AsinPi(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => AsinOperator<T>.Invoke(x) / Vector128.Create(T.Pi);
-            public static Vector256<T> Invoke(Vector256<T> x) => AsinOperator<T>.Invoke(x) / Vector256.Create(T.Pi);
-            public static Vector512<T> Invoke(Vector512<T> x) => AsinOperator<T>.Invoke(x) / Vector512.Create(T.Pi);
+            public static TVector Invoke(TVector x) where TVector : struct, ISimdVector<TVector, T> => AsinOperator<T>.Invoke(x) / TVector.Create(T.Pi);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Asinh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Asinh.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AsinhOperator<T>>(x, destination);
 
         /// <summary>T.Asinh(x)</summary>
-        internal readonly struct AsinhOperator<T> : IUnaryOperator<T, T>
+        internal readonly struct AsinhOperator<T> : IUnaryOperator<T>
             where T : IHyperbolicFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Asinh(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AtanOperator<T>>(x, destination);
 
         /// <summary>T.Atan(x)</summary>
-        internal readonly struct AtanOperator<T> : IUnaryOperator<T, T>
+        internal readonly struct AtanOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Atan(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan2.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan2.cs
@@ -72,9 +72,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T y, T x) => T.Atan2(y, x);
-            public static Vector128<T> Invoke(Vector128<T> y, Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> y, Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> y, Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector y, TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan2Pi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan2Pi.cs
@@ -72,9 +72,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => Atan2Operator<T>.Vectorizable;
             public static T Invoke(T y, T x) => T.Atan2Pi(y, x);
-            public static Vector128<T> Invoke(Vector128<T> y, Vector128<T> x) => Atan2Operator<T>.Invoke(y, x) / Vector128.Create(T.Pi);
-            public static Vector256<T> Invoke(Vector256<T> y, Vector256<T> x) => Atan2Operator<T>.Invoke(y, x) / Vector256.Create(T.Pi);
-            public static Vector512<T> Invoke(Vector512<T> y, Vector512<T> x) => Atan2Operator<T>.Invoke(y, x) / Vector512.Create(T.Pi);
+            public static TVector Invoke<TVector>(TVector y, TVector x) where TVector : struct, ISimdVector<TVector, T> => Atan2Operator<T>.Invoke(y, x) / TVector.Create(T.Pi);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AtanPi.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.AtanPi.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AtanPiOperator<T>>(x, destination);
 
         /// <summary>T.AtanPi(x)</summary>
-        internal readonly struct AtanPiOperator<T> : IUnaryOperator<T, T>
+        internal readonly struct AtanPiOperator<T> : IUnaryOperator<T>
             where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => AtanOperator<T>.Vectorizable;
             public static T Invoke(T x) => T.AtanPi(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => AtanOperator<T>.Invoke(x) / Vector128.Create(T.Pi);
-            public static Vector256<T> Invoke(Vector256<T> x) => AtanOperator<T>.Invoke(x) / Vector256.Create(T.Pi);
-            public static Vector512<T> Invoke(Vector512<T> x) => AtanOperator<T>.Invoke(x) / Vector512.Create(T.Pi);
+            public static TVector Invoke(TVector x) where TVector : struct, ISimdVector<TVector, T> => AtanOperator<T>.Invoke(x) / TVector.Create(T.Pi);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atanh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atanh.cs
@@ -26,14 +26,12 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, AtanhOperator<T>>(x, destination);
 
         /// <summary>T.Atanh(x)</summary>
-        internal readonly struct AtanhOperator<T> : IUnaryOperator<T, T>
+        internal readonly struct AtanhOperator<T> : IUnaryOperator<T>
             where T : IHyperbolicFunctions<T>
         {
             public static bool Vectorizable => false; // TODO: Vectorize
             public static T Invoke(T x) => T.Atanh(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseAnd.cs
@@ -44,9 +44,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
             public static T Invoke(T x, T y) => x & y;
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => x & y;
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => x & y;
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => x & y;
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T> => x & y;
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.BitwiseOr.cs
@@ -44,9 +44,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
             public static T Invoke(T x, T y) => x | y;
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => x | y;
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => x | y;
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => x | y;
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T> => x | y;
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cbrt.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cbrt.cs
@@ -23,49 +23,23 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, CbrtOperator<T>>(x, destination);
 
         /// <summary>T.Cbrt(x)</summary>
-        private readonly struct CbrtOperator<T> : IUnaryOperator<T, T>
+        private readonly struct CbrtOperator<T> : IUnaryOperator<T>
             where T : IRootFunctions<T>
         {
             public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);
 
             public static T Invoke(T x) => T.Cbrt(x);
 
-            public static Vector128<T> Invoke(Vector128<T> x)
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T>
             {
                 if (typeof(T) == typeof(float))
                 {
-                    return ExpOperator<float>.Invoke(LogOperator<float>.Invoke(x.AsSingle()) / Vector128.Create(3f)).As<float, T>();
+                    return ExpOperator<float>.Invoke(LogOperator<float>.Invoke(x.AsSingle()) / TVector.Create(3f)).As<float, T>();
                 }
                 else
                 {
                     Debug.Assert(typeof(T) == typeof(double));
-                    return ExpOperator<double>.Invoke(LogOperator<double>.Invoke(x.AsDouble()) / Vector128.Create(3d)).As<double, T>();
-                }
-            }
-
-            public static Vector256<T> Invoke(Vector256<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return ExpOperator<float>.Invoke(LogOperator<float>.Invoke(x.AsSingle()) / Vector256.Create(3f)).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return ExpOperator<double>.Invoke(LogOperator<double>.Invoke(x.AsDouble()) / Vector256.Create(3d)).As<double, T>();
-                }
-            }
-
-            public static Vector512<T> Invoke(Vector512<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return ExpOperator<float>.Invoke(LogOperator<float>.Invoke(x.AsSingle()) / Vector512.Create(3f)).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return ExpOperator<double>.Invoke(LogOperator<double>.Invoke(x.AsDouble()) / Vector512.Create(3d)).As<double, T>();
+                    return ExpOperator<double>.Invoke(LogOperator<double>.Invoke(x.AsDouble()) / TVector.Create(3d)).As<double, T>();
                 }
             }
         }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ceiling.cs
@@ -22,50 +22,13 @@ namespace System.Numerics.Tensors
             where T : IFloatingPoint<T> =>
             InvokeSpanIntoSpan<T, CeilingOperator<T>>(x, destination);
 
-        private readonly struct CeilingOperator<T> : IUnaryOperator<T, T> where T : IFloatingPoint<T>
+        private readonly struct CeilingOperator<T> : IUnaryOperator<T> where T : IFloatingPoint<T>
         {
             public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);
 
             public static T Invoke(T x) => T.Ceiling(x);
 
-            public static Vector128<T> Invoke(Vector128<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector128.Ceiling(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector128.Ceiling(x.AsDouble()).As<double, T>();
-                }
-            }
-
-            public static Vector256<T> Invoke(Vector256<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector256.Ceiling(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector256.Ceiling(x.AsDouble()).As<double, T>();
-                }
-            }
-
-            public static Vector512<T> Invoke(Vector512<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector512.Ceiling(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector512.Ceiling(x.AsDouble()).As<double, T>();
-                }
-            }
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => TVector.Ceiling(x);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.CopySign.cs
@@ -45,85 +45,29 @@ namespace System.Numerics.Tensors
 
             public static T Invoke(T x, T y) => T.CopySign(x, y);
 
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y)
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T>
             {
                 if (typeof(T) == typeof(float))
                 {
-                    return Vector128.ConditionalSelect(Vector128.Create(-0.0f).As<float, T>(), y, x);
+                    return TVector.ConditionalSelect(TVector.Create((T)(object)(-0.0f)), y, x);
                 }
 
                 if (typeof(T) == typeof(double))
                 {
-                    return Vector128.ConditionalSelect(Vector128.Create(-0.0d).As<double, T>(), y, x);
+                    return TVector.ConditionalSelect(TVector.Create((T)(object)(-0.0d)), y, x);
                 }
 
                 if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(short) || typeof(T) == typeof(int) || typeof(T) == typeof(long) || typeof(T) == typeof(nint))
                 {
-                    Vector128<T> absValue = Vector128.Abs(x);
-                    Vector128<T> sign = Vector128.GreaterThanOrEqual(y, Vector128<T>.Zero);
-                    Vector128<T> error = sign & Vector128.LessThan(absValue, Vector128<T>.Zero);
-                    if (error != Vector128<T>.Zero)
+                    TVector absValue = TVector.Abs(x);
+                    TVector sign = TVector.GreaterThanOrEqual(y, TVector.Zero);
+                    TVector error = sign & TVector.LessThan(absValue, TVector.Zero);
+                    if (error != TVector.Zero)
                     {
                         Math.Abs(int.MinValue); // throw OverflowException
                     }
 
-                    return Vector128.ConditionalSelect(sign, absValue, -absValue);
-                }
-
-                return x;
-            }
-
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector256.ConditionalSelect(Vector256.Create(-0.0f).As<float, T>(), y, x);
-                }
-
-                if (typeof(T) == typeof(double))
-                {
-                    return Vector256.ConditionalSelect(Vector256.Create(-0.0d).As<double, T>(), y, x);
-                }
-
-                if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(short) || typeof(T) == typeof(int) || typeof(T) == typeof(long) || typeof(T) == typeof(nint))
-                {
-                    Vector256<T> absValue = Vector256.Abs(x);
-                    Vector256<T> sign = Vector256.GreaterThanOrEqual(y, Vector256<T>.Zero);
-                    Vector256<T> error = sign & Vector256.LessThan(absValue, Vector256<T>.Zero);
-                    if (error != Vector256<T>.Zero)
-                    {
-                        Math.Abs(int.MinValue); // throw OverflowException
-                    }
-
-                    return Vector256.ConditionalSelect(sign, absValue, -absValue);
-                }
-
-                return x;
-            }
-
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector512.ConditionalSelect(Vector512.Create(-0.0f).As<float, T>(), y, x);
-                }
-
-                if (typeof(T) == typeof(double))
-                {
-                    return Vector512.ConditionalSelect(Vector512.Create(-0.0d).As<double, T>(), y, x);
-                }
-
-                if (typeof(T) == typeof(sbyte) || typeof(T) == typeof(short) || typeof(T) == typeof(int) || typeof(T) == typeof(long) || typeof(T) == typeof(nint))
-                {
-                    Vector512<T> absValue = Vector512.Abs(x);
-                    Vector512<T> sign = Vector512.GreaterThanOrEqual(y, Vector512<T>.Zero);
-                    Vector512<T> error = sign & Vector512.LessThan(absValue, Vector512<T>.Zero);
-                    if (error != Vector512<T>.Zero)
-                    {
-                        Math.Abs(int.MinValue); // throw OverflowException
-                    }
-
-                    return Vector512.ConditionalSelect(sign, absValue, -absValue);
+                    return TVector.ConditionalSelect(sign, absValue, -absValue);
                 }
 
                 return x;

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.DegreesToRadians.cs
@@ -22,13 +22,11 @@ namespace System.Numerics.Tensors
             InvokeSpanIntoSpan<T, DegreesToRadiansOperator<T>>(x, destination);
 
         /// <summary>T.DegreesToRadians(x)</summary>
-        private readonly struct DegreesToRadiansOperator<T> : IUnaryOperator<T, T> where T : ITrigonometricFunctions<T>
+        private readonly struct DegreesToRadiansOperator<T> : IUnaryOperator<T> where T : ITrigonometricFunctions<T>
         {
             public static bool Vectorizable => true;
             public static T Invoke(T x) => T.DegreesToRadians(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => (x * T.Pi) / T.CreateChecked(180);
-            public static Vector256<T> Invoke(Vector256<T> x) => (x * T.Pi) / T.CreateChecked(180);
-            public static Vector512<T> Invoke(Vector512<T> x) => (x * T.Pi) / T.CreateChecked(180);
+            public static TVector Invoke<TVector>(TVector x) where TVector : struct, ISimdVector<TVector, T> => (x * T.Pi) / T.CreateChecked(180);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Distance.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Distance.cs
@@ -53,21 +53,9 @@ namespace System.Numerics.Tensors
                 return tmp * tmp;
             }
 
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y)
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T>
             {
-                Vector128<T> tmp = x - y;
-                return tmp * tmp;
-            }
-
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y)
-            {
-                Vector256<T> tmp = x - y;
-                return tmp * tmp;
-            }
-
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y)
-            {
-                Vector512<T> tmp = x - y;
+                TVector tmp = x - y;
                 return tmp * tmp;
             }
         }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Divide.cs
@@ -71,9 +71,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
             public static T Invoke(T x, T y) => x / y;
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => x / y;
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => x / y;
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => x / y;
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : ISimdVector<TVector, T> => x / y;
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Floor.cs
@@ -28,44 +28,7 @@ namespace System.Numerics.Tensors
 
             public static T Invoke(T x) => T.Floor(x);
 
-            public static Vector128<T> Invoke(Vector128<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector128.Floor(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector128.Floor(x.AsDouble()).As<double, T>();
-                }
-            }
-
-            public static Vector256<T> Invoke(Vector256<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector256.Floor(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector256.Floor(x.AsDouble()).As<double, T>();
-                }
-            }
-
-            public static Vector512<T> Invoke(Vector512<T> x)
-            {
-                if (typeof(T) == typeof(float))
-                {
-                    return Vector512.Floor(x.AsSingle()).As<float, T>();
-                }
-                else
-                {
-                    Debug.Assert(typeof(T) == typeof(double));
-                    return Vector512.Floor(x.AsDouble()).As<double, T>();
-                }
-            }
+            public static TVector Invoke(TVector x) where TVector : struct, ISimdVector<TVector, T> => TVector.Floor(x);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Hypot.cs
@@ -30,9 +30,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => true;
             public static T Invoke(T x, T y) => T.Hypot(x, y);
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => Vector128.Sqrt((x * x) + (y * y));
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => Vector256.Sqrt((x * x) + (y * y));
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => Vector512.Sqrt((x * x) + (y * y));
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T> => TVector.Sqrt((x * x) + (y * y));
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ieee754Remainder.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Ieee754Remainder.cs
@@ -60,9 +60,7 @@ namespace System.Numerics.Tensors
         {
             public static bool Vectorizable => false;
             public static T Invoke(T x, T y) => T.Ieee754Remainder(x, y);
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y) => throw new NotSupportedException();
+            public static TVector Invoke<TVector>(TVector x, TVector y) where TVector : struct, ISimdVector<TVector, T> => throw new NotSupportedException();
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Lerp.cs
@@ -75,9 +75,7 @@ namespace System.Numerics.Tensors
         private readonly struct LerpOperator<T> : ITernaryOperator<T> where T : IFloatingPointIeee754<T>
         {
             public static T Invoke(T x, T y, T amount) => T.Lerp(x, y, amount);
-            public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y, Vector128<T> amount) => (x * (Vector128<T>.One - amount)) + (y * amount);
-            public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y, Vector256<T> amount) => (x * (Vector256<T>.One - amount)) + (y * amount);
-            public static Vector512<T> Invoke(Vector512<T> x, Vector512<T> y, Vector512<T> amount) => (x * (Vector512<T>.One - amount)) + (y * amount);
+            public static TVector Invoke<TVector>(TVector x, TVector y, TVector amount) where TVector : struct, ISimdVector<TVector, T> => (x * (TVector.One - amount)) + (y * amount);
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Pow.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Pow.cs
@@ -56,7 +56,7 @@ namespace System.Numerics.Tensors
             InvokeScalarSpanIntoSpan<T, PowOperator<T>>(x, y, destination);
 
         /// <summary>T.Pow(x, y)</summary>
-        private readonly struct PowOperator<T> : IBinaryOperator<T>
+        private readonly struct PowOperator<T> : IManualBinaryOperator<T>
             where T : IPowerFunctions<T>
         {
             public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);


### PR DESCRIPTION
🚧 WIP 🚧
- Use `ISimdVector` for `TensorPrimitives` in .NET 9+ on applicable APIs
- Not all implemented, nor compilable currently
- Currently just changing the files as if <9 doesn't exist, once all are implemented and we've figured it out enough, I will split the changed files into pre 9 and 9+ files, or similar
- When <9 is no longer supported, we can keep just the new versions of the files, which use `ISimdVector`