### PR TITLE
Rename MSBuild property MicrosoftNativeQuicMsQuicVersion -> MicrosoftNativeQuicMsQuicSchannelVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -222,7 +222,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-preview.3.24155.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicVersion>2.2.3</MicrosoftNativeQuicMsQuicVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.2.3</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24162.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>16.0.5-alpha.1.24154.3</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -172,7 +172,7 @@
                       GeneratePathProperty="true" />
 
     <PackageReference Include="Microsoft.Native.Quic.MsQuic.Schannel"
-                      Version="$(MicrosoftNativeQuicMsQuicVersion)"
+                      Version="$(MicrosoftNativeQuicMsQuicSchannelVersion)"
                       PrivateAssets="all"
                       Condition="'$(UseQuicTransportPackage)' != 'true'"
                       GeneratePathProperty="true" />


### PR DESCRIPTION
MSBuild properties representing package versions should contain the full name of [the package](https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-public/NuGet/Microsoft.Native.Quic.MsQuic.Schannel).
Servicing PRs:
- https://github.com/dotnet/runtime/pull/99714
- https://github.com/dotnet/runtime/pull/99715