### PR TITLE
[RISC-V] Fix struct info value in crossgen2

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -153,7 +153,7 @@ namespace Internal.JitInterface
                             Debug.Assert(fieldIndex == 1);
                             if ((floatFieldFlags2 & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                             {
-                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_MERGE_FIRST_SECOND;
+                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND;
                             }
                             if (field.FieldType.GetElementSize().AsInt == 8)
                             {

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -56,6 +56,13 @@ namespace Internal.JitInterface
                 {
                     continue;
                 }
+                else if (fieldIndex == 1)
+                {
+                    if (firstField.Offset.AsInt != 0 || field.Offset.AsInt == 0 || firstFieldSize > field.Offset.AsInt)
+                    {
+                        return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
+                    }
+                }
 
                 Debug.Assert(fieldIndex < numIntroducedFields);
 


### PR DESCRIPTION
Fixed assertions in `fgMorphMultiregStructArg` when crossgen2 compiles in Debug build with `--verify-type-and-field-layout` option

Error messages
```
/runtime/src/coreclr/jit/morph.cpp:3766
Assertion failed 'roundUp(structSize, TARGET_POINTER_SIZE) == roundUp(loadExtent, TARGET_POINTER_SIZE)' in ...
```

- `System.Private.CoreLib.dll`: ValueType which contains two double fields
- `./Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/MarshalStructAsLayoutExp`: ValueType which contains `FieldOffset`.

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung