### PR TITLE
[wasm] Add limited constant propagation to the jiterpreter for ldc.i4 and ldloca

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -1879,6 +1879,7 @@ export type JiterpreterOptions = {
     enableWasmEh: boolean;
     enableSimd: boolean;
     zeroPageOptimization: boolean;
+    cprop: boolean;
     // For locations where the jiterpreter heuristic says we will be unable to generate
     //  a trace, insert an entry point opcode anyway. This enables collecting accurate
     //  stats for options like estimateHeat, but raises overhead.
@@ -1924,6 +1925,7 @@ const optionNames: { [jsName: string]: string } = {
     "enableWasmEh": "jiterpreter-wasm-eh-enabled",
     "enableSimd": "jiterpreter-simd-enabled",
     "zeroPageOptimization": "jiterpreter-zero-page-optimization",
+    "cprop": "jiterpreter-constant-propagation",
     "enableStats": "jiterpreter-stats-enabled",
     "disableHeuristic": "jiterpreter-disable-heuristic",
     "estimateHeat": "jiterpreter-estimate-heat",

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -121,6 +121,10 @@ DEFINE_BOOL(jiterpreter_backward_branches_enabled, "jiterpreter-backward-branche
 DEFINE_BOOL(jiterpreter_enable_simd, "jiterpreter-simd-enabled", TRUE, "Attempt to use WebAssembly SIMD support")
 // Since the zero page is unallocated, loading array/string/span lengths from null ptrs will yield zero
 DEFINE_BOOL(jiterpreter_zero_page_optimization, "jiterpreter-zero-page-optimization", TRUE, "Exploit the zero page being unallocated to optimize out null checks")
+// We can produce higher quality code by embedding known constants directly into traces instead of loading
+//  the constant from its storage location in the interpreter's locals in memory, even if we can't skip
+//  the write of the constant into memory.
+DEFINE_BOOL(jiterpreter_constant_propagation, "jiterpreter-constant-propagation", TRUE, "Propagate ldc.i4 and ldloca expressions forward to locations where those constants are used")
 // When compiling a jit_call wrapper, bypass sharedvt wrappers if possible by inlining their
 //  logic into the compiled wrapper and calling the target AOTed function with native call convention
 DEFINE_BOOL(jiterpreter_direct_jit_call, "jiterpreter-direct-jit-calls", TRUE, "Bypass gsharedvt wrappers when compiling JIT call wrappers")


### PR DESCRIPTION
Right now if an interpreter opcode stores a constant (`ldc.i4`) or effectively-constant (`ldloca`) expression into an interpreter local, we have to read it back from memory before using it later in a trace. However, there are many scenarios where it would be profitable to not do this, and instead embed the constant into the trace where the load would otherwise happen. This furthermore enables optimizing out null checks in some cases, since if the address being null-checked is constant, we can determine statically whether it is null and omit the runtime check entirely.

The `System.Runtime.Intrinsics.Tests.Perf_Vector128Of(UInt16).LessThanOrEqualAnyBenchmark` perf case is a good example for this, because both types of cprop occur for it in my test harness.

First, ldloca constant propagation eliminates a memory load and a null-check of the load (because the load was a pointer), for the following pair of interp opcodes:
```
 IR_003e: ldloca.s       [128 <- nil], 32
 IR_0041: ldind_off_add_mul_imm.u2 [128 <- 128 40], 0,2
```
![image](https://github.com/dotnet/runtime/assets/198130/70fc509e-24fa-49ec-9af5-cfc055a08e4e)
In the above example we perform a ldloca, computing `pLocals + 32` and store it into `pLocals[128]`.
Then we load `pLocals[128]` to use it as the base address for an indirect-load-with-offset, which requires null checking the loaded pointer, and jiterp stores the null-checked pointer into what I call `cknull_ptr`. Then the null-checked pointer can finally be used to compute the address for the indirect load, and perform the load.
With constant propagation, the null check disappears and instead of reading `pLocals[128]` back, we just compute the address again from scratch. From outside the trace this is unobservable, since we still wrote the result of the ldloca opcode into the locals like we were supposed to, we're just not reading it.

Second, the constant propagation makes the benchmark loop termination condition faster. The loop count is too big to fit into the interpreter's compare-with-immediate superinstructions, but jiterp is able to propagate the constant into the comparison, so it still gets a little faster:
```
 IR_00a4: ldc.i4         [120 <- nil], 50000000
 IR_00a8: blt.i4.s       [nil <- 16 120], IR_0019
```
![image](https://github.com/dotnet/runtime/assets/198130/b6ecaa6e-2594-4ab5-94d3-de61ca7b5c18)

This is still a somewhat fragile optimization (if the jiterpreter's constant analysis breaks, this will break stuff), so there's a new runtime option we can use to turn it off. However, the jiterpreter already uses constant analysis for various things (SIMD requires it), so if it's broken, we want to know about it... and this should surface any brokenness. The constant analysis is conservative by design (we discard all of our analysis info any time we cross a branch target).

Fixing `VectorNN.GetElementUnsafe<T>` to not generate extremely-hard-to-optimize code is left as an exercise for the reader.