### PR TITLE
Make SpinLock class smaller

### DIFF
--- a/src/coreclr/vm/spinlock.cpp
+++ b/src/coreclr/vm/spinlock.cpp
@@ -33,7 +33,11 @@ SpinLock::SpinLock()
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
 
+    m_lock = 0;
+
+#ifdef _DEBUG
     m_Initialized = UnInitialized;
+#endif
 }
 
 void SpinLock::Init(LOCK_TYPE type, bool RequireCoopGC)
@@ -45,6 +49,7 @@ void SpinLock::Init(LOCK_TYPE type, bool RequireCoopGC)
     }
     CONTRACTL_END;
 
+#ifdef _DEBUG
     if (m_Initialized == Initialized)
     {
         _ASSERTE (type == m_LockType);
@@ -72,17 +77,12 @@ void SpinLock::Init(LOCK_TYPE type, bool RequireCoopGC)
         }
     }
 
-    {
-        m_lock = 0;
-    }
-
-#ifdef _DEBUG
     m_LockType = type;
     m_requireCoopGCMode = RequireCoopGC;
-#endif
 
     _ASSERTE (m_Initialized == BeingInitialized);
     m_Initialized = Initialized;
+#endif
 }
 
 #ifdef _DEBUG

--- a/src/coreclr/vm/spinlock.h
+++ b/src/coreclr/vm/spinlock.h
@@ -153,6 +153,7 @@ private:
         LONG                m_lock;     // LONG used in interlocked exchange
     };
 
+#ifdef _DEBUG
     enum SpinLockState
     {
         UnInitialized,
@@ -163,7 +164,6 @@ private:
     Volatile<SpinLockState>      m_Initialized; // To verify initialized
                                         // And initialize once
 
-#ifdef _DEBUG
     LOCK_TYPE           m_LockType;     // lock type to track statistics
 
     // Check for dead lock situation.


### PR DESCRIPTION
- During other work, I noticed that the SpinLock class's `m_Initialized` field was only useful for DEBUG builds, and for ensuring that m_lock was set to 0 sometime after construction of the SpinLock
- Set `m_lock` to 0 in the constructor instead
- Move all handling of `m_initialized` to withing a DEBUG block