### PR TITLE
[6.0] Reset OOB packages enabled in the March release

### DIFF
--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -5,7 +5,7 @@
     <!-- Reference the outputs for the dependency nodes calculation. -->
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ServicingVersion>8</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>


### PR DESCRIPTION
The following OOB packages were enabled for building in the March Release but were not re-enabled in the April Release:

- Microsoft.Windows.Compatibility https://github.com/dotnet/runtime/pull/98711

The following OOB package was enabled for building in the March Release but we are re-enabling it for building in the April Release, so we should not reset it until next month:

- Microsoft.NETCore.Platforms 
  - March https://github.com/dotnet/runtime/pull/98080
  - April https://github.com/dotnet/runtime/pull/99560