### PR TITLE
Don't log error from background service if host is gracefully stopped while still starting

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         private IEnumerable<IHostedService>? _hostedServices;
         private IEnumerable<IHostedLifecycleService>? _hostedLifecycleServices;
         private bool _hostStarting;
-        private volatile bool _stopCalled;
         private bool _hostStopped;
 
         public Host(IServiceProvider services,
@@ -190,7 +189,7 @@ namespace Microsoft.Extensions.Hosting.Internal
             {
                 // When the host is being stopped, it cancels the background services.
                 // This isn't an error condition, so don't log it as an error.
-                if (_stopCalled && backgroundTask.IsCanceled && ex is OperationCanceledException)
+                if (_applicationLifetime.ApplicationStopping.IsCancellationRequested && backgroundTask.IsCanceled && ex is OperationCanceledException)
                 {
                     return;
                 }
@@ -217,7 +216,6 @@ namespace Microsoft.Extensions.Hosting.Internal
         /// </summary>
         public async Task StopAsync(CancellationToken cancellationToken = default)
         {
-            _stopCalled = true;
             _logger.Stopping();
 
             CancellationTokenSource? cts = null;


### PR DESCRIPTION
Fixes #98935

# Description

Previous work supressed errors for canceled background services when the host stops gracefully, but did not do so unless the host had finished starting. This fix does so even if the host is still starting.

This change checks the ApplicationStopping CancellationToken on the ApplicationLifetime (which should be updated as soon as the stop is requested) instead of using the _stopCalled flag.

# Testing

Added a xUnit test covering the reported scenario
