### PR TITLE
ILVerify after kept member validation

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -101,6 +101,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					if (!HasActiveSkipKeptItemsValidationAttribute(linkResult.TestCase.FindTypeDefinition (original))) {
 						CreateAssemblyChecker (original, linked, linkResult).Verify ();
 					}
+					CreateILChecker ().Check(linkResult, original);
 				}
 
 				VerifyLinkingOfOtherAssemblies (original);
@@ -279,7 +280,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		protected virtual void InitialChecking (TrimmedTestCaseResult linkResult, AssemblyDefinition original, AssemblyDefinition linked)
 		{
-			CreateILChecker ().Check(linkResult, original);
 			ValidateTypeRefsHaveValidAssemblyRefs (linked);
 		}
 


### PR DESCRIPTION
ILVerify will fail with unhelpful messages if some members are not kept, and kept member validation won't be run. To make the errors more informative, run kept member validation first, then ILVerify.