### PR TITLE
Fix AV in HttpTelemetry.WriteEvent

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -381,9 +381,9 @@ namespace System.Net.Http
                     DataPointer = (IntPtr)arg7Ptr,
                     Size = (arg7.Length + 1) * sizeof(char)
                 };
-            }
 
-            WriteEventCore(eventId, NumEventDatas, descrs);
+                WriteEventCore(eventId, NumEventDatas, descrs);
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -339,13 +339,13 @@ namespace System.Net.Http
             arg5 ??= "";
             arg7 ??= "";
 
-            const int NumEventDatas = 7;
-            EventData* descrs = stackalloc EventData[NumEventDatas];
-
             fixed (char* arg4Ptr = arg4)
             fixed (char* arg5Ptr = arg5)
             fixed (char* arg7Ptr = arg7)
             {
+                const int NumEventDatas = 7;
+                EventData* descrs = stackalloc EventData[NumEventDatas];
+
                 descrs[0] = new EventData
                 {
                     DataPointer = (IntPtr)(&arg1),


### PR DESCRIPTION
Fixes #99603

I checked other networking `EventSource`s and I didn't see a similar mistake elsewhere.