### PR TITLE
[browser][MT] dedicated io thread

### DIFF
--- a/eng/testing/WasmRunnerTemplate.cmd
+++ b/eng/testing/WasmRunnerTemplate.cmd
@@ -59,6 +59,9 @@ if /I [%XHARNESS_COMMAND%] == [test] (
     if [%BROWSER_PATH%] == [] if not [%HELIX_CORRELATION_PAYLOAD%] == [] (
         set "BROWSER_PATH=--browser-path^=%HELIX_CORRELATION_PAYLOAD%\chrome-win\chrome.exe"
     )
+    if [%JS_ENGINE_ARGS%] == [] (
+        set "JS_ENGINE_ARGS=--browser-arg^=--js-flags^=--stack-trace-limit^=1000"
+    )
 )
 
 if [%XHARNESS_ARGS%] == [] (

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -58,6 +58,10 @@ if [[ "$XHARNESS_COMMAND" == "test" ]]; then
 			fi
 		fi
 	fi
+else
+	if [[ -z "$JS_ENGINE_ARGS" ]]; then
+		JS_ENGINE_ARGS="--browser-arg=--js-flags=--stack-trace-limit=1000"
+	fi
 fi
 
 if [[ -z "$XHARNESS_ARGS" ]]; then

--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -87,7 +87,6 @@
     <_AppArgs Condition="'$(IsFunctionalTest)' != 'true' and '$(WasmMainAssemblyFileName)' != ''">--run $(WasmMainAssemblyFileName)</_AppArgs>
     <_AppArgs Condition="'$(IsFunctionalTest)' == 'true'">--run $(AssemblyName).dll</_AppArgs>
 
-    <_XUnitBackgroundExec Condition="'$(_XUnitBackgroundExec)' == '' and '$(WasmEnableThreads)' == 'true'">true</_XUnitBackgroundExec>
     <WasmTestAppArgs Condition="'$(_XUnitBackgroundExec)' == 'true'">$(WasmTestAppArgs) -backgroundExec</WasmTestAppArgs>
     <WasmXHarnessMonoArgs Condition="'$(_XUnitBackgroundExec)' == 'true'">$(WasmXHarnessMonoArgs) --setenv=IsWasmBackgroundExec=true</WasmXHarnessMonoArgs>
     <_AppArgs Condition="'$(WasmTestAppArgs)' != ''">$(_AppArgs) $(WasmTestAppArgs)</_AppArgs>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/BrowserHttpInterop.cs
@@ -147,7 +147,7 @@ namespace System.Net.Http
                     }
                 }, (promise, jsController)))
                 {
-                    await promise.ConfigureAwait(true);
+                    await promise.ConfigureAwait(false);
                 }
             }
             catch (OperationCanceledException oce) when (cancellationToken.IsCancellationRequested)

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_AllowXmlAttributes.cs
@@ -273,7 +273,7 @@ namespace System.Xml.XmlSchemaTests
             if (xsdFile != null)
                 xss.Add(null, Path.Combine(testData, xsdFile));
 
-            XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, allowXmlAttributes);
+            using XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, allowXmlAttributes);
             while (vr.Read()) ;
 
             Assert.Equal(warningCount, expectedWarningCount);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_EnableUpaCheck.cs
@@ -146,7 +146,7 @@ namespace System.Xml.XmlSchemaTests
             xss.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             xss.Add(null, Path.Combine(testData, xsdFile));
 
-            XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, false);
+            using XmlReader vr = CreateReader(Path.Combine(testData, xmlFile), xss, false);
             while (vr.Read()) ;
 
             CError.Compare(errorCount, expectedErrorCount, "Error Count mismatch");

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
@@ -89,7 +89,7 @@ namespace System.Xml.XmlSchemaTests
                                        XmlSchemaValidationFlags.ProcessInlineSchema;
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             settings.Schemas.Add(ss);
-            XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "bug115049.xml"), settings);
+            using XmlReader vr = XmlReader.Create(Path.Combine(TestData._Root, "bug115049.xml"), settings);
             while (vr.Read()) ;
             CError.Compare(errorCount, 1, "Error Count mismatch!");
             return;
@@ -108,7 +108,7 @@ namespace System.Xml.XmlSchemaTests
                                        XmlSchemaValidationFlags.ProcessSchemaLocation |
                                        XmlSchemaValidationFlags.ProcessInlineSchema;
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
-            XmlReader vr = XmlReader.Create(new StringReader(xml), settings, (string)null);
+            using XmlReader vr = XmlReader.Create(new StringReader(xml), settings, (string)null);
             while (vr.Read()) ;
             CError.Compare(errorCount, 0, "Error Count mismatch!");
             CError.Compare(warningCount, 1, "Warning Count mismatch!");
@@ -531,7 +531,7 @@ namespace System.Xml.XmlSchemaTests
 #pragma warning disable 0618
             settings.ProhibitDtd = false;
 #pragma warning restore 0618
-            XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "XMLSchema.xsd"), settings);
+            using XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "XMLSchema.xsd"), settings);
             ss1.Add(null, r);
             ss1.Compile();
 
@@ -568,7 +568,7 @@ namespace System.Xml.XmlSchemaTests
             settings.Schemas.Add(schemaSet);
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             settings.ValidationType = ValidationType.Schema;
-            XmlReader vr = XmlReader.Create(new StringReader(strXml), settings);
+            using XmlReader vr = XmlReader.Create(new StringReader(strXml), settings);
 
             while (vr.Read()) ;
 
@@ -742,7 +742,7 @@ namespace System.Xml.XmlSchemaTests
             XmlSchema mainSchema = set.Add(null, Path.Combine(TestData._Root, "bug382035a.xsd"));
             set.Compile();
 
-            XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "bug382035a1.xsd"));
+            using XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, "bug382035a1.xsd"));
             XmlSchema reParsedInclude = XmlSchema.Read(r, new ValidationEventHandler(ValidationCallback));
 
             ((XmlSchemaExternal)mainSchema.Includes[0]).Schema = reParsedInclude;
@@ -766,7 +766,7 @@ namespace System.Xml.XmlSchemaTests
             settings.ValidationFlags |= XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessSchemaLocation;
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             settings.ValidationType = ValidationType.Schema;
-            XmlReader vr = XmlReader.Create(new StringReader(strXml), settings);
+            using XmlReader vr = XmlReader.Create(new StringReader(strXml), settings);
 
             while (vr.Read()) ;
 
@@ -1056,7 +1056,7 @@ namespace System.Xml.XmlSchemaTests
             string xsd = Path.Combine(TestData._Root, "bug511217.xsd");
             XmlSchemaSet s = new XmlSchemaSet();
             s.XmlResolver = new XmlUrlResolver();
-            XmlReader r = XmlReader.Create(xsd);
+            using XmlReader r = XmlReader.Create(xsd);
             s.Add(null, r);
             s.Compile();
             XmlReaderSettings rs = new XmlReaderSettings();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_NmTokens.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_NmTokens.cs
@@ -30,7 +30,7 @@ namespace System.Xml.XmlSchemaTests
                 Assert.True(negative, args.Message);
                 numevents++;
             };            
-            XmlReader r = XmlReader.Create(xsd);
+            using XmlReader r = XmlReader.Create(xsd);
             s.Add(null, r);
             s.Compile();            
             Assert.False(negative && numevents != 1);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
@@ -149,7 +149,7 @@ namespace System.Xml.XmlSchemaTests
             Initialize();
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
             try
             {
                 xss.Add(null, r);
@@ -190,7 +190,7 @@ namespace System.Xml.XmlSchemaTests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"));
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"));
             try
             {
                 xss.Add(null, r);
@@ -314,7 +314,7 @@ namespace System.Xml.XmlSchemaTests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
             try
             {
                 xss.Add(null, r);
@@ -363,8 +363,8 @@ namespace System.Xml.XmlSchemaTests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
-            XmlReader r2 = CreateReader(r, true);
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
+            using XmlReader r2 = CreateReader(r, true);
             try
             {
                 xss.Add(null, r2);
@@ -387,8 +387,8 @@ namespace System.Xml.XmlSchemaTests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
-            XmlReader r2 = CreateReader(r, true);
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, param0.ToString()), false);
+            using XmlReader r2 = CreateReader(r, true);
 
             try
             {
@@ -413,7 +413,7 @@ namespace System.Xml.XmlSchemaTests
             xss.XmlResolver = new XmlUrlResolver();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"), false);
+            using XmlReader r = CreateReader(Path.Combine(TestData._Root, "bug356711.xsd"), false);
 
             try
             {
@@ -437,8 +437,8 @@ namespace System.Xml.XmlSchemaTests
             XmlSchemaSet xss = new XmlSchemaSet();
             xss.ValidationEventHandler += ValidationCallback;
 
-            XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
-            XmlReader r2 = CreateReader(Path.Combine(TestData._Root, "bug356711_b.xsd"), false);
+            using XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_a.xsd"));
+            using XmlReader r2 = CreateReader(Path.Combine(TestData._Root, "bug356711_b.xsd"), false);
 
             try
             {
@@ -482,7 +482,7 @@ namespace System.Xml.XmlSchemaTests
 
             try
             {
-                XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, true);
+                using XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, true);
                 while (reader.Read()) ;
             }
             catch (XmlException)
@@ -539,7 +539,7 @@ namespace System.Xml.XmlSchemaTests
 
             try
             {
-                XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, false);
+                using XmlReader reader = CreateReader(Path.Combine(TestData._Root, param0.ToString()), xss, false);
                 while (reader.Read()) ;
             }
             catch (XmlException)
@@ -561,8 +561,8 @@ namespace System.Xml.XmlSchemaTests
 
             try
             {
-                XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_1.xml"), true);
-                XmlReader r2 = CreateReader(r1, xss, false);
+                using XmlReader r1 = CreateReader(Path.Combine(TestData._Root, "bug356711_1.xml"), true);
+                using XmlReader r2 = CreateReader(r1, xss, false);
                 while (r2.Read()) ;
             }
             catch (XmlException)

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
@@ -560,7 +560,7 @@ namespace System.Xml.XmlSchemaTests
             settings.ValidationEventHandler += new ValidationEventHandler(ValidationCallback);
             settings.ValidationType = ValidationType.Schema;
             settings.Schemas = set;
-            XmlReader reader = XmlReader.Create(xmlFile, settings);
+            using XmlReader reader = XmlReader.Create(xmlFile, settings);
             while (reader.Read()) { }
 
             CError.Compare(bWarningCallback, false, "Warning count mismatch");
@@ -581,8 +581,8 @@ namespace System.Xml.XmlSchemaTests
             bErrorCallback = false;
             _output.WriteLine("Second validation ***************");
             settings.Schemas = set;
-            reader = XmlReader.Create(xmlFile, settings);
-            while (reader.Read()) { }
+            using XmlReader reader2 = XmlReader.Create(xmlFile, settings);
+            while (reader2.Read()) { }
 
             CError.Compare(bWarningCallback, false, "Warning count mismatch");
             CError.Compare(bErrorCallback, false, "Error count mismatch");
@@ -606,8 +606,8 @@ namespace System.Xml.XmlSchemaTests
 
             _output.WriteLine("Third validation, Expecting errors ***************");
             settings.Schemas = set;
-            reader = XmlReader.Create(xmlFile, settings);
-            while (reader.Read()) { }
+            using XmlReader reader3 = XmlReader.Create(xmlFile, settings);
+            while (reader3.Read()) { }
 
             CError.Compare(bWarningCallback, false, "Warning count mismatch");
             CError.Compare(bErrorCallback, true, "Error count mismatch");
@@ -623,7 +623,7 @@ namespace System.Xml.XmlSchemaTests
             _output.WriteLine("Correct uri: " + correctUri);
             using (Stream s = new FileStream(Path.GetFullPath(path), FileMode.Open, FileAccess.Read, FileShare.Read, 1))
             {
-                XmlReader r = XmlReader.Create(s, new XmlReaderSettings(), includeUri);
+                using XmlReader r = XmlReader.Create(s, new XmlReaderSettings(), includeUri);
                 _output.WriteLine("Reader uri: " + r.BaseURI);
                 using (r)
                 {

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
@@ -306,7 +306,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
             XmlSchemaInfo info = new XmlSchemaInfo();
 
             XmlSchemaValidator val = CreateValidator(CreateSchemaSetFromXml(xmlSrc));
-            XmlReader r = XmlReader.Create(new StringReader(xmlSrc));
+            using XmlReader r = XmlReader.Create(new StringReader(xmlSrc));
 
             val.LineInfoProvider = (r as IXmlLineInfo);
 

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -901,7 +901,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
                 // TempDirectory path must end with a DirectorySeratorChar, otherwise it will throw in the Xml validation.
                 settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(tempDirectory.Path)));
                 settings.ValidationType = ValidationType.Schema;
-                XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
+                using XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
                 XmlDocument doc = new XmlDocument();
 
                 doc.Load(reader);
@@ -926,7 +926,7 @@ namespace System.Xml.XmlSchemaValidatorApiTests
                 // TempDirectory path must end with a DirectorySeratorChar, otherwise it will throw in the Xml validation.
                 settings.Schemas.Add("mainschema", XmlReader.Create(new StringReader(xsd), null, EnsureTrailingSlash(tempDirectory.Path)));
                 settings.ValidationType = ValidationType.Schema;
-                XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
+                using XmlReader reader = XmlReader.Create(new StringReader(xml), settings);
                 XmlDocument doc = new XmlDocument();
 
                 doc.Load(reader);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -104,8 +104,8 @@ namespace System.Runtime.InteropServices.JavaScript
 
             try
             {
-                // when we arrive here, we are on the thread which owns the proxies
-                var ctx = arg_exc.AssertCurrentThreadContext();
+                // when we arrive here, we are on the thread which owns the proxies or on IO thread
+                var ctx = arg_exc.ToManagedContext;
                 ctx.ReleaseJSOwnedObjectByGCHandle(arg_1.slot.GCHandle);
             }
             catch (Exception ex)
@@ -131,6 +131,11 @@ namespace System.Runtime.InteropServices.JavaScript
                 // we may need to consider how to solve blocking of the synchronous call
                 // see also https://github.com/dotnet/runtime/issues/76958#issuecomment-1921418290
                 arg_exc.AssertCurrentThreadContext();
+
+                if (JSProxyContext.ThreadBlockingMode == JSHostImplementation.JSThreadBlockingMode.AllowBlockingWaitInAsyncCode)
+                {
+                    Thread.ThrowOnBlockingWaitOnJSInteropThread = true;
+                }
 #endif
 
                 GCHandle callback_gc_handle = (GCHandle)arg_1.slot.GCHandle;
@@ -148,8 +153,16 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 arg_exc.ToJS(ex);
             }
+#if FEATURE_WASM_MANAGED_THREADS
+            finally
+            {
+                if (JSProxyContext.ThreadBlockingMode == JSHostImplementation.JSThreadBlockingMode.AllowBlockingWaitInAsyncCode)
+                {
+                    Thread.ThrowOnBlockingWaitOnJSInteropThread = false;
+                }
+            }
+#endif
         }
-
         // the marshaled signature is: void CompleteTask<T>(GCHandle holder, Exception? exceptionResult, T? result)
         public static void CompleteTask(JSMarshalerArgument* arguments_buffer)
         {
@@ -161,8 +174,8 @@ namespace System.Runtime.InteropServices.JavaScript
 
             try
             {
-                // when we arrive here, we are on the thread which owns the proxies
-                var ctx = arg_exc.AssertCurrentThreadContext();
+                // when we arrive here, we are on the thread which owns the proxies or on IO thread
+                var ctx = arg_exc.ToManagedContext;
                 var holder = ctx.GetPromiseHolder(arg_1.slot.GCHandle);
                 JSHostImplementation.ToManagedCallback callback;
 
@@ -270,6 +283,10 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 var ctx = arg_exc.AssertCurrentThreadContext();
                 ctx.IsPendingSynchronousCall = true;
+                if (JSProxyContext.ThreadBlockingMode == JSHostImplementation.JSThreadBlockingMode.AllowBlockingWaitInAsyncCode)
+                {
+                    Thread.ThrowOnBlockingWaitOnJSInteropThread = true;
+                }
             }
             catch (Exception ex)
             {
@@ -288,6 +305,10 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 var ctx = arg_exc.AssertCurrentThreadContext();
                 ctx.IsPendingSynchronousCall = false;
+                if (JSProxyContext.ThreadBlockingMode == JSHostImplementation.JSThreadBlockingMode.AllowBlockingWaitInAsyncCode)
+                {
+                    Thread.ThrowOnBlockingWaitOnJSInteropThread = false;
+                }
             }
             catch (Exception ex)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.Types.cs
@@ -72,6 +72,8 @@ namespace System.Runtime.InteropServices.JavaScript
             UIThread = 0,
             // Running the managed main thread on dedicated WebWorker. Marshaling all JavaScript calls to and from the main thread.
             DeputyThread = 1,
+            // TODO comments
+            DeputyAndIOThreads = 2,
         }
 
         // keep in sync with types\internal.ts
@@ -80,6 +82,8 @@ namespace System.Runtime.InteropServices.JavaScript
             // throw PlatformNotSupportedException if blocking .Wait is called on threads with JS interop, like JSWebWorker and Main thread.
             // Avoids deadlocks (typically with pending JS promises on the same thread) by throwing exceptions.
             NoBlockingWait = 0,
+            // TODO comments
+            AllowBlockingWaitInAsyncCode = 1,
             // allow .Wait on all threads.
             // Could cause deadlocks with blocking .Wait on a pending JS Task/Promise on the same thread or similar Task/Promise chain.
             AllowBlockingWait = 100,

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSHostImplementation.cs
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 CancelablePromise.CancelPromise((Task<JSObject>)s!);
             }, jsTask))
             {
-                return await jsTask.ConfigureAwait(true);
+                return await jsTask.ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSProxyContext.cs
@@ -43,7 +43,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public JSAsyncTaskScheduler? AsyncTaskScheduler;
 
         public static MainThreadingMode MainThreadingMode = MainThreadingMode.DeputyThread;
-        public static JSThreadBlockingMode ThreadBlockingMode = JSThreadBlockingMode.NoBlockingWait;
+        public static JSThreadBlockingMode ThreadBlockingMode = JSThreadBlockingMode.AllowBlockingWaitInAsyncCode;
         public static JSThreadInteropMode ThreadInteropMode = JSThreadInteropMode.SimpleSynchronousJSInterop;
         public bool IsPendingSynchronousCall;
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -50,14 +50,15 @@ namespace System.Runtime.InteropServices.JavaScript
             lock (ctx)
             {
                 PromiseHolder holder = ctx.GetPromiseHolder(slot.GCHandle);
-                // we want to run the continuations on the original thread which called the JSImport, so RunContinuationsAsynchronously, rather than ExecuteSynchronously
-                // TODO TaskCreationOptions.RunContinuationsAsynchronously
-                TaskCompletionSource tcs = new TaskCompletionSource(holder);
+                TaskCompletionSource tcs = new TaskCompletionSource(holder, TaskCreationOptions.RunContinuationsAsynchronously);
                 ToManagedCallback callback = (JSMarshalerArgument* arguments_buffer) =>
                 {
                     if (arguments_buffer == null)
                     {
-                        tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated."));
+                        if (!tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated.")))
+                        {
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                        }
                         return;
                     }
                     ref JSMarshalerArgument arg_2 = ref arguments_buffer[3]; // set by caller when this is SetException call
@@ -65,11 +66,17 @@ namespace System.Runtime.InteropServices.JavaScript
                     if (arg_2.slot.Type != MarshalerType.None)
                     {
                         arg_2.ToManaged(out Exception? fail);
-                        tcs.TrySetException(fail!);
+                        if (!tcs.TrySetException(fail!))
+                        {
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                        }
                     }
                     else
                     {
-                        tcs.TrySetResult();
+                        if (!tcs.TrySetResult())
+                        {
+                            Environment.FailFast("Failed to set result to TaskCompletionSource");
+                        }
                     }
                     // eventual exception is handled by caller
                 };
@@ -101,14 +108,15 @@ namespace System.Runtime.InteropServices.JavaScript
             lock (ctx)
             {
                 var holder = ctx.GetPromiseHolder(slot.GCHandle);
-                // we want to run the continuations on the original thread which called the JSImport, so RunContinuationsAsynchronously, rather than ExecuteSynchronously
-                // TODO TaskCreationOptions.RunContinuationsAsynchronously
-                TaskCompletionSource<T> tcs = new TaskCompletionSource<T>(holder);
+                TaskCompletionSource<T> tcs = new TaskCompletionSource<T>(holder, TaskCreationOptions.RunContinuationsAsynchronously);
                 ToManagedCallback callback = (JSMarshalerArgument* arguments_buffer) =>
                 {
                     if (arguments_buffer == null)
                     {
-                        tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated."));
+                        if (!tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated.")))
+                        {
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                        }
                         return;
                     }
 
@@ -118,12 +126,18 @@ namespace System.Runtime.InteropServices.JavaScript
                     {
                         arg_2.ToManaged(out Exception? fail);
                         if (fail == null) throw new InvalidOperationException(SR.FailedToMarshalException);
-                        tcs.TrySetException(fail);
+                        if (!tcs.TrySetException(fail))
+                        {
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                        }
                     }
                     else
                     {
                         marshaler(ref arg_3, out T result);
-                        tcs.TrySetResult(result);
+                        if(!tcs.TrySetResult(result))
+                        {
+                            Environment.FailFast("Failed to set result to TaskCompletionSource");
+                        }
                     }
                     // eventual exception is handled by caller
                 };

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -136,7 +136,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         marshaler(ref arg_3, out T result);
                         if(!tcs.TrySetResult(result))
                         {
-                            Environment.FailFast("Failed to set result to TaskCompletionSource");
+                            Environment.FailFast("Failed to set result to TaskCompletionSource (marshaler type is none)");
                         }
                     }
                     // eventual exception is handled by caller

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         arg_2.ToManaged(out Exception? fail);
                         if (!tcs.TrySetException(fail!))
                         {
-                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource (exception raised)");
                         }
                     }
                     else

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -57,7 +57,7 @@ namespace System.Runtime.InteropServices.JavaScript
                     {
                         if (!tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated.")))
                         {
-                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource (arguments buffer is null)");
                         }
                         return;
                     }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -75,7 +75,7 @@ namespace System.Runtime.InteropServices.JavaScript
                     {
                         if (!tcs.TrySetResult())
                         {
-                            Environment.FailFast("Failed to set result to TaskCompletionSource");
+                            Environment.FailFast("Failed to set result to TaskCompletionSource (marshaler type is none)");
                         }
                     }
                     // eventual exception is handled by caller

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -128,7 +128,7 @@ namespace System.Runtime.InteropServices.JavaScript
                         if (fail == null) throw new InvalidOperationException(SR.FailedToMarshalException);
                         if (!tcs.TrySetException(fail))
                         {
-                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource (exception raised)");
                         }
                     }
                     else

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Task.cs
@@ -115,7 +115,7 @@ namespace System.Runtime.InteropServices.JavaScript
                     {
                         if (!tcs.TrySetException(new TaskCanceledException("WebWorker which is origin of the Promise is being terminated.")))
                         {
-                            Environment.FailFast("Failed to set exception to TaskCompletionSource");
+                            Environment.FailFast("Failed to set exception to TaskCompletionSource (arguments buffer is null)");
                         }
                         return;
                     }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/BackgroundExec/System.Runtime.InteropServices.JavaScript.BackgroundExec.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/BackgroundExec/System.Runtime.InteropServices.JavaScript.BackgroundExec.Tests.csproj
@@ -1,7 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <_XUnitBackgroundExec Condition="'$(_XUnitBackgroundExec)' == ''">true</_XUnitBackgroundExec>
-    <AssemblyName>System.Runtime.InteropServices.JavaScript.Tests</AssemblyName>
-  </PropertyGroup>
-  <Import Project="$(MSBuildThisFileDirectory)..\System.Runtime.InteropServices.JavaScript.Tests.csproj" />
-</Project>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSExportTest.cs
@@ -37,7 +37,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         {
             JavaScriptTestHelper.optimizedReached=0;
             JavaScriptTestHelper.invoke1O(value);
-            await JavaScriptTestHelper.Delay(0);
+            await JavaScriptTestHelper.Delay(50);
             Assert.Equal(value, JavaScriptTestHelper.optimizedReached);
         }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -45,9 +45,17 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             return Enum.GetValues<ExecutorType>().Select(type => new object[] { new Executor(type) });
         }
 
-        public static IEnumerable<object[]> GetSpecificTargetThreads()
+        public static IEnumerable<object[]> GetBlockingFriendlyTargetThreads()
         {
-            yield return new object[] { new Executor(ExecutorType.JSWebWorker), new Executor(ExecutorType.Main) };
+            yield return new object[] { new Executor(ExecutorType.Main) };
+            yield return new object[] { new Executor(ExecutorType.NewThread) };
+            yield return new object[] { new Executor(ExecutorType.ThreadPool) };
+            // JSWebWorker is missing here because JS can't resolve promises while blocked
+        }
+
+        public static IEnumerable<object[]> GetSpecificTargetThreads2x()
+        {
+            yield return new object[] { new Executor(ExecutorType.Main), new Executor(ExecutorType.Main) };
             yield break;
         }
 
@@ -135,15 +143,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                 }
                 throw;
             }
-        }
-
-        public class NamedCall
-        {
-            public string Name { get; set; }
-            public delegate void Method(CancellationToken ct);
-            public Method Call { get; set; }
-
-            override public string ToString() => Name;
         }
 
         public static IEnumerable<NamedCall> BlockingCalls = new List<NamedCall>

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.cs
@@ -18,6 +18,7 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         public static readonly string LocalWsEcho = "ws://" + Environment.GetEnvironmentVariable("DOTNET_TEST_WEBSOCKETHOST") + "/WebSocket/EchoWebSocket.ashx";
 
         [JSImport("globalThis.console.log")]
+        [return: JSMarshalAs<JSType.DiscardNoWait>]
         public static partial void Log(string message);
 
         [JSImport("delay", "InlineTestHelper")]
@@ -37,6 +38,30 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
 
         [JSImport("promiseValidateState", "WebWorkerTestHelper")]
         public static partial Task<bool> PromiseValidateState(JSObject state);
+
+        [JSImport("callMeBackSync", "WebWorkerTestHelper")]
+        public static partial Task CallMeBackSync([JSMarshalAs<JSType.Function>] Action syncCallback);
+
+        [JSImport("callExportBackSync", "WebWorkerTestHelper")]
+        public static partial Task CallExportBackSync(string syncExportName);
+
+        public static NamedCall CurrentCallback;
+        public static CancellationToken CurrentCancellationToken = CancellationToken.None;
+        public static Exception? LastException = null;
+        
+        [JSExport]
+        public static void CallCurrentCallback()
+        {
+            LastException = null;
+            try
+            {
+                CurrentCallback.Call(CurrentCancellationToken);
+            }
+            catch (Exception ex)
+            {
+                LastException = ex;
+            }
+        }
 
         public static string GetOriginUrl()
         {
@@ -121,7 +146,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
     public class Executor
     {
         public int ExecutorTID;
-        public SynchronizationContext ExecutorSynchronizationContext;
         private static SynchronizationContext _mainSynchronizationContext;
         public static SynchronizationContext MainSynchronizationContext
         {
@@ -156,7 +180,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Task wrapExecute()
             {
                 ExecutorTID = Environment.CurrentManagedThreadId;
-                ExecutorSynchronizationContext = SynchronizationContext.Current ?? MainSynchronizationContext;
                 AssertTargetThread();
                 return job();
             }
@@ -194,6 +217,15 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             {
                 Assert.False(Thread.CurrentThread.IsThreadPoolThread, "IsThreadPoolThread:" + Thread.CurrentThread.IsThreadPoolThread + " Type " + Type);
             }
+            if (Type == ExecutorType.Main || Type == ExecutorType.JSWebWorker)
+            {
+                Assert.NotNull(SynchronizationContext.Current);
+                Assert.Equal("System.Runtime.InteropServices.JavaScript.JSSynchronizationContext", SynchronizationContext.Current.GetType().FullName);
+            }
+            else
+            {
+                Assert.Null(SynchronizationContext.Current);
+            }
         }
 
         public void AssertAwaitCapturedContext()
@@ -226,51 +258,6 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
                     // it could migrate to any TP thread
                     Assert.NotEqual(1, Environment.CurrentManagedThreadId);
                     Assert.True(Thread.CurrentThread.IsThreadPoolThread);
-                    break;
-            }
-        }
-
-        public void AssertBlockingWait(Exception? exception)
-        {
-            switch (Type)
-            {
-                case ExecutorType.Main:
-                case ExecutorType.JSWebWorker:
-                    Assert.NotNull(exception);
-                    Assert.IsType<PlatformNotSupportedException>(exception);
-                    break;
-                case ExecutorType.NewThread:
-                case ExecutorType.ThreadPool:
-                    Assert.Null(exception);
-                    break;
-            }
-        }
-
-        public void AssertInteropThread()
-        {
-            switch (Type)
-            {
-                case ExecutorType.Main:
-                    Assert.Equal(1, Environment.CurrentManagedThreadId);
-                    Assert.Equal(ExecutorTID, Environment.CurrentManagedThreadId);
-                    Assert.False(Thread.CurrentThread.IsThreadPoolThread);
-                    break;
-                case ExecutorType.JSWebWorker:
-                    Assert.NotEqual(1, Environment.CurrentManagedThreadId);
-                    Assert.Equal(ExecutorTID, Environment.CurrentManagedThreadId);
-                    Assert.False(Thread.CurrentThread.IsThreadPoolThread);
-                    break;
-                case ExecutorType.NewThread:
-                    // it will synchronously continue on the UI thread
-                    Assert.Equal(1, Environment.CurrentManagedThreadId);
-                    Assert.NotEqual(ExecutorTID, Environment.CurrentManagedThreadId);
-                    Assert.False(Thread.CurrentThread.IsThreadPoolThread);
-                    break;
-                case ExecutorType.ThreadPool:
-                    // it will synchronously continue on the UI thread
-                    Assert.Equal(1, Environment.CurrentManagedThreadId);
-                    Assert.NotEqual(ExecutorTID, Environment.CurrentManagedThreadId);
-                    Assert.False(Thread.CurrentThread.IsThreadPoolThread);
                     break;
             }
         }
@@ -394,4 +381,14 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
     }
 
     #endregion
+
+    public class NamedCall
+    {
+        public string Name { get; set; }
+        public delegate void Method(CancellationToken ct);
+        public Method Call { get; set; }
+
+        override public string ToString() => Name;
+    }
+
 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestHelper.mjs
@@ -73,3 +73,13 @@ export function delay(ms) {
 export function getRndInteger(min, max) {
     return Math.floor(Math.random() * (max - min)) + min;
 }
+
+export async function callMeBackSync(syncCallback) {
+    syncCallback();
+}
+
+export async function callExportBackSync(syncExportName) {
+    const WebWorkerTestHelper = dllExports.System.Runtime.InteropServices.JavaScript.Tests.WebWorkerTestHelper;
+    const method = WebWorkerTestHelper[syncExportName]
+    method();
+}

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/CancellationTokenTests.cs
@@ -874,6 +874,7 @@ namespace System.Threading.Tasks.Tests
 
         // Several tests for deriving custom user types from CancellationTokenSource
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void DerivedCancellationTokenSource()
         {
             // Verify that a derived CTS is functional

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/MethodCoverage.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/MethodCoverage.cs
@@ -279,6 +279,7 @@ namespace TaskCoverage
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99500", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void CancellationTokenRegitration()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -296,6 +297,7 @@ namespace TaskCoverage
         /// verify that the taskawaiter.UnsafeOnCompleted is invoked
         /// </summary>
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TaskAwaiter()
         {
             ManualResetEvent mre = new ManualResetEvent(false);

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
@@ -3,6 +3,8 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
     <XunitShowProgress>true</XunitShowProgress>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/Task/AsyncEnumerableToBlockingEnumerableTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/Task/AsyncEnumerableToBlockingEnumerableTests.cs
@@ -70,6 +70,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AsyncEnumerableWithDelays()
         {
             var source = new InstrumentedAsyncEnumerable<int>(CreateSourceEnumerable());
@@ -104,6 +105,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AsyncEnumerableWithException()
         {
             var source = new InstrumentedAsyncEnumerable<int>(CreateSourceEnumerable());
@@ -132,6 +134,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void AsyncEnumerableWithCancellation()
         {
             var source = new InstrumentedAsyncEnumerable<string>(CreateSourceEnumerable());

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/Task/TaskContinueWithTests.cs
@@ -1076,6 +1076,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void TestNoDeadlockOnContinueWith()
         {
             Debug.WriteLine("TestNoDeadlockOnContinueWith:  shouldn't deadlock if it passes.");
@@ -1255,6 +1256,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99519", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void LongContinuationChain_Await_DoesNotStackOverflow()
         {
             const int DiveDepth = 12_000;

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -90,6 +90,7 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99501", typeof(PlatformDetection), nameof(PlatformDetection.IsWasmThreadingSupported))]
         public static void RunSemaphoreSlimTest1_WaitAsync_NegativeCases()
         {
             // Invalid timeout

--- a/src/libraries/System.Threading/tests/System.Threading.Tests.csproj
+++ b/src/libraries/System.Threading/tests/System.Threading.Tests.csproj
@@ -7,6 +7,9 @@
     <!-- CA2252: Opt in to preview features before using them (Lock) -->
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <XunitShowProgress>true</XunitShowProgress>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AsyncLocalTests.cs" />
     <Compile Include="AutoResetEventTests.cs" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -400,10 +400,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Globalization.Calendars.Tests\Hybrid\System.Globalization.Calendars.Hybrid.WASM.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(WasmEnableThreads)' != 'true' and '$(RunDisabledWasmTests)' != 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.JavaScript\tests\System.Runtime.InteropServices.JavaScript.UnitTests\BackgroundExec\System.Runtime.InteropServices.JavaScript.BackgroundExec.Tests.csproj" />
-  </ItemGroup>
-
   <!-- Aggressive Trimming related failures -->
   <ItemGroup Condition="('$(TargetOS)' != 'browser' and '$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true') or ('$(TargetOS)' == 'browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true')">
   </ItemGroup>

--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -27,8 +27,12 @@ const threading_cwraps: SigLine[] = WasmEnableThreads ? [
     [false, "mono_wasm_init_finalizer_thread", null, []],
     [false, "mono_wasm_invoke_jsexport_async_post", "void", ["number", "number", "number"]],
     [false, "mono_wasm_invoke_jsexport_sync_send", "void", ["number", "number", "number"]],
+    [false, "mono_wasm_invoke_jsexport_sync", "void", ["number", "number"]],
     [true, "mono_wasm_create_deputy_thread", "number", []],
+    [true, "mono_wasm_create_io_thread", "number", []],
     [true, "mono_wasm_register_ui_thread", "void", []],
+    [true, "mono_wasm_register_io_thread", "void", []],
+    [true, "mono_wasm_print_thread_dump", "void", []],
 ] : [];
 
 // when the method is assigned/cached at usage, instead of being invoked directly from cwraps, it can't be marked lazy, because it would be re-bound on each call
@@ -146,8 +150,12 @@ export interface t_ThreadingCwraps {
     mono_wasm_init_finalizer_thread(): void;
     mono_wasm_invoke_jsexport_async_post(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
     mono_wasm_invoke_jsexport_sync_send(targetTID: PThreadPtr, method: MonoMethod, args: VoidPtr): void;
+    mono_wasm_invoke_jsexport_sync(method: MonoMethod, args: VoidPtr): void;
     mono_wasm_create_deputy_thread(): PThreadPtr;
+    mono_wasm_create_io_thread(): PThreadPtr;
     mono_wasm_register_ui_thread(): void;
+    mono_wasm_register_io_thread(): void;
+    mono_wasm_print_thread_dump(): void;
 }
 
 export interface t_ProfilerCwraps {

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -257,15 +257,25 @@ mono_wasm_invoke_jsexport (MonoMethod *method, void* args)
 
 extern void mono_threads_wasm_async_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 extern void mono_threads_wasm_sync_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+extern void mono_print_thread_dump (void *sigctx);
+
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_print_thread_dump (void)
+{
+	mono_print_thread_dump (NULL);
+}
 
 // this is running on the target thread
 static void
 mono_wasm_invoke_jsexport_async_post_cb (MonoMethod *method, void* args)
 {
 	mono_wasm_invoke_jsexport (method, args);
-	// TODO assert receiver_should_free ?
-	if (args)
-		free (args);
+	if (args) {
+		MonoBoolean *is_receiver_should_free = (MonoBoolean *)(args + 20/*JSMarshalerArgumentOffsets.ReceiverShouldFree*/);
+		if(*is_receiver_should_free != 0){
+			free (args);
+		}
+	}
 }
 
 // async
@@ -281,8 +291,8 @@ extern js_interop_event before_sync_js_import;
 extern js_interop_event after_sync_js_import;
 
 // this is running on the target thread
-static void
-mono_wasm_invoke_jsexport_sync_send_cb (MonoMethod *method, void* args)
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_invoke_jsexport_sync (MonoMethod *method, void* args)
 {
 	before_sync_js_import (args);
 	mono_wasm_invoke_jsexport (method, args);
@@ -293,7 +303,7 @@ mono_wasm_invoke_jsexport_sync_send_cb (MonoMethod *method, void* args)
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_invoke_jsexport_sync_send (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
 {
-	mono_threads_wasm_sync_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport_sync_send_cb, method, args);
+	mono_threads_wasm_sync_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport_sync, method, args);
 }
 
 #endif /* DISABLE_THREADS */

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -29,7 +29,7 @@ import { mono_wasm_cancel_promise } from "./cancelable-promise";
 import {
     mono_wasm_start_deputy_thread_async,
     mono_wasm_pthread_on_pthread_attached, mono_wasm_pthread_on_pthread_unregistered,
-    mono_wasm_pthread_on_pthread_registered, mono_wasm_pthread_set_name, mono_wasm_install_js_worker_interop, mono_wasm_uninstall_js_worker_interop
+    mono_wasm_pthread_on_pthread_registered, mono_wasm_pthread_set_name, mono_wasm_install_js_worker_interop, mono_wasm_uninstall_js_worker_interop, mono_wasm_start_io_thread_async
 } from "./pthreads";
 import { mono_wasm_dump_threads } from "./pthreads/ui-thread";
 
@@ -43,6 +43,7 @@ export const mono_wasm_threads_imports = !WasmEnableThreads ? [] : [
     mono_wasm_pthread_on_pthread_unregistered,
     mono_wasm_pthread_set_name,
     mono_wasm_start_deputy_thread_async,
+    mono_wasm_start_io_thread_async,
 
     // mono-threads.c
     mono_wasm_dump_threads,

--- a/src/mono/browser/runtime/exports-internal.ts
+++ b/src/mono/browser/runtime/exports-internal.ts
@@ -4,7 +4,7 @@
 import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { MonoObjectNull, type MonoObject } from "./types/internal";
-import cwraps, { profiler_c_functions } from "./cwraps";
+import cwraps, { profiler_c_functions, threads_c_functions as twraps } from "./cwraps";
 import { mono_wasm_send_dbg_command_with_parms, mono_wasm_send_dbg_command, mono_wasm_get_dbg_command_info, mono_wasm_get_details, mono_wasm_release_object, mono_wasm_call_function_on, mono_wasm_debugger_resume, mono_wasm_detach_debugger, mono_wasm_raise_debug_event, mono_wasm_change_debugger_log_level, mono_wasm_debugger_attached } from "./debug";
 import { http_wasm_supports_streaming_request, http_wasm_supports_streaming_response, http_wasm_create_controller, http_wasm_abort_request, http_wasm_abort_response, http_wasm_transform_stream_write, http_wasm_transform_stream_close, http_wasm_fetch, http_wasm_fetch_stream, http_wasm_fetch_bytes, http_wasm_get_response_header_names, http_wasm_get_response_header_values, http_wasm_get_response_bytes, http_wasm_get_response_length, http_wasm_get_streamed_response_bytes, http_wasm_get_response_type, http_wasm_get_response_status } from "./http";
 import { exportedRuntimeAPI, Module, runtimeHelpers } from "./globals";
@@ -120,6 +120,7 @@ export function cwraps_internal(internal: any): void {
         mono_wasm_profiler_init_aot: profiler_c_functions.mono_wasm_profiler_init_aot,
         mono_wasm_profiler_init_browser: profiler_c_functions.mono_wasm_profiler_init_browser,
         mono_wasm_exec_regression: cwraps.mono_wasm_exec_regression,
+        mono_wasm_print_thread_dump: WasmEnableThreads ? twraps.mono_wasm_print_thread_dump : undefined,
     });
 }
 

--- a/src/mono/browser/runtime/globals.ts
+++ b/src/mono/browser/runtime/globals.ts
@@ -65,6 +65,7 @@ export function setRuntimeGlobals(globalObjects: GlobalObjects) {
         afterPreRun: createPromiseController<void>(),
         beforeOnRuntimeInitialized: createPromiseController<void>(),
         afterMonoStarted: createPromiseController<GCHandle | undefined>(),
+        afterIOStarted: createPromiseController<void>(),
         afterOnRuntimeInitialized: createPromiseController<void>(),
         afterPostRun: createPromiseController<void>(),
         nativeAbort: (reason: any) => { throw reason || new Error("abort"); },

--- a/src/mono/browser/runtime/invoke-cs.ts
+++ b/src/mono/browser/runtime/invoke-cs.ts
@@ -208,7 +208,7 @@ function bind_fn_1RA(closure: BindingClosure) {
             let promise = res_converter(args);
 
             // call C# side
-            invoke_async_jsexport(method, args, size);
+            invoke_async_jsexport(runtimeHelpers.managedThreadTID, method, args, size);
 
             // in case the C# side returned synchronously
             promise = end_marshal_task_to_js(args, undefined, promise);
@@ -273,7 +273,7 @@ function bind_fn_2RA(closure: BindingClosure) {
             let promise = res_converter(args);
 
             // call C# side
-            invoke_async_jsexport(method, args, size);
+            invoke_async_jsexport(runtimeHelpers.managedThreadTID, method, args, size);
 
             // in case the C# side returned synchronously
             promise = end_marshal_task_to_js(args, undefined, promise);
@@ -318,13 +318,13 @@ function bind_fn(closure: BindingClosure) {
 
             // call C# side
             if (is_async) {
-                invoke_async_jsexport(method, args, size);
+                invoke_async_jsexport(runtimeHelpers.managedThreadTID, method, args, size);
                 // in case the C# side returned synchronously
                 js_result = end_marshal_task_to_js(args, undefined, js_result);
             }
             else if (is_discard_no_wait) {
                 // call C# side, fire and forget
-                invoke_async_jsexport(method, args, size);
+                invoke_async_jsexport(runtimeHelpers.managedThreadTID, method, args, size);
             }
             else {
                 invoke_sync_jsexport(method, args);

--- a/src/mono/browser/runtime/loader/config.ts
+++ b/src/mono/browser/runtime/loader/config.ts
@@ -199,10 +199,10 @@ export function normalizeConfig() {
             config.finalizerThreadStartDelayMs = 200;
         }
         if (config.mainThreadingMode == undefined) {
-            config.mainThreadingMode = MainThreadingMode.DeputyThread;
+            config.mainThreadingMode = MainThreadingMode.DeputyAndIOThreads;
         }
         if (config.jsThreadBlockingMode == undefined) {
-            config.jsThreadBlockingMode = JSThreadBlockingMode.NoBlockingWait;
+            config.jsThreadBlockingMode = JSThreadBlockingMode.AllowBlockingWaitInAsyncCode;
         }
         if (config.jsThreadInteropMode == undefined) {
             config.jsThreadInteropMode = JSThreadInteropMode.SimpleSynchronousJSInterop;
@@ -210,6 +210,12 @@ export function normalizeConfig() {
         let validModes = false;
         if (config.mainThreadingMode == MainThreadingMode.DeputyThread
             && config.jsThreadBlockingMode == JSThreadBlockingMode.NoBlockingWait
+            && config.jsThreadInteropMode == JSThreadInteropMode.SimpleSynchronousJSInterop
+        ) {
+            validModes = true;
+        }
+        else if (config.mainThreadingMode == MainThreadingMode.DeputyAndIOThreads
+            && config.jsThreadBlockingMode == JSThreadBlockingMode.AllowBlockingWaitInAsyncCode
             && config.jsThreadInteropMode == JSThreadInteropMode.SimpleSynchronousJSInterop
         ) {
             validModes = true;

--- a/src/mono/browser/runtime/multi-threading.md
+++ b/src/mono/browser/runtime/multi-threading.md
@@ -12,7 +12,7 @@
     - DOM events like `onClick` need to be asynchronous, if the handler needs use synchronous `[JSImport]`
     - synchronous calls to `[JSImport]`/`[JSExport]` can't synchronously call back
 
- * `MainThreadingMode.DeputyThread` + `JSThreadBlockingMode.AllowBlockingWaitInAsyncCode` + `JSThreadInteropMode.SimpleSynchronousJSInterop`
+ * `MainThreadingMode.DeputyAndIOThreads` + `JSThreadBlockingMode.AllowBlockingWaitInAsyncCode` + `JSThreadInteropMode.SimpleSynchronousJSInterop`
     + **default threading**, safe, tested, supported
     + blocking `.Wait` is allowed on thread pool and new threads
     - blocking `.Wait` throws `PlatformNotSupportedException` on `JSWebWorker` and main thread only when they are called from JS via synchronous `JSExport`

--- a/src/mono/browser/runtime/multi-threading.md
+++ b/src/mono/browser/runtime/multi-threading.md
@@ -12,6 +12,13 @@
     - DOM events like `onClick` need to be asynchronous, if the handler needs use synchronous `[JSImport]`
     - synchronous calls to `[JSImport]`/`[JSExport]` can't synchronously call back
 
+ * `MainThreadingMode.DeputyThread` + `JSThreadBlockingMode.AllowBlockingWaitInAsyncCode` + `JSThreadInteropMode.SimpleSynchronousJSInterop`
+    + **default threading**, safe, tested, supported
+    + blocking `.Wait` is allowed on thread pool and new threads
+    - blocking `.Wait` throws `PlatformNotSupportedException` on `JSWebWorker` and main thread only when they are called from JS via synchronous `JSExport`
+    - DOM events like `onClick` need to be asynchronous, if the handler needs use synchronous `[JSImport]`
+    - synchronous calls to `[JSImport]`/`[JSExport]` can't synchronously call back
+
  * `MainThreadingMode.DeputyThread` + `JSThreadBlockingMode.AllowBlockingWait` + `JSThreadInteropMode.SimpleSynchronousJSInterop`
     + pragmatic for legacy codebase, which contains blocking code and can't be fully executed on thread pool or new threads
     - ** could cause deadlocks !!!**

--- a/src/mono/browser/runtime/pthreads/index.ts
+++ b/src/mono/browser/runtime/pthreads/index.ts
@@ -17,3 +17,4 @@ export {
 } from "./worker-thread";
 
 export { mono_wasm_start_deputy_thread_async } from "./deputy-thread";
+export { mono_wasm_start_io_thread_async } from "./io-thread";

--- a/src/mono/browser/runtime/pthreads/io-thread.ts
+++ b/src/mono/browser/runtime/pthreads/io-thread.ts
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import WasmEnableThreads from "consts:wasmEnableThreads";
+import BuildConfiguration from "consts:configuration";
+
+import { mono_log_error, mono_log_info } from "../logging";
+import { monoThreadInfo, postMessageToMain, update_thread_info } from "./shared";
+import { Module, loaderHelpers } from "../globals";
+import { WorkerToMainMessageType } from "../types/internal";
+import { threads_c_functions as tcwraps } from "../cwraps";
+
+export function mono_wasm_start_io_thread_async() {
+    if (!WasmEnableThreads) return;
+
+
+    if (BuildConfiguration === "Debug" && globalThis.setInterval) globalThis.setInterval(() => {
+        mono_log_info("I/O thread is alive!");
+    }, 3000);
+
+    try {
+        monoThreadInfo.isIo = true;
+        monoThreadInfo.threadName = "JS I/O Thread";
+        update_thread_info();
+        tcwraps.mono_wasm_register_io_thread();
+        postMessageToMain({
+            monoCmd: WorkerToMainMessageType.ioStarted,
+            info: monoThreadInfo,
+        });
+        Module.runtimeKeepalivePush();
+    }
+    catch (err) {
+        mono_log_error("mono_wasm_start_io_thread_async() failed", err);
+        loaderHelpers.mono_exit(1, err);
+        throw err;
+    }
+
+    // same as emscripten_exit_with_live_runtime()
+    throw "unwind";
+}

--- a/src/mono/browser/runtime/pthreads/shared.ts
+++ b/src/mono/browser/runtime/pthreads/shared.ts
@@ -71,14 +71,15 @@ export function update_thread_info(): void {
     const threadType = !monoThreadInfo.isRegistered ? "emsc"
         : monoThreadInfo.isUI ? "-UI-"
             : monoThreadInfo.isDeputy ? "dpty"
-                : monoThreadInfo.isTimer ? "timr"
-                    : monoThreadInfo.isLongRunning ? "long"
-                        : monoThreadInfo.isThreadPoolGate ? "gate"
-                            : monoThreadInfo.isDebugger ? "dbgr"
-                                : monoThreadInfo.isThreadPoolWorker ? "pool"
-                                    : monoThreadInfo.isExternalEventLoop ? "jsww"
-                                        : monoThreadInfo.isBackground ? "back"
-                                            : "norm";
+                : monoThreadInfo.isIo ? "-IO-"
+                    : monoThreadInfo.isTimer ? "timr"
+                        : monoThreadInfo.isLongRunning ? "long"
+                            : monoThreadInfo.isThreadPoolGate ? "gate"
+                                : monoThreadInfo.isDebugger ? "dbgr"
+                                    : monoThreadInfo.isThreadPoolWorker ? "pool"
+                                        : monoThreadInfo.isExternalEventLoop ? "jsww"
+                                            : monoThreadInfo.isBackground ? "back"
+                                                : "norm";
     const hexPtr = (monoThreadInfo.pthreadId as any).toString(16).padStart(8, "0");
     const hexPrefix = monoThreadInfo.isRegistered ? "0x" : "--";
     monoThreadInfo.threadPrefix = `${hexPrefix}${hexPtr}-${threadType}`;

--- a/src/mono/browser/runtime/pthreads/ui-thread.ts
+++ b/src/mono/browser/runtime/pthreads/ui-thread.ts
@@ -100,6 +100,9 @@ function monoWorkerMessageHandler(worker: PThreadWorker, ev: MessageEvent<any>):
         case WorkerToMainMessageType.deputyStarted:
             runtimeHelpers.afterMonoStarted.promise_control.resolve(message.deputyProxyGCHandle);
             break;
+        case WorkerToMainMessageType.ioStarted:
+            runtimeHelpers.afterIOStarted.promise_control.resolve();
+            break;
         case WorkerToMainMessageType.deputyFailed:
             runtimeHelpers.afterMonoStarted.promise_control.reject(new Error(message.error));
             break;

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -209,6 +209,7 @@ export type RuntimeHelpers = {
     monoThreadInfo: PThreadInfo,
     proxyGCHandle: GCHandle | undefined,
     managedThreadTID: PThreadPtr,
+    ioThreadTID: PThreadPtr,
     currentThreadTID: PThreadPtr,
     isManagedRunningOnCurrentThread: boolean,
     isPendingSynchronousCall: boolean, // true when we are in the middle of a synchronous call from managed code from same thread
@@ -222,6 +223,7 @@ export type RuntimeHelpers = {
     afterPreRun: PromiseAndController<void>,
     beforeOnRuntimeInitialized: PromiseAndController<void>,
     afterMonoStarted: PromiseAndController<GCHandle | undefined>,
+    afterIOStarted: PromiseAndController<void>,
     afterOnRuntimeInitialized: PromiseAndController<void>,
     afterPostRun: PromiseAndController<void>,
 
@@ -495,6 +497,7 @@ export const enum WorkerToMainMessageType {
     deputyCreated = "createdDeputy",
     deputyFailed = "deputyFailed",
     deputyStarted = "monoStarted",
+    ioStarted = "ioStarted",
     preload = "preload",
 }
 
@@ -525,6 +528,7 @@ export interface PThreadInfo {
     isRunning?: boolean,
     isAttached?: boolean,
     isDeputy?: boolean,
+    isIo?: boolean,
     isExternalEventLoop?: boolean,
     isUI?: boolean;
     isBackground?: boolean,
@@ -573,6 +577,8 @@ export const enum MainThreadingMode {
     UIThread = 0,
     // Running the managed main thread on dedicated WebWorker. Marshaling all JavaScript calls to and from the main thread.
     DeputyThread = 1,
+    // TODO comment
+    DeputyAndIOThreads = 2,
 }
 
 // keep in sync with JSHostImplementation.Types.cs
@@ -580,6 +586,8 @@ export const enum JSThreadBlockingMode {
     // throw PlatformNotSupportedException if blocking .Wait is called on threads with JS interop, like JSWebWorker and Main thread.
     // Avoids deadlocks (typically with pending JS promises on the same thread) by throwing exceptions.
     NoBlockingWait = 0,
+    // TODO comment
+    AllowBlockingWaitInAsyncCode = 1,
     // allow .Wait on all threads. 
     // Could cause deadlocks with blocking .Wait on a pending JS Task/Promise on the same thread or similar Task/Promise chain.
     AllowBlockingWait = 100,

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -496,7 +496,7 @@ mono_threads_wasm_on_thread_attached (pthread_t tid, const char* thread_name, gb
 #else
 	if (mono_threads_wasm_is_ui_thread ()) {
 		// FIXME: we should not be attaching UI thread with deputy design
-		// but right now we do, because mono_wasm_load_runtime is running in UI thread
+		// but right now we do
 		// g_assert(!mono_threads_wasm_is_ui_thread ());
 		return;
 	}
@@ -542,7 +542,9 @@ mono_threads_wasm_on_thread_registered (void)
 
 #ifndef DISABLE_THREADS
 static pthread_t deputy_thread_tid;
+static pthread_t io_thread_tid;
 extern void mono_wasm_start_deputy_thread_async (void);
+extern void mono_wasm_start_io_thread_async (void);
 extern void mono_wasm_trace_logger (const char *log_domain, const char *log_level, const char *message, mono_bool fatal, void *user_data);
 extern void mono_wasm_dump_threads (void);
 
@@ -582,9 +584,54 @@ mono_wasm_create_deputy_thread (void)
 	return deputy_thread_tid;
 }
 
+gboolean
+mono_threads_wasm_is_io_thread (void)
+{
+	return pthread_self () == io_thread_tid;
+}
+
+MonoNativeThreadId
+mono_threads_wasm_io_thread_tid (void)
+{
+	return (MonoNativeThreadId) io_thread_tid;
+}
+
+// this is running in io thread
+static gsize
+io_thread_fn (void* unused_arg G_GNUC_UNUSED)
+{
+	io_thread_tid = pthread_self ();
+
+	// this will throw JS "unwind"
+	mono_wasm_start_io_thread_async();
+	
+	return 0;// never reached
+}
+
+EMSCRIPTEN_KEEPALIVE MonoNativeThreadId
+mono_wasm_create_io_thread (void)
+{
+	pthread_create (&io_thread_tid, NULL, (void *(*)(void *)) io_thread_fn, NULL);
+	return io_thread_tid;
+}
+
 // TODO ideally we should not need to have UI thread registered as managed
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_register_ui_thread (void)
+{
+	MonoThread *thread = mono_thread_internal_attach (mono_get_root_domain ());
+	mono_thread_set_state (thread, ThreadState_Background);
+	mono_thread_info_set_flags (MONO_THREAD_INFO_FLAGS_NONE);
+
+	MonoThreadInfo *info = mono_thread_info_current_unchecked ();
+	g_assert (info);
+	info->runtime_thread = TRUE;
+	MONO_ENTER_GC_SAFE_UNBALANCED;
+}
+
+// TODO ideally we should not need to have UI thread registered as managed
+EMSCRIPTEN_KEEPALIVE void
+mono_wasm_register_io_thread (void)
 {
 	MonoThread *thread = mono_thread_internal_attach (mono_get_root_domain ());
 	mono_thread_set_state (thread, ThreadState_Background);

--- a/src/mono/mono/utils/mono-threads-wasm.h
+++ b/src/mono/mono/utils/mono-threads-wasm.h
@@ -34,14 +34,26 @@ mono_wasm_dump_threads_async (void);
 gboolean
 mono_threads_wasm_is_deputy_thread (void);
 
+gboolean
+mono_threads_wasm_is_io_thread (void);
+
 MonoNativeThreadId
 mono_threads_wasm_deputy_thread_tid (void);
 
 MonoNativeThreadId
+mono_threads_wasm_io_thread_tid (void);
+
+MonoNativeThreadId
 mono_wasm_create_deputy_thread (void);
+
+MonoNativeThreadId
+mono_wasm_create_io_thread (void);
 
 void
 mono_wasm_register_ui_thread (void);
+
+void
+mono_wasm_register_io_thread (void);
 
 void
 mono_threads_wasm_async_run_in_target_thread (pthread_t target_thread, void (*func) (void));

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -218,6 +218,7 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestBase
             Assert.Equal("Current count: 0", txt);
 
             await page.Locator("text=\"Click me\"").ClickAsync();
+            await Task.Delay(300);
             txt = await page.Locator("p[role='status']").InnerHTMLAsync();
             Assert.Equal("Current count: 1", txt);
         }


### PR DESCRIPTION
- dispatch Task resolve/reject to dedicated managed I/O thread and continuations to managed ThreadPool
- allow blocking `.Wait` on deputy thread in async methods, async JSExport, C# `Main()`
- keep throwing PNSE inside synchronous JSExport or callback

## changes
- new JSThreadBlockingMode.AllowBlockingWaitInAsyncCode, make it default
- ToManaged(Task) creates Task with TaskCreationOptions.RunContinuationsAsynchronously
- mono_wasm_create_io_thread, mono_wasm_register_io_thread, mono_wasm_start_io_thread_async
- dispatch Promise/Task resolution to I/O Thread
- dispatch release_js_owned_object_by_gc_handle to I/O thread from UI thread
- call `BeforeSyncJSExport` and `AfterSyncJSExport` also on `JSWebWorker` (same thread)
- fix `ConfigureAwait(true)` in HTTP client
- add `mono_wasm_print_thread_dump` to `INTERNAL`

## tests
- `WaitDoesNotAssertInAsyncCode` <-- this is why we do this!
- `WaitAssertsOnSyncCallback`
- `WaitAssertsOnSyncJSExport`
- _XUnitBackgroundExec not default, we don't need it anymore because blocking is fine!
- delete `System.Runtime.InteropServices.JavaScript.BackgroundExec.Tests` 

## new active issues 
- https://github.com/dotnet/runtime/issues/99519
- https://github.com/dotnet/runtime/issues/99500
- https://github.com/dotnet/runtime/issues/99501
