### PR TITLE
JIT: Remove hasLikelihood checks; make FlowEdge::m_likelihoodSet debug-only

### DIFF
--- a/src/coreclr/jit/block.cpp
+++ b/src/coreclr/jit/block.cpp
@@ -80,6 +80,7 @@ void FlowEdge::setLikelihood(weight_t likelihood)
     assert(likelihood >= 0.0);
     assert(likelihood <= 1.0);
 
+#ifdef DEBUG
     if (m_likelihoodSet)
     {
         JITDUMP("setting likelihood of " FMT_BB " -> " FMT_BB " from " FMT_WT " to " FMT_WT "\n", m_sourceBlock->bbNum,
@@ -92,7 +93,9 @@ void FlowEdge::setLikelihood(weight_t likelihood)
     }
 
     m_likelihoodSet = true;
-    m_likelihood    = likelihood;
+#endif // DEBUG
+
+    m_likelihood = likelihood;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -674,6 +674,7 @@ public:
 
     weight_t getLikelihood() const
     {
+        assert(m_likelihoodSet);
         return m_likelihood;
     }
 

--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -598,7 +598,7 @@ private:
     unsigned m_dupCount;
 
     // True if likelihood has been set
-    bool m_likelihoodSet;
+    INDEBUG(bool m_likelihoodSet);
 
 public:
     FlowEdge(BasicBlock* sourceBlock, BasicBlock* destBlock, FlowEdge* rest)
@@ -609,7 +609,9 @@ public:
         , m_edgeWeightMax(0)
         , m_likelihood(0)
         , m_dupCount(0)
+#ifdef DEBUG
         , m_likelihoodSet(false)
+#endif // DEBUG
     {
     }
 
@@ -680,14 +682,16 @@ public:
 
     void clearLikelihood()
     {
-        m_likelihood    = 0.0;
-        m_likelihoodSet = false;
+        m_likelihood = 0.0;
+        INDEBUG(m_likelihoodSet = false);
     }
 
+#ifdef DEBUG
     bool hasLikelihood() const
     {
         return m_likelihoodSet;
     }
+#endif // DEBUG
 
     weight_t getLikelyWeight() const;
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -729,8 +729,6 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
                 assert(newEdge != nullptr);
                 assert(newEdge->getSourceBlock() == block);
                 assert(newEdge->getDestinationBlock() == newTarget);
-                assert(newEdge->hasLikelihood());
-                assert(oldEdge->hasLikelihood());
 
                 newEdge->addLikelihood(oldEdge->getLikelihood());
             }

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -729,11 +729,10 @@ void Compiler::fgReplaceJumpTarget(BasicBlock* block, BasicBlock* oldTarget, Bas
                 assert(newEdge != nullptr);
                 assert(newEdge->getSourceBlock() == block);
                 assert(newEdge->getDestinationBlock() == newTarget);
+                assert(newEdge->hasLikelihood());
+                assert(oldEdge->hasLikelihood());
 
-                if (newEdge->hasLikelihood() && oldEdge->hasLikelihood())
-                {
-                    newEdge->addLikelihood(oldEdge->getLikelihood());
-                }
+                newEdge->addLikelihood(oldEdge->getLikelihood());
             }
 
             assert(changed);

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -185,10 +185,11 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
         {
             block->bbLastPred = flow;
         }
-        else if ((oldEdge != nullptr) && oldEdge->hasLikelihood())
+        else if (oldEdge != nullptr)
         {
-            // Copy likelihood from old edge, if any.
+            // Copy likelihood from old edge.
             //
+            assert(oldEdge->hasLikelihood());
             flow->setLikelihood(oldEdge->getLikelihood());
         }
 

--- a/src/coreclr/jit/fgflow.cpp
+++ b/src/coreclr/jit/fgflow.cpp
@@ -189,7 +189,6 @@ FlowEdge* Compiler::fgAddRefPred(BasicBlock* block, BasicBlock* blockPred, FlowE
         {
             // Copy likelihood from old edge.
             //
-            assert(oldEdge->hasLikelihood());
             flow->setLikelihood(oldEdge->getLikelihood());
         }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1849,7 +1849,6 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             // Update edge likelihoods
             // Note old edge may still be "in use" so we decrease its likelihood.
             //
-            assert(oldEdge->hasLikelihood());
 
             // We want to move this much likelihood from old->new
             //

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1849,23 +1849,22 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             // Update edge likelihoods
             // Note old edge may still be "in use" so we decrease its likelihood.
             //
-            if (oldEdge->hasLikelihood())
+            assert(oldEdge->hasLikelihood());
+
+            // We want to move this much likelihood from old->new
+            //
+            const weight_t likelihoodFraction = oldEdge->getLikelihood() / (oldEdge->getDupCount() + 1);
+
+            if (newEdge->getDupCount() == 1)
             {
-                // We want to move this much likelihood from old->new
-                //
-                const weight_t likelihoodFraction = oldEdge->getLikelihood() / (oldEdge->getDupCount() + 1);
-
-                if (newEdge->getDupCount() == 1)
-                {
-                    newEdge->setLikelihood(likelihoodFraction);
-                }
-                else
-                {
-                    newEdge->addLikelihood(likelihoodFraction);
-                }
-
-                oldEdge->addLikelihood(-likelihoodFraction);
+                newEdge->setLikelihood(likelihoodFraction);
             }
+            else
+            {
+                newEdge->addLikelihood(likelihoodFraction);
+            }
+
+            oldEdge->addLikelihood(-likelihoodFraction);
 
             // we optimized a Switch label - goto REPEAT_SWITCH to follow this new jump
             modified = true;

--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -605,8 +605,7 @@ private:
                 assert(prevCheckBlock->KindIs(BBJ_ALWAYS));
                 assert(prevCheckBlock->JumpsToNext());
                 FlowEdge* const prevCheckThenEdge = prevCheckBlock->GetTargetEdge();
-                assert(prevCheckThenEdge->hasLikelihood());
-                weight_t checkLikelihood = max(0.0, 1.0 - prevCheckThenEdge->getLikelihood());
+                weight_t        checkLikelihood   = max(0.0, 1.0 - prevCheckThenEdge->getLikelihood());
 
                 JITDUMP("Level %u Check block " FMT_BB " success likelihood " FMT_WT "\n", checkIdx, checkBlock->bbNum,
                         checkLikelihood);
@@ -1090,9 +1089,8 @@ private:
             // just use that to figure out the "else" likelihood.
             //
             assert(checkBlock->KindIs(BBJ_ALWAYS));
-            FlowEdge* const checkThenEdge = checkBlock->GetTargetEdge();
-            assert(checkThenEdge->hasLikelihood());
-            weight_t elseLikelihood = max(0.0, 1.0 - checkThenEdge->getLikelihood());
+            FlowEdge* const checkThenEdge  = checkBlock->GetTargetEdge();
+            weight_t        elseLikelihood = max(0.0, 1.0 - checkThenEdge->getLikelihood());
 
             // CheckBlock flows into elseBlock unless we deal with the case
             // where we know the last check is always true (in case of "exact" GDV)


### PR DESCRIPTION
Part of #93020. Now that edge likelihoods are expected to be set throughout all phases, when transferring the likelihood of an existing edge to a new edge, we should assume the former edge's likelihood should already be set. By removing all non-debug conditional logic that uses `hasLikelihood`, we can make `m_likelihoodSet` available only in Debug builds again.