### PR TITLE
Seal overridden virtual method `SetDefaultFallbacks`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
@@ -26,7 +26,7 @@ namespace System.Text
         public override ReadOnlySpan<byte> Preamble => default;
 
         // Default fallback that we'll use.
-        internal override void SetDefaultFallbacks()
+        internal sealed override void SetDefaultFallbacks()
         {
             // We use best-fit mappings by default when encoding.
             encoderFallback = EncoderLatin1BestFitFallback.SingletonInstance;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
@@ -62,7 +62,7 @@ namespace System.Text
                 SetDefaultFallbacks();
         }
 
-        internal override void SetDefaultFallbacks()
+        internal sealed override void SetDefaultFallbacks()
         {
             // For UTF-X encodings, we use a replacement fallback with an empty string
             if (_isThrowException)


### PR DESCRIPTION
Fix [CA2214: Do not call overridable methods in constructors](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2214).
