### PR TITLE
Fix disposal bug in `DiagnosticListener`

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -183,7 +183,7 @@ namespace System.Diagnostics
 
             // Indicate completion to all subscribers.
             DiagnosticSubscription? subscriber = null;
-            Interlocked.Exchange(ref subscriber, _subscriptions);
+            subscriber = Interlocked.Exchange(ref _subscriptions, subscriber);
             while (subscriber != null)
             {
                 subscriber.Observer.OnCompleted();

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/DiagnosticSourceTests.cs
@@ -116,6 +116,10 @@ namespace System.Diagnostics.Tests
             listener.Dispose();
             Assert.True(observer.Completed);
 
+            // Subscriptions are removed when listener is disposed and don't receive further notifications
+            listener.Write("AnotherNotification", null);
+            Assert.Equal(1, result.Count);
+
             // confirm that we can unsubscribe without crashing
             subscription.Dispose();
 


### PR DESCRIPTION
Addresses a bug where subscribers receive notifications after disposing of a `DiagnosticListener`.

Fixes #99523

cc @noahfalk 