### PR TITLE
Fix a set of minor DAC bugs I encountered recently

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5650,10 +5650,13 @@ void DacDbiInterfaceImpl::LookupEnCVersions(Module*          pModule,
     DebuggerJitInfo * pDJI = NULL;
     EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
     {
-        pDMI = g_pDebugger->GetOrCreateMethodInfo(pModule, mdMethod);
-        if (pDMI != NULL)
+        if (g_pDebugger != NULL)
         {
-            pDJI = pDMI->FindJitInfo(pMD, CORDB_ADDRESS_TO_TADDR(pNativeStartAddress));
+            pDMI = g_pDebugger->GetOrCreateMethodInfo(pModule, mdMethod);
+            if (pDMI != NULL)
+            {
+                pDJI = pDMI->FindJitInfo(pMD, CORDB_ADDRESS_TO_TADDR(pNativeStartAddress));
+            }
         }
     }
     EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
@@ -7512,6 +7515,10 @@ HRESULT DacDbiInterfaceImpl::GetDefinesBitField(ULONG32 *pDefines)
     DD_ENTER_MAY_THROW;
     if (pDefines == NULL)
         return E_INVALIDARG;
+
+    if (g_pDebugger == NULL)
+        return CORDBG_E_NOTREADY;
+        
     *pDefines = g_pDebugger->m_defines;
     return S_OK;
 }
@@ -7521,6 +7528,10 @@ HRESULT DacDbiInterfaceImpl::GetMDStructuresVersion(ULONG32* pMDStructuresVersio
     DD_ENTER_MAY_THROW;
     if (pMDStructuresVersion == NULL)
         return E_INVALIDARG;
+
+    if (g_pDebugger == NULL)
+        return CORDBG_E_NOTREADY;
+
     *pMDStructuresVersion = g_pDebugger->m_mdDataStructureVersion;
     return S_OK;
 }

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -4250,12 +4250,12 @@ HRESULT CordbNativeCode::GetILToNativeMapping(ULONG32                    cMap,
         LoadNativeInfo();
 
         SequencePoints * pSeqPts = GetSequencePoints();
-        DebuggerILToNativeMap * rgMapInt = pSeqPts->GetMapAddr();
         ULONG32 cMapIntCount = pSeqPts->GetEntryCount();
 
         // If they gave us space to copy into...
-        if (map != NULL)
+        if (map != NULL && cMapIntCount != 0)
         {
+            DebuggerILToNativeMap * rgMapInt = pSeqPts->GetMapAddr();
             // Only copy as much as either they gave us or we have to copy.
             ULONG32 cMapToCopy = min(cMap, cMapIntCount);
 

--- a/src/coreclr/utilcode/collections.cpp
+++ b/src/coreclr/utilcode/collections.cpp
@@ -268,6 +268,12 @@ BYTE *CHashTable::FindNextEntry(        // The next entry, or0 for end of list.
         if (psSrch->iNext != UINT32_MAX)
         {
             psEntry = EntryPtr(psSrch->iNext);
+#if DACCESS_COMPILE
+            // If there is a simple infinite loop in the linked list
+            // If more complex forms of infinite loops are present, this code may need to be adjusted to handle an arbitrary cycle.
+            if (psEntry->iNext == psSrch->iNext)
+                return NULL;
+#endif
             psSrch->iNext = psEntry->iNext;
             return ((BYTE *) psEntry);
         }


### PR DESCRIPTION
In src/coreclr/debug/daccess/dacdbiimpl.cpp
- If `g_pDebugger` is NULL, produce an error, or NULL result instead of an invalid memory access.
- This caused problems when debugging with a debug version of the DAC

In src/coreclr/debug/di/module.cpp
- Avoid attempting to get the `MapAddr` if the number of entries in the map is 0, as it may not yet be fully initialized and attempting to call the `GetMapAddr` function may cause an ASSERT in debug/checked versions of the DAC

In src/coreclr/utilcode/collections.cpp
- If a `CHashTable` is not fully initialized, or is in an intermediate state, its possible for the linked list to have an infinite cycle. Tweak the iteration here under the DAC to stop
  - This is known to cause stack walking to loop infinitely in the debugger when debugging a runtime which has suspended at a non-safe point