### PR TITLE
Use JitEnableOptionalRelocs in getHelperFtn

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10721,7 +10721,11 @@ void* CEEJitInfo::getHelperFtn(CorInfoHelpFunc    ftnNum,         /* IN  */
             // so we no longer need to use indirections and can emit a direct call instead.
             //
             // Avoid taking the lock for foreground jit compilations
-            if (!GetAppDomain()->GetTieredCompilationManager()->IsTieringDelayActive())
+            //
+            // JitEnableOptionalRelocs being false means we should avoid non-deterministic
+            // optimizations that can randomly change codegen.
+            if (!GetAppDomain()->GetTieredCompilationManager()->IsTieringDelayActive() &&
+                g_pConfig->JitEnableOptionalRelocs())
             {
                 MethodDesc* helperMD = pPrecode->GetMethodDesc();
                 _ASSERT(helperMD != nullptr);


### PR DESCRIPTION
Some helper calls may be emitted as direct calls or indirect depending on non-deterministic timing. We try to avoid things like that with `jit-diffs` so I decided to re-use `JitEnableOptionalRelocs` that is already used for the same reason.

I didn't want to introduce a new knob here, a better way is to probably rename `JitEnableOptionalRelocs` to something generic like `Diffable` or `Deterministic`, but that will require changes in two repos to sync (jit-utils and MihuBot)

cc @MihaZupan this fixes the noise in MihuBot we talked about today