### PR TITLE
JIT: Fix LA64 and RISCV64 build errors on Windows

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -3426,6 +3426,11 @@ public:
 //
 #define IMAGE_REL_BASED_REL_THUMB_MOV32_PCREL   0x14
 
+#define IMAGE_REL_LOONGARCH64_JIR 0x0004
+#define IMAGE_REL_LOONGARCH64_PC 0x0008
+
+#define IMAGE_REL_RISCV64_PC 0x0003
+
 /**********************************************************************************/
 #ifdef TARGET_64BIT
 #define USE_PER_FRAME_PINVOKE_INIT

--- a/src/coreclr/inc/gcinfotypes.h
+++ b/src/coreclr/inc/gcinfotypes.h
@@ -785,8 +785,8 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define DENORMALIZE_STACK_SLOT(x) ((x)<<3)
 #define NORMALIZE_CODE_LENGTH(x) ((x)>>2)   // All Instructions are 4 bytes long
 #define DENORMALIZE_CODE_LENGTH(x) ((x)<<2)
-#define NORMALIZE_STACK_BASE_REGISTER(x) ((x) == 22 ? 0 : 1) // Encode Frame pointer fp=$22 as zero
-#define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 22 : 3)
+#define NORMALIZE_STACK_BASE_REGISTER(x) ((x) == 22 ? 0u : 1u) // Encode Frame pointer fp=$22 as zero
+#define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 22u : 3u)
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>3)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<3)
 #define CODE_OFFSETS_NEED_NORMALIZATION 0
@@ -840,8 +840,8 @@ void FASTCALL decodeCallPattern(int         pattern,
 #define DENORMALIZE_STACK_SLOT(x) ((x)<<3)
 #define NORMALIZE_CODE_LENGTH(x) ((x)>>2)   // All Instructions are 4 bytes long
 #define DENORMALIZE_CODE_LENGTH(x) ((x)<<2)
-#define NORMALIZE_STACK_BASE_REGISTER(x) ((x) == 8 ? 0 : 1) // Encode Frame pointer X8 as zero, sp/x2 as 1
-#define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 8 : 2)
+#define NORMALIZE_STACK_BASE_REGISTER(x) ((x) == 8 ? 0u : 1u) // Encode Frame pointer X8 as zero, sp/x2 as 1
+#define DENORMALIZE_STACK_BASE_REGISTER(x) ((x) == 0 ? 8u : 2u)
 #define NORMALIZE_SIZE_OF_STACK_AREA(x) ((x)>>3)
 #define DENORMALIZE_SIZE_OF_STACK_AREA(x) ((x)<<3)
 #define CODE_OFFSETS_NEED_NORMALIZATION 0

--- a/src/coreclr/inc/palclr.h
+++ b/src/coreclr/inc/palclr.h
@@ -610,4 +610,8 @@
 #define IMAGE_FILE_MACHINE_LOONGARCH64       0x6264  // LOONGARCH64.
 #endif
 
+#ifndef IMAGE_FILE_MACHINE_RISCV64
+#define IMAGE_FILE_MACHINE_RISCV64       0x5064
+#endif
+
 #endif // defined(HOST_WINDOWS)

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -2930,10 +2930,9 @@ static inline bool isImmed(GenTree* treeNode)
 
 instruction CodeGen::genGetInsForOper(GenTree* treeNode)
 {
-    var_types  type = treeNode->TypeGet();
-    genTreeOps oper = treeNode->OperGet();
-    GenTree*   op1  = treeNode->gtGetOp1();
-    GenTree*   op2;
+    var_types  type  = treeNode->TypeGet();
+    genTreeOps oper  = treeNode->OperGet();
+    GenTree*   op1   = treeNode->gtGetOp1();
     emitAttr   attr  = emitActualTypeSize(treeNode);
     bool       isImm = false;
 
@@ -8346,7 +8345,6 @@ void CodeGen::genFnPrologCalleeRegArgs()
 
     if (regArgNum > 0)
     {
-        instruction ins;
         for (int i = MAX_REG_ARG - 1; i >= 0; i--)
         {
             if (regArg[i] > 0)

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -2013,7 +2013,7 @@ void CodeGen::genLclHeap(GenTree* tree)
     noway_assert(isFramePointerUsed()); // localloc requires Frame Pointer to be established since SP changes
     noway_assert(genStackLevel == 0);   // Can't have anything on the stack
 
-    const target_ssize_t pageSize = compiler->eeGetPageSize();
+    const size_t pageSize = (size_t)compiler->eeGetPageSize();
 
     // According to RISC-V Privileged ISA page size is 4KiB
     noway_assert(pageSize == 0x1000);
@@ -7049,8 +7049,6 @@ void CodeGen::genIntToIntCast(GenTreeCast* cast)
 
     if ((desc.ExtendKind() != GenIntCastDesc::COPY) || (srcReg != dstReg))
     {
-        instruction ins;
-
         switch (desc.ExtendKind())
         {
             case GenIntCastDesc::ZERO_EXTEND_SMALL_INT:
@@ -8431,9 +8429,9 @@ void CodeGen::genFnPrologCalleeRegArgs()
                 int      count = 0;     // Number of nodes in list
                 bool     loop  = false; // List has a loop
 
-                for (unsigned cur = i; regArg[cur] != REG_NA; count++)
+                for (unsigned cur = (unsigned)i; regArg[cur] != REG_NA; count++)
                 {
-                    if (cur == i && count > 0)
+                    if (cur == (unsigned)i && count > 0)
                     {
                         loop = true;
                         break;

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -13,6 +13,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "jitpch.h"
 #ifdef _MSC_VER
 #pragma hdrstop
+#pragma warning(disable : 4244 4267)
 #endif
 
 #if defined(TARGET_RISCV64)
@@ -4398,7 +4399,7 @@ void emitter::emitDispIns(
     emitDispInsInstrNum(id);
 
     const BYTE* instr = pCode + writeableOffset;
-    size_t      instrSize;
+    unsigned    instrSize;
     for (size_t i = 0; i < sz; instr += instrSize, i += instrSize, offset += instrSize)
     {
         // TODO-RISCV64: support different size instructions

--- a/src/coreclr/pal/inc/rt/ntimage.h
+++ b/src/coreclr/pal/inc/rt/ntimage.h
@@ -1016,17 +1016,6 @@ typedef IMAGE_RELOCATION UNALIGNED *PIMAGE_RELOCATION;
 #define IMAGE_REL_IA64_ADDEND           0x001F
 
 //
-// LOONGARCH64 relocation types
-//
-#define IMAGE_REL_LOONGARCH64_PC        0x0003
-#define IMAGE_REL_LOONGARCH64_JIR       0x0004
-
-//
-// RISCV64 relocation types
-//
-#define IMAGE_REL_RISCV64_PC            0x0003
-
-//
 // CEF relocation types.
 //
 #define IMAGE_REL_CEF_ABSOLUTE          0x0000  // Reference is absolute, no relocation is necessary


### PR DESCRIPTION
This allows the LA64 and RISCV64 crossjits to build with MSVC (when enabled in the CMakeLists.txt files for JIT and gcinfo).

The motivation is to make it easier to validate that we don't break RISC-V/LA64 builds during broad refactorings (case in point -- #100091).