### PR TITLE
[mono] Split the negative ref struct substitution testcases to enable the one working with Mono

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -3879,7 +3879,7 @@ mono_class_setup_interface_id (MonoClass *klass)
 /*
  * mono_class_setup_interfaces:
  *
- *   Initialize klass->interfaces/interfaces_count.
+ *   Initialize klass->interfaces/interface_count.
  * LOCKING: Acquires the loader lock.
  * This function can fail the type.
  */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -807,33 +807,6 @@ inflate_generic_type (MonoImage *image, MonoType *type, MonoGenericContext *cont
 				return type;
 		}
 
-		// Compare accept byreflike constraint of generic parameters between parent (gclass->context.class_inst) and
-		// child (context->class_inst) interfaces
-		for (int i = 0; i < gclass->context.class_inst->type_argc; ++i) {
-			MonoType *child_param_type = NULL;
-			MonoType *parent_param_type = gclass->context.class_inst->type_argv [i];
-			switch (parent_param_type->type) {
-			case MONO_TYPE_VAR:
-				child_param_type = context->class_inst->type_argv [i];
-				break;
-			case MONO_TYPE_MVAR:
-				child_param_type = context->method_inst->type_argv [i];
-				break;
-			default:
-				continue;
-			}
-			MonoGenericParam *child_gparam = child_param_type->data.generic_param;
-			MonoGenericParamInfo *child_tinfo = mono_generic_param_info (child_gparam);
-			if ((child_tinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_ACCEPT_BYREFLIKE_CONSTRAINTS) != 0) {
-				MonoGenericParam *parent_gparam = parent_param_type->data.generic_param;
-				MonoGenericParamInfo *parent_tinfo = mono_generic_param_info (parent_gparam);
-				if ((parent_tinfo->flags & GENERIC_PARAMETER_ATTRIBUTE_ACCEPT_BYREFLIKE_CONSTRAINTS) == 0) {
-					mono_error_set_type_load_name (error, NULL, NULL, "Derived class can't allow byreflike, when parent doesn't allow it");
-					return NULL;
-				}
-			}
-		}
-
 		inst = mono_metadata_inflate_generic_inst (gclass->context.class_inst, context, error);
 		return_val_if_nok (error, NULL);
 
@@ -2915,7 +2888,7 @@ mono_class_get_and_inflate_typespec_checked (MonoImage *image, guint32 type_toke
 
 	if (klass && context && mono_metadata_token_table (type_token) == MONO_TABLE_TYPESPEC)
 		klass = mono_class_inflate_generic_class_checked (klass, context, error);
-	
+
 	return klass;
 }
 /**

--- a/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharpNegative.ilproj
+++ b/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharpNegative.ilproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>library</OutputType>
     <MonoAotIncompatible>true</MonoAotIncompatible>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InvalidCSharpNegative.il" />

--- a/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.cs
@@ -12,14 +12,13 @@ using Xunit;
 public class ValidateNegative
 {
     [Fact]
-    [SkipOnMono("Mono does not support ByRefLike generics yet")]
     public static void AllowByRefLike_Substituted_For_NonByRefLike_Invalid()
     {
         Console.WriteLine($"{nameof(AllowByRefLike_Substituted_For_NonByRefLike_Invalid)}...");
 
         Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInterfaceImplementationAllowByRefLikeIntoNonByRefLike(); });
-        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike(); });
-        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike(); });
-        Assert.Throws<TypeLoadException>(() => { Exec.OverrideMethodNotByRefLike(); });
+        // Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike(); });
+        // Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike(); });
+        // Assert.Throws<TypeLoadException>(() => { Exec.OverrideMethodNotByRefLike(); });
     }
 }

--- a/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.cs
@@ -12,13 +12,21 @@ using Xunit;
 public class ValidateNegative
 {
     [Fact]
+    [SkipOnMono("https://github.com/dotnet/runtime/issues/99820")]
     public static void AllowByRefLike_Substituted_For_NonByRefLike_Invalid()
     {
         Console.WriteLine($"{nameof(AllowByRefLike_Substituted_For_NonByRefLike_Invalid)}...");
 
         Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInterfaceImplementationAllowByRefLikeIntoNonByRefLike(); });
-        // Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike(); });
-        // Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike(); });
-        // Assert.Throws<TypeLoadException>(() => { Exec.OverrideMethodNotByRefLike(); });
+        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionFieldAllowByRefLikeIntoNonByRefLike(); });
+        Assert.Throws<TypeLoadException>(() => { Exec.OverrideMethodNotByRefLike(); });
+    }
+
+    [Fact]
+    public static void AllowByRefLike_Substituted_For_NonByRefLike_Invalid_Class()
+    {
+        Console.WriteLine($"{nameof(AllowByRefLike_Substituted_For_NonByRefLike_Invalid_Class)}...");
+
+        Assert.Throws<TypeLoadException>(() => { Exec.TypeSubstitutionInheritanceAllowByRefLikeIntoNonByRefLike(); });
     }
 }

--- a/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.csproj
+++ b/src/tests/Loader/classloader/generics/ByRefLike/ValidateNegative.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableProjectBuild>
 
     <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
     <CrossGenTest>false</CrossGenTest>


### PR DESCRIPTION
Contributes to #94415