### PR TITLE
[browser][MT] invocation of user JS in UI thread till next event loop tick

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSMarshalerArgument.cs
@@ -68,6 +68,9 @@ namespace System.Runtime.InteropServices.JavaScript
 
             [FieldOffset(24)]
             internal IntPtr CallerNativeTID;
+
+            [FieldOffset(28)]
+            internal IntPtr SyncDoneSemaphorePtr;
 #endif
         }
 

--- a/src/mono/browser/runtime/cancelable-promise.ts
+++ b/src/mono/browser/runtime/cancelable-promise.ts
@@ -11,6 +11,7 @@ import { compareExchangeI32, forceThreadMemoryViewRefresh } from "./memory";
 import { mono_log_debug } from "./logging";
 import { complete_task } from "./managed-exports";
 import { marshal_cs_object_to_cs } from "./marshal-to-cs";
+import { invoke_later_when_on_ui_thread_async } from "./invoke-js";
 
 export const _are_promises_supported = ((typeof Promise === "object") || (typeof Promise === "function")) && (typeof Promise.resolve === "function");
 
@@ -35,6 +36,11 @@ export function wrap_as_cancelable<T>(inner: Promise<T>): ControllablePromise<T>
 }
 
 export function mono_wasm_cancel_promise(task_holder_gc_handle: GCHandle): void {
+    // cancelation should not arrive earlier than the promise created by marshaling in mono_wasm_invoke_jsimport_MT 
+    invoke_later_when_on_ui_thread_async(() => mono_wasm_cancel_promise_impl(task_holder_gc_handle));
+}
+
+export function mono_wasm_cancel_promise_impl(task_holder_gc_handle: GCHandle): void {
     if (!loaderHelpers.is_runtime_running()) {
         mono_log_debug("This promise can't be canceled, mono runtime already exited.");
         return;

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -44,13 +44,13 @@ void mono_wasm_cancel_promise_post (pthread_t target_tid, int task_holder_gc_han
 extern void mono_wasm_install_js_worker_interop (int context_gc_handle);
 void mono_wasm_install_js_worker_interop_wrapper (int context_gc_handle, void* beforeSyncJSImport, void* afterSyncJSImport);
 extern void mono_wasm_uninstall_js_worker_interop ();
-extern void mono_wasm_invoke_jsimport (void* signature, void* args);
+extern void mono_wasm_invoke_jsimport_MT (void* signature, void* args);
 void mono_wasm_invoke_jsimport_async_post (pthread_t target_tid, void* signature, void* args);
 void mono_wasm_invoke_jsimport_sync_send (pthread_t target_tid, void* signature, void* args);
 void mono_wasm_invoke_js_function_send (pthread_t target_tid, int function_js_handle, void *args);
 extern void mono_threads_wasm_async_run_in_target_thread_vi (pthread_t target_thread, void (*func) (gpointer), gpointer user_data1);
 extern void mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
-extern void mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+extern void mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args);
 #else
 extern void mono_wasm_bind_js_import (void *signature, int *is_exception, MonoObject **result);
 extern void mono_wasm_invoke_jsimport_ST (int function_handle, void *args);
@@ -80,7 +80,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/Runtime::ResolveOrRejectPromisePost", mono_wasm_resolve_or_reject_promise_post);
 	mono_add_internal_call ("Interop/Runtime::InstallWebWorkerInterop", mono_wasm_install_js_worker_interop_wrapper);
 	mono_add_internal_call ("Interop/Runtime::UninstallWebWorkerInterop", mono_wasm_uninstall_js_worker_interop);
-	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSync", mono_wasm_invoke_jsimport);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSync", mono_wasm_invoke_jsimport_MT);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSImportSyncSend", mono_wasm_invoke_jsimport_sync_send);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSImportAsyncPost", mono_wasm_invoke_jsimport_async_post);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSFunctionSend", mono_wasm_invoke_js_function_send);
@@ -285,13 +285,13 @@ void mono_wasm_cancel_promise_post (pthread_t target_tid, int task_holder_gc_han
 // async
 void mono_wasm_invoke_jsimport_async_post (pthread_t target_tid, void* signature, void* args)
 {
-	mono_threads_wasm_async_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport, (gpointer)signature, (gpointer)args);
+	mono_threads_wasm_async_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport_MT, (gpointer)signature, (gpointer)args);
 }
 
 // sync
 void mono_wasm_invoke_jsimport_sync_send (pthread_t target_tid, void* signature, void* args)
 {
-	mono_threads_wasm_sync_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport, (gpointer)signature, (gpointer)args);
+	mono_threads_wasm_sync_run_in_target_thread_vii (target_tid, (void (*) (gpointer, gpointer))mono_wasm_invoke_jsimport_MT, (gpointer)signature, (gpointer)args);
 }
 
 // sync

--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -33,6 +33,7 @@ const threading_cwraps: SigLine[] = WasmEnableThreads ? [
     [true, "mono_wasm_register_ui_thread", "void", []],
     [true, "mono_wasm_register_io_thread", "void", []],
     [true, "mono_wasm_print_thread_dump", "void", []],
+    [true, "mono_threads_wasm_sync_run_in_target_thread_done", "void", ["number"]],
 ] : [];
 
 // when the method is assigned/cached at usage, instead of being invoked directly from cwraps, it can't be marked lazy, because it would be re-bound on each call
@@ -156,6 +157,7 @@ export interface t_ThreadingCwraps {
     mono_wasm_register_ui_thread(): void;
     mono_wasm_register_io_thread(): void;
     mono_wasm_print_thread_dump(): void;
+    mono_threads_wasm_sync_run_in_target_thread_done(sem: VoidPtr): void;
 }
 
 export interface t_ProfilerCwraps {

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -256,7 +256,7 @@ mono_wasm_invoke_jsexport (MonoMethod *method, void* args)
 #ifndef DISABLE_THREADS
 
 extern void mono_threads_wasm_async_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
-extern void mono_threads_wasm_sync_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+extern void mono_threads_wasm_sync_run_in_target_thread_vii (void* target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args);
 extern void mono_print_thread_dump (void *sigctx);
 
 EMSCRIPTEN_KEEPALIVE void
@@ -303,7 +303,7 @@ mono_wasm_invoke_jsexport_sync (MonoMethod *method, void* args)
 EMSCRIPTEN_KEEPALIVE void
 mono_wasm_invoke_jsexport_sync_send (void* target_thread, MonoMethod *method, void* args /*JSMarshalerArguments*/)
 {
-	mono_threads_wasm_sync_run_in_target_thread_vii(target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport_sync, method, args);
+	mono_threads_wasm_sync_run_in_target_thread_vii (target_thread, (void (*)(gpointer, gpointer))mono_wasm_invoke_jsexport_sync, method, args);
 }
 
 #endif /* DISABLE_THREADS */

--- a/src/mono/browser/runtime/driver.c
+++ b/src/mono/browser/runtime/driver.c
@@ -271,7 +271,7 @@ mono_wasm_invoke_jsexport_async_post_cb (MonoMethod *method, void* args)
 {
 	mono_wasm_invoke_jsexport (method, args);
 	if (args) {
-		MonoBoolean *is_receiver_should_free = (MonoBoolean *)(args + 20/*JSMarshalerArgumentOffsets.ReceiverShouldFree*/);
+		MonoBoolean *is_receiver_should_free = (MonoBoolean *)(((char *) args) + 20/*JSMarshalerArgumentOffsets.ReceiverShouldFree*/);
 		if(*is_receiver_should_free != 0){
 			free (args);
 		}

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -5,7 +5,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { mono_wasm_debugger_log, mono_wasm_add_dbg_command_received, mono_wasm_set_entrypoint_breakpoint, mono_wasm_fire_debugger_agent_message_with_data, mono_wasm_fire_debugger_agent_message_with_data_to_pause } from "./debug";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
-import { mono_wasm_bind_js_import, mono_wasm_invoke_js_function, mono_wasm_invoke_jsimport, mono_wasm_invoke_jsimport_ST } from "./invoke-js";
+import { mono_wasm_bind_js_import, mono_wasm_invoke_js_function, mono_wasm_invoke_jsimport_MT, mono_wasm_invoke_jsimport_ST } from "./invoke-js";
 import { mono_interp_tier_prepare_jiterpreter, mono_jiterp_free_method_data_js } from "./jiterpreter";
 import { mono_interp_jit_wasm_entry_trampoline, mono_interp_record_interp_entry } from "./jiterpreter-interp-entry";
 import { mono_interp_jit_wasm_jit_call_trampoline, mono_interp_invoke_wasm_jit_call_trampoline, mono_interp_flush_jitcall_queue } from "./jiterpreter-jit-call";
@@ -55,7 +55,7 @@ export const mono_wasm_threads_imports = !WasmEnableThreads ? [] : [
     // corebindings.c
     mono_wasm_install_js_worker_interop,
     mono_wasm_uninstall_js_worker_interop,
-    mono_wasm_invoke_jsimport,
+    mono_wasm_invoke_jsimport_MT,
 ];
 
 export const mono_wasm_imports = [

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -7,7 +7,7 @@ import { js_owned_gc_handle_symbol, teardown_managed_proxy } from "./gc-handles"
 import { Module, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
 import { getF32, getF64, getI16, getI32, getI64Big, getU16, getU32, getU8, setF32, setF64, setI16, setI32, setI64Big, setU16, setU32, setU8, localHeapViewF64, localHeapViewI32, localHeapViewU8, _zero_region, getB32, setB32, forceThreadMemoryViewRefresh } from "./memory";
 import { mono_wasm_new_external_root } from "./roots";
-import { GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot, MarshalerType, PThreadPtr, PThreadPtrNull } from "./types/internal";
+import { GCHandle, JSHandle, MonoObject, MonoString, GCHandleNull, JSMarshalerArguments, JSFunctionSignature, JSMarshalerType, JSMarshalerArgument, MarshalerToJs, MarshalerToCs, WasmRoot, MarshalerType, PThreadPtr, PThreadPtrNull, VoidPtrNull } from "./types/internal";
 import { TypedArray, VoidPtr } from "./types/emscripten";
 import { utf16ToString } from "./strings";
 import { get_managed_stack_trace } from "./managed-exports";
@@ -39,6 +39,7 @@ const enum JSMarshalerArgumentOffsets {
     ContextHandle = 16,
     ReceiverShouldFree = 20,
     CallerNativeTID = 24,
+    SyncDoneSemaphorePtr = 28,
 }
 export const JSMarshalerTypeSize = 32;
 // keep in sync with JSFunctionBinding.JSBindingType
@@ -89,6 +90,12 @@ export function is_receiver_should_free(args: JSMarshalerArguments): boolean {
     if (!WasmEnableThreads) return false;
     mono_assert(args, "Null args");
     return getB32(<any>args + JSMarshalerArgumentOffsets.ReceiverShouldFree);
+}
+
+export function get_sync_done_semaphore_ptr(args: JSMarshalerArguments): VoidPtr {
+    if (!WasmEnableThreads) return VoidPtrNull;
+    mono_assert(args, "Null args");
+    return getI32(<any>args + JSMarshalerArgumentOffsets.SyncDoneSemaphorePtr) as any;
 }
 
 export function get_caller_native_tid(args: JSMarshalerArguments): PThreadPtr {

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -661,7 +661,7 @@ mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void 
 	emscripten_dispatch_to_thread_async (target_thread, EM_FUNC_SIG_VII, func, NULL, user_data1, user_data2);
 }
 
-static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *done, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args)
+static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *done, void (*func) (gpointer, gpointer), gpointer user_data1, void* args)
 {
 	// in UI thread we postpone the execution via safeSetTimeout so that emscripten_proxy_execute_queue is not blocked by this call
 	// see invoke_later_on_ui_thread
@@ -675,7 +675,6 @@ static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *don
 		mono_coop_sem_post (done);
 	}
 }
-
 
 EMSCRIPTEN_KEEPALIVE void 
 mono_threads_wasm_sync_run_in_target_thread_done (MonoCoopSem *sem)

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -661,18 +661,34 @@ mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void 
 	emscripten_dispatch_to_thread_async (target_thread, EM_FUNC_SIG_VII, func, NULL, user_data1, user_data2);
 }
 
-static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *done, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2)
+static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *done, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args)
 {
-	func (user_data1, user_data2);
-	mono_coop_sem_post (done);
+	// in UI thread we postpone the execution via safeSetTimeout so that emscripten_proxy_execute_queue is not blocked by this call
+	// see invoke_later_on_ui_thread
+	if (mono_threads_wasm_is_ui_thread()) {
+		MonoCoopSem **semPtrPtr = (MonoCoopSem **)(args + 28/*JSMarshalerArgumentOffsets.SyncDoneSemaphorePtr*/);
+		*semPtrPtr = done;
+		func (user_data1, args);
+	}
+	else {
+		func (user_data1, args);
+		mono_coop_sem_post (done);
+	}
+}
+
+
+EMSCRIPTEN_KEEPALIVE void 
+mono_threads_wasm_sync_run_in_target_thread_done (MonoCoopSem *sem)
+{
+	mono_coop_sem_post (sem);
 }
 
 void
-mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2)
+mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args)
 {
 	MonoCoopSem sem;
 	mono_coop_sem_init (&sem, 0);
-	emscripten_dispatch_to_thread_async (target_thread, EM_FUNC_SIG_VIIII, mono_threads_wasm_sync_run_in_target_thread_vii_cb, NULL, &sem, func, user_data1, user_data2);
+	emscripten_dispatch_to_thread_async (target_thread, EM_FUNC_SIG_VIIII, mono_threads_wasm_sync_run_in_target_thread_vii_cb, NULL, &sem, func, user_data1, args);
 
 	MONO_ENTER_GC_UNSAFE;
 	mono_coop_sem_wait (&sem, MONO_SEM_FLAGS_NONE);

--- a/src/mono/mono/utils/mono-threads-wasm.c
+++ b/src/mono/mono/utils/mono-threads-wasm.c
@@ -666,7 +666,7 @@ static void mono_threads_wasm_sync_run_in_target_thread_vii_cb (MonoCoopSem *don
 	// in UI thread we postpone the execution via safeSetTimeout so that emscripten_proxy_execute_queue is not blocked by this call
 	// see invoke_later_on_ui_thread
 	if (mono_threads_wasm_is_ui_thread()) {
-		MonoCoopSem **semPtrPtr = (MonoCoopSem **)(args + 28/*JSMarshalerArgumentOffsets.SyncDoneSemaphorePtr*/);
+		MonoCoopSem **semPtrPtr = (MonoCoopSem **)(((char *) args) + 28/*JSMarshalerArgumentOffsets.SyncDoneSemaphorePtr*/);
 		*semPtrPtr = done;
 		func (user_data1, args);
 	}

--- a/src/mono/mono/utils/mono-threads-wasm.h
+++ b/src/mono/mono/utils/mono-threads-wasm.h
@@ -65,7 +65,7 @@ void
 mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 
 void
-mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
+mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args);
 
 static inline
 int32_t

--- a/src/mono/mono/utils/mono-threads-wasm.h
+++ b/src/mono/mono/utils/mono-threads-wasm.h
@@ -67,6 +67,9 @@ mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void 
 void
 mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args);
 
+void 
+mono_threads_wasm_sync_run_in_target_thread_done (MonoCoopSem *sem);
+
 static inline
 int32_t
 mono_wasm_atomic_wait_i32 (volatile int32_t *addr, int32_t expected, int32_t timeout_ns)

--- a/src/mono/sample/wasm/browser-threads/Program.cs
+++ b/src/mono/sample/wasm/browser-threads/Program.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading;
@@ -17,9 +18,10 @@ public partial class Test
     private static bool _isRunning = false;
     private static readonly IReadOnlyList<string> _animations = new string[] { "\u2680", "\u2681", "\u2682", "\u2683", "\u2684", "\u2685" };
 
-    public static int Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         Console.WriteLine("Hello, World!");
+        await updateProgress2();
         return 0;
     }
 
@@ -28,6 +30,18 @@ public partial class Test
 
     [JSImport("Sample.Test.updateProgress", "main.js")]
     private static partial Task updateProgress(string status);
+
+    [JSImport("Sample.Test.updateProgress2", "main.js")]
+    private static partial Task updateProgress2();
+
+    [JSExport]
+    public static void Progress2()
+    {
+        // both calls here are sync POSIX calls dispatched to UI thread, which is already blocked because this is synchronous method on deputy thread
+        // in should not deadlock anyway, see also invoke_later_when_on_ui_thread_sync and emscripten_yield
+        var cwd = Directory.GetCurrentDirectory();
+        Console.WriteLine("Progress! "+ cwd); 
+    }
 
     [JSExport]
     public static bool Progress()

--- a/src/mono/sample/wasm/browser-threads/main.js
+++ b/src/mono/sample/wasm/browser-threads/main.js
@@ -22,7 +22,8 @@ try {
     setModuleImports("main.js", {
         Sample: {
             Test: {
-                updateProgress
+                updateProgress,
+                updateProgress2
             }
         }
     });
@@ -61,6 +62,10 @@ export async function updateProgress(status) {
     } else {
         console.log("Progress: " + status);
     }
+}
+
+export async function updateProgress2() {
+    exports.Sample.Test.Progress2();
 }
 
 function delay(ms) {


### PR DESCRIPTION
postpone invocation of user JS in UI thread till next event loop tick, so that `em_task_queue_execute` is not blocked by it. 
That allows `emscripten_yield` to process FS POSIX calls even if the UI is spin-waiting for the return from synchonous call to `JSExport`

 - new args field `SyncDoneSemaphorePtr`
 - new `invoke_later_when_on_ui_thread_sync`
 - new `invoke_later_when_on_ui_thread_async` which postpone invocation of user code till next event loop tick
 - rename `mono_wasm_invoke_jsimport_MT`
 - test in `browser-threads` sample, more tests in next PR