### PR TITLE
[release/8.0-staging] Be more liberal when detecting cgroup version

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -39,7 +39,6 @@ Abstract:
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
 #define PROC_CGROUP_FILENAME "/proc/self/cgroup"
@@ -125,12 +124,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/cgroupcpu.cpp
@@ -36,7 +36,6 @@ Abstract:
 #include "cgroupcpu.h"
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define BASE_TEN 10
 
@@ -100,12 +99,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -28,7 +28,6 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define BASE_TEN 10
 
@@ -133,12 +132,16 @@ private:
         if (result != 0)
             return 0;
 
-        switch (stats.f_type)
+        if (stats.f_type == CGROUP2_SUPER_MAGIC)
         {
-            case TMPFS_MAGIC: return 1;
-            case CGROUP2_SUPER_MAGIC: return 2;
-            default:
-                return 0;
+            return 2;
+        }
+        else
+        {
+            // Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+            // it is cgroup v1. Typically the file system type is tmpfs, but other values have
+            // been seen in the wild.
+            return 1;
         }
 #endif
     }

--- a/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
+++ b/src/libraries/Common/src/Interop/Linux/cgroups/Interop.cgroups.cs
@@ -115,8 +115,7 @@ internal static partial class Interop
                 return new DriveInfo(SysFsCgroupFileSystemPath).DriveFormat switch
                 {
                     "cgroup2fs" => CGroupVersion.CGroup2,
-                    "tmpfs" => CGroupVersion.CGroup1,
-                    _ => CGroupVersion.None,
+                    _ => CGroupVersion.CGroup1,
                 };
             }
             catch (Exception ex) when (ex is DriveNotFoundException || ex is ArgumentException)

--- a/src/mono/mono/utils/mono-cgroup.c
+++ b/src/mono/mono/utils/mono-cgroup.c
@@ -45,7 +45,6 @@ Abstract:
 #endif
 
 #define CGROUP2_SUPER_MAGIC 0x63677270
-#define TMPFS_MAGIC 0x01021994
 
 #define PROC_MOUNTINFO_FILENAME "/proc/self/mountinfo"
 #define PROC_CGROUP_FILENAME "/proc/self/cgroup"
@@ -219,10 +218,13 @@ findCGroupVersion(void)
 	if (result != 0)
 		return 0;
 
-	switch (stats.f_type) {
-	case TMPFS_MAGIC: return 1;
-	case CGROUP2_SUPER_MAGIC: return 2;
-	default: return 0;
+	if (stats.f_type == CGROUP2_SUPER_MAGIC) {
+		return 2;
+	} else {
+		// Assume that if /sys/fs/cgroup exists and the file system type is not cgroup2fs,
+		// it is cgroup v1. Typically the file system type is tmpfs, but other values have
+		// been seen in the wild.
+		return 1;
 	}
 }
 


### PR DESCRIPTION
Fixes Issue #99046

main PR #99508

# Description

This changes the detection of cgroups to assume that if /sys/fs/cgroup is mounted and it is not cgroup v2, it is cgroup v1. While typically the file system type of /sys/fs/cgroup is TMPFS when cgroups v1 is being used, some emulated environments mount it as SYSFS.

# Customer Impact

Excessive memory usage in some environments, leading to OOM. Customers can work around this issue by setting the `DOTNET_PROCESSOR_COUNT` environment variable to override the number of processors.

# Regression

The check for TMPFS was introduced when cgroup2 supported was added in #34334 for .NET 5. It is likely that prior versions of .NET will detect the number of CPUs correctly, but I have not confirmed this.

# Testing

I deployed a service to a Google Cloud Run generation 1 environment. I confirmed that the CPU count returned by `Environment.ProcessorCount` reflected the CPU limit set for the container.

# Risk

While this change is small, it will cause execution to take a different path through a fair amount of string parsing code written in C. Looking at this string parsing code in cgroup.cpp, it appears to take care to be handle missing files and unexpected values. I also ran this code in debug mode in Cloud Run gen 1 to confirm no asserts were triggered.

# Package authoring signed off?

IMPORTANT: If this change touches code that ships in a NuGet package, please make certain that you have added any necessary [package authoring](../../docs/project/library-servicing.md) and gotten it explicitly reviewed.

I don't believe any of the code touched in this PR ships in a NuGet package. The C# code is included in `System.Diagnostics.Process`, which is part of the shared framework.