### PR TITLE
Run HTTP3 stress with Adress sanitization

### DIFF
--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 RUN git clone --recursive https://github.com/microsoft/msquic --depth 1
 RUN cd msquic/ && \
     mkdir build && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
     cmake --build . --config Release
 RUN cd msquic/build/bin/Release && \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
     gem install fpm
-RUN git clone -b recv-buffer-data-loss --recursive https://github.com/rzikm/msquic
+RUN git clone -b recv-buffer-data-loss-v2 --recursive https://github.com/rzikm/msquic
 RUN cd msquic/ && \
     mkdir build && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update -y && \
     apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
     gem install fpm
 RUN git clone -b recv-buffer-data-loss --recursive https://github.com/rzikm/msquic
-RUN cd msquic/src/msquic && \
+RUN cd msquic/ && \
     mkdir build && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
     cmake --build . --config Release
-RUN cd msquic/src/msquic/build/bin/Release && \
+RUN cd msquic/build/bin/Release && \
     rm libmsquic.so && \
     fpm -f -s dir -t deb -n libmsquic -v $( find -type f | cut -d "." -f 4- ) \
     --license MIT --url https://github.com/microsoft/msquic --log error \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
     gem install fpm
-RUN git clone -b recv-buffer-data-loss-v2 --recursive https://github.com/rzikm/msquic
+RUN git clone --recursive https://github.com/microsoft/msquic --depth 1
 RUN cd msquic/ && \
     mkdir build && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
@@ -40,10 +40,12 @@ ENV DOTNET_DbgMiniDumpName="/dumps-share/coredump.%p"
 
 EXPOSE 5001
 
+# configure adress sanitizer
+ENV ASAN_OPTIONS='detect_leaks=0'
+ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so
+
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV HTTPSTRESS_ARGS=''
-ENV ASAN_OPTIONS='detect_leaks=0'
-ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so
 CMD /live-runtime-artifacts/testhost/net$VERSION-linux-$CONFIGURATION-x64/dotnet exec --roll-forward Major \
     ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -y && \
 RUN git clone --recursive https://github.com/dotnet/msquic
 RUN cd msquic/src/msquic && \
     mkdir build && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
     cmake --build . --config Release
 RUN cd msquic/src/msquic/build/bin/Release && \
@@ -43,5 +43,7 @@ EXPOSE 5001
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV HTTPSTRESS_ARGS=''
+ENV ASAN_OPTIONS='detect_leaks=0'
+ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so 
 CMD /live-runtime-artifacts/testhost/net$VERSION-linux-$CONFIGURATION-x64/dotnet exec --roll-forward Major \
     ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -10,10 +10,10 @@ RUN apt-get update -y && \
 RUN git clone --recursive https://github.com/microsoft/msquic --depth 1
 RUN cd msquic/ && \
     mkdir build && \
-    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3 -DQUIC_ENABLE_SANITIZERS=on && \
     cd build && \
-    cmake --build . --config Release
-RUN cd msquic/build/bin/Release && \
+    cmake --build . --config Debug
+RUN cd msquic/build/bin/Debug && \
     rm libmsquic.so && \
     fpm -f -s dir -t deb -n libmsquic -v $( find -type f | cut -d "." -f 4- ) \
     --license MIT --url https://github.com/microsoft/msquic --log error \
@@ -42,7 +42,7 @@ EXPOSE 5001
 
 # configure adress sanitizer
 ENV ASAN_OPTIONS='detect_leaks=0'
-ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so
+ENV LD_PRELOAD=/usr/lib/gcc/x86_64-linux-gnu/12/libasan.so
 
 ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update -y && \
     apt-get upgrade -y && \
     apt-get install -y cmake clang ruby-dev gem lttng-tools libssl-dev && \
     gem install fpm
-RUN git clone --recursive https://github.com/dotnet/msquic
+RUN git clone -b recv-buffer-data-loss --recursive https://github.com/rzikm/msquic
 RUN cd msquic/src/msquic && \
     mkdir build && \
     cmake -B build -DCMAKE_BUILD_TYPE=Release -DQUIC_ENABLE_LOGGING=false -DQUIC_USE_SYSTEM_LIBCRYPTO=true -DQUIC_BUILD_TOOLS=off -DQUIC_BUILD_TEST=off -DQUIC_BUILD_PERF=off -DQUIC_TLS=openssl3  -DQUIC_ENABLE_SANITIZERS=on && \
@@ -44,6 +44,6 @@ ENV VERSION=$VERSION
 ENV CONFIGURATION=$CONFIGURATION
 ENV HTTPSTRESS_ARGS=''
 ENV ASAN_OPTIONS='detect_leaks=0'
-ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so 
+ENV LD_PRELOAD=/usr/bin/../lib/gcc/x86_64-linux-gnu/12/libasan.so
 CMD /live-runtime-artifacts/testhost/net$VERSION-linux-$CONFIGURATION-x64/dotnet exec --roll-forward Major \
     ./bin/$CONFIGURATION/net$VERSION/HttpStress.dll $HTTPSTRESS_ARGS


### PR DESCRIPTION
This PR turns on MsQuic address sanitization on Linux Http3 stress runs.