### PR TITLE
[mono][interp] Various optimizations for box patterns used in byreflike struct generics

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -6426,6 +6426,13 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			MonoVTable *vtable = (MonoVTable*)frame->imethod->data_items [ip [3]];
 			MonoClass *c = vtable->klass;
 
+			if (G_UNLIKELY (m_class_is_byreflike (c))) {
+				char *str = g_strdup_printf ("Cannot box IsByRefLike type '%s.%s'", m_class_get_name_space (c), m_class_get_name (c));
+				MonoException *ex = mono_exception_from_name_msg (mono_defaults.corlib, "System", "InvalidProgramException", str);
+				g_free (str);
+				THROW_EX (ex, ip);
+			}
+
 			// FIXME push/pop LMF
 			MonoObject *o = mono_gc_alloc_obj (vtable, m_class_get_instance_size (c));
 			SET_TEMP_POINTER(o);

--- a/src/mono/mono/mini/interp/mintops.h
+++ b/src/mono/mono/mini/interp/mintops.h
@@ -235,9 +235,10 @@ typedef enum {
 #define MINT_IS_LDIND_OFFSET(op) ((op) >= MINT_LDIND_OFFSET_I1 && (op) <= MINT_LDIND_OFFSET_I8)
 #define MINT_IS_SIMD_CREATE(op) ((op) >= MINT_SIMD_V128_I1_CREATE && (op) <= MINT_SIMD_V128_I8_CREATE)
 #define MINT_IS_RETURN(op) (((op) >= MINT_RET && (op) <= MINT_RET_U2) || (op) == MINT_RET_I4_IMM || (op) == MINT_RET_I8_IMM)
+#define MINT_IS_BOX(op) ((op) == MINT_BOX || (op) == MINT_BOX_VT || (op) == MINT_BOX_PTR || (op) == MINT_BOX_NULLABLE_PTR)
 
 // TODO Add more
-#define MINT_NO_SIDE_EFFECTS(op) (MINT_IS_MOV (op) || MINT_IS_LDC_I4 (op) || MINT_IS_LDC_I8 (op) || op == MINT_LDC_R4 || op == MINT_LDC_R8 || op == MINT_LDPTR || op == MINT_BOX || op == MINT_INITLOCAL)
+#define MINT_NO_SIDE_EFFECTS(op) (MINT_IS_MOV (op) || MINT_IS_LDC_I4 (op) || MINT_IS_LDC_I8 (op) || op == MINT_LDC_R4 || op == MINT_LDC_R8 || op == MINT_LDPTR || MINT_IS_BOX(op) || op == MINT_INITLOCAL)
 
 #define MINT_CALL_ARGS 2
 #define MINT_CALL_ARGS_SREG -2

--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -3182,7 +3182,7 @@ retry_instruction:
 					td->var_values [ins->sregs [0]].ref_count--;
 					goto retry_instruction;
 				}
-			} else if (opcode == MINT_BOX) {
+			} else if (MINT_IS_BOX (opcode)) {
 				// TODO Add more relevant opcodes
 				td->var_values [dreg].type = VAR_VALUE_NON_NULL;
 			}

--- a/src/mono/mono/mini/interp/transform-opt.c
+++ b/src/mono/mono/mini/interp/transform-opt.c
@@ -2340,6 +2340,51 @@ interp_fold_binop (TransformData *td, InterpInst *ins, gboolean *folded)
 
 	if (!val1 || !val2)
 		return ins;
+
+	if ((val1->type == VAR_VALUE_I4 || val1->type == VAR_VALUE_I8) && val2->type == VAR_VALUE_NON_NULL) {
+		gint64 imm = (val1->type == VAR_VALUE_I4) ? (gint64)val1->i : val1->l;
+		if (imm == 0) {
+			result.type = VAR_VALUE_NONE;
+			switch (ins->opcode) {
+				case MINT_CEQ_I4:
+				case MINT_CEQ_I8:
+				case MINT_CGT_UN_I4:
+				case MINT_CGT_UN_I8:
+					result.type = VAR_VALUE_I4;
+					result.i = 0;
+					goto fold_ok;
+				case MINT_CNE_I4:
+				case MINT_CNE_I8:
+				case MINT_CLT_UN_I4:
+				case MINT_CLT_UN_I8:
+					result.type = VAR_VALUE_I4;
+					result.i = 1;
+					goto fold_ok;
+			}
+		}
+	} else if (val1->type == VAR_VALUE_NON_NULL && (val2->type == VAR_VALUE_I4 || val2->type == VAR_VALUE_I8)) {
+		gint64 imm = (val2->type == VAR_VALUE_I4) ? (gint64)val2->i : val2->l;
+		if (imm == 0) {
+			result.type = VAR_VALUE_NONE;
+			switch (ins->opcode) {
+				case MINT_CNE_I4:
+				case MINT_CNE_I8:
+				case MINT_CGT_UN_I4:
+				case MINT_CGT_UN_I8:
+					result.type = VAR_VALUE_I4;
+					result.i = 1;
+					goto fold_ok;
+				case MINT_CEQ_I4:
+				case MINT_CEQ_I8:
+				case MINT_CLT_UN_I4:
+				case MINT_CLT_UN_I8:
+					result.type = VAR_VALUE_I4;
+					result.i = 0;
+					goto fold_ok;
+			}
+		}
+	}
+
 	if (val1->type != VAR_VALUE_I4 && val1->type != VAR_VALUE_I8)
 		return ins;
 	if (val2->type != VAR_VALUE_I4 && val2->type != VAR_VALUE_I8)
@@ -2407,6 +2452,7 @@ interp_fold_binop (TransformData *td, InterpInst *ins, gboolean *folded)
 			return ins;
 	}
 
+fold_ok:
 	// We were able to compute the result of the ins instruction. We replace the binop
 	// with a LDC of the constant. We leave alone the sregs of this instruction, for
 	// deadce to kill the instructions initializing them.

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -353,6 +353,8 @@ typedef struct
 	guint need_optimization_retry : 1;
 	guint disable_ssa : 1;
 	guint eh_vars_computed : 1;
+	guint retry_compilation : 1;
+	guint retry_with_inlining : 1;
 } TransformData;
 
 #define STACK_TYPE_I4 0

--- a/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
@@ -45,7 +45,6 @@ public class Validate
     }
 
     [Fact]
-    [SkipOnMono("https://github.com/dotnet/runtime/issues/99379")]
     public static void Validate_RecognizedOpCodeSequences_Scenarios()
     {
         Console.WriteLine($"{nameof(Validate_RecognizedOpCodeSequences_Scenarios)}...");


### PR DESCRIPTION
When we were trying to emit a box of a byreflike type, we were throwing exception during compilation time. We no longer throw exception, we let the optimization passes attempt to optimize the box out. If the box instruction is not optimized out, we will throw the exception at runtime. This means that, if untiered method encounters such a box instruction, it will disable tiering and recompile the method will all optimizations enabled. This so we can avoid hardcoding a bunc of IL patterns. Box instruction will have its result marked as not null and constant folding can compute the results of some comparison operators, in a general fashion.

Contributes to https://github.com/dotnet/runtime/issues/99379

I didn't yet run the byreflike tests.