### PR TITLE
JIT: Remove BBF_NONE_QUIRK check when optimizing branch to empty unconditional

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4867,9 +4867,8 @@ bool Compiler::fgUpdateFlowGraph(bool doTailDuplication /* = false */, bool isPh
                 if (bDest->KindIs(BBJ_ALWAYS) && !bDest->TargetIs(bDest) && // special case for self jumps
                     bDest->isEmpty())
                 {
-                    // TODO: Allow optimizing branches to blocks that jump to the next block
-                    const bool optimizeBranch = !bDest->JumpsToNext() || !bDest->HasFlag(BBF_NONE_QUIRK);
-                    if (optimizeBranch && fgOptimizeBranchToEmptyUnconditional(block, bDest))
+                    // Empty blocks that jump to the next block can probably be compacted instead
+                    if (!bDest->JumpsToNext() && fgOptimizeBranchToEmptyUnconditional(block, bDest))
                     {
                         change   = true;
                         modified = true;


### PR DESCRIPTION
Part of #95998. Removing the `JumpsToNext` check altogether seems to affect loop cloning, and also exposes a rare pattern where `bDest`'s jump target is `bDest`, and we enter an infinite loop where we first try to optimize `block -> bDest -> bDestTarget`, then we try to optimize `block -> bDestTarget -> bDest`, etc. Just compacting `bDest` later on seems easier, and if we are able to compact it, we end up with `block -> bDestTarget`.

If this PR and #99783 are both merged, we can (finally) get rid of `BBF_NONE_QUIRK`.