### PR TITLE
Fix detection of exceptionally called funclet in stack walk

### DIFF
--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1907,9 +1907,11 @@ ProcessFuncletsForGCReporting:
 
                                         if (g_isNewExceptionHandlingEnabled)
                                         {
-                                            if (!m_fFoundFirstFunclet &&  pExInfo > (void*)GetRegdisplaySP(m_crawl.GetRegisterSet()))
+                                            if (!m_fFoundFirstFunclet && (pExInfo > (void*)GetRegdisplaySP(m_crawl.GetRegisterSet())) && ((void*)m_sfParent.SP > pExInfo))
                                             {
-                                                // For the first funclet we encounter below the topmost ExInfo, we instruct the GC scanning of the frame
+                                                // For the first funclet we encounter below the topmost ExInfo that has a parent above that ExInfo
+                                                // (so it is an exceptionally called funclet for the exception represented by the ExInfo),
+                                                // we instruct the GC scanning of the frame
                                                 // to save information on the funclet so that we can use it to report references in the parent frame if
                                                 // no such funclet is found in future GC scans for the same exception.
                                                 _ASSERTE(pExInfo != NULL);


### PR DESCRIPTION
There is a problem with stack walking detecting funclets called during exception handling with the new EH enabled. The code was considering any funclet it found below the topmost `ExInfo`, but I have not realized it can also hit non-exceptionally called finallys. Those don't have any exception handling going on and thus are incorrectly used for storing information that it used later at the parent to track GC references. We need to consider only funclets that were called exceptionally.

Close #99884