### PR TITLE
[RISC-V] Fix hijack

### DIFF
--- a/src/coreclr/unwinder/riscv64/unwinder.cpp
+++ b/src/coreclr/unwinder/riscv64/unwinder.cpp
@@ -106,7 +106,9 @@ do {                                                                            
     if (ARGUMENT_PRESENT(Params)) {                                                   \
         PT_KNONVOLATILE_CONTEXT_POINTERS ContextPointers = (Params)->ContextPointers; \
         if (ARGUMENT_PRESENT(ContextPointers)) {                                      \
-            if (RegisterNumber == 8)                                                  \
+            if (RegisterNumber == 1)                                                  \
+                ContextPointers->Ra = (PDWORD64)Address;                              \
+            else if (RegisterNumber == 8)                                             \
                 ContextPointers->Fp = (PDWORD64)Address;                              \
             else if (RegisterNumber == 9)                                             \
                 ContextPointers->S1 = (PDWORD64)Address;                              \

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -687,23 +687,24 @@ LEAF_END JIT_GetSharedGCStaticBaseNoCtor_SingleAppDomain, _TEXT
 // ------------------------------------------------------------------
 // Hijack function for functions which return a scalar type or a struct (value type)
 NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 0x90
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 0xa0
 
     // Spill callee saved registers
     PROLOG_SAVE_REG_PAIR   s1, s2, 16
     PROLOG_SAVE_REG_PAIR   s3, s4, 32
     PROLOG_SAVE_REG_PAIR   s5, s6, 48
     PROLOG_SAVE_REG_PAIR   s7, s8, 64
-    PROLOG_SAVE_REG_PAIR   s9, s10, 80 
-    PROLOG_SAVE_REG s11, 96
+    PROLOG_SAVE_REG_PAIR   s9, s10, 80
+    PROLOG_SAVE_REG_PAIR   s11, gp, 96
+    PROLOG_SAVE_REG        tp, 112
 
     // save any integral return value(s)
-    sd  a0, 104(sp)
-    sd  a1, 112(sp)
+    sd  a0, 120(sp)
+    sd  a1, 128(sp)
 
     // save any FP/HFA return value(s)
-    fsd  f0, 120(sp)
-    fsd  f1, 128(sp)
+    fsd  f0, 136(sp)
+    fsd  f1, 144(sp)
 
     addi  a0, sp, 0
     call  C_FUNC(OnHijackWorker)
@@ -711,20 +712,21 @@ NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
     // restore callee saved registers
 
     // restore any integral return value(s)
-    ld  a0, 104(sp)
-    ld  a1, 112(sp)
+    ld  a0, 120(sp)
+    ld  a1, 128(sp)
 
     // restore any FP/HFA return value(s)
-    fld  f0, 120(sp)
-    fld  f1, 128(sp)
+    fld  f0, 136(sp)
+    fld  f1, 144(sp)
 
     EPILOG_RESTORE_REG_PAIR   s1, s2, 16
     EPILOG_RESTORE_REG_PAIR   s3, s4, 32
     EPILOG_RESTORE_REG_PAIR   s5, s6, 48
     EPILOG_RESTORE_REG_PAIR   s7, s8, 64
     EPILOG_RESTORE_REG_PAIR   s9, s10, 80
-    EPILOG_RESTORE_REG  s11, 96 
-    EPILOG_RESTORE_REG_PAIR_INDEXED  fp, ra, 0x90
+    EPILOG_RESTORE_REG_PAIR   s11, gp, 96
+    EPILOG_RESTORE_REG        tp, 112
+    EPILOG_RESTORE_REG_PAIR_INDEXED  fp, ra, 0xa0
     EPILOG_RETURN
 NESTED_END OnHijackTripThread, _TEXT
 

--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -423,6 +423,13 @@ struct DECLSPEC_ALIGN(16) UMEntryThunkCode
 
 struct HijackArgs
 {
+    DWORD64 Fp; // frame pointer
+    union
+    {
+        DWORD64 Ra;
+        size_t ReturnAddress;
+    };
+    DWORD64 S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11, Gp, Tp;
     union
     {
         struct {
@@ -439,14 +446,7 @@ struct HijackArgs
          };
         size_t FPReturnValue[2];
     };
-    DWORD64 Fp; // frame pointer
-    DWORD64 Gp, Tp, S1, S2, S3, S4, S5, S6, S7, S8, S9, S10, S11;
-    union
-    {
-        DWORD64 Ra;
-        size_t ReturnAddress;
-    };
- };
+};
 
 // Precode to shuffle this and retbuf for closed delegates over static methods with return buffer
 struct ThisPtrRetBufPrecode {


### PR DESCRIPTION
Fixes `Timeout JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314/b425314.dll` with disabled TierJit.

Checked both with and without #95565.

cc @dotnet/samsung. Part of #84834.