### PR TITLE
JIT: Fix an invalid use of remainder liveness in physical promotion

### DIFF
--- a/src/coreclr/jit/promotiondecomposition.cpp
+++ b/src/coreclr/jit/promotiondecomposition.cpp
@@ -760,7 +760,7 @@ private:
             // If the destination has replacements we still have usable
             // liveness information for the remainder. This case happens if the
             // source was also promoted.
-            if (m_dstInvolvesReplacements && deaths.IsRemainderDying())
+            if (m_dstInvolvesReplacements && !m_hasNonRemainderUseOfStructLocal && deaths.IsRemainderDying())
             {
 #ifdef DEBUG
                 if (dump)


### PR DESCRIPTION
Physical promotion computes liveness for all locals it promotes, including the liveness of the remainder of the local (i.e. all the non-promoted segments of the struct). This liveness information is used to skip unnecessary stores during decomposition. However, in some cases physical promotion may need to use the base struct local as scratch space to handle various edge cases (for example, partially overlapping copies). In those cases the remainder liveness cannot be used to skip optimizations. This was already handled in one place; this change handles it in another place as well.

Fix #99882