### PR TITLE
[RISC-V] Simplify flags for passing struct in registers

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1235,6 +1235,7 @@ namespace Internal.JitInterface
     //   bit 5: `1` means the second field's size is 8.
     //
     // Note that bit 0 and 3 cannot both be set.
+    [Flags]
     public enum StructFloatFieldInfoFlags
     {
         STRUCT_NO_FLOAT_FIELD         = 0x0,

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -153,7 +153,7 @@ namespace Internal.JitInterface
                             Debug.Assert(fieldIndex == 1);
                             if ((floatFieldFlags2 & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
                             {
-                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_MERGE_FIRST_SECOND;
+                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND;
                             }
                             if (field.FieldType.GetElementSize().AsInt == 8)
                             {

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -70,7 +70,6 @@ namespace Internal.JitInterface
                     StructFloatFieldInfoFlags type =
                         (category is TypeFlags.Single or TypeFlags.Double ? STRUCT_FLOAT_FIELD_FIRST : (StructFloatFieldInfoFlags)0) |
                         (field.FieldType.GetElementSize().AsInt == TARGET_POINTER_SIZE ? STRUCT_FIRST_FIELD_SIZE_IS8 : (StructFloatFieldInfoFlags)0);
-
                     types[typeIndex++] = type;
                 }
                 else
@@ -78,9 +77,6 @@ namespace Internal.JitInterface
                     return false;
                 }
             }
-
-            if (nFields == 0)
-                return true;
 
             if ((td as MetadataType).HasImpliedRepeatedFields())
             {

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -1,217 +1,129 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using ILCompiler;
 using Internal.TypeSystem;
+using static Internal.JitInterface.StructFloatFieldInfoFlags;
 
 namespace Internal.JitInterface
 {
-
     internal static class RISCV64PassStructInRegister
     {
-        public static uint GetRISCV64PassStructInRegisterFlags(TypeDesc typeDesc)
+        private const int
+            ENREGISTERED_PARAMTYPE_MAXSIZE = 16,
+            TARGET_POINTER_SIZE = 8;
+
+        private static bool HandleInlineArray(int elementTypeIndex, int nElements, StructFloatFieldInfoFlags[] types, ref int typeIndex)
         {
-            FieldDesc firstField = null;
-            uint floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-            int numIntroducedFields = 0;
-            foreach (FieldDesc field in typeDesc.GetFields())
+            int nFlattenedFieldsPerElement = typeIndex - elementTypeIndex;
+            if (nFlattenedFieldsPerElement == 0)
+                return true;
+
+            Debug.Assert(nFlattenedFieldsPerElement == 1 || nFlattenedFieldsPerElement == 2);
+
+            if (nElements > 2)
+                return false;
+
+            if (nElements == 2)
             {
-                if (!field.IsStatic)
-                {
-                    firstField ??= field;
-                    numIntroducedFields++;
-                }
+                if (typeIndex + nFlattenedFieldsPerElement > 2)
+                    return false;
+
+                Debug.Assert(elementTypeIndex == 0);
+                Debug.Assert(typeIndex == 1);
+                types[typeIndex++] = types[elementTypeIndex]; // duplicate the array element type
             }
+            return true;
+        }
 
-            if ((numIntroducedFields == 0) || (numIntroducedFields > 2) || (typeDesc.GetElementSize().AsInt > 16))
+        private static bool FlattenFieldTypes(TypeDesc td, StructFloatFieldInfoFlags[] types, ref int typeIndex)
+        {
+            IEnumerable<FieldDesc> fields = td.GetFields();
+            int nFields = 0;
+            int elementTypeIndex = typeIndex;
+            FieldDesc prevField = null;
+            foreach (FieldDesc field in fields)
             {
-                return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-            }
-
-            MetadataType mdType = typeDesc as MetadataType;
-            Debug.Assert(mdType != null);
-
-            TypeDesc firstFieldElementType = firstField.FieldType;
-            int firstFieldSize = firstFieldElementType.GetElementSize().AsInt;
-            bool hasImpliedRepeatedFields = mdType.HasImpliedRepeatedFields();
-
-            if (hasImpliedRepeatedFields)
-            {
-                numIntroducedFields = typeDesc.GetElementSize().AsInt / firstFieldSize;
-                if (numIntroducedFields > 2)
-                {
-                    return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                }
-            }
-
-            int fieldIndex = 0;
-            foreach (FieldDesc field in typeDesc.GetFields())
-            {
-                if (fieldIndex > 1)
-                {
-                    return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                }
-                else if (field.IsStatic)
-                {
+                if (field.IsStatic)
                     continue;
-                }
-                else if (fieldIndex == 1)
+                nFields++;
+
+                if (prevField != null && prevField.Offset.AsInt + prevField.FieldType.GetElementSize().AsInt > field.Offset.AsInt)
+                    return false; // overlapping fields
+
+                prevField = field;
+
+                TypeFlags category = field.FieldType.Category;
+                if (category == TypeFlags.ValueType)
                 {
-                    if (firstField.Offset.AsInt != 0 || field.Offset.AsInt == 0 || firstFieldSize > field.Offset.AsInt)
-                    {
-                        return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                    }
+                    TypeDesc nested = field.FieldType;
+                    if (!FlattenFieldTypes(nested, types, ref typeIndex))
+                        return false;
                 }
-
-                Debug.Assert(fieldIndex < numIntroducedFields);
-
-                switch (field.FieldType.Category)
+                else if (field.FieldType.GetElementSize().AsInt <= TARGET_POINTER_SIZE)
                 {
-                    case TypeFlags.Double:
-                    {
-                        if (numIntroducedFields == 1)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE;
-                        }
-                        else if (fieldIndex == 0)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FIRST_FIELD_DOUBLE;
-                        }
-                        else if ((floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST) != 0)
-                        {
-                            floatFieldFlags ^= (uint)StructFloatFieldInfoFlags.STRUCT_MERGE_FIRST_SECOND_8;
-                        }
-                        else
-                        {
-                            floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_SECOND_FIELD_DOUBLE;
-                        }
+                    if (typeIndex >= 2)
+                        return false;
 
-                        // Pass with two integer registers in `struct {int a, int b, float/double c}` cases
-                        if (fieldIndex == 1 &&
-                                (floatFieldFlags |
-                                 (uint)StructFloatFieldInfoFlags.STRUCT_FIRST_FIELD_SIZE_IS8 |
-                                 (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND) ==
-                                floatFieldFlags)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                        }
-                    }
-                    break;
+                    StructFloatFieldInfoFlags type =
+                        (category is TypeFlags.Single or TypeFlags.Double ? STRUCT_FLOAT_FIELD_FIRST : (StructFloatFieldInfoFlags)0) |
+                        (field.FieldType.GetElementSize().AsInt == TARGET_POINTER_SIZE ? STRUCT_FIRST_FIELD_SIZE_IS8 : (StructFloatFieldInfoFlags)0);
 
-                    case  TypeFlags.Single:
-                    {
-                        if (numIntroducedFields == 1)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE;
-                        }
-                        else if (fieldIndex == 0)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST;
-                        }
-                        else if ((floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST) != 0)
-                        {
-                            floatFieldFlags ^= (uint)StructFloatFieldInfoFlags.STRUCT_MERGE_FIRST_SECOND;
-                        }
-                        else
-                        {
-                            floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND;
-                        }
-
-                        // Pass with two integer registers in `struct {int a, int b, float/double c}` cases
-                        if (fieldIndex == 1 &&
-                                (floatFieldFlags |
-                                 (uint)StructFloatFieldInfoFlags.STRUCT_FIRST_FIELD_SIZE_IS8 |
-                                 (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND) ==
-                                floatFieldFlags)
-                        {
-                            floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                        }
-                    }
-                    break;
-
-                    case TypeFlags.ValueType:
-                    //case TypeFlags.Class:
-                    //case TypeFlags.Array:
-                    //case TypeFlags.SzArray:
-                    {
-                        uint floatFieldFlags2 = GetRISCV64PassStructInRegisterFlags(field.FieldType);
-                        if (numIntroducedFields == 1)
-                        {
-                            floatFieldFlags = floatFieldFlags2;
-                        }
-                        else if (field.FieldType.GetElementSize().AsInt > 8)
-                        {
-                            return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                        }
-                        else if (fieldIndex == 0)
-                        {
-                            if ((floatFieldFlags2 & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
-                            {
-                                floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST;
-                            }
-                            if (field.FieldType.GetElementSize().AsInt == 8)
-                            {
-                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_FIRST_FIELD_SIZE_IS8;
-                            }
-                        }
-                        else
-                        {
-                            Debug.Assert(fieldIndex == 1);
-                            if ((floatFieldFlags2 & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_ONE) != 0)
-                            {
-                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND;
-                            }
-                            if (field.FieldType.GetElementSize().AsInt == 8)
-                            {
-                                floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_SECOND_FIELD_SIZE_IS8;
-                            }
-
-                            floatFieldFlags2 = floatFieldFlags & ((uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST | (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND);
-                            if (floatFieldFlags2 == 0)
-                            {
-                                floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                            }
-                            else if (floatFieldFlags2 == ((uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST | (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND))
-                            {
-                                floatFieldFlags ^= ((uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_ONLY_TWO | (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST | (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND);
-                            }
-                        }
-                    }
-                    break;
-
-                    default:
-                    {
-                        if (field.FieldType.GetElementSize().AsInt == 8)
-                        {
-                            if (numIntroducedFields > 1)
-                            {
-                                if (fieldIndex == 0)
-                                {
-                                    floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_FIRST_FIELD_SIZE_IS8;
-                                }
-                                else if ((floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST) != 0)
-                                {
-                                    floatFieldFlags |= (uint)StructFloatFieldInfoFlags.STRUCT_SECOND_FIELD_SIZE_IS8;
-                                }
-                                else
-                                {
-                                    floatFieldFlags = (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                                }
-                            }
-                        }
-                        else if (fieldIndex == 1)
-                        {
-                            floatFieldFlags = (floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_FIRST) > 0 ? floatFieldFlags : (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
-                        }
-                        break;
-                    }
+                    types[typeIndex++] = type;
                 }
-
-                fieldIndex++;
+                else
+                {
+                    return false;
+                }
             }
 
-            return floatFieldFlags;
+            if (nFields == 0)
+                return true;
+
+            if ((td as MetadataType).HasImpliedRepeatedFields())
+            {
+                Debug.Assert(nFields == 1);
+                int nElements = td.GetElementSize().AsInt / prevField.FieldType.GetElementSize().AsInt;
+                if (!HandleInlineArray(elementTypeIndex, nElements, types, ref typeIndex))
+                    return false;
+            }
+            return true;
+        }
+
+        public static uint GetRISCV64PassStructInRegisterFlags(TypeDesc td)
+        {
+            if (td.GetElementSize().AsInt > ENREGISTERED_PARAMTYPE_MAXSIZE)
+                return (uint)STRUCT_NO_FLOAT_FIELD;
+
+            StructFloatFieldInfoFlags[] types = {STRUCT_NO_FLOAT_FIELD, STRUCT_NO_FLOAT_FIELD};
+            int nFields = 0;
+            if (!FlattenFieldTypes(td, types, ref nFields) || nFields == 0)
+                return (uint)STRUCT_NO_FLOAT_FIELD;
+
+            Debug.Assert(nFields == 1 || nFields == 2);
+
+            Debug.Assert((uint)(STRUCT_FLOAT_FIELD_SECOND | STRUCT_SECOND_FIELD_SIZE_IS8)
+                == (uint)(STRUCT_FLOAT_FIELD_FIRST | STRUCT_FIRST_FIELD_SIZE_IS8) << 1,
+                "SECOND flags need to be FIRST shifted by 1");
+            StructFloatFieldInfoFlags flags = types[0] | (StructFloatFieldInfoFlags)((uint)types[1] << 1);
+
+            const StructFloatFieldInfoFlags bothFloat = STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND;
+            if ((flags & bothFloat) == 0)
+                return (uint)STRUCT_NO_FLOAT_FIELD;
+
+            if ((flags & bothFloat) == bothFloat)
+            {
+                Debug.Assert(nFields == 2);
+                flags ^= (bothFloat | STRUCT_FLOAT_FIELD_ONLY_TWO); // replace bothFloat with ONLY_TWO
+            }
+            else if (nFields == 1)
+            {
+                Debug.Assert((flags & STRUCT_FLOAT_FIELD_FIRST) != 0);
+                flags ^= (STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_ONLY_ONE); // replace FIRST with ONLY_ONE
+            }
+            return (uint)flags;
         }
     }
 }

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -56,6 +56,13 @@ namespace Internal.JitInterface
                 {
                     continue;
                 }
+                else if (fieldIndex == 1)
+                {
+                    if (firstField.Offset.AsInt != 0 || field.Offset.AsInt == 0 || firstFieldSize > field.Offset.AsInt)
+                    {
+                        return (uint)StructFloatFieldInfoFlags.STRUCT_NO_FLOAT_FIELD;
+                    }
+                }
 
                 Debug.Assert(fieldIndex < numIntroducedFields);
 

--- a/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
+++ b/src/coreclr/tools/Common/JitInterface/RISCV64PassStructInRegister.cs
@@ -15,7 +15,7 @@ namespace Internal.JitInterface
             ENREGISTERED_PARAMTYPE_MAXSIZE = 16,
             TARGET_POINTER_SIZE = 8;
 
-        private static bool HandleInlineArray(int elementTypeIndex, int nElements, StructFloatFieldInfoFlags[] types, ref int typeIndex)
+        private static bool HandleInlineArray(int elementTypeIndex, int nElements, Span<StructFloatFieldInfoFlags> types, ref int typeIndex)
         {
             int nFlattenedFieldsPerElement = typeIndex - elementTypeIndex;
             if (nFlattenedFieldsPerElement == 0)
@@ -38,7 +38,7 @@ namespace Internal.JitInterface
             return true;
         }
 
-        private static bool FlattenFieldTypes(TypeDesc td, StructFloatFieldInfoFlags[] types, ref int typeIndex)
+        private static bool FlattenFieldTypes(TypeDesc td, Span<StructFloatFieldInfoFlags> types, ref int typeIndex)
         {
             IEnumerable<FieldDesc> fields = td.GetFields();
             int nFields = 0;
@@ -93,7 +93,9 @@ namespace Internal.JitInterface
             if (td.GetElementSize().AsInt > ENREGISTERED_PARAMTYPE_MAXSIZE)
                 return (uint)STRUCT_NO_FLOAT_FIELD;
 
-            StructFloatFieldInfoFlags[] types = {STRUCT_NO_FLOAT_FIELD, STRUCT_NO_FLOAT_FIELD};
+            Span<StructFloatFieldInfoFlags> types = stackalloc StructFloatFieldInfoFlags[] {
+                STRUCT_NO_FLOAT_FIELD, STRUCT_NO_FLOAT_FIELD
+            };
             int nFields = 0;
             if (!FlattenFieldTypes(td, types, ref nFields) || nFields == 0)
                 return (uint)STRUCT_NO_FLOAT_FIELD;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1816,17 +1816,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
         }
         else
         {
-            MethodTable* pMethodTable = nullptr;
-
-            if (!thValueType.IsTypeDesc())
-                pMethodTable = thValueType.AsMethodTable();
-            else
-            {
-                _ASSERTE(thValueType.IsNativeValueType());
-                pMethodTable = thValueType.AsNativeValueType();
-            }
-            _ASSERTE(pMethodTable != nullptr);
-            flags = MethodTable::GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable);
+            flags = MethodTable::GetRiscV64PassStructInRegisterFlags(thValueType);
             if (flags & STRUCT_HAS_FLOAT_FIELDS_MASK)
             {
                 cFPRegs = (flags & STRUCT_FLOAT_FIELD_ONLY_TWO) ? 2 : 1;
@@ -2038,9 +2028,7 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ComputeReturnFlags()
             if  (size <= ENREGISTERED_RETURNTYPE_INTEGER_MAXSIZE)
             {
                 assert(!thValueType.IsTypeDesc());
-
-                MethodTable *pMethodTable = thValueType.AsMethodTable();
-                flags = (MethodTable::GetRiscV64PassStructInRegisterFlags((CORINFO_CLASS_HANDLE)pMethodTable) & 0xff) << RETURN_FP_SIZE_SHIFT;
+                flags = (MethodTable::GetRiscV64PassStructInRegisterFlags(thValueType) & 0xff) << RETURN_FP_SIZE_SHIFT;
                 break;
             }
 #else

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -9641,7 +9641,7 @@ uint32_t CEEInfo::getRISCV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
     uint32_t size = STRUCT_NO_FLOAT_FIELD;
 
 #if defined(TARGET_RISCV64)
-    size = (uint32_t)MethodTable::GetRiscV64PassStructInRegisterFlags(cls);
+    size = (uint32_t)MethodTable::GetRiscV64PassStructInRegisterFlags(TypeHandle(cls));
 #endif // TARGET_RISCV64
 
     EE_TO_JIT_TRANSITION_LEAF();

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3483,16 +3483,19 @@ static bool GetFlattenedFieldTypes(MethodTable* pMT, CorElementType types[2], in
     {
         assert(nFields == 1);
 
-        int nFieldsPerElement = *typeIndex - elementTypeIndex;
-        assert(nFieldsPerElement == 1 || nFieldsPerElement == 2);
+        int nFlattenedFieldsPerElement = *typeIndex - elementTypeIndex;
+        if (nFlattenedFieldsPerElement == 0)
+            return true;
+
+        assert(nFlattenedFieldsPerElement == 1 || nFlattenedFieldsPerElement == 2);
 
         int nElements = pMT->GetNumInstanceFieldBytes() / fields[0].GetSize();
         if (nElements > 2)
             return false;
 
-        if (nElements == 2 && nFieldsPerElement == 1)
+        if (nElements == 2)
         {
-            if (*typeIndex + 1 > 2)
+            if (*typeIndex + nFlattenedFieldsPerElement > 2)
                 return false;
 
             assert(elementTypeIndex == 0);

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2074,6 +2074,11 @@ namespace
         }
 
         DWORD numIntroducedFields = pMT->GetNumIntroducedInstanceFields();
+        if (numIntroducedFields != 1)
+        {
+            return false;
+        }
+
         FieldDesc *pFieldStart = pMT->GetApproxFieldDescListRaw();
         CorElementType firstFieldElementType = pFieldStart->GetFieldType();
 
@@ -2084,8 +2089,7 @@ namespace
         // instead of adding additional padding at the end of a one-field structure.
         // We do this check here to save looking up the FixedBufferAttribute when loading the field
         // from metadata.
-        return numIntroducedFields == 1
-                        && ( CorTypeInfo::IsPrimitiveType_NoThrow(firstFieldElementType)
+        return (CorTypeInfo::IsPrimitiveType_NoThrow(firstFieldElementType)
                             || firstFieldElementType == ELEMENT_TYPE_VALUETYPE)
                         && (pFieldStart->GetOffset() == 0)
                         && pMT->HasLayout()

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3525,21 +3525,25 @@ int MethodTable::GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
 
         size =
             (CorTypeInfo::IsFloat_NoThrow(types[0]) ? STRUCT_FLOAT_FIELD_FIRST : 0) |
-            (CorTypeInfo::IsFloat_NoThrow(types[1]) ? STRUCT_FLOAT_FIELD_SECOND : 0) |
+            (CorTypeInfo::IsFloat_NoThrow(types[1]) ? STRUCT_FLOAT_FIELD_SECOND : 0);
+
+        if (size == 0)
+            goto _End_arg;
+
+        if (size == (STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND))
+        {
+            assert(nFields == 2);
+            size = STRUCT_FLOAT_FIELD_ONLY_TWO;
+        }
+        else if (nFields == 1)
+        {
+            assert(size == STRUCT_FLOAT_FIELD_FIRST);
+            size = STRUCT_FLOAT_FIELD_ONLY_ONE;
+        }
+
+        size |=
             (CorTypeInfo::Size_NoThrow(types[0]) == 8 ? STRUCT_FIRST_FIELD_SIZE_IS8 : 0) |
             (CorTypeInfo::Size_NoThrow(types[1]) == 8 ? STRUCT_SECOND_FIELD_SIZE_IS8 : 0);
-
-        int firstOrSecond = size & (STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND);
-        if (firstOrSecond == (STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND))
-        {
-            size |= STRUCT_FLOAT_FIELD_ONLY_TWO;
-            size &= ~(STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND);
-        }
-        else if (firstOrSecond != 0 && nFields == 1)
-        {
-            size |= STRUCT_FLOAT_FIELD_ONLY_ONE;
-            size &= ~(STRUCT_FLOAT_FIELD_FIRST | STRUCT_FLOAT_FIELD_SECOND);
-        }
     }
     else
     {

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3467,8 +3467,6 @@ static bool FlattenFieldTypes(CORINFO_CLASS_HANDLE cls, StructFloatFieldInfoFlag
     bool isManaged = !th.IsTypeDesc();
     MethodTable* pMT = isManaged ? th.AsMethodTable() : th.AsNativeValueType();
     int nFields = isManaged ? pMT->GetNumIntroducedInstanceFields() : pMT->GetNativeLayoutInfo()->GetNumFields();
-    if (nFields == 0)
-        return true;
 
     // TODO: templatize isManaged and use if constexpr for differences when we migrate to C++17
     // because the logic for both branches is nearly the same.
@@ -3496,7 +3494,6 @@ static bool FlattenFieldTypes(CORINFO_CLASS_HANDLE cls, StructFloatFieldInfoFlag
                 StructFloatFieldInfoFlags retType = StructFloatFieldInfoFlags(
                     (CorTypeInfo::IsFloat_NoThrow(type) ? STRUCT_FLOAT_FIELD_FIRST : 0) |
                     (CorTypeInfo::Size_NoThrow(type) == TARGET_POINTER_SIZE ? STRUCT_FIRST_FIELD_SIZE_IS8 : 0));
-
                 types[typeIndex++] = retType;
             }
             else
@@ -3543,7 +3540,6 @@ static bool FlattenFieldTypes(CORINFO_CLASS_HANDLE cls, StructFloatFieldInfoFlag
                 StructFloatFieldInfoFlags type = StructFloatFieldInfoFlags(
                     (category == NativeFieldCategory::FLOAT ? STRUCT_FLOAT_FIELD_FIRST : 0) |
                     (fields[i].NativeSize() == TARGET_POINTER_SIZE ? STRUCT_FIRST_FIELD_SIZE_IS8 : 0));
-
                 types[typeIndex++] = type;
             }
             else

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3517,10 +3517,8 @@ int MethodTable::GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE cls)
             goto _End_arg;
 
         assert(nFields == 1 || nFields == 2);
-    #ifdef DEBUG
         assert(CorTypeInfo::IsPrimitiveType_NoThrow(types[0]));
-        assert(CorTypeInfo::IsPrimitiveType_NoThrow(types[1]));
-    #endif
+        assert(CorTypeInfo::IsPrimitiveType_NoThrow(types[1]) || nFields == 1);
 
         size =
             (CorTypeInfo::IsFloat_NoThrow(types[0]) ? STRUCT_FLOAT_FIELD_FIRST : 0) |

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -3446,6 +3446,9 @@ static bool GetFlattenedFieldTypes(MethodTable* pMT, CorElementType types[2], in
     if (*typeIndex + nFields > 2)
         return false;
 
+    if (nFields == 0)
+        return true;
+
     assert(nFields == 1 || nFields == 2);
 
     FieldDesc* fields = pMT->GetApproxFieldDescListRaw();

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -824,13 +824,11 @@ public:
     // during object construction.
     void CheckRunClassInitAsIfConstructingThrowing();
 
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
-    static bool IsOnlyOneField(MethodTable * pMT);
 #if defined(TARGET_LOONGARCH64)
+    static bool IsOnlyOneField(MethodTable * pMT);
     static int GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
 #elif defined(TARGET_RISCV64)
     static int GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
-#endif
 #endif
 
 #if defined(UNIX_AMD64_ABI_ITF)

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -828,7 +828,7 @@ public:
     static bool IsOnlyOneField(MethodTable * pMT);
     static int GetLoongArch64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
 #elif defined(TARGET_RISCV64)
-    static int GetRiscV64PassStructInRegisterFlags(CORINFO_CLASS_HANDLE clh);
+    static int GetRiscV64PassStructInRegisterFlags(TypeHandle th);
 #endif
 
 #if defined(UNIX_AMD64_ABI_ITF)


### PR DESCRIPTION
Discussion in #99602 pointed out that MethodTable::GetRiscV64PassStructInRegisterFlags grew too complicated to properly compare against its crossgen2 version in RISCV64PassStructInRegister.cs (and understand in general). This PR simplifies it (LOC count reduced by ~70%) by following the wording of RISC-V ABI more closely, in particular by introducing an explicit step for struct field hierarchy flattening which the ABI enregistration rules are based on.

As a result of the re-write, MethodTable::GetRiscV64PassStructInRegisterFlags started returning correct flags (pass in float+integer registers) for the two cases:
* `struct { float; struct { string; }; }` - the wrapper struct for string (one pointer) shouldn't matter
* `struct { float; struct {/*empty*/}; int; }` - empty struct fields should be ignored

RISCV64PassStructInRegister.GetRISCV64PassStructInRegisterFlags was also re-written to match MethodTable::GetRiscV64PassStructInRegisterFlags.

This PR also fixes assertions in fgMorphMultiregStructArg when crossgen2 compiles in Debug build with --verify-type-and-field-layout option. Error messages:
```
/runtime/src/coreclr/jit/morph.cpp:3766
Assertion failed 'roundUp(structSize, TARGET_POINTER_SIZE) == roundUp(loadExtent, TARGET_POINTER_SIZE)' in ...
```
* System.Private.CoreLib.dll: ValueType which contains two double fields
* ./Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/MarshalStructAsLayoutExp: ValueType which contains FieldOffset.

Part of #84834, cc @dotnet/samsung