### PR TITLE
Remove ref assembly code from CodeQL scans

### DIFF
--- a/src/.CodeQL.yml
+++ b/src/.CodeQL.yml
@@ -1,0 +1,10 @@
+# This file configures CodeQL runs and TSA bug autofiling. For more information, see:
+# https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/troubleshooting/bugs/generated-library-code
+# (Access restricted to Microsoft employees only.)
+
+path_classifiers:
+  refs:
+    # The ref/ directories don't contain shipping implementations of code, so they should
+    # be excluded from analysis. If there is a problem at the API layer, the analysis
+    # engine will detect the problem in the src/ implementations anyway.
+    - src/libraries/**/ref/*


### PR DESCRIPTION
Configures the bug autofiler to ignore matches in **ref/** subfolders, which should reduce the amount of noise hitting our alert portal. I've confirmed through a one-off custom run that this exclusion is honored correctly by TSA.
