### PR TITLE
Disable jiterp safepoints in single-threaded WASM

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -1246,12 +1246,14 @@ class Cfg {
             this.overheadBytes += 11;
         }
 
-        // Account for the size of the safepoint
-        if (
-            (branchType === CfgBranchType.SafepointConditional) ||
-            (branchType === CfgBranchType.SafepointUnconditional)
-        ) {
-            this.overheadBytes += 17;
+        if (WasmEnableThreads) {
+            // Account for the size of the safepoint
+            if (
+                (branchType === CfgBranchType.SafepointConditional) ||
+                (branchType === CfgBranchType.SafepointUnconditional)
+            ) {
+                this.overheadBytes += 17;
+            }
         }
     }
 

--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -1505,6 +1505,9 @@ export const _now = (globalThis.performance && globalThis.performance.now)
 let scratchBuffer: NativePointer = <any>0;
 
 export function append_safepoint(builder: WasmBuilder, ip: MintOpcodePtr) {
+    // safepoints are never triggered in a single-threaded build
+    if (!WasmEnableThreads)
+        return;
     // Check whether a safepoint is required
     builder.ptr_const(cwraps.mono_jiterp_get_polling_required_address());
     builder.appendU8(WasmOpcode.i32_load);


### PR DESCRIPTION
May make https://github.com/dotnet/runtime/issues/99554 partially or completely go away.
The introduction of the imm branch opcodes is an improvement for native interp since safepoints are pretty cheap there, but in jiterp safepoints are somewhat expensive (theoretically) because they bloat traces, add more branches to push things out of the branch predictor table, and potentially cause trace compilation to end earlier. Before these superinstructions were added, the relevant branch would have been a non-safepoint branch.

Vlad pointed out the obvious: safepoints don't do anything in single threaded wasm, so the jiterp can just not generate any code for them. This should hopefully make the affected vector code fast again by shrinking traces, and potentially speed up other traces too.