### PR TITLE
[mono] Fix warnings in s390x-specific code

### DIFF
--- a/src/mono/mono/mini/exceptions-s390x.c
+++ b/src/mono/mono/mini/exceptions-s390x.c
@@ -515,7 +515,6 @@ mono_arch_unwind_frame (MonoJitTlsData *jit_tls,
 	*new_ctx = *ctx;
 
 	if (ji != NULL) {
-		uintptr_t address;
 		guint8 *cfa;
 		guint32 unwind_info_len;
 		guint8 *unwind_info;
@@ -527,8 +526,6 @@ mono_arch_unwind_frame (MonoJitTlsData *jit_tls,
 			frame->type = FRAME_TYPE_MANAGED;
 
 		unwind_info = mono_jinfo_get_unwind_info (ji, &unwind_info_len);
-
-		address = (char *)ip - (char *)ji->code_start;
 
 		if (ji->has_arch_eh_info)
 			epilog = (guint8*)ji->code_start + ji->code_size - mono_jinfo_get_epilog_size (ji);

--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -3400,13 +3400,13 @@ mono_arch_output_basic_block (MonoCompile *cfg, MonoBasicBlock *bb)
 			break;
 		case OP_AOTCONST: {
 			mono_add_patch_info (cfg, code - cfg->native_code,
-				(MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
+				(MonoJumpInfoType)(gsize)ins->inst_i1, ins->inst_p0);
 			S390_LOAD_TEMPLATE (code, ins->dreg);
 		}
 			break;
 		case OP_JUMP_TABLE: {
 			mono_add_patch_info (cfg, code - cfg->native_code,
-				(MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
+				(MonoJumpInfoType)(gsize)ins->inst_i1, ins->inst_p0);
 			S390_LOAD_TEMPLATE (code, ins->dreg);
 		}
 			break;


### PR DESCRIPTION
```
 /repo/runtime/src/mono/mono/mini/exceptions-s390x.c:518:13: warning: variable 'address' set but not used [-Wunused-but-set-variable]
                  uintptr_t address;
                            ^
```

```
  /repo/runtime/src/mono/mono/mini/mini-s390x.c:3403:5: warning: cast to smaller integer type 'MonoJumpInfoType' from 'MonoInst *' (aka 'struct MonoInst *') [-Wpointer-to-enum-cast]
                                  (MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /repo/runtime/src/mono/mono/mini/mini-s390x.c:3409:5: warning: cast to smaller integer type 'MonoJumpInfoType' from 'MonoInst *' (aka 'struct MonoInst *') [-Wpointer-to-enum-cast]
                                  (MonoJumpInfoType)ins->inst_i1, ins->inst_p0);
                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ```