### PR TITLE
[wasm][bench] Check for the muteErrors presence

### DIFF
--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -205,7 +205,9 @@ class MainApp {
     }
 
     removeFrame() {
-        this._frame.contentWindow.muteErrors();
+        if (this._frame.contentWindow.muteErrors !== undefined)
+            this._frame.contentWindow.muteErrors();
+
         document.body.removeChild(this._frame);
     }
 }


### PR DESCRIPTION
to avoid rare exceptions we get during the measurements `TypeError: this._frame.contentWindow.muteErrors is not a function`