### PR TITLE
JIT: Use sentinel arg to clear error register pre-Swift call

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3374,17 +3374,6 @@ void CodeGen::genCall(GenTreeCall* call)
         genDefineTempLabel(genCreateTempLabel());
     }
 
-#ifdef SWIFT_SUPPORT
-    // Clear the Swift error register before calling a Swift method,
-    // so we can check if it set the error register after returning.
-    // (Flag is only set if we know we need to check the error register)
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
-    {
-        assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
-        instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_SWIFT_ERROR);
-    }
-#endif // SWIFT_SUPPORT
-
     genCallInstruction(call);
 
     genDefinePendingCallLabel(call);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6014,17 +6014,6 @@ void CodeGen::genCall(GenTreeCall* call)
         instGen(INS_vzeroupper);
     }
 
-#ifdef SWIFT_SUPPORT
-    // Clear the Swift error register before calling a Swift method,
-    // so we can check if it set the error register after returning.
-    // (Flag is only set if we know we need to check the error register)
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
-    {
-        assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
-        instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_SWIFT_ERROR);
-    }
-#endif // SWIFT_SUPPORT
-
     genCallInstruction(call X86_ARG(stackArgBytes));
 
     genDefinePendingCallLabel(call);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1488,9 +1488,6 @@ CallArgs::CallArgs()
 #ifdef UNIX_X86_ABI
     , m_alignmentDone(false)
 #endif
-#ifdef SWIFT_SUPPORT
-    , m_hasSwiftErrorHandling(false)
-#endif // SWIFT_SUPPORT
 {
 }
 
@@ -1733,11 +1730,6 @@ void CallArgs::AddedWellKnownArg(WellKnownArg arg)
         case WellKnownArg::RetBuffer:
             m_hasRetBuffer = true;
             break;
-#ifdef SWIFT_SUPPORT
-        case WellKnownArg::SwiftError:
-            m_hasSwiftErrorHandling = true;
-            break;
-#endif // SWIFT_SUPPORT
         default:
             break;
     }
@@ -1760,10 +1752,6 @@ void CallArgs::RemovedWellKnownArg(WellKnownArg arg)
         case WellKnownArg::RetBuffer:
             assert(FindWellKnownArg(arg) == nullptr);
             m_hasRetBuffer = false;
-            break;
-        case WellKnownArg::SwiftError:
-            assert(FindWellKnownArg(arg) == nullptr);
-            m_hasSwiftErrorHandling = false;
             break;
         default:
             break;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1845,6 +1845,10 @@ regNumber CallArgs::GetCustomRegister(Compiler* comp, CorInfoCallConvExtension c
 #endif
 
 #ifdef SWIFT_SUPPORT
+        case WellKnownArg::SwiftError:
+            assert(cc == CorInfoCallConvExtension::Swift);
+            return REG_SWIFT_ERROR;
+
         case WellKnownArg::SwiftSelf:
             assert(cc == CorInfoCallConvExtension::Swift);
             return REG_SWIFT_SELF;
@@ -13101,6 +13105,8 @@ const char* Compiler::gtGetWellKnownArgNameForArgMsg(WellKnownArg arg)
         case WellKnownArg::ValidateIndirectCallTarget:
         case WellKnownArg::DispatchIndirectCallTarget:
             return "cfg tgt";
+        case WellKnownArg::SwiftError:
+            return "swift error";
         case WellKnownArg::SwiftSelf:
             return "swift self";
         default:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1733,6 +1733,11 @@ void CallArgs::AddedWellKnownArg(WellKnownArg arg)
         case WellKnownArg::RetBuffer:
             m_hasRetBuffer = true;
             break;
+#ifdef SWIFT_SUPPORT
+        case WellKnownArg::SwiftError:
+            m_hasSwiftErrorHandling = true;
+            break;
+#endif // SWIFT_SUPPORT
         default:
             break;
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1761,6 +1761,10 @@ void CallArgs::RemovedWellKnownArg(WellKnownArg arg)
             assert(FindWellKnownArg(arg) == nullptr);
             m_hasRetBuffer = false;
             break;
+        case WellKnownArg::SwiftError:
+            assert(FindWellKnownArg(arg) == nullptr);
+            m_hasSwiftErrorHandling = false;
+            break;
         default:
             break;
     }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1488,6 +1488,9 @@ CallArgs::CallArgs()
 #ifdef UNIX_X86_ABI
     , m_alignmentDone(false)
 #endif
+#ifdef SWIFT_SUPPORT
+    , m_hasSwiftErrorHandling(false)
+#endif // SWIFT_SUPPORT
 {
 }
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4785,6 +4785,10 @@ class CallArgs
     // Updateable flag, set to 'true' after we've done any required alignment.
     bool m_alignmentDone : 1;
 #endif
+#ifdef SWIFT_SUPPORT
+    // True if we are calling a Swift method that may throw.
+    bool m_hasSwiftErrorHandling : 1;
+#endif // SWIFT_SUPPORT
 
     void AddedWellKnownArg(WellKnownArg arg);
     void RemovedWellKnownArg(WellKnownArg arg);
@@ -4854,6 +4858,11 @@ public:
     bool HasRegArgs() const { return m_hasRegArgs; }
     bool HasStackArgs() const { return m_hasStackArgs; }
     bool NeedsTemps() const { return m_needsTemps; }
+
+#ifdef SWIFT_SUPPORT
+    bool HasSwiftErrorHandling() const { return m_hasSwiftErrorHandling; }
+    void SetHasSwiftErrorHandling() { m_hasSwiftErrorHandling = true; }
+#endif // SWIFT_SUPPORT
 
 #ifdef UNIX_X86_ABI
     void ComputeStackAlignment(unsigned curStackLevelInBytes)
@@ -5217,15 +5226,6 @@ struct GenTreeCall final : public GenTree
     {
         return (gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0;
     }
-
-#ifdef SWIFT_SUPPORT
-    bool HasSwiftErrorHandling()
-    {
-        // Most calls aren't Swift calls, so short-circuit this check by checking the calling convention first.
-        return (unmgdCallConv == CorInfoCallConvExtension::Swift) &&
-               (gtArgs.FindWellKnownArg(WellKnownArg::SwiftError) != nullptr);
-    }
-#endif // SWIFT_SUPPORT
 
     bool IsR2ROrVirtualStubRelativeIndir()
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4419,6 +4419,7 @@ enum class WellKnownArg : unsigned
     R2RIndirectionCell,
     ValidateIndirectCallTarget,
     DispatchIndirectCallTarget,
+    SwiftError,
     SwiftSelf,
 };
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5222,7 +5222,8 @@ struct GenTreeCall final : public GenTree
     bool HasSwiftErrorHandling()
     {
         // Most calls aren't Swift calls, so short-circuit this check by checking the calling convention first.
-        return (unmgdCallConv == CorInfoCallConvExtension::Swift) && (gtArgs.FindWellKnownArg(WellKnownArg::SwiftError) != nullptr);
+        return (unmgdCallConv == CorInfoCallConvExtension::Swift) &&
+               (gtArgs.FindWellKnownArg(WellKnownArg::SwiftError) != nullptr);
     }
 #endif // SWIFT_SUPPORT
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4785,10 +4785,6 @@ class CallArgs
     // Updateable flag, set to 'true' after we've done any required alignment.
     bool m_alignmentDone : 1;
 #endif
-#ifdef SWIFT_SUPPORT
-    // True if we are calling a Swift method that may throw.
-    bool m_hasSwiftErrorHandling : 1;
-#endif // SWIFT_SUPPORT
 
     void AddedWellKnownArg(WellKnownArg arg);
     void RemovedWellKnownArg(WellKnownArg arg);
@@ -4858,10 +4854,6 @@ public:
     bool HasRegArgs() const { return m_hasRegArgs; }
     bool HasStackArgs() const { return m_hasStackArgs; }
     bool NeedsTemps() const { return m_needsTemps; }
-
-#ifdef SWIFT_SUPPORT
-    bool HasSwiftErrorHandling() const { return m_hasSwiftErrorHandling; }
-#endif // SWIFT_SUPPORT
 
 #ifdef UNIX_X86_ABI
     void ComputeStackAlignment(unsigned curStackLevelInBytes)
@@ -5225,6 +5217,15 @@ struct GenTreeCall final : public GenTree
     {
         return (gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0;
     }
+
+#ifdef SWIFT_SUPPORT
+    bool HasSwiftErrorHandling()
+    {
+        // Most calls aren't Swift calls, so short-circuit this check by checking the calling convention first.
+        return (GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift) &&
+               (gtArgs.FindWellKnownArg(WellKnownArg::SwiftError) != nullptr);
+    }
+#endif // SWIFT_SUPPORT
 
     bool IsR2ROrVirtualStubRelativeIndir()
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4112,10 +4112,6 @@ enum GenTreeCallFlags : unsigned int
     GTF_CALL_M_CAST_CAN_BE_EXPANDED    = 0x04000000, // this cast (helper call) can be expanded if it's profitable. To be removed.
     GTF_CALL_M_CAST_OBJ_NONNULL        = 0x08000000, // if we expand this specific cast we don't need to check the input object for null
                                                      // NOTE: if needed, this flag can be removed, and we can introduce new _NONNUL cast helpers
-
-#ifdef SWIFT_SUPPORT
-    GTF_CALL_M_SWIFT_ERROR_HANDLING    = 0x10000000, // call uses the Swift calling convention, and error register will be checked after it returns.
-#endif // SWIFT_SUPPORT
 };
 
 inline constexpr GenTreeCallFlags operator ~(GenTreeCallFlags a)
@@ -5221,6 +5217,14 @@ struct GenTreeCall final : public GenTree
     {
         return (gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0;
     }
+
+#ifdef SWIFT_SUPPORT
+    bool HasSwiftErrorHandling()
+    {
+        // Most calls aren't Swift calls, so short-circuit this check by checking the calling convention first.
+        return (unmgdCallConv == CorInfoCallConvExtension::Swift) && (gtArgs.FindWellKnownArg(WellKnownArg::SwiftError) != nullptr);
+    }
+#endif // SWIFT_SUPPORT
 
     bool IsR2ROrVirtualStubRelativeIndir()
     {

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4861,7 +4861,6 @@ public:
 
 #ifdef SWIFT_SUPPORT
     bool HasSwiftErrorHandling() const { return m_hasSwiftErrorHandling; }
-    void SetHasSwiftErrorHandling() { m_hasSwiftErrorHandling = true; }
 #endif // SWIFT_SUPPORT
 
 #ifdef UNIX_X86_ABI

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2045,7 +2045,7 @@ void Compiler::impPopArgsForUnmanagedCall(GenTreeCall*        call,
 void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftErrorArg)
 {
     assert(call != nullptr);
-    assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
+    assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
     assert(swiftErrorArg != nullptr);
 
     GenTree* const argNode = swiftErrorArg->GetNode();
@@ -2066,6 +2066,7 @@ void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftE
     GenTree* errorSentinelValueNode = gtNewIconNode(0);
     call->gtArgs.InsertAfter(this, swiftErrorArg,
                              NewCallArg::Primitive(errorSentinelValueNode).WellKnown(WellKnownArg::SwiftError));
+    call->gtArgs.SetHasSwiftErrorHandling();
 
     // Swift call isn't going to use the SwiftError* arg, so don't bother emitting it
     call->gtArgs.Remove(swiftErrorArg);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2059,11 +2059,8 @@ void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftE
     GenTreeStoreInd* swiftErrorStore = gtNewStoreIndNode(argNode->TypeGet(), argNode, errorRegNode);
     impAppendTree(swiftErrorStore, CHECK_SPILL_ALL, impCurStmtDI, false);
 
-    // Indicate the error register will be checked after this call returns
-    call->gtCallMoreFlags |= GTF_CALL_M_SWIFT_ERROR_HANDLING;
-
-    GenTree* errorInitValueNode = gtNewIconNode(0);
-    call->gtArgs.InsertAfter(this, swiftErrorArg, NewCallArg::Primitive(errorInitValueNode).WellKnown(WellKnownArg::SwiftError));
+    GenTree* errorSentinelValueNode = gtNewIconNode(0);
+    call->gtArgs.InsertAfter(this, swiftErrorArg, NewCallArg::Primitive(errorSentinelValueNode).WellKnown(WellKnownArg::SwiftError));
 
     // Swift call isn't going to use the SwiftError* arg, so don't bother emitting it
     call->gtArgs.Remove(swiftErrorArg);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2045,7 +2045,7 @@ void Compiler::impPopArgsForUnmanagedCall(GenTreeCall*        call,
 void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftErrorArg)
 {
     assert(call != nullptr);
-    assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
+    assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
     assert(swiftErrorArg != nullptr);
 
     GenTree* const argNode = swiftErrorArg->GetNode();

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2059,8 +2059,13 @@ void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftE
     GenTreeStoreInd* swiftErrorStore = gtNewStoreIndNode(argNode->TypeGet(), argNode, errorRegNode);
     impAppendTree(swiftErrorStore, CHECK_SPILL_ALL, impCurStmtDI, false);
 
+    // Before calling a Swift method that may throw, the error register must be cleared for the error check to work.
+    // By adding a well-known "sentinel" argument that uses the error register,
+    // the JIT will emit code for clearing the error register before the call, and will mark the error register as busy
+    // so that it isn't used to hold the function call's address.
     GenTree* errorSentinelValueNode = gtNewIconNode(0);
-    call->gtArgs.InsertAfter(this, swiftErrorArg, NewCallArg::Primitive(errorSentinelValueNode).WellKnown(WellKnownArg::SwiftError));
+    call->gtArgs.InsertAfter(this, swiftErrorArg,
+                             NewCallArg::Primitive(errorSentinelValueNode).WellKnown(WellKnownArg::SwiftError));
 
     // Swift call isn't going to use the SwiftError* arg, so don't bother emitting it
     call->gtArgs.Remove(swiftErrorArg);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2066,7 +2066,6 @@ void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftE
     GenTree* errorSentinelValueNode = gtNewIconNode(0);
     call->gtArgs.InsertAfter(this, swiftErrorArg,
                              NewCallArg::Primitive(errorSentinelValueNode).WellKnown(WellKnownArg::SwiftError));
-    call->gtArgs.SetHasSwiftErrorHandling();
 
     // Swift call isn't going to use the SwiftError* arg, so don't bother emitting it
     call->gtArgs.Remove(swiftErrorArg);

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -2062,6 +2062,9 @@ void Compiler::impAppendSwiftErrorStore(GenTreeCall* call, CallArg* const swiftE
     // Indicate the error register will be checked after this call returns
     call->gtCallMoreFlags |= GTF_CALL_M_SWIFT_ERROR_HANDLING;
 
+    GenTree* errorInitValueNode = gtNewIconNode(0);
+    call->gtArgs.InsertAfter(this, swiftErrorArg, NewCallArg::Primitive(errorInitValueNode).WellKnown(WellKnownArg::SwiftError));
+
     // Swift call isn't going to use the SwiftError* arg, so don't bother emitting it
     call->gtArgs.Remove(swiftErrorArg);
 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6003,7 +6003,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
     // For Swift calls that require error handling, ensure the GT_SWIFT_ERROR node
     // that consumes the error register is the call node's successor.
     // This is to simplify logic for marking the error register as busy in LSRA.
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
+    if (call->HasSwiftErrorHandling())
     {
         GenTree* swiftErrorNode = call->gtNext;
         assert(swiftErrorNode != nullptr);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6003,7 +6003,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
     // For Swift calls that require error handling, ensure the GT_SWIFT_ERROR node
     // that consumes the error register is the call node's successor.
     // This is to simplify logic for marking the error register as busy in LSRA.
-    if (call->HasSwiftErrorHandling())
+    if (call->gtArgs.HasSwiftErrorHandling())
     {
         GenTree* swiftErrorNode = call->gtNext;
         assert(swiftErrorNode != nullptr);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6003,7 +6003,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
     // For Swift calls that require error handling, ensure the GT_SWIFT_ERROR node
     // that consumes the error register is the call node's successor.
     // This is to simplify logic for marking the error register as busy in LSRA.
-    if (call->gtArgs.HasSwiftErrorHandling())
+    if (call->HasSwiftErrorHandling())
     {
         GenTree* swiftErrorNode = call->gtNext;
         assert(swiftErrorNode != nullptr);

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -397,7 +397,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
     if (call->gtArgs.HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
-        assert(call->getUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
+        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -394,9 +394,10 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if (call->HasSwiftErrorHandling())
+    if (call->gtArgs.HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
+        assert(call->getUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -394,10 +394,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if (call->gtArgs.HasSwiftErrorHandling())
+    if (call->HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
-        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -394,10 +394,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
+    if (call->HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
-        assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -885,9 +885,7 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
 #ifdef SWIFT_SUPPORT
     // Swift calls that throw may trash the callee-saved error register,
     // so don't use the register post-call until it is consumed by SwiftError.
-    // GTF_CALL_M_SWIFT_ERROR_HANDLING indicates the call has a SwiftError* argument,
-    // so the error register value will eventually be consumed post-call.
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
+    if (call->HasSwiftErrorHandling())
     {
         assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
         killMask |= RBM_SWIFT_ERROR;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -885,9 +885,8 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
 #ifdef SWIFT_SUPPORT
     // Swift calls that throw may trash the callee-saved error register,
     // so don't use the register post-call until it is consumed by SwiftError.
-    if (call->gtArgs.HasSwiftErrorHandling())
+    if (call->HasSwiftErrorHandling())
     {
-        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         killMask |= RBM_SWIFT_ERROR;
     }
 #endif // SWIFT_SUPPORT

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -885,9 +885,9 @@ regMaskTP LinearScan::getKillSetForCall(GenTreeCall* call)
 #ifdef SWIFT_SUPPORT
     // Swift calls that throw may trash the callee-saved error register,
     // so don't use the register post-call until it is consumed by SwiftError.
-    if (call->HasSwiftErrorHandling())
+    if (call->gtArgs.HasSwiftErrorHandling())
     {
-        assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
+        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         killMask |= RBM_SWIFT_ERROR;
     }
 #endif // SWIFT_SUPPORT

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1371,10 +1371,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if ((call->gtCallMoreFlags & GTF_CALL_M_SWIFT_ERROR_HANDLING) != 0)
+    if (call->HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
-        assert(call->unmgdCallConv == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1371,10 +1371,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if (call->gtArgs.HasSwiftErrorHandling())
+    if (call->HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
-        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1371,9 +1371,10 @@ int LinearScan::BuildCall(GenTreeCall* call)
     BuildDefsWithKills(call, dstCount, dstCandidates, killMask);
 
 #ifdef SWIFT_SUPPORT
-    if (call->HasSwiftErrorHandling())
+    if (call->gtArgs.HasSwiftErrorHandling())
     {
         // Tree is a Swift call with error handling; error register should have been killed
+        assert(call->GetUnmanagedCallConv() == CorInfoCallConvExtension::Swift);
         assert((killMask & RBM_SWIFT_ERROR) != 0);
 
         // After a Swift call that might throw returns, we expect the error register to be consumed

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -765,6 +765,8 @@ const char* getWellKnownArgName(WellKnownArg arg)
             return "ValidateIndirectCallTarget";
         case WellKnownArg::DispatchIndirectCallTarget:
             return "DispatchIndirectCallTarget";
+        case WellKnownArg::SwiftError:
+            return "SwiftError";
         case WellKnownArg::SwiftSelf:
             return "SwiftSelf";
     }


### PR DESCRIPTION
Fixes #99414. By adding a well-known zero argument to Swift calls with error handling that is always passed via the error register, we can get the JIT to clear the error register before the call, and also prevent the function address from being passed in the error register.