### PR TITLE
Trivial performance suggestion for Linq `Where`

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Where.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Where.cs
@@ -38,6 +38,11 @@ namespace System.Linq
 
             if (source is List<TSource> list)
             {
+                if (list.Count == 0)
+                {
+                    return list; // Simply return the original list, it is empty anyway. Saves creating an extra iterator
+                }
+                
                 return new ListWhereIterator<TSource>(list, predicate);
             }
 


### PR DESCRIPTION
When the `Where` Linq extension method receives an empty list as the input, we can add a `Count == 0` check similar to arrays. If the incoming list is empty - why not just return this empty list and save allocating an extra `ListWhereIterator`.

I did not file an issue since this is a trivial change, sorry.

Feel free to reject if this change is against the guidelines/vision, and in that case - apologies.

## Benchmarks

My benchmark shows, that on an empty `List<int>` the code is 58x times faster and zero-allocations

| Method | Mean      | Error     | StdDev    | Gen0   | Allocated |
|------- |----------:|----------:|----------:|-------:|----------:|
| NoCountCheck  | 8.7855 ns | 0.7069 ns | 0.0387 ns | 0.0014 |      72 B |
| WithCountCheck  | 0.1559 ns | 0.0465 ns | 0.0025 ns |      - |         - |