### PR TITLE
Guard ToolboxItem by a new feature switch

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/Resources/Strings.resx
@@ -172,6 +172,9 @@
   <data name="CultureInfoConverterInvalidCulture" xml:space="preserve">
     <value>The {0} culture cannot be converted to a CultureInfo object on this computer.</value>
   </data>
+  <data name="IDesignerHostNotSupported" xml:space="preserve">
+    <value>Designer support has been disabled in the app configuration and is not supported.</value>
+  </data>
   <data name="ErrorInvalidServiceInstance" xml:space="preserve">
     <value>The service instance must derive from or implement {0}.</value>
   </data>

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/IDesignerHost.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/IDesignerHost.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.ComponentModel.Design
 {
     /// <summary>
@@ -9,6 +11,9 @@ namespace System.ComponentModel.Design
     /// </summary>
     public interface IDesignerHost : IServiceContainer
     {
+        [FeatureSwitchDefinition("System.ComponentModel.Design.IDesignerHost.IsSupported")]
+        internal static bool IsSupported => AppContext.TryGetSwitch("System.ComponentModel.Design.IDesignerHost.IsSupported", out bool isSupported) ? isSupported : true;
+
         /// <summary>
         /// Gets or sets a value indicating whether the designer host
         /// is currently loading the document.

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemAttribute.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ToolboxItemAttribute.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.ComponentModel
@@ -16,10 +17,12 @@ namespace System.ComponentModel
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private readonly string? _toolboxItemTypeName;
 
+        private const string DefaultToolboxItemTypeName = "System.Drawing.Design.ToolboxItem, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+
         /// <summary>
         /// Initializes a new instance of ToolboxItemAttribute and sets the type to
         /// </summary>
-        public static readonly ToolboxItemAttribute Default = new ToolboxItemAttribute("System.Drawing.Design.ToolboxItem, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+        public static readonly ToolboxItemAttribute Default = new ToolboxItemAttribute(DefaultToolboxItemTypeName);
 
         /// <summary>
         /// Initializes a new instance of ToolboxItemAttribute and sets the type to
@@ -30,7 +33,7 @@ namespace System.ComponentModel
         /// <summary>
         /// Gets whether the attribute is the default attribute.
         /// </summary>
-        public override bool IsDefaultAttribute() => Equals(Default);
+        public override bool IsDefaultAttribute() => _toolboxItemTypeName == DefaultToolboxItemTypeName;
 
         /// <summary>
         /// Initializes a new instance of ToolboxItemAttribute and specifies if default values should be used.
@@ -39,7 +42,12 @@ namespace System.ComponentModel
         {
             if (defaultType)
             {
-                _toolboxItemTypeName = "System.Drawing.Design.ToolboxItem, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+                if (!IDesignerHost.IsSupported)
+                {
+                    throw new NotSupportedException(SR.IDesignerHostNotSupported);
+                }
+
+                _toolboxItemTypeName = DefaultToolboxItemTypeName;
             }
         }
 


### PR DESCRIPTION
This gets rid of the remaining references to System.Windows.Forms.Design in a trimmed empty winforms app, when the feature switch is set to false.

I'm not sure what is a good name or API location for the feature switch. I've made it internal on `IDesignerHost` for now, but looking for feedback.