### PR TITLE
[8.0] Reset OOB packages enabled in the April release

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);SA1205</NoWarn>
     <EnableTrimAnalyzer Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETFramework'">false</EnableTrimAnalyzer>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides Classes that allow you to decouple code logging rich (unserializable) diagnostics/telemetry (e.g. framework) from code that consumes it (e.g. tools)
 


### PR DESCRIPTION
This PR should be merged on Code Complete day for the May release (around mid April).

The following packages were enabled for building in the April release and need to be reset:

- System.Diagnostics.DiagnosticSource https://github.com/dotnet/runtime/pull/99045

The following packages were enabled for building in the May release and need to stay enabled:
- None

The following package is enabled to ship in May: 
- System.Security.Cryptography.Xml https://github.com/dotnet/runtime/pull/99651