### PR TITLE
Fix overaggressive switch optimization in regex source generator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -1789,16 +1789,6 @@ namespace System.Text.RegularExpressions.Generator
                                     sliceStaticPos++;
                                     break;
 
-                                case RegexNodeKind.Onelazy or RegexNodeKind.Oneloop or RegexNodeKind.Oneloopatomic:
-                                case RegexNodeKind.Setlazy or RegexNodeKind.Setloop or RegexNodeKind.Setloopatomic:
-                                    // First character of the loop was handled by the switch. Emit matching code for the remainder of the loop.
-                                    Debug.Assert(child == startingLiteralNode);
-                                    Debug.Assert(child.M > 0);
-                                    sliceStaticPos++;
-                                    EmitNode(child.CloneCharLoopWithOneLessIteration());
-                                    writer.WriteLine();
-                                    break;
-
                                 case RegexNodeKind.Multi:
                                     // First character was handled by the switch. Emit matching code for the remainder of the multi string.
                                     sliceStaticPos++;
@@ -1808,16 +1798,20 @@ namespace System.Text.RegularExpressions.Generator
                                     writer.WriteLine();
                                     break;
 
-                                case RegexNodeKind.Concatenate when child.Child(0) == startingLiteralNode && (startingLiteralNode.IsOneFamily || startingLiteralNode.IsSetFamily || startingLiteralNode.Kind is RegexNodeKind.Multi):
-                                    // This is a concatenation where its first node is the starting literal we found. This is a common
+                                case RegexNodeKind.Concatenate when child.Child(0) == startingLiteralNode && (startingLiteralNode.Kind is RegexNodeKind.One or RegexNodeKind.Set or RegexNodeKind.Multi):
+                                    // This is a concatenation where its first node is the starting literal we found and that starting literal
+                                    // is one of the nodes above that we know how to handle completely. This is a common
                                     // enough case that we want to special-case it to avoid duplicating the processing for that character
                                     // unnecessarily. So, we'll shave off that first node from the concatenation and then handle the remainder.
+                                    // Note that it's critical startingLiteralNode is something we can fully handle above: if it's not,
+                                    // we'll end up losing some of the pattern due to overwriting `remainder`.
                                     remainder = child;
                                     child = child.Child(0);
                                     remainder.ReplaceChild(0, new RegexNode(RegexNodeKind.Empty, remainder.Options));
                                     goto HandleChild; // reprocess just the first node that was saved; the remainder will then be processed below
 
                                 default:
+                                    Debug.Assert(remainder is null);
                                     remainder = child;
                                     break;
                             }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -660,8 +660,15 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@$"^{aOptional}{{1,2}}?b", "aaab", RegexOptions.None, 0, 4, false, "");
                 yield return (@$"^{aOptional}{{2}}b", "aab", RegexOptions.None, 0, 3, true, "aab");
             }
+            yield return (@"(a+.|b+.)", "aaac", RegexOptions.None, 0, 4, true, "aaac");
+            yield return (@"(a+?.|b+?.)", "aaac", RegexOptions.None, 0, 4, true, "aa");
+            yield return (@"((a+?).|(b+?).)", "aaac", RegexOptions.None, 0, 4, true, "aa");
+            yield return (@"((a+?)+.|(b+?)+.)", "aaac", RegexOptions.None, 0, 4, true, "aaac");
+            yield return (@"((a+?)+?.|(b+?)+?.)", "aaac", RegexOptions.None, 0, 4, true, "aa");
             if (!RegexHelpers.IsNonBacktracking(engine))
             {
+                yield return (@"((?>a+).|(?>b+).)", "aaac", RegexOptions.None, 0, 4, true, "aaac");
+
                 yield return ("(?(dog2))", "dog2", RegexOptions.None, 0, 4, true, string.Empty);
                 yield return ("(?(a:b))", "a", RegexOptions.None, 0, 1, true, string.Empty);
                 yield return ("(?(a:))", "a", RegexOptions.None, 0, 1, true, string.Empty);


### PR DESCRIPTION
We recently updated the source generator to be able to employ its alternation optimization that employs switch constructs in more places. However, it was being a bit overaggressive, in two ways:
1. Because of how it was slicing off the first character from a character loop, it was manufacturing a new node that the analysis engine hadn't seen before. As a result, it would report the node didn't contain any backtracking constructs, even if it did, and that would lead to braces possibly being emitted in the source where they shouldn't have been, which would lead to compilation failures when trying to goto a label inside of that block.
2. A concatenation of two nodes might lose the latter half of the concatenation if the first half isn't one of the few nodes we know how to handle.

Both of these come about from trying to avoid recomparing the single character at the beginning of the construct that was used in the switch. We can avoid the challenges by just doing that additional comparison, if necessary. In practice, the only case we can't do that where we were doing it is where the branch begins with a char loop.

(This was causing an outerloop test to fail, but it was masked by another recently-fixed issue that caused outerloop test failures to not be reported.)