### PR TITLE
DATAS fixes distribute_other_procs for small heap counts

### DIFF
--- a/src/coreclr/inc/gcmsg.inl
+++ b/src/coreclr/inc/gcmsg.inl
@@ -44,7 +44,7 @@
     static const char* gcDetailedStartMsg()
     {
         STATIC_CONTRACT_LEAF;
-        return "*GC* %d(gen0:%d)(%d)(alloc: %zd)(%s)(%d)";
+        return "*GC* %d(gen0:%d)(%d)(alloc: %zd)(%s)(%d)(%d)";
     }
 
     static const char* gcDetailedEndMsg()


### PR DESCRIPTION
the way `distribute_other_procs` is written now is really just for when you specify to have 1 or 2 fewer than the default number of heaps. of course this is necessarily the case for DATAS at all. and the fact we are distributing the majority of the procs to heaps makes the heap balance non optimal, especially because for DATAS the gen0 budget can be very small. I'm the alloc ratio (total allocated / total budget) is around 50% for many of the aspnet benchmarks when I limit the max heap count to a small number (2 or 4). and that means we are triggering GC much more often. with the fix we distribute much better. an example -

run | benchmark | gen0 | pause | alloc/gc | pct | max  mem | rps | latency | gc  count
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
baseline_0 | CachingPlatform | 3529 | 1.43 | 2.81 | 13.68 | 55 | 380.92 | 0.81 | 3539
baseline_1 | CachingPlatform | 3515 | 1.59 | 2.82 | 15.15 | 53 | 377.06 | 0.87 | 3523
baseline_2 | CachingPlatform | 3553 | 1.45 | 2.83 | 14.17 | 50 | 382.59 | 0.83 | 3560
fix_0 | CachingPlatform | 2270 | 1.53 | 4.83 | 9.67 | 52 | 413.68 | 0.78 | 2276
fix_1 | CachingPlatform | 2231 | 1.58 | 4.84 | 9.51 | 52 | 411.15 | 0.8 | 2239
fix_2 | CachingPlatform | 2217 | 1.58 | 4.85 | 9.53 | 51 | 405.7 | 0.79 | 2222

the # of GCs are significantly lower because we are able to allocate almost to the full budget. rps is higher but the GC pauses are slightly longer because the survival is a bit higher. 
(edit to get rid of some columns otherwise it gets displayed in a non readable way)