### PR TITLE
Add back NoWarn

### DIFF
--- a/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
+++ b/src/tests/nativeaot/SmokeTests/ComWrappers/ComWrappers.csproj
@@ -3,6 +3,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
 
+    <!-- Shouldn't need this: https://github.com/dotnet/linker/issues/2618 -->
+    <NoWarn>$(NoWarn);IL2050</NoWarn>
+
     <!-- Registers a global 'ComWrappers' instance for marshalling. -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>


### PR DESCRIPTION
#98469 deleted this line. The test is generating half a dozen of these warnings, so put it back, along with the old context.