### PR TITLE
[mono] Don't inline methods with the DoesNotReturn attribute in interp

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2867,6 +2867,14 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 	if (td->prof_coverage)
 		return FALSE;
 
+	/*
+	 * doesnotreturn methods are not profitable to inline, since they almost certainly will not
+	 * actually run during normal execution, and if they do they will only run once, so the
+	 * upside to inlining them is effectively zero, and we'd waste time doing the inline
+	 */
+	if (has_doesnotreturn_attribute (method))
+		return FALSE;
+
 	if (!is_metadata_update_disabled () && mono_metadata_update_no_inline (td->method, method))
 		return FALSE;
 


### PR DESCRIPTION
Right now we will attempt to inline methods that have the DoesNotReturn attribute; this is a waste of time and resources, since it's not profitable to inline them and they are virtually always going to be unreachable code anyway.

Noticed this behavior while investigating a regression in LessThanOrEqualAnyBenchmark. It's not responsible for the regression, but it was worsening the pre-optimization IR quality in the benchmark, and this will probably improve startup perf (by reducing time spent in interp codegen) by a tiny amount... I can imagine this actually improving post-optimization code quality in some cases, but I don't know what an example of that would look like.