### PR TITLE
Avoid OrderBy.ToArray/ToList overheads for length 1

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.SpeedOpt.cs
@@ -15,7 +15,7 @@ namespace System.Linq
             public override TElement[] ToArray()
             {
                 TElement[] buffer = _source.ToArray();
-                if (buffer.Length == 0)
+                if (buffer.Length <= 1)
                 {
                     return buffer;
                 }
@@ -29,10 +29,14 @@ namespace System.Linq
             {
                 TElement[] buffer = _source.ToArray();
 
-                List<TElement> list = new();
-                if (buffer.Length > 0)
+                List<TElement> list = new(buffer.Length);
+                if (buffer.Length >= 2)
                 {
                     Fill(buffer, SetCountAndGetSpan(list, buffer.Length));
+                }
+                else if (buffer.Length == 1)
+                {
+                    list.Add(buffer[0]);
                 }
 
                 return list;


### PR DESCRIPTION
We already special-case length 0. That can trivially be extended to length 1.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);

[MemoryDiagnoser(false)]
[HideColumns("Job", "Error", "StdDev", "Median", "RatioSD")]
public class Tests
{
    private IEnumerable<string> _data;

    [Params(1)]
    public int Count { get; set; }

    [GlobalSetup]
    public void Setup() => _data = Enumerable.Range(0, Count).Select(i => i.ToString());

    [Benchmark]
    public string[] OrderArray() => _data.Order().ToArray();

    [Benchmark]
    public List<string> OrderList() => _data.Order().ToList();
}
```

| Method     | Toolchain         | Count | Mean      | Ratio | Allocated | Alloc Ratio |
|----------- |------------------ |------ |----------:|------:|----------:|------------:|
| OrderArray | \main\corerun.exe | 1     |  85.30 ns |  1.00 |     336 B |        1.00 |
| OrderArray | \pr\corerun.exe   | 1     |  33.53 ns |  0.39 |     120 B |        0.36 |
|            |                   |       |           |       |           |             |
| OrderList  | \main\corerun.exe | 1     |  91.46 ns |  1.00 |     392 B |        1.00 |
| OrderList  | \pr\corerun.exe   | 1     |  42.60 ns |  0.47 |     184 B |        0.47 |