### PR TITLE
[release/8.0] disable optimizations for PopCount

### DIFF
--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -3192,6 +3192,11 @@ uint32_t BitOperations::Log2(uint64_t value)
 // Return Value:
 //    The population count (number of bits set) of value
 //
+#if defined(_MSC_VER)
+// Disable optimizations for PopCount to avoid the compiler from generating intrinsics
+// not supported on all platforms.
+#pragma optimize("", off)
+#endif // _MSC_VER
 uint32_t BitOperations::PopCount(uint32_t value)
 {
 #if defined(_MSC_VER)
@@ -3244,6 +3249,9 @@ uint32_t BitOperations::PopCount(uint64_t value)
     return static_cast<uint32_t>(result);
 #endif
 }
+#if defined(_MSC_VER)
+#pragma optimize("", on)
+#endif // _MSC_VER
 
 //------------------------------------------------------------------------
 // BitOperations::ReverseBits: Reverses the bits in an integer value


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/runtime/pull/99832 to include it in the release/8.0 branch for the April Release.

@jeffschwMSFT @mangod9 @mmitche @vseanreesermsft 