### PR TITLE
Add a parent check to the forward substitution tree walk

### DIFF
--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -221,7 +221,7 @@ public:
                 // fgGetStubAddrArg cannot handle complex trees (it calls gtClone)
                 //
                 bool isCallTarget = false;
-                if (parent->IsCall())
+                if ((parent != nullptr) && parent->IsCall())
                 {
                     GenTreeCall* const parentCall = parent->AsCall();
                     isCallTarget = (parentCall->gtCallType == CT_INDIRECT) && (parentCall->gtCallAddr == node);

--- a/src/coreclr/jit/forwardsub.cpp
+++ b/src/coreclr/jit/forwardsub.cpp
@@ -319,7 +319,7 @@ public:
 
     bool IsCallArg() const
     {
-        return m_parentNode->IsCall();
+        return (m_parentNode != nullptr) && m_parentNode->IsCall();
     }
 
     unsigned GetComplexity() const
@@ -749,7 +749,7 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
     if (fsv.IsCallArg() && fsv.GetNode()->TypeIs(TYP_STRUCT) &&
         !fwdSubNode->OperIs(GT_BLK, GT_LCL_VAR, GT_LCL_FLD, GT_MKREFANY))
     {
-        JITDUMP(" use is a struct arg; fwd sub node is not OBJ/LCL_VAR/LCL_FLD/MKREFANY\n");
+        JITDUMP(" use is a struct arg; fwd sub node is not BLK/LCL_VAR/LCL_FLD/MKREFANY\n");
         return false;
     }
 
@@ -772,7 +772,7 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
     {
         GenTree* const parentNode = fsv.GetParentNode();
 
-        if (!parentNode->OperIs(GT_STORE_LCL_VAR))
+        if ((parentNode == nullptr) || !parentNode->OperIs(GT_STORE_LCL_VAR))
         {
             JITDUMP(" multi-reg struct node, parent not STORE_LCL_VAR\n");
             return false;
@@ -794,7 +794,8 @@ bool Compiler::fgForwardSubStatement(Statement* stmt)
     // for them on all 32 bit targets is a CQ regression due to some bad
     // interaction between decomposition and RA.
     //
-    if (compMethodReturnsMultiRegRetType() && fsv.GetParentNode()->OperIs(GT_RETURN))
+    if (compMethodReturnsMultiRegRetType() && (fsv.GetParentNode() != nullptr) &&
+        fsv.GetParentNode()->OperIs(GT_RETURN))
     {
 #if defined(TARGET_X86)
         if (fwdSubNode->TypeGet() == TYP_LONG)


### PR DESCRIPTION
In rather rare circumstances, we can see top-level `LCL_VAR`s here. In the example from #99540, this happens due to an unused result from an inlined call.

Fixes #99540.