### PR TITLE
[mono] Optimize mono_metadata_decode_row_col_raw

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -933,6 +933,7 @@ delta_info_initialize_mutants (const MonoImage *base, const BaselineInfo *base_i
 			tbl->row_size = prev_table->row_size;
 			tbl->size_bitfield = prev_table->size_bitfield;
 		}
+		mono_metadata_compute_column_offsets (tbl);
 		tbl->rows_ = rows;
 		g_assert (tbl->rows_ > 0 && tbl->row_size != 0);
 
@@ -1890,7 +1891,7 @@ apply_enclog_pass2 (Pass2Context *ctx, MonoImage *image_base, BaselineInfo *base
 		gboolean is_addition = token_index-1 >= delta_info->count[token_table].prev_gen_rows ;
 
 		*should_invalidate_transformed_code |= table_should_invalidate_transformed_code (token_table);
-		
+
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_METADATA_UPDATE, "enclog i=%d: token=0x%08x (table=%s): %d:\t%s", i, log_token, mono_meta_table_name (token_table), func_code, (is_addition ? "ADD" : "UPDATE"));
 
 
@@ -2934,7 +2935,7 @@ add_property_to_existing_class (MonoImage *image_base, BaselineInfo *base_info, 
 	parent_info->generation = generation;
 
 	return prop;
-	
+
 }
 
 MonoClassMetadataUpdateEvent *
@@ -2962,7 +2963,7 @@ add_event_to_existing_class (MonoImage *image_base, BaselineInfo *base_info, uin
 	parent_info->generation = generation;
 
 	return evt;
-	
+
 }
 
 
@@ -3017,7 +3018,7 @@ add_semantic_method_to_existing_event (MonoImage *image_base, BaselineInfo *base
 	g_assert (m_event_is_from_update (evt));
 
 	MonoMethod **dest = NULL;
-	
+
 	switch (semantics) {
 	case METHOD_SEMANTIC_ADD_ON:
 		dest = &evt->add;
@@ -3425,7 +3426,7 @@ recompute_ginst_props (MonoClass *ginst, MonoClassMetadataUpdateInfo *info,
 	for (GSList *ptr = gtd_info->added_props; ptr; ptr = ptr->next) {
 		MonoClassMetadataUpdateProperty *gtd_added_prop = (MonoClassMetadataUpdateProperty *)ptr->data;
 		MonoClassMetadataUpdateProperty *added_prop = mono_class_new0 (ginst, MonoClassMetadataUpdateProperty, 1);
-		
+
 		added_prop->prop = gtd_added_prop->prop;
 		added_prop->token = gtd_added_prop->token;
 
@@ -3453,7 +3454,7 @@ recompute_ginst_events (MonoClass *ginst, MonoClassMetadataUpdateInfo *info,
 	for (GSList *ptr = gtd_info->added_events; ptr; ptr = ptr->next) {
 		MonoClassMetadataUpdateEvent *gtd_added_event = (MonoClassMetadataUpdateEvent *)ptr->data;
 		MonoClassMetadataUpdateEvent *added_event = mono_class_new0 (ginst, MonoClassMetadataUpdateEvent, 1);
-		
+
 		added_event->evt = gtd_added_event->evt;
 
 		if (added_event->evt.add)
@@ -3466,7 +3467,7 @@ recompute_ginst_events (MonoClass *ginst, MonoClassMetadataUpdateInfo *info,
 			added_event->evt.raise = mono_class_inflate_generic_method_full_checked (
 				added_event->evt.raise, ginst, mono_class_get_context (ginst), error);
 		mono_error_assert_ok (error); /*FIXME proper error handling*/
-		
+
 		added_event->evt.parent = ginst;
 
 		info->added_events = g_slist_prepend_mem_manager (m_class_get_mem_manager (ginst), info->added_events, (gpointer)added_event);
@@ -3506,7 +3507,7 @@ recompute_ginst_update_info(MonoClass *ginst, MonoClass *gtd, MonoClassMetadataU
 {
 	// if ginst has a `MonoClassMetadataUpdateInfo`, use it to start with, otherwise, allocate a new one
 	MonoClassMetadataUpdateInfo *info = mono_class_get_or_add_metadata_update_info (ginst);
-  
+
 	if (!info)
 		info = mono_class_new0 (ginst, MonoClassMetadataUpdateInfo, 1);
 
@@ -3517,13 +3518,13 @@ recompute_ginst_update_info(MonoClass *ginst, MonoClass *gtd, MonoClassMetadataU
 
 	recompute_ginst_events (ginst, info, gtd, gtd_info, error);
 	mono_error_assert_ok (error);
-	
+
 	recompute_ginst_fields (ginst, info, gtd, gtd_info, error);
 	mono_error_assert_ok (error);
 
 	// finally, update the generation of the ginst info to the same one as the gtd
 	info->generation = gtd_info->generation;
-	// we're done info is now up to date    
+	// we're done info is now up to date
 }
 
 static MonoProperty *

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -896,6 +896,7 @@ mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_i
 MONO_COMPONENT_API
 const char *   mono_meta_table_name              (int table);
 void           mono_metadata_compute_table_bases (MonoImage *meta);
+void           mono_metadata_compute_column_offsets (MonoTableInfo *table);
 
 gboolean
 mono_metadata_interfaces_from_typedef_full  (MonoImage             *image,

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -234,6 +234,12 @@ struct _MonoTableInfo {
 	 * we only need 4, but 8 is aligned no shift required.
 	 */
 	guint32   size_bitfield;
+
+	/*
+	 * optimize out the loop in mono_metadata_decode_row_col_raw.
+	 * 4 * 9 easily fits in a uint8
+	 */
+	guint8    column_offsets[9];
 };
 
 #define REFERENCE_MISSING ((gpointer) -1)

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -217,6 +217,8 @@ typedef struct {
 	guint32  size;
 } MonoStreamHeader;
 
+#define MONO_TABLE_INFO_MAX_COLUMNS 9
+
 struct _MonoTableInfo {
 	const char *base;
 	guint       rows_     : 24;	/* don't access directly, use table_info_get_rows */
@@ -239,7 +241,7 @@ struct _MonoTableInfo {
 	 * optimize out the loop in mono_metadata_decode_row_col_raw.
 	 * 4 * 9 easily fits in a uint8
 	 */
-	guint8    column_offsets[9];
+	guint8    column_offsets[MONO_TABLE_INFO_MAX_COLUMNS];
 };
 
 #define REFERENCE_MISSING ((gpointer) -1)

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -896,6 +896,7 @@ mono_metadata_table_bounds_check (MonoImage *image, int table_index, int token_i
 MONO_COMPONENT_API
 const char *   mono_meta_table_name              (int table);
 void           mono_metadata_compute_table_bases (MonoImage *meta);
+MONO_COMPONENT_API
 void           mono_metadata_compute_column_offsets (MonoTableInfo *table);
 
 gboolean

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1484,11 +1484,12 @@ mono_metadata_decode_row_col_raw (const MonoTableInfo *t, int idx, guint col)
 	const char *data;
 	int n;
 	guint8 column_offset;
+	guint32 bitfield = t->size_bitfield;
 
 	g_assert (GINT_TO_UINT32(idx) < table_info_get_rows (t));
-	g_assert (col < mono_metadata_table_count (t->size_bitfield));
+	g_assert (col < mono_metadata_table_count (bitfield));
 	data = t->base + idx * t->row_size + t->column_offsets [col];
-	n = mono_metadata_table_size (t->size_bitfield, col);
+	n = mono_metadata_table_size (bitfield, col);
 	switch (n) {
 	case 1:
 		return *data;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1003,14 +1003,14 @@ mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int to
         return mono_metadata_update_table_bounds_check (image, table_index, token_index);
 }
 
-static void
-compute_column_offsets (guint32 bitfield, guint8 column_offsets[MONO_TABLE_INFO_MAX_COLUMNS])
+void
+mono_metadata_compute_column_offsets (MonoTableInfo *table)
 {
-	int offset = 0, c = mono_metadata_table_count (bitfield);
-	memset(column_offsets, 0, MONO_TABLE_INFO_MAX_COLUMNS);
+	int offset = 0, c = mono_metadata_table_count (table->size_bitfield);
+	memset(table->column_offsets, 0, MONO_TABLE_INFO_MAX_COLUMNS);
 	for (int i = 0; i < c; i++) {
-		int size = mono_metadata_table_size (bitfield, i);
-		column_offsets[i] = (guint8)offset;
+		int size = mono_metadata_table_size (table->size_bitfield, i);
+		table->column_offsets[i] = (guint8)offset;
 		offset += size;
 	}
 }
@@ -1034,7 +1034,7 @@ mono_metadata_compute_table_bases (MonoImage *meta)
 			continue;
 
 		table->row_size = mono_metadata_compute_size (meta, i, &table->size_bitfield);
-		compute_column_offsets (table->size_bitfield, table->column_offsets);
+		mono_metadata_compute_column_offsets (table);
 		table->base = base;
 		base += table_info_get_rows (table) * table->row_size;
 	}

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1007,14 +1007,11 @@ static void
 compute_column_offsets (guint32 bitfield, guint8 column_offsets[MONO_TABLE_INFO_MAX_COLUMNS])
 {
 	int offset = 0, c = mono_metadata_table_count (bitfield);
-	for (int i = 0; i < MONO_TABLE_INFO_MAX_COLUMNS; i++) {
-		if (i >= c) {
-			column_offsets[i] = 0xFFu;
-		} else {
-			int size = mono_metadata_table_size (bitfield, i);
-			column_offsets[i] = (guint8)offset;
-			offset += size;
-		}
+	memset(column_offsets, 0, MONO_TABLE_INFO_MAX_COLUMNS);
+	for (int i = 0; i < c; i++) {
+		int size = mono_metadata_table_size (bitfield, i);
+		column_offsets[i] = (guint8)offset;
+		offset += size;
 	}
 }
 
@@ -1488,16 +1485,10 @@ mono_metadata_decode_row_col_raw (const MonoTableInfo *t, int idx, guint col)
 	int n;
 	guint8 column_offset;
 
-	guint32 bitfield = t->size_bitfield;
-
 	g_assert (GINT_TO_UINT32(idx) < table_info_get_rows (t));
-	g_assert (col < mono_metadata_table_count (bitfield));
-	data = t->base + idx * t->row_size;
-
-	n = mono_metadata_table_size (bitfield, col);
-	column_offset = t->column_offsets [col];
-	g_assert (column_offset < 0xFFu);
-	data += column_offset;
+	g_assert (col < mono_metadata_table_count (t->size_bitfield));
+	data = t->base + idx * t->row_size + t->column_offsets [col];
+	n = mono_metadata_table_size (t->size_bitfield, col);
 	switch (n) {
 	case 1:
 		return *data;

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1004,10 +1004,10 @@ mono_metadata_table_bounds_check_slow (MonoImage *image, int table_index, int to
 }
 
 static void
-mono_metadata_compute_column_offsets (guint32 bitfield, guint8 column_offsets[9])
+compute_column_offsets (guint32 bitfield, guint8 column_offsets[MONO_TABLE_INFO_MAX_COLUMNS])
 {
 	int offset = 0, c = mono_metadata_table_count (bitfield);
-	for (int i = 0; i < 9; i++) {
+	for (int i = 0; i < MONO_TABLE_INFO_MAX_COLUMNS; i++) {
 		if (i >= c) {
 			column_offsets[i] = 0xFFu;
 		} else {
@@ -1037,7 +1037,7 @@ mono_metadata_compute_table_bases (MonoImage *meta)
 			continue;
 
 		table->row_size = mono_metadata_compute_size (meta, i, &table->size_bitfield);
-		mono_metadata_compute_column_offsets (table->size_bitfield, table->column_offsets);
+		compute_column_offsets (table->size_bitfield, table->column_offsets);
 		table->base = base;
 		base += table_info_get_rows (table) * table->row_size;
 	}

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1483,7 +1483,6 @@ mono_metadata_decode_row_col_raw (const MonoTableInfo *t, int idx, guint col)
 {
 	const char *data;
 	int n;
-	guint8 column_offset;
 	guint32 bitfield = t->size_bitfield;
 
 	g_assert (GINT_TO_UINT32(idx) < table_info_get_rows (t));


### PR DESCRIPTION
The loop in this function is somewhat expensive, and in some wasm startup profiles I did we spent around 1% of cpu time inside it. From some quick tests this seems to make it a little bit faster, at the price of 9 bytes per MonoTableInfo (~500 bytes per assembly), which I think is worth it.