### PR TITLE
JIT: Remove bbFallsThrough restriction in fgOptimizeEmptyBlock

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5924,12 +5924,6 @@ BasicBlock* Compiler::fgRelocateEHRange(unsigned regionIndex, FG_RELOCATE_TYPE r
                insertAfterBlk->Next()); // We insert at the end, not at the beginning, of the funclet region.
     }
 
-    // These asserts assume we aren't moving try regions (which we might need to do). Only
-    // try regions can have fall through into or out of the region.
-
-    noway_assert(!bPrev->bbFallsThrough()); // There can be no fall through into a filter or handler region
-    noway_assert(!bLast->bbFallsThrough()); // There can be no fall through out of a handler region
-
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1621,15 +1621,6 @@ bool Compiler::fgOptimizeEmptyBlock(BasicBlock* block)
                     break;
                 }
             }
-            else
-            {
-                // TODO-NoFallThrough: Once BBJ_COND blocks have pointers to their false branches,
-                // allow removing empty BBJ_ALWAYS and pointing bPrev's false branch to block's target.
-                if (bPrev->bbFallsThrough() && !block->JumpsToNext())
-                {
-                    break;
-                }
-            }
 
             /* Do not remove a block that jumps to itself - used for while (true){} */
             if (block->TargetIs(block))


### PR DESCRIPTION
Now that the JIT's implicit fallthrough assumption for certain block kinds is gone, we should start stripping out any logic dependent on `bbFallsThrough`. Note that `fgReorderBlocks` makes several decisions using `bbFallsThrough` -- I hope we can get rid of all of that in one go when we try a new block layout algorithm.

As for this change to `fgOptimizeEmptyBlock`, the pattern of always placing a `BBJ_ALWAYS` after a `BBJ_COND` to maintain implicit fallthrough is gone, so if we have a `BBJ_COND` block that "falls through" to an empty `BBJ_ALWAYS` that jumps somewhere else, this is logically equivalent to the `BBJ_COND`'s false successor simply being the target of the `BBJ_ALWAYS` block, so we should have no problem removing the latter block. However, this creates churn during later optimization phases...