### PR TITLE
JIT: don't create degenerate flow in `fgReplaceJumpTarget`

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -664,7 +664,6 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
                 {
                     // Branch was degenerate, simplify it first
                     //
-                    // fgRemoveRefPred returns nullptr for BBJ_COND blocks with two flow edges to target
                     fgRemoveConditionalJump(block);
                     assert(block->KindIs(BBJ_ALWAYS));
                     assert(block->TargetIs(oldTarget));
@@ -690,15 +689,8 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
                 assert(block->FalseTargetIs(oldTarget));
                 FlowEdge* const oldEdge = block->GetFalseEdge();
 
-                if (block->TrueEdgeIs(oldEdge))
-                {
-                    // Branch was degenerate
-                    //
-                    // fgRemoveRefPred returns nullptr for BBJ_COND blocks with two flow edges to target
-                    fgRemoveConditionalJump(block);
-                    assert(block->KindIs(BBJ_ALWAYS));
-                    assert(block->TargetIs(oldTarget));
-                }
+                // Already degenerate cases should have taken the true path above.
+                assert(!block->TrueEdgeIs(oldEdge));
 
                 // fgRemoveRefPred should have removed the flow edge
                 fgRemoveRefPred(oldEdge);
@@ -716,7 +708,7 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
                 }
             }
 
-            if (block->GetFalseEdge() == block->GetTrueEdge())
+            if (block->KindIs(BBJ_COND) && (block->GetFalseEdge() == block->GetTrueEdge()))
             {
                 // Block became degenerate, simplify
                 //


### PR DESCRIPTION
Detect if the update has created degenerate BBJ_COND flow, and simplify. Also symmetrize the true/false cases.

Fixes #48609.

Also fixes some issues seen in enhanced likelihood checking.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=597117&view=ms.vss-build-web.run-extensions-tab)