### PR TITLE
Fix workloads build by bringing back some needed variables

### DIFF
--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -42,8 +42,6 @@ jobs:
         value: '/p:OfficialBuildId=$(Build.BuildNumber)'
     - name: SignType
       value: $[ coalesce(variables.OfficialSignType, 'real') ]
-    - name: monoRepoRoot
-      value: '$(Build.SourcesDirectory)/src/mono'
     - name: workloadPackagesPath
       value: $(Build.SourcesDirectory)/artifacts/workloadPackages
     - name: workloadArtifactsPath

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -42,6 +42,12 @@ jobs:
         value: '/p:OfficialBuildId=$(Build.BuildNumber)'
     - name: SignType
       value: $[ coalesce(variables.OfficialSignType, 'real') ]
+    - name: monoRepoRoot
+      value: '$(Build.SourcesDirectory)/src/mono'
+    - name: workloadPackagesPath
+      value: $(Build.SourcesDirectory)/artifacts/workloadPackages
+    - name: workloadArtifactsPath
+      value: $(Build.SourcesDirectory)/artifacts/workloads
     - ${{ parameters.variables }}
 
     steps:


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/99179 made some changes and switched the template the workloads build was using. In the process, workloadArtifactsPath and workloadPackagesPath got dropped, which meant the workloads build did not pick up any manifests to process. As a result, the build failed.