### PR TITLE
[release/8.0] Update dependencies from dotnet/source-build-externals and dotnet/source-build-reference-packages

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -99,14 +99,14 @@
       <Sha>08a90ca2c88b17f1b5d081318354a41db0882cff</Sha>
       <SourceBuild RepoName="emsdk" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.24061.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="8.0.0-alpha.1.24163.3">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
-      <Sha>453a37ef7ae6c335cd49b3b9ab7713c87faeb265</Sha>
+      <Sha>79827eed138fd2575a8b24820b4f385ee4ffb6e6</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.24158.3">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-externals" Version="8.0.0-alpha.1.24161.1">
       <Uri>https://github.com/dotnet/source-build-externals</Uri>
-      <Sha>7a9b99e457a2b9792a3c17ccaf95d80038725108</Sha>
+      <Sha>00fb7841c80b44262646e57bcfbe90a1b7bc3151</Sha>
       <SourceBuild RepoName="source-build-externals" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:39647677-83df-4932-cc45-08db9e4039c1)
## From https://github.com/dotnet/source-build-reference-packages
- **Subscription**: 39647677-83df-4932-cc45-08db9e4039c1
- **Build**: 
- **Date Produced**: March 13, 2024 7:36:11 PM UTC
- **Commit**: 79827eed138fd2575a8b24820b4f385ee4ffb6e6
- **Branch**: refs/heads/release/8.0

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.SourceBuild.Intermediate.source-build-reference-packages**: [from 8.0.0-alpha.1.24162.3 to 8.0.0-alpha.1.24163.3][1]

[1]: https://github.com/dotnet/source-build-reference-packages/compare/c08ec59adc...79827eed13

[DependencyUpdate]: <> (End)


[marker]: <> (End:39647677-83df-4932-cc45-08db9e4039c1)

[marker]: <> (Begin:afe8dfcf-d1a6-4a21-a787-08db9e4038dc)
## From https://github.com/dotnet/source-build-externals
- **Subscription**: afe8dfcf-d1a6-4a21-a787-08db9e4038dc
- **Build**: 20240311.1
- **Date Produced**: March 11, 2024 2:03:09 PM UTC
- **Commit**: 00fb7841c80b44262646e57bcfbe90a1b7bc3151
- **Branch**: refs/heads/release/8.0

[DependencyUpdate]: <> (Begin)

- **Updates**:
  - **Microsoft.SourceBuild.Intermediate.source-build-externals**: [from 8.0.0-alpha.1.24158.3 to 8.0.0-alpha.1.24161.1][1]

[1]: https://github.com/dotnet/source-build-externals/compare/7a9b99e457...00fb7841c8

[DependencyUpdate]: <> (End)


[marker]: <> (End:afe8dfcf-d1a6-4a21-a787-08db9e4038dc)

