### PR TITLE
Add JitOptRepeat configuration options

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2897,6 +2897,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAlignment = false;
     opts.disCodeBytes = false;
 
+#ifdef OPT_CONFIG
+    opts.optRepeat      = false;
+    opts.optRepeatCount = 1;
+#endif // OPT_CONFIG
+
 #ifdef DEBUG
     opts.dspInstrs       = false;
     opts.dspLines        = false;
@@ -2911,7 +2916,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAsm2         = false;
     opts.dspUnwind       = false;
     opts.compLongAddress = false;
-    opts.optRepeat       = false;
 
 #ifdef LATE_DISASM
     opts.doLateDisasm = false;
@@ -2993,9 +2997,11 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             opts.compLongAddress = true;
         }
 
-        if (JitConfig.JitOptRepeat().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args))
+        if ((JitConfig.JitEnableOptRepeat() != 0) &&
+            (JitConfig.JitOptRepeat().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args)))
         {
-            opts.optRepeat = true;
+            opts.optRepeat      = true;
+            opts.optRepeatCount = JitConfig.JitOptRepeatCount();
         }
 
         opts.dspMetrics = (JitConfig.JitMetrics() != 0);
@@ -3095,7 +3101,46 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
     }
 
-//-------------------------------------------------------------------------
+#ifdef OPT_CONFIG
+
+    if (opts.optRepeat)
+    {
+        // Defer printing this until now, after the "START" line printed above.
+        JITDUMP("\n*************** JitOptRepeat enabled; repetition count: %d\n\n", opts.optRepeatCount);
+    }
+    else if (JitConfig.JitEnableOptRepeat() != 0)
+    {
+#ifdef DEBUG
+        // Opt-in to JitOptRepeat based on method hash ranges.
+        // The default is no JitOptRepeat.
+        static ConfigMethodRange fJitOptRepeatRange;
+        fJitOptRepeatRange.EnsureInit(JitConfig.JitOptRepeatRange());
+        assert(!fJitOptRepeatRange.Error());
+        if (!fJitOptRepeatRange.IsEmpty() && fJitOptRepeatRange.Contains(info.compMethodHash()))
+        {
+            opts.optRepeat      = true;
+            opts.optRepeatCount = JitConfig.JitOptRepeatCount();
+
+            JITDUMP("\n*************** JitOptRepeat enabled by JitOptRepeatRange; repetition count: %d\n\n",
+                    opts.optRepeatCount);
+        }
+#endif // DEBUG
+
+        if (!opts.optRepeat && compStressCompile(STRESS_OPT_REPEAT, 10))
+        {
+            // Turn on optRepeat as part of JitStress. In this case, decide how many iterations to do, from 2 to 5,
+            // based on a random number seeded by the method hash.
+            opts.optRepeat = true;
+
+            CLRRandom rng;
+            rng.Init(info.compMethodHash());
+            opts.optRepeatCount = rng.Next(4) + 2; // generates [2..5]
+
+            JITDUMP("\n*************** JitOptRepeat for stress; repetition count: %d\n\n", opts.optRepeatCount);
+        }
+    }
+
+#endif // OPT_CONFIG
 
 #ifdef DEBUG
     assert(!codeGen->isGCTypeFixed());
@@ -4953,7 +4998,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
         if (opts.optRepeat)
         {
-            iterations = JitConfig.JitOptRepeatCount();
+            iterations = opts.optRepeatCount;
         }
 #endif // defined(OPT_CONFIG)
 
@@ -5070,6 +5115,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
                 DoPhase(this, PHASE_COMPUTE_EDGE_WEIGHTS2, &Compiler::fgComputeEdgeWeights);
             }
 
+#ifdef DEBUG
+            if (verbose && opts.optRepeat)
+            {
+                printf("\n*************** JitOptRepeat: iterations remaining: %d\n\n", iterations - 1);
+            }
+#endif // DEBUG
+
             // Iterate if requested, resetting annotations first.
             if (--iterations == 0)
             {
@@ -5084,6 +5136,14 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 
             ResetOptAnnotations();
             RecomputeFlowGraphAnnotations();
+
+#ifdef DEBUG
+            if (verbose)
+            {
+                printf("Trees before next JitOptRepeat iteration:\n");
+                fgDispBasicBlocks(true);
+            }
+#endif // DEBUG
         }
     }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9836,7 +9836,8 @@ public:
         bool altJit;     // True if we are an altjit and are compiling this method
 
 #ifdef OPT_CONFIG
-        bool optRepeat; // Repeat optimizer phases k times
+        bool optRepeat;      // Repeat optimizer phases k times
+        int  optRepeatCount; // How many times to repeat. By default, comes from JitConfig.JitOptRepeatCount().
 #endif
 
         bool disAsm;       // Display native code as it is generated
@@ -10081,13 +10082,14 @@ public:
         STRESS_MODE(PHYSICAL_PROMOTION) /* Use physical promotion */                            \
         STRESS_MODE(PHYSICAL_PROMOTION_COST)                                                    \
         STRESS_MODE(UNWIND) /* stress unwind info; e.g., create function fragments */           \
+        STRESS_MODE(OPT_REPEAT) /* stress JitOptRepeat */                                       \
                                                                                                 \
         /* After COUNT_VARN, stress level 2 does all of these all the time */                   \
                                                                                                 \
         STRESS_MODE(COUNT_VARN)                                                                 \
                                                                                                 \
         /* "Check" stress areas that can be exhaustively used if we */                          \
-        /*  dont care about performance at all */                                               \
+        /*  don't care about performance at all */                                              \
                                                                                                 \
         STRESS_MODE(FORCE_INLINE) /* Treat every method as AggressiveInlining */                \
         STRESS_MODE(CHK_FLOW_UPDATE)                                                            \

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -505,8 +505,11 @@ CONFIG_STRING(JitEnableInductionVariableOptsRange, W("JitEnableInductionVariable
 CONFIG_INTEGER(JitDoSsa, W("JitDoSsa"), 1) // Perform Static Single Assignment (SSA) numbering on the variables
 CONFIG_INTEGER(JitDoValueNumber, W("JitDoValueNumber"), 1) // Perform value numbering on method expressions
 
-CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))            // Runs optimizer multiple times on the method
-CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2) // Number of times to repeat opts when repeating
+CONFIG_INTEGER(JitEnableOptRepeat, W("JitEnableOptRepeat"), 0) // If zero, do not allow JitOptRepeat
+CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))              // Runs optimizer multiple times on specified methods
+CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2)   // Number of times to repeat opts when repeating
+CONFIG_STRING(JitOptRepeatRange, W("JitOptRepeatRange"))       // Enable JitOptRepeat based on method hash range
+
 CONFIG_INTEGER(JitDoIfConversion, W("JitDoIfConversion"), 1) // Perform If conversion
 #endif                                                       // defined(OPT_CONFIG)
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -503,14 +503,14 @@ bool Compiler::optExtractInitTestIncr(
         if (initStmt->GetRootNode()->OperIs(GT_JTRUE))
         {
             bool doGetPrev = true;
-#ifdef DEBUG
+#ifdef OPT_CONFIG
             if (opts.optRepeat)
             {
                 // Previous optimization passes may have inserted compiler-generated
                 // statements other than duplicated loop conditions.
                 doGetPrev = (initStmt->GetPrevStmt() != nullptr);
             }
-#endif // DEBUG
+#endif // OPT_CONFIG
             if (doGetPrev)
             {
                 initStmt = initStmt->GetPrevStmt();

--- a/src/tests/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_56953/Runtime_56953.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableOptRepeat" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeat" Value="*" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_62108/Runtime_62108.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_62108/Runtime_62108.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableOptRepeat" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeat" Value="LeafMethod6" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64700/Runtime_64700.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64700/Runtime_64700.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
 
+    <CLRTestEnvironmentVariable Include="DOTNET_JitEnableOptRepeat" Value="1" />
     <CLRTestEnvironmentVariable Include="DOTNET_JitOptRepeat" Value="ProblemWithCopyProp" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
JitOptRepeat is still off by default.

1. Add a `DOTNET_JitEnableOptRepeat` option. By default this is zero, meaning OptRepeat is disabled. Set it to one to enable JitOptRepeat. Enabling it will allow OptRepeat to kick in during JitStress, but will not otherwise enable it. Also setting `DOTNET_JitOptRepeat` to a method set will enable JitOptRepeat for that exact set of methods. The number of repetitions is specified by `DOTNET_JitOptRepeatCount`.
2. Enable JitOptRepeat to kick in for stress (if `DOTNET_JitEnableOptRepeat` is set to non-zero). The repetition count is set randomly (based on method hash seed) between 2 and 5.
3. Add `DOTNET_JitOptRepeatRange`. This limits JitOptRepeat to a method hash range, for isolating JitOptRepeat related bad codegen.