### PR TITLE
Fix tiny regression in Enumerable.ElementAt

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AppendPrepend.SpeedOpt.cs
@@ -171,9 +171,7 @@ namespace System.Linq
                     }
 
                     index--;
-                    return
-                        _source is Iterator<TSource> iterator ? iterator.TryGetElementAt(index, out found) :
-                        TryGetElementAtNonIterator(_source, index, out found);
+                    return _source.TryGetElementAt(index, out found);
                 }
 
                 return base.TryGetElementAt(index, out found);


### PR DESCRIPTION
This just moves a few ns around, mainly putting the check for IList before the check for Iterator, matching how it was previously.

Addresses ElementAt benchmarks in https://github.com/dotnet/runtime/issues/99318, https://github.com/dotnet/runtime/issues/99315, and https://github.com/dotnet/runtime/issues/99417.