### PR TITLE
[wasm] use sbrk instead of emscripten mmap or malloc when loading bytes into heap

### DIFF
--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -200,6 +200,7 @@
       <EmccExportedFunction Include="_free" />
       <EmccExportedFunction Include="_htons" />
       <EmccExportedFunction Include="_malloc" />
+      <EmccExportedFunction Include="_sbrk" />
       <EmccExportedFunction Include="_memalign" />
       <EmccExportedFunction Include="_memset" />
       <EmccExportedFunction Include="_ntohs" />

--- a/src/mono/browser/runtime/assets.ts
+++ b/src/mono/browser/runtime/assets.ts
@@ -7,7 +7,7 @@ import cwraps from "./cwraps";
 import { mono_wasm_load_icu_data } from "./icu";
 import { Module, loaderHelpers, mono_assert, runtimeHelpers } from "./globals";
 import { mono_log_info, mono_log_debug, parseSymbolMapFile } from "./logging";
-import { mono_wasm_load_bytes_into_heap } from "./memory";
+import { mono_wasm_load_bytes_into_heap_persistent } from "./memory";
 import { endMeasure, MeasuredBlock, startMeasure } from "./profiler";
 import { AssetEntry } from "./types";
 import { VoidPtr } from "./types/emscripten";
@@ -37,7 +37,7 @@ export function instantiate_asset (asset: AssetEntry, url: string, bytes: Uint8A
         // falls through
         case "heap":
         case "icu":
-            offset = mono_wasm_load_bytes_into_heap(bytes);
+            offset = mono_wasm_load_bytes_into_heap_persistent(bytes);
             break;
 
         case "vfs": {

--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -20,6 +20,7 @@ declare interface Int32Ptr extends NativePointer {
 declare interface EmscriptenModule {
     _malloc(size: number): VoidPtr;
     _free(ptr: VoidPtr): void;
+    _sbrk(size: number): VoidPtr;
     out(message: string): void;
     err(message: string): void;
     ccall<T>(ident: string, returnType?: string | null, argTypes?: string[], args?: any[], opts?: any): T;

--- a/src/mono/browser/runtime/memory.ts
+++ b/src/mono/browser/runtime/memory.ts
@@ -325,7 +325,8 @@ export function withStackAlloc<T1, T2, T3, TResult> (bytesWanted: number, f: (pt
 // @bytes must be a typed array. space is allocated for it in the native heap
 //  and it is copied to that location. returns the address of the allocation.
 export function mono_wasm_load_bytes_into_heap (bytes: Uint8Array): VoidPtr {
-    const memoryOffset = Module._malloc(bytes.length);
+    // pad sizes by 16 bytes for simd
+    const memoryOffset = Module._malloc(bytes.length + 16);
     const heapBytes = new Uint8Array(localHeapViewU8().buffer, <any>memoryOffset, bytes.length);
     heapBytes.set(bytes);
     return memoryOffset;
@@ -336,7 +337,12 @@ export function mono_wasm_load_bytes_into_heap (bytes: Uint8Array): VoidPtr {
 // the result pointer *cannot* be freed because malloc is bypassed for speed.
 export function mono_wasm_load_bytes_into_heap_persistent (bytes: Uint8Array): VoidPtr {
     // pad sizes by 16 bytes for simd
-    const memoryOffset = Module._sbrk(bytes.length + 16);
+    const desiredSize = bytes.length + 16;
+    // wasm memory page size is 64kb. allocations smaller than that are probably best
+    //  serviced by malloc
+    const memoryOffset = (desiredSize < (64 * 1024))
+        ? Module._malloc(desiredSize)
+        : Module._sbrk(desiredSize);
     const heapBytes = new Uint8Array(localHeapViewU8().buffer, <any>memoryOffset, bytes.length);
     heapBytes.set(bytes);
     return memoryOffset;

--- a/src/mono/browser/runtime/memory.ts
+++ b/src/mono/browser/runtime/memory.ts
@@ -331,6 +331,17 @@ export function mono_wasm_load_bytes_into_heap (bytes: Uint8Array): VoidPtr {
     return memoryOffset;
 }
 
+// @bytes must be a typed array. space is allocated for it in memory
+//  and it is copied to that location. returns the address of the data.
+// the result pointer *cannot* be freed because malloc is bypassed for speed.
+export function mono_wasm_load_bytes_into_heap_persistent (bytes: Uint8Array): VoidPtr {
+    // pad sizes by 16 bytes for simd
+    const memoryOffset = Module._sbrk(bytes.length + 16);
+    const heapBytes = new Uint8Array(localHeapViewU8().buffer, <any>memoryOffset, bytes.length);
+    heapBytes.set(bytes);
+    return memoryOffset;
+}
+
 export function getEnv (name: string): string | null {
     let charPtr: CharPtr = <any>0;
     try {

--- a/src/mono/browser/runtime/types/emscripten.ts
+++ b/src/mono/browser/runtime/types/emscripten.ts
@@ -26,6 +26,7 @@ export declare interface EmscriptenModule {
     // this should match emcc -s EXPORTED_FUNCTIONS
     _malloc(size: number): VoidPtr;
     _free(ptr: VoidPtr): void;
+    _sbrk(size: number): VoidPtr;
 
     // this should match emcc -s EXPORTED_RUNTIME_METHODS
     out(message: string): void;

--- a/src/mono/mono/utils/dlmalloc.c
+++ b/src/mono/mono/utils/dlmalloc.c
@@ -19,24 +19,13 @@
  * - the defines below
  */
 
-#include <config.h>
 #include "mono-mmap.h"
 
 #define USE_DL_PREFIX 1
 #define USE_LOCKS 1
-
-#ifdef HOST_WASM
-#pragma clang diagnostic ignored "-Wunused-variable"
-/* Use sbrk to allocate memory, and never release pages since emscripten mmap is fake */
-#define HAVE_MORECORE 1
-#define NO_MALLINFO 1
-#undef HAVE_MMAP
-#define HAVE_MMAP 0
-#else
 /* Use mmap for allocating memory */
 #define HAVE_MORECORE 0
 #define NO_MALLINFO 1
-#endif // HOST_WASM
 #include <mono/utils/dlmalloc.h>
 
 /*

--- a/src/mono/mono/utils/dlmalloc.c
+++ b/src/mono/mono/utils/dlmalloc.c
@@ -19,13 +19,24 @@
  * - the defines below
  */
 
+#include <config.h>
 #include "mono-mmap.h"
 
 #define USE_DL_PREFIX 1
 #define USE_LOCKS 1
+
+#ifdef HOST_WASM
+#pragma clang diagnostic ignored "-Wunused-variable"
+/* Use sbrk to allocate memory, and never release pages since emscripten mmap is fake */
+#define HAVE_MORECORE 1
+#define NO_MALLINFO 1
+#undef HAVE_MMAP
+#define HAVE_MMAP 0
+#else
 /* Use mmap for allocating memory */
 #define HAVE_MORECORE 0
 #define NO_MALLINFO 1
+#endif // HOST_WASM
 #include <mono/utils/dlmalloc.h>
 
 /*


### PR DESCRIPTION
Emscripten's implementations of `mmap` and `malloc` have a lot of overhead, particularly time spent calling `memset` to zero brand new pages it got by growing the heap. During startup we lose a lot of time to this, because we have to reserve space for things like the sgen card tables and the contents of all our dll files (they live in the heap for metadata decoding).

This PR tries using `sbrk` instead in the hot paths for improved startup, and based on my measurements, it makes most of the time spent in `memset` go away. It's theoretically a breaking change though since someone could have been relying on the ability to `_free` the result of `mono_wasm_load_bytes_into_heap`'d preloaded assets, and our code might be relying on the ability to release pages to the "OS" in wasm?

EDIT: PR updated to not replace all our uses of mmap, and only replace `load_bytes_into_heap` for now - the rest of them will take more work to replace.