### PR TITLE
[wasm] Make back branches faster in the jiterpreter and clean up some code

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-enums.ts
+++ b/src/mono/browser/runtime/jiterpreter-enums.ts
@@ -44,6 +44,8 @@ export const enum JiterpMember {
     ClassRank,
     ClassElementClass,
     BoxedValueData,
+    BackwardBranchTaken,
+    BailoutOpcodeCount,
 }
 
 // keep in sync with jiterpreter.c, see mono_jiterp_write_number_unaligned

--- a/src/mono/browser/runtime/jiterpreter.ts
+++ b/src/mono/browser/runtime/jiterpreter.ts
@@ -779,7 +779,6 @@ function generate_wasm(
             "math_rhs64": WasmValtype.i64,
             "temp_f32": WasmValtype.f32,
             "temp_f64": WasmValtype.f64,
-            "backbranched": WasmValtype.i32,
         };
         if (builder.options.enableSimd) {
             traceLocals["v128_zero"] = WasmValtype.v128;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3863,11 +3863,6 @@ max_d (double lhs, double rhs)
 		return fmax (lhs, rhs);
 }
 
-#if HOST_BROWSER
-// Dummy call info used outside of monitoring phase. We don't care what's in it
-static JiterpreterCallInfo jiterpreter_call_info = { 0 };
-#endif
-
 /*
  * If CLAUSE_ARGS is non-null, start executing from it.
  * The ERROR argument is used to avoid declaring an error object for every interp frame, its not used
@@ -7865,7 +7860,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 						// now execute the trace
 						// this isn't important for performance, but it makes it easier to use the
 						//  jiterpreter early in automated tests where code only runs once
-						offset = prepare_result (frame, locals, &jiterpreter_call_info, ip);
+						offset = prepare_result (frame, locals, NULL, ip);
 						ip = (guint16*) (((guint8*)ip) + offset);
 						break;
 				}
@@ -7888,7 +7883,7 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_TIER_ENTER_JITERPRETER) {
 			// The fn ptr is encoded in a guint16 relative to the index of the first trace fn ptr, so compute the actual ptr
 			JiterpreterThunk thunk = (JiterpreterThunk)(void *)(((JiterpreterOpcode *)ip)->relative_fn_ptr + mono_jiterp_first_trace_fn_ptr);
-			ptrdiff_t offset = thunk (frame, locals, &jiterpreter_call_info, ip);
+			ptrdiff_t offset = thunk (frame, locals, NULL, ip);
 			ip = (guint16*) (((guint8*)ip) + offset);
 			MINT_IN_BREAK;
 		}

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1179,7 +1179,9 @@ enum {
 	JITERP_MEMBER_VTABLE_KLASS,
 	JITERP_MEMBER_CLASS_RANK,
 	JITERP_MEMBER_CLASS_ELEMENT_CLASS,
-	JITERP_MEMBER_BOXED_VALUE_DATA
+	JITERP_MEMBER_BOXED_VALUE_DATA,
+	JITERP_MEMBER_BACKWARD_BRANCH_TAKEN,
+	JITERP_MEMBER_BAILOUT_OPCODE_COUNT,
 };
 
 
@@ -1222,6 +1224,10 @@ mono_jiterp_get_member_offset (int member) {
 		// see mono_object_get_data
 		case JITERP_MEMBER_BOXED_VALUE_DATA:
 			return MONO_ABI_SIZEOF (MonoObject);
+		case JITERP_MEMBER_BACKWARD_BRANCH_TAKEN:
+			return offsetof (JiterpreterCallInfo, backward_branch_taken);
+		case JITERP_MEMBER_BAILOUT_OPCODE_COUNT:
+			return offsetof (JiterpreterCallInfo, bailout_opcode_count);
 		default:
 			g_assert_not_reached();
 	}


### PR DESCRIPTION
Right now the jiterpreter maintains a local variable tracking whether a backward branch has ever been taken, and flushes it to memory upon abnormal exit to notify the monitoring code whether the trace took any backward branches.

I realized this variable isn't actually necessary, because the design of the jiterpreter's dispatch code ensures that the existing `disp` variable will only have the value 0 on first execution, and will always have a nonzero value after any backwards branch is taken. So we can just flush `disp` to memory on abnormal exit instead. This means we don't have to waste valuable cycles setting the flag every time we take a backwards branch, since we're already setting `disp`.

I also took the opportunity to change things so we pass a `NULL` `cinfo` to traces when they're not being monitored. In most scenarios this shouldn't matter, but for hot traces that abnormally exit this will reduce the number of pointless memory writes they do a little bit, and it will also fix the minor problem that in multithreaded scenarios, all traces compete to write to the same dummy static `cinfo` variable (now they won't perform the write at all).

While adding this optimization I also noticed that conditional back-branches were modifying `disp` even when the branch wasn't taken, which would raise the cost of each of those branches for no good reason, so I cleaned that up as well.

This makes abnormal exits ~5 bytes longer, but it makes back-branches 1 byte shorter, so it should be a trace size reduction on average.

There were a couple hard-coded offsets in the typescript and I took the opportunity to change them into JiterpMembers as well.