### PR TITLE
JIT: Add pred block iterator that tolerates pred list modifications

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1531,10 +1531,18 @@ public:
     // PredBlocks: convenience method for enabling range-based `for` iteration over predecessor blocks, e.g.:
     //    for (BasicBlock* const predBlock : block->PredBlocks()) ...
     //
-    template <bool            allowEdits = false>
-    PredBlockList<allowEdits> PredBlocks() const
+    PredBlockList<false> PredBlocks() const
     {
-        return PredBlockList<allowEdits>(bbPreds);
+        return PredBlockList<false>(bbPreds);
+    }
+
+    // PredBlocksEditing: convenience method for enabling range-based `for` iteration over predecessor blocks, e.g.:
+    //    for (BasicBlock* const predBlock : block->PredBlocksList()) ...
+    // This iterator tolerates modifications to bbPreds.
+    //
+    PredBlockList<true> PredBlocksEditing() const
+    {
+        return PredBlockList<true>(bbPreds);
     }
 
     // Pred list maintenance

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -2431,6 +2431,7 @@ inline typename PredBlockList<allowEdits>::iterator& PredBlockList<allowEdits>::
 {
     if (allowEdits)
     {
+        // For editing iterators, m_next is always used and maintained
         m_pred = m_next;
         m_next = (m_next == nullptr) ? nullptr : m_next->getNextPredEdge();
     }

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1531,7 +1531,7 @@ public:
     // PredBlocks: convenience method for enabling range-based `for` iteration over predecessor blocks, e.g.:
     //    for (BasicBlock* const predBlock : block->PredBlocks()) ...
     //
-    template <bool allowEdits = false>
+    template <bool            allowEdits = false>
     PredBlockList<allowEdits> PredBlocks() const
     {
         return PredBlockList<allowEdits>(bbPreds);
@@ -2412,17 +2412,17 @@ inline PredBlockList<allowEdits>::iterator::iterator(FlowEdge* pred) : m_pred(pr
     }
 }
 
-template <bool allowEdits>
+template <bool     allowEdits>
 inline BasicBlock* PredBlockList<allowEdits>::iterator::operator*() const
 {
     return m_pred->getSourceBlock();
 }
 
-template <bool allowEdits>
+template <bool                                       allowEdits>
 inline typename PredBlockList<allowEdits>::iterator& PredBlockList<allowEdits>::iterator::operator++()
 {
-    FlowEdge* next = m_pred->getNextPredEdge();
-    bool updateNextPointer = allowEdits;
+    FlowEdge* next              = m_pred->getNextPredEdge();
+    bool      updateNextPointer = allowEdits;
 
 #ifdef DEBUG
     // If allowEdits=false, check that the next block is the one we expect to see.
@@ -2434,7 +2434,7 @@ inline typename PredBlockList<allowEdits>::iterator& PredBlockList<allowEdits>::
 
     if (updateNextPointer)
     {
-        next = m_next;
+        next   = m_next;
         m_next = (m_next == nullptr) ? nullptr : m_next->getNextPredEdge();
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -2429,24 +2429,24 @@ inline BasicBlock* PredBlockList<allowEdits>::iterator::operator*() const
 template <bool                                       allowEdits>
 inline typename PredBlockList<allowEdits>::iterator& PredBlockList<allowEdits>::iterator::operator++()
 {
-    FlowEdge* next              = m_pred->getNextPredEdge();
-    bool      updateNextPointer = allowEdits;
-
-#ifdef DEBUG
-    // If allowEdits=false, check that the next block is the one we expect to see.
-    // If allowEdits=true, the user can modify the predecessor list while traversing it,
-    // so (next == m_next) may not be true. Since we cached the next pointer in m_next, this won't break iteration.
-    assert((next == m_next) || allowEdits);
-    updateNextPointer = true;
-#endif // DEBUG
-
-    if (updateNextPointer)
+    if (allowEdits)
     {
-        next   = m_next;
+        m_pred = m_next;
         m_next = (m_next == nullptr) ? nullptr : m_next->getNextPredEdge();
     }
+    else
+    {
+        FlowEdge* next = m_pred->getNextPredEdge();
 
-    m_pred = next;
+#ifdef DEBUG
+        // If allowEdits=false, check that the next block is the one we expect to see.
+        assert(next == m_next);
+        m_next = (m_next == nullptr) ? nullptr : m_next->getNextPredEdge();
+#endif // DEBUG
+
+        m_pred = next;
+    }
+
     return *this;
 }
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5291,8 +5291,7 @@ BasicBlock* Compiler::fgRemoveBlock(BasicBlock* block, bool unreachable)
 
         fgRemoveRefPred(block->GetTargetEdge());
 
-        constexpr bool allowEdits = true;
-        for (BasicBlock* const predBlock : block->PredBlocks<allowEdits>())
+        for (BasicBlock* const predBlock : block->PredBlocksEditing())
         {
             /* change all jumps/refs to the removed block */
             switch (predBlock->GetKind())

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2002,36 +2002,31 @@ PhaseStatus Compiler::fgTailMergeThrows()
 
         // Walk pred list of the non canonical block, updating flow to target
         // the canonical block instead.
-        for (FlowEdge* predEdge = nonCanonicalBlock->bbPreds; predEdge != nullptr; predEdge = nextPredEdge)
+        constexpr bool allowEdits = true;
+        for (BasicBlock* const predBlock : nonCanonicalBlock->PredBlocks<allowEdits>())
         {
-            BasicBlock* const predBlock = predEdge->getSourceBlock();
-            nextPredEdge                = predEdge->getNextPredEdge();
-
             switch (predBlock->GetKind())
             {
-                case BBJ_ALWAYS:
-                {
-                    fgTailMergeThrowsJumpToHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
-                    updated = true;
-                }
-                break;
-
+                // TODO: Use fgReplaceJumpTarget once it preserves edge weights for BBJ_COND blocks
                 case BBJ_COND:
                 {
-                    // Flow to non canonical block could be via fall through or jump or both.
+                    // Flow to non canonical block could be via true or false target.
                     if (predBlock->FalseTargetIs(nonCanonicalBlock))
                     {
-                        fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
+                        fgTailMergeThrowsFallThroughHelper(predBlock, nonCanonicalBlock, canonicalBlock,
+                                                           predBlock->GetFalseEdge());
                     }
 
                     if (predBlock->TrueTargetIs(nonCanonicalBlock))
                     {
-                        fgTailMergeThrowsJumpToHelper(predBlock, nonCanonicalBlock, canonicalBlock, predEdge);
+                        fgTailMergeThrowsJumpToHelper(predBlock, nonCanonicalBlock, canonicalBlock,
+                                                      predBlock->GetTrueEdge());
                     }
                     updated = true;
                 }
                 break;
 
+                case BBJ_ALWAYS:
                 case BBJ_SWITCH:
                 {
                     JITDUMP("*** " FMT_BB " now branching to " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
@@ -2127,21 +2122,12 @@ void Compiler::fgTailMergeThrowsJumpToHelper(BasicBlock* predBlock,
 {
     JITDUMP("*** " FMT_BB " now branching to " FMT_BB "\n", predBlock->bbNum, canonicalBlock->bbNum);
 
-    if (predBlock->KindIs(BBJ_ALWAYS))
-    {
-        // Update flow to new target
-        assert(predBlock->TargetIs(nonCanonicalBlock));
-        fgRedirectTargetEdge(predBlock, canonicalBlock);
-    }
-    else
-    {
-        // Remove the old flow
-        assert(predBlock->KindIs(BBJ_COND));
-        assert(predBlock->TrueTargetIs(nonCanonicalBlock));
-        fgRemoveRefPred(predBlock->GetTrueEdge());
+    // Remove the old flow
+    assert(predBlock->KindIs(BBJ_COND));
+    assert(predBlock->TrueTargetIs(nonCanonicalBlock));
+    fgRemoveRefPred(predBlock->GetTrueEdge());
 
-        // Wire up the new flow
-        FlowEdge* const trueEdge = fgAddRefPred(canonicalBlock, predBlock, predEdge);
-        predBlock->SetTrueEdge(trueEdge);
-    }
+    // Wire up the new flow
+    FlowEdge* const trueEdge = fgAddRefPred(canonicalBlock, predBlock, predEdge);
+    predBlock->SetTrueEdge(trueEdge);
 }

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -2002,8 +2002,7 @@ PhaseStatus Compiler::fgTailMergeThrows()
 
         // Walk pred list of the non canonical block, updating flow to target
         // the canonical block instead.
-        constexpr bool allowEdits = true;
-        for (BasicBlock* const predBlock : nonCanonicalBlock->PredBlocks<allowEdits>())
+        for (BasicBlock* const predBlock : nonCanonicalBlock->PredBlocksEditing())
         {
             switch (predBlock->GetKind())
             {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2247,8 +2247,7 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     //
     unsigned const loopFirstNum  = bTop->bbNum;
     unsigned const loopBottomNum = bTest->bbNum;
-    constexpr bool allowEdits    = true;
-    for (BasicBlock* const predBlock : bTest->PredBlocks<allowEdits>())
+    for (BasicBlock* const predBlock : bTest->PredBlocksEditing())
     {
         unsigned const bNum = predBlock->bbNum;
         if ((loopFirstNum <= bNum) && (bNum <= loopBottomNum))
@@ -3155,8 +3154,7 @@ bool Compiler::optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit)
     JITDUMP("Created new exit " FMT_BB " to replace " FMT_BB " for " FMT_LP "\n", newExit->bbNum, exit->bbNum,
             loop->GetIndex());
 
-    constexpr bool allowEdits = true;
-    for (BasicBlock* pred : exit->PredBlocks<allowEdits>())
+    for (BasicBlock* pred : exit->PredBlocksEditing())
     {
         if (loop->ContainsBlock(pred))
         {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2247,7 +2247,8 @@ bool Compiler::optInvertWhileLoop(BasicBlock* block)
     //
     unsigned const loopFirstNum  = bTop->bbNum;
     unsigned const loopBottomNum = bTest->bbNum;
-    for (BasicBlock* const predBlock : bTest->PredBlocks())
+    constexpr bool allowEdits    = true;
+    for (BasicBlock* const predBlock : bTest->PredBlocks<allowEdits>())
     {
         unsigned const bNum = predBlock->bbNum;
         if ((loopFirstNum <= bNum) && (bNum <= loopBottomNum))
@@ -3154,7 +3155,8 @@ bool Compiler::optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit)
     JITDUMP("Created new exit " FMT_BB " to replace " FMT_BB " for " FMT_LP "\n", newExit->bbNum, exit->bbNum,
             loop->GetIndex());
 
-    for (BasicBlock* pred : exit->PredBlocks())
+    constexpr bool allowEdits = true;
+    for (BasicBlock* pred : exit->PredBlocks<allowEdits>())
     {
         if (loop->ContainsBlock(pred))
         {

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1600,7 +1600,8 @@ bool Compiler::optJumpThreadCore(JumpThreadInfo& jti)
     // If this pred is in the set that will reuse block, do nothing.
     // Else revise pred to branch directly to the appropriate successor of block.
     //
-    for (BasicBlock* const predBlock : jti.m_block->PredBlocks())
+    constexpr bool allowEdits = true;
+    for (BasicBlock* const predBlock : jti.m_block->PredBlocks<allowEdits>())
     {
         // If this was an ambiguous pred, skip.
         //

--- a/src/coreclr/jit/redundantbranchopts.cpp
+++ b/src/coreclr/jit/redundantbranchopts.cpp
@@ -1600,8 +1600,7 @@ bool Compiler::optJumpThreadCore(JumpThreadInfo& jti)
     // If this pred is in the set that will reuse block, do nothing.
     // Else revise pred to branch directly to the appropriate successor of block.
     //
-    constexpr bool allowEdits = true;
-    for (BasicBlock* const predBlock : jti.m_block->PredBlocks<allowEdits>())
+    for (BasicBlock* const predBlock : jti.m_block->PredBlocksEditing())
     {
         // If this was an ambiguous pred, skip.
         //


### PR DESCRIPTION
Follow-up to #99362. `fgRedirectTargetEdge` modifies the predecessor lists of the old and new successor blocks, so if we want to be able to use it in `fgReplaceJumpTarget`, we need a pred block iterator that is resilient to these changes, as we frequently call the latter method while iterating predecessors.

I haven't found the need to update the pred edge iterator to allow updates too, but I imagine it would look the same as the pred block iterator.

`fgTailMergeThrows` looks a bit awkward right now. After this change is merged, I plan to add a new method similar to `fgRedirectTargetEdge` for `BBJ_COND` blocks, and leverage it in `fgReplaceJumpTarget`. Since that new method will preserve edge weights, we won't lose anything in `fgTailMergeThrows` by just calling `fgReplaceJumpTarget`. I think that will be a good opportunity to clean up `fgTailMergeThrows` by getting rid of all its helpers for updating edges.

cc @dotnet/jit-contrib, @AndyAyersMS PTAL.