### PR TITLE
Port arm64 INLINE_GETTHREAD from NativeAOT

### DIFF
--- a/src/coreclr/vm/arm64/PInvokeStubs.asm
+++ b/src/coreclr/vm/arm64/PInvokeStubs.asm
@@ -188,8 +188,6 @@ RarePath
 
         LEAF_END
 
-        INLINE_GETTHREAD_CONSTANT_POOL
-
 ; ------------------------------------------------------------------
 ; VarargPInvokeStub & VarargPInvokeGenILStub
 ;

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -346,8 +346,13 @@ TrashRegister32Bit SETS "w":CC:("$TrashRegister32Bit":RIGHT:((:LEN:TrashRegister
 ;;
 ;; Macro to get a pointer to the Thread* object for the currently executing thread
 ;;
+    SETALIAS gCurrentThreadInfo, ?gCurrentThreadInfo@@3UThreadLocalInfo@@A
+
     MACRO
         INLINE_GETTHREAD $destReg, $trashReg
 
-        INLINE_GET_TLS_VAR $destReg, $trashReg, tls_CurrentThread
+        EXTERN $gCurrentThreadInfo
+
+        INLINE_GET_TLS_VAR $destReg, $trashReg, gCurrentThreadInfo
+        ldr $destReg, [$destReg] ; return gCurrentThreadInfo.m_pThread
     MEND

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -353,5 +353,5 @@ TrashRegister32Bit SETS "w":CC:("$TrashRegister32Bit":RIGHT:((:LEN:TrashRegister
         EXTERN $gCurrentThreadInfo
 
         INLINE_GET_TLS_VAR $destReg, $trashReg, $gCurrentThreadInfo
-        ldr $destReg, [$destReg] ; return gCurrentThreadInfo.m_pThread
+        ldr $destReg, [$destReg]                            ;; return gCurrentThreadInfo.m_pThread
     MEND

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -324,7 +324,6 @@ __tls_array     equ 0x58    ;; offsetof(TEB, ThreadLocalStoragePointer)
         INLINE_GET_TLS_VAR $destReg, $trashReg, $variable
 
         EXTERN _tls_index
-        EXTERN $variable
 
         ;; The following macro variables are just some assembler magic to get the name of the 32-bit version
         ;; of $trashReg. It does it by string manipulation. Replaces something like x3 with w3.
@@ -353,6 +352,6 @@ TrashRegister32Bit SETS "w":CC:("$TrashRegister32Bit":RIGHT:((:LEN:TrashRegister
 
         EXTERN $gCurrentThreadInfo
 
-        INLINE_GET_TLS_VAR $destReg, $trashReg, gCurrentThreadInfo
+        INLINE_GET_TLS_VAR $destReg, $trashReg, $gCurrentThreadInfo
         ldr $destReg, [$destReg] ; return gCurrentThreadInfo.m_pThread
     MEND

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -313,18 +313,18 @@ $__RedirectionStubEndFuncName
 
         MEND
 
-;-----------------------------------------------------------------------------
-; Macro to get a pointer to the Thread* object for the currently executing thread
-;
+;; -----------------------------------------------------------------------------
+;;
+;; Macro to get a pointer to a threadlocal symbol for the currently executing thread
+;;
+
 __tls_array     equ 0x58    ;; offsetof(TEB, ThreadLocalStoragePointer)
 
-    EXTERN _tls_index
-
-    GBLS __SECTIONREL_gCurrentThreadInfo
-__SECTIONREL_gCurrentThreadInfo SETS "SECTIONREL_gCurrentThreadInfo"
-
     MACRO
-        INLINE_GETTHREAD $destReg, $trashReg
+        INLINE_GET_TLS_VAR $destReg, $trashReg, $variable
+
+        EXTERN _tls_index
+        EXTERN $variable
 
         ;; The following macro variables are just some assembler magic to get the name of the 32-bit version
         ;; of $trashReg. It does it by string manipulation. Replaces something like x3 with w3.
@@ -332,33 +332,22 @@ __SECTIONREL_gCurrentThreadInfo SETS "SECTIONREL_gCurrentThreadInfo"
 TrashRegister32Bit SETS "$trashReg"
 TrashRegister32Bit SETS "w":CC:("$TrashRegister32Bit":RIGHT:((:LEN:TrashRegister32Bit) - 1))
 
-        ldr         $trashReg, =_tls_index
-        ldr         $TrashRegister32Bit, [$trashReg]
+        adrp        $destReg, _tls_index
+        ldr         $TrashRegister32Bit, [$destReg, _tls_index]
         ldr         $destReg, [xpr, #__tls_array]
-        ldr         $destReg, [$destReg, $trashReg lsl #3]
-        ldr         $trashReg, =$__SECTIONREL_gCurrentThreadInfo
-        ldr         $trashReg, [$trashReg]
-        ldr         $destReg, [$destReg, $trashReg]        ; return gCurrentThreadInfo.m_pThread
+        ldr         $destReg, [$destReg, $TrashRegister32Bit uxtw #3]
+        add         $destReg, $destReg, #0, lsl #0xC
+        RELOC       0xA, $variable                          ;; IMAGE_REL_ARM64_SECREL_HIGH12A
+        add         $destReg, $destReg, #0, lsl #0
+        RELOC       0x9, $variable                          ;; IMAGE_REL_ARM64_SECREL_LOW12A
     MEND
 
-;-----------------------------------------------------------------------------
-; INLINE_GETTHREAD_CONSTANT_POOL macro has to be used after the last function in the .asm file that used
-; INLINE_GETTHREAD. Optionally, it can be also used after any function that used INLINE_GETTHREAD
-; to improve density, or to reduce distance between the constant pool and its use.
-;
-    SETALIAS gCurrentThreadInfo, ?gCurrentThreadInfo@@3UThreadLocalInfo@@A
-
+;; -----------------------------------------------------------------------------
+;;
+;; Macro to get a pointer to the Thread* object for the currently executing thread
+;;
     MACRO
-        INLINE_GETTHREAD_CONSTANT_POOL
+        INLINE_GETTHREAD $destReg, $trashReg
 
-        EXTERN $gCurrentThreadInfo
-
-    ;; Section relocs are 32 bits. Using an extra DCD initialized to zero for 8-byte alignment.
-$__SECTIONREL_gCurrentThreadInfo
-        DCD $gCurrentThreadInfo
-        RELOC 8, $gCurrentThreadInfo    ;; SECREL
-        DCD 0
-
-__SECTIONREL_gCurrentThreadInfo SETS "$__SECTIONREL_gCurrentThreadInfo":CC:"_"
-
+        INLINE_GET_TLS_VAR $destReg, $trashReg, tls_CurrentThread
     MEND


### PR DESCRIPTION
The NativeAOT version is slightly better as it does not need the `INLINE_GETTHREAD_CONSTANT_POOL`

NOTE: this is a windows-specific change.
Also the macro is not used as extensively as in NativeAOT, but still makes sense to copy over.