### PR TITLE
Update publishing to include *.pkg files

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -24,6 +24,7 @@
                                    $(ArtifactsPackagesDir)**\*.zip;
                                    $(ArtifactsPackagesDir)**\*.deb;
                                    $(ArtifactsPackagesDir)**\*.rpm;
+                                   $(ArtifactsPackagesDir)**\*.pkg;
                                    $(ArtifactsPackagesDir)**\*.exe;
                                    $(ArtifactsPackagesDir)**\*.msi"
                           Exclude="$(ArtifactsPackagesDir)**\Symbols.runtime.tar.gz" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/4236

This is a backport of a new VMR patch for runtime repo.