### PR TITLE
Use attributes for IsDynamicCodeSupported feature switch

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
+++ b/src/coreclr/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
@@ -2,11 +2,6 @@
   <assembly fullname="System.Private.CoreLib">
     <type fullname="System.Runtime.CompilerServices.RuntimeFeature" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="true">
       <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="true" />
-      <method signature="System.Boolean get_IsDynamicCodeSupported()" body="stub" value="true" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.RuntimeFeature" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false">
-      <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
-      <method signature="System.Boolean get_IsDynamicCodeSupported()" body="stub" value="false" />
     </type>
   </assembly>
 </linker>

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.xml
@@ -1,8 +1,4 @@
 <linker>
-  <type fullname="System.Runtime.CompilerServices.RuntimeFeature">
-    <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
-    <method signature="System.Boolean get_IsDynamicCodeSupported()" body="stub" value="false" />
-  </type>
 
   <type fullname="System.Collections.Generic.Comparer`1" feature="System.Collections.Generic.DefaultComparers" featurevalue="false">
     <method signature="System.Boolean get_SupportsGenericIComparableInterfaces()" body="stub" />

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NativeAot.cs
@@ -1,11 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Runtime.CompilerServices
 {
     public static partial class RuntimeFeature
     {
+        [FeatureSwitchDefinition("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported")]
         public static bool IsDynamicCodeSupported => false;
+
+        [FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
         public static bool IsDynamicCodeCompiled => false;
     }
 }

--- a/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Linq.Expressions/src/ILLink/ILLink.Substitutions.xml
@@ -1,13 +1,7 @@
 <linker>
   <assembly fullname="System.Linq.Expressions">
-    <type fullname="System.Linq.Expressions.LambdaExpression">
-      <method signature="System.Boolean get_CanCompileToIL()" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false" body="stub" value="false" />
-    </type>
     <type fullname="System.Dynamic.Utils.DelegateHelpers">
       <method signature="System.Boolean get_CanEmitObjectArrayDelegate()" feature="System.Linq.Expressions.CanEmitObjectArrayDelegate" featurevalue="false" body="stub" value="false" />
-    </type>
-    <type fullname="System.Linq.Expressions.Interpreter.CallInstruction">
-      <method signature="System.Boolean get_CanCreateArbitraryDelegates()" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false" body="stub" value="false" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -41,7 +41,6 @@ namespace System.Dynamic.Utils
         {
             if (RuntimeFeature.IsDynamicCodeSupported)
             {
-                // Analyzer doesn't yet understand feature switches
                 return GetNullableType(type);
             }
             if (!type.IsValueType || IsNullableType(type))

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/TypeUtils.cs
@@ -41,10 +41,8 @@ namespace System.Dynamic.Utils
         {
             if (RuntimeFeature.IsDynamicCodeSupported)
             {
-#pragma warning disable IL3050
                 // Analyzer doesn't yet understand feature switches
                 return GetNullableType(type);
-#pragma warning restore IL3050
             }
             if (!type.IsValueType || IsNullableType(type))
             {

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/DelegateHelpers.cs
@@ -122,13 +122,10 @@ namespace System.Linq.Expressions.Compiler
                 const MethodImplAttributes implAttributes = MethodImplAttributes.Runtime | MethodImplAttributes.Managed;
                 const MethodAttributes invokeAttributes = MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual;
 
-#pragma warning disable IL3050
-                // Suppress analyzer warnings since they don't currently support feature flags
                 TypeBuilder builder = AssemblyGen.DefineDelegateType("Delegate" + types.Length);
                 builder.DefineConstructor(ctorAttributes, CallingConventions.Standard, delegateCtorSignature).SetImplementationFlags(implAttributes);
                 builder.DefineMethod("Invoke", invokeAttributes, returnType, parameters).SetImplementationFlags(implAttributes);
                 return builder.CreateTypeInfo();
-#pragma warning restore IL3050
             }
             else
             {

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/CallInstruction.cs
@@ -16,6 +16,7 @@ namespace System.Linq.Expressions.Interpreter
         /// </summary>
         public abstract int ArgumentCount { get; }
 
+        [FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
         private static bool CanCreateArbitraryDelegates => RuntimeFeature.IsDynamicCodeSupported;
 
         #region Construction
@@ -50,8 +51,6 @@ namespace System.Linq.Expressions.Interpreter
             if (!CanCreateArbitraryDelegates)
                 return new MethodInfoCallInstruction(info, argumentCount);
 
-            // This code should be unreachable in AOT. The analyzer currently doesn't understand feature switches
-#pragma warning disable IL3050
             if (!info.IsStatic && info.DeclaringType!.IsValueType)
             {
                 return new MethodInfoCallInstruction(info, argumentCount);
@@ -115,7 +114,6 @@ namespace System.Linq.Expressions.Interpreter
             s_cache[info] = res;
 
             return res;
-#pragma warning restore IL3050
         }
 
         private static CallInstruction GetArrayAccessor(MethodInfo info, int argumentCount)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Expressions
 
         private readonly Expression _body;
 
-        // This can be flipped to false using feature switches at publishing time
+        [FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
         public static bool CanCompileToIL => RuntimeFeature.IsDynamicCodeSupported;
 
         // This could be flipped to false using feature switches at publishing time
@@ -138,10 +138,7 @@ namespace System.Linq.Expressions
         {
             if (CanCompileToIL)
             {
-#pragma warning disable IL3050
-                // Analyzer doesn't yet understand feature switches
                 return Compiler.LambdaCompiler.Compile(this);
-#pragma warning restore IL3050
             }
             else
             {
@@ -221,10 +218,7 @@ namespace System.Linq.Expressions
         {
             if (CanCompileToIL)
             {
-#pragma warning disable IL3050
-                // Analyzer doesn't yet understand feature switches
                 return (TDelegate)(object)Compiler.LambdaCompiler.Compile(this);
-#pragma warning restore IL3050
             }
             else
             {
@@ -629,10 +623,7 @@ namespace System.Linq.Expressions
                 MethodInfo create;
                 if (LambdaExpression.CanCompileToIL)
                 {
-#pragma warning disable IL3050
-                    // Analyzer doesn't yet understand feature switches
                     create = typeof(Expression<>).MakeGenericType(delegateType).GetMethod("Create", BindingFlags.Static | BindingFlags.NonPublic)!;
-#pragma warning restore IL3050
                 }
                 else
                 {

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -289,10 +289,7 @@ namespace System.Runtime.CompilerServices
             if (System.Linq.Expressions.LambdaExpression.CanCompileToIL
                 && target.IsGenericType && IsSimpleSignature(invoke, out Type[] args))
             {
-#pragma warning disable IL3050
-                // Analyzer doesn't yet understand feature switches
                 return MakeUpdateDelegateWhenCanCompileToIL();
-#pragma warning restore IL3050
             }
 
             s_cachedNoMatch = CreateCustomNoMatchDelegate(invoke);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NonNativeAot.cs
@@ -1,10 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Runtime.CompilerServices
 {
     public static partial class RuntimeFeature
     {
+        [FeatureSwitchDefinition("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported")]
         public static bool IsDynamicCodeSupported
         {
 #if MONO
@@ -13,6 +16,7 @@ namespace System.Runtime.CompilerServices
             get;
         } = AppContext.TryGetSwitch("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", out bool isDynamicCodeSupported) ? isDynamicCodeSupported : true;
 
+        [FeatureGuard(typeof(RequiresDynamicCodeAttribute))]
         public static bool IsDynamicCodeCompiled
         {
 #if MONO

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13138,7 +13138,9 @@ namespace System.Runtime.CompilerServices
         public const string PortablePdb = "PortablePdb";
         public const string UnmanagedSignatureCallingConvention = "UnmanagedSignatureCallingConvention";
         public const string VirtualStaticsInInterfaces = "VirtualStaticsInInterfaces";
+        [System.Diagnostics.CodeAnalysis.FeatureGuard(typeof(System.Diagnostics.CodeAnalysis.RequiresDynamicCodeAttribute))]
         public static bool IsDynamicCodeCompiled { get { throw null; } }
+        [System.Diagnostics.CodeAnalysis.FeatureSwitchDefinition("System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported")]
         public static bool IsDynamicCodeSupported { get { throw null; } }
         public static bool IsSupported(string feature) { throw null; }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptionsUpdateHandler.cs
@@ -28,9 +28,7 @@ namespace System.Text.Json
             if (RuntimeFeature.IsDynamicCodeSupported)
             {
                 // Flush the dynamic method cache
-#pragma warning disable IL3050 // The analyzer doesn't understand runtime feature conditions: https://github.com/dotnet/linker/issues/2715
                 ReflectionEmitCachingMemberAccessor.Clear();
-#pragma warning restore IL3050
             }
         }
     }

--- a/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.iOS.xml
+++ b/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.iOS.xml
@@ -3,8 +3,5 @@
     <type fullname="System.Runtime.CompilerServices.RuntimeFeature">
       <method signature="System.Boolean get_IsDynamicCodeCompiled()" body="stub" value="false" />
     </type>
-    <type fullname="System.Runtime.CompilerServices.RuntimeFeature" feature="System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported" featurevalue="false">
-        <method signature="System.Boolean get_IsDynamicCodeSupported()" body="stub" value="false" />
-    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
And remove some warning suppression pragmas.

Fixes https://github.com/dotnet/runtime/issues/97273 (the analyzer will now be able to see that IsDynamicCodeCompiled guards APIs annotated with RequiresDynamicCodeAttribute).