### PR TITLE
Fix failing BerConverterTests.Decode_TestData test

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -191,7 +191,6 @@ namespace System.DirectoryServices.Protocols.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99725")]
         [Theory]
         [MemberData(nameof(Decode_TestData))]
         public void Decode_Bytes_ReturnsExpected(string format, byte[] values, object[] expected)

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -159,10 +159,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
                 // Content: sequence containing three octet strings
                 // Parsed as two sequences of octet strings
-                // This is parsed differently between Windows 7 and later versions: the first element returned by Windows 7 will be an array of length 2,
-                // while this will be an array of length 3 in later versions.
-                yield return new object[] { "vv", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 },
-                    Environment.OSVersion.Version <= new Version(6, 1) ? new object[] { new string[] { "abc", "" }, null } : new object[] { new string[] { "abc", "", "" }, null } };
+                yield return new object[] { "vv", new byte[] { 48, 132, 0, 0, 0, 12, 4, 3, 97, 98, 99, 4, 2, 100, 101, 4, 1, 102 }, new object[] { new string[] { "abc", "de", "f" }, null } };
 
                 // Content: sequence containing two sequences of octet strings
                 // Parsed as such
@@ -182,10 +179,7 @@ namespace System.DirectoryServices.Protocols.Tests
 
                 // Content: sequence of octet strings
                 // Parsed as two sequences of octet strings (returned as bytes)
-                // This is parsed differently between Windows 7 and later versions: the first element returned by Windows 7 will be an array of length 2,
-                // while this will be an array of length 3 in later versions.
-                yield return new object[] { "VV", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 },
-                    Environment.OSVersion.Version <= new Version(6, 1) ? new object[] { new byte[][] { [97, 98, 99], [] }, null } : new object[]{ new byte[][] { [97, 98, 99], [], [] }, null } };
+                yield return new object[] { "VV", new byte[] { 48, 132, 0, 0, 0, 12, 4, 3, 97, 98, 99, 4, 2, 100, 101, 4, 1, 102 },new object[]{ new byte[][] { [97, 98, 99], [100, 101], [102] }, null } };
 
                 // Content: sequence containing two booleans
                 // Parsed as a sequence containing two sequences of octet strings (returned as bytes)

--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -159,7 +159,10 @@ namespace System.DirectoryServices.Protocols.Tests
 
                 // Content: sequence containing three octet strings
                 // Parsed as two sequences of octet strings
-                yield return new object[] { "vv", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 }, new object[] { new string[] { "abc", "" }, null } };
+                // This is parsed differently between Windows 7 and later versions: the first element returned by Windows 7 will be an array of length 2,
+                // while this will be an array of length 3 in later versions.
+                yield return new object[] { "vv", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 },
+                    Environment.OSVersion.Version <= new Version(6, 1) ? new object[] { new string[] { "abc", "" }, null } : new object[] { new string[] { "abc", "", "" }, null } };
 
                 // Content: sequence containing two sequences of octet strings
                 // Parsed as such
@@ -179,7 +182,10 @@ namespace System.DirectoryServices.Protocols.Tests
 
                 // Content: sequence of octet strings
                 // Parsed as two sequences of octet strings (returned as bytes)
-                yield return new object[] { "VV", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 }, new object[] { new byte[][] { [97, 98, 99], [] }, null } };
+                // This is parsed differently between Windows 7 and later versions: the first element returned by Windows 7 will be an array of length 2,
+                // while this will be an array of length 3 in later versions.
+                yield return new object[] { "VV", new byte[] { 48, 132, 0, 0, 0, 9, 4, 3, 97, 98, 99, 4, 0, 4, 0 },
+                    Environment.OSVersion.Version <= new Version(6, 1) ? new object[] { new byte[][] { [97, 98, 99], [] }, null } : new object[]{ new byte[][] { [97, 98, 99], [], [] }, null } };
 
                 // Content: sequence containing two booleans
                 // Parsed as a sequence containing two sequences of octet strings (returned as bytes)


### PR DESCRIPTION
Resolves #99725 and allows the Decode_TestData test to run under CI again. Also replaces #99773.

There's different behaviour between Windows 7 and later versions - the `V` and `v` format specifiers in `ber_scanf` return a two-element array for the test data in Windows 7, and a three-element array in later versions. I've adjusted the test to account for times when it runs on Windows 7.

I'll leave the PR on draft so that the build can run and confirm the test's now working properly in both scenarios prior to merge.