### PR TITLE
[8.0] Rename MSBuild property MicrosoftNativeQuicMsQuicVersion -> MicrosoftNativeQuicMsQuicSchannelVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -219,7 +219,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>8.0.0-rtm.23523.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicVersion>2.2.3</MicrosoftNativeQuicMsQuicVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.2.3</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>8.0.0-alpha.1.23527.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>16.0.5-alpha.1.23566.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -148,7 +148,7 @@
                       GeneratePathProperty="true" />
 
     <PackageReference Include="Microsoft.Native.Quic.MsQuic.Schannel"
-                      Version="$(MicrosoftNativeQuicMsQuicVersion)"
+                      Version="$(MicrosoftNativeQuicMsQuicSchannelVersion)"
                       PrivateAssets="all"
                       Condition="'$(UseQuicTransportPackage)' != 'true'"
                       GeneratePathProperty="true" />


### PR DESCRIPTION
MSBuild properties representing package versions should contain the full name of [the package](https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-public/NuGet/Microsoft.Native.Quic.MsQuic.Schannel).

Tell mode (infra).