### PR TITLE
[mono] Add unchecked version of stelem_ref interpreter opcode

### DIFF
--- a/src/mono/browser/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/browser/runtime/jiterpreter-trace-generator.ts
@@ -3339,7 +3339,8 @@ function emit_arrayop (builder: WasmBuilder, frame: NativePointer, ip: MintOpcod
             append_stloc_tail(builder, valueOffset, WasmOpcode.i32_store);
             return true;
         }
-        case MintOpcode.MINT_STELEM_REF: {
+        case MintOpcode.MINT_STELEM_REF:
+        case MintOpcode.MINT_STELEM_REF_UNCHECKED: {
             builder.block();
             // array
             append_ldloc(builder, getArgU16(ip, 1), WasmOpcode.i32_load);
@@ -3347,7 +3348,9 @@ function emit_arrayop (builder: WasmBuilder, frame: NativePointer, ip: MintOpcod
             append_ldloc(builder, getArgU16(ip, 2), WasmOpcode.i32_load);
             // value
             append_ldloc(builder, getArgU16(ip, 3), WasmOpcode.i32_load);
-            builder.callImport("stelem_ref");
+            builder.callImport(opcode === MintOpcode.MINT_STELEM_REF
+                ? "stelemr_tc"
+                : "stelemr");
             builder.appendU8(WasmOpcode.br_if);
             builder.appendULeb(0);
             append_bailout(builder, ip, BailoutReason.ArrayStoreFailed);

--- a/src/mono/browser/runtime/jiterpreter-trace-generator.ts
+++ b/src/mono/browser/runtime/jiterpreter-trace-generator.ts
@@ -3339,8 +3339,7 @@ function emit_arrayop (builder: WasmBuilder, frame: NativePointer, ip: MintOpcod
             append_stloc_tail(builder, valueOffset, WasmOpcode.i32_store);
             return true;
         }
-        case MintOpcode.MINT_STELEM_REF:
-        case MintOpcode.MINT_STELEM_REF_UNCHECKED: {
+        case MintOpcode.MINT_STELEM_REF: {
             builder.block();
             // array
             append_ldloc(builder, getArgU16(ip, 1), WasmOpcode.i32_load);
@@ -3348,13 +3347,19 @@ function emit_arrayop (builder: WasmBuilder, frame: NativePointer, ip: MintOpcod
             append_ldloc(builder, getArgU16(ip, 2), WasmOpcode.i32_load);
             // value
             append_ldloc(builder, getArgU16(ip, 3), WasmOpcode.i32_load);
-            builder.callImport(opcode === MintOpcode.MINT_STELEM_REF
-                ? "stelemr_tc"
-                : "stelemr");
+            builder.callImport("stelemr_tc");
             builder.appendU8(WasmOpcode.br_if);
             builder.appendULeb(0);
             append_bailout(builder, ip, BailoutReason.ArrayStoreFailed);
             builder.endBlock();
+            return true;
+        }
+        case MintOpcode.MINT_STELEM_REF_UNCHECKED: {
+            // dest
+            append_getelema1(builder, ip, objectOffset, indexOffset, 4);
+            // &value (src)
+            append_ldloca(builder, valueOffset, 0);
+            builder.callImport("copy_ptr");
             return true;
         }
         case MintOpcode.MINT_LDELEM_REF:

--- a/src/mono/browser/runtime/jiterpreter.ts
+++ b/src/mono/browser/runtime/jiterpreter.ts
@@ -286,7 +286,6 @@ function getTraceImports () {
         importDef("cmpxchg_i32", getRawCwrap("mono_jiterp_cas_i32")),
         importDef("cmpxchg_i64", getRawCwrap("mono_jiterp_cas_i64")),
         ["stelemr_tc", "stelemr", getRawCwrap("mono_jiterp_stelem_ref")],
-        ["stelemr", "stelemr", getRawCwrap("mono_jiterp_stelem_ref_unchecked")],
         importDef("fma", getRawCwrap("fma")),
         importDef("fmaf", getRawCwrap("fmaf")),
     ];

--- a/src/mono/browser/runtime/jiterpreter.ts
+++ b/src/mono/browser/runtime/jiterpreter.ts
@@ -285,7 +285,8 @@ function getTraceImports () {
         importDef("stfld_o", getRawCwrap("mono_jiterp_set_object_field")),
         importDef("cmpxchg_i32", getRawCwrap("mono_jiterp_cas_i32")),
         importDef("cmpxchg_i64", getRawCwrap("mono_jiterp_cas_i64")),
-        importDef("stelem_ref", getRawCwrap("mono_jiterp_stelem_ref")),
+        ["stelemr_tc", "stelemr", getRawCwrap("mono_jiterp_stelem_ref")],
+        ["stelemr", "stelemr", getRawCwrap("mono_jiterp_stelem_ref_unchecked")],
         importDef("fma", getRawCwrap("fma")),
         importDef("fmaf", getRawCwrap("fmaf")),
     ];
@@ -649,7 +650,7 @@ function initialize_builder (builder: WasmBuilder) {
         WasmValtype.void, true
     );
     builder.defineType(
-        "stelem_ref",
+        "stelemr",
         {
             "o": WasmValtype.i32,
             "aindex": WasmValtype.i32,

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -6628,6 +6628,14 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STELEM_I8) STELEM(gint64, gint64); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STELEM_R4) STELEM(float, float); MINT_IN_BREAK;
 		MINT_IN_CASE(MINT_STELEM_R8) STELEM(double, double); MINT_IN_BREAK;
+		MINT_IN_CASE(MINT_STELEM_REF_UNCHECKED) {
+			MonoArray *o;
+			guint32 aindex;
+			STELEM_PROLOG(o, aindex);
+			mono_array_setref_fast ((MonoArray *) o, aindex, LOCAL_VAR (ip [3], MonoObject*));
+			ip += 4;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_STELEM_REF) {
 			MonoArray *o;
 			guint32 aindex;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -6652,7 +6652,6 @@ MINT_IN_CASE(MINT_BRTRUE_I8_SP) ZEROP_SP(gint64, !=); MINT_IN_BREAK;
 			ip += 4;
 			MINT_IN_BREAK;
 		}
-
 		MINT_IN_CASE(MINT_STELEM_VT) {
 			MonoArray *o = LOCAL_VAR (ip [1], MonoArray*);
 			NULL_CHECK (o);

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1177,19 +1177,6 @@ mono_jiterp_stelem_ref (
 	return 1;
 }
 
-// FIXME: Inline this into traces
-EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_stelem_ref_unchecked (
-	MonoArray *o, gint32 aindex, MonoObject *ref
-) {
-	if (!o)
-		return 0;
-	if (aindex >= mono_array_length_internal (o))
-		return 0;
-	mono_array_setref_fast ((MonoArray *) o, aindex, ref);
-	return 1;
-}
-
 // keep in sync with jiterpreter-enums.ts JiterpMember
 enum {
 	JITERP_MEMBER_VT_INITIALIZED = 0,

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1177,6 +1177,19 @@ mono_jiterp_stelem_ref (
 	return 1;
 }
 
+// FIXME: Inline this into traces
+EMSCRIPTEN_KEEPALIVE int
+mono_jiterp_stelem_ref_unchecked (
+	MonoArray *o, gint32 aindex, MonoObject *ref
+) {
+	if (!o)
+		return 0;
+	if (aindex >= mono_array_length_internal (o))
+		return 0;
+	mono_array_setref_fast ((MonoArray *) o, aindex, ref);
+	return 1;
+}
+
 // keep in sync with jiterpreter-enums.ts JiterpMember
 enum {
 	JITERP_MEMBER_VT_INITIALIZED = 0,

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -402,8 +402,6 @@ OPDEF(MINT_LDELEMA1, "ldelema1", 5, 1, 2, MintOpShortInt)
 OPDEF(MINT_LDELEMA, "ldelema", 5, 1, 1, MintOpTwoShorts)
 OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 4, 1, 1, MintOpTwoShorts)
 
-/* these opcodes need to line up with the ldelem ones or things will
-   crash mysteriously at runtime */
 OPDEF(MINT_STELEM_I1, "stelem.i1", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_U1, "stelem.u1", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_I2, "stelem.i2", 4, 0, 3, MintOpNoArgs)

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -402,6 +402,8 @@ OPDEF(MINT_LDELEMA1, "ldelema1", 5, 1, 2, MintOpShortInt)
 OPDEF(MINT_LDELEMA, "ldelema", 5, 1, 1, MintOpTwoShorts)
 OPDEF(MINT_LDELEMA_TC, "ldelema.tc", 4, 1, 1, MintOpTwoShorts)
 
+/* these opcodes need to line up with the ldelem ones or things will
+   crash mysteriously at runtime */
 OPDEF(MINT_STELEM_I1, "stelem.i1", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_U1, "stelem.u1", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_I2, "stelem.i2", 4, 0, 3, MintOpNoArgs)
@@ -413,6 +415,7 @@ OPDEF(MINT_STELEM_R8, "stelem.r8", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_REF, "stelem.ref", 4, 0, 3, MintOpNoArgs)
 OPDEF(MINT_STELEM_VT, "stelem.vt", 6, 0, 3, MintOpTwoShorts)
 OPDEF(MINT_STELEM_VT_NOREF, "stelem.vt.noref", 6, 0, 3, MintOpTwoShorts)
+OPDEF(MINT_STELEM_REF_UNCHECKED, "stelem.ref.unchecked", 4, 0, 3, MintOpNoArgs)
 
 OPDEF(MINT_LDLEN, "ldlen", 3, 1, 1, MintOpNoArgs)
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4808,6 +4808,30 @@ handle_stelem (TransformData *td, int op)
 	interp_add_ins (td, op);
 	td->sp -= 3;
 	interp_ins_set_sregs3 (td->last_ins, td->sp [0].var, td->sp [1].var, td->sp [2].var);
+
+	if (op == MINT_STELEM_REF) {
+		InterpVar *array_var = &td->vars [td->last_ins->sregs [0]],
+			*value_var = &td->vars [td->last_ins->sregs [2]];
+		MonoClass *array_var_klass = mono_class_from_mono_type_internal (array_var->type),
+			*value_var_klass = mono_class_from_mono_type_internal (value_var->type);
+
+		if (m_class_is_array (array_var_klass)) {
+			MonoClass *array_element_klass = m_class_get_element_class (array_var_klass);
+			// If lhs is T[] and rhs is T and T is sealed, we can skip the runtime typecheck
+			// FIXME: right now this passes for Object[][] since Array is sealed, should it?
+			if (m_class_is_sealed (array_element_klass) &&
+				m_class_is_sealed (value_var_klass)) {
+				if (td->verbose_level > 2)
+					g_printf (
+						"MINT_STELEM_REF_UNCHECKED for %s in %s::%s\n",
+						m_class_get_name (value_var_klass),
+						m_class_get_name (td->method->klass), td->method->name
+					);
+				td->last_ins->opcode = MINT_STELEM_REF_UNCHECKED;
+			}
+		}
+	}
+
 	++td->ip;
 }
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4816,11 +4816,20 @@ handle_stelem (TransformData *td, int op)
 			*value_var_klass = mono_class_from_mono_type_internal (value_var->type);
 
 		if (m_class_is_array (array_var_klass)) {
+			ERROR_DECL (error);
 			MonoClass *array_element_klass = m_class_get_element_class (array_var_klass);
 			// If lhs is T[] and rhs is T and T is sealed, we can skip the runtime typecheck
 			// FIXME: right now this passes for Object[][] since Array is sealed, should it?
-			if (m_class_is_sealed (array_element_klass) &&
-				m_class_is_sealed (value_var_klass)) {
+			gboolean isinst;
+			// Make sure lhs and rhs element types are compatible, even though they usually would be
+			mono_class_is_assignable_from_checked (array_element_klass, value_var_klass, &isinst, error);
+			mono_error_cleanup (error); // FIXME: do not swallow the error
+			if (isinst &&
+				// We already know lhs and rhs are compatible, so if they're both sealed they
+				//  should be the same exactly
+				m_class_is_sealed (array_element_klass) &&
+				m_class_is_sealed (value_var_klass)
+			) {
 				if (td->verbose_level > 2)
 					g_printf (
 						"MINT_STELEM_REF_UNCHECKED for %s in %s::%s\n",


### PR DESCRIPTION
The generic opcode for storing reference types into arrays has to perform a full type check for the new element to make sure it's compatible with the destination array, due to array variance. In many cases however, if the element type of the array is sealed, we can theoretically skip this check and do the assignment safely in all cases. My understanding is that ryujit already does a form of this optimization, so I added a basic version of it to the mono interpreter.

The jiterpreter is also updated to exploit this opcode, because with the removal of the type-check it's now possible to inline most of the opcode into traces instead of calling a more expensive helper to do the array store. This will enable other existing jiterpreter optimizations like null check fusion to apply to stelem_ref that couldn't before.

My initial testing shows that this hits many uses of `string[]` during a run of System.Runtime.Tests, and according to some quick jiterpreter instrumentation the new opcode appears in some hot paths during the test run as well, so I'm hoping this will be profitable for some real-world code. (It's hard for me to measure locally.)