### PR TITLE
Fix failing CertificateValidationRemoteServer.ConnectWithRevocation_WithCallback test

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -950,8 +950,8 @@ SingleResponse ::= SEQUENCE {
             PkiOptions pkiOptions,
             bool includePkiOptions)
         {
-            string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
             string testNamePart = !string.IsNullOrWhiteSpace(testName) ? $", O=\"{testName}\"" : "";
+            string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
 
             return $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
         }

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 subject,
                 publicKey,
                 TimeSpan.FromSeconds(1),
-                new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_ocspResponderEku},
+                new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_ocspResponderEku },
                 ocspResponder: true);
         }
 
@@ -950,12 +950,10 @@ SingleResponse ::= SEQUENCE {
             PkiOptions pkiOptions,
             bool includePkiOptions)
         {
-            if (includePkiOptions)
-            {
-                return $"CN=\"{cn}\", O=\"{testName}\", OU=\"{pkiOptions}\"";
-            }
+            string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
+            string testNamePart = !string.IsNullOrWhiteSpace(testName) ? $", O=\"{testName}\"" : "";
 
-            return $"CN=\"{cn}\", O=\"{testName}\"";
+            return $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
@@ -187,7 +188,8 @@ namespace System.Net.Security.Tests
         private async Task ConnectWithRevocation_WithCallback_Core(
             X509RevocationMode revocationMode,
             bool? offlineContext = false,
-            bool noIntermediates = false)
+            bool noIntermediates = false,
+            [CallerMemberName] string testName = null)
         {
             string offlinePart = offlineContext.HasValue ? offlineContext.GetValueOrDefault().ToString().ToLower() : "null";
             string serverName = $"{revocationMode.ToString().ToLower()}.{offlinePart}.server.example";
@@ -195,14 +197,14 @@ namespace System.Net.Security.Tests
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
 
             CertificateAuthority.BuildPrivatePki(
-                PkiOptions.EndEntityRevocationViaOcsp | PkiOptions.CrlEverywhere,
+                PkiOptions.CrlEverywhere,
                 out RevocationResponder responder,
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority[] intermediateAuthorities,
                 out X509Certificate2 serverCert,
+                testName: testName,
                 intermediateAuthorityCount: noIntermediates ? 0 : 1,
                 subjectName: serverName,
-                keySize: 2048,
                 extensions: Configuration.Certificates.BuildTlsServerCertExtensions(serverName));
 
             CertificateAuthority issuingAuthority = noIntermediates ? rootAuthority : intermediateAuthorities[0];

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -197,7 +197,7 @@ namespace System.Net.Security.Tests
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
 
             CertificateAuthority.BuildPrivatePki(
-                PkiOptions.CrlEverywhere,
+                PkiOptions.EndEntityRevocationViaOcsp | PkiOptions.CrlEverywhere,
                 out RevocationResponder responder,
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority[] intermediateAuthorities,
@@ -205,6 +205,7 @@ namespace System.Net.Security.Tests
                 testName: testName,
                 intermediateAuthorityCount: noIntermediates ? 0 : 1,
                 subjectName: serverName,
+                keySize: 2048,
                 extensions: Configuration.Certificates.BuildTlsServerCertExtensions(serverName));
 
             CertificateAuthority issuingAuthority = noIntermediates ? rootAuthority : intermediateAuthorities[0];

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateContextTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateContextTests.cs
@@ -26,6 +26,7 @@ namespace System.Net.Security.Tests
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority[] intermediateAuthorities,
                 out X509Certificate2 serverCert,
+                testName: nameof(Create_OcspDoesNotReturnOrCacheInvalidStapleData),
                 intermediateAuthorityCount: 1,
                 subjectName: serverName,
                 keySize: 2048,


### PR DESCRIPTION
Fixes issue reported in #99425.

Missing `testName` parameter to `BuildPrivatePki` led to end entity cert Subjects like `CN=server.example, O=""` which caused chain building on Windows to fail with exception.