### PR TITLE
Enable publishing in VMR

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -47,7 +47,7 @@
            Properties that control flags from the VMR build, and the expected output for the VMR build should be added to this file. -->
 
       <!-- Enable regular Arcade publishing in VMR build -->
-      <InnerBuildArgs Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)publish</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)publish</InnerBuildArgs>
 
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -45,6 +45,10 @@
       <!-- Properties that control source-only build configurations should be added to the repository and guarded with DotNetBuildSourceOnly conditions.
            This allows to build the repository using './build.sh <args> /p:DotNetBuildSourceOnly=true'.
            Properties that control flags from the VMR build, and the expected output for the VMR build should be added to this file. -->
+
+      <!-- Enable regular Arcade publishing in VMR build -->
+      <InnerBuildArgs Condition="'$(DotNetBuildFromSourceFlavor)' == 'Product' or '$(DotNetBuildOrchestrator)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)restore $(FlagParameterPrefix)build $(FlagParameterPrefix)publish</InnerBuildArgs>
+
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)arch $(TargetArch)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(DotNetBuildSourceOnly)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)os $(TargetOS)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(TargetArch)' != '$(_hostArch)' and '$(ShortStack)' != 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)cross</InnerBuildArgs>
@@ -74,6 +78,12 @@
       <InnerBuildArgs Condition="'$(ContinuousIntegrationBuild)' != ''">$(InnerBuildArgs) /p:ContinuousIntegrationBuild=$(ContinuousIntegrationBuild)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(PortableBuild)' != ''">$(InnerBuildArgs) /p:PortableBuild=$(PortableBuild)</InnerBuildArgs>
       <InnerBuildArgs Condition="'$(RestoreConfigFile)' != ''">$(InnerBuildArgs) /p:RestoreConfigFile=$(RestoreConfigFile)</InnerBuildArgs>
+
+      <!-- Pass locations for assets and packages -->
+      <InnerBuildArgs Condition="'$(SourceBuiltAssetsDir)' != ''">$(InnerBuildArgs) /p:SourceBuiltAssetsDir=$(SourceBuiltAssetsDir)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(SourceBuiltShippingPackagesDir)' != ''">$(InnerBuildArgs) /p:SourceBuiltShippingPackagesDir=$(SourceBuiltShippingPackagesDir)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(SourceBuiltNonShippingPackagesDir)' != ''">$(InnerBuildArgs) /p:SourceBuiltNonShippingPackagesDir=$(SourceBuiltNonShippingPackagesDir)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(SourceBuiltAssetManifestsDir)' != ''">$(InnerBuildArgs) /p:SourceBuiltAssetManifestsDir=$(SourceBuiltAssetManifestsDir)</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,6 +2,60 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
   </PropertyGroup>
+
+  <ItemGroup>
+    <_InstallersToPublish Remove="@(_InstallersToPublish)" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.deb" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.rpm" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+  </ItemGroup>
+
+  <Target Name="_PublishInstallers">
+
+    <ItemGroup>
+      <_SymbolsArchive Include="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+      <!-- Exclude Symbols archive as it is already included, with correct blob path, in Publish.proj. -->
+      <_InstallersToPublish Remove="@(_SymbolsArchive)" Condition="'$(DotNetBuildFromSource)' == 'true'" />
+    </ItemGroup>
+
+    <!-- Discover the runtime package version from dotnet-runtime-<version-<Rid>.<Extension> archive. -->
+    <PropertyGroup>
+      <_RuntimeFilenamePrefix>dotnet-runtime-</_RuntimeFilenamePrefix>
+      <_PackageRid>$(OutputRID)</_PackageRid>
+      <!-- Use TargetRid if OutputRID isn't available, i.e. on Windows. -->
+      <_PackageRid Condition="'$(_PackageRid)' == ''">$(TargetRid)</_PackageRid>
+    </PropertyGroup>
+    <ItemGroup>
+      <_RuntimeArchiveItem Include="$(ArtifactsPackagesDir)**\$(_RuntimeFilenamePrefix)*$(_PackageRid)$(ArchiveExtension)" />
+      <_RuntimeInternalArchiveItem Include="$(ArtifactsPackagesDir)**\dotnet-runtime-internal*$(_PackageRid)$(ArchiveExtension)" />
+      <_RuntimeArchiveItem Remove="@(_RuntimeInternalArchiveItem)" />
+    </ItemGroup>
+
+    <!-- Extract runtime version from runtime archive filename. -->
+    <PropertyGroup>
+      <_RuntimeArchiveFilename>%(_RuntimeArchiveItem.Filename)%(_RuntimeArchiveItem.Extension)</_RuntimeArchiveFilename>
+      <_RuntimeVersion>$(_RuntimeArchiveFilename.Replace('$(_RuntimeFilenamePrefix)','').Replace('-$(_PackageRid)$(ArchiveExtension)',''))</_RuntimeVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
+           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
+           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
+           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
+           and Build.proj is invoked from the wrapper build. -->
+      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
+
+      <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
+        <ManifestArtifactData>NonShipping=false</ManifestArtifactData>
+        <PublishFlatContainer>true</PublishFlatContainer>
+        <RelativeBlobPath>%(_InstallersToPublish.UploadPathSegment)/$(_RuntimeVersion)/%(Filename)%(Extension)</RelativeBlobPath>
+      </ItemsToPushToBlobFeed>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,29 +2,20 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    <PublishDependsOnTargets Condition="'$(DotNetBuildRepo)' == 'true'">$(PublishDependsOnTargets);PublishRuntimeInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
   <!-- Include installer archives and packages which aren't globbed by default.
        Don't include Symbols archive as it is already included in Arcade's Publish.proj, with correct blob path. -->
-  <Target Name="PublishRuntimeInstallers">
-    <!-- Discover the runtime package version from dotnet-runtime-<Version>-<Rid>.<Extension> archive. -->
-    <PropertyGroup>
-      <_RuntimeFilenamePrefix>dotnet-runtime-</_RuntimeFilenamePrefix>
-      <!-- Use TargetRid if OutputRID isn't available, i.e. on Windows. -->
-      <_PackageRid>$([MSBuild]::ValueOrDefault('$(OutputRID)', '$(TargetRid)'))</_PackageRid>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <_RuntimeArchiveItem Include="$(ArtifactsPackagesDir)**\$(_RuntimeFilenamePrefix)*$(_PackageRid)$(ArchiveExtension)"
-                           Exclude="$(ArtifactsPackagesDir)**\dotnet-runtime-internal*$(_PackageRid)$(ArchiveExtension)" />
-    </ItemGroup>
-
-    <!-- Extract runtime version from runtime archive filename. -->
-    <PropertyGroup>
-      <_RuntimeArchiveFilename>%(_RuntimeArchiveItem.Filename)%(_RuntimeArchiveItem.Extension)</_RuntimeArchiveFilename>
-      <_RuntimeVersion>$(_RuntimeArchiveFilename.Replace('$(_RuntimeFilenamePrefix)','').Replace('-$(_PackageRid)$(ArchiveExtension)',''))</_RuntimeVersion>
-    </PropertyGroup>
+  <Target Name="PublishRuntimeInstallers"
+          BeforeTargets="BeforePublish"
+          Condition="'$(DotNetBuildRepo)' == 'true'">
+    <!-- Retrieve runtime's runtime pack product version.
+         Don't stabilize the package version in order to retrieve the VersionSuffix. -->
+    <MSBuild Projects="$(RepoRoot)src/installer/pkg/sfx/Microsoft.NETCoreApp/Microsoft.NETCore.App.Runtime.sfxproj"
+             Targets="ReturnProductVersion"
+             Properties="IsShipping=false">
+      <Output TaskParameter="TargetOutputs" PropertyName="RuntimeRuntimePackProductVersion" />
+    </MSBuild>
 
     <ItemGroup>
       <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz;
@@ -34,13 +25,11 @@
                                    $(ArtifactsPackagesDir)**\*.exe;
                                    $(ArtifactsPackagesDir)**\*.msi"
                           Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
-                             ManifestArtifactData="NonShipping=false"
+                             IsShipping="true"
+                             ManifestArtifactData="DotNetReleaseShipping=true"
                              PublishFlatContainer="true"
-                             RelativeBlobPath="Runtime/$(_RuntimeVersion)/%(Filename)%(Extension)" />
+                             RelativeBlobPath="Runtime/$(RuntimeRuntimePackProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -26,7 +26,7 @@
       <_RuntimeVersion>$(_RuntimeArchiveFilename.Replace('$(_RuntimeFilenamePrefix)','').Replace('-$(_PackageRid)$(ArchiveExtension)',''))</_RuntimeVersion>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
+    <ItemGroup>
       <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz;
                                    $(ArtifactsPackagesDir)**\*.zip;
                                    $(ArtifactsPackagesDir)**\*.deb;

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,38 +2,22 @@
 
   <PropertyGroup>
     <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
+    <PublishDependsOnTargets Condition="'$(DotNetBuildRepo)' == 'true'">$(PublishDependsOnTargets);PublishRuntimeInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
-    <_InstallersToPublish Remove="@(_InstallersToPublish)" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.deb" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.rpm" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="Runtime" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="Runtime" />
-  </ItemGroup>
-
-  <Target Name="_PublishInstallers">
-
-    <ItemGroup>
-      <_SymbolsArchive Include="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" Condition="'$(DotNetBuildFromSource)' == 'true'" />
-      <!-- Exclude Symbols archive as it is already included, with correct blob path, in Publish.proj. -->
-      <_InstallersToPublish Remove="@(_SymbolsArchive)" Condition="'$(DotNetBuildFromSource)' == 'true'" />
-    </ItemGroup>
-
+  <!-- Include installer archives and packages which aren't globbed by default.
+       Don't include Symbols archive as it is already included in Arcade's Publish.proj, with correct blob path. -->
+  <Target Name="PublishRuntimeInstallers">
     <!-- Discover the runtime package version from dotnet-runtime-<Version>-<Rid>.<Extension> archive. -->
     <PropertyGroup>
       <_RuntimeFilenamePrefix>dotnet-runtime-</_RuntimeFilenamePrefix>
-      <_PackageRid>$(OutputRID)</_PackageRid>
       <!-- Use TargetRid if OutputRID isn't available, i.e. on Windows. -->
-      <_PackageRid Condition="'$(_PackageRid)' == ''">$(TargetRid)</_PackageRid>
+      <_PackageRid>$([MSBuild]::ValueOrDefault('$(OutputRID)', '$(TargetRid)'))</_PackageRid>
     </PropertyGroup>
+
     <ItemGroup>
-      <_RuntimeArchiveItem Include="$(ArtifactsPackagesDir)**\$(_RuntimeFilenamePrefix)*$(_PackageRid)$(ArchiveExtension)" />
-      <_RuntimeInternalArchiveItem Include="$(ArtifactsPackagesDir)**\dotnet-runtime-internal*$(_PackageRid)$(ArchiveExtension)" />
-      <_RuntimeArchiveItem Remove="@(_RuntimeInternalArchiveItem)" />
+      <_RuntimeArchiveItem Include="$(ArtifactsPackagesDir)**\$(_RuntimeFilenamePrefix)*$(_PackageRid)$(ArchiveExtension)"
+                           Exclude="$(ArtifactsPackagesDir)**\dotnet-runtime-internal*$(_PackageRid)$(ArchiveExtension)" />
     </ItemGroup>
 
     <!-- Extract runtime version from runtime archive filename. -->
@@ -42,12 +26,22 @@
       <_RuntimeVersion>$(_RuntimeArchiveFilename.Replace('$(_RuntimeFilenamePrefix)','').Replace('-$(_PackageRid)$(ArchiveExtension)',''))</_RuntimeVersion>
     </PropertyGroup>
 
+    <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
+      <InstallerToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz;
+                                   $(ArtifactsPackagesDir)**\*.zip;
+                                   $(ArtifactsPackagesDir)**\*.deb;
+                                   $(ArtifactsPackagesDir)**\*.rpm;
+                                   $(ArtifactsPackagesDir)**\*.exe;
+                                   $(ArtifactsPackagesDir)**\*.msi"
+                          Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz"
+                          UploadPathSegment="Runtime" />
+    </ItemGroup>
+
     <ItemGroup>
-      <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
-        <ManifestArtifactData>NonShipping=false</ManifestArtifactData>
-        <PublishFlatContainer>true</PublishFlatContainer>
-        <RelativeBlobPath>%(_InstallersToPublish.UploadPathSegment)/$(_RuntimeVersion)/%(Filename)%(Extension)</RelativeBlobPath>
-      </ItemsToPushToBlobFeed>
+      <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
+                             ManifestArtifactData="NonShipping=false"
+                             PublishFlatContainer"true"
+                             RelativeBlobPath="%(InstallerToPublish.UploadPathSegment)/$(_RuntimeVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -33,15 +33,14 @@
                                    $(ArtifactsPackagesDir)**\*.rpm;
                                    $(ArtifactsPackagesDir)**\*.exe;
                                    $(ArtifactsPackagesDir)**\*.msi"
-                          Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz"
-                          UploadPathSegment="Runtime" />
+                          Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" />
     </ItemGroup>
 
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
                              ManifestArtifactData="NonShipping=false"
                              PublishFlatContainer="true"
-                             RelativeBlobPath="%(InstallerToPublish.UploadPathSegment)/$(_RuntimeVersion)/%(Filename)%(Extension)" />
+                             RelativeBlobPath="Runtime/$(_RuntimeVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -13,7 +13,9 @@
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
     <MSBuild Projects="$(RepoRoot)src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj"
              Targets="ReturnProductVersion"
-             Properties="IsShipping=false">
+             Properties="IsShipping=false;
+                         Crossgen2SdkOverridePropsPath=;
+                         Crossgen2SdkOverrideTargetsPath=">
       <Output TaskParameter="TargetOutputs" PropertyName="RuntimeRuntimePackProductVersion" />
     </MSBuild>
 

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -5,14 +5,14 @@
     <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishInstallers</PublishDependsOnTargets>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildRepo)' == 'true'">
     <_InstallersToPublish Remove="@(_InstallersToPublish)" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.deb" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.rpm" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
-    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="Runtime" Condition="'$(DotNetBuildRepo)' == 'true'" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.tar.gz" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.zip" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.deb" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.rpm" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.exe" UploadPathSegment="Runtime" />
+    <_InstallersToPublish Include="$(ArtifactsPackagesDir)**\*.msi" UploadPathSegment="Runtime" />
   </ItemGroup>
 
   <Target Name="_PublishInstallers">
@@ -23,7 +23,7 @@
       <_InstallersToPublish Remove="@(_SymbolsArchive)" Condition="'$(DotNetBuildFromSource)' == 'true'" />
     </ItemGroup>
 
-    <!-- Discover the runtime package version from dotnet-runtime-<version-<Rid>.<Extension> archive. -->
+    <!-- Discover the runtime package version from dotnet-runtime-<Version>-<Rid>.<Extension> archive. -->
     <PropertyGroup>
       <_RuntimeFilenamePrefix>dotnet-runtime-</_RuntimeFilenamePrefix>
       <_PackageRid>$(OutputRID)</_PackageRid>
@@ -43,13 +43,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <!-- Do not push .nupkg files from Linux and macOS builds. They'll be packed up separately and signed on Windows.
-           Do not remove if post build sign is true, as we avoid the xplat codesign jobs, and need to have
-           the nupkgs pushed. Do not do this if building from source, since we want the source build intermediate package
-           to be published. Use DotNetBuildRepo as DotNetBuildFromSource is only set in the internal source build,
-           and Build.proj is invoked from the wrapper build. -->
-      <ItemsToPushToBlobFeed Remove="@(ItemsToPushToBlobFeed)" Condition="'$(OS)' != 'Windows_NT' and '$(PostBuildSign)' != 'true' and '$(DotNetBuildRepo)' != 'true'" />
-
       <ItemsToPushToBlobFeed Include="@(_InstallersToPublish)">
         <ManifestArtifactData>NonShipping=false</ManifestArtifactData>
         <PublishFlatContainer>true</PublishFlatContainer>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -11,7 +11,7 @@
           Condition="'$(DotNetBuildRepo)' == 'true'">
     <!-- Retrieve runtime's runtime pack product version.
          Don't stabilize the package version in order to retrieve the VersionSuffix. -->
-    <MSBuild Projects="$(RepoRoot)src/installer/pkg/sfx/Microsoft.NETCoreApp/Microsoft.NETCore.App.Runtime.sfxproj"
+    <MSBuild Projects="$(RepoRoot)src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.sfxproj"
              Targets="ReturnProductVersion"
              Properties="IsShipping=false">
       <Output TaskParameter="TargetOutputs" PropertyName="RuntimeRuntimePackProductVersion" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -40,7 +40,7 @@
     <ItemGroup>
       <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
                              ManifestArtifactData="NonShipping=false"
-                             PublishFlatContainer"true"
+                             PublishFlatContainer="true"
                              RelativeBlobPath="%(InstallerToPublish.UploadPathSegment)/$(_RuntimeVersion)/%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -25,9 +25,9 @@
                                    $(ArtifactsPackagesDir)**\*.exe;
                                    $(ArtifactsPackagesDir)**\*.msi"
                           Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" />
+
       <ItemsToPushToBlobFeed Include="@(InstallerToPublish)"
-                             IsShipping="true"
-                             ManifestArtifactData="DotNetReleaseShipping=true"
+                             IsShipping="$([System.String]::Copy('%(RecursiveDir)').StartsWith('Shipping'))"
                              PublishFlatContainer="true"
                              RelativeBlobPath="Runtime/$(RuntimeRuntimePackProductVersion)/%(Filename)%(Extension)" />
     </ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4101

Enables publishing in VMR.

Installers are not collected by common arcade publishing infra. All repos that build installers need to collect them in Publishing.props file.

Additionally installers need to be published to correct blob path, which includes runtime package version. I'm obtaining this from dotnet-runtime-<Version-<Rid>.<Extension> archive.