### PR TITLE
[release/8.0-staging] [HTTP/2] Fix handling of effectively empty DATA frame (#99502)

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -765,12 +765,14 @@ namespace System.Net.Http
             // Just ignore the frame in this case.
 
             ReadOnlySpan<byte> frameData = GetFrameData(_incomingBuffer.ActiveSpan.Slice(0, frameHeader.PayloadLength), hasPad: frameHeader.PaddedFlag, hasPriority: false);
-
             if (http2Stream != null)
             {
                 bool endStream = frameHeader.EndStreamFlag;
 
-                http2Stream.OnResponseData(frameData, endStream);
+                if (frameData.Length > 0 || endStream)
+                {
+                    http2Stream.OnResponseData(frameData, endStream);
+                }
 
                 if (!endStream && frameData.Length > 0)
                 {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -204,6 +204,50 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public async Task Http2_DataFrameOnlyPadding_Success()
+        {
+            using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
+            using (HttpClient client = CreateHttpClient())
+            {
+                Task<HttpResponseMessage> sendTask = client.GetAsync(server.Address, HttpCompletionOption.ResponseHeadersRead);
+
+                Http2LoopbackConnection connection = await server.EstablishConnectionAsync();
+
+                int streamId = await connection.ReadRequestHeaderAsync();
+
+                await connection.SendDefaultResponseHeadersAsync(streamId);
+
+                // Send zero-length DATA frame with padding
+                byte paddingLength = byte.MaxValue;
+                int dataLength = 1024;
+                DataFrame frame = new DataFrame(new byte[0], FrameFlags.Padded, paddingLength, streamId);
+                await connection.WriteFrameAsync(frame);
+
+                HttpResponseMessage response = await sendTask;
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                using var responseStream = response.Content.ReadAsStream();
+
+                // The read must pend because we havent received any data yet.
+                var buffer = new byte[dataLength];
+                var readTask = responseStream.ReadAtLeastAsync(buffer, dataLength);
+                Assert.False(readTask.IsCompleted);
+
+                // Send DATA frame with padding
+                frame = new DataFrame(new byte[dataLength], FrameFlags.Padded, paddingLength, streamId);
+                await connection.WriteFrameAsync(frame);
+
+                Assert.Equal(dataLength, await readTask);
+
+                // Send zero-length, end-stream DATA frame with padding
+                frame = new DataFrame(new byte[0], FrameFlags.Padded | FrameFlags.EndStream, paddingLength, streamId);
+                await connection.WriteFrameAsync(frame);
+
+                Assert.Equal(0, await responseStream.ReadAsync(buffer));
+            }
+        }
+
         [Theory]
         [InlineData("Client content", null)]
         [InlineData("Client content", "Server content")]


### PR DESCRIPTION
Backport of #99502 to release/8.0-staging

## Customer Impact

Reported by Bing crawler. It impacts about 4-5 million URLs they visit a day.

The problem is with specific HTTP/2 servers, which send RFC-valid responses, which are a bit unusual -- they return DATA frame with only padding and no data.
We will interpret it as end of stream (truncating the HTTP response).

Known impacted servers:
- [OpenGSE](https://code.google.com/archive/p/opengse/) (archived Google server, which is not maintained anymore)

## Regression

Not a regression.

## Testing

Manual testing by user repro case.
We added functional test for this specific case.
Customer validated private bits.

## Risk

Low. Specific server behaving in allowed but non-standard way. Also, the change is very small, non-invasive and tested.