### PR TITLE
Trim unused interfaces

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -146,12 +146,17 @@ namespace System.Runtime
                         interfaceMap++;
                         interfaceCount--;
                     } while (interfaceCount > 0);
+                }
 
-                extra:
-                    if (mt->IsIDynamicInterfaceCastable)
-                    {
-                        goto slowPath;
-                    }
+            extra:
+                // NOTE: this check is outside the `if (interfaceCount != 0)` check because
+                // we could have devirtualized and inlined all uses of IDynamicInterfaceCastable
+                // (and optimized the interface MethodTable away) and still have a type that
+                // is legitimately marked IDynamicInterfaceCastable (without having the MethodTable
+                // of IDynamicInterfaceCastable in the interface list).
+                if (mt->IsIDynamicInterfaceCastable)
+                {
+                    goto slowPath;
                 }
 
                 obj = null;

--- a/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -121,6 +121,12 @@ namespace ILCompiler.Dataflow
                 foreach (var e in typeDefinition.GetEventsOnTypeHierarchy(filter: null, bindingFlags: BindingFlags.Public | declaredOnlyFlags))
                     yield return e;
             }
+
+            if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.Interfaces))
+            {
+                foreach (DefType iface in typeDefinition.GetAllInterfaceImplementations(declaredOnly: true))
+                    yield return iface;
+            }
         }
 
         public static IEnumerable<MethodDesc> GetConstructorsOnType(this TypeDesc type, Func<MethodDesc, bool> filter, BindingFlags? bindingFlags = null)

--- a/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/DynamicallyAccessedMembersBinder.cs
@@ -124,7 +124,7 @@ namespace ILCompiler.Dataflow
 
             if (memberTypes.HasFlag(DynamicallyAccessedMemberTypes.Interfaces))
             {
-                foreach (DefType iface in typeDefinition.GetAllInterfaceImplementations(declaredOnly: true))
+                foreach (DefType iface in typeDefinition.GetAllInterfaceImplementations(declaredOnly))
                     yield return iface;
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/AnalysisBasedMetadataManager.cs
@@ -261,6 +261,11 @@ namespace ILCompiler
                 return GeneratesMetadata(targetType);
             }
 
+            public bool GeneratesInterfaceImpl(MetadataType typeDef, MetadataType interfaceImpl)
+            {
+                return _parent.IsInterfaceUsed(interfaceImpl.GetTypeDefinition());
+            }
+
             public bool IsBlocked(MetadataType typeDef)
             {
                 return _blockingPolicy.IsBlocked(typeDef);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMarker.cs
@@ -79,7 +79,7 @@ namespace ILCompiler.Dataflow
                     MarkEvent(origin, @event, reason, accessKind);
                     break;
                     // case InterfaceImplementation
-                    //  Nothing to do currently as Native AOT will preserve all interfaces on a preserved type
+                    //  This is handled in the MetadataType case above
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -96,8 +96,12 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override void OutputInterfaceMap(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            for (int i = 0; i < _type.RuntimeInterfaces.Length; i++)
+            foreach (DefType intface in _type.RuntimeInterfaces)
             {
+                // If the interface was optimized away, skip it
+                if (!factory.InterfaceUse(intface.GetTypeDefinition()).Marked)
+                    continue;
+
                 // Interface omitted for canonical instantiations (constructed at runtime for dynamic types from the native layout info)
                 objData.EmitZeroPointer();
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -299,6 +299,12 @@ namespace ILCompiler.DependencyAnalysis
                     return true;
                 }
 
+                // If the type implements at least one interface, calls against that interface could result in this type's
+                // implementation being used.
+                // It might also be necessary for casting purposes.
+                if (_type.RuntimeInterfaces.Length > 0)
+                    return true;
+
                 if (!EmitVirtualSlots)
                     return false;
 
@@ -327,11 +333,6 @@ namespace ILCompiler.DependencyAnalysis
 
                     currentType = currentType.BaseType;
                 }
-
-                // If the type implements at least one interface, calls against that interface could result in this type's
-                // implementation being used.
-                if (_type.RuntimeInterfaces.Length > 0)
-                    return true;
 
                 return _hasConditionalDependenciesFromMetadataManager;
             }
@@ -365,6 +366,18 @@ namespace ILCompiler.DependencyAnalysis
                     factory.GenericStaticBaseInfo((MetadataType)_type),
                     factory.NativeLayout.TemplateTypeLayout(canonOwningType),
                     "Information about static bases for type with template"));
+            }
+
+            if (!_type.IsGenericDefinition && !_type.IsCanonicalSubtype(CanonicalFormKind.Any))
+            {
+                foreach (DefType iface in _type.RuntimeInterfaces)
+                {
+                    var ifaceDefinition = (DefType)iface.GetTypeDefinition();
+                    result.Add(new CombinedDependencyListEntry(
+                        GetInterfaceTypeNode(factory, iface),
+                        factory.InterfaceUse(ifaceDefinition),
+                        "Interface definition was visible"));
+                }
             }
 
             if (!EmitVirtualSlots)
@@ -526,6 +539,14 @@ namespace ILCompiler.DependencyAnalysis
                                 {
                                     // Canonical instance default methods need to go through a thunk that adds the right generic context
                                     defaultIntfMethod = factory.TypeSystemContext.GetDefaultInterfaceMethodImplementationThunk(defaultIntfMethod, defType.ConvertToCanonForm(CanonicalFormKind.Specific), providingInterfaceDefinitionType);
+
+                                    // The above thunk will index into interface list to find the right context. Make sure to keep all interfaces prior to this one
+                                    for (int i = 0; i < interfaceIndex; i++)
+                                    {
+                                        result.Add(new CombinedDependencyListEntry(
+                                            factory.InterfaceUse(defTypeRuntimeInterfaces[i].GetTypeDefinition()),
+                                            factory.VirtualMethodUse(interfaceMethod), "Interface with shared default methods folows this"));
+                                    }
                                 }
                                 result.Add(new CombinedDependencyListEntry(factory.MethodEntrypoint(defaultIntfMethod), factory.VirtualMethodUse(interfaceMethod), "Interface method"));
 
@@ -579,6 +600,9 @@ namespace ILCompiler.DependencyAnalysis
             // generate any relocs to it, and the optional fields node will instruct the object writer to skip
             // emitting it.
             dependencies.Add(new DependencyListEntry(_optionalFieldsNode, "Optional fields"));
+
+            if (_type.IsInterface)
+                dependencies.Add(factory.InterfaceUse(_type.GetTypeDefinition()), "Interface is used");
 
             if (EmitVirtualSlots)
             {
@@ -690,7 +714,11 @@ namespace ILCompiler.DependencyAnalysis
 
             // Emit interface map
             SlotCounter interfaceSlotCounter = SlotCounter.BeginCounting(ref /* readonly */ objData);
-            OutputInterfaceMap(factory, ref objData);
+
+            if (!relocsOnly)
+            {
+                OutputInterfaceMap(factory, ref objData);
+            }
 
             // Update slot count
             int numberOfInterfaceSlots = interfaceSlotCounter.CountSlots(ref /* readonly */ objData);
@@ -1090,7 +1118,13 @@ namespace ILCompiler.DependencyAnalysis
         {
             foreach (var itf in _type.RuntimeInterfaces)
             {
-                objData.EmitPointerReloc(GetInterfaceTypeNode(factory, itf));
+                IEETypeNode interfaceTypeNode = GetInterfaceTypeNode(factory, itf);
+
+                // Only emit interfaces that were not optimized away.
+                if (interfaceTypeNode.Marked)
+                {
+                    objData.EmitPointerReloc(interfaceTypeNode);
+                }
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceUseNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceUseNode.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using ILCompiler.DependencyAnalysisFramework;
+
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    /// <summary>
+    /// Tracks uses of interface in IL sense: at the level of type definitions.
+    /// Trim warning suppressions within the framework prevent us from optimizing
+    /// at a smaller granularity (e.g. canonical forms or concrete instantiations).
+    /// </summary>
+    internal sealed class InterfaceUseNode : DependencyNodeCore<NodeFactory>
+    {
+        public TypeDesc Type { get; }
+
+        public InterfaceUseNode(TypeDesc type)
+        {
+            Debug.Assert(type.IsTypeDefinition);
+            Debug.Assert(type.IsInterface);
+            Type = type;
+        }
+
+        protected override string GetName(NodeFactory factory) => $"Interface use: {Type}";
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory factory) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -909,6 +909,15 @@ namespace ILCompiler.DependencyAnalysis
                 }
             }
 
+            foreach (GenericParameterDesc genericParam in _method.GetTypicalMethodDefinition().Instantiation)
+            {
+                foreach (TypeDesc typeConstraint in genericParam.TypeConstraints)
+                {
+                    if (typeConstraint.IsInterface)
+                        yield return new DependencyListEntry(context.InterfaceUse(typeConstraint.GetTypeDefinition()), "Used as constraint");
+                }
+            }
+
             yield return new DependencyListEntry(context.GenericDictionaryLayout(_method), "Dictionary layout");
         }
 
@@ -1024,6 +1033,15 @@ namespace ILCompiler.DependencyAnalysis
             if (context.PreinitializationManager.HasLazyStaticConstructor(_type.ConvertToCanonForm(CanonicalFormKind.Specific)))
             {
                 yield return new DependencyListEntry(context.MethodEntrypoint(_type.GetStaticConstructor().GetCanonMethodTarget(CanonicalFormKind.Specific)), "cctor for template");
+            }
+
+            foreach (GenericParameterDesc genericParam in _type.GetTypeDefinition().Instantiation)
+            {
+                foreach (TypeDesc typeConstraint in genericParam.TypeConstraints)
+                {
+                    if (typeConstraint.IsInterface)
+                        yield return new DependencyListEntry(context.InterfaceUse(typeConstraint.GetTypeDefinition()), "Used as constraint");
+                }
             }
 
             if (!_isUniversalCanon)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
@@ -23,8 +23,12 @@ namespace ILCompiler.DependencyAnalysis
 
         protected override void OutputInterfaceMap(NodeFactory factory, ref ObjectDataBuilder objData)
         {
-            for (int i = 0; i < _type.RuntimeInterfaces.Length; i++)
+            foreach (DefType intface in _type.RuntimeInterfaces)
             {
+                // If the interface was optimized away, skip it
+                if (!factory.InterfaceUse(intface.GetTypeDefinition()).Marked)
+                    continue;
+
                 // Interface omitted for canonical instantiations (constructed at runtime for dynamic types from the native layout info)
                 objData.EmitZeroPointer();
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -366,6 +366,11 @@ namespace ILCompiler.DependencyAnalysis
                 return new VariantInterfaceMethodUseNode(method);
             });
 
+            _interfaceUses = new NodeCache<TypeDesc, InterfaceUseNode>((TypeDesc type) =>
+            {
+                return new InterfaceUseNode(type);
+            });
+
             _readyToRunHelpers = new NodeCache<ReadyToRunHelperKey, ISymbolNode>(CreateReadyToRunHelperNode);
 
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(CreateGenericLookupFromDictionaryNode);
@@ -1173,6 +1178,13 @@ namespace ILCompiler.DependencyAnalysis
         public DependencyNodeCore<NodeFactory> VariantInterfaceMethodUse(MethodDesc decl)
         {
             return _variantMethods.GetOrAdd(decl);
+        }
+
+        private NodeCache<TypeDesc, InterfaceUseNode> _interfaceUses;
+
+        public DependencyNodeCore<NodeFactory> InterfaceUse(TypeDesc type)
+        {
+            return _interfaceUses.GetOrAdd(type);
         }
 
         private NodeCache<ReadyToRunHelperKey, ISymbolNode> _readyToRunHelpers;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeMetadataNode.cs
@@ -49,10 +49,6 @@ namespace ILCompiler.DependencyAnalysis
             if (baseType != null)
                 GetMetadataDependencies(ref dependencies, factory, baseType, "Base type of a reflectable type");
 
-            // TODO-SIZE: if we start trimming interface lists, we can probably trim here
-            foreach (DefType interfaceType in _type.ExplicitlyImplementedInterfaces)
-                GetMetadataDependencies(ref dependencies, factory, interfaceType, "Interface of a reflectable type");
-
             var mdManager = (UsageBasedMetadataManager)factory.MetadataManager;
 
             if (_type.IsEnum)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -77,6 +77,7 @@ namespace ILCompiler
         private readonly SortedSet<TypeDesc> _typeTemplates = new SortedSet<TypeDesc>(TypeSystemComparer.Instance);
         private readonly SortedSet<MetadataType> _typesWithGenericStaticBaseInfo = new SortedSet<MetadataType>(TypeSystemComparer.Instance);
         private readonly SortedSet<MethodDesc> _genericMethodHashtableEntries = new SortedSet<MethodDesc>(TypeSystemComparer.Instance);
+        private readonly HashSet<TypeDesc> _usedInterfaces = new HashSet<TypeDesc>();
 
         private List<(DehydratableObjectNode Node, ObjectNode.ObjectData Data)> _dehydratableData = new List<(DehydratableObjectNode Node, ObjectNode.ObjectData data)>();
 
@@ -327,6 +328,11 @@ namespace ILCompiler
             if (obj is GenericMethodsHashtableEntryNode genericMethodsHashtableEntryNode)
             {
                 _genericMethodHashtableEntries.Add(genericMethodsHashtableEntryNode.Method);
+            }
+
+            if (obj is InterfaceUseNode interfaceUse)
+            {
+                _usedInterfaces.Add(interfaceUse.Type);
             }
         }
 
@@ -983,6 +989,12 @@ namespace ILCompiler
         public IEnumerable<MethodDesc> GetGenericMethodHashtableEntries()
         {
             return _genericMethodHashtableEntries;
+        }
+
+        public bool IsInterfaceUsed(TypeDesc type)
+        {
+            Debug.Assert(type.IsTypeDefinition);
+            return _usedInterfaces.Contains(type);
         }
 
         internal IEnumerable<IMethodBodyNode> GetCompiledMethodBodies()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs
@@ -1041,6 +1041,11 @@ namespace ILCompiler
                 return GeneratesMetadata(targetType) || !_factory.CompilationModuleGroup.ContainsType(targetType);
             }
 
+            public bool GeneratesInterfaceImpl(MetadataType typeDef, MetadataType interfaceImpl)
+            {
+                return _factory.MetadataManager.IsInterfaceUsed(interfaceImpl.GetTypeDefinition());
+            }
+
             public bool IsBlocked(MetadataType typeDef)
             {
                 return _blockingPolicy.IsBlocked(typeDef);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -422,6 +422,7 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodImplNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InlineableStringsResourceNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceDispatchCellSectionNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InterfaceUseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\MethodExceptionHandlingInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ModuleInitializerListNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NotReadOnlyFieldNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/IMetadataPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/IMetadataPolicy.cs
@@ -49,6 +49,11 @@ namespace ILCompiler.Metadata
         bool GeneratesMetadata(Cts.Ecma.EcmaModule module, Ecma.ExportedTypeHandle exportedType);
 
         /// <summary>
+        /// Returns true if InterfaceImpl should be generated for this type.
+        /// </summary>
+        bool GeneratesInterfaceImpl(Cts.MetadataType typeDef, Cts.MetadataType interfaceImpl);
+
+        /// <summary>
         /// Returns true if a type should be blocked from generating any metadata.
         /// Blocked interfaces are skipped from interface lists, and custom attributes referring to
         /// blocked types are dropped from metadata.

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Type.cs
@@ -287,6 +287,9 @@ namespace ILCompiler.Metadata
                 {
                     if (IsBlocked(interfaceType))
                         continue;
+                    if (!_policy.GeneratesInterfaceImpl(entity, (Cts.MetadataType)interfaceType))
+                        continue;
+
                     record.Interfaces.Add(HandleType(interfaceType));
                 }
             }

--- a/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
+++ b/src/tests/nativeaot/SmokeTests/Reflection/Reflection.cs
@@ -1042,7 +1042,9 @@ internal static class ReflectionTest
     {
         interface IUnreferenced { }
 
-        class UnreferencedBaseType : IUnreferenced { }
+        interface IReferenced { }
+
+        class UnreferencedBaseType : IUnreferenced, IReferenced { }
         class UnreferencedMidType : UnreferencedBaseType { }
         class ReferencedDerivedType : UnreferencedMidType { }
 
@@ -1061,8 +1063,9 @@ internal static class ReflectionTest
 
             Assert.Equal(count, 3);
 
-            // This one could in theory fail if we start trimming interface lists
+            // We expect to see only IReferenced but not IUnreferenced
             Assert.Equal(1, mi.GetParameters()[0].ParameterType.GetInterfaces().Length);
+            Assert.Equal(typeof(IReferenced), mi.GetParameters()[0].ParameterType.GetInterfaces()[0]);
         }
     }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/TypeWithPreserveFieldsHasBackingFieldsOfPropertiesRemoved.cs
@@ -40,32 +40,28 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 			int IFoo<IFoo<int>>.Bar { get; set; }
 		}
 
-		[Kept (By = Tool.NativeAot)]
 		interface IDog
 		{
 			string Name { get; set; }
 		}
 
-		[Kept]
+		[Kept (By = Tool.Trimmer)]
 		interface IFoo<T>
 		{
 
 			int Bar { get; set; }
 		}
 
-		[Kept (By = Tool.NativeAot)]
 		interface IFoo2<T>
 		{
 			int Bar2 { get; set; }
 		}
 
-		[Kept (By = Tool.NativeAot)]
 		interface IFoo3<T, K, J>
 		{
 			int Bar3 { get; set; }
 		}
 
-		[Kept (By = Tool.NativeAot)]
 		class Cat
 		{
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UnusedInterfaceTypeOnTypeWithPreserveNothingIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/UnusedInterfaceTypeOnTypeWithPreserveNothingIsRemoved.cs
@@ -10,7 +10,6 @@ namespace Mono.Linker.Tests.Cases.LinkXml
 		{
 		}
 
-		[Kept (By = Tool.NativeAot)]
 		interface IFoo
 		{
 		}


### PR DESCRIPTION
So far, the compiler could only trim unused interface __methods__; the interface __types__ themselves were left alone. There is not a huge cost associated with having these extra `MethodTable`s, but it sill impacts size/working set/startup. Initial estimate showed this could actually be up to 2% for BasicMinimalApi so I decided to investigate a fix.

This is an attempt to start trimming them. I chose a relatively conservative approach:

* Stop unconditionally rooting the interface `MethodTable` in the implementing class `MethodTable` InterfaceList. Instead check whether someone else marked it first.
* Track whether an interface type definition is used in any way. This avoids problem with variance, etc. If an interface definition is used, all instantiations that we were trying to optimize away get the `MethodTable` and won't be optimized. We should be able to do better than this, maybe, at some point.
* Classes that implement generic interfaces with default methods need special treatment because we index into interface list at runtime and we might not know the correct index yet. So just forget the optimization in that case.

Fixes #66716.