### PR TITLE
Special-case Dictionary for string keys

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3336,6 +3336,13 @@ GenTree* Compiler::impIntrinsic(GenTree*                newobjThis,
                     JITDUMP("\nExpanding RuntimeHelpers.IsKnownConstant to true early\n");
                     // We can also consider FTN_ADDR here
                 }
+                else if (op1->IsHelperCall() && gtIsTypeHandleToRuntimeTypeHelper(op1->AsCall()) &&
+                         op1->AsCall()->gtArgs.GetArgByIndex(0)->GetNode()->IsIconHandle(GTF_ICON_CLASS_HDL))
+                {
+                    // We don't use gtIsTypeof here because it may return true for shared generic types
+                    retNode = gtNewIconNode(1);
+                    JITDUMP("\nExpanding RuntimeHelpers.IsKnownConstant(typeof(T)) to true early\n");
+                }
                 else if (opts.OptimizationDisabled())
                 {
                     // It doesn't make sense to carry it as GT_INTRINSIC till Morph in Tier0

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9660,9 +9660,10 @@ DONE_MORPHING_CHILDREN:
                 assert(!optValnumCSE_phase);
 
                 JITDUMP("\nExpanding RuntimeHelpers.IsKnownConstant to ");
-                if (op1->OperIsConst() || gtIsTypeof(op1))
+                if (op1->OperIsConst())
                 {
-                    // We're lucky to catch a constant here while importer was not
+                    // We're lucky to catch a constant here while importer was not.
+                    // typeof(T) is expected to be expanded into a nongc constant handle by now.
                     JITDUMP("true\n");
                     DEBUG_DESTROY_NODE(tree, op1);
                     tree = gtNewIconNode(1);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -73,7 +73,7 @@ namespace System.Collections.Generic
             info.SetType(typeof(GenericEqualityComparer<string>));
         }
 
-        private sealed class OrdinalComparer : NonRandomizedStringEqualityComparer
+        internal sealed class OrdinalComparer : NonRandomizedStringEqualityComparer
         {
             internal OrdinalComparer(IEqualityComparer<string?> wrappedComparer)
                 : base(wrappedComparer)


### PR DESCRIPTION
Just an experiment. I see `FindValue` way too often in various perf traces and considering that string is, probably, the most popular key type (among ref types), maybe we can special case it? It gives us:
1) We can inline the hash code function
2) We can inline the string compare function (when hash matches)
3) Maybe we can even intrinsify hashcode for known string literals?

Currently PGO can't devirtualize anything inside FindValue due to known limitations.

In my benchmarks this improves Lookup (indexer/TryGetValue) by 30%