### PR TITLE
Fix building ILC in Visual Studio

### DIFF
--- a/src/coreclr/tools/aot/ilc.sln
+++ b/src/coreclr/tools/aot/ilc.sln
@@ -28,6 +28,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ILLink.Shared", "..\..\..\t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Trimming.Tests", "ILCompiler.Trimming.Tests\ILCompiler.Trimming.Tests.csproj", "{C331F49A-B2BA-46A4-975B-E922AA43FB6F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILLink.RoslynAnalyzer", "..\..\..\tools\illink\src\ILLink.RoslynAnalyzer\ILLink.RoslynAnalyzer.csproj", "{B49A6D20-EF0F-48EE-A686-0E615D6640B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Checked|Any CPU = Checked|Any CPU
@@ -236,6 +238,24 @@ Global
 		{C331F49A-B2BA-46A4-975B-E922AA43FB6F}.Release|x64.Build.0 = Release|x64
 		{C331F49A-B2BA-46A4-975B-E922AA43FB6F}.Release|x86.ActiveCfg = Release|x86
 		{C331F49A-B2BA-46A4-975B-E922AA43FB6F}.Release|x86.Build.0 = Release|x86
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|Any CPU.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|Any CPU.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|x64.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|x64.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|x86.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Checked|x86.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Debug|x86.Build.0 = Debug|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|x64.Build.0 = Release|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{B49A6D20-EF0F-48EE-A686-0E615D6640B0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -244,6 +264,7 @@ Global
 		SolutionGuid = {A484CF9D-B203-427F-9D15-A5BBC6013421}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\..\..\tools\illink\src\ILLink.Shared\ILLink.Shared.projitems*{b49a6d20-ef0f-48ee-a686-0e615d6640b0}*SharedItemsImports = 5
 		..\..\..\tools\illink\test\Trimming.Tests.Shared\Trimming.Tests.Shared.projitems*{c331f49a-b2ba-46a4-975b-e922aa43fb6f}*SharedItemsImports = 5
 		..\..\..\tools\illink\src\ILLink.Shared\ILLink.Shared.projitems*{ff598e93-8e9e-4091-9f50-61a7572663ae}*SharedItemsImports = 13
 		..\..\..\tools\illink\src\ILLink.Shared\ILLink.Shared.projitems*{ffbd9619-de6f-4a98-8732-8a14ec3c1a18}*SharedItemsImports = 5


### PR DESCRIPTION
ILC stopped building in VS recently. There's a disagreement between where build.cmd places the ILLink Roslyn analyzer and where the VS build expects to find the analyzer DLL. (The disagreement is about whether `$(Platform)` is part of the path.)

I couldn't quickly find out why, so just do what every sln file under libraries does - include the analyzer in the solution...

Cc @dotnet/ilc-contrib 