### PR TITLE
Disable time tracking in wasm release builds because it's expensive

### DIFF
--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2811,12 +2811,20 @@ void mono_cfg_add_try_hole (MonoCompile *cfg, MonoExceptionClause *clause, guint
 void mono_cfg_set_exception (MonoCompile *cfg, MonoExceptionType type);
 void mono_cfg_set_exception_invalid_program (MonoCompile *cfg, const char *msg);
 
+#if defined(HOST_WASM) && !(defined(DEBUG) || defined(_DEBUG))
+#define MONO_TIME_TRACK(a, phase) \
+	{ \
+		(phase) ; \
+		a = 0; \
+	}
+#else
 #define MONO_TIME_TRACK(a, phase) \
 	{ \
 		gint64 start = mono_time_track_start (); \
 		(phase) ; \
 		mono_time_track_end (&(a), start); \
 	}
+#endif // HOST_WASM && !DEBUG
 
 gint64 mono_time_track_start (void);
 void mono_time_track_end (gint64 *time, gint64 start);

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2811,7 +2811,7 @@ void mono_cfg_add_try_hole (MonoCompile *cfg, MonoExceptionClause *clause, guint
 void mono_cfg_set_exception (MonoCompile *cfg, MonoExceptionType type);
 void mono_cfg_set_exception_invalid_program (MonoCompile *cfg, const char *msg);
 
-#if defined(HOST_WASM) && !(defined(DEBUG) || defined(_DEBUG))
+#if defined(HOST_WASM)
 #define MONO_TIME_TRACK(a, phase) \
 	{ \
 		(phase) ; \
@@ -2824,7 +2824,7 @@ void mono_cfg_set_exception_invalid_program (MonoCompile *cfg, const char *msg);
 		(phase) ; \
 		mono_time_track_end (&(a), start); \
 	}
-#endif // HOST_WASM && !DEBUG
+#endif // HOST_WASM
 
 gint64 mono_time_track_start (void);
 void mono_time_track_end (gint64 *time, gint64 start);


### PR DESCRIPTION
Right now on main we spend a good chunk of cpu time just calling _emscripten_get_now in order to measure how long interpreter code generation takes. On most targets the equivalent timestamp checks are fast but on wasm, they're not.

So this PR disables those checks in wasm release builds specifically. Based on my measurements this should improve startup time a little bit.