### PR TITLE
[release/8.0] Fix failing CertificateValidationRemoteServer.ConnectWithRevocation_WithCallback test (#99915)

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -179,7 +179,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 subject,
                 publicKey,
                 TimeSpan.FromSeconds(1),
-                new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_ocspResponderEku},
+                new X509ExtensionCollection() { s_eeConstraints, s_eeKeyUsage, s_ocspResponderEku },
                 ocspResponder: true);
         }
 
@@ -950,12 +950,10 @@ SingleResponse ::= SEQUENCE {
             PkiOptions pkiOptions,
             bool includePkiOptions)
         {
-            if (includePkiOptions)
-            {
-                return $"CN=\"{cn}\", O=\"{testName}\", OU=\"{pkiOptions}\"";
-            }
+            string testNamePart = !string.IsNullOrWhiteSpace(testName) ? $", O=\"{testName}\"" : "";
+            string pkiOptionsPart = includePkiOptions ? $", OU=\"{pkiOptions}\"" : "";
 
-            return $"CN=\"{cn}\", O=\"{testName}\"";
+            return $"CN=\"{cn}\"" + testNamePart + pkiOptionsPart;
         }
     }
 }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.X509Certificates.Tests.Common;
@@ -188,7 +189,8 @@ namespace System.Net.Security.Tests
         private async Task ConnectWithRevocation_WithCallback_Core(
             X509RevocationMode revocationMode,
             bool? offlineContext = false,
-            bool noIntermediates = false)
+            bool noIntermediates = false,
+            [CallerMemberName] string testName = null)
         {
             string offlinePart = offlineContext.HasValue ? offlineContext.GetValueOrDefault().ToString().ToLower() : "null";
             string serverName = $"{revocationMode.ToString().ToLower()}.{offlinePart}.server.example";
@@ -201,6 +203,7 @@ namespace System.Net.Security.Tests
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority[] intermediateAuthorities,
                 out X509Certificate2 serverCert,
+                testName: testName,
                 intermediateAuthorityCount: noIntermediates ? 0 : 1,
                 subjectName: serverName,
                 keySize: 2048,

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateContextTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamCertificateContextTests.cs
@@ -24,6 +24,7 @@ namespace System.Net.Security.Tests
                 out CertificateAuthority rootAuthority,
                 out CertificateAuthority[] intermediateAuthorities,
                 out X509Certificate2 serverCert,
+                testName: nameof(Create_OcspDoesNotReturnOrCacheInvalidStapleData),
                 intermediateAuthorityCount: 1,
                 subjectName: serverName,
                 keySize: 2048,


### PR DESCRIPTION
Closes #99425.

Manual port of #99915

## Customer Impact

- [ ] Customer reported
- [x] Found internally

Test only change to cleanup CI, see #99425

## Regression

- [x] Yes
- [ ] No

Surfaced likely after https://github.com/dotnet/runtime/commit/72e5ae975785990e904372573c93dd661279f662.

## Testing

Via CI.

## Risk

Low, affected code is test only and does not ship with .NET.