### PR TITLE
JIT: Type fat pointer locals precisely, and avoid unnecessary normalization in inlining

### DIFF
--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -1151,13 +1151,25 @@ bool Compiler::fgCastNeeded(GenTree* tree, var_types toType)
     //
     // Is the tree as GT_CAST or a GT_CALL ?
     //
-    if (tree->OperGet() == GT_CAST)
+    if (tree->OperIs(GT_CAST))
     {
         fromType = tree->CastToType();
     }
-    else if (tree->OperGet() == GT_CALL)
+    else if (tree->OperIs(GT_CALL))
     {
         fromType = (var_types)tree->AsCall()->gtReturnType;
+    }
+    else if (tree->OperIs(GT_LCL_VAR))
+    {
+        LclVarDsc* varDsc = lvaGetDesc(tree->AsLclVarCommon());
+        if (varDsc->lvNormalizeOnStore())
+        {
+            fromType = varDsc->TypeGet();
+        }
+        else
+        {
+            fromType = tree->TypeGet();
+        }
     }
     else
     {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1406,14 +1406,22 @@ DONE_CALL:
                     // Such form allows to find statements with fat calls without walking through whole trees
                     // and removes problems with cutting trees.
                     assert(IsTargetAbi(CORINFO_NATIVEAOT_ABI));
-                    if (call->OperGet() != GT_LCL_VAR) // can be already converted by impFixupCallStructReturn.
+                    if (!call->OperIs(GT_LCL_VAR)) // can be already converted by impFixupCallStructReturn.
                     {
                         unsigned   calliSlot = lvaGrabTemp(true DEBUGARG("calli"));
                         LclVarDsc* varDsc    = lvaGetDesc(calliSlot);
+                        // Keep the information about small typedness to avoid
+                        // inserting unnecessary casts around normalization.
+                        if (call->IsCall() && varTypeIsSmall(call->AsCall()->gtReturnType))
+                        {
+                            assert(call->AsCall()->NormalizesSmallTypesOnReturn());
+                            varDsc->lvType = call->AsCall()->gtReturnType;
+                        }
 
+                        // TODO-Bug: CHECK_SPILL_NONE here looks wrong.
                         impStoreTemp(calliSlot, call, CHECK_SPILL_NONE);
                         // impStoreTemp can change src arg list and return type for call that returns struct.
-                        var_types type = genActualType(lvaTable[calliSlot].TypeGet());
+                        var_types type = genActualType(varDsc);
                         call           = gtNewLclvNode(calliSlot, type);
                     }
                 }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1421,7 +1421,7 @@ DONE_CALL:
                         // TODO-Bug: CHECK_SPILL_NONE here looks wrong.
                         impStoreTemp(calliSlot, call, CHECK_SPILL_NONE);
                         // impStoreTemp can change src arg list and return type for call that returns struct.
-                        var_types type = genActualType(varDsc);
+                        var_types type = genActualType(lvaTable[calliSlot].TypeGet());
                         call           = gtNewLclvNode(calliSlot, type);
                     }
                 }


### PR DESCRIPTION
During call importation, for fat pointer calls we will introduce a local and spill the call to it. This loses track of the small typedness of the value, which can cause inlining to introduce unnecessary normalization casts later. For tailcalls this can cause us to add IR after the call that we do not expect, causing issues like #99798.

Fix the problem by enhancing logic in a few places:
- Make the local created for these fat pointer calls small typed like regular small normalize-on-store locals
- Enhance `fgCastNeeded` to take into account the small-typedness of these locals (like `IntegralRange::ForNode`)

Some regressions because we remove unnecessary casts which makes this early-out in forward sub kick in:
https://github.com/dotnet/runtime/blob/b94364e90056c371e17e057f352f9f9e9c55511c/src/coreclr/jit/forwardsub.cpp#L724-L743

Fix #99798