### PR TITLE
Be more resilient against invalid metadata in fields

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingHelpers.cs
@@ -227,6 +227,16 @@ namespace ILCompiler
                     ((MetadataType)owningType).MakeInstantiatedType(inst));
             }
 
+            try
+            {
+                // Make sure we're not putting something into the graph that will crash later.
+                factory.TypeSystemContext.EnsureLoadableType(field.FieldType);
+            }
+            catch (TypeSystemException)
+            {
+                return false;
+            }
+
             dependencies.Add(factory.ReflectedField(field), reason);
 
             return true;


### PR DESCRIPTION
Addresses some of the problems seen in #99580.

We already check methods and types are loadable. Should do the same for fields.

Cc @dotnet/ilc-contrib 