### PR TITLE
[NativeAOT/x86] Implement GetConservativeUpperBoundForOutgoingArgs

### DIFF
--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -590,7 +590,7 @@ uintptr_t CoffNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
                               (PTR_CBYTE)(m_moduleBase + pNativeMethodInfo->runtimeFunction->BeginAddress),
                               (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT,
                               true);
-        upperBound = dac_cast<TADDR>(registerSet.PCTAddr + sizeof(TADDR));
+        upperBound = dac_cast<TADDR>(registerSet.PCTAddr);
 #endif
     }
     return upperBound;

--- a/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/CoffNativeCodeManager.cpp
@@ -582,21 +582,15 @@ uintptr_t CoffNativeCodeManager::GetConservativeUpperBoundForOutgoingArgs(Method
 
         REGDISPLAY registerSet = *pRegisterSet;
 
-        if (::UnwindStackFrameX86(&registerSet,
-                                  (PTR_CBYTE)(m_moduleBase + pNativeMethodInfo->mainRuntimeFunction->BeginAddress),
-                                  codeOffset,
-                                  &infoBuf,
-                                  table,
-                                  (PTR_CBYTE)(m_moduleBase + pNativeMethodInfo->runtimeFunction->BeginAddress),
-                                  (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT,
-                                  true))
-        {
-            upperBound = dac_cast<TADDR>(registerSet.PCTAddr - sizeof(TADDR));
-        }
-        else
-        {
-            upperBound = registerSet.GetSP();
-        }
+        ::UnwindStackFrameX86(&registerSet,
+                              (PTR_CBYTE)(m_moduleBase + pNativeMethodInfo->mainRuntimeFunction->BeginAddress),
+                              codeOffset,
+                              &infoBuf,
+                              table,
+                              (PTR_CBYTE)(m_moduleBase + pNativeMethodInfo->runtimeFunction->BeginAddress),
+                              (unwindBlockFlags & UBF_FUNC_KIND_MASK) != UBF_FUNC_KIND_ROOT,
+                              true);
+        upperBound = dac_cast<TADDR>(registerSet.PCTAddr + sizeof(TADDR));
 #endif
     }
     return upperBound;


### PR DESCRIPTION
I left this API out when integrating the x86 unwinding code. Turns out it may be necessary for running System.Runtime.Tests.