### PR TITLE
Be more liberal when detecting cgroup version

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -39,7 +39,6 @@ Abstract:
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
 #define PROC_CGROUP_FILENAME "/proc/self/cgroup"
@@ -129,12 +128,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
@@ -36,7 +36,6 @@ Abstract:
 #include "cgroupcpu.h"
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define BASE_TEN 10
 
@@ -100,12 +99,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -28,7 +28,6 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define BASE_TEN 10
 
@@ -94,12 +93,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/mono/mono/utils/mono-cgroup.c
+++ b/src/mono/mono/utils/mono-cgroup.c
@@ -45,7 +45,6 @@ Abstract:
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
 #define PROC_CGROUP_FILENAME "/proc/self/cgroup"
@@ -219,10 +218,13 @@ findCGroupVersion(void)
 	if (result != 0)
 		return 0;
 
-	switch (stats.f_type) {
-	case TMPFS_MAGIC: return 1;
-	case CGROUP2_SUPER_MAGIC: return 2;
-	default: return 0;
+	if (stats.f_type == CGROUP2_SUPER_MAGIC) {
+		return 2;
+	} else {
+		// Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+		// it is cgroup v1. Typically the file system type is tmpfs, but other values have
+		// been seen in the wild.
+		return 1;
 	}
 }
 


### PR DESCRIPTION
This changes the detection of cgroups to assume that if `/sys/fs/cgroup` is mounted and it is not cgroup v2, it is cgroup v1. While typically the file system type of `/sys/fs/cgroup` is TMPFS when cgroups v1 is being used, some emulated environments mount it as SYSFS.

To test this change, I applied it to .NET 8 branch and deployed a service to a Google Cloud Run generation 1 environment. I confirmed that the CPU count returned by `Environment.ProcessorCount` reflected the CPU limit set for the container.

Fixes #99046