### PR TITLE
Fix template parameter name in SuperPMI jobs

### DIFF
--- a/eng/pipelines/coreclr/templates/superpmi-asmdiffs-checked-release-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-asmdiffs-checked-release-job.yml
@@ -42,7 +42,7 @@ jobs:
         artifactFileName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
         artifactName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)'
         displayName: 'JIT checked build'
-        cleanupUnpackFolder: false
+        cleanUnpackFolder: false
 
     # Download jit release builds
     - template: /eng/pipelines/common/download-artifact-step.yml
@@ -51,4 +51,4 @@ jobs:
         artifactFileName: 'ReleaseJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
         artifactName: 'ReleaseJIT_$(osGroup)$(osSubgroup)_$(archType)'
         displayName: 'JIT release build'
-        cleanupUnpackFolder: false
+        cleanUnpackFolder: false

--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -59,7 +59,7 @@ jobs:
           artifactFileName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
           artifactName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)'
           displayName: 'JIT checked build'
-          cleanupUnpackFolder: false
+          cleanUnpackFolder: false
 
     - ${{ if in(parameters.diffType, 'tpdiff', 'all') }}:
       # Download jit release builds
@@ -69,4 +69,4 @@ jobs:
           artifactFileName: 'ReleaseJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
           artifactName: 'ReleaseJIT_$(osGroup)$(osSubgroup)_$(archType)'
           displayName: 'JIT release build'
-          cleanupUnpackFolder: false
+          cleanUnpackFolder: false

--- a/eng/pipelines/coreclr/templates/superpmi-replay-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-replay-job.yml
@@ -39,4 +39,4 @@ jobs:
         artifactFileName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)$(archiveExtension)'
         artifactName: 'CheckedJIT_$(osGroup)$(osSubgroup)_$(archType)'
         displayName: 'JIT checked build'
-        cleanupUnpackFolder: false
+        cleanUnpackFolder: false


### PR DESCRIPTION
Fix the parameter name for the `download-artifact-step` template to correctly not clean the download folder.