### PR TITLE
[WIP] [release/8.0][browser] BrowserWebSocket.ReceiveAsync after server initiated close 

### DIFF
--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
@@ -144,6 +144,22 @@ namespace NetCoreServer
                     {
                         await Task.Delay(5000);
                     }
+                    else if (receivedMessage == ".receiveMessageAfterClose")
+                    {
+                        byte[] buffer = new byte[1024];
+                        string message1 = $"{receivedMessage} 1 {DateTime.Now.ToString("HH:mm:ss")}";
+                        buffer = System.Text.Encoding.UTF8.GetBytes(message1);
+                        var stamp = DateTime.Now.ToString("HH:mm:ss");
+                        Console.WriteLine($"[{stamp}]: Sending message: {message1}");
+                        await socket.SendAsync(
+                            new ArraySegment<byte>(buffer, 0, message1.Length),
+                            WebSocketMessageType.Text,
+                            true,
+                            CancellationToken.None);
+                        stamp = DateTime.Now.ToString("HH:mm:ss");
+                        Console.WriteLine($"[{stamp}] Closing the socket");
+                        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, receivedMessage, CancellationToken.None);
+                    }
                     else if (socket.State == WebSocketState.Open)
                     {
                         sendMessage = true;

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
@@ -147,20 +147,14 @@ namespace NetCoreServer
                     else if (receivedMessage == ".receiveMessageAfterClose")
                     {
                         byte[] buffer = new byte[1024];
-                        string message1 = $"{receivedMessage} 1 {DateTime.Now.ToString("HH:mm:ss")}";
-                        buffer = System.Text.Encoding.UTF8.GetBytes(message1);
-                        var stamp = DateTime.Now.ToString("HH:mm:ss");
-                        Console.WriteLine($"[{stamp}] Server => Sending message: {message1}");
+                        string message = $"{receivedMessage} {DateTime.Now.ToString("HH:mm:ss")}";
+                        buffer = System.Text.Encoding.UTF8.GetBytes(message);
                         await socket.SendAsync(
-                            new ArraySegment<byte>(buffer, 0, message1.Length),
+                            new ArraySegment<byte>(buffer, 0, message.Length),
                             WebSocketMessageType.Text,
                             true,
                             CancellationToken.None);
-                        stamp = DateTime.Now.ToString("HH:mm:ss");
-                        Console.WriteLine($"[{stamp}] Server => Closing the socket");
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, receivedMessage, CancellationToken.None);
-                        stamp = DateTime.Now.ToString("HH:mm:ss");
-                        Console.WriteLine($"[{stamp}] Server => Socket got closed");
                     }
                     else if (socket.State == WebSocketState.Open)
                     {

--- a/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
+++ b/src/libraries/Common/tests/System/Net/Prerequisites/NetCoreServer/Handlers/EchoWebSocketHandler.cs
@@ -150,15 +150,17 @@ namespace NetCoreServer
                         string message1 = $"{receivedMessage} 1 {DateTime.Now.ToString("HH:mm:ss")}";
                         buffer = System.Text.Encoding.UTF8.GetBytes(message1);
                         var stamp = DateTime.Now.ToString("HH:mm:ss");
-                        Console.WriteLine($"[{stamp}]: Sending message: {message1}");
+                        Console.WriteLine($"[{stamp}] Server => Sending message: {message1}");
                         await socket.SendAsync(
                             new ArraySegment<byte>(buffer, 0, message1.Length),
                             WebSocketMessageType.Text,
                             true,
                             CancellationToken.None);
                         stamp = DateTime.Now.ToString("HH:mm:ss");
-                        Console.WriteLine($"[{stamp}] Closing the socket");
+                        Console.WriteLine($"[{stamp}] Server => Closing the socket");
                         await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, receivedMessage, CancellationToken.None);
+                        stamp = DateTime.Now.ToString("HH:mm:ss");
+                        Console.WriteLine($"[{stamp}] Server => Socket got closed");
                     }
                     else if (socket.State == WebSocketState.Open)
                     {

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/BrowserWebSockets/BrowserWebSocket.cs
@@ -385,12 +385,6 @@ namespace System.Net.WebSockets
 #endif
                         _closeStatus = (WebSocketCloseStatus)code;
                         _closeStatusDescription = reason;
-                        _closeReceived = true;
-                        WebSocketState state = State;
-                        if (state == WebSocketState.Connecting || state == WebSocketState.Open || state == WebSocketState.CloseSent)
-                        {
-                            FastState = WebSocketState.Closed;
-                        }
 #if FEATURE_WASM_THREADS
                     } //lock
 #endif

--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -374,23 +374,27 @@ namespace System.Net.WebSockets.Client.Tests
             using (ClientWebSocket cws = await GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
             {
                 var cts = new CancellationTokenSource(TimeOutMilliseconds);
-
                 await cws.SendAsync(
                     WebSocketData.GetBufferFromText(".receiveMessageAfterClose"),
                     WebSocketMessageType.Text,
                     true,
                     cts.Token);
 
-                var recvBuffer = new ArraySegment<byte>(new byte[1024]);
-                await Task.Delay(2000); // even if we decrease to 100, it still fails with
+                int delay = 2000;
+                var stamp = DateTime.Now.ToString("HH:mm:ss");
+                Console.WriteLine($"[{stamp}] Client -> '.receiveMessageAfterClose' was sent, waiting {delay}ms. cws.State={cws.State}");
+                await Task.Delay(delay); // even if we decrease to 100, it still fails with
                 // System.Net.WebSockets.WebSocketException : The WebSocket is in an invalid state ('Closed') for this operation. Valid states are: 'Open, CloseSent'
                 // in the manual demo we can wait even 6 sec and the message arrives just fine
-                var stamp = DateTime.Now.ToString("HH:mm:ss");
-                Console.WriteLine($"[{stamp}] Attempting to receive data... cws.State={cws.State}");
+
+                stamp = DateTime.Now.ToString("HH:mm:ss");
+                Console.WriteLine($"[{stamp}] Client -> Attempting to receive data... cws.State={cws.State}");
+                var recvBuffer = new ArraySegment<byte>(new byte[1024]);
                 WebSocketReceiveResult recvResult = await cws.ReceiveAsync(recvBuffer, cts.Token);
                 var message = Encoding.UTF8.GetString(recvBuffer.ToArray(), 0, recvResult.Count);
+
                 stamp = DateTime.Now.ToString("HH:mm:ss");
-                Console.WriteLine($"[{stamp}] Received message={message}");
+                Console.WriteLine($"[{stamp}] Client -> Received message={message}");
                 Assert.Contains(".shutdownAfterTwoMessages 1", message);
                 Console.WriteLine($"cws.State={cws.State}");
             }

--- a/src/mono/wasm/runtime/web-socket.ts
+++ b/src/mono/wasm/runtime/web-socket.ts
@@ -175,15 +175,6 @@ export function ws_wasm_receive(ws: WebSocketExtension, buffer_ptr: VoidPtr, buf
         return null;
     }
 
-    const readyState = ws.readyState;
-    if (readyState == WebSocket.CLOSED) {
-        const receive_status_ptr = ws[wasm_ws_receive_status_ptr];
-        setI32(receive_status_ptr, 0); // count
-        setI32(<any>receive_status_ptr + 4, 2); // type:close
-        setI32(<any>receive_status_ptr + 8, 1);// end_of_message: true
-        return null;
-    }
-
     const { promise, promise_control } = createPromiseController<void>();
     const receive_promise_control = promise_control as ReceivePromiseControl;
     receive_promise_control.buffer_ptr = buffer_ptr;


### PR DESCRIPTION
Follow up for https://github.com/dotnet/runtime/pull/97002.

1) Add tests for receiving messages after closing the socket in 2 situations:
- C# and JS synchronized the websocket states after close and C# knows server closed it (client checked the WS state) -> throw exception.
- Client did not check the WS state, JS got the "onClose" event but it did not get propagated to C# -> receive the buffered messages.
2) Change logic of closing:
- We used to inform C# at once about receiving "onClose" event in JS (setting "closeReceived = true" and changing the state). This lead to a situation where we could get "receive" request from the client when WS was already in "closeReceived" state and we were not leaving a possibility to receive buffered messages.
- Now we let the "receive" event to arrive and leave a promise in JS even when WS got already closed.