### PR TITLE
disable optimizations for PopCount

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -3436,6 +3436,11 @@ uint32_t BitOperations::Log2(uint64_t value)
 // Return Value:
 //    The population count (number of bits set) of value
 //
+#if defined(_MSC_VER)
+// Disable optimizations for PopCount to avoid the compiler from generating intrinsics
+// not supported on all platforms. 
+#pragma optimize("", off)
+#endif // _MSC_VER
 uint32_t BitOperations::PopCount(uint32_t value)
 {
 #if defined(_MSC_VER)
@@ -3488,6 +3493,9 @@ uint32_t BitOperations::PopCount(uint64_t value)
     return static_cast<uint32_t>(result);
 #endif
 }
+#if defined(_MSC_VER)
+#pragma optimize("", on)
+#endif // _MSC_VER
 
 //------------------------------------------------------------------------
 // BitOperations::ReverseBits: Reverses the bits in an integer value

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -3438,7 +3438,7 @@ uint32_t BitOperations::Log2(uint64_t value)
 //
 #if defined(_MSC_VER)
 // Disable optimizations for PopCount to avoid the compiler from generating intrinsics
-// not supported on all platforms. 
+// not supported on all platforms.
 #pragma optimize("", off)
 #endif // _MSC_VER
 uint32_t BitOperations::PopCount(uint32_t value)


### PR DESCRIPTION
avoid using an optimization which might fail on non-SSE4 cpus. Latest VC toolset seems to be optimizing the sequence to popcnt instruction which is problematic. 