### PR TITLE
[NativeAOT/x86] Fix null check in RhpLockCmpXchg64

### DIFF
--- a/src/coreclr/nativeaot/Runtime/i386/Interlocked.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/Interlocked.asm
@@ -14,6 +14,10 @@ FASTCALL_FUNC  RhpLockCmpXchg64, 20
 _value$ = 16
 _comparand$ = 8
 
+ALTERNATE_ENTRY _RhpLockCmpXchg64AVLocation
+        ;; Null check
+        cmp     dword ptr [ecx], ecx
+
         mov     eax, DWORD PTR _comparand$[esp-4]
         mov     edx, DWORD PTR _comparand$[esp]
         push    ebx
@@ -21,7 +25,6 @@ _comparand$ = 8
         push    esi
         mov     esi, ecx
         mov     ecx, DWORD PTR _value$[esp+8]
-ALTERNATE_ENTRY _RhpLockCmpXchg64AVLocation
         lock cmpxchg8b QWORD PTR [esi]
         pop     esi
         pop     ebx


### PR DESCRIPTION
The AV is processed with `UnwindSimpleHelperToCaller` which expects no temporary variables on the stack. We could either special case it there or do an explicit null check. ARM also does the explicit null check so align with that.

Fixes crash in System.Threading library tests.