### PR TITLE
Fix RhpLockCmpXchg64 FCall on win-x86

### DIFF
--- a/src/coreclr/nativeaot/Runtime/CommonMacros.h
+++ b/src/coreclr/nativeaot/Runtime/CommonMacros.h
@@ -255,6 +255,10 @@ typedef uint8_t CODE_LOCATION;
     FCIMPL_RENAME_ARGSIZE(_rettype, _method, 24) \
     EXTERN_C _rettype F_CALL_CONV _method##_FCall (c, b, a) \
     {
+#define FCIMPL3_ILL(_rettype, _method, a, b, c) \
+    FCIMPL_RENAME_ARGSIZE(_rettype, _method, 20) \
+    EXTERN_C _rettype F_CALL_CONV _method##_FCall (a, c, b) \
+    {
 
 #else
 
@@ -287,6 +291,9 @@ typedef uint8_t CODE_LOCATION;
     EXTERN_C _rettype F_CALL_CONV _method (a, b, c) \
     {
 #define FCIMPL3_DDD(_rettype, _method, a, b, c) \
+    EXTERN_C _rettype F_CALL_CONV _method (a, b, c) \
+    {
+#define FCIMPL3_ILL(_rettype, _method, a, b, c) \
     EXTERN_C _rettype F_CALL_CONV _method (a, b, c) \
     {
 

--- a/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/MiscHelpers.cpp
@@ -423,7 +423,7 @@ FCIMPL3(int32_t, RhpLockCmpXchg32, int32_t * location, int32_t value, int32_t co
 }
 FCIMPLEND
 
-FCIMPL3(int64_t, RhpLockCmpXchg64, int64_t * location, int64_t value, int64_t comparand)
+FCIMPL3_ILL(int64_t, RhpLockCmpXchg64, int64_t * location, int64_t value, int64_t comparand)
 {
     return PalInterlockedCompareExchange64(location, value, comparand);
 }


### PR DESCRIPTION
I broke win-x86 builds with PR #100021 when `RhpLockCmpXchg64` was moved to C code. On x86 we need to properly name mangle it and reverse the parameter order.