### PR TITLE
JIT ARM64-SVE: Add more templated encode immediate methods

### DIFF
--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12148,17 +12148,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
 /*****************************************************************************
  *
- *  Returns the encoding for the immediate value that is a multiple of 2 as 4-bits at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeSimm4_MultipleOf2_19_to_16(ssize_t imm)
-{
-    assert((isValidSimm_MultipleOf<4, 2>(imm)));
-    return insEncodeSimm<19, 16>(imm / 2);
-}
-
-/*****************************************************************************
- *
  *  Returns the encoding for the immediate value that is a multiple of 3 as 4-bits at bit locations '19-16'.
  */
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12148,50 +12148,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
 /*****************************************************************************
  *
- *  Returns the encoding for the immediate value that is a multiple of 3 as 4-bits at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeSimm4_MultipleOf3_19_to_16(ssize_t imm)
-{
-    assert((isValidSimm_MultipleOf<4, 3>(imm)));
-    return insEncodeSimm<19, 16>(imm / 3);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 4 as 4-bits at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeSimm4_MultipleOf4_19_to_16(ssize_t imm)
-{
-    assert((isValidSimm_MultipleOf<4, 4>(imm)));
-    return insEncodeSimm<19, 16>(imm / 4);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 16 as 4-bits at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeSimm4_MultipleOf16_19_to_16(ssize_t imm)
-{
-    assert((isValidSimm_MultipleOf<4, 16>(imm)));
-    return insEncodeSimm<19, 16>(imm / 16);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 32 as 4-bits at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeSimm4_MultipleOf32_19_to_16(ssize_t imm)
-{
-    assert((isValidSimm_MultipleOf<4, 32>(imm)));
-    return insEncodeSimm<19, 16>(imm / 32);
-}
-
-/*****************************************************************************
- *
  *  Returns the encoding for the immediate value that is a multiple of 2 as 5-bits at bit locations '20-16'.
  */
 

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -12148,83 +12148,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
 
 /*****************************************************************************
  *
- *  Returns the encoding for the immediate value that is a multiple of 2 as 5-bits at bit locations '20-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm5_MultipleOf2_20_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<5, 2>(imm)));
-    return insEncodeUimm<20, 16>(imm / 2);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 4 as 5-bits at bit locations '20-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm5_MultipleOf4_20_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<5, 4>(imm)));
-    return insEncodeUimm<20, 16>(imm / 4);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 8 as 5-bits at bit locations '20-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm5_MultipleOf8_20_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<5, 8>(imm)));
-    return insEncodeUimm<20, 16>(imm / 8);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 2 as 6-bits at bit locations '21-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm6_MultipleOf2_21_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<6, 2>(imm)));
-    return insEncodeUimm<21, 16>(imm / 2);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 4 as 6-bits at bit locations '21-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm6_MultipleOf4_21_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<6, 4>(imm)));
-    return insEncodeUimm<21, 16>(imm / 4);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value that is a multiple of 8 as 6-bits at bit locations '21-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm6_MultipleOf8_21_to_16(ssize_t imm)
-{
-    assert((isValidUimm_MultipleOf<6, 8>(imm)));
-    return insEncodeUimm<21, 16>(imm / 8);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value as 1-bit at bit locations '23'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm1_23(ssize_t imm)
-{
-    assert(isValidUimm<1>(imm));
-    return (code_t)imm << 23;
-}
-
-/*****************************************************************************
- *
  *  Returns the encoding for the immediate value as 3-bits at bit locations '23-22' for high and '12' for low.
  */
 
@@ -12236,17 +12159,6 @@ void emitter::emitIns_Call(EmitCallType          callType,
     code_t l = (code_t)(imm & 0x1) << 12; // encode low 1-bit at locations '12'
 
     return (h | l);
-}
-
-/*****************************************************************************
- *
- *  Returns the encoding for the immediate value as 4-bits starting from 1, at bit locations '19-16'.
- */
-
-/*static*/ emitter::code_t emitter::insEncodeUimm4From1_19_to_16(ssize_t imm)
-{
-    assert(isValidUimmFrom1<4>(imm));
-    return (code_t)(imm - 1) << 16;
 }
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -676,6 +676,16 @@ static code_t insEncodeSimm(ssize_t imm)
     return result << lo;
 }
 
+// Returns the encoding for unsigned immediate `imm` that is a multiple of `mul` with `bits` number of bits,
+// starting at bit location `lo`.
+template <const size_t bits, const ssize_t mul, const size_t lo>
+static code_t insEncodeUimm_MultipleOf(ssize_t imm)
+{
+    assert((isValidUimm_MultipleOf<bits, mul>(imm)));
+    constexpr size_t hi = lo + bits - 1;
+    return insEncodeUimm<hi, lo>(imm / mul);
+}
+
 // Returns the encoding for signed immediate `imm` that is a multiple of `mul` with `bits` number of bits,
 // starting at bit location `lo`.
 template <const size_t bits, const ssize_t mul, const size_t lo>

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -676,7 +676,8 @@ static code_t insEncodeSimm(ssize_t imm)
     return result << lo;
 }
 
-// Returns the encoding for `imm` that is a multiple of `mul`, as `bits` number of bits, starting at bit location `lo`.
+// Returns the encoding for signed immediate `imm` that is a multiple of `mul` with `bits` number of bits,
+// starting at bit location `lo`.
 template <const size_t bits, const ssize_t mul, const size_t lo>
 static code_t insEncodeSimm_MultipleOf(ssize_t imm)
 {
@@ -687,18 +688,6 @@ static code_t insEncodeSimm_MultipleOf(ssize_t imm)
 
 // Returns the encoding for the immediate value as 9-bits at bit locations '21-16' for high and '12-10' for low.
 static code_t insEncodeSimm9h9l_21_to_16_and_12_to_10(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 3 as 4-bits at bit locations '19-16'.
-static code_t insEncodeSimm4_MultipleOf3_19_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 4 as 4-bits at bit locations '19-16'.
-static code_t insEncodeSimm4_MultipleOf4_19_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 16 as 4-bits at bit locations '19-16'.
-static code_t insEncodeSimm4_MultipleOf16_19_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 32 as 4-bits at bit locations '19-16'.
-static code_t insEncodeSimm4_MultipleOf32_19_to_16(ssize_t imm);
 
 // Returns the encoding for the immediate value that is a multiple of 2 as 5-bits at bit locations '20-16'.
 static code_t insEncodeUimm5_MultipleOf2_20_to_16(ssize_t imm);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -699,32 +699,8 @@ static code_t insEncodeSimm_MultipleOf(ssize_t imm)
 // Returns the encoding for the immediate value as 9-bits at bit locations '21-16' for high and '12-10' for low.
 static code_t insEncodeSimm9h9l_21_to_16_and_12_to_10(ssize_t imm);
 
-// Returns the encoding for the immediate value that is a multiple of 2 as 5-bits at bit locations '20-16'.
-static code_t insEncodeUimm5_MultipleOf2_20_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 4 as 5-bits at bit locations '20-16'.
-static code_t insEncodeUimm5_MultipleOf4_20_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 8 as 5-bits at bit locations '20-16'.
-static code_t insEncodeUimm5_MultipleOf8_20_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 2 as 6-bits at bit locations '21-16'.
-static code_t insEncodeUimm6_MultipleOf2_21_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 4 as 6-bits at bit locations '21-16'.
-static code_t insEncodeUimm6_MultipleOf4_21_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 8 as 6-bits at bit locations '21-16'.
-static code_t insEncodeUimm6_MultipleOf8_21_to_16(ssize_t imm);
-
-// Returns the encoding for the immediate value as 1-bit at bit locations '23'.
-static code_t insEncodeUimm1_23(ssize_t imm);
-
 // Returns the encoding for the immediate value as 3-bits at bit locations '23-22' for high and '12' for low.
 static code_t insEncodeUimm3h3l_23_to_22_and_12(ssize_t imm);
-
-// Returns the encoding for the immediate value as 4-bits starting from 1, at bit locations '19-16'.
-static code_t insEncodeUimm4From1_19_to_16(ssize_t imm);
 
 // Returns the encoding for the immediate value as 8-bits at bit locations '12-5'.
 static code_t insEncodeImm8_12_to_5(ssize_t imm);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -677,22 +677,23 @@ static code_t insEncodeSimm(ssize_t imm)
 }
 
 // Returns the encoding for unsigned immediate `imm` that is a multiple of `mul` with `bits` number of bits,
-// starting at bit location `lo`.
-template <const size_t bits, const ssize_t mul, const size_t lo>
+// for bit locations `hi-lo`.
+template <const size_t hi, const size_t lo, const ssize_t mul>
 static code_t insEncodeUimm_MultipleOf(ssize_t imm)
 {
+
+    constexpr size_t bits = hi - lo + 1;
     assert((isValidUimm_MultipleOf<bits, mul>(imm)));
-    constexpr size_t hi = lo + bits - 1;
     return insEncodeUimm<hi, lo>(imm / mul);
 }
 
 // Returns the encoding for signed immediate `imm` that is a multiple of `mul` with `bits` number of bits,
-// starting at bit location `lo`.
-template <const size_t bits, const ssize_t mul, const size_t lo>
+// for bit locations `hi-lo`.
+template <const size_t hi, const size_t lo, const ssize_t mul>
 static code_t insEncodeSimm_MultipleOf(ssize_t imm)
 {
+    constexpr size_t bits = hi - lo + 1;
     assert((isValidSimm_MultipleOf<bits, mul>(imm)));
-    constexpr size_t hi = lo + bits - 1;
     return insEncodeSimm<hi, lo>(imm / mul);
 }
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -676,11 +676,17 @@ static code_t insEncodeSimm(ssize_t imm)
     return result << lo;
 }
 
+// Returns the encoding for `imm` that is a multiple of `mul`, as `bits` number of bits, starting at bit location `lo`.
+template <const size_t bits, const ssize_t mul, const size_t lo>
+static code_t insEncodeSimm_MultipleOf(ssize_t imm)
+{
+    assert((isValidSimm_MultipleOf<bits, mul>(imm)));
+    constexpr size_t hi = lo + bits - 1;
+    return insEncodeSimm<hi, lo>(imm / mul);
+}
+
 // Returns the encoding for the immediate value as 9-bits at bit locations '21-16' for high and '12-10' for low.
 static code_t insEncodeSimm9h9l_21_to_16_and_12_to_10(ssize_t imm);
-
-// Returns the encoding for the immediate value that is a multiple of 2 as 4-bits at bit locations '19-16'.
-static code_t insEncodeSimm4_MultipleOf2_19_to_16(ssize_t imm);
 
 // Returns the encoding for the immediate value that is a multiple of 3 as 4-bits at bit locations '19-16'.
 static code_t insEncodeSimm4_MultipleOf3_19_to_16(ssize_t imm);

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -11678,9 +11678,9 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
         case IF_SVE_JL_3A: // ...........iiiii ...gggnnnnnttttt -- SVE 64-bit scatter store (vector plus immediate)
             imm  = emitGetInsSC(id);
             code = emitInsCodeSve(ins, fmt);
-            code |= insEncodeReg_V_4_to_0(id->idReg1());     // ttttt
-            code |= insEncodeReg_P_12_to_10(id->idReg2());   // ggg
-            code |= insEncodeReg_V_9_to_5(id->idReg3());     // nnnnn
+            code |= insEncodeReg_V_4_to_0(id->idReg1());      // ttttt
+            code |= insEncodeReg_P_12_to_10(id->idReg2());    // ggg
+            code |= insEncodeReg_V_9_to_5(id->idReg3());      // nnnnn
             code |= insEncodeUimm_MultipleOf<20, 16, 8>(imm); // iiiii
             dst += emitOutput_Instr(dst, code);
             break;

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -10071,7 +10071,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             code = emitInsCodeSve(ins, fmt);
             code |= insEncodeReg_Rd(id->idReg1());           // ddddd
             code |= insEncodeSvePattern(id->idSvePattern()); // ppppp
-            code |= insEncodeUimm4From1_19_to_16(imm);       // iiii
+            code |= insEncodeUimm<19, 16>(imm - 1);          // iiii
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -10080,7 +10080,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             code = emitInsCodeSve(ins, fmt);
             code |= insEncodeReg_Rd(id->idReg1());              // ddddd
             code |= insEncodeSvePattern(id->idSvePattern());    // ppppp
-            code |= insEncodeUimm4From1_19_to_16(imm);          // iiii
+            code |= insEncodeUimm<19, 16>(imm - 1);             // iiii
             code |= insEncodeSveElemsize_sz_20(id->idOpSize()); // X
             dst += emitOutput_Instr(dst, code);
             break;
@@ -10102,7 +10102,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             code = emitInsCodeSve(ins, fmt);
             code |= insEncodeReg_V_4_to_0(id->idReg1());     // ddddd
             code |= insEncodeSvePattern(id->idSvePattern()); // ppppp
-            code |= insEncodeUimm4From1_19_to_16(imm);       // iiii
+            code |= insEncodeUimm<19, 16>(imm - 1);          // iiii
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -11554,7 +11554,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             code |= insEncodeReg_V_4_to_0(id->idReg1());   // ddddd
             code |= insEncodeReg_V_9_to_5(id->idReg2());   // nnnnn
             code |= insEncodeReg_V_20_to_16(id->idReg3()); // mmmmm
-            code |= insEncodeUimm1_23(imm);                // i
+            code |= insEncodeUimm<23, 23>(imm);            // i
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -11616,15 +11616,15 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_prfh:
-                    code |= insEncodeUimm5_MultipleOf2_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
                     break;
 
                 case INS_sve_prfw:
-                    code |= insEncodeUimm5_MultipleOf4_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
                     break;
 
                 case INS_sve_prfd:
-                    code |= insEncodeUimm5_MultipleOf8_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
                     break;
 
                 default:
@@ -11657,18 +11657,18 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             {
                 case INS_sve_ld1d:
                 case INS_sve_ldff1d:
-                    code |= insEncodeUimm5_MultipleOf8_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
                     break;
 
                 case INS_sve_ld1w:
                 case INS_sve_ld1sw:
                 case INS_sve_ldff1w:
                 case INS_sve_ldff1sw:
-                    code |= insEncodeUimm5_MultipleOf4_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
                     break;
 
                 default:
-                    code |= insEncodeUimm5_MultipleOf2_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
                     break;
             }
 
@@ -11678,10 +11678,10 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
         case IF_SVE_JL_3A: // ...........iiiii ...gggnnnnnttttt -- SVE 64-bit scatter store (vector plus immediate)
             imm  = emitGetInsSC(id);
             code = emitInsCodeSve(ins, fmt);
-            code |= insEncodeReg_V_4_to_0(id->idReg1());      // ttttt
-            code |= insEncodeReg_P_12_to_10(id->idReg2());    // ggg
-            code |= insEncodeReg_V_9_to_5(id->idReg3());      // nnnnn
-            code |= insEncodeUimm5_MultipleOf8_20_to_16(imm); // iiiii
+            code |= insEncodeReg_V_4_to_0(id->idReg1());     // ttttt
+            code |= insEncodeReg_P_12_to_10(id->idReg2());   // ggg
+            code |= insEncodeReg_V_9_to_5(id->idReg3());     // nnnnn
+            code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -11696,11 +11696,11 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_st1h:
-                    code |= insEncodeUimm5_MultipleOf2_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
                     break;
 
                 case INS_sve_st1w:
-                    code |= insEncodeUimm5_MultipleOf4_20_to_16(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
                     break;
 
                 default:
@@ -11732,12 +11732,12 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_ld1rd:
-                    code |= insEncodeUimm6_MultipleOf8_21_to_16(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<6, 8, 16>(imm); // iiiiii
                     break;
 
                 default:
                     assert(ins == INS_sve_ld1rsw);
-                    code |= insEncodeUimm6_MultipleOf4_21_to_16(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<6, 4, 16>(imm); // iiiiii
                     break;
             }
 
@@ -11757,12 +11757,12 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_ld1rw:
-                    code |= insEncodeUimm6_MultipleOf4_21_to_16(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<6, 4, 16>(imm); // iiiiii
                     break;
 
                 case INS_sve_ld1rh:
                 case INS_sve_ld1rsh:
-                    code |= insEncodeUimm6_MultipleOf2_21_to_16(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<6, 2, 16>(imm); // iiiiii
                     break;
 
                 default:

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -11142,7 +11142,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st3w:
                 case INS_sve_st3d:
                 case INS_sve_st3q:
-                    code |= insEncodeSimm4_MultipleOf3_19_to_16(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<4, 3, 16>(imm); // iiii
                     break;
 
                 case INS_sve_ld4b:
@@ -11155,21 +11155,21 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st4w:
                 case INS_sve_st4d:
                 case INS_sve_st4q:
-                    code |= insEncodeSimm4_MultipleOf4_19_to_16(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<4, 4, 16>(imm); // iiii
                     break;
 
                 case INS_sve_ld1rqb:
                 case INS_sve_ld1rqd:
                 case INS_sve_ld1rqh:
                 case INS_sve_ld1rqw:
-                    code |= insEncodeSimm4_MultipleOf16_19_to_16(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<4, 16, 16>(imm); // iiii
                     break;
 
                 case INS_sve_ld1rob:
                 case INS_sve_ld1rod:
                 case INS_sve_ld1roh:
                 case INS_sve_ld1row:
-                    code |= insEncodeSimm4_MultipleOf32_19_to_16(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<4, 32, 16>(imm); // iiii
                     break;
 
                 default:

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -11129,7 +11129,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st2w:
                 case INS_sve_st2d:
                 case INS_sve_st2q:
-                    code |= insEncodeSimm4_MultipleOf2_19_to_16(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<4, 2, 16>(imm); // iiii
                     break;
 
                 case INS_sve_ld3b:

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -11129,7 +11129,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st2w:
                 case INS_sve_st2d:
                 case INS_sve_st2q:
-                    code |= insEncodeSimm_MultipleOf<4, 2, 16>(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<19, 16, 2>(imm); // iiii
                     break;
 
                 case INS_sve_ld3b:
@@ -11142,7 +11142,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st3w:
                 case INS_sve_st3d:
                 case INS_sve_st3q:
-                    code |= insEncodeSimm_MultipleOf<4, 3, 16>(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<19, 16, 3>(imm); // iiii
                     break;
 
                 case INS_sve_ld4b:
@@ -11155,21 +11155,21 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
                 case INS_sve_st4w:
                 case INS_sve_st4d:
                 case INS_sve_st4q:
-                    code |= insEncodeSimm_MultipleOf<4, 4, 16>(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<19, 16, 4>(imm); // iiii
                     break;
 
                 case INS_sve_ld1rqb:
                 case INS_sve_ld1rqd:
                 case INS_sve_ld1rqh:
                 case INS_sve_ld1rqw:
-                    code |= insEncodeSimm_MultipleOf<4, 16, 16>(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<19, 16, 16>(imm); // iiii
                     break;
 
                 case INS_sve_ld1rob:
                 case INS_sve_ld1rod:
                 case INS_sve_ld1roh:
                 case INS_sve_ld1row:
-                    code |= insEncodeSimm_MultipleOf<4, 32, 16>(imm); // iiii
+                    code |= insEncodeSimm_MultipleOf<19, 16, 32>(imm); // iiii
                     break;
 
                 default:
@@ -11616,15 +11616,15 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_prfh:
-                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 2>(imm); // iiiii
                     break;
 
                 case INS_sve_prfw:
-                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 4>(imm); // iiiii
                     break;
 
                 case INS_sve_prfd:
-                    code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 8>(imm); // iiiii
                     break;
 
                 default:
@@ -11657,18 +11657,18 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             {
                 case INS_sve_ld1d:
                 case INS_sve_ldff1d:
-                    code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 8>(imm); // iiiii
                     break;
 
                 case INS_sve_ld1w:
                 case INS_sve_ld1sw:
                 case INS_sve_ldff1w:
                 case INS_sve_ldff1sw:
-                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 4>(imm); // iiiii
                     break;
 
                 default:
-                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 2>(imm); // iiiii
                     break;
             }
 
@@ -11681,7 +11681,7 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             code |= insEncodeReg_V_4_to_0(id->idReg1());     // ttttt
             code |= insEncodeReg_P_12_to_10(id->idReg2());   // ggg
             code |= insEncodeReg_V_9_to_5(id->idReg3());     // nnnnn
-            code |= insEncodeUimm_MultipleOf<5, 8, 16>(imm); // iiiii
+            code |= insEncodeUimm_MultipleOf<20, 16, 8>(imm); // iiiii
             dst += emitOutput_Instr(dst, code);
             break;
 
@@ -11696,11 +11696,11 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_st1h:
-                    code |= insEncodeUimm_MultipleOf<5, 2, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 2>(imm); // iiiii
                     break;
 
                 case INS_sve_st1w:
-                    code |= insEncodeUimm_MultipleOf<5, 4, 16>(imm); // iiiii
+                    code |= insEncodeUimm_MultipleOf<20, 16, 4>(imm); // iiiii
                     break;
 
                 default:
@@ -11732,12 +11732,12 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_ld1rd:
-                    code |= insEncodeUimm_MultipleOf<6, 8, 16>(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<21, 16, 8>(imm); // iiiiii
                     break;
 
                 default:
                     assert(ins == INS_sve_ld1rsw);
-                    code |= insEncodeUimm_MultipleOf<6, 4, 16>(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<21, 16, 4>(imm); // iiiiii
                     break;
             }
 
@@ -11757,12 +11757,12 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             switch (ins)
             {
                 case INS_sve_ld1rw:
-                    code |= insEncodeUimm_MultipleOf<6, 4, 16>(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<21, 16, 4>(imm); // iiiiii
                     break;
 
                 case INS_sve_ld1rh:
                 case INS_sve_ld1rsh:
-                    code |= insEncodeUimm_MultipleOf<6, 2, 16>(imm); // iiiiii
+                    code |= insEncodeUimm_MultipleOf<21, 16, 2>(imm); // iiiiii
                     break;
 
                 default:


### PR DESCRIPTION
Adds templated `insEncodeUimm_MultipleOf` and  `insEncodeSimm_MultipleOf` methods to further reduce redundancy. The SVE unit test output remains unchanged.

cc @dotnet/arm64-contrib 