### PR TITLE
[release/8.0-staging][mono][debugger] Fix inspect Span<byte>

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -5589,6 +5589,7 @@ decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *bu
 	if (type != t->type && !MONO_TYPE_IS_REFERENCE (t) &&
 		!(t->type == MONO_TYPE_I && type == MONO_TYPE_VALUETYPE) &&
 		!(type == VALUE_TYPE_ID_FIXED_ARRAY) &&
+		!(type == MDBGPROT_VALUE_TYPE_ID_NULL) &&
 		!(t->type == MONO_TYPE_U && type == MONO_TYPE_VALUETYPE) &&
 		!(t->type == MONO_TYPE_PTR && type == MONO_TYPE_I8) &&
 		!(t->type == MONO_TYPE_FNPTR && type == MONO_TYPE_I8) &&

--- a/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
+++ b/src/mono/wasm/debugger/DebuggerTestSuite/MiscTests.cs
@@ -1188,5 +1188,24 @@ namespace DebuggerTests
             Assert.Equal(locals[1]["value"]["type"], "number");
             Assert.Equal(locals[1]["name"], "currentThread");
         }
+
+        [Fact]
+        public async Task InspectSpanByte()
+        {
+            var expression = $"{{ invoke_static_method('[debugger-test] SpanByte:Run'); }}";
+
+            await EvaluateAndCheck(
+                "window.setTimeout(function() {" + expression + "; }, 1);",
+                "dotnet://debugger-test.dll/debugger-test.cs", 1664, 8,
+                "SpanByte.Run",
+                wait_for_event_fn: async (pause_location) =>
+                {
+                    var id = pause_location["callFrames"][0]["callFrameId"].Value<string>();
+                    await EvaluateOnCallFrameAndCheck(id,
+                        ("span", TObject("System.Span<byte>", null))
+                    );
+                }
+            );
+        }
     }
 }

--- a/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
+++ b/src/mono/wasm/debugger/tests/debugger-test/debugger-test.cs
@@ -1656,3 +1656,12 @@ public class GenericCustomAttributeDecoratedClassInheritsFromNonUserCodeClassTha
 
     public int myField;
 }
+
+public class SpanByte
+{
+    public static void Run()
+    {
+        System.Span<byte> span = new ();
+        System.Diagnostics.Debugger.Break();
+    }
+}


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/99843 to release/8.0-staging

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Reported by customers in https://github.com/xamarin/xamarin-android/issues/8792. While debugging a MAUI/Blazor Wasm app and it's paused in a breakpoint/stepping and there is any local that is of type Span<T> the runtime will throw an assertion and finish the debugging session.

## Regression

- [X] Yes it works on .NET 7
- [ ] No

## Testing
- Manually tested.
- Unit tests were added to prevent the fix from regressing.

## Risk

Low. The change only checks if the value that is coming from SDB is NULL and then do not throw the assertion.
