### PR TITLE
[wasm] Fix "we can't find snapshot urls"

### DIFF
--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -266,12 +266,12 @@ public partial class UpdateChromeVersions : MBU.Task
             }
         }
 
-        return File.OpenRead(filePath);
+        return File.OpenRead(filePath); 
     }
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)
     {
-        string baseUrl = $"{s_snapshotBaseUrl}/{osPrefix}";
+        string baseUrl = $"{s_snapshotBaseUrl}?prefix={osPrefix}";
 
         int branchPosition = int.Parse(version.branch_base_position);
         for (int i = 0; i < MaxBranchPositionsToCheck; i++)

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -266,7 +266,7 @@ public partial class UpdateChromeVersions : MBU.Task
             }
         }
 
-        return File.OpenRead(filePath); 
+        return File.OpenRead(filePath);
     }
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/97364.

### Without this PR:
Snapshot not found (e.g. see: `https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1250580` - the current value in `ChromeVersions.props`).
![image](https://github.com/dotnet/runtime/assets/32700855/7601250b-5e53-4a43-a9d8-545515b7a049)


### With this PR:
Urls of `https://storage.googleapis.com/chromium-browser-snapshots?prefix=Linux_x64/125058` format - found.
![image](https://github.com/dotnet/runtime/assets/32700855/b6ecf346-b4d3-4c21-8ce5-25f86c351e3a)
