### PR TITLE
[Fix] pr-guide.md broken link to area-owners.md

### DIFF
--- a/docs/workflow/ci/pr-guide.md
+++ b/docs/workflow/ci/pr-guide.md
@@ -15,7 +15,7 @@ To merge pull requests, you must have write permissions in the repository. If yo
 
 ## Pull Request Ownership
 
-Every pull request will have automatically a single `area-*` label assigned. The label not only indicates the code segment which the change touches but also the owner. We maintain a list of [areas owners](area-owners.md) for all dotnet/runtime labels. They are responsible for landing pull requests in their area in a timely manner and for helping contributors with their submitted pull request. You can ask them for assistance if you need help with landing your changes.
+Every pull request will have automatically a single `area-*` label assigned. The label not only indicates the code segment which the change touches but also the owner. We maintain a list of [areas owners](../../area-owners.md) for all dotnet/runtime labels. They are responsible for landing pull requests in their area in a timely manner and for helping contributors with their submitted pull request. You can ask them for assistance if you need help with landing your changes.
 
 If during the code review process a merge conflict occurs the area owner is responsible for its resolution. Pull requests should not be on hold due to the author's unwillingness to resolve code conflicts. GitHub makes this easier by allowing simple conflict resolution using the [conflict-editor](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/resolving-a-merge-conflict-on-github).
 


### PR DESCRIPTION
Hello,

This PR resolves an issue in the `pr-guide.md` file where a reference is made to the `area-owners.md` file under a non-existent URL.

Please let me know in case there is anything I overlooked or is in need of change.