### PR TITLE
[mono] unify and vectorize implementation of decode_value metadata API

### DIFF
--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -211,6 +211,9 @@ if(HOST_WIN32 AND NOT DISABLE_SHARED_LIBS)
 endif()
 
 add_library(metadata_objects OBJECT ${metadata_sources})
+if(HOST_WASM)
+  set_target_properties(metadata_objects PROPERTIES COMPILE_FLAGS "-msimd128")
+endif()
 target_compile_definitions(metadata_objects PRIVATE ${metadata_compile_definitions})
 target_link_libraries(metadata_objects PRIVATE monoapi eglib_api utils_objects)
 # note: metadata_objects is an object library, so this doesn't force linking with sgen,

--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -211,9 +211,6 @@ if(HOST_WIN32 AND NOT DISABLE_SHARED_LIBS)
 endif()
 
 add_library(metadata_objects OBJECT ${metadata_sources})
-if(HOST_WASM)
-  set_target_properties(metadata_objects PROPERTIES COMPILE_FLAGS "-msimd128")
-endif()
 target_compile_definitions(metadata_objects PRIVATE ${metadata_compile_definitions})
 target_link_libraries(metadata_objects PRIVATE monoapi eglib_api utils_objects)
 # note: metadata_objects is an object library, so this doesn't force linking with sgen,

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1296,4 +1296,7 @@ mono_method_signature_has_ext_callconv (MonoMethodSignature *sig, MonoExtCallCon
 	return (sig->ext_callconv & flags) != 0;
 }
 
+guint32
+mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr);
+
 #endif /* __MONO_METADATA_INTERNALS_H__ */

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1538,7 +1538,7 @@ decode_value_scalar (const guint8 *ptr, const guint8 **new_ptr)
 MONO_ALWAYS_INLINE guint32
 mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
 {
-#ifdef __clang__
+#if defined(__clang__) && __LITTLE_ENDIAN__
 	guint32 result;
 
 	typedef guint8 v64_u1 __attribute__ ((vector_size (8)));

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1502,78 +1502,10 @@ mono_metadata_decode_row_col_raw (const MonoTableInfo *t, int idx, guint col)
 	return 0;
 }
 
-typedef guint8 v128_u1 __attribute__ ((vector_size (16)));
-typedef guint32 v128_u4 __attribute__ ((vector_size (16)));
-
 MONO_ALWAYS_INLINE guint32
-mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
+mono_metadata_decode_value_scalar (const guint8 *ptr, const guint8 **new_ptr)
 {
 	guint32 result;
-
-#ifdef __clang__
-	// this will generate v128-ized code on x64 and wasm as long as SIMD is enabled at build time.
-	// if simd isn't enabled, it generates fairly adequate scalar code.
-	// *(bytes *)ptr and *(guint32 *)ptr by themselves don't force an i32 load of
-	//  ptr in either x64 or wasm clang, so this is the only way to prefetch all the bytes
-	// without doing this, decode_value will do 5 individual single-byte memory loads,
-	//  and each individual load is potentially bounds-checked. we produce one wide load
-	// we could overrun the source buffer by up to 11 bytes, but doing that on wasm is
-	//  safe unless we're decoding from the absolute end of memory.
-	// we pad all buffers by 16 bytes in mono_wasm_load_bytes_into_heap, so we're fine
-	union {
-		v128_u1 b;
-		v128_u4 i;
-	} v;
-	v.b = *(v128_u1 *)ptr;
-	// mask and shift two bits so we can have a 4-element jump table in wasm
-	guint8 flags = (v.b[0] & (0x80u | 0x40u)) >> 6;
-	switch (flags) {
-		case 0b00u:
-		case 0b01u:
-			// if (b & 0x80) == 0
-			result = v.b[0] & 0x7Fu;
-			++ptr;
-			break;
-		case 0b10u:
-			// (b * 0x80) != 0, and (b & 0x40) == 0
-			// v.b = { ptr[1], ptr[0], ptr[0], ptr[0] }
-			v.b = __builtin_shufflevector(
-				v.b, v.b,
-				1, 0, 0, 0, -1, -1, -1, -1,
-				-1, -1, -1, -1, -1, -1, -1, -1
-			);
-			// result = v.b[0..3] where v.b[1..2] = 0 and v.b[0] &= 0x3F
-			result = v.i[0] & 0x3FFFu;
-			ptr += 2;
-			break;
-		case 0b11u:
-		// i don't know why the default case is necessary here, but without it the jump table has 5 entries.
-		default:
-			// (b * 0x80) != 0, and (b & 0x40) != 0
-			if (v.b[0] == 0xFFu) {
-				// v.b = { ptr[4], ptr[3], ptr[2], ptr[1] }
-				v.b = __builtin_shufflevector(
-					v.b, v.b,
-					4, 3, 2, 1, -1, -1, -1, -1,
-					-1, -1, -1, -1, -1, -1, -1, -1
-				);
-				// result = v.b[0..3];
-				result = v.i[0];
-				ptr += 5;
-			} else {
-				// v.b = { ptr[3], ptr[2], ptr[1], ptr[0] }
-				v.b = __builtin_shufflevector(
-					v.b, v.b,
-					3, 2, 1, 0, -1, -1, -1, -1,
-					-1, -1, -1, -1, -1, -1, -1, -1
-				);
-				// result = v.b[0..3] where v.b[0] &= 0x1F
-				result = v.i[0] & 0x1FFFFFFFu;
-				ptr += 4;
-			}
-			break;
-	}
-#else
 	guint8 b = *ptr;
 
 	if ((b & 0x80) == 0){
@@ -1593,12 +1525,88 @@ mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
 		result = (ptr [1] << 24) | (ptr [2] << 16) | (ptr [3] << 8) | ptr [4];
 		ptr += 5;
 	}
-#endif
+
+	return result;
+}
+
+MONO_ALWAYS_INLINE guint32
+mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
+{
+#ifdef __clang__
+	guint32 result;
+
+	typedef guint8 v64_u1 __attribute__ ((vector_size (8)));
+	typedef guint32 v64_u4 __attribute__ ((vector_size (8)));
+
+	// this will generate vectorized code on x64 and wasm as long as SIMD is enabled
+	// if simd isn't enabled, it generates fairly adequate scalar code.
+	// *(bytes *)ptr and *(guint32 *)ptr by themselves don't force an i32 load of
+	//  ptr in either x64 or wasm clang, so this is the only way to prefetch all the bytes
+	// without doing this, decode_value will do 5 conditional single-byte memory loads,
+	//  and each individual load is potentially bounds-checked. we produce one wide load
+	// we could overrun the source buffer by up to 7 bytes, but doing that on wasm is
+	//  safe unless we're decoding from the absolute end of memory.
+	// we pad all buffers by 16 bytes in mono_wasm_load_bytes_into_heap, so we're fine
+	// clang happily upsizes these 8-byte vectors into 16-byte ones for wasm, and uses 8-byte
+	//  insns on x64 as appropriate. armv8 looks fine too, albeit a little weird
+	union {
+		v64_u1 b;
+		v64_u4 i;
+	} v;
+	v.b = *(v64_u1 *)ptr;
+	// mask and shift two bits so we can have a 4-element jump table in wasm
+	guint8 flags = (v.b[0] & (0x80u | 0x40u)) >> 6;
+	switch (flags) {
+		case 0b00u:
+		case 0b01u:
+			// if (b & 0x80) == 0
+			result = v.b[0] & 0x7Fu;
+			++ptr;
+			break;
+		case 0b10u:
+			// (b * 0x80) != 0, and (b & 0x40) == 0
+			// v.b = { ptr[1], ptr[0], ptr[0], ptr[0] }
+			v.b = __builtin_shufflevector(
+				v.b, v.b,
+				1, 0, -1, -1, -1, -1, -1, -1
+			);
+			// result = v.b[0..3] where v.b[1..2] = 0 and v.b[0] &= 0x3F
+			result = v.i[0] & 0x3FFFu;
+			ptr += 2;
+			break;
+		case 0b11u:
+		// i don't know why the default case is necessary here, but without it the jump table has 5 entries.
+		default:
+			// (b * 0x80) != 0, and (b & 0x40) != 0
+			if (v.b[0] == 0xFFu) {
+				// v.b = { ptr[4], ptr[3], ptr[2], ptr[1] }
+				v.b = __builtin_shufflevector(
+					v.b, v.b,
+					4, 3, 2, 1, -1, -1, -1, -1
+				);
+				// result = v.b[0..3];
+				result = v.i[0];
+				ptr += 5;
+			} else {
+				// v.b = { ptr[3], ptr[2], ptr[1], ptr[0] }
+				v.b = __builtin_shufflevector(
+					v.b, v.b,
+					3, 2, 1, 0, -1, -1, -1, -1
+				);
+				// result = v.b[0..3] where v.b[0] &= 0x1F
+				result = v.i[0] & 0x1FFFFFFFu;
+				ptr += 4;
+			}
+			break;
+	}
 
 	if (new_ptr)
 		*new_ptr = ptr;
 
 	return result;
+#else
+	return mono_metadata_decode_value_scalar (ptr, rptr);
+#endif
 }
 
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1538,7 +1538,7 @@ decode_value_scalar (const guint8 *ptr, const guint8 **new_ptr)
 MONO_ALWAYS_INLINE guint32
 mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
 {
-#if defined(__clang__) && __LITTLE_ENDIAN__
+#if defined(__clang__) && (G_BYTE_ORDER == G_LITTLE_ENDIAN)
 	guint32 result;
 
 	typedef guint8 v64_u1 __attribute__ ((vector_size (8)));

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -1502,8 +1502,8 @@ mono_metadata_decode_row_col_raw (const MonoTableInfo *t, int idx, guint col)
 	return 0;
 }
 
-MONO_ALWAYS_INLINE guint32
-mono_metadata_decode_value_scalar (const guint8 *ptr, const guint8 **new_ptr)
+static MONO_ALWAYS_INLINE guint32
+decode_value_scalar (const guint8 *ptr, const guint8 **new_ptr)
 {
 	guint32 result;
 	guint8 b = *ptr;
@@ -1605,7 +1605,7 @@ mono_metadata_decode_value_simd (const guint8 *ptr, const guint8 **new_ptr)
 
 	return result;
 #else
-	return mono_metadata_decode_value_scalar (ptr, rptr);
+	return decode_value_scalar (ptr, rptr);
 #endif
 }
 

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -345,31 +345,7 @@ load_image (MonoAotModule *amodule, int index, MonoError *error)
 static gint32
 decode_value (guint8 *ptr, guint8 **rptr)
 {
-	guint8 b = *ptr;
-	gint32 len;
-
-	if ((b & 0x80) == 0){
-		len = b;
-		++ptr;
-	} else if ((b & 0x40) == 0){
-		len = ((b & 0x3f) << 8 | ptr [1]);
-		ptr += 2;
-	} else if (b != 0xff) {
-		len = ((b & 0x1f) << 24) |
-			(ptr [1] << 16) |
-			(ptr [2] << 8) |
-			ptr [3];
-		ptr += 4;
-	}
-	else {
-		len = (ptr [1] << 24) | (ptr [2] << 16) | (ptr [3] << 8) | ptr [4];
-		ptr += 5;
-	}
-	if (rptr)
-		*rptr = ptr;
-
-	//printf ("DECODE: %d.\n", len);
-	return len;
+	return mono_metadata_decode_value_simd ((const guint8 *)ptr, (const guint8 **)rptr);
 }
 
 static guint32
@@ -2480,7 +2456,7 @@ load_container_amodule (MonoAssemblyLoadContext *alc)
 
 	mono_loader_lock ();
 	// There might be several threads that passed the first check
-	// Adding another check to ensure single load of a container assembly due to race condition 
+	// Adding another check to ensure single load of a container assembly due to race condition
 	if (!container_amodule) {
 		ERROR_DECL (error);
 

--- a/src/mono/mono/mini/debug-mini.c
+++ b/src/mono/mono/mini/debug-mini.c
@@ -390,31 +390,7 @@ encode_value (gint32 value, guint8 *buf, guint8 **endbuf)
 static gint32
 decode_value (guint8 *ptr, guint8 **rptr)
 {
-	guint8 b = *ptr;
-	gint32 len;
-
-	if ((b & 0x80) == 0){
-		len = b;
-		++ptr;
-	} else if ((b & 0x40) == 0){
-		len = ((b & 0x3f) << 8 | ptr [1]);
-		ptr += 2;
-	} else if (b != 0xff) {
-		len = ((b & 0x1f) << 24) |
-			(ptr [1] << 16) |
-			(ptr [2] << 8) |
-			ptr [3];
-		ptr += 4;
-	}
-	else {
-		len = (ptr [1] << 24) | (ptr [2] << 16) | (ptr [3] << 8) | ptr [4];
-		ptr += 5;
-	}
-	if (rptr)
-		*rptr = ptr;
-
-	//printf ("DECODE: %d.\n", len);
-	return len;
+	return mono_metadata_decode_value_simd ((const guint8 *)ptr, (const guint8 **)rptr);
 }
 
 static void


### PR DESCRIPTION
We have multiple copies of the same decode_value function spread across the mono runtime. This PR unifies them all into a single implementation under metadata/, and then vectorizes it using clang vector builtins.

A basic benchmark on x64 using clang -O3 showed a 13% time reduction, and the generated wasm for this is pretty efficient, so I'm hoping it will be a small startup time win for any target where we enable it. It's hard to actually measure in practice locally though...

I verified that the vectorized implementation works correctly by comparing its output against the scalar version for all possible 5-byte sequences, so this should be a safe switch-over as long as there aren't endianness issues.

Pending stuff to fix for this PR:
* Enable SIMD for metadata on wasm the correct way
* Make certain that it's actually safe to swap all the other copies of the algorithm over to this one (at least one appears to have contained a bug)
* Is it safe to overrun when reading on other targets? POSIX rounds mmap up to page-sized units, and extra bytes off the end are zeroes, so it might be?