### PR TITLE
Skip ro segments which are not in range when walking heap for GC diagnostics

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -52095,7 +52095,7 @@ void CFinalize::CheckFinalizerObjects()
 void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOOL walk_large_object_heap_p)
 {
     generation* gen = gc_heap::generation_of (gen_number);
-    heap_segment*    seg = generation_start_segment (gen);
+    heap_segment*    seg = heap_segment_in_range (generation_start_segment (gen));
     uint8_t* x = ((gen_number == max_generation) ? heap_segment_mem (seg) : get_soh_start_object (seg, gen));
     uint8_t*       end = heap_segment_allocated (seg);
     int align_const = get_alignment_constant (TRUE);
@@ -52105,7 +52105,7 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
     {
         if (x >= end)
         {
-            if ((seg = heap_segment_next (seg)) != 0)
+            if ((seg = heap_segment_next_in_range (seg)) != 0)
             {
                 x = heap_segment_mem (seg);
                 end = heap_segment_allocated (seg);
@@ -52117,7 +52117,7 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
                 // advance to next lower generation
                 gen_number--;
                 gen = gc_heap::generation_of (gen_number);
-                seg = generation_start_segment (gen);
+                seg = heap_segment_in_range (generation_start_segment (gen));
 
                 x = heap_segment_mem (seg);
                 end = heap_segment_allocated (seg);
@@ -52129,12 +52129,12 @@ void gc_heap::walk_heap_per_heap (walk_fn fn, void* context, int gen_number, BOO
                 if (walk_large_object_heap_p)
                 {
                     walk_large_object_heap_p = FALSE;
-                    seg = generation_start_segment (large_object_generation);
+                    seg = heap_segment_in_range (generation_start_segment (large_object_generation));
                 }
                 else if (walk_pinned_object_heap)
                 {
                     walk_pinned_object_heap = FALSE;
-                    seg = generation_start_segment (pinned_object_generation);
+                    seg = heap_segment_in_range (generation_start_segment (pinned_object_generation));
                 }
                 else
                 {


### PR DESCRIPTION
Fixed crash in gc_heap::walk_heap_per_heap when walking frozen segments

**Motivation:**

Enabling `COR_PRF_MONITOR_GC` GC Heap diagnostics flag causes crash after initiating AssemblyLoadContext unloading with the following callstack.

```
[Inline Frame] coreclr.dll!WKS::my_get_size(Object *) Line 11572	C++	Symbols loaded.
>	coreclr.dll!WKS::gc_heap::walk_heap_per_heap(bool(*)(Object *, void *) fn, void * context, int gen_number, int walk_large_object_heap_p) Line 51974	C++	Symbols loaded.
 	coreclr.dll!GCProfileWalkHeapWorker(int fProfilerPinned, int fShouldWalkHeapRootsForEtw, int fShouldWalkHeapObjectsForEtw) Line 727	C++	Symbols loaded.
 	coreclr.dll!GCToEEInterface::DiagGCEnd(unsigned __int64 fConcurrent, int index, int gen, bool reason) Line 818	C++	Symbols loaded.
 	coreclr.dll!WKS::gc_heap::do_post_gc() Line 50183	C++	Symbols loaded.
 	coreclr.dll!WKS::gc_heap::gc1() Line 22865	C++	Symbols loaded.
 	[Inline Frame] coreclr.dll!GCToOSInterface::GetLowPrecisionTimeStamp() Line 1091	C++	Symbols loaded.
 	coreclr.dll!WKS::gc_heap::garbage_collect(int n) Line 24329	C++	Symbols loaded.
 	coreclr.dll!WKS::GCHeap::GarbageCollectGeneration(unsigned int gen, gc_reason reason) Line 50526	C++	Symbols loaded.
 	coreclr.dll!WKS::GCHeap::GarbageCollect(int generation, bool low_memory_p, int mode) Line 49681	C++	Symbols loaded.
 	coreclr.dll!ETW::GCLog::ForceGCForDiagnostics() Line 492	C++	Symbols loaded.
 	[Inline Frame] coreclr.dll!ETW::GCLog::ForceGC(__int64) Line 431	C++	
```

I was suspecting invalid profiler setup, however the issue was also reproducible with [PerfView](https://github.com/microsoft/perfview) tool without enabling `COR_PRF_MONITOR_GC` flag via profiler dll at startup - tool crashes on GC Heap dump once one of assemblies from  AssemblyLoadContext gets unloaded.

I was suspecting then heap corruption, but was not able to gather any proof of that by running `gc::verify_heap` every GC and native/managed transition (the latter was painfully slow 😁). Further comparison with `gc::verify_heap` yielded that heap verification uses `heap_segment_in_range/heap_segment_next_in_range` methods [to get the heap segment to iterate over](https://github.com/dotnet/runtime/blob/main/src/coreclr/gc/gc.cpp#L47873). `heap_segment_in_range` checks that segment is not readonly/frozen (`heap_segment_flags_readonly` flag) or if it is “in range” (`heap_segment_flags_inrange` flag). At the same time `gc_heap::walk_heap_per_heap` scans through all segments.

**Changes**:

My hypothesis is that assembly unloading may free/rollback segments that are used for string/type/etc data in frozen segments and thus we need to skip such segments when traversing heap for diagnostics. I might be wrong given my limited understanding of `USE_RANGES` feature and would appreciate other ideas 😄 