### PR TITLE
Remove assert when setting DOTNET_MaxVectorTBitwidth to 512

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1297,9 +1297,6 @@ void EEJitManager::SetCpuInfo()
         CPUCompileFlags.Set(InstructionSet_VectorT512);
     }
 
-    // TODO-XArch: Add support for 512-bit Vector<T>
-    _ASSERTE(!CPUCompileFlags.IsSet(InstructionSet_VectorT512));
-
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_EnableHWIntrinsic))
     {
         CPUCompileFlags.Set(InstructionSet_X86Base);


### PR DESCRIPTION
When forcing Vector<T> to 512 bits using `DOTNET_MaxVectorTBitwidth=512`, we hit the following assert
https://github.com/dotnet/runtime/blob/4018d5891722e7992eeb541fa216e33c1cf0a9a8/src/coreclr/vm/codeman.cpp#L1301

This assert is not required since we set the 'InstructionSet_VectorT512' when using `DOTNET_MaxVectorTBitwidth=512`