### PR TITLE
[mono] Fix function prototype in jiterpreter

### DIFF
--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1683,7 +1683,7 @@ mono_jiterp_is_enabled (void);
 #endif // HOST_BROWSER
 
 int
-mono_jiterp_is_enabled () {
+mono_jiterp_is_enabled (void) {
 #if HOST_BROWSER
 	return mono_opt_jiterpreter_traces_enabled;
 #else

--- a/src/mono/mono/mini/interp/jiterpreter.h
+++ b/src/mono/mono/mini/interp/jiterpreter.h
@@ -240,6 +240,6 @@ mono_jiterp_tlqueue_purge_all (gpointer item);
 #endif // HOST_BROWSER
 
 int
-mono_jiterp_is_enabled ();
+mono_jiterp_is_enabled (void);
 
 #endif // __MONO_MINI_JITERPRETER_H__


### PR DESCRIPTION
This causes a warning. Introduced in https://github.com/dotnet/runtime/pull/99273.

```
  src/mono/mono/mini/interp/jiterpreter.c:1686:24: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
  mono_jiterp_is_enabled () {
                         ^
                          void
  1 warning generated.
```