### PR TITLE
Re-enable calendars tests on NativeAOT/ARM32

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -445,10 +445,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.SourceGeneration.Tests\System.Text.Json.SourceGeneration.Roslyn4.4.Tests.csproj"
                       Condition="'$(TargetOS)' == 'linux'" />
 
-    <!-- https://github.com/dotnet/runtime/issues/98795 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Globalization.Calendars.Tests\System.Globalization.Calendars.Tests.csproj"
-                      Condition="'$(TargetArchitecture)' == 'arm'" />
-
     <!-- https://github.com/dotnet/runtime/issues/94653 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Threading.Tasks.Tests\System.Threading.Tasks.Tests.csproj"
                        Condition="'$(TargetsLinuxMusl)' == 'true'" />


### PR DESCRIPTION
Fixes #98795

Recent fixes for linker thunk generation and unwinding logic seemed to fix the failure. Tested with multiple successful runs on Raspberry Pi hardware.