### PR TITLE
Disable new warnings introduced with clang 18

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -612,6 +612,9 @@ if (CLR_CMAKE_HOST_UNIX)
     # other clang 16.0 suppressions
     add_compile_options(-Wno-single-bit-bitfield-constant-conversion)
     add_compile_options(-Wno-cast-function-type-strict)
+
+    # clang 18.1 supressions
+    add_compile_options(-Wno-switch-default)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)


### PR DESCRIPTION
clang 18 introduces `-Wswitch-default`, which requires that every switch must have a `default` branch. We can add missing `default` in switches, but the other option `-Wcovered-switch-default` complains if all the cases in a switch are exhaustive and `default` doesn't do anything. So disable one of these mutually exclusive warnings.

We will also need to merge in the changes from
https://github.com/dotnet/arcade/pull/14572 to actually try and use clang-18/clang++-18.