### PR TITLE
Fix ComponentGovernance running on public PR/CI jobs

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -32,7 +32,7 @@ parameters:
   preBuildSteps: []
   enableRichCodeNavigation: false
   richCodeNavigationLanguage: 'csharp'
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
 
 jobs:
 - template: /eng/common/templates/job/job.yml

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -19,7 +19,7 @@ parameters:
   timeoutInMinutes: ''
   enableMicrobuild: ''
   gatherAssetManifests: false
-  disableComponentGovernance: false
+  disableComponentGovernance: ''
 
   variables: {} ## any extra variables to add to the defaults defined below
 
@@ -64,9 +64,11 @@ jobs:
     ${{ if eq(parameters.osGroup, 'windows') }}:
       agentOs: windows
 
-    # Disable component governance if requested or on musl machines where it does not work well
-    ${{ if or(eq(parameters.disableComponentGovernance, true), eq(parameters.osSubGroup, '_musl')) }}:
+    # Component governance does not work on musl machines
+    ${{ if eq(parameters.osSubGroup, '_musl') }}:
       disableComponentGovernance: true
+    ${{ else }}:
+      disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
 
     # Setting this results in the arcade job template including a step
     # that gathers asset manifests and publishes them to pipeline

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -50,8 +50,8 @@ jobs:
       # To run the tests we just send to helix and wait, use ubuntu hosted pools for faster providing and to not back up our build pools
       pool: ${{ parameters.pool }}
 
-      # Disable component governance if requested or on musl machines where it does not work well
-      ${{ if or(eq(parameters.disableComponentGovernance, true), eq(parameters.osSubGroup, '_musl')) }}:
+      # Component governance does not work on musl machines
+      ${{ if eq(parameters.osSubGroup, '_musl') }}:
         disableComponentGovernance: true
 
       dependsOn:


### PR DESCRIPTION
This seems to be a side-effect of https://github.com/dotnet/runtime/pull/99179

Arcade checks whether `disableComponentGovernance` is the empty string to apply the default skipping logic: https://github.com/dotnet/arcade/blob/ace00d8719b8d1fdfd0cc05f71bb9af216338d27/eng/common/templates/job/job.yml#L168-L174

Changed our templates to make sure we pass that correctly.