### PR TITLE
Add missing reference to native library

### DIFF
--- a/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/BSTR/BSTRTest.csproj
@@ -12,5 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <CMakeProjectReference Include="./CMakeLists.txt" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
+++ b/src/tests/Interop/StringMarshalling/LPSTR/LPSTRTest.csproj
@@ -10,5 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <CMakeProjectReference Include="./CMakeLists.txt" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes failing coreclr tests:
* Interop/StringMarshalling/BSTR/BSTRTest/BSTRTest.sh
* Interop/StringMarshalling/LPSTR/LPSTRTest/LPSTRTest.sh

because of "cannot open shared object file: No such file or directory" error:

```
/runtime/artifacts/tests/coreclr/linux.riscv64.Checked/Interop/StringMarshalling/BSTR/BSTRTest/libBStrTestNative.so: cannot open shared object file: No such file or directory
/runtime/artifacts/tests/coreclr/linux.riscv64.Checked/Interop/StringMarshalling/LPSTR/LPSTRTest/libLPStrTestNative.so: cannot open shared object file: No such file or directory
```

Adding CMakeProjectReference to the native library:
* builds the native library if not already built
* copies the library to the test folder so it can be found during the test execution

Part of #84834, cc @dotnet/samsung