### PR TITLE
Fix "[wasm] Fix "we can't find snapshot urls""

### DIFF
--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -271,12 +271,12 @@ public partial class UpdateChromeVersions : MBU.Task
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)
     {
-        string baseUrl = $"{s_snapshotBaseUrl}/{osPrefix}";
+        string baseUrlForRevision = $"{s_snapshotBaseUrl}?prefix={osPrefix}";
 
         int branchPosition = int.Parse(version.branch_base_position);
         for (int i = 0; i < MaxBranchPositionsToCheck; i++)
         {
-            string branchUrl = $"{baseUrl}/{branchPosition}";
+            string branchUrl = $"{baseUrlForRevision}/{branchPosition}";
             string url = $"{branchUrl}/REVISIONS";
 
             Log.LogMessage(MessageImportance.Low, $"Checking if {url} exists ..");
@@ -285,14 +285,16 @@ public partial class UpdateChromeVersions : MBU.Task
                                                     .ConfigureAwait(false);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                Log.LogMessage(MessageImportance.Low, $"Found {url}");
-                return branchUrl;
+                string baseUrlForDownload = $"{s_snapshotBaseUrl}/{osPrefix}";
+                string snapshotUrl = $"{baseUrlForDownload}/{branchPosition}";
+                Log.LogMessage(MessageImportance.Low, $"Found {url}. Snapshots should be under ${snapshotUrl}");
+                return snapshotUrl;
             }
 
             branchPosition += 1;
         }
 
-        string message = $"Could not find a chrome snapshot folder under {baseUrl}, " +
+        string message = $"Could not find a chrome snapshot folder under {baseUrlForRevision}, " +
                             $"for branch positions {version.branch_base_position} to " +
                             $"{branchPosition}, for version {version.version}. " +
                             "A fixed version+url can be set in eng/testing/ProvisioningVersions.props .";

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -271,7 +271,7 @@ public partial class UpdateChromeVersions : MBU.Task
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)
     {
-        string baseUrl = $"{s_snapshotBaseUrl}?prefix={osPrefix}";
+        string baseUrl = $"{s_snapshotBaseUrl}/{osPrefix}";
 
         int branchPosition = int.Parse(version.branch_base_position);
         for (int i = 0; i < MaxBranchPositionsToCheck; i++)


### PR DESCRIPTION
Follow-up for the PR: dotnet/runtime#99814.

This was not a correct fix, error:
`/__w/1/s/eng/testing/wasm-provisioning.targets(110,5): error MSB3933: Failed to open zip file "/__w/1/s/artifacts/obj/chromium-browser-snapshots".  End of Central Directory record could not be found..`
https://github.com/dotnet/runtime/pull/99873/checks?check_run_id=22748465249

On PR: https://github.com/dotnet/runtime/pull/99873

The fix was only partial, the url change for checking the revision is correct (with the query argument) `https://storage.googleapis.com/chromium-browser-snapshots?prefix=Linux_x64/1250580/REVISION` but the download link is still in the old version (without the query argument), so `https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1250580/chrome-linux.zip`, not as expected `https://storage.googleapis.com/chromium-browser-snapshots?prefix=Linux_x64/1250580/chrome-linux.zip`.
