### PR TITLE
Adjust allocation behavior for type system to attempt to reduce TLB c…

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -792,6 +792,13 @@ RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableArm64Sve,               W("EnableArm64Sv
 #endif
 
 ///
+/// TypeSystem
+///
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_MaxMethodsToContributeToGenericDictionary,               W("MaxMethodsToContributeToGenericDictionary"),            20, "Allows adjusting the heuristic for generic dictionary growth")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_MethodsWhichContributeFullyToGenericDictionary,          W("MethodsWhichContributeFullyToGenericDictionary"),       10, "Allows adjusting the heuristic for generic dictionary growth")
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_UseHighFrequencyMethodTableHeap,                         W("UseHighFrequencyMethodTableHeap"),             1,  "Control whether or not there is a special high frequency method table heap")
+
+///
 /// Uncategorized
 ///
 //

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -674,12 +674,19 @@ private:
 //
 
 #define LOW_FREQUENCY_HEAP_RESERVE_SIZE        (3 * GetOsPageSize())
+#define LOW_FREQUENCY_HEAP_INITIAL_RESERVE_SIZE (512 * GetOsPageSize())
 #define LOW_FREQUENCY_HEAP_COMMIT_SIZE         (1 * GetOsPageSize())
 
 #define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (10 * GetOsPageSize())
+#define HIGH_FREQUENCY_HEAP_INITIAL_RESERVE_SIZE (768 * GetOsPageSize())
 #define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * GetOsPageSize())
 
+#define HIGH_FREQUENCY_METHODTABLE_HEAP_RESERVE_SIZE (10 * GetOsPageSize())
+#define HIGH_FREQUENCY_METHODTABLE_HEAP_INITIAL_RESERVE_SIZE (253 * GetOsPageSize())
+#define HIGH_FREQUENCY_METHODTABLE_HEAP_COMMIT_SIZE (1 * GetOsPageSize())
+
 #define STUB_HEAP_RESERVE_SIZE                 (3 * GetOsPageSize())
+#define STUB_HEAP_INITIAL_RESERVE_SIZE         (3 * GetOsPageSize())
 #define STUB_HEAP_COMMIT_SIZE                  (1 * GetOsPageSize())
 
 // --------------------------------------------------------------------------------

--- a/src/coreclr/vm/array.cpp
+++ b/src/coreclr/vm/array.cpp
@@ -314,7 +314,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
 
     // ArrayClass already includes one void*
     LoaderAllocator* pAllocator= this->GetLoaderAllocator();
-    BYTE* pMemory = (BYTE *)pamTracker->Track(pAllocator->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(cbArrayClass) +
+    BYTE* pMemory = (BYTE *)pamTracker->Track(pAllocator->GetHighFrequencyMethodTableHeap()->AllocMem(S_SIZE_T(cbArrayClass) +
                                                                                             S_SIZE_T(cbMT)));
 
     // Note: Memory allocated on loader heap is zero filled
@@ -334,7 +334,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     MethodTable* pMT = (MethodTable *) pMTHead;
 
     // Allocate the private data block ("private" during runtime in the ngen'ed case).
-    pMT->AllocateAuxiliaryData(pAllocator, this, pamTracker, false, static_cast<WORD>(numNonVirtualSlots));
+    pMT->AllocateAuxiliaryData(pAllocator->GetHighFrequencyMethodTableHeap(), this, pamTracker, false, static_cast<WORD>(numNonVirtualSlots));
     pMT->SetLoaderAllocator(pAllocator);
     pMT->SetModule(elemTypeHnd.GetModule());
 

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -772,6 +772,9 @@ HRESULT EEConfig::sync()
 #if defined(FEATURE_GDBJIT_FRAME)
     fGDBJitEmitDebugFrame = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GDBJitEmitDebugFrame) != 0;
 #endif
+
+    maxMethodsToContributeToGenericDictionary = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_MaxMethodsToContributeToGenericDictionary);
+    methodsWhichContributeFullyToGenericDictionary = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_MethodsWhichContributeFullyToGenericDictionary);
     return hr;
 }
 

--- a/src/coreclr/vm/eeconfig.h
+++ b/src/coreclr/vm/eeconfig.h
@@ -448,9 +448,16 @@ public:
 
 #endif
 
+    uint32_t GetMaxMethodsToContributeToGenericDictionary() const { LIMITED_METHOD_CONTRACT; return maxMethodsToContributeToGenericDictionary; }
+    uint32_t GetMethodsWhichContributeFullyToGenericDictionary() const { LIMITED_METHOD_CONTRACT; return methodsWhichContributeFullyToGenericDictionary; }
+
 private: //----------------------------------------------------------------
 
     bool fInited;                   // have we synced to the registry at least once?
+
+    // Type system config
+    uint32_t maxMethodsToContributeToGenericDictionary;
+    uint32_t methodsWhichContributeFullyToGenericDictionary;
 
     // Jit-config
 

--- a/src/coreclr/vm/genericdict.h
+++ b/src/coreclr/vm/genericdict.h
@@ -120,7 +120,10 @@ private:
                                 CORINFO_RUNTIME_LOOKUP*             pResult,
                                 WORD*                               pSlotOut,
                                 DWORD                               scanFromSlot,
-                                BOOL                                useEmptySlotIfFound);
+                                BOOL                                useEmptySlotIfFound,
+                                MethodTable*                        pMT,
+                                MethodDesc*                         pMD
+                                );
 
 
     static DictionaryLayout* ExpandDictionaryLayout(LoaderAllocator*                pAllocator,

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -251,7 +251,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // will expand the dictionary at that point.
     DWORD cbInstAndDictSlotSize;
     DWORD cbInstAndDictAllocSize = pOldMT->GetInstAndDictSize(&cbInstAndDictSlotSize);
-    printf("InstAndDictSize %d\n", cbInstAndDictAllocSize);
 
     // Allocate from the high frequence heap of the correct domain
     S_SIZE_T allocSize = safe_cbMT;

--- a/src/coreclr/vm/loaderallocator.hpp
+++ b/src/coreclr/vm/loaderallocator.hpp
@@ -302,12 +302,14 @@ protected:
     BYTE *              m_InitialReservedMemForLoaderHeaps;
     BYTE                m_LowFreqHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_HighFreqHeapInstance[sizeof(LoaderHeap)];
+    BYTE                m_HighFreqMethodTableHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_StubHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_PrecodeHeapInstance[sizeof(CodeFragmentHeap)];
     BYTE                m_FixupPrecodeHeapInstance[sizeof(LoaderHeap)];
     BYTE                m_NewStubPrecodeHeapInstance[sizeof(LoaderHeap)];
     PTR_LoaderHeap      m_pLowFrequencyHeap;
     PTR_LoaderHeap      m_pHighFrequencyHeap;
+    PTR_LoaderHeap      m_pHighFrequencyMethodTableHeap;
     PTR_LoaderHeap      m_pStubHeap; // stubs for PInvoke, remoting, etc
     PTR_CodeFragmentHeap m_pPrecodeHeap;
     PTR_LoaderHeap      m_pExecutableHeap;
@@ -580,6 +582,12 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         return m_pHighFrequencyHeap;
+    }
+
+    PTR_LoaderHeap GetHighFrequencyMethodTableHeap()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pHighFrequencyMethodTableHeap;
     }
 
     PTR_LoaderHeap GetStubHeap()

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -671,7 +671,7 @@ MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD, 
 }
 #endif // FEATURE_COMINTEROP
 
-void MethodTable::AllocateAuxiliaryData(LoaderAllocator *pAllocator, Module *pLoaderModule, AllocMemTracker *pamTracker, bool hasGenericStatics, WORD nonVirtualSlots, S_SIZE_T extraAllocation)
+void MethodTable::AllocateAuxiliaryData(LoaderHeap *pHeap, Module *pLoaderModule, AllocMemTracker *pamTracker, bool hasGenericStatics, WORD nonVirtualSlots, S_SIZE_T extraAllocation)
 {
     S_SIZE_T cbAuxiliaryData = S_SIZE_T(sizeof(MethodTableAuxiliaryData));
 
@@ -687,7 +687,7 @@ void MethodTable::AllocateAuxiliaryData(LoaderAllocator *pAllocator, Module *pLo
         ThrowHR(COR_E_OVERFLOW);
 
     BYTE* pAuxiliaryDataRegion = (BYTE *)
-        pamTracker->Track(pAllocator->GetHighFrequencyHeap()->AllocMem(cbAuxiliaryData));
+        pamTracker->Track(pHeap->AllocMem(cbAuxiliaryData));
 
     MethodTableAuxiliaryData * pMTAuxiliaryData;
     pMTAuxiliaryData = (MethodTableAuxiliaryData *)(pAuxiliaryDataRegion + prependedAllocationSpace);
@@ -724,7 +724,7 @@ MethodTable* CreateMinimalMethodTable(Module* pContainingModule,
     // memset(pMT, 0, sizeof(MethodTable));
 
     // Allocate the private data block ("private" during runtime in the ngen'ed case).
-    pMT->AllocateAuxiliaryData(pLoaderAllocator, pContainingModule, pamTracker);
+    pMT->AllocateAuxiliaryData(pLoaderAllocator->GetHighFrequencyHeap(), pContainingModule, pamTracker);
     pMT->SetModule(pContainingModule);
     pMT->SetLoaderAllocator(pLoaderAllocator);
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2685,7 +2685,7 @@ public:
     // ------------------------------------------------------------------
 
 #ifndef DACCESS_COMPILE
-    void AllocateAuxiliaryData(LoaderAllocator *pAllocator, Module *pLoaderModule, AllocMemTracker *pamTracker, bool hasGenericStatics = false, WORD nonVirtualSlots = 0, S_SIZE_T extraAllocation = S_SIZE_T(0));
+    void AllocateAuxiliaryData(LoaderHeap *pHeap, Module *pLoaderModule, AllocMemTracker *pamTracker, bool hasGenericStatics = false, WORD nonVirtualSlots = 0, S_SIZE_T extraAllocation = S_SIZE_T(0));
 #endif
 
     inline PTR_Const_MethodTableAuxiliaryData GetAuxiliaryData() const

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -1880,6 +1880,7 @@ private:
 
         //-----------------------------------------------------------------------------------------
         DWORD           dwNumDeclaredNonAbstractMethods; // For calculating approx generic dictionary size
+        DWORD           dwNumDeclaredGenericNonAbstractMethods; // For calculating approx generic dictionary size
         DWORD           dwNumberMethodImpls;    // Number of method impls defined for this type
         DWORD           dwNumberInexactMethodImplCandidates; // Number of inexact method impl candidates (used for type equivalent interfaces)
 


### PR DESCRIPTION
…osts

- Reduce allocation size of initial generic dictionary
- Allocate MethodTables which are likely to be used for allocated objects on special LoaderHeap, to try and increase density
- Adjust initial allocations sizes to something which is a realistic amount of initial program allocation

Add
DOTNET_MaxMethodsToContributeToGenericDictionary which defaults to 20 DOTNET_MethodsWhichContributeFullyToGenericDictionary which defaults to 10 to control generic dicitionary heuristic

and
DOTNET_UseHighFrequencyMethodTableHeap which controls whether or not we have use a separate heap for high frequency methodtables