### PR TITLE
[RISC-V] Fix a mistake in genInstrWithConstant

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -80,6 +80,9 @@ bool CodeGen::genInstrWithConstant(instruction ins,
         case INS_flw:
         case INS_ld:
         case INS_fld:
+        case INS_lbu:
+        case INS_lhu:
+        case INS_lwu:
             break;
 
         default:


### PR DESCRIPTION
In genInstrWithConstant, some instructions are missed.
- `lbu`, `lhu` and `lwu`

Fixed assertion when crossgen2 compiles dll file
- `./JIT/Regression/JitBlue/GitHub_65988/GitHub_65988/GitHub_65988.sh`
- `./JIT/opt/OSR/invalidpromotion/invalidpromotion.sh`

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung