### PR TITLE
[mono][interp] Remove MINT_CKNULL when doing a virtcall

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -4274,6 +4274,7 @@ main_loop:
 			call_args_offset = ip [2];
 
 			this_arg = LOCAL_VAR (call_args_offset, MonoObject*);
+			NULL_CHECK (this_arg);
 
 			slot = (gint16)ip [4];
 			ip += 5;


### PR DESCRIPTION
Callvirt opcode always dereferences this ptr for vtable lookup. We can do the null check in the callvirt opcode instead of adding a separate CKNULL instruction.

On System.Runtime.Tests suite this leads to removal of around 0.7% of executed opcodes.