### PR TITLE
[7.0] Reset OOB packages enabled in the March release

### DIFF
--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -5,7 +5,7 @@
     <!-- Reference the outputs for the dependency nodes calculation. -->
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ServicingVersion>6</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
The following OOB packages were enabled for building last month but were not re-enabled this month:

- Microsoft.Windows.Compatibility: https://github.com/dotnet/runtime/pull/97883

@ericstj