### PR TITLE
Fix x86 hardware intrinsics

### DIFF
--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -80,8 +80,6 @@ namespace ILCompiler
             }
             else if (architecture == TargetArchitecture.X86)
             {
-                if (potentialType.Name == "X64")
-                    potentialType = (MetadataType)potentialType.ContainingType;
                 if (potentialType.Name == "VL")
                     potentialType = (MetadataType)potentialType.ContainingType;
                 if (potentialType.Namespace != "System.Runtime.Intrinsics.X86")


### PR DESCRIPTION
`GetHardwareIntrinsicId` should not handle x64 intrinsics on x86.

However, we were relying on this happening in `IsHardwareIntrinsic`. So also fixing `IsHardwareIntrinsic` to work the same as CoreCLR VM.

Cc @dotnet/ilc-contrib 