### PR TITLE
Switch to iSimdVector and Align WidenAsciiToUtf16

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
@@ -553,11 +553,18 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
-        /// <summary>Checks if the MSB of any of the vector lanes is non zero.</summary>
-        /// <param name="vector">The vector to check MSB.</param>
-        /// <returns><c>true</c> if <paramref name="vector" /> has any lanes with a non-zero MSB otherwise, <c>false</c> if MSB is zero for all lanes />.</returns>
+        /// <summary>Checks if any of the vector lanes are equivalent to value.</summary>
+        /// <param name="vector">The Vector.</param>
+        /// <param name="value">The Value to check.</param>
+        /// <returns><c>true</c> if <paramref name="vector" /> has any lanes equivalent to <paramref name="value" /> otherwise, <c>false</c> if none of the lanes are equivalent to <paramref name="value" /> />.</returns>
         /// <exception cref="NotSupportedException">The type of the elements in the vector (<typeparamref name="T" />) is not supported.</exception>
-        static abstract bool AnyMatches(TSelf vector);
+        static abstract bool Any(TSelf vector, T value);
+
+        /// <summary>Checks if any of the vector lanes have All Bits set.</summary>
+        /// <param name="vector">The Vector to check.</param>
+        /// <returns><c>true</c> if <paramref name="vector" /> has any lanes with All Bits set otherwise, <c>false</c> if none of the lanes have All Bits set />.</returns>
+        /// <exception cref="NotSupportedException">The type of the elements in the vector (<typeparamref name="T" />) is not supported.</exception>
+        static abstract bool AnyWhereAllBitsSet(TSelf vector);
 
         static abstract int IndexOfLastMatch(TSelf vector);
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
@@ -553,6 +553,12 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
+        /// <summary>Checks if the MSB of any of the vector lanes is non zero.</summary>
+        /// <param name="vector">The vector to check MSB.</param>
+        /// <returns><c>true</c> if <paramref name="vector" /> has any lanes with a non-zero MSB otherwise, <c>false</c> if MSB is zero for all lanes />.</returns>
+        /// <exception cref="NotSupportedException">The type of the elements in the vector (<typeparamref name="T" />) is not supported.</exception>
+        static abstract bool AnyMatches(TSelf vector);
+
         static abstract int IndexOfLastMatch(TSelf vector);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
@@ -692,6 +692,11 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
+        static bool ISimdVector<Vector128<T>, T>.AnyMatches(Vector128<T> vector)
+        {
+            return (vector != Vector128<T>.Zero);
+        }
+
         static int ISimdVector<Vector128<T>, T>.IndexOfLastMatch(Vector128<T> vector)
         {
             uint mask = vector.ExtractMostSignificantBits();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
@@ -692,9 +692,14 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
-        static bool ISimdVector<Vector128<T>, T>.AnyMatches(Vector128<T> vector)
+        static bool ISimdVector<Vector128<T>, T>.AnyWhereAllBitsSet(Vector128<T> vector)
         {
-            return (vector != Vector128<T>.Zero);
+            return (Vector128.EqualsAny(vector, Vector128<T>.AllBitsSet));
+        }
+
+        static bool ISimdVector<Vector128<T>, T>.Any(Vector128<T> vector, T value)
+        {
+            return (Vector128.EqualsAny(vector, Vector128.Create((T)value)));
         }
 
         static int ISimdVector<Vector128<T>, T>.IndexOfLastMatch(Vector128<T> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
@@ -682,6 +682,11 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
+        static bool ISimdVector<Vector256<T>, T>.AnyMatches(Vector256<T> vector)
+        {
+            return (vector != Vector256<T>.Zero);
+        }
+
         static int ISimdVector<Vector256<T>, T>.IndexOfLastMatch(Vector256<T> vector)
         {
             uint mask = vector.ExtractMostSignificantBits();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
@@ -682,9 +682,14 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
-        static bool ISimdVector<Vector256<T>, T>.AnyMatches(Vector256<T> vector)
+        static bool ISimdVector<Vector256<T>, T>.AnyWhereAllBitsSet(Vector256<T> vector)
         {
-            return (vector != Vector256<T>.Zero);
+            return (Vector256.EqualsAny(vector, Vector256<T>.AllBitsSet));
+        }
+
+        static bool ISimdVector<Vector256<T>, T>.Any(Vector256<T> vector, T value)
+        {
+            return (Vector256.EqualsAny(vector, Vector256.Create((T)value)));
         }
 
         static int ISimdVector<Vector256<T>, T>.IndexOfLastMatch(Vector256<T> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
@@ -682,9 +682,14 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
-        static bool ISimdVector<Vector512<T>, T>.AnyMatches(Vector512<T> vector)
+        static bool ISimdVector<Vector512<T>, T>.AnyWhereAllBitsSet(Vector512<T> vector)
         {
-            return (vector != Vector512<T>.Zero);
+            return (Vector512.EqualsAny(vector, Vector512<T>.AllBitsSet));
+        }
+
+        static bool ISimdVector<Vector512<T>, T>.Any(Vector512<T> vector, T value)
+        {
+            return (Vector512.EqualsAny(vector, Vector512.Create((T)value)));
         }
 
         static int ISimdVector<Vector512<T>, T>.IndexOfLastMatch(Vector512<T> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
@@ -682,6 +682,11 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
+        static bool ISimdVector<Vector512<T>, T>.AnyMatches(Vector512<T> vector)
+        {
+            return (vector != Vector512<T>.Zero);
+        }
+
         static int ISimdVector<Vector512<T>, T>.IndexOfLastMatch(Vector512<T> vector)
         {
             ulong mask = vector.ExtractMostSignificantBits();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -757,6 +757,11 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
+        static bool ISimdVector<Vector64<T>, T>.AnyMatches(Vector64<T> vector)
+        {
+            return (vector != Vector64<T>.Zero);
+        }
+
         static int ISimdVector<Vector64<T>, T>.IndexOfLastMatch(Vector64<T> vector)
         {
             uint mask = vector.ExtractMostSignificantBits();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -757,9 +757,14 @@ namespace System.Runtime.Intrinsics
         // New Surface Area
         //
 
-        static bool ISimdVector<Vector64<T>, T>.AnyMatches(Vector64<T> vector)
+        static bool ISimdVector<Vector64<T>, T>.AnyWhereAllBitsSet(Vector64<T> vector)
         {
-            return (vector != Vector64<T>.Zero);
+            return (Vector64.EqualsAny(vector, Vector64<T>.AllBitsSet));
+        }
+
+        static bool ISimdVector<Vector64<T>, T>.Any(Vector64<T> vector, T value)
+        {
+            return (Vector64.EqualsAny(vector, Vector64.Create((T)value)));
         }
 
         static int ISimdVector<Vector64<T>, T>.IndexOfLastMatch(Vector64<T> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2038,79 +2038,17 @@ namespace System.Text
 
             if (BitConverter.IsLittleEndian && Vector128.IsHardwareAccelerated && elementCount >= (uint)Vector128<byte>.Count)
             {
-                ushort* pCurrentWriteAddress = (ushort*)pUtf16Buffer;
-
-                if (Vector512.IsHardwareAccelerated && elementCount >= (uint)Vector512<byte>.Count)
+                if (Vector512.IsHardwareAccelerated && (elementCount - currentOffset) >= (uint)Vector512<byte>.Count)
                 {
-                    // Calculating the destination address outside the loop results in significant
-                    // perf wins vs. relying on the JIT to fold memory addressing logic into the
-                    // write instructions. See: https://github.com/dotnet/runtime/issues/33002
-                    nuint finalOffsetWhereCanRunLoop = elementCount - (uint)Vector512<byte>.Count;
-
-                    do
-                    {
-                        Vector512<byte> asciiVector = Vector512.Load(pAsciiBuffer + currentOffset);
-
-                        if (asciiVector.ExtractMostSignificantBits() != 0)
-                        {
-                            break;
-                        }
-
-                        (Vector512<ushort> utf16LowVector, Vector512<ushort> utf16HighVector) = Vector512.Widen(asciiVector);
-                        utf16LowVector.Store(pCurrentWriteAddress);
-                        utf16HighVector.Store(pCurrentWriteAddress + Vector512<ushort>.Count);
-
-                        currentOffset += (nuint)Vector512<byte>.Count;
-                        pCurrentWriteAddress += (nuint)Vector512<byte>.Count;
-                    } while (currentOffset <= finalOffsetWhereCanRunLoop);
+                    WidenAsciiToUtf1_Vector<Vector512<byte>, Vector512<ushort>>(pAsciiBuffer, pUtf16Buffer, ref currentOffset, elementCount);
                 }
-                else if (Vector256.IsHardwareAccelerated && elementCount >= (uint)Vector256<byte>.Count)
+                else if (Vector256.IsHardwareAccelerated && (elementCount - currentOffset) >= (uint)Vector256<byte>.Count)
                 {
-                    // Calculating the destination address outside the loop results in significant
-                    // perf wins vs. relying on the JIT to fold memory addressing logic into the
-                    // write instructions. See: https://github.com/dotnet/runtime/issues/33002
-                    nuint finalOffsetWhereCanRunLoop = elementCount - (uint)Vector256<byte>.Count;
-
-                    do
-                    {
-                        Vector256<byte> asciiVector = Vector256.Load(pAsciiBuffer + currentOffset);
-
-                        if (asciiVector.ExtractMostSignificantBits() != 0)
-                        {
-                            break;
-                        }
-
-                        (Vector256<ushort> utf16LowVector, Vector256<ushort> utf16HighVector) = Vector256.Widen(asciiVector);
-                        utf16LowVector.Store(pCurrentWriteAddress);
-                        utf16HighVector.Store(pCurrentWriteAddress + Vector256<ushort>.Count);
-
-                        currentOffset += (nuint)Vector256<byte>.Count;
-                        pCurrentWriteAddress += (nuint)Vector256<byte>.Count;
-                    } while (currentOffset <= finalOffsetWhereCanRunLoop);
+                    WidenAsciiToUtf1_Vector<Vector256<byte>, Vector256<ushort>>(pAsciiBuffer, pUtf16Buffer, ref currentOffset, elementCount);
                 }
-                else
+                else if (Vector128.IsHardwareAccelerated && (elementCount - currentOffset) >= (uint)Vector128<byte>.Count)
                 {
-                    // Calculating the destination address outside the loop results in significant
-                    // perf wins vs. relying on the JIT to fold memory addressing logic into the
-                    // write instructions. See: https://github.com/dotnet/runtime/issues/33002
-                    nuint finalOffsetWhereCanRunLoop = elementCount - (uint)Vector128<byte>.Count;
-
-                    do
-                    {
-                        Vector128<byte> asciiVector = Vector128.Load(pAsciiBuffer + currentOffset);
-
-                        if (VectorContainsNonAsciiChar(asciiVector))
-                        {
-                            break;
-                        }
-
-                        (Vector128<ushort> utf16LowVector, Vector128<ushort> utf16HighVector) = Vector128.Widen(asciiVector);
-                        utf16LowVector.Store(pCurrentWriteAddress);
-                        utf16HighVector.Store(pCurrentWriteAddress + Vector128<ushort>.Count);
-
-                        currentOffset += (nuint)Vector128<byte>.Count;
-                        pCurrentWriteAddress += (nuint)Vector128<byte>.Count;
-                    } while (currentOffset <= finalOffsetWhereCanRunLoop);
+                    WidenAsciiToUtf1_Vector<Vector128<byte>, Vector128<ushort>>(pAsciiBuffer, pUtf16Buffer, ref currentOffset, elementCount);
                 }
             }
 
@@ -2211,6 +2149,84 @@ namespace System.Text
 
             goto Finish;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void WidenAsciiToUtf1_Vector<TVectorByte, TVectorUShort>(byte* pAsciiBuffer, char* pUtf16Buffer, ref nuint currentOffset, nuint elementCount)
+            where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
+            where TVectorUShort : unmanaged, ISimdVector<TVectorUShort, ushort>
+        {
+            ushort* pCurrentWriteAddress = (ushort*)pUtf16Buffer;
+            // Calculating the destination address outside the loop results in significant
+            // perf wins vs. relying on the JIT to fold memory addressing logic into the
+            // write instructions. See: https://github.com/dotnet/runtime/issues/33002
+            nuint finalOffsetWhereCanRunLoop = elementCount - (nuint)TVectorByte.Count;
+            TVectorByte asciiVector = TVectorByte.Load(pAsciiBuffer + currentOffset);
+            if (!HasMatch<TVectorByte>(asciiVector))
+            {
+                (TVectorUShort utf16LowVector, TVectorUShort utf16HighVector) = Widen<TVectorByte, TVectorUShort>(asciiVector);
+                utf16LowVector.Store(pCurrentWriteAddress);
+                utf16HighVector.Store(pCurrentWriteAddress + TVectorUShort.Count);
+                pCurrentWriteAddress += (nuint)(TVectorUShort.Count * 2);
+                if (((int)pCurrentWriteAddress & 1) == 0)
+                {
+                    // Bump write buffer up to the next aligned boundary
+                    pCurrentWriteAddress = (ushort*)((nuint)pCurrentWriteAddress & ~(nuint)(TVectorUShort.Alignment - 1));
+                    nuint numBytesWritten = (nuint)pCurrentWriteAddress - (nuint)pUtf16Buffer;
+                    currentOffset += (nuint)numBytesWritten / 2;
+                }
+                else
+                {
+                    // If input isn't char aligned, we won't be able to align it to a Vector
+                    currentOffset += (nuint)TVectorByte.Count;
+                }
+                while (currentOffset <= finalOffsetWhereCanRunLoop)
+                {
+                    asciiVector = TVectorByte.Load(pAsciiBuffer + currentOffset);
+                    if (HasMatch<TVectorByte>(asciiVector))
+                    {
+                        break;
+                    }
+                    (utf16LowVector, utf16HighVector) = Widen<TVectorByte, TVectorUShort>(asciiVector);
+                    utf16LowVector.StoreAligned(pCurrentWriteAddress);
+                    utf16HighVector.StoreAligned(pCurrentWriteAddress + TVectorUShort.Count);
+                    currentOffset += (nuint)TVectorByte.Count;
+                    pCurrentWriteAddress += (nuint)(TVectorUShort.Count * 2);
+                }
+            }
+            return;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool HasMatch<TVectorByte>(TVectorByte vector)
+            where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
+        {
+            if (AdvSimd.IsSupported && typeof(TVectorByte) == typeof(Vector128<byte>))
+            {
+                return VectorContainsNonAsciiChar((Vector128<byte>)(object)vector);
+            }
+            return ((vector & TVectorByte.Create((byte)0b1000_0000)) != TVectorByte.Zero);
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe (TVectorUShort Lower, TVectorUShort Upper) Widen<TVectorByte, TVectorUShort>(TVectorByte vector)
+            where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
+            where TVectorUShort : unmanaged, ISimdVector<TVectorUShort, ushort>
+        {
+            if (typeof(TVectorByte) == typeof(Vector256<byte>))
+            {
+                (Vector256<ushort> Lower256, Vector256<ushort> Upper256) = Vector256.Widen((Vector256<byte>)(object)vector);
+                return ((TVectorUShort)(object)Lower256, (TVectorUShort)(object)Upper256);
+            }
+            else if (typeof(TVectorByte) == typeof(Vector512<byte>))
+            {
+                (Vector512<ushort> Lower512, Vector512<ushort> Upper512) = Vector512.Widen((Vector512<byte>)(object)vector);
+                return ((TVectorUShort)(object)Lower512, (TVectorUShort)(object)Upper512);
+            }
+            (Vector128<ushort> Lower128, Vector128<ushort> Upper128) = Vector128.Widen((Vector128<byte>)(object)vector);
+            return ((TVectorUShort)(object)Lower128, (TVectorUShort)(object)Upper128);
+        }
+
 
         /// <summary>
         /// Given a DWORD which represents a buffer of 4 bytes, widens the buffer into 4 WORDs and

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2200,11 +2200,7 @@ namespace System.Text
         private static unsafe bool HasMatch<TVectorByte>(TVectorByte vector)
             where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
         {
-            if (AdvSimd.IsSupported && typeof(TVectorByte) == typeof(Vector128<byte>))
-            {
-                return VectorContainsNonAsciiChar((Vector128<byte>)(object)vector);
-            }
-            return ((vector & TVectorByte.Create((byte)0b1000_0000)) != TVectorByte.Zero);
+            return !(vector & TVectorByte.Create((byte)0x80)).Equals(TVectorByte.Zero);
         }
 
 


### PR DESCRIPTION
This is an updated version of this PR(https://github.com/dotnet/runtime/pull/89892). It does  the following
1. Add ' `AnyMatches`' support for iSimdVector
2. Use iSimdVector to clean up '`WidenAsciiToUtf16`' implementation
3. Align memory stores

### Perf Results

Ran the following tests(sizes : 16, 512, 1024, 5120, 10240) on EMR: (base = main branch, diff = with change)https://github.com/dotnet/performance/blob/47d21ee9571164a8e3f8088d8709ca4061d96827/src/benchmarks/micro/libraries/System.Text.Encoding/Perf.Encoding.cs

On EMR
![image](https://github.com/dotnet/runtime/assets/17969209/179a2edc-3075-4ca2-9fdc-3b36c72b0424)

On ICX - Not much diff
![image](https://github.com/dotnet/runtime/assets/17969209/7cbfc331-54bb-47cc-85d9-83dfa5d4a1d8)











