### PR TITLE
Build NAOT runtime packs for linux-bionic-arm

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -158,6 +158,30 @@ jobs:
         crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+# Linux Bionic arm
+
+- ${{ if containsValue(parameters.platforms, 'linux_bionic_arm') }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      osSubgroup: _bionic
+      archType: arm
+      targetRid: linux-bionic-arm
+      platform: linux_bionic_arm
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_bionic
+      jobParameters:
+        runtimeFlavor: mono
+        # We build on Linux, but the test queue runs Windows, so
+        # we need to override the test script generation
+        runScriptWindowsCmd: true
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # Linux Bionic arm64
 
 - ${{ if containsValue(parameters.platforms, 'linux_bionic_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -96,7 +96,7 @@ jobs:
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
       - Ubuntu.2204.Amd64.Android.29.Open
-    - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm64') }}:
+    - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64') }}:
       - Windows.11.Amd64.Android.Open
 
     # iOS Simulator/Mac Catalyst arm64

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -316,6 +316,7 @@ extends:
           - linux_musl_arm
           - linux_musl_arm64
           - linux_bionic_x64
+          - linux_bionic_arm
           - linux_bionic_arm64
           - windows_x64
           - windows_arm64


### PR DESCRIPTION
This is more than just the one-liner in runtime-official because we don't produce these for Mono.

Cc @dotnet/ilc-contrib 