### PR TITLE
Fix regression from test merging

### DIFF
--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
@@ -165,12 +165,7 @@ public class EntryPointMain
             new CoreFXTestLibrary.Internal.TestInfo("GenericVirtualMethods.TestCoAndContraVariantCalls", () => global::GenericVirtualMethods.TestCoAndContraVariantCalls(), null)
         };
 
-        // This is a placeholder for the RunTests() call below that expects an
-        // args array as a parameter. Tests using the Merged Wrapper system rely
-        // on the TestEntryPoint(), which receives no parameters, whereas the
-        // legacy system had a Main(string[] args) signature. However, in this
-        // specific test's case, the args array was always empty.
-        string[] args = new string[] { };
+        string[] args = Environment.GetCommandLineArgs()[1..];
 
         bool passed = CoreFXTestLibrary.Internal.Runner.RunTests(tests, args);
         CoreFXTestLibrary.Logger.LogInformation("Passed: {0}, Failed: {1}, Number of Tests Run: {2}",

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/DynamicGenerics.main.cs
@@ -165,7 +165,7 @@ public class EntryPointMain
             new CoreFXTestLibrary.Internal.TestInfo("GenericVirtualMethods.TestCoAndContraVariantCalls", () => global::GenericVirtualMethods.TestCoAndContraVariantCalls(), null)
         };
 
-        string[] args = Environment.GetCommandLineArgs()[1..];
+        string[] args = System.Environment.GetCommandLineArgs()[1..];
 
         bool passed = CoreFXTestLibrary.Internal.Runner.RunTests(tests, args);
         CoreFXTestLibrary.Logger.LogInformation("Passed: {0}, Failed: {1}, Number of Tests Run: {2}",


### PR DESCRIPTION
#98469 regressed a development scenario around passing command line arguments to this test. Command line argument can selectively choose one test to run. This is extremely useful when there’s test failures. The test does a ton of things and ability to zoom in is useful.

Alternatively, we could put the test on the non-merged plan, same way we left nativeaot\SmokeTests\ControlFlowGuard on the non-merged plan (I assume for the same reason because it uses command line arguments?). I would prefer that solution but made a PR for the other approach because if I understand it correctly, we don't want to leave tests like ControlFlowGuard.