### PR TITLE
Use existing Range vectorized fill in Enumerable.OrderBy

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -339,12 +339,9 @@ namespace System.Linq
             private int[] ComputeMap(TElement[] elements, int count)
             {
                 ComputeKeys(elements, count);
-                int[] map = new int[count];
-                for (int i = 0; i < map.Length; i++)
-                {
-                    map[i] = i;
-                }
 
+                int[] map = new int[count];
+                FillIncrementing(map, 0);
                 return map;
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.SpeedOpt.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
@@ -21,7 +18,7 @@ namespace System.Linq
             {
                 int start = _start;
                 int[] array = new int[_end - start];
-                Fill(array, start);
+                FillIncrementing(array, start);
                 return array;
             }
 
@@ -29,43 +26,12 @@ namespace System.Linq
             {
                 (int start, int end) = (_start, _end);
                 List<int> list = new List<int>(end - start);
-                Fill(SetCountAndGetSpan(list, end - start), start);
+                FillIncrementing(SetCountAndGetSpan(list, end - start), start);
                 return list;
             }
 
             public void CopyTo(int[] array, int arrayIndex) =>
-                Fill(array.AsSpan(arrayIndex, _end - _start), _start);
-
-            private static void Fill(Span<int> destination, int value)
-            {
-                ref int pos = ref MemoryMarshal.GetReference(destination);
-                ref int end = ref Unsafe.Add(ref pos, destination.Length);
-
-                if (Vector.IsHardwareAccelerated &&
-                    destination.Length >= Vector<int>.Count)
-                {
-                    Vector<int> init = Vector<int>.Indices;
-                    Vector<int> current = new Vector<int>(value) + init;
-                    Vector<int> increment = new Vector<int>(Vector<int>.Count);
-
-                    ref int oneVectorFromEnd = ref Unsafe.Subtract(ref end, Vector<int>.Count);
-                    do
-                    {
-                        current.StoreUnsafe(ref pos);
-                        current += increment;
-                        pos = ref Unsafe.Add(ref pos, Vector<int>.Count);
-                    }
-                    while (!Unsafe.IsAddressGreaterThan(ref pos, ref oneVectorFromEnd));
-
-                    value = current[0];
-                }
-
-                while (Unsafe.IsAddressLessThan(ref pos, ref end))
-                {
-                    pos = value++;
-                    pos = ref Unsafe.Add(ref pos, 1);
-                }
-            }
+                FillIncrementing(array.AsSpan(arrayIndex, _end - _start), _start);
 
             public override int GetCount(bool onlyIfCheap) => _end - _start;
 

--- a/src/libraries/System.Linq/src/System/Linq/Range.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.cs
@@ -3,6 +3,9 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
@@ -69,6 +72,38 @@ namespace System.Linq
             public override void Dispose()
             {
                 _state = -1; // Don't reset current
+            }
+        }
+
+        /// <summary>Fills the <paramref name="destination"/> with incrementing numbers, starting from <paramref name="value"/>.</summary>
+        private static void FillIncrementing(Span<int> destination, int value)
+        {
+            ref int pos = ref MemoryMarshal.GetReference(destination);
+            ref int end = ref Unsafe.Add(ref pos, destination.Length);
+
+            if (Vector.IsHardwareAccelerated &&
+                destination.Length >= Vector<int>.Count)
+            {
+                Vector<int> init = Vector<int>.Indices;
+                Vector<int> current = new Vector<int>(value) + init;
+                Vector<int> increment = new Vector<int>(Vector<int>.Count);
+
+                ref int oneVectorFromEnd = ref Unsafe.Subtract(ref end, Vector<int>.Count);
+                do
+                {
+                    current.StoreUnsafe(ref pos);
+                    current += increment;
+                    pos = ref Unsafe.Add(ref pos, Vector<int>.Count);
+                }
+                while (!Unsafe.IsAddressGreaterThan(ref pos, ref oneVectorFromEnd));
+
+                value = current[0];
+            }
+
+            while (Unsafe.IsAddressLessThan(ref pos, ref end))
+            {
+                pos = value++;
+                pos = ref Unsafe.Add(ref pos, 1);
             }
         }
     }


### PR DESCRIPTION
We already have a method that vectorizes the fill in Enumerable.Range. We can use the same helper in OrderBy when filling the integer map used to enable stability.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class Tests
{
    private IEnumerable<int> _data;

    [Params(4, 40, 400)]
    public int Count { get; set; }

    [GlobalSetup]
    public void Setup() => _data = Enumerable.Range(0, Count).ToArray();

    [Benchmark]
    public int OrderBy()
    {
        int sum = 0;
        foreach (int value in _data.OrderBy(i => i))
            sum += value;
        return sum;
    }
}
```

| Method  | Toolchain         | Count | Mean        | Ratio |
|-------- |------------------ |------ |------------:|------:|
| OrderBy | \main\corerun.exe | 4     |    98.84 ns |  1.00 |
| OrderBy | \pr\corerun.exe   | 4     |    99.85 ns |  1.01 |
|         |                   |       |             |       |
| OrderBy | \main\corerun.exe | 40    |   515.74 ns |  1.00 |
| OrderBy | \pr\corerun.exe   | 40    |   490.10 ns |  0.95 |
|         |                   |       |             |       |
| OrderBy | \main\corerun.exe | 400   | 6,716.60 ns |  1.00 |
| OrderBy | \pr\corerun.exe   | 400   | 6,200.64 ns |  0.93 |