### PR TITLE
JIT: Set `bbCodeOffsEnd` to BAD_IL_OFFSET when expanding static init calls

### DIFF
--- a/src/coreclr/jit/helperexpansion.cpp
+++ b/src/coreclr/jit/helperexpansion.cpp
@@ -1504,15 +1504,8 @@ bool Compiler::fgExpandStaticInitForCall(BasicBlock** pBlock, Statement* stmt, G
     // Clear gtInitClsHnd as a mark that we've already visited this call
     call->gtInitClsHnd = NO_CLASS_HANDLE;
 
-    // Update the IL offsets of the blocks to match the split.
-
-    // prevBb->bbCodeOffs remains the same
-    block->bbCodeOffsEnd = prevBb->bbCodeOffsEnd;
-
-    IL_OFFSET splitPointILOffset = fgFindBlockILOffset(block);
-
-    prevBb->bbCodeOffsEnd = max(prevBb->bbCodeOffs, splitPointILOffset);
-    block->bbCodeOffs     = min(splitPointILOffset, block->bbCodeOffsEnd);
+    // The blocks and statements have been modified enough to make the ending offset invalid.
+    block->bbCodeOffsEnd = BAD_IL_OFFSET;
 
     return true;
 }

--- a/src/tests/JIT/Stress/ABI/pinvokes_d.csproj
+++ b/src/tests/JIT/Stress/ABI/pinvokes_d.csproj
@@ -10,9 +10,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
-
-    <!-- https://github.com/dotnet/runtime/issues/100125 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Stress/ABI/pinvokes_do.csproj
+++ b/src/tests/JIT/Stress/ABI/pinvokes_do.csproj
@@ -10,9 +10,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
-
-    <!-- https://github.com/dotnet/runtime/issues/100125 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Stress/ABI/stubs_do.csproj
+++ b/src/tests/JIT/Stress/ABI/stubs_do.csproj
@@ -10,9 +10,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
-
-    <!-- https://github.com/dotnet/runtime/issues/100125 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Stress/ABI/tailcalls_d.csproj
+++ b/src/tests/JIT/Stress/ABI/tailcalls_d.csproj
@@ -10,9 +10,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
-
-    <!-- https://github.com/dotnet/runtime/issues/100125 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Stress/ABI/tailcalls_do.csproj
+++ b/src/tests/JIT/Stress/ABI/tailcalls_do.csproj
@@ -10,9 +10,6 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <GCStressIncompatible>true</GCStressIncompatible>
-
-    <!-- https://github.com/dotnet/runtime/issues/100125 -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
Will resolve https://github.com/dotnet/runtime/issues/100125

The IL offsets in expanding static init is really tricky as a lot happens here, even in Debug compilations. Such as, user statements can actually be modified, as well as user blocks.

Since this is only limited to expanding static init calls, the quickest and easiest solution is to simply set the block's ending offset to BAD_IL_OFFSET.