### PR TITLE
Show the VMR commit hash in dotnet --info

### DIFF
--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.props
@@ -164,8 +164,12 @@
     <ItemGroup>
       <_VersionFile Include="$(IntermediateOutputPath).version" TargetPath="shared/$(SharedFrameworkName)/$(Version)/" />
     </ItemGroup>
+    <PropertyGroup>
+      <CommitHashForVersionFile Condition="'$(DotNetGitCommitHash)' != ''">$(DotNetGitCommitHash)</CommitHashForVersionFile>
+      <CommitHashForVersionFile Condition="'$(DotNetGitCommitHash)' == ''">$(SourceRevisionId)</CommitHashForVersionFile>
+    </PropertyGroup>
     <WriteLinesToFile
-      Lines="$(SourceRevisionId);$(Version)"
+      Lines="$(CommitHashForVersionFile);$(Version)"
       File="@(_VersionFile)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true" />

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -74,9 +74,13 @@
       <CMakeBuildDir>$(IntermediateOutputRootPath)corehost\cmake\</CMakeBuildDir>
       <BuildScript>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'build.sh'))</BuildScript>
 
+      <CommitHash Condition="('$(CommitHash)' == '') and ('$(DotNetGitCommitHash)' != '')">$(DotNetGitCommitHash)</CommitHash>
+      <CommitHash Condition="('$(CommitHash)' == '') and ('$(SourcerevisionId)' != '')">$(SourceRevisionId)</CommitHash>
+      <CommitHash Condition="'$(CommitHash)' == ''">N/A</CommitHash>
+
       <_CoreHostUnixTargetOS>$(TargetOS)</_CoreHostUnixTargetOS>
       <_CoreHostUnixTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_CoreHostUnixTargetOS>
-      <BuildArgs>$(Configuration) $(TargetArchitecture) -commithash "$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))" -os $(_CoreHostUnixTargetOS)</BuildArgs>
+      <BuildArgs>$(Configuration) $(TargetArchitecture) -commithash "$(CommitHash)" -os $(_CoreHostUnixTargetOS)</BuildArgs>
       <BuildArgs>$(BuildArgs) -cmakeargs "-DVERSION_FILE_PATH=$(NativeVersionFile)"</BuildArgs>
       <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) -configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' != 'true'">$(BuildArgs) -portablebuild=false</BuildArgs>


### PR DESCRIPTION
The VMR defines DotNetGitCommitHash when building runtime. Use that to populate the .version file and corehost's commit hash. That results in showing the VMR's commit hash in the `dotnet --info` output.

Contributes to https://github.com/dotnet/source-build/issues/3643