### PR TITLE
[browser] Revert to full `NativeName` by interop with JS

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Locale.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Locale.cs
@@ -14,6 +14,6 @@ internal static partial class Interop
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern unsafe int GetFirstWeekOfYear(in string culture, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
-        internal static extern unsafe int GetNativeName(in string locale, in string culture, char* buffer, int bufferLength, out int exceptionalResult, out object result);
+        internal static extern unsafe int GetLocaleInfo(in string locale, in string culture, char* buffer, int bufferLength, out int exceptionalResult, out object result);
     }
 }

--- a/src/libraries/Common/src/Interop/Browser/Interop.Locale.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Locale.cs
@@ -13,5 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int GetFirstDayOfWeek(in string culture, out int exceptionalResult, out object result);
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         internal static extern unsafe int GetFirstWeekOfYear(in string culture, out int exceptionalResult, out object result);
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        internal static extern unsafe int GetNativeName(in string locale, in string culture, char* buffer, int bufferLength, out int exceptionalResult, out object result);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -25,7 +25,6 @@ namespace System.Globalization
             }
             else
             {
-                // ToDo: make sure we do not re-ask for it
                 // English locale info
                 (culture._sEnglishLanguage, culture._sEnglishCountry) = culture.JSGetLocaleInfo("en-US", localeName);
                 culture._sEnglishDisplayName = string.IsNullOrEmpty(culture._sEnglishCountry) ?

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -19,9 +19,7 @@ namespace System.Globalization
             string cultureName = uiCultureName ?? localeName;
             // the longest possible NativeName is 50 characters
             char* buffer = stackalloc char[CULTURE_INFO_BUFFER_LEN];
-            int exception;
-            object exResult;
-            int resultLength = Interop.JsGlobalization.GetNativeName(localeName, cultureName, buffer, CULTURE_INFO_BUFFER_LEN, out exception, out exResult);
+            int resultLength = Interop.JsGlobalization.GetNativeName(localeName, cultureName, buffer, CULTURE_INFO_BUFFER_LEN, out int exception, out object exResult);
             if (exception != 0)
                 throw new Exception((string)exResult);
             return new string(buffer, 0, resultLength);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -12,31 +12,31 @@ namespace System.Globalization
         private const int CULTURE_INFO_BUFFER_LEN = 50;
         private const int LOCALE_INFO_BUFFER_LEN = 80;
 
-        private static CultureData JSInitLocaleInfo(string? localeName, CultureData culture)
+        private void JSInitLocaleInfo()
         {
+            string? localeName = _sName;
             if (string.IsNullOrEmpty(localeName))
             {
-                culture._sEnglishLanguage = "Invariant Language";
-                culture._sNativeLanguage = culture._sEnglishLanguage;
-                culture._sEnglishCountry = "Invariant Country";
-                culture._sNativeCountry = culture._sEnglishCountry;
-                culture._sEnglishDisplayName = $"{culture._sEnglishLanguage} ({culture._sEnglishCountry})";
-                culture._sNativeDisplayName = culture._sEnglishDisplayName;
+                _sEnglishLanguage = "Invariant Language";
+                _sNativeLanguage = _sEnglishLanguage;
+                _sEnglishCountry = "Invariant Country";
+                _sNativeCountry = _sEnglishCountry;
+                _sEnglishDisplayName = $"{_sEnglishLanguage} ({_sEnglishCountry})";
+                _sNativeDisplayName = _sEnglishDisplayName;
             }
             else
             {
                 // English locale info
-                (culture._sEnglishLanguage, culture._sEnglishCountry) = culture.JSGetLocaleInfo("en-US", localeName);
-                culture._sEnglishDisplayName = string.IsNullOrEmpty(culture._sEnglishCountry) ?
-                    culture._sEnglishLanguage :
-                    $"{culture._sEnglishLanguage} ({culture._sEnglishCountry})";
+                (_sEnglishLanguage, _sEnglishCountry) = JSGetLocaleInfo("en-US", localeName);
+                _sEnglishDisplayName = string.IsNullOrEmpty(_sEnglishCountry) ?
+                    _sEnglishLanguage :
+                    $"{_sEnglishLanguage} ({_sEnglishCountry})";
                 // Native locale info
-                (culture._sNativeLanguage, culture._sNativeCountry) = culture.JSGetLocaleInfo(localeName, localeName);
-                culture._sNativeDisplayName = string.IsNullOrEmpty(culture._sNativeCountry) ?
-                    culture._sNativeLanguage :
-                    $"{culture._sNativeLanguage} ({culture._sNativeCountry})";
+                (_sNativeLanguage, _sNativeCountry) = JSGetLocaleInfo(localeName, localeName);
+                _sNativeDisplayName = string.IsNullOrEmpty(_sNativeCountry) ?
+                    _sNativeLanguage :
+                    $"{_sNativeLanguage} ({_sNativeCountry})";
             }
-            return culture;
         }
 
         private unsafe (string, string) JSGetLocaleInfo(string cultureName, string localeName)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Browser.cs
@@ -11,6 +11,22 @@ namespace System.Globalization
     {
         private const int CULTURE_INFO_BUFFER_LEN = 50;
 
+        private unsafe string JSGetNativeName(string localeName, string? uiCultureName = null)
+        {
+            if (string.IsNullOrEmpty(localeName))
+                return "Invariant Language (Invariant Country)";
+
+            string cultureName = uiCultureName ?? localeName;
+            // the longest possible NativeName is 50 characters
+            char* buffer = stackalloc char[CULTURE_INFO_BUFFER_LEN];
+            int exception;
+            object exResult;
+            int resultLength = Interop.JsGlobalization.GetNativeName(localeName, cultureName, buffer, CULTURE_INFO_BUFFER_LEN, out exception, out exResult);
+            if (exception != 0)
+                throw new Exception((string)exResult);
+            return new string(buffer, 0, resultLength);
+        }
+
         private static unsafe CultureData JSLoadCultureInfoFromBrowser(string localeName, CultureData culture)
         {
             char* buffer = stackalloc char[CULTURE_INFO_BUFFER_LEN];

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -203,7 +203,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(_sWindowsName != null, "[CultureData.IcuGetLocaleInfo] Expected _sWindowsName to be populated already");
-#if TARGET_BROWSER
+#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
             if (type == LocaleStringData.NativeDisplayName)
             {
                 return JSGetNativeDisplayName(_sWindowsName, uiCultureName ?? _sWindowsName);
@@ -310,7 +310,7 @@ namespace System.Globalization
 
         private string IcuGetLanguageDisplayName(string cultureName)
         {
-#if TARGET_BROWSER
+#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
             return JSGetNativeDisplayName(CultureInfo.CurrentUICulture.Name, cultureName);
 #else
             return IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName, CultureInfo.CurrentUICulture.Name);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -203,6 +203,12 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(_sWindowsName != null, "[CultureData.IcuGetLocaleInfo] Expected _sWindowsName to be populated already");
+#if TARGET_BROWSER
+            if (type == LocaleStringData.NativeDisplayName)
+            {
+                return JSGetNativeName(_sWindowsName, uiCultureName);
+            }
+#endif
             return IcuGetLocaleInfo(_sWindowsName, type, uiCultureName);
         }
 
@@ -302,7 +308,14 @@ namespace System.Globalization
         // no support to lookup by region name, other than the hard-coded list in CultureData
         private static CultureData? IcuGetCultureDataFromRegionName() => null;
 
-        private string IcuGetLanguageDisplayName(string cultureName) => IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName, CultureInfo.CurrentUICulture.Name);
+        private string IcuGetLanguageDisplayName(string cultureName)
+        {
+#if TARGET_BROWSER
+            return JSGetNativeName(CultureInfo.CurrentUICulture.Name, cultureName);
+#else
+            return IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName, CultureInfo.CurrentUICulture.Name);
+#endif
+        }
 
         // use the fallback which is to return NativeName
         private static string? IcuGetRegionDisplayName() => null;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Icu.cs
@@ -206,7 +206,7 @@ namespace System.Globalization
 #if TARGET_BROWSER
             if (type == LocaleStringData.NativeDisplayName)
             {
-                return JSGetNativeName(_sWindowsName, uiCultureName);
+                return JSGetNativeDisplayName(_sWindowsName, uiCultureName ?? _sWindowsName);
             }
 #endif
             return IcuGetLocaleInfo(_sWindowsName, type, uiCultureName);
@@ -311,7 +311,7 @@ namespace System.Globalization
         private string IcuGetLanguageDisplayName(string cultureName)
         {
 #if TARGET_BROWSER
-            return JSGetNativeName(CultureInfo.CurrentUICulture.Name, cultureName);
+            return JSGetNativeDisplayName(CultureInfo.CurrentUICulture.Name, cultureName);
 #else
             return IcuGetLocaleInfo(cultureName, LocaleStringData.LocalizedDisplayName, CultureInfo.CurrentUICulture.Name);
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -816,7 +816,7 @@ namespace System.Globalization
             {
                 return null;
             }
-#if TARGET_BROWSER
+#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
             // populate fields for which ICU does not provide data in Hybrid mode
             if (GlobalizationMode.Hybrid && !string.IsNullOrEmpty(culture._sName))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -822,6 +822,7 @@ namespace System.Globalization
             {
                 culture = JSLoadCultureInfoFromBrowser(culture._sName, culture);
             }
+            culture = JSInitLocaleInfo(culture._sName, culture);
 #endif
 
             // We need _sWindowsName to be initialized to know if we're using overrides.

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -822,7 +822,7 @@ namespace System.Globalization
             {
                 culture = JSLoadCultureInfoFromBrowser(culture._sName, culture);
             }
-            culture = JSInitLocaleInfo(culture._sName, culture);
+            culture.JSInitLocaleInfo();
 #endif
 
             // We need _sWindowsName to be initialized to know if we're using overrides.

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoEnglishName.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoEnglishName.cs
@@ -9,13 +9,14 @@ namespace System.Globalization.Tests
     public class CultureInfoEnglishName
     {
         // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-        public static bool SupportFullGlobalizationData => PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid;
+        // Browser uses JS to get the NativeName that is missing in ICU
+        public static bool SupportFullGlobalizationData => !PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform;
 
         public static IEnumerable<object[]> EnglishName_TestData()
         {
             yield return new object[] { CultureInfo.CurrentCulture.Name, CultureInfo.CurrentCulture.EnglishName };
 
-            if (SupportFullGlobalizationData || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            if (SupportFullGlobalizationData)
             {
                 yield return new object[] { "en-US", "English (United States)" };
                 yield return new object[] { "fr-FR", "French (France)" };
@@ -41,12 +42,12 @@ namespace System.Globalization.Tests
         public void ChineseNeutralEnglishName()
         {
             CultureInfo ci = new CultureInfo("zh-Hans");
-            Assert.True(ci.EnglishName == "Chinese (Simplified)" || ci.EnglishName == "Chinese, Simplified",
-                        $"'{ci.EnglishName}' not equal to `Chinese (Simplified)` nor `Chinese, Simplified`");
+            Assert.True(ci.EnglishName == "Chinese (Simplified)" || ci.EnglishName == "Chinese, Simplified" || ci.EnglishName == "Simplified Chinese",
+                        $"'{ci.EnglishName}' not equal to `Chinese (Simplified)` nor `Chinese, Simplified` nor `Simplified Chinese`");
 
             ci = new CultureInfo("zh-HanT");
-            Assert.True(ci.EnglishName == "Chinese (Traditional)" || ci.EnglishName == "Chinese, Traditional",
-                        $"'{ci.EnglishName}' not equal to `Chinese (Traditional)` nor `Chinese, Traditional`");
+            Assert.True(ci.EnglishName == "Chinese (Traditional)" || ci.EnglishName == "Chinese, Traditional" || ci.EnglishName == "Traditional Chinese",
+                        $"'{ci.EnglishName}' not equal to `Chinese (Traditional)` nor `Chinese, Traditional` nor `Traditional Chinese`");
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoEnglishName.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoEnglishName.cs
@@ -9,8 +9,9 @@ namespace System.Globalization.Tests
     public class CultureInfoEnglishName
     {
         // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-        // Browser uses JS to get the NativeName that is missing in ICU
-        public static bool SupportFullGlobalizationData => !PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform;
+        // Browser uses JS to get the NativeName that is missing in ICU (in the singlethreaded runtime only)
+        public static bool SupportFullGlobalizationData =>
+            (!PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform) && !PlatformDetection.IsWasmThreadingSupported;
 
         public static IEnumerable<object[]> EnglishName_TestData()
         {
@@ -24,7 +25,6 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // Mobile / Browser ICU doesn't contain CultureInfo.EnglishName
                 yield return new object[] { "en-US", "en (US)" };
                 yield return new object[] { "fr-FR", "fr (FR)" };
             }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNames.cs
@@ -10,19 +10,31 @@ namespace System.Globalization.Tests
 {
     public class CultureInfoNames
     {
-        private static bool SupportFullIcuResources => (PlatformDetection.IsNotMobile && PlatformDetection.IsIcuGlobalization) || PlatformDetection.IsHybridGlobalizationOnApplePlatform;
+        private static bool SupportFullIcuResources =>
+            (PlatformDetection.IsNotMobile && PlatformDetection.IsIcuGlobalization) ||
+            PlatformDetection.IsHybridGlobalizationOnApplePlatform ||
+            PlatformDetection.IsBrowser;
+        
+        public static IEnumerable<object[]> SupportedCultures_TestData()
+        {
+            // Browser does not support all ICU locales but it uses JS to get the correct native name
+            if (!PlatformDetection.IsBrowser)
+            {
+                yield return new object[] { "aa", "aa", "Afar", "Afar" };
+                yield return new object[] { "aa-ER", "aa-ER", "Afar (Eritrea)", "Afar (Eritrea)" };
+            }
+            yield return new object[] { "en", "en", "English", "English" };
+            yield return new object[] { "en", "fr", "English", "anglais" };
+            yield return new object[] { "en-US", "en-US", "English (United States)", "English (United States)" };
+            yield return new object[] { "en-US", "fr-FR", "English (United States)", "anglais (\u00C9tats-Unis)" };
+            yield return new object[] { "en-US", "de-DE", "English (United States)", "Englisch (Vereinigte Staaten)" };
+            yield return new object[] { "", "en-US", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)" };
+            yield return new object[] { "", "fr-FR", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)" };
+            yield return new object[] { "", "", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)" };
+        }
 
         [ConditionalTheory(nameof(SupportFullIcuResources))]
-        [InlineData("en", "en", "English", "English")]
-        [InlineData("en", "fr", "English", "anglais")]
-        [InlineData("aa", "aa", "Afar", "Afar")]
-        [InlineData("en-US", "en-US", "English (United States)", "English (United States)")]
-        [InlineData("en-US", "fr-FR", "English (United States)", "anglais (\u00C9tats-Unis)")]
-        [InlineData("en-US", "de-DE", "English (United States)", "Englisch (Vereinigte Staaten)")]
-        [InlineData("aa-ER", "aa-ER", "Afar (Eritrea)", "Afar (Eritrea)")]
-        [InlineData("", "en-US", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
-        [InlineData("", "fr-FR", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
-        [InlineData("", "", "Invariant Language (Invariant Country)", "Invariant Language (Invariant Country)")]
+        [MemberData(nameof(SupportedCultures_TestData))]
         public void TestDisplayName(string cultureName, string uiCultureName, string nativeName, string displayName)
         {
             using (new ThreadCultureChange(null, CultureInfo.GetCultureInfo(uiCultureName)))

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNames.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNames.cs
@@ -10,10 +10,10 @@ namespace System.Globalization.Tests
 {
     public class CultureInfoNames
     {
+        // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+        // Browser uses JS to get the NativeName that is missing in ICU (in the singlethreaded runtime only)
         private static bool SupportFullIcuResources =>
-            (PlatformDetection.IsNotMobile && PlatformDetection.IsIcuGlobalization) ||
-            PlatformDetection.IsHybridGlobalizationOnApplePlatform ||
-            PlatformDetection.IsBrowser;
+            !PlatformDetection.IsWasi && !PlatformDetection.IsAndroid && PlatformDetection.IsIcuGlobalization && !PlatformDetection.IsWasmThreadingSupported;
         
         public static IEnumerable<object[]> SupportedCultures_TestData()
         {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNativeName.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNativeName.cs
@@ -13,7 +13,8 @@ namespace System.Globalization.Tests
             yield return new object[] { CultureInfo.CurrentCulture.Name, CultureInfo.CurrentCulture.NativeName };
 
             // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            // Browser uses JS to get the NativeName that is missing in ICU
+            if (!PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
             {
                 yield return new object[] { "en-US", "English (United States)" };
                 yield return new object[] { "en-CA", "English (Canada)" };
@@ -21,7 +22,7 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // Mobile / Browser ICU doesn't contain CultureInfo.NativeName
+                // WASI's ICU doesn't contain CultureInfo.NativeName
                 yield return new object[] { "en-US", "en (US)" };
                 yield return new object[] { "en-CA", "en (CA)" };
             }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNativeName.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/CultureInfo/CultureInfoNativeName.cs
@@ -8,13 +8,16 @@ namespace System.Globalization.Tests
 {
     public class CultureInfoNativeName
     {
+        // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+        // Browser uses JS to get the NativeName that is missing in ICU (in the singlethreaded runtime only)
+        private static bool SupportFullIcuResources =>
+            (!PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform) && !PlatformDetection.IsWasmThreadingSupported;
+
         public static IEnumerable<object[]> NativeName_TestData()
         {
             yield return new object[] { CultureInfo.CurrentCulture.Name, CultureInfo.CurrentCulture.NativeName };
 
-            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            // Browser uses JS to get the NativeName that is missing in ICU
-            if (!PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            if (SupportFullIcuResources)
             {
                 yield return new object[] { "en-US", "English (United States)" };
                 yield return new object[] { "en-CA", "English (Canada)" };
@@ -22,7 +25,6 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // WASI's ICU doesn't contain CultureInfo.NativeName
                 yield return new object[] { "en-US", "en (US)" };
                 yield return new object[] { "en-CA", "en (CA)" };
             }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
@@ -136,7 +136,7 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, new RegionInfo(name).NativeName);
         }
 
-        public static IEnumerable<object[]> EnglishName_TestData() // this might be failing, in that case - fix it or block it
+        public static IEnumerable<object[]> EnglishName_TestData()
         {
             if (SupportFullGlobalizationData)
             {

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
@@ -102,7 +102,6 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", "United States")]
         [OuterLoop("May fail on machines with multiple language packs installed")] // see https://github.com/dotnet/runtime/issues/30132
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/45951", TestPlatforms.Browser)]
         public void DisplayName(string name, string expected)
         {
             using (new ThreadCultureChange(null, new CultureInfo(name)))

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
@@ -12,7 +12,10 @@ namespace System.Globalization.Tests
 {
     public class RegionInfoPropertyTests
     {
-        public static bool SupportFullGlobalizationData => !PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform;
+        // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
+        // Browser uses JS to get the NativeName that is missing in ICU (in the singlethreaded runtime only)
+        public static bool SupportFullGlobalizationData =>
+            (!PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform) && !PlatformDetection.IsWasmThreadingSupported;
 
         [Theory]
         [InlineData("US", "US", "US")]
@@ -112,8 +115,6 @@ namespace System.Globalization.Tests
 
         public static IEnumerable<object[]> NativeName_TestData()
         {
-            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            // Browser uses JS to get the NativeName that is missing in ICU
             if (SupportFullGlobalizationData)
             {
                 yield return new object[] { "GB", "United Kingdom" };
@@ -122,7 +123,6 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // WASI's ICU doesn't contain RegionInfo.NativeName
                 yield return new object[] { "GB", "GB" };
                 yield return new object[] { "SE", "SE" };
                 yield return new object[] { "FR", "FR" };
@@ -138,8 +138,6 @@ namespace System.Globalization.Tests
 
         public static IEnumerable<object[]> EnglishName_TestData() // this might be failing, in that case - fix it or block it
         {
-            // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            // Browser uses JS to get the NativeName that is missing in ICU
             if (SupportFullGlobalizationData)
             {
                 yield return new object[] { "en-US", new string[] { "United States" } };
@@ -149,7 +147,6 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // WASI's ICU doesn't contain RegionInfo.EnglishName
                 yield return new object[] { "en-US", new string[] { "US" } };
                 yield return new object[] { "US", new string[] { "US" } };
                 yield return new object[] { "zh-CN", new string[] { "CN" }};

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/System/Globalization/RegionInfoTests.cs
@@ -12,6 +12,8 @@ namespace System.Globalization.Tests
 {
     public class RegionInfoPropertyTests
     {
+        public static bool SupportFullGlobalizationData => !PlatformDetection.IsWasi || PlatformDetection.IsHybridGlobalizationOnApplePlatform;
+
         [Theory]
         [InlineData("US", "US", "US")]
         [InlineData("IT", "IT", "IT")]
@@ -112,7 +114,8 @@ namespace System.Globalization.Tests
         public static IEnumerable<object[]> NativeName_TestData()
         {
             // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            // Browser uses JS to get the NativeName that is missing in ICU
+            if (SupportFullGlobalizationData)
             {
                 yield return new object[] { "GB", "United Kingdom" };
                 yield return new object[] { "SE", "Sverige" };
@@ -120,7 +123,7 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // Browser's ICU doesn't contain RegionInfo.NativeName
+                // WASI's ICU doesn't contain RegionInfo.NativeName
                 yield return new object[] { "GB", "GB" };
                 yield return new object[] { "SE", "SE" };
                 yield return new object[] { "FR", "FR" };
@@ -134,10 +137,11 @@ namespace System.Globalization.Tests
             Assert.Equal(expected, new RegionInfo(name).NativeName);
         }
 
-        public static IEnumerable<object[]> EnglishName_TestData()
+        public static IEnumerable<object[]> EnglishName_TestData() // this might be failing, in that case - fix it or block it
         {
             // Android has its own ICU, which doesn't 100% map to UsingLimitedCultures
-            if (PlatformDetection.IsNotUsingLimitedCultures || PlatformDetection.IsAndroid || PlatformDetection.IsHybridGlobalizationOnApplePlatform)
+            // Browser uses JS to get the NativeName that is missing in ICU
+            if (SupportFullGlobalizationData)
             {
                 yield return new object[] { "en-US", new string[] { "United States" } };
                 yield return new object[] { "US", new string[] { "United States" } };
@@ -146,7 +150,7 @@ namespace System.Globalization.Tests
             }
             else
             {
-                // Browser's ICU doesn't contain RegionInfo.EnglishName
+                // WASI's ICU doesn't contain RegionInfo.EnglishName
                 yield return new object[] { "en-US", new string[] { "US" } };
                 yield return new object[] { "US", new string[] { "US" } };
                 yield return new object[] { "zh-CN", new string[] { "CN" }};

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -64,6 +64,7 @@ extern mono_bool mono_wasm_starts_with (MonoString **culture, const uint16_t* st
 extern mono_bool mono_wasm_ends_with (MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_index_of (MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options, mono_bool fromBeginning, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_calendar_info (MonoString **culture, int32_t calendarId, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
+extern int mono_wasm_get_native_display_name (MonoString **locale, MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_culture_info (MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_day_of_week (MonoString **culture, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_week_of_year (MonoString **culture, int *is_exception, MonoObject** ex_result);
@@ -105,6 +106,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/JsGlobalization::EndsWith", mono_wasm_ends_with);
 	mono_add_internal_call ("Interop/JsGlobalization::IndexOf", mono_wasm_index_of);
 	mono_add_internal_call ("Interop/JsGlobalization::GetCalendarInfo", mono_wasm_get_calendar_info);
+	mono_add_internal_call ("Interop/JsGlobalization::GetNativeName", mono_wasm_get_native_display_name);
 	mono_add_internal_call ("Interop/JsGlobalization::GetCultureInfo", mono_wasm_get_culture_info);
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstDayOfWeek", mono_wasm_get_first_day_of_week);
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstWeekOfYear", mono_wasm_get_first_week_of_year);

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -64,7 +64,7 @@ extern mono_bool mono_wasm_starts_with (MonoString **culture, const uint16_t* st
 extern mono_bool mono_wasm_ends_with (MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_index_of (MonoString **culture, const uint16_t* str1, int32_t str1Length, const uint16_t* str2, int32_t str2Length, int32_t options, mono_bool fromBeginning, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_calendar_info (MonoString **culture, int32_t calendarId, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
-extern int mono_wasm_get_native_display_name (MonoString **locale, MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
+extern int mono_wasm_get_locale_info (MonoString **locale, MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_culture_info (MonoString **culture, const uint16_t* result, int32_t resultLength, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_day_of_week (MonoString **culture, int *is_exception, MonoObject** ex_result);
 extern int mono_wasm_get_first_week_of_year (MonoString **culture, int *is_exception, MonoObject** ex_result);
@@ -106,7 +106,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/JsGlobalization::EndsWith", mono_wasm_ends_with);
 	mono_add_internal_call ("Interop/JsGlobalization::IndexOf", mono_wasm_index_of);
 	mono_add_internal_call ("Interop/JsGlobalization::GetCalendarInfo", mono_wasm_get_calendar_info);
-	mono_add_internal_call ("Interop/JsGlobalization::GetNativeName", mono_wasm_get_native_display_name);
+	mono_add_internal_call ("Interop/JsGlobalization::GetLocaleInfo", mono_wasm_get_locale_info);
 	mono_add_internal_call ("Interop/JsGlobalization::GetCultureInfo", mono_wasm_get_culture_info);
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstDayOfWeek", mono_wasm_get_first_day_of_week);
 	mono_add_internal_call ("Interop/JsGlobalization::GetFirstWeekOfYear", mono_wasm_get_first_week_of_year);

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -22,7 +22,7 @@ import { mono_wasm_compare_string, mono_wasm_ends_with, mono_wasm_starts_with, m
 import { mono_wasm_get_calendar_info } from "./hybrid-globalization/calendar";
 
 import { mono_wasm_get_culture_info } from "./hybrid-globalization/culture-info";
-import { mono_wasm_get_first_day_of_week, mono_wasm_get_first_week_of_year } from "./hybrid-globalization/locales";
+import { mono_wasm_get_native_display_name, mono_wasm_get_first_day_of_week, mono_wasm_get_first_week_of_year } from "./hybrid-globalization/locales";
 import { mono_wasm_browser_entropy } from "./crypto";
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 
@@ -107,6 +107,7 @@ export const mono_wasm_imports = [
     mono_wasm_index_of,
     mono_wasm_get_calendar_info,
     mono_wasm_get_culture_info,
+    mono_wasm_get_native_display_name,
     mono_wasm_get_first_day_of_week,
     mono_wasm_get_first_week_of_year,
 ];

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -22,7 +22,7 @@ import { mono_wasm_compare_string, mono_wasm_ends_with, mono_wasm_starts_with, m
 import { mono_wasm_get_calendar_info } from "./hybrid-globalization/calendar";
 
 import { mono_wasm_get_culture_info } from "./hybrid-globalization/culture-info";
-import { mono_wasm_get_native_display_name, mono_wasm_get_first_day_of_week, mono_wasm_get_first_week_of_year } from "./hybrid-globalization/locales";
+import { mono_wasm_get_locale_info, mono_wasm_get_first_day_of_week, mono_wasm_get_first_week_of_year } from "./hybrid-globalization/locales";
 import { mono_wasm_browser_entropy } from "./crypto";
 import { mono_wasm_cancel_promise } from "./cancelable-promise";
 
@@ -107,7 +107,7 @@ export const mono_wasm_imports = [
     mono_wasm_index_of,
     mono_wasm_get_calendar_info,
     mono_wasm_get_culture_info,
-    mono_wasm_get_native_display_name,
+    mono_wasm_get_locale_info,
     mono_wasm_get_first_day_of_week,
     mono_wasm_get_first_week_of_year,
 ];

--- a/src/mono/browser/runtime/hybrid-globalization/helpers.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/helpers.ts
@@ -25,9 +25,9 @@ export function normalizeLocale(locale: string | null)
         const canonicalLocales = (Intl as any).getCanonicalLocales(locale.replace("_", "-"));
         return canonicalLocales.length > 0 ? canonicalLocales[0] : undefined;
     }
-    catch(ex: any)
+    catch
     {
-        throw new Error(`Get culture info failed for culture = ${locale} with error: ${ex}`);
+        return undefined;
     }
 }
 

--- a/src/mono/browser/runtime/hybrid-globalization/locales.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/locales.ts
@@ -48,7 +48,7 @@ export function mono_wasm_get_locale_info(culture: MonoStringRef, locale: MonoSt
         {
             if (error instanceof RangeError && error.message === "invalid_argument")
             {
-                // it failed from this reason then cultureName is in a form "language-script", without region
+                // if it failed from this reason then cultureName is in a form "language-script", without region
                 try
                 {
                     languageName = new Intl.DisplayNames([cultureName], {type: "language"}).of(localeName);

--- a/src/mono/browser/runtime/hybrid-globalization/locales.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/locales.ts
@@ -29,7 +29,7 @@ export function mono_wasm_get_locale_info(culture: MonoStringRef, locale: MonoSt
         if (!localeName || !cultureName)
             throw new Error(`Locale or culture name is null or empty. localeName=${localeName}, cultureName=${cultureName}`);
 
-        const localeParts = localeName.split("-"); // de-DE-u-co-phonebk-u-xx
+        const localeParts = localeName.split("-");
         // cultureName can be in a form of:
         // 1) "language", e.g. "zh"
         // 2) "language-region", e.g. "zn-CN"

--- a/src/mono/browser/runtime/hybrid-globalization/locales.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/locales.ts
@@ -89,7 +89,7 @@ function getFirstDayOfWeek(locale: string)
     const weekInfo = getWeekInfo(locale);
     if (weekInfo)
     {
-        // JS"s Sunday == 7 while dotnet"s Sunday == 0
+        // JS's Sunday == 7 while dotnet's Sunday == 0
         return weekInfo.firstDay == 7 ? 0 : weekInfo.firstDay;
     }
     // Firefox does not support it rn but we can make a temporary workaround for it,

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
@@ -141,11 +141,11 @@ public class WorkloadRequiredTests : BlazorWasmTestBase
         }
         else
         {
-            string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "es-ES" : "espa\u00F1ol (Espa\u00F1a)"; // MT does not use JS to get the full name
             Assert.DoesNotContain("Could not create es-ES culture", output);
             Assert.DoesNotContain("invalid culture", output);
             Assert.DoesNotContain("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
-            Assert.Contains($"es-ES: Is-LCID-InvariantCulture: False, NativeName: {nativeName}", output);
+            Assert.Contains("es-ES: Is Invariant LCID: False", output);
+            Assert.Contains("NativeName: espa\u00F1ol (Espa\u00F1a)", output);
 
             // ignoring the last line of the output which prints the current culture
         }

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
@@ -144,7 +144,7 @@ public class WorkloadRequiredTests : BlazorWasmTestBase
             Assert.DoesNotContain("Could not create es-ES culture", output);
             Assert.DoesNotContain("invalid culture", output);
             Assert.DoesNotContain("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
-            Assert.Contains("es-ES: Is Invariant LCID: False", output);
+            Assert.Contains("es-ES: Is-LCID-InvariantCulture: False", output);
             Assert.Contains("NativeName: espa\u00F1ol (Espa\u00F1a)", output);
 
             // ignoring the last line of the output which prints the current culture

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/WorkloadRequiredTests.cs
@@ -141,10 +141,11 @@ public class WorkloadRequiredTests : BlazorWasmTestBase
         }
         else
         {
+            string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "es-ES" : "espa\u00F1ol (Espa\u00F1a)"; // MT does not use JS to get the full name
             Assert.DoesNotContain("Could not create es-ES culture", output);
             Assert.DoesNotContain("invalid culture", output);
             Assert.DoesNotContain("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
-            Assert.Contains("es-ES: Is-LCID-InvariantCulture: False, NativeName: es (ES)", output);
+            Assert.Contains($"es-ES: Is-LCID-InvariantCulture: False, NativeName: {nativeName}", output);
 
             // ignoring the last line of the output which prints the current culture
         }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -69,9 +69,8 @@ namespace Wasm.Build.Tests
             }
             else
             {
-                string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
+                string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id, args: "nativename=\"espa\u00F1ol (Espa\u00F1a)\"");
                 Assert.Contains("es-ES: Is Invariant LCID: False", output);
-                Assert.Contains("NativeName: espa\u00F1ol (Espa\u00F1a)", output);
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -64,14 +64,14 @@ namespace Wasm.Build.Tests
             if (invariantGlobalization == true)
             {
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains("Could not create es-ES culture", output);
+                Assert.Contains("Could not create de-DE culture", output);
                 Assert.Contains("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
             }
             else
             {
-                string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "es-ES" : "espa\u00F1ol (Espa\u00F1a)"; // MT does not use JS to get the full name
+                string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "de-DE" : "Deutsch (Deutschland)"; // MT does not use JS to get the full name
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains($"es-ES: Is Invariant LCID: False, NativeName: {nativeName}", output);
+                Assert.Contains($"de-DE: Is Invariant LCID: False, NativeName: {nativeName}", output);
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -71,11 +71,7 @@ namespace Wasm.Build.Tests
             {
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
                 Assert.Contains("es-ES: Is Invariant LCID: False", output);
-#if FEATURE_WASM_MANAGED_THREADS
-                Assert.Contains("NativeName: es-ES", output); // MT does not use JS to get the full name
-#else
                 Assert.Contains("NativeName: espa\u00F1ol (Espa\u00F1a)", output);
-#endif
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -71,7 +71,8 @@ namespace Wasm.Build.Tests
             {
                 string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "de-DE" : "Deutsch (Deutschland)"; // MT does not use JS to get the full name
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains($"de-DE: Is Invariant LCID: False, NativeName: {nativeName}", output);
+                Assert.Contains("de-DE: Is Invariant LCID: False", output);
+                Assert.Contains($"NativeName: {nativeName}", output);
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -69,10 +69,13 @@ namespace Wasm.Build.Tests
             }
             else
             {
-                string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "de-DE" : "Deutsch (Deutschland)"; // MT does not use JS to get the full name
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
                 Assert.Contains("de-DE: Is Invariant LCID: False", output);
-                Assert.Contains($"NativeName: {nativeName}", output);
+#if FEATURE_WASM_MANAGED_THREADS
+                Assert.Contains("NativeName: de-DE", output); // MT does not use JS to get the full name
+#else
+                Assert.Contains("NativeName: Deutsch (Deutschland)", output);
+#endif
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -64,17 +64,17 @@ namespace Wasm.Build.Tests
             if (invariantGlobalization == true)
             {
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains("Could not create de-DE culture", output);
+                Assert.Contains("Could not create es-ES culture", output);
                 Assert.Contains("CurrentCulture.NativeName: Invariant Language (Invariant Country)", output);
             }
             else
             {
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains("de-DE: Is Invariant LCID: False", output);
+                Assert.Contains("es-ES: Is Invariant LCID: False", output);
 #if FEATURE_WASM_MANAGED_THREADS
-                Assert.Contains("NativeName: de-DE", output); // MT does not use JS to get the full name
+                Assert.Contains("NativeName: es-ES", output); // MT does not use JS to get the full name
 #else
-                Assert.Contains("NativeName: Deutsch (Deutschland)", output);
+                Assert.Contains("NativeName: espa\u00F1ol (Espa\u00F1a)", output);
 #endif
 
                 // ignoring the last line of the output which prints the current culture

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -70,7 +70,9 @@ namespace Wasm.Build.Tests
             else
             {
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains("es-ES: Is Invariant LCID: False, NativeName: es (ES)", output);
+                Assert.Contains(IsWorkloadWithMultiThreadingForDefaultFramework ?
+                    "es-ES: Is Invariant LCID: False, NativeName: es (ES)" : // MT does not use JS to get the full name
+                    "es-ES: Is Invariant LCID: False, NativeName: espa\u00F1ol (Espa\u00F1a)", output);
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/InvariantGlobalizationTests.cs
@@ -69,10 +69,9 @@ namespace Wasm.Build.Tests
             }
             else
             {
+                string nativeName = IsWorkloadWithMultiThreadingForDefaultFramework ? "es-ES" : "espa\u00F1ol (Espa\u00F1a)"; // MT does not use JS to get the full name
                 string output = RunAndTestWasmApp(buildArgs, expectedExitCode: 42, host: host, id: id);
-                Assert.Contains(IsWorkloadWithMultiThreadingForDefaultFramework ?
-                    "es-ES: Is Invariant LCID: False, NativeName: es (ES)" : // MT does not use JS to get the full name
-                    "es-ES: Is Invariant LCID: False, NativeName: espa\u00F1ol (Espa\u00F1a)", output);
+                Assert.Contains($"es-ES: Is Invariant LCID: False, NativeName: {nativeName}", output);
 
                 // ignoring the last line of the output which prints the current culture
             }

--- a/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
+++ b/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
@@ -1,11 +1,20 @@
 using System;
 using System.Globalization;
+using System.Linq;
 
 // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
 try
 {
     CultureInfo culture = new ("es-ES", false);
-    Console.WriteLine($"es-ES: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
+    Console.WriteLine($"es-ES: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}");
+    
+    var nativeNameArg = args.FirstOrDefault(arg => arg.StartsWith("nativename="));
+    if (nativeNameArg == null)
+        throw new ArgumentException($"When not in invariant mode, InvariantGlobalization.cs expects nativename argument with expected es-ES NativeName.");
+    string expectedNativeName = nativeNameArg.Substring(11).Trim('"'); // skip nativename=
+    string nativeName = culture.NativeName;
+    if (nativeName != expectedNativeName)
+        throw new ArgumentException($"Expected es-ES NativeName: {expectedNativeName}, but got: {nativeName}");
 }
 catch (CultureNotFoundException cnfe)
 {

--- a/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
+++ b/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
@@ -4,12 +4,12 @@ using System.Globalization;
 // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
 try
 {
-    CultureInfo culture = new ("de-DE", false);
+    CultureInfo culture = new ("es-ES", false);
     Console.WriteLine($"de-DE: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
 }
 catch (CultureNotFoundException cnfe)
 {
-    Console.WriteLine($"Could not create de-DE culture: {cnfe.Message}");
+    Console.WriteLine($"Could not create es-ES culture: {cnfe.Message}");
 }
 
 Console.WriteLine($"CurrentCulture.NativeName: {CultureInfo.CurrentCulture.NativeName}");

--- a/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
+++ b/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
@@ -4,12 +4,12 @@ using System.Globalization;
 // https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md#cultures-and-culture-data
 try
 {
-    CultureInfo culture = new ("es-ES", false);
-    Console.WriteLine($"es-ES: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
+    CultureInfo culture = new ("de-DE", false);
+    Console.WriteLine($"de-DE: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
 }
 catch (CultureNotFoundException cnfe)
 {
-    Console.WriteLine($"Could not create es-ES culture: {cnfe.Message}");
+    Console.WriteLine($"Could not create de-DE culture: {cnfe.Message}");
 }
 
 Console.WriteLine($"CurrentCulture.NativeName: {CultureInfo.CurrentCulture.NativeName}");

--- a/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
+++ b/src/mono/wasm/testassets/Wasm.Buid.Tests.Programs/InvariantGlobalization.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 try
 {
     CultureInfo culture = new ("es-ES", false);
-    Console.WriteLine($"de-DE: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
+    Console.WriteLine($"es-ES: Is Invariant LCID: {culture.LCID == CultureInfo.InvariantCulture.LCID}, NativeName: {culture.NativeName}");
 }
 catch (CultureNotFoundException cnfe)
 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/44739, https://github.com/dotnet/runtime/issues/45951.

## Reason for this PR:
For size savings we removed `lang_tree` and `region_tree` from [ICU WASM filters](https://github.com/dotnet/icu/blob/dotnet/main/icu-filters/icudt_wasm.json). We were returning a short form of `NativeName` and `DisplayName` for ~200 supported locales in the browser, e.g. `en (US)`. After experimenting with `HybridGlobalization` we proved that we can get the missing data from JS to patch the regression caused by the size reduction. Now, `NativeName` and `DisplayName` will be fetched from WebAPI `Intl.DisplayNames`. Other Globalization APIs (other `LocaleStringData` types) continue to be fetched from ICU.

## Logic change

### Without this PR:
We ask ICU about `NativeDisplayName` but it does not have this info and returns empty data. In https://github.com/dotnet/runtime/blob/8fbfb3204abba1eb7b42c617a656fa6aff8df84c/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs#L1086 we construct the backup response on the managed side.
Similar mechanism is used for `LocalizedDisplayName`.

`new CultureInfo("zh-Hans").EnglishName` -> "zh-Hans"

### With this PR:
For all `LocaleStringData` types but `NativeDisplayName`, `EnglishDisplayName` and `LocalizedDisplayName` we continue fetching the data from ICU. In these three cases we call to JS.

Fixed APIs:
`CultureInfo.NativeName`, `CultureInfo.EnglishName`, `CultureInfo.DisplayName`, `RegionInfo.NativeName`, `RegionInfo.EnglishName`, `RegionInfo.DisplayName`. 
They depend on ECMAScript's `Intl` API, so some responses might differ from ICU responses, e.g. `new CultureInfo("zh-Hans").EnglishName` -> "Simplified Chinese", not "Chinese (Simplified)".

Result:
```
Thread.CurrentThread.CurrentCulture = new CultureInfo("zh-Hans-CN");
var native = Thread.CurrentThread.CurrentCulture.NativeName;
Console.WriteLine(native); // Simplified Chinese (China)'
```

## Performance impact

The `CultureInfo` constructor call interops with JS / ICU API, the next calls to `English/Native` properties rely on cached value.  Measuring performance for `NativeName` and `DisplayName`:
### Without this PR:
```
  |                     String, NativeName |     0.3859us |
  |                    String, DisplayName |     0.3859us |
```
### With this PR:
```
  |                     String, NativeName |     0.5079us |
  |                    String, DisplayName |     0.5039us |
```
Multithreaded runtime still uses the truncated data version, fetching data from JS fails there see: https://github.com/dotnet/runtime/issues/98483
```
System.Globalization.Tests.CompareInfoTests.GetCompareInfo(name: "zh-Hans")
[21:06:32] info: System.TypeInitializationException : Exception of type 'System.TypeInitializationException' was thrown.
[21:06:32] info:    at System.Object.InvokeStub_CompareInfoTests..ctor(Object , Object , IntPtr* )
[21:06:32] info:    at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
```