### PR TITLE
[release/8.0][browser] Fix failures in `CalendarTestBase` affecting several globalization tests 

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
@@ -170,7 +170,9 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
-            string[] norwegianMonths = new string [] { "jan.", "feb.", "mars", "apr.", "mai", "juni", "juli", "aug.", "sep.", "okt.", "nov.", "des.", "" }; // "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "
+            string[] norwegianMonths = PlatformDetection.IsBrowserDomSupported ? // dotnet responds like non-browser
+                new string [] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" } :
+                new string [] { "jan.", "feb.", "mars", "apr.", "mai", "juni", "juli", "aug.", "sep.", "okt.", "nov.", "des.", "" };
             yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, norwegianMonths };
             yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, norwegianMonths };
             string[] dutchMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoAbbreviatedMonthGenitiveNames.cs
@@ -170,8 +170,9 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("ms-BN").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-MY").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
             yield return new object[] { new CultureInfo("ms-SG").DateTimeFormat, new string[] { "Jan", "Feb", "Mac", "Apr", "Mei", "Jun", "Jul", "Ogo", "Sep", "Okt", "Nov", "Dis", "" } };
-            yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, new string[] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" } };
-            yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, new string[] { "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "" } };
+            string[] norwegianMonths = new string [] { "jan.", "feb.", "mars", "apr.", "mai", "juni", "juli", "aug.", "sep.", "okt.", "nov.", "des.", "" }; // "jan.", "feb.", "mar.", "apr.", "mai", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "des.", "
+            yield return new object[] { new CultureInfo("nb-NO").DateTimeFormat, norwegianMonths };
+            yield return new object[] { new CultureInfo("no-NO").DateTimeFormat, norwegianMonths };
             string[] dutchMonths = PlatformDetection.IsNodeJS ? // NodeJs responds like dotnet
                 new string[] { "jan.", "feb.", "mrt.", "apr.", "mei", "jun.", "jul.", "aug.", "sep.", "okt.", "nov.", "dec.", "" } :
                 new string[] { "jan", "feb", "mrt", "apr", "mei", "jun", "jul", "aug", "sep", "okt", "nov", "dec", "" };

--- a/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
+++ b/src/mono/wasm/runtime/hybrid-globalization/culture-info.ts
@@ -47,8 +47,8 @@ export function mono_wasm_get_culture_info(culture: MonoStringRef, dst: number, 
 
 function getAmPmDesignators(locale: any)
 {
-    const pmTime = new Date("August 19, 1975 12:15:30"); // do not change, some PM hours result in hour digits change, e.g. 13 -> 01 or 1
-    const amTime = new Date("August 19, 1975 11:15:30"); // do not change, some AM hours result in hour digits change, e.g. 9 -> 09
+    const pmTime = new Date("August 19, 1975 12:15:33"); // do not change, some PM hours result in hour digits change, e.g. 13 -> 01 or 1
+    const amTime = new Date("August 19, 1975 11:15:33"); // do not change, some AM hours result in hour digits change, e.g. 9 -> 09
     const pmDesignator = getDesignator(pmTime, locale);
     const amDesignator = getDesignator(amTime, locale);
     return {
@@ -59,7 +59,14 @@ function getAmPmDesignators(locale: any)
 
 function getDesignator(time: Date, locale: string)
 {
-    const withDesignator = time.toLocaleTimeString(locale, { hourCycle: "h12"});
+    let withDesignator = time.toLocaleTimeString(locale, { hourCycle: "h12"});
+    const localizedZero = (0).toLocaleString(locale);
+    if (withDesignator.includes(localizedZero))
+    {
+        // in v8>=11.8 "12" changes to "0" for ja-JP
+        const localizedTwelve = (12).toLocaleString(locale);
+        withDesignator = withDesignator.replace(localizedZero, localizedTwelve);
+    }
     const withoutDesignator = time.toLocaleTimeString(locale, { hourCycle: "h24"});
     const designator = withDesignator.replace(withoutDesignator, "").trim();
     if (new RegExp("[0-9]$").test(designator)){


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/99378.
On net9 the fix was provided in https://github.com/dotnet/runtime/pull/90881, this PR is a partial backport. 

# Description

The failures are caused by changing v8 version. `HybridGlobalization` relies directly on v8's functions output, so with the version change these tests are prone to break. Currently we test on Linux with v8=12.4.105.

# Customer Impact

Users that called globalization APIs connected with time with `HybridGlobalization` on and `ja-JP` locale and are using v8 newer than 11.8 are affected.

# Regression

Yes, with older v8 the output is correct.

# Testing

Existing automated unit tests.

# Risk

Small, it impacts only one specific use-case.
