### PR TITLE
Add 0/null checks for various cases in the COM/dynamic VARIANT extensions

### DIFF
--- a/src/libraries/Common/src/System/Runtime/InteropServices/BuiltInVariantExtensions.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/BuiltInVariantExtensions.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices
             return ref Unsafe.AsRef<T>((void*)variant.GetRawDataRef<nint>());
         }
 
-        public static unsafe void CopyFromIndirect(this ref ComVariant variant, object value)
+        public static unsafe void CopyFromIndirect(this ref ComVariant variant, object? value)
         {
             VarEnum vt = (VarEnum)(((int)variant.VarType) & ~((int)VarEnum.VT_BYREF));
 

--- a/src/libraries/Common/src/System/Runtime/InteropServices/BuiltInVariantExtensions.cs
+++ b/src/libraries/Common/src/System/Runtime/InteropServices/BuiltInVariantExtensions.cs
@@ -154,9 +154,8 @@ namespace System.Runtime.InteropServices
                 VarEnum.VT_DECIMAL => variant.As<decimal>(),
                 VarEnum.VT_CY => decimal.FromOACurrency(variant.GetRawDataRef<long>()),
                 VarEnum.VT_DATE => variant.As<DateTime>(),
-                VarEnum.VT_BSTR => Marshal.PtrToStringBSTR(variant.GetRawDataRef<nint>()),
-                VarEnum.VT_UNKNOWN => Marshal.GetObjectForIUnknown(variant.GetRawDataRef<nint>()),
-                VarEnum.VT_DISPATCH => Marshal.GetObjectForIUnknown(variant.GetRawDataRef<nint>()),
+                VarEnum.VT_BSTR => variant.GetRawDataRef<nint>() is 0 ? null : Marshal.PtrToStringBSTR(variant.GetRawDataRef<nint>()),
+                VarEnum.VT_UNKNOWN or VarEnum.VT_DISPATCH => variant.GetRawDataRef<nint>() is 0 ? null : Marshal.GetObjectForIUnknown(variant.GetRawDataRef<nint>()),
                 _ => GetObjectFromNativeVariant(ref variant),
             };
         }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DynamicVariantExtensions.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DynamicVariantExtensions.cs
@@ -381,12 +381,12 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         public static void SetUnknown(this ref ComVariant variant, object value)
         {
-            variant = ComVariant.CreateRaw(VarEnum.VT_UNKNOWN, Marshal.GetIUnknownForObject(value));
+            variant = ComVariant.CreateRaw(VarEnum.VT_UNKNOWN, value is null ? IntPtr.Zero : Marshal.GetIUnknownForObject(value));
         }
 
         public static void SetDispatch(this ref ComVariant variant, object value)
         {
-            variant = ComVariant.CreateRaw(VarEnum.VT_DISPATCH, Marshal.GetIDispatchForObject(value));
+            variant = ComVariant.CreateRaw(VarEnum.VT_DISPATCH, value is null ? IntPtr.Zero : Marshal.GetIDispatchForObject(value));
         }
 
         public static void SetError(this ref ComVariant variant, int value)

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DynamicVariantExtensions.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/DynamicVariantExtensions.cs
@@ -379,12 +379,12 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             variant = ComVariant.Create(new BStrWrapper(value));
         }
 
-        public static void SetUnknown(this ref ComVariant variant, object value)
+        public static void SetUnknown(this ref ComVariant variant, object? value)
         {
             variant = ComVariant.CreateRaw(VarEnum.VT_UNKNOWN, value is null ? IntPtr.Zero : Marshal.GetIUnknownForObject(value));
         }
 
-        public static void SetDispatch(this ref ComVariant variant, object value)
+        public static void SetDispatch(this ref ComVariant variant, object? value)
         {
             variant = ComVariant.CreateRaw(VarEnum.VT_DISPATCH, value is null ? IntPtr.Zero : Marshal.GetIDispatchForObject(value));
         }

--- a/src/tests/Interop/COM/Dynamic/BasicTest.cs
+++ b/src/tests/Interop/COM/Dynamic/BasicTest.cs
@@ -424,7 +424,7 @@ namespace Dynamic
             obj.String_Property = null;
             Assert.Equal(string.Empty, obj.String_Property);
 
-            obj.Dispatch_Property = null;
+            obj.Dispatch_Property = new DispatchWrapper(null);
             Assert.Null(obj.Dispatch_Property);
         }
 

--- a/src/tests/Interop/COM/Dynamic/BasicTest.cs
+++ b/src/tests/Interop/COM/Dynamic/BasicTest.cs
@@ -423,6 +423,9 @@ namespace Dynamic
 
             obj.String_Property = null;
             Assert.Equal(string.Empty, obj.String_Property);
+
+            obj.Dispatch_Property = null;
+            Assert.Null(obj.Dispatch_Property);
         }
 
         private void StringWrapper(string toWrap, string expected)


### PR DESCRIPTION
This fixes various regressions in some null corner cases that were found by a DTS customer.