### PR TITLE
Add a new GC handle and use it to simplify NativeAOT corelib

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7740,7 +7740,7 @@ void CALLBACK DacHandleWalker::EnumCallback(PTR_UNCHECKED_OBJECTREF handle, uint
 
     data.Handle = TO_CDADDR(handle.GetAddr());
     data.Type = param->Type;
-    if (param->Type == HNDTYPE_DEPENDENT)
+    if (param->Type == HNDTYPE_DEPENDENT || param->Type == HNDTYPE_DEPENDENT_DEFER_FINALIZE)
         data.Secondary = GetDependentHandleSecondary(handle.GetAddr()).GetAddr();
     else
         data.Secondary = 0;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7582,6 +7582,9 @@ UINT32 DacRefWalker::GetHandleWalkerMask()
     if (mHandleMask & CorHandleStrongSizedByref)
         result |= (1 << HNDTYPE_SIZEDREF);
 
+    if (mHandleMask & CorHandleStrongDependentDeferFinalize)
+        result |= (1 << HNDTYPE_DEPENDENT_DEFER_FINALIZE);
+
     return result;
 }
 
@@ -7720,6 +7723,11 @@ HRESULT DacHandleWalker::Next(ULONG count, DacGcReference roots[], ULONG *pFetch
 
             case HNDTYPE_SIZEDREF:
                 roots[i].dwType = (DWORD)CorHandleStrongSizedByref;
+                break;
+
+            case HNDTYPE_DEPENDENT_DEFER_FINALIZE:
+                roots[i].dwType = (DWORD)CorHandleStrongDependentDeferFinalize;
+                roots[i].i64ExtraData = GetDependentHandleSecondary(CLRDATA_ADDRESS_TO_TADDR(handle.Handle)).GetAddr();
                 break;
         }
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -3255,7 +3255,7 @@ ClrDataAccess::GetThreadLocalModuleData(CLRDATA_ADDRESS thread, unsigned int ind
 HRESULT ClrDataAccess::GetHandleEnum(ISOSHandleEnum **ppHandleEnum)
 {
     unsigned int types[] = {HNDTYPE_WEAK_SHORT, HNDTYPE_WEAK_LONG, HNDTYPE_STRONG, HNDTYPE_PINNED, HNDTYPE_DEPENDENT,
-                            HNDTYPE_SIZEDREF,
+                            HNDTYPE_SIZEDREF, HNDTYPE_DEPENDENT_DEFER_FINALIZE,
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS) || defined(FEATURE_OBJCMARSHAL)
                             HNDTYPE_REFCOUNTED,
 #endif // FEATURE_COMINTEROP || FEATURE_COMWRAPPERS || FEATURE_OBJCMARSHAL
@@ -3293,7 +3293,7 @@ HRESULT ClrDataAccess::GetHandleEnumForGC(unsigned int gen, ISOSHandleEnum **ppH
     SOSDacEnter();
 
     unsigned int types[] = {HNDTYPE_WEAK_SHORT, HNDTYPE_WEAK_LONG, HNDTYPE_STRONG, HNDTYPE_PINNED, HNDTYPE_DEPENDENT,
-                            HNDTYPE_SIZEDREF,
+                            HNDTYPE_SIZEDREF, HNDTYPE_DEPENDENT_DEFER_FINALIZE,
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_COMWRAPPERS) || defined(FEATURE_OBJCMARSHAL)
                             HNDTYPE_REFCOUNTED,
 #endif // FEATURE_COMINTEROP || FEATURE_COMWRAPPERS || FEATURE_OBJCMARSHAL

--- a/src/coreclr/gc/gchandletableimpl.h
+++ b/src/coreclr/gc/gchandletableimpl.h
@@ -20,7 +20,7 @@ public:
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, HandleType type, void* pExtraInfo);
 
-    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary);
+    virtual OBJECTHANDLE CreateDependentHandle(HandleType type, Object* primary, Object* secondary);
 
     virtual ~GCHandleStore();
 
@@ -61,7 +61,7 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object);
 
-    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object);
+    virtual void SetDependentHandleSecondary(HandleType type, OBJECTHANDLE handle, Object* object);
 
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle);
 

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -6,7 +6,7 @@
 
 // The major version of the IGCHeap interface. Breaking changes to this interface
 // require bumps in the major version number.
-#define GC_INTERFACE_MAJOR_VERSION 5
+#define GC_INTERFACE_MAJOR_VERSION 6
 
 // The minor version of the IGCHeap interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number
@@ -502,7 +502,17 @@ typedef enum
      *       but we are keeping it here for backward compatibility purposes"
      *
      */
-    HNDTYPE_WEAK_NATIVE_COM   = 9
+    HNDTYPE_WEAK_NATIVE_COM   = 9,
+
+    /*
+     * DEPENDENT DEFER FINIALIZE HANDLES
+     *
+     * Like HNDTYPE_DEPENDENT, but the secondary is always promoted until
+     * the primary is collected.
+     *
+     *
+     */
+    HNDTYPE_DEPENDENT_DEFER_FINALIZE    = 10
 } HandleType;
 
 typedef enum
@@ -543,7 +553,7 @@ public:
 
     virtual OBJECTHANDLE CreateHandleWithExtraInfo(Object* object, HandleType type, void* pExtraInfo) PURE_VIRTUAL
 
-    virtual OBJECTHANDLE CreateDependentHandle(Object* primary, Object* secondary) PURE_VIRTUAL
+    virtual OBJECTHANDLE CreateDependentHandle(HandleType type, Object* primary, Object* secondary) PURE_VIRTUAL
 
     virtual ~IGCHandleStore() {};
 };
@@ -577,7 +587,7 @@ public:
 
     virtual bool StoreObjectInHandleIfNull(OBJECTHANDLE handle, Object* object) PURE_VIRTUAL
 
-    virtual void SetDependentHandleSecondary(OBJECTHANDLE handle, Object* object) PURE_VIRTUAL
+    virtual void SetDependentHandleSecondary(HandleType type, OBJECTHANDLE handle, Object* object) PURE_VIRTUAL
 
     virtual Object* GetDependentHandleSecondary(OBJECTHANDLE handle) PURE_VIRTUAL
 

--- a/src/coreclr/gc/handletable.cpp
+++ b/src/coreclr/gc/handletable.cpp
@@ -597,7 +597,7 @@ void HndWriteBarrierWorker(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
         }
 #endif
 
-        if (uType == HNDTYPE_DEPENDENT)
+        if (uType == HNDTYPE_DEPENDENT || uType == HNDTYPE_DEPENDENT_DEFER_FINALIZE)
         {
             generation = 0;
         }

--- a/src/coreclr/gc/handletablescan.cpp
+++ b/src/coreclr/gc/handletablescan.cpp
@@ -978,7 +978,7 @@ void BlockVerifyAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sc
                         });
 #endif
 
-                    if (uType == HNDTYPE_DEPENDENT)
+                    if (uType == HNDTYPE_DEPENDENT || uType == HNDTYPE_DEPENDENT_DEFER_FINALIZE)
                     {
                         PTR_uintptr_t pUserData = HandleQuickFetchUserDataPointer((OBJECTHANDLE)pValue);
 

--- a/src/coreclr/gc/objecthandle.h
+++ b/src/coreclr/gc/objecthandle.h
@@ -58,7 +58,7 @@ GC_DAC_VISIBLE
 OBJECTREF GetDependentHandleSecondary(OBJECTHANDLE handle);
 
 #ifndef DACCESS_COMPILE
-void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF secondary);
+void SetDependentHandleSecondary(HandleType type, OBJECTHANDLE handle, OBJECTREF secondary);
 #endif // !DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/inc/cordebug.idl
+++ b/src/coreclr/inc/cordebug.idl
@@ -2575,6 +2575,7 @@ typedef enum CorGCReferenceType
     CorHandleStrongAsyncPinned = 1<<7,
     CorHandleStrongSizedByref = 1<<8,
     CorHandleWeakNativeCom = 1<<9,
+    CorHandleStrongDependentDeferFinalize = 1<<10,
     CorHandleWeakWinRT = CorHandleWeakNativeCom,
 
     CorReferenceStack = 0x80000001,

--- a/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
@@ -21,9 +21,10 @@ FCIMPL2(OBJECTHANDLE, RhpHandleAlloc, Object *pObject, int type)
 }
 FCIMPLEND
 
-FCIMPL2(OBJECTHANDLE, RhpHandleAllocDependent, Object *pPrimary, Object *pSecondary)
+FCIMPL3(OBJECTHANDLE, RhpHandleAllocDependent, CLR_BOOL isDeferFinalize, Object *pPrimary, Object *pSecondary)
 {
-    return GCHandleUtilities::GetGCHandleManager()->GetGlobalHandleStore()->CreateDependentHandle(pPrimary, pSecondary);
+    HandleType type = isDeferFinalize ? HNDTYPE_DEPENDENT_DEFER_FINALIZE : HNDTYPE_DEPENDENT;
+    return GCHandleUtilities::GetGCHandleManager()->GetGlobalHandleStore()->CreateDependentHandle(type, pPrimary, pSecondary);
 }
 FCIMPLEND
 
@@ -47,9 +48,10 @@ FCIMPL2(Object *, RhHandleGetDependent, OBJECTHANDLE handle, Object **ppSecondar
 }
 FCIMPLEND
 
-FCIMPL2(void, RhHandleSetDependentSecondary, OBJECTHANDLE handle, Object *pSecondary)
+FCIMPL3(void, RhHandleSetDependentSecondary, CLR_BOOL isDeferFinalize, OBJECTHANDLE handle, Object *pSecondary)
 {
-    SetDependentHandleSecondary(handle, pSecondary);
+    HandleType type = isDeferFinalize ? HNDTYPE_DEPENDENT_DEFER_FINALIZE : HNDTYPE_DEPENDENT;
+    SetDependentHandleSecondary(type, handle, pSecondary);
 }
 FCIMPLEND
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/PInvokeMarshal.cs
@@ -89,7 +89,7 @@ namespace System.Runtime.InteropServices
             {
                 Interlocked.CompareExchange(
                     ref s_pInvokeDelegates,
-                    new ConditionalWeakTable<Delegate, PInvokeDelegateThunk>(),
+                    new ConditionalWeakTable<Delegate, PInvokeDelegateThunk>(isDeferFinalize: true),
                     null
                 );
             }
@@ -151,13 +151,6 @@ namespace System.Runtime.InteropServices
                     GCHandle handle = ((ThunkContextData*)ContextData)->Handle;
                     if (handle.IsAllocated)
                     {
-                        // If the delegate is still alive, defer finalization.
-                        if (handle.Target != null)
-                        {
-                            GC.ReRegisterForFinalize(this);
-                            return;
-                        }
-
                         handle.Free();
                     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.NativeAot.cs
@@ -357,11 +357,11 @@ namespace System.Runtime.InteropServices
             if (handle != default)
             {
                 RuntimeImports.RhHandleSet(handle, target);
-                RuntimeImports.RhHandleSetDependentSecondary(handle, dependent);
+                RuntimeImports.RhHandleSetDependentSecondary(false, handle, dependent);
             }
             else
             {
-                _pHandles[_freeIndex] = RuntimeImports.RhpHandleAllocDependent(target, dependent);
+                _pHandles[_freeIndex] = RuntimeImports.RhpHandleAllocDependent(false, target, dependent);
                 if (_pHandles[_freeIndex] == default)
                 {
                     return false;
@@ -412,7 +412,7 @@ namespace System.Runtime.InteropServices
                 if (handle != default)
                 {
                     RuntimeImports.RhHandleSet(handle, null);
-                    RuntimeImports.RhHandleSetDependentSecondary(handle, null);
+                    RuntimeImports.RhHandleSetDependentSecondary(false, handle, null);
                 }
             }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/RuntimeImports.cs
@@ -291,11 +291,11 @@ namespace System.Runtime
         // Allocate handle for dependent handle case where a secondary can be set at the same time.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhpHandleAllocDependent")]
-        internal static extern IntPtr RhpHandleAllocDependent(object primary, object secondary);
+        internal static extern IntPtr RhpHandleAllocDependent(bool isDeferFinalize, object primary, object secondary);
 
-        internal static IntPtr RhHandleAllocDependent(object primary, object secondary)
+        internal static IntPtr RhHandleAllocDependent(bool isDeferFinalize, object primary, object secondary)
         {
-            IntPtr h = RhpHandleAllocDependent(primary, secondary);
+            IntPtr h = RhpHandleAllocDependent(isDeferFinalize, primary, secondary);
             if (h == IntPtr.Zero)
                 throw new OutOfMemoryException();
             return h;
@@ -334,7 +334,7 @@ namespace System.Runtime
         // Set the secondary object reference into a dependent handle.
         [MethodImpl(MethodImplOptions.InternalCall)]
         [RuntimeImport(RuntimeLibrary, "RhHandleSetDependentSecondary")]
-        internal static extern void RhHandleSetDependentSecondary(IntPtr handle, object secondary);
+        internal static extern void RhHandleSetDependentSecondary(bool isDeferFinalize, IntPtr handle, object secondary);
 
         //
         // calls to runtime for thunk pool

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/SyncTable.cs
@@ -102,7 +102,7 @@ namespace System.Threading
             // Allocate the synchronization object outside the lock
             Lock lck = new Lock();
             DeadEntryCollector collector = new DeadEntryCollector();
-            DependentHandle handle = new DependentHandle(obj, collector);
+            DependentHandle handle = new DependentHandle(true, obj, collector);
 
             try
             {
@@ -309,12 +309,7 @@ namespace System.Threading
                 {
                     ref Entry entry = ref s_entries[_index];
 
-                    if (entry.Owner.Target != null)
-                    {
-                        // Retry later if the owner is not collected yet.
-                        GC.ReRegisterForFinalize(this);
-                        return;
-                    }
+                    Debug.Assert(entry.Owner.Target is null);
 
                     dependentHandleToDispose = entry.Owner;
                     entry.Owner = default;

--- a/src/coreclr/pal/prebuilt/inc/cordebug.h
+++ b/src/coreclr/pal/prebuilt/inc/cordebug.h
@@ -6707,6 +6707,7 @@ enum CorGCReferenceType
         CorHandleStrongAsyncPinned  = ( 1 << 7 ) ,
         CorHandleStrongSizedByref   = ( 1 << 8 ) ,
         CorHandleWeakNativeCom  = ( 1 << 9 ) ,
+        CorHandleStrongDependentDeferFinalize	= ( 1 << 10 ) ,
         CorHandleWeakWinRT  = CorHandleWeakNativeCom,
         CorReferenceStack   = 0x80000001,
         CorReferenceFinalizer   = 80000002,

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -1068,7 +1068,13 @@ public:
     OBJECTHANDLE CreateDependentHandle(OBJECTREF primary, OBJECTREF secondary)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateDependentHandle(m_handleStore, primary, secondary);
+        return ::CreateDependentHandle(false, m_handleStore, primary, secondary);
+    }
+
+    OBJECTHANDLE CreateDependentHandleDeferFinalize(OBJECTREF primary, OBJECTREF secondary)
+    {
+        WRAPPER_NO_CONTRACT;
+        return ::CreateDependentHandle(true, m_handleStore, primary, secondary);
     }
 
 #endif // DACCESS_COMPILE

--- a/src/coreclr/vm/comdependenthandle.h
+++ b/src/coreclr/vm/comdependenthandle.h
@@ -40,16 +40,16 @@
 class DependentHandle
 {
 public:
-    static FCDECL2(OBJECTHANDLE, InternalAlloc, Object *target, Object *dependent);
+    static FCDECL3(OBJECTHANDLE, InternalAlloc, CLR_BOOL isDeferFinalize, Object *target, Object *dependent);
     static FCDECL1(Object *, InternalGetTarget, OBJECTHANDLE handle);
     static FCDECL1(Object *, InternalGetDependent, OBJECTHANDLE handle);
     static FCDECL2(Object *, InternalGetTargetAndDependent, OBJECTHANDLE handle, Object **outDependent);
     static FCDECL1(VOID, InternalSetTargetToNull, OBJECTHANDLE handle);
-    static FCDECL2(VOID, InternalSetDependent, OBJECTHANDLE handle, Object *dependent);
-    static FCDECL1(FC_BOOL_RET, InternalFree, OBJECTHANDLE handle);
+    static FCDECL3(VOID, InternalSetDependent, CLR_BOOL isDeferFinalize, OBJECTHANDLE handle, Object *dependent);
+    static FCDECL2(FC_BOOL_RET, InternalFree, CLR_BOOL isDeferFinalize, OBJECTHANDLE handle);
 };
 
-extern "C" OBJECTHANDLE QCALLTYPE DependentHandle_InternalAllocWithGCTransition(QCall::ObjectHandleOnStack target, QCall::ObjectHandleOnStack dependent);
-extern "C" void QCALLTYPE DependentHandle_InternalFreeWithGCTransition(OBJECTHANDLE handle);
+extern "C" OBJECTHANDLE QCALLTYPE DependentHandle_InternalAllocWithGCTransition(BOOL isDeferFinalize, QCall::ObjectHandleOnStack target, QCall::ObjectHandleOnStack dependent);
+extern "C" void QCALLTYPE DependentHandle_InternalFreeWithGCTransition(BOOL isDeferFinalize, OBJECTHANDLE handle);
 
 #endif

--- a/src/coreclr/vm/gchandleutilities.h
+++ b/src/coreclr/vm/gchandleutilities.h
@@ -135,9 +135,9 @@ inline OBJECTHANDLE CreateSizedRefHandle(IGCHandleStore* store, OBJECTREF object
     return hnd;
 }
 
-inline OBJECTHANDLE CreateDependentHandle(IGCHandleStore* store, OBJECTREF primary, OBJECTREF secondary)
+inline OBJECTHANDLE CreateDependentHandle(bool isDeferFinalize, IGCHandleStore* store, OBJECTREF primary, OBJECTREF secondary)
 {
-    OBJECTHANDLE hnd = store->CreateDependentHandle(OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
+    OBJECTHANDLE hnd = store->CreateDependentHandle(isDeferFinalize ? HNDTYPE_DEPENDENT_DEFER_FINALIZE : HNDTYPE_DEPENDENT, OBJECTREFToObject(primary), OBJECTREFToObject(secondary));
     if (!hnd)
     {
         COMPlusThrowOM();
@@ -284,6 +284,11 @@ inline void DestroyRefcountedHandle(OBJECTHANDLE handle)
 inline void DestroyDependentHandle(OBJECTHANDLE handle)
 {
     DestroyHandleCommon(handle, HNDTYPE_DEPENDENT);
+}
+
+inline void DestroyDependentDeferFinalizeHandle(OBJECTHANDLE handle)
+{
+    DestroyHandleCommon(handle, HNDTYPE_DEPENDENT_DEFER_FINALIZE);
 }
 
 inline void DestroyGlobalHandle(OBJECTHANDLE handle)

--- a/src/coreclr/vm/rcwrefcache.cpp
+++ b/src/coreclr/vm/rcwrefcache.cpp
@@ -174,7 +174,7 @@ void RCWRefCache::ShrinkDependentHandles()
 
         IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
         mgr->StoreObjectInHandle(depHnd, NULL);
-        mgr->SetDependentHandleSecondary(depHnd, NULL);
+        mgr->SetDependentHandleSecondary(HNDTYPE_DEPENDENT, depHnd, NULL);
 
         LOG((LF_INTEROP, LL_INFO1000, "\t[RCWRefCache 0x%p] DependentHandle 0x%p cleared @ index %d\n", this, depHnd, (ULONG) i));
     }
@@ -260,7 +260,7 @@ HRESULT RCWRefCache::AddReferenceUsingDependentHandle(OBJECTREF obj1, OBJECTREF 
 
         IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
         mgr->StoreObjectInHandle(depHnd, OBJECTREFToObject(obj1));
-        mgr->SetDependentHandleSecondary(depHnd, OBJECTREFToObject(obj2));
+        mgr->SetDependentHandleSecondary(HNDTYPE_DEPENDENT, depHnd, OBJECTREFToObject(obj2));
 
         STRESS_LOG3(
             LF_INTEROP, LL_INFO1000,


### PR DESCRIPTION

### Problem

In the .NET runtime, particularly in its interop systems, it is common to attached some extra state
to an object. In CoreCLR, this data is often stored in the `SyncBlock` of an object. In NativeAOT, this
is often accomplished using a `ConditionalWeakTable`.

A disadvantage of using `ConditionalWeakTable` compared to the `SyncBlock` is the behavior around
finalization. The `SyncBlock` system hooks into the GC to detect when an object is collected and waits until
that moment to schedule the deallocation of data associated with an object. When using a `ConditionalWeakTable`,
the value in a table is queued for finalization as soon as the key is queued for finalization.
The NativeAOT corelib has to ensure that the key in the table has been fully collected and call
`GC.ReRegisterForFinalize` to defer finialization if it has not. Failure to check for this condition
has cause a couple of bugs in the past:
[#86882](https://github.com/dotnet/runtime/pull/86882)
[#99185](https://github.com/dotnet/runtime/pull/99185#issuecomment-1974512197)

### This PR's solution

With a small tweak, the dependant handle and the `ConditionalWeakTable` can make writing these
sorts of finalizers in the corelib easier. If the dependant handle always promotes its secondary
as long as the primary was a alive, the secondary object will not be put on the finalization queue
until the primary object has been fully collected. This PR implements a new type of GC handle with
this behavior called a "defer finalize dependant handle".

### Use cases

This PR uses the handle in 4 places in the NativeAOT corelib:

* Objective-C Marshal. The new handle type has the most impact here: it simplifies the code and removes
  an extra GC handle allocation per tracked object.
* SyncTable
* Marshaling of delegates in P/Invoke
* COM managed object wrapper

I've identified a couple places in CoreCLR where this handle could be used, but have not implemented
it in this PR:

* [LoaderAllocatorScout](https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs)
* [DestroyScout for dynamic methods](https://github.com/dotnet/runtime/blob/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs#L663)

Conceivably, functionality that currently is placed on the SyncBlock in CoreCLR could be moved to use
this new handle to manage the lifetime of data. This might allow for more sharing between CoreCLR
and NativeAOT. Longer term, the `SyncBlock` and its custom handle table could removed in favor of using
this new GC handle.

### Analysis

Here are some of the pros and cons I can think of. Please let me know if there are other considerations
or if there are any best practices to quantify the performance impact of a change like this.

Pros:

* Simplifies implementation of the CoreLib
* Potentially improves performance by not having to rerun finalizers

Cons:

* Introduces a new GCHandle type that diagnostic tools need to know about
* Potentially increases memory usage by extending the lifetime of the secondary object in the dependant handle

### TODO

* [ ] Gain consensus on whether adding a new GC handle is worth it
* [ ] Quantify performance impact if possible
* [ ] Add more test coverage
* [ ] Figure out if there is a better way to write tests against corelib implementation details than using UnsafeAccessor. Maybe move the test to /src/tests?