### PR TITLE
[6.0] Append job attempt number to log artifact name to get rid of file exists failure on reattempts

### DIFF
--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -2,7 +2,7 @@ parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromPlatform: ''
   isOfficialBuild: false
-  logArtifactName: 'Logs-PrepareSignedArtifacts'
+  logArtifactName: 'Logs-PrepareSignedArtifacts_Attempt$(System.JobAttempt)'
 
 jobs:
 - job: PrepareSignedArtifacts


### PR DESCRIPTION
If we don't add the attempt number at the end, the builds fail to get queued sometimes and don't execute again. 
We already do this in the 8.0 branch: https://github.com/dotnet/runtime/blob/release/8.0/eng/pipelines/official/jobs/prepare-signed-artifacts.yml#L5
Noticed by @vseanreesermsft 
Sending directly to the base branch so it quickly propagates to internal and staging.