### PR TITLE
[QUIC] Move 0 byte read before semaphore release

### DIFF
--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -1249,10 +1249,11 @@ namespace System.Net.Quic.Tests
                     {
                         await stream.WritesClosed;
                     }
-                    serverSem.Release();
-                    await clientSem.WaitAsync();
 
                     var _ = await stream.ReadAsync(new byte[0]);
+
+                    serverSem.Release();
+                    await clientSem.WaitAsync();
 
                     if (closeServer)
                     {
@@ -1281,10 +1282,11 @@ namespace System.Net.Quic.Tests
                     {
                         await stream.WritesClosed;
                     }
-                    clientSem.Release();
-                    await serverSem.WaitAsync();
 
                     var _ = await stream.ReadAsync(new byte[0]);
+
+                    clientSem.Release();
+                    await serverSem.WaitAsync();
 
                     if (!closeServer)
                     {


### PR DESCRIPTION
Fixes #100121. After the introduction of 0 byte read (#100093), it started to race with connection close and connection was aborted by peer.