### PR TITLE
[mono][eventpipe] Fix firing dynamic method wrappers crash

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -779,6 +779,8 @@ include_method (MonoMethod *method)
 		return false;
 	} else if (!m_method_is_wrapper (method)) {
 		return true;
+	} else if (method->wrapper_type == MONO_WRAPPER_DYNAMIC_METHOD){
+		return true;
 	} else {
 		WrapperInfo *wrapper = mono_marshal_get_wrapper_info (method);
 		return (wrapper && wrapper->subtype == WRAPPER_SUBTYPE_PINVOKE) ? true : false;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93687 and https://github.com/dotnet/diagnostics/issues/4542

When firing mono rundown events, dynamic method wrappers do not have their `method_data` set, and as a result, [this assert](https://github.com/dotnet/runtime/blob/4018d5891722e7992eeb541fa216e33c1cf0a9a8/src/mono/mono/metadata/loader.c#L1654) fails and crashes the application. Including dynamic method wrappers in the list of conditions for when to fire a particular method as a method event circumvents the assertion.