### PR TITLE
[wasm] Codespaces need more disc to succeed building on container creation

### DIFF
--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -50,8 +50,11 @@ ram_pid=$!
 while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
 disk_pid=$!
 
+while true; do echo -e "$(date)\n$(du -sh /workspaces/{*,.*})"; sleep 5; done >> dirs.txt &
+dirs_pid=$!
+
 # Set traps to kill the background jobs when the script exits
-trap "kill $inode_pid $ram_pid $disk_pid" EXIT
+trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
 
 opt=$1
 case "$opt" in

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -1,89 +1,42 @@
-# #!/usr/bin/env bash
+#!/usr/bin/env bash
 
-# set -e
+set -e
 
-# function wasm_common() {
-#     # prebuild for WASM, so it is ready for wasm development
-#     echo "[$(date)] provisioning..." >> build.txt
-#     make -C src/mono/browser provision-wasm
-#     echo "[$(date)] export emsdk path..." >> build.txt
-#     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
-#     case "$1" in
-#     wasm)
-#         # Put your common commands for wasm here
-#         echo "[$(date)] cleaning the packages cache..." >> build.txt
-#         sudo apt-get clean
-#         echo "[$(date)] restoring for wasm mono subset..." >> build.txt
-#         ./build.sh mono -os browser -c Release --restore
-#         echo "[$(date)] cleaning cache after restore..." >> build.txt
-#         dotnet nuget locals all --clear
-#         echo "[$(date)] restoring for wasm libs subset..." >> build.txt
-#         ./build.sh libs -os browser -c Release --restore
-#         echo "[$(date)] building for wasm..." >> build.txt
-#         ./build.sh mono+libs -os browser -c Release --build
-#         echo "[$(date)] building succeeded" >> build.txt
-#         ;;
-#     wasm-multithreaded)
-#         # Put your common commands for wasm-multithread here
-#         echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
-#         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
-#         echo "[$(date)] building for wasm-multithreaded..." >> build.txt
-#         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
-#         echo "[$(date)] building succeeded" >> build.txt
-#         ;;
-#     *)
-#     echo "[$(date)] installing dotnet serve" >> build.txt
-#         # install dotnet-serve for running wasm samples
-#     ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
-#     echo "[$(date)] finish" >> build.txt
-#     ;;
-#     esac
-# }
+function wasm_common() {
+    echo "[$(date)] provisioning..." >> build.txt
+    make -C src/mono/browser provision-wasm
+}
 
-# echo "[$(date)] removing hidden directories..." >> build.txt
-# sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
+# hidden dir are occupying disc space that could be better used (~12GB)
+# active discussion: https://github.com/orgs/community/discussions/57767
+echo "[$(date)] removing not used hidden directories..." >> build.txt
+sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
 
-# # Start background jobs that run df -i, free -h, and df -h every second
-# while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
-# inode_pid=$!
+opt=$1
+case "$opt" in
 
-# while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
-# ram_pid=$!
+    libraries)
+        # prebuild the repo, so it is ready for development
+        ./build.sh libs+clr -rc Release
+        # restore libs tests so that the project is ready to be loaded by OmniSharp
+        ./build.sh libs.tests -restore
+    ;;
 
-# while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
-# disk_pid=$!
+    android)
+        # prebuild the repo for Mono, so it is ready for development
+        ./build.sh mono+libs -os android
+        # restore libs tests so that the project is ready to be loaded by OmniSharp
+        ./build.sh libs.tests -restore
+    ;;
 
-# while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces/shared)"; sleep 5; done >> dirs.txt &
-# dirs_pid=$!
+    wasm)
+        wasm_common $opt
+    ;;
 
-# # Set traps to kill the background jobs when the script exits
-# trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
+    wasm-multithreaded)
+        wasm_common $opt
+    ;;
+esac
 
-# opt=$1
-# case "$opt" in
-
-#     libraries)
-#         # prebuild the repo, so it is ready for development
-#         ./build.sh libs+clr -rc Release
-#         # restore libs tests so that the project is ready to be loaded by OmniSharp
-#         ./build.sh libs.tests -restore
-#     ;;
-
-#     android)
-#         # prebuild the repo for Mono, so it is ready for development
-#         ./build.sh mono+libs -os android
-#         # restore libs tests so that the project is ready to be loaded by OmniSharp
-#         ./build.sh libs.tests -restore
-#     ;;
-
-#     wasm)
-#         wasm_common $opt
-#     ;;
-
-#     wasm-multithreaded)
-#         wasm_common $opt
-#     ;;
-# esac
-
-# # save the commit hash of the currently built assemblies, so developers know which version was built
-# git rev-parse HEAD > ./artifacts/prebuild.sha
+# save the commit hash of the currently built assemblies, so developers know which version was built
+git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -4,8 +4,6 @@ set -e
 
 function wasm_common() {
     # prebuild for WASM, so it is ready for wasm development
-    echo "[$(date)] removing hidden directories..." >> build.txt
-    rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
     echo "[$(date)] provisioning..." >> build.txt
     make -C src/mono/browser provision-wasm
     echo "[$(date)] export emsdk path..." >> build.txt
@@ -42,6 +40,9 @@ function wasm_common() {
     esac
 }
 
+echo "[$(date)] removing hidden directories..." >> build.txt
+sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
+
 # Start background jobs that run df -i, free -h, and df -h every second
 while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
 inode_pid=$!
@@ -52,7 +53,7 @@ ram_pid=$!
 while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
 disk_pid=$!
 
-while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/{*,.*})"; sleep 5; done >> dirs.txt &
+while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces/shared)"; sleep 5; done >> dirs.txt &
 dirs_pid=$!
 
 # Set traps to kill the background jobs when the script exits

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -11,8 +11,14 @@ function wasm_common() {
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        echo "[$(date)] restoring for wasm..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release --restore
+        echo "[$(date)] cleaning the packages cache..." >> build.txt
+        sudo apt-get clean
+        echo "[$(date)] restoring for wasm mono subset..." >> build.txt
+        ./build.sh mono -os browser -c Release --restore
+        echo "[$(date)] cleaning cache after restore..." >> build.txt
+        dotnet nuget locals all --clear
+        echo "[$(date)] restoring for wasm libs subset..." >> build.txt
+        ./build.sh libs -os browser -c Release --restore
         echo "[$(date)] building for wasm..." >> build.txt
         ./build.sh mono+libs -os browser -c Release --build
         echo "[$(date)] building succeeded" >> build.txt

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -1,89 +1,89 @@
-#!/usr/bin/env bash
+# #!/usr/bin/env bash
 
-set -e
+# set -e
 
-function wasm_common() {
-    # prebuild for WASM, so it is ready for wasm development
-    echo "[$(date)] provisioning..." >> build.txt
-    make -C src/mono/browser provision-wasm
-    echo "[$(date)] export emsdk path..." >> build.txt
-    export EMSDK_PATH=$PWD/src/mono/browser/emsdk
-    case "$1" in
-    wasm)
-        # Put your common commands for wasm here
-        echo "[$(date)] cleaning the packages cache..." >> build.txt
-        sudo apt-get clean
-        echo "[$(date)] restoring for wasm mono subset..." >> build.txt
-        ./build.sh mono -os browser -c Release --restore
-        echo "[$(date)] cleaning cache after restore..." >> build.txt
-        dotnet nuget locals all --clear
-        echo "[$(date)] restoring for wasm libs subset..." >> build.txt
-        ./build.sh libs -os browser -c Release --restore
-        echo "[$(date)] building for wasm..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release --build
-        echo "[$(date)] building succeeded" >> build.txt
-        ;;
-    wasm-multithreaded)
-        # Put your common commands for wasm-multithread here
-        echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
-        echo "[$(date)] building for wasm-multithreaded..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
-        echo "[$(date)] building succeeded" >> build.txt
-        ;;
-    *)
-    echo "[$(date)] installing dotnet serve" >> build.txt
-        # install dotnet-serve for running wasm samples
-    ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
-    echo "[$(date)] finish" >> build.txt
-    ;;
-    esac
-}
+# function wasm_common() {
+#     # prebuild for WASM, so it is ready for wasm development
+#     echo "[$(date)] provisioning..." >> build.txt
+#     make -C src/mono/browser provision-wasm
+#     echo "[$(date)] export emsdk path..." >> build.txt
+#     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
+#     case "$1" in
+#     wasm)
+#         # Put your common commands for wasm here
+#         echo "[$(date)] cleaning the packages cache..." >> build.txt
+#         sudo apt-get clean
+#         echo "[$(date)] restoring for wasm mono subset..." >> build.txt
+#         ./build.sh mono -os browser -c Release --restore
+#         echo "[$(date)] cleaning cache after restore..." >> build.txt
+#         dotnet nuget locals all --clear
+#         echo "[$(date)] restoring for wasm libs subset..." >> build.txt
+#         ./build.sh libs -os browser -c Release --restore
+#         echo "[$(date)] building for wasm..." >> build.txt
+#         ./build.sh mono+libs -os browser -c Release --build
+#         echo "[$(date)] building succeeded" >> build.txt
+#         ;;
+#     wasm-multithreaded)
+#         # Put your common commands for wasm-multithread here
+#         echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
+#         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
+#         echo "[$(date)] building for wasm-multithreaded..." >> build.txt
+#         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
+#         echo "[$(date)] building succeeded" >> build.txt
+#         ;;
+#     *)
+#     echo "[$(date)] installing dotnet serve" >> build.txt
+#         # install dotnet-serve for running wasm samples
+#     ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
+#     echo "[$(date)] finish" >> build.txt
+#     ;;
+#     esac
+# }
 
-echo "[$(date)] removing hidden directories..." >> build.txt
-sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
+# echo "[$(date)] removing hidden directories..." >> build.txt
+# sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
 
-# Start background jobs that run df -i, free -h, and df -h every second
-while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
-inode_pid=$!
+# # Start background jobs that run df -i, free -h, and df -h every second
+# while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
+# inode_pid=$!
 
-while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
-ram_pid=$!
+# while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
+# ram_pid=$!
 
-while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
-disk_pid=$!
+# while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
+# disk_pid=$!
 
-while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces/shared)"; sleep 5; done >> dirs.txt &
-dirs_pid=$!
+# while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces/shared)"; sleep 5; done >> dirs.txt &
+# dirs_pid=$!
 
-# Set traps to kill the background jobs when the script exits
-trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
+# # Set traps to kill the background jobs when the script exits
+# trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
 
-opt=$1
-case "$opt" in
+# opt=$1
+# case "$opt" in
 
-    libraries)
-        # prebuild the repo, so it is ready for development
-        ./build.sh libs+clr -rc Release
-        # restore libs tests so that the project is ready to be loaded by OmniSharp
-        ./build.sh libs.tests -restore
-    ;;
+#     libraries)
+#         # prebuild the repo, so it is ready for development
+#         ./build.sh libs+clr -rc Release
+#         # restore libs tests so that the project is ready to be loaded by OmniSharp
+#         ./build.sh libs.tests -restore
+#     ;;
 
-    android)
-        # prebuild the repo for Mono, so it is ready for development
-        ./build.sh mono+libs -os android
-        # restore libs tests so that the project is ready to be loaded by OmniSharp
-        ./build.sh libs.tests -restore
-    ;;
+#     android)
+#         # prebuild the repo for Mono, so it is ready for development
+#         ./build.sh mono+libs -os android
+#         # restore libs tests so that the project is ready to be loaded by OmniSharp
+#         ./build.sh libs.tests -restore
+#     ;;
 
-    wasm)
-        wasm_common $opt
-    ;;
+#     wasm)
+#         wasm_common $opt
+#     ;;
 
-    wasm-multithreaded)
-        wasm_common $opt
-    ;;
-esac
+#     wasm-multithreaded)
+#         wasm_common $opt
+#     ;;
+# esac
 
-# save the commit hash of the currently built assemblies, so developers know which version was built
-git rev-parse HEAD > ./artifacts/prebuild.sha
+# # save the commit hash of the currently built assemblies, so developers know which version was built
+# git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -4,28 +4,32 @@ set -e
 
 function wasm_common() {
     # prebuild for WASM, so it is ready for wasm development
+    echo "[$(date)] provisioning..." >> build.txt
     make -C src/mono/browser provision-wasm
+    echo "[$(date)] export emsdk path..." >> build.txt
     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        echo "[DEBUG] restoring for wasm..."
+        echo "[$(date)] restoring for wasm..." >> build.txt
         ./build.sh mono+libs -os browser -c Release --restore
-        echo "[DEBUG] building for wasm..."
+        echo "[$(date)] building for wasm..." >> build.txt
         ./build.sh mono+libs -os browser -c Release --build
-        echo "[DEBUG] building succeeded"
+        echo "[$(date)] building succeeded" >> build.txt
         ;;
     wasm-multithreaded)
         # Put your common commands for wasm-multithread here
-        echo "[DEBUG] restoring for wasm-multithreaded..."
+        echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
-        echo "[DEBUG] building for wasm-multithreaded..."
+        echo "[$(date)] building for wasm-multithreaded..." >> build.txt
         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
-        echo "[DEBUG] building succeeded"
+        echo "[$(date)] building succeeded" >> build.txt
         ;;
     *)
+    echo "[$(date)] installing dotnet serve" >> build.txt
         # install dotnet-serve for running wasm samples
     ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
+    echo "[$(date)] finish" >> build.txt
     ;;
     esac
 }

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -3,13 +3,11 @@
 set -e
 
 function wasm_common() {
-    echo "[$(date)] provisioning..." >> build.txt
     make -C src/mono/browser provision-wasm
 }
 
 # hidden dir are occupying disc space that could be better used (~12GB)
 # active discussion: https://github.com/orgs/community/discussions/57767
-echo "[$(date)] removing not used hidden directories..." >> build.txt
 sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
 
 opt=$1

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -9,11 +9,19 @@ function wasm_common() {
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        ./build.sh mono+libs -os browser -c Release
+        echo "[DEBUG] restoring for wasm..."
+        ./build.sh mono+libs -os browser -c Release --restore
+        echo "[DEBUG] building for wasm..."
+        ./build.sh mono+libs -os browser -c Release --build
+        echo "[DEBUG] building succeeded"
         ;;
     wasm-multithreaded)
         # Put your common commands for wasm-multithread here
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true
+        echo "[DEBUG] restoring for wasm-multithreaded..."
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
+        echo "[DEBUG] building for wasm-multithreaded..."
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
+        echo "[DEBUG] building succeeded"
         ;;
     *)
         # install dotnet-serve for running wasm samples
@@ -21,6 +29,19 @@ function wasm_common() {
     ;;
     esac
 }
+
+# Start background jobs that run df -i, free -h, and df -h every second
+while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
+inode_pid=$!
+
+while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
+ram_pid=$!
+
+while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
+disk_pid=$!
+
+# Set traps to kill the background jobs when the script exits
+trap "kill $inode_pid $ram_pid $disk_pid" EXIT
 
 opt=$1
 case "$opt" in

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -39,4 +39,5 @@ case "$opt" in
 esac
 
 # save the commit hash of the currently built assemblies, so developers know which version was built
+mkdir -p ./artifacts/
 git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -3,29 +3,24 @@
 set -e
 
 function wasm_common() {
+    # prebuild for WASM, so it is ready for wasm development
     make -C src/mono/browser provision-wasm
     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        ./build.sh mono -os browser -c Release
-        dotnet nuget locals all --clear
+        ./build.sh mono+libs -os browser -c Release
         ;;
     wasm-multithreaded)
-        # Put your common commands for wasm-multithread here        
-        ./build.sh mono -os browser -c Release /p:WasmEnableThreads=true
-        dotnet nuget locals all --clear
+        # Put your common commands for wasm-multithread here
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true
         ;;
     *)
-    # install dotnet-serve for running wasm samples
+        # install dotnet-serve for running wasm samples
     ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
     ;;
     esac
 }
-
-# hidden dir are occupying disc space that could be better used (~12GB)
-# active discussion: https://github.com/orgs/community/discussions/57767
-sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
 
 opt=$1
 case "$opt" in

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -4,6 +4,23 @@ set -e
 
 function wasm_common() {
     make -C src/mono/browser provision-wasm
+    export EMSDK_PATH=$PWD/src/mono/browser/emsdk
+    case "$1" in
+    wasm)
+        # Put your common commands for wasm here
+        ./build.sh mono -os browser -c Release
+        dotnet nuget locals all --clear
+        ;;
+    wasm-multithreaded)
+        # Put your common commands for wasm-multithread here        
+        ./build.sh mono -os browser -c Release /p:WasmEnableThreads=true
+        dotnet nuget locals all --clear
+        ;;
+    *)
+    # install dotnet-serve for running wasm samples
+    ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
+    ;;
+    esac
 }
 
 # hidden dir are occupying disc space that could be better used (~12GB)
@@ -37,5 +54,4 @@ case "$opt" in
 esac
 
 # save the commit hash of the currently built assemblies, so developers know which version was built
-mkdir -p ./artifacts/
 git rev-parse HEAD > ./artifacts/prebuild.sha

--- a/.devcontainer/scripts/onCreateCommand.sh
+++ b/.devcontainer/scripts/onCreateCommand.sh
@@ -4,6 +4,8 @@ set -e
 
 function wasm_common() {
     # prebuild for WASM, so it is ready for wasm development
+    echo "[$(date)] removing hidden directories..." >> build.txt
+    rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
     echo "[$(date)] provisioning..." >> build.txt
     make -C src/mono/browser provision-wasm
     echo "[$(date)] export emsdk path..." >> build.txt
@@ -50,7 +52,7 @@ ram_pid=$!
 while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
 disk_pid=$!
 
-while true; do echo -e "$(date)\n$(du -sh /workspaces/{*,.*})"; sleep 5; done >> dirs.txt &
+while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/{*,.*})"; sleep 5; done >> dirs.txt &
 dirs_pid=$!
 
 # Set traps to kill the background jobs when the script exits

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -2,41 +2,11 @@
 
 set -e
 
-function wasm_common() {
-    # moving this to post-create for wasm till
-    # https://github.com/orgs/community/discussions/57767 gets resolved
-    # prebuild for WASM, so it is ready for wasm development
-    export EMSDK_PATH=$PWD/src/mono/browser/emsdk
-    case "$1" in
-    wasm)
-        # Put your common commands for wasm here
-        ./build.sh libs -os browser -c Release
-        ;;
-    wasm-multithreaded)
-        # Put your common commands for wasm-multithread here        
-        ./build.sh libs -os browser -c Release /p:WasmEnableThreads=true
-        ;;
-    *)
-    # install dotnet-serve for running wasm samples
-    ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
-    ;;
-    esac
-}
-
 opt=$1
 case "$opt" in
-
     android)
         # Create the Android emulator.
         ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools/bin/avdmanager -s create avd --name ${EMULATOR_NAME_X64} --package "system-images;android-${SDK_API_LEVEL};default;x86_64"
-    ;;
-
-    wasm)
-        wasm_common $opt
-    ;;
-
-    wasm-multithreaded)
-        wasm_common $opt
     ;;
 esac
 

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -4,31 +4,19 @@ set -e
 
 function wasm_common() {
     # prebuild for WASM, so it is ready for wasm development
-    echo "[$(date)] provisioning..." >> build.txt
-    make -C src/mono/browser provision-wasm
     echo "[$(date)] export emsdk path..." >> build.txt
     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        echo "[$(date)] cleaning the packages cache..." >> build.txt
-        sudo apt-get clean
-        echo "[$(date)] restoring for wasm mono subset..." >> build.txt
-        ./build.sh mono -os browser -c Release --restore
-        echo "[$(date)] cleaning cache after restore..." >> build.txt
-        dotnet nuget locals all --clear
-        echo "[$(date)] restoring for wasm libs subset..." >> build.txt
-        ./build.sh libs -os browser -c Release --restore
-        echo "[$(date)] building for wasm..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release --build
+        echo "[$(date)] building for wasm mono subset..." >> build.txt
+        ./build.sh mono+libs -os browser -c Release
         echo "[$(date)] building succeeded" >> build.txt
         ;;
     wasm-multithreaded)
-        # Put your common commands for wasm-multithread here
-        echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
-        echo "[$(date)] building for wasm-multithreaded..." >> build.txt
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
+        # Put your common commands for wasm-multithread here        
+        echo "[$(date)] building for wasm mono subset..." >> build.txt
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=tru
         echo "[$(date)] building succeeded" >> build.txt
         ;;
     *)

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -3,65 +3,30 @@
 set -e
 
 function wasm_common() {
+    # moving this to post-create for wasm till
+    # https://github.com/orgs/community/discussions/57767 gets resolved
     # prebuild for WASM, so it is ready for wasm development
-    echo "[$(date)] export emsdk path..." >> build.txt
     export EMSDK_PATH=$PWD/src/mono/browser/emsdk
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        echo "[$(date)] building for wasm mono subset..." >> build.txt
         ./build.sh mono+libs -os browser -c Release
-        echo "[$(date)] building succeeded" >> build.txt
         ;;
     wasm-multithreaded)
         # Put your common commands for wasm-multithread here        
-        echo "[$(date)] building for wasm mono subset..." >> build.txt
         ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=tru
-        echo "[$(date)] building succeeded" >> build.txt
         ;;
     *)
-    echo "[$(date)] installing dotnet serve" >> build.txt
-        # install dotnet-serve for running wasm samples
+    # install dotnet-serve for running wasm samples
     ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
-    echo "[$(date)] finish" >> build.txt
     ;;
     esac
 }
 
-echo "[$(date)] removing hidden directories..." >> build.txt
-sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
-
-# Start background jobs that run df -i, free -h, and df -h every second
-while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
-inode_pid=$!
-
-while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
-ram_pid=$!
-
-while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
-disk_pid=$!
-
-while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces && sudo du -sh /workspaces)"; sleep 5; done >> dirs.txt &
-dirs_pid=$!
-
-# Set traps to kill the background jobs when the script exits
-trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
-
 opt=$1
 case "$opt" in
 
-    libraries)
-        # prebuild the repo, so it is ready for development
-        ./build.sh libs+clr -rc Release
-        # restore libs tests so that the project is ready to be loaded by OmniSharp
-        ./build.sh libs.tests -restore
-    ;;
-
     android)
-        # prebuild the repo for Mono, so it is ready for development
-        ./build.sh mono+libs -os android
-        # restore libs tests so that the project is ready to be loaded by OmniSharp
-        ./build.sh libs.tests -restore
         # Create the Android emulator.
         ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools/bin/avdmanager -s create avd --name ${EMULATOR_NAME_X64} --package "system-images;android-${SDK_API_LEVEL};default;x86_64"
     ;;
@@ -74,9 +39,6 @@ case "$opt" in
         wasm_common $opt
     ;;
 esac
-
-# save the commit hash of the currently built assemblies, so developers know which version was built
-git rev-parse HEAD > ./artifacts/prebuild.sha
 
 # reset the repo to the commit hash that was used to build the prebuilt Codespace
 git reset --hard $(cat ./artifacts/prebuild.sha)

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -2,13 +2,93 @@
 
 set -e
 
+function wasm_common() {
+    # prebuild for WASM, so it is ready for wasm development
+    echo "[$(date)] provisioning..." >> build.txt
+    make -C src/mono/browser provision-wasm
+    echo "[$(date)] export emsdk path..." >> build.txt
+    export EMSDK_PATH=$PWD/src/mono/browser/emsdk
+    case "$1" in
+    wasm)
+        # Put your common commands for wasm here
+        echo "[$(date)] cleaning the packages cache..." >> build.txt
+        sudo apt-get clean
+        echo "[$(date)] restoring for wasm mono subset..." >> build.txt
+        ./build.sh mono -os browser -c Release --restore
+        echo "[$(date)] cleaning cache after restore..." >> build.txt
+        dotnet nuget locals all --clear
+        echo "[$(date)] restoring for wasm libs subset..." >> build.txt
+        ./build.sh libs -os browser -c Release --restore
+        echo "[$(date)] building for wasm..." >> build.txt
+        ./build.sh mono+libs -os browser -c Release --build
+        echo "[$(date)] building succeeded" >> build.txt
+        ;;
+    wasm-multithreaded)
+        # Put your common commands for wasm-multithread here
+        echo "[$(date)] restoring for wasm-multithreaded..." >> build.txt
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --restore
+        echo "[$(date)] building for wasm-multithreaded..." >> build.txt
+        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=true --build
+        echo "[$(date)] building succeeded" >> build.txt
+        ;;
+    *)
+    echo "[$(date)] installing dotnet serve" >> build.txt
+        # install dotnet-serve for running wasm samples
+    ./dotnet.sh tool install dotnet-serve --version 1.10.172 --tool-path ./.dotnet-tools-global
+    echo "[$(date)] finish" >> build.txt
+    ;;
+    esac
+}
+
+echo "[$(date)] removing hidden directories..." >> build.txt
+sudo rm -rf /workspaces/.codespaces/shared/editors/jetbrains/
+
+# Start background jobs that run df -i, free -h, and df -h every second
+while true; do echo -e "$(date)\n$(df -i)"; sleep 5; done >> inodes.txt &
+inode_pid=$!
+
+while true; do echo -e "$(date)\n$(free -h)"; sleep 5; done >> ram.txt &
+ram_pid=$!
+
+while true; do echo -e "$(date)\n$(df -h)"; sleep 5; done >> disk.txt &
+disk_pid=$!
+
+while true; do echo -e "$(date)\n$(sudo du -sh /workspaces/.codespaces && sudo du -sh /workspaces)"; sleep 5; done >> dirs.txt &
+dirs_pid=$!
+
+# Set traps to kill the background jobs when the script exits
+trap "kill $inode_pid $ram_pid $disk_pid $dirs_pid" EXIT
+
 opt=$1
 case "$opt" in
+
+    libraries)
+        # prebuild the repo, so it is ready for development
+        ./build.sh libs+clr -rc Release
+        # restore libs tests so that the project is ready to be loaded by OmniSharp
+        ./build.sh libs.tests -restore
+    ;;
+
     android)
+        # prebuild the repo for Mono, so it is ready for development
+        ./build.sh mono+libs -os android
+        # restore libs tests so that the project is ready to be loaded by OmniSharp
+        ./build.sh libs.tests -restore
         # Create the Android emulator.
         ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools/bin/avdmanager -s create avd --name ${EMULATOR_NAME_X64} --package "system-images;android-${SDK_API_LEVEL};default;x86_64"
     ;;
+
+    wasm)
+        wasm_common $opt
+    ;;
+
+    wasm-multithreaded)
+        wasm_common $opt
+    ;;
 esac
+
+# save the commit hash of the currently built assemblies, so developers know which version was built
+git rev-parse HEAD > ./artifacts/prebuild.sha
 
 # reset the repo to the commit hash that was used to build the prebuilt Codespace
 git reset --hard $(cat ./artifacts/prebuild.sha)

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -10,11 +10,11 @@ function wasm_common() {
     case "$1" in
     wasm)
         # Put your common commands for wasm here
-        ./build.sh mono+libs -os browser -c Release
+        ./build.sh libs -os browser -c Release
         ;;
     wasm-multithreaded)
         # Put your common commands for wasm-multithread here        
-        ./build.sh mono+libs -os browser -c Release /p:WasmEnableThreads=tru
+        ./build.sh libs -os browser -c Release /p:WasmEnableThreads=true
         ;;
     *)
     # install dotnet-serve for running wasm samples

--- a/.devcontainer/wasm-multiThreaded/devcontainer.json
+++ b/.devcontainer/wasm-multiThreaded/devcontainer.json
@@ -10,7 +10,8 @@
 	},
 	"hostRequirements": {
 		"cpus": 4,
-		"memory": "8gb"
+		"memory": "8gb",
+		"storage": "40gb"
 	},
 
 	"features": {

--- a/.devcontainer/wasm-multiThreaded/devcontainer.json
+++ b/.devcontainer/wasm-multiThreaded/devcontainer.json
@@ -40,7 +40,7 @@
 	"onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/onCreateCommand.sh wasm-multithreaded",
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh",
+	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh wasm-multithreaded",
 
 	// Add the locally installed dotnet to the path to ensure that it is activated
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.

--- a/.devcontainer/wasm/devcontainer.json
+++ b/.devcontainer/wasm/devcontainer.json
@@ -10,7 +10,8 @@
 	},
 	"hostRequirements": {
 		"cpus": 4,
-		"memory": "8gb"
+		"memory": "8gb",
+		"storage": "40gb"
 	},
 
 	"features": {

--- a/.devcontainer/wasm/devcontainer.json
+++ b/.devcontainer/wasm/devcontainer.json
@@ -40,7 +40,7 @@
 	"onCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/onCreateCommand.sh wasm",
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh",
+	"postCreateCommand": "${containerWorkspaceFolder}/.devcontainer/scripts/postCreateCommand.sh wasm",
 
 	// Add the locally installed dotnet to the path to ensure that it is activated
 	// This allows developers to just use 'dotnet build' on the command-line, and the local dotnet version will be used.


### PR DESCRIPTION
Temporary fix for https://github.com/dotnet/runtime/issues/99690. There are no machines of same number of cores and RAM as the currently lowest required one, so as the result of this PR we will be able to use pre-built codespaces for wasm / wasm MT only with 8-core machine. The PR can be most probably reverted when codespaces will fix the issue with excessive size occupancy for `codespaces/shared/editors/jetbrains`.

https://github.com/orgs/community/discussions/57767