### PR TITLE
[RISC-V] Fix alignment for vector types

### DIFF
--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -60,8 +60,10 @@ namespace ILCompiler
                 }
                 else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
                 {
-                    // The alignment requirement for the fixed length vector shall be equivalent to
-                    // the alignment requirement of its elemental type.
+                    // For fixed-length vector, the alignment requirement for the fixed length vector
+                    // shall be equivalent to the alignment requirement of its elemental type.
+                    // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     alignment = new LayoutInt(16);
                 }
                 else
@@ -87,8 +89,10 @@ namespace ILCompiler
                 }
                 else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
                 {
-                    // The alignment requirement for the fixed length vector shall be equivalent to
-                    // the alignment requirement of its elemental type.
+                    // For fixed-length vector, the alignment requirement for the fixed length vector
+                    // shall be equivalent to the alignment requirement of its elemental type.
+                    // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     alignment = new LayoutInt(16);
                 }
                 else

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -60,11 +60,9 @@ namespace ILCompiler
                 }
                 else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
                 {
-                    // For fixed-length vector, the alignment requirement for the fixed length vector
-                    // shall be equivalent to the alignment requirement of its elemental type.
-                    // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
-                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+                    // RISC-V Vector Extenstion Intrinsic Document
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     alignment = new LayoutInt(16);
                 }
                 else
@@ -90,11 +88,9 @@ namespace ILCompiler
                 }
                 else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
                 {
-                    // For fixed-length vector, the alignment requirement for the fixed length vector
-                    // shall be equivalent to the alignment requirement of its elemental type.
-                    // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
-                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+                    // RISC-V Vector Extenstion Intrinsic Document
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     alignment = new LayoutInt(16);
                 }
                 else

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -52,10 +52,16 @@ namespace ILCompiler
                     // to the same alignment as __m128, which is supported by the ABI.
                     alignment = new LayoutInt(8);
                 }
-                else if (defType.Context.Target.Architecture == TargetArchitecture.ARM64 || defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
+                else if (defType.Context.Target.Architecture == TargetArchitecture.ARM64)
                 {
                     // The Procedure Call Standard for ARM 64-bit (with SVE support) defaults to
                     // 16-byte alignment for __m256.
+                    alignment = new LayoutInt(16);
+                }
+                else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
+                {
+                    // The alignment requirement for the fixed length vector shall be equivalent to
+                    // the alignment requirement of its elemental type.
                     alignment = new LayoutInt(16);
                 }
                 else
@@ -73,10 +79,16 @@ namespace ILCompiler
                     // to the same alignment as __m128, which is supported by the ABI.
                     alignment = new LayoutInt(8);
                 }
-                else if (defType.Context.Target.Architecture == TargetArchitecture.ARM64 || defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
+                else if (defType.Context.Target.Architecture == TargetArchitecture.ARM64)
                 {
                     // The Procedure Call Standard for ARM 64-bit (with SVE support) defaults to
                     // 16-byte alignment for __m256.
+                    alignment = new LayoutInt(16);
+                }
+                else if (defType.Context.Target.Architecture == TargetArchitecture.RiscV64)
+                {
+                    // The alignment requirement for the fixed length vector shall be equivalent to
+                    // the alignment requirement of its elemental type.
                     alignment = new LayoutInt(16);
                 }
                 else

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -64,6 +64,7 @@ namespace ILCompiler
                     // shall be equivalent to the alignment requirement of its elemental type.
                     // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
                     // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
+                    // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
                     alignment = new LayoutInt(16);
                 }
                 else
@@ -93,6 +94,7 @@ namespace ILCompiler
                     // shall be equivalent to the alignment requirement of its elemental type.
                     // For other vector types in RISC-V Vector Extenstion Intrinsic Document,
                     // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
+                    // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
                     alignment = new LayoutInt(16);
                 }
                 else

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10052,6 +10052,10 @@ void MethodTableBuilder::CheckForSystemTypes()
                     // 16-byte alignment for __m256.
 
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
+    #elif defined(TARGET_RISC64)
+                    // The alignment requirement for the fixed length vector shall be equivalent to
+                    // the alignment requirement of its elemental type.
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
     #else
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 32; // sizeof(__m256)
     #endif // TARGET_ARM elif TARGET_ARM64
@@ -10067,6 +10071,11 @@ void MethodTableBuilder::CheckForSystemTypes()
                     // The Procedure Call Standard for ARM 64-bit (with SVE support) defaults to
                     // 16-byte alignment for __m256.
 
+                    pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
+
+    #elif defined(TARGET_RISC64)
+                    // The alignment requirement for the fixed length vector shall be equivalent to
+                    // the alignment requirement of its elemental type.
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
     #else
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 64; // sizeof(__m512)

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10052,7 +10052,7 @@ void MethodTableBuilder::CheckForSystemTypes()
                     // 16-byte alignment for __m256.
 
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
-    #elif defined(TARGET_RISC64)
+    #elif defined(TARGET_RISCV64)
                     // The alignment requirement for the fixed length vector shall be equivalent to
                     // the alignment requirement of its elemental type.
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
@@ -10073,7 +10073,7 @@ void MethodTableBuilder::CheckForSystemTypes()
 
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
 
-    #elif defined(TARGET_RISC64)
+    #elif defined(TARGET_RISCV64)
                     // The alignment requirement for the fixed length vector shall be equivalent to
                     // the alignment requirement of its elemental type.
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10053,8 +10053,9 @@ void MethodTableBuilder::CheckForSystemTypes()
 
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
     #elif defined(TARGET_RISCV64)
-                    // The alignment requirement for the fixed length vector shall be equivalent to
-                    // the alignment requirement of its elemental type.
+                    // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+                    // RISC-V Vector Extenstion Intrinsic Document
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
     #else
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 32; // sizeof(__m256)
@@ -10074,8 +10075,9 @@ void MethodTableBuilder::CheckForSystemTypes()
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
 
     #elif defined(TARGET_RISCV64)
-                    // The alignment requirement for the fixed length vector shall be equivalent to
-                    // the alignment requirement of its elemental type.
+                    // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+                    // RISC-V Vector Extenstion Intrinsic Document
+                    // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/vector_type_infos.adoc
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 16;
     #else
                     pLayout->m_ManagedLargestAlignmentRequirementOfAllMembers = 64; // sizeof(__m512)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -36,6 +36,9 @@ namespace System.Runtime.Intrinsics
         internal const int Alignment = 8;
 #elif TARGET_ARM64
         internal const int Alignment = 16;
+#elif TARGET_RISCV64
+        // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+        internal const int Alignment = 16;
 #else
         internal const int Alignment = 32;
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -36,6 +36,9 @@ namespace System.Runtime.Intrinsics
         internal const int Alignment = 8;
 #elif TARGET_ARM64
         internal const int Alignment = 16;
+#elif TARGET_RISCV64
+        // TODO-RISCV64: Update alignment to proper value when we implement RISC-V intrinsic.
+        internal const int Alignment = 16;
 #else
         internal const int Alignment = 64;
 #endif


### PR DESCRIPTION
Fixed the error caused by alignment mismatch for vector256 and vector 512.
```
Assert failure(PID 2678722 [0x0028dfc2], Thread: 2678722 [0x28dfc2]): Verify_TypeLayout 'System.Runtime.Intrinsics.Vector256`1' failed to verify type layout
     File: /home/clamp/Work/dotnet/riscv/crossgen2/src/coreclr/vm/jitinterface.cpp:13839         
     Image: /riscv/crossgen2/artifacts/tests/coreclr/linux.riscv64.Checked/Tests/Core_Root/corerun
                                                                                                  
 Type System.Runtime.Intrinsics.Vector256`1: expected alignment 0x00000010, actual 0x00000020    
```
This sets alignment to possible max alignment value for vector types reference on https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung