### PR TITLE
Initialize values for yield normalization during startup

### DIFF
--- a/src/coreclr/inc/yieldprocessornormalized.h
+++ b/src/coreclr/inc/yieldprocessornormalized.h
@@ -43,7 +43,7 @@ public:
         return s_isMeasurementScheduled;
     }
 
-    static void GCHeapSetYieldProcessorScalingFactor();
+    static void NotifyGC();
 
     static void PerformMeasurement();
 

--- a/src/coreclr/inc/yieldprocessornormalized.h
+++ b/src/coreclr/inc/yieldprocessornormalized.h
@@ -43,6 +43,8 @@ public:
         return s_isMeasurementScheduled;
     }
 
+    static void GCHeapSetYieldProcessorScalingFactor();
+
     static void PerformMeasurement();
 
 private:

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -163,6 +163,7 @@
 #include "jithost.h"
 #include "pgo.h"
 #include "pendingload.h"
+#include "yieldprocessornormalized.h"
 
 #ifndef TARGET_UNIX
 #include "dwreport.h"

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -883,6 +883,8 @@ void EEStartupHelper()
             LogErrorToHost("GC heap initialization failed with error 0x%08X", hr);
         }
 
+        YieldProcessorNormalization::GCHeapSetYieldProcessorScalingFactor();
+
         IfFailGo(hr);
 
 #ifdef FEATURE_PERFTRACING

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -163,7 +163,7 @@
 #include "jithost.h"
 #include "pgo.h"
 #include "pendingload.h"
-#include "yieldprocessornormalized.h"
+// #include "yieldprocessornormalized.h"
 
 #ifndef TARGET_UNIX
 #include "dwreport.h"
@@ -782,7 +782,7 @@ void EEStartupHelper()
 
         // Perform some measurements before garbage collector is initialized
         // so GC initialization and the first few GCs can use the normalized yield
-        YieldProcessorNormalization::PerformMeasurement();
+        // YieldProcessorNormalization::PerformMeasurement();
 
         InitializeGarbageCollector();
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -779,6 +779,10 @@ void EEStartupHelper()
         StubPrecode::StaticInitialize();
         FixupPrecode::StaticInitialize();
 
+        // Perform some measurements before garbage collector is initialized
+        // so GC initialization and the first few GCs can use the normalized yield
+        YieldProcessorNormalization::PerformMeasurement();
+
         InitializeGarbageCollector();
 
         if (!GCHandleUtilities::GetGCHandleManager()->Initialize())

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -883,7 +883,7 @@ void EEStartupHelper()
             LogErrorToHost("GC heap initialization failed with error 0x%08X", hr);
         }
 
-        YieldProcessorNormalization::GCHeapSetYieldProcessorScalingFactor();
+        YieldProcessorNormalization::NotifyGC();
 
         IfFailGo(hr);
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -163,7 +163,7 @@
 #include "jithost.h"
 #include "pgo.h"
 #include "pendingload.h"
-// #include "yieldprocessornormalized.h"
+#include "yieldprocessornormalized.h"
 
 #ifndef TARGET_UNIX
 #include "dwreport.h"
@@ -782,7 +782,7 @@ void EEStartupHelper()
 
         // Perform some measurements before garbage collector is initialized
         // so GC initialization and the first few GCs can use the normalized yield
-        // YieldProcessorNormalization::PerformMeasurement();
+        YieldProcessorNormalization::PerformMeasurement();
 
         InitializeGarbageCollector();
 

--- a/src/coreclr/vm/yieldprocessornormalized.cpp
+++ b/src/coreclr/vm/yieldprocessornormalized.cpp
@@ -110,6 +110,14 @@ static double MeasureNsPerYield(unsigned int measureDurationUs)
     return Max(MinNsPerYield, Min((double)elapsedTicks * NsPerS / ((double)yieldCount * ticksPerS), MaxNsPerYield));
 }
 
+void YieldProcessorNormalization::GCHeapSetYieldProcessorScalingFactor()
+{
+    if (GCHeapUtilities::IsGCHeapInitialized())
+    {
+        GCHeapUtilities::GetGCHeap()->SetYieldProcessorScalingFactor((float)s_yieldsPerNormalizedYield);
+    }
+}
+
 void YieldProcessorNormalization::PerformMeasurement()
 {
     CONTRACTL
@@ -217,7 +225,7 @@ void YieldProcessorNormalization::PerformMeasurement()
         Max(1u, (unsigned int)(TargetMaxNsPerSpinIteration / (yieldsPerNormalizedYield * establishedNsPerYield) + 0.5));
     _ASSERTE(s_optimalMaxNormalizedYieldsPerSpinIteration <= MaxOptimalMaxNormalizedYieldsPerSpinIteration);
 
-    GCHeapUtilities::GetGCHeap()->SetYieldProcessorScalingFactor((float)yieldsPerNormalizedYield);
+    GCHeapSetYieldProcessorScalingFactor();
 
     if (s_normalizationState != NormalizationState::Uninitialized)
     {


### PR DESCRIPTION
For yield normalization, we currently start by doing 8 iterations of ~1 microsecond measurements of the system yield. These iterations are scheduled lazily so the very first spin waits happen before the first measurements. Because of this, GC initialization and the first GCs can't use the adjusted yield which led to spin waits slower than should have been in some scenarios.

This is an attempt to solve this problem by doing 2 of those 8 iterations during startup (before GC initialization) while keeping the remaining 6 happening lazily so the first spin waits (including the ones done by the GC) can use an adjusted yield.