### PR TITLE
[7.0] Rename MSBuild property MicrosoftNativeQuicMsQuicVersion -> MicrosoftNativeQuicMsQuicSchannelVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -179,7 +179,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>7.0.0-rtm.24115.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicVersion>2.2.3</MicrosoftNativeQuicMsQuicVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.2.3</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>7.0.0-alpha.1.22459.1</SystemNetMsQuicTransportVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>11.1.0-alpha.1.23115.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -105,7 +105,7 @@
                       GeneratePathProperty="true"
                       Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <PackageReference Include="Microsoft.Native.Quic.MsQuic.Schannel"
-                      Version="$(MicrosoftNativeQuicMsQuicVersion)"
+                      Version="$(MicrosoftNativeQuicMsQuicSchannelVersion)"
                       PrivateAssets="all"
                       GeneratePathProperty="true"
                       Condition="'$(DotNetBuildFromSource)' != 'true'" />


### PR DESCRIPTION
MSBuild properties representing package versions should contain the full name of [the package](https://dnceng.visualstudio.com/public/_artifacts/feed/dotnet-public/NuGet/Microsoft.Native.Quic.MsQuic.Schannel).

Tell mode (infra).