### PR TITLE
[LoongArch64] Fix hijack.

### DIFF
--- a/src/coreclr/unwinder/loongarch64/unwinder.cpp
+++ b/src/coreclr/unwinder/loongarch64/unwinder.cpp
@@ -106,7 +106,9 @@ do {                                                                            
     if (ARGUMENT_PRESENT(Params)) {                                                   \
         PT_KNONVOLATILE_CONTEXT_POINTERS ContextPointers = (Params)->ContextPointers; \
         if (ARGUMENT_PRESENT(ContextPointers)) {                                      \
-            if (RegisterNumber ==  22)                                                \
+            if (RegisterNumber == 1)                                                  \
+                ContextPointers->Ra = (PDWORD64)Address;                              \
+            else if (RegisterNumber == 22)                                            \
                 ContextPointers->Fp = (PDWORD64)Address;                              \
             else if (RegisterNumber >=  23 && RegisterNumber <= 31) {                 \
                 (&ContextPointers->S0)[RegisterNumber - 23] = (PDWORD64)Address;      \

--- a/src/coreclr/vm/loongarch64/asmhelpers.S
+++ b/src/coreclr/vm/loongarch64/asmhelpers.S
@@ -822,13 +822,13 @@ NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR   25, 26, 32
     PROLOG_SAVE_REG_PAIR   27, 28, 48
     PROLOG_SAVE_REG_PAIR   29, 30, 64
-    PROLOG_SAVE_REG 31, 80
+    PROLOG_SAVE_REG_PAIR   31, 2, 80
 
     // save any integral return value(s)
     st.d  $a0, $sp, 96
     st.d  $a1, $sp, 104
 
-    // save any FP/HFA return value(s)
+    // save any FP return value(s)
     fst.d  $f0, $sp, 112
     fst.d  $f1, $sp, 120
 
@@ -841,15 +841,15 @@ NESTED_ENTRY OnHijackTripThread, _TEXT, NoHandler
     ld.d  $a0, $sp, 96
     ld.d  $a1, $sp, 104
 
-    // restore any FP/HFA return value(s)
-    fst.d  $f0, $sp, 112
-    fst.d  $f1, $sp, 120
+    // restore any FP return value(s)
+    fld.d  $f0, $sp, 112
+    fld.d  $f1, $sp, 120
 
     EPILOG_RESTORE_REG_PAIR   23, 24, 16
     EPILOG_RESTORE_REG_PAIR   25, 26, 32
     EPILOG_RESTORE_REG_PAIR   27, 28, 48
     EPILOG_RESTORE_REG_PAIR   29, 30, 64
-    EPILOG_RESTORE_REG  31, 80
+    EPILOG_RESTORE_REG_PAIR   31, 2,  80
     //                              $fp,$ra
     EPILOG_RESTORE_REG_PAIR_INDEXED  22, 1, 0x80
     EPILOG_RETURN

--- a/src/coreclr/vm/loongarch64/cgencpu.h
+++ b/src/coreclr/vm/loongarch64/cgencpu.h
@@ -448,11 +448,18 @@ struct DECLSPEC_ALIGN(16) UMEntryThunkCode
 
 struct HijackArgs
 {
+    DWORD64 Fp; // frame pointer
+    union
+    {
+        DWORD64 Ra;
+        size_t ReturnAddress;
+    };
+    DWORD64 S0, S1, S2, S3, S4, S5, S6, S7, S8, Tp;
     union
     {
         struct {
-             DWORD64 V0;
-             DWORD64 V1;
+             DWORD64 A0;
+             DWORD64 A1;
          };
         size_t ReturnValue[2];
     };
@@ -463,13 +470,6 @@ struct HijackArgs
              DWORD64 F1;
          };
         size_t FPReturnValue[2];
-    };
-    DWORD64 S0, S1, S2, S3, S4, S5, S6, S7, S8, Tp;
-    DWORD64 Fp; // frame pointer
-    union
-    {
-        DWORD64 Ra;
-        size_t ReturnAddress;
     };
 };
 


### PR DESCRIPTION
Fix hijack for LoongArch64.
This is mentioned in PR https://github.com/dotnet/runtime/pull/99809 .