### PR TITLE
[NativeAOT/x86] Workaround for issue #97272 when building tests

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Type.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Type.cs
@@ -135,7 +135,15 @@ namespace System
             get => IsPrimitiveImpl();
         }
         protected abstract bool IsPrimitiveImpl();
-        public bool IsValueType { [Intrinsic] get => IsValueTypeImpl(); }
+        public bool IsValueType
+        {
+#if NATIVEAOT
+            // https://github.com/dotnet/runtime/issues/97272
+            [MethodImpl(MethodImplOptions.NoOptimization)]
+#endif
+            [Intrinsic]
+            get => IsValueTypeImpl();
+        }
         protected virtual bool IsValueTypeImpl() => IsSubclassOf(typeof(ValueType));
 
         [Intrinsic]


### PR DESCRIPTION
Same workaround was already used for `IsPrimitive`. This unblocks building the runtime tests.