### PR TITLE
[RISC-V] Enable crossgen for corelib

### DIFF
--- a/src/coreclr/crossgen-corelib.proj
+++ b/src/coreclr/crossgen-corelib.proj
@@ -23,7 +23,6 @@
   <PropertyGroup>
     <BuildDll>true</BuildDll>
     <BuildDll Condition="'$(TargetOS)' == 'netbsd' or '$(TargetOS)' == 'illumos' or '$(TargetOS)' == 'solaris' or '$(TargetOS)' == 'haiku'">false</BuildDll>
-    <BuildDll Condition="'$(TargetArchitecture)' == 'riscv64'">false</BuildDll>
 
     <BuildPdb>false</BuildPdb>
     <BuildPdb Condition="$(BuildDll) and '$(OS)' == 'Windows_NT' and '$(TargetOS)' == 'windows'">true</BuildPdb>


### PR DESCRIPTION
This enables crossgen2 for corelib because
- We fixed many bugs on crossgen2. I think crossgen2 is enough for corelib.
- To prevent breaks on RISC-V, I want to add a checker in RISC-V build CI.

Actually, there are still some bugs like https://github.com/dotnet/runtime/pull/97877, but I beleive that we can fix them soon.
\+ **To run with crossgened files on RISC-V, we need to disable `EnableWriteXorExecute`. (`DOTNET_EnableWriteXorExecute=0`)**

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung