### PR TITLE
[6.0] Reset OOB packages enabled in the April release

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/Microsoft.NETCore.Platforms.csproj
@@ -19,7 +19,7 @@
     <!-- When building from source, ensure the RID we're building for is part of the RID graph -->
     <AdditionalRuntimeIdentifiers Condition="'$(DotNetBuildFromSource)' == 'true'">$(AdditionalRuntimeIdentifiers);$(OutputRID)</AdditionalRuntimeIdentifiers>
     <ServicingVersion>13</ServicingVersion>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
+++ b/src/libraries/System.Security.AccessControl/src/System.Security.AccessControl.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);netstandard2.0-windows;netstandard2.0;net461-windows</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides base classes that enable managing access and audit control lists on securable objects.
 


### PR DESCRIPTION
This PR should be merged on Code Complete day for the May release (around mid April).

The following packages were enabled for building in the April release and need to be reset:

- Microsoft.NETCore.Platforms https://github.com/dotnet/runtime/pull/99560
- System.Security.AccessControl https://github.com/dotnet/runtime/pull/99462

The following packages were enabled for building in the May release and need to stay enabled:

- none