### PR TITLE
JIT: Remove bbFallsThrough checks in fgNewBBbefore/after

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6039,11 +6039,6 @@ BasicBlock* Compiler::fgNewBBbefore(BBKinds jumpKind, BasicBlock* block, bool ex
 
     newBlk->bbRefs = 0;
 
-    if (newBlk->bbFallsThrough() && block->isRunRarely())
-    {
-        newBlk->bbSetRunRarely();
-    }
-
     if (extendRegion)
     {
         fgExtendEHRegionBefore(block);
@@ -6077,11 +6072,6 @@ BasicBlock* Compiler::fgNewBBafter(BBKinds jumpKind, BasicBlock* block, bool ext
     fgInsertBBafter(block, newBlk);
 
     newBlk->bbRefs = 0;
-
-    if (block->bbFallsThrough() && block->isRunRarely())
-    {
-        newBlk->bbSetRunRarely();
-    }
 
     if (extendRegion)
     {


### PR DESCRIPTION
Now that implicit fallthrough is gone, it doesn't make sense to mark a new block as rarely run if the previous block is rarely run, as there's no guarantee the previous block flows into the next. It would make more sense to rely on the weights of a block's predecessor edges to determine if it's rarely run.

cc @dotnet/jit-contrib. Surprisingly, this was a no-diff change locally.