### PR TITLE
[7.0] Append job attempt number to log artifact name to get rid of file exists failure on reattempts

### DIFF
--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -26,7 +26,7 @@ jobs:
     fetchDepth: 20
 
   - ${{ if eq(parameters.isOfficialBuild, true) }}:
-    - task: NuGetAuthenticate@0
+    - task: NuGetAuthenticate@1
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -2,7 +2,7 @@ parameters:
   dependsOn: []
   PublishRidAgnosticPackagesFromPlatform: ''
   isOfficialBuild: false
-  logArtifactName: 'Logs-PrepareSignedArtifacts'
+  logArtifactName: 'Logs-PrepareSignedArtifacts_Attempt$(System.JobAttempt)'
 
 jobs:
 - job: PrepareSignedArtifacts
@@ -26,7 +26,7 @@ jobs:
     fetchDepth: 20
 
   - ${{ if eq(parameters.isOfficialBuild, true) }}:
-    - task: NuGetAuthenticate@1
+    - task: NuGetAuthenticate@0
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
If we don't add the attempt number at the end, the builds fail to get queued sometimes and don't execute again. 
We already do this in the 8.0 branch: https://github.com/dotnet/runtime/blob/release/8.0/eng/pipelines/official/jobs/prepare-signed-artifacts.yml#L5
Noticed by @vseanreesermsft 
Sending directly to the base branch so it quickly propagates to internal and staging.