### PR TITLE
Don't set ENABLE_WERROR in VMR CI build in mono.proj

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -97,7 +97,7 @@
   </PropertyGroup>
 
   <!-- CI specific build options -->
-  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and ('$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true' or '$(Targetsillumos)' == 'true')">
+  <ItemGroup Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(DotNetBuildOrchestrator)' != 'true' and ('$(TargetsOSX)' == 'true' or '$(TargetsMacCatalyst)' == 'true' or '$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true' or '$(Targetsillumos)' == 'true')">
     <_MonoCMakeArgs Include="-DENABLE_WERROR=1"/>
   </ItemGroup>
 


### PR DESCRIPTION
We can have different machine configuration in the VMR context so we don't want to potentially break the build on warnings there.

Fixes https://github.com/dotnet/source-build/issues/4197#issuecomment-1988669682