### PR TITLE
[mono] Optimize (typedef|table|declsec)_locator metadata loading

### DIFF
--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2796,10 +2796,10 @@ hot_reload_metadata_linear_search (MonoImage *base_image, MonoTableInfo *base_ta
 	g_assert (success);
 	uint32_t rows = table_info_get_rows (latest_mod_table);
 
-	locator_t *loc = (locator_t*)key;
+	mono_locator_t *loc = (mono_locator_t*)key;
 	g_assert (loc);
 	/* HACK: this is so that the locator can compute the row index of the given row. but passing the mutant table to other metadata functions could backfire. */
-	*loc = locator_init ((MonoTableInfo*)latest_mod_table, loc->idx, loc->col_idx);
+	*loc = mono_locator_init ((MonoTableInfo*)latest_mod_table, loc->idx, loc->col_idx);
 	for (uint32_t idx = 0; idx < rows; ++idx) {
 		const char *row = latest_mod_table->base + idx * latest_mod_table->row_size;
 		if (!comparer (loc, row))

--- a/src/mono/mono/component/hot_reload.c
+++ b/src/mono/mono/component/hot_reload.c
@@ -2776,14 +2776,6 @@ add_param_info_for_method (BaselineInfo *base_info, uint32_t param_token, uint32
 	}
 }
 
-/* HACK - keep in sync with locator_t in metadata/metadata.c */
-typedef struct {
-	guint32 idx;			/* The index that we are trying to locate */
-	guint32 col_idx;		/* The index in the row where idx may be stored */
-	MonoTableInfo *t;	/* pointer to the table */
-	guint32 result;
-} upd_locator_t;
-
 void*
 hot_reload_metadata_linear_search (MonoImage *base_image, MonoTableInfo *base_table, const void *key, BinarySearchComparer comparer)
 {
@@ -2804,11 +2796,10 @@ hot_reload_metadata_linear_search (MonoImage *base_image, MonoTableInfo *base_ta
 	g_assert (success);
 	uint32_t rows = table_info_get_rows (latest_mod_table);
 
-	upd_locator_t *loc = (upd_locator_t*)key;
+	locator_t *loc = (locator_t*)key;
 	g_assert (loc);
-	loc->result = 0;
 	/* HACK: this is so that the locator can compute the row index of the given row. but passing the mutant table to other metadata functions could backfire. */
-	loc->t = (MonoTableInfo*)latest_mod_table;
+	*loc = locator_init ((MonoTableInfo*)latest_mod_table, loc->idx, loc->col_idx);
 	for (uint32_t idx = 0; idx < rows; ++idx) {
 		const char *row = latest_mod_table->base + idx * latest_mod_table->row_size;
 		if (!comparer (loc, row))

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -60,7 +60,7 @@ enum {
 	MONO_HAS_CUSTOM_DEBUG_MASK = 0x1f
 };
 
-gboolean 
+gboolean
 mono_get_pe_debug_info_full (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *out_timestamp, guint8 **ppdb_data,
 				   int *ppdb_uncompressed_size, int *ppdb_compressed_size, char **pdb_path, GArray *pdb_checksum_hash_type, GArray *pdb_checksum)
 {
@@ -761,16 +761,7 @@ mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo)
 	return mono_ppdb_lookup_locals_internal (image, method_idx);
 }
 
-/*
-* We use this to pass context information to the row locator
-*/
-typedef struct {
-	guint32 idx;			/* The index that we are trying to locate */
-	guint32 col_idx;		/* The index in the row where idx may be stored */
-	MonoTableInfo *t;	/* pointer to the table */
-	guint32 result;
-} locator_t;
-
+// FIXME: This duplicates table_locator from metadata.c
 static int
 table_locator (const void *a, const void *b)
 {
@@ -813,9 +804,11 @@ lookup_custom_debug_information (MonoImage* image, guint32 token, uint8_t parent
 	if (!table->base)
 		return 0;
 
-	loc.idx = (mono_metadata_token_index (token) << MONO_HAS_CUSTOM_DEBUG_BITS) | parent_type;
-	loc.col_idx = MONO_CUSTOMDEBUGINFORMATION_PARENT;
-	loc.t = table;
+	loc = locator_init (
+		table,
+		(mono_metadata_token_index (token) << MONO_HAS_CUSTOM_DEBUG_BITS) | parent_type,
+		MONO_CUSTOMDEBUGINFORMATION_PARENT
+	);
 
 	if (!mono_binary_search (&loc, table->base, table_info_get_rows (table), table->row_size, table_locator))
 		return NULL;

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -765,7 +765,7 @@ mono_ppdb_lookup_locals (MonoDebugMethodInfo *minfo)
 static int
 table_locator (const void *a, const void *b)
 {
-	locator_t *loc = (locator_t *)a;
+	mono_locator_t *loc = (mono_locator_t *)a;
 	const char *bb = (const char *)b;
 	guint32 table_index = GPTRDIFF_TO_UINT32 ((bb - loc->t->base) / loc->t->row_size);
 	guint32 col;
@@ -799,12 +799,12 @@ lookup_custom_debug_information (MonoImage* image, guint32 token, uint8_t parent
 {
 	MonoTableInfo *tables = image->tables;
 	MonoTableInfo *table = &tables[MONO_TABLE_CUSTOMDEBUGINFORMATION];
-	locator_t loc;
+	mono_locator_t loc;
 
 	if (!table->base)
 		return 0;
 
-	loc = locator_init (
+	loc = mono_locator_init (
 		table,
 		(mono_metadata_token_index (token) << MONO_HAS_CUSTOM_DEBUG_BITS) | parent_type,
 		MONO_CUSTOMDEBUGINFORMATION_PARENT

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1158,7 +1158,7 @@ typedef struct {
 	guint32 result;
 } mono_locator_t;
 
-MONO_ALWAYS_INLINE static inline mono_locator_t
+MONO_ALWAYS_INLINE static mono_locator_t
 mono_locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
 {
 	mono_locator_t result = { 0, };

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1156,12 +1156,12 @@ typedef struct {
 
 	// result
 	guint32 result;
-} locator_t;
+} mono_locator_t;
 
-MONO_ALWAYS_INLINE static locator_t
-locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
+MONO_ALWAYS_INLINE static inline mono_locator_t
+mono_locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
 {
-	locator_t result = { 0, };
+	mono_locator_t result = { 0, };
 
 	result.idx = idx;
 	result.col_idx = col_idx;

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1134,6 +1134,56 @@ mono_metadata_get_class_guid (MonoClass* klass, uint8_t* guid, MonoError *error)
 
 #define MONO_CLASS_IS_INTERFACE_INTERNAL(c) ((mono_class_get_flags (c) & TYPE_ATTRIBUTE_INTERFACE) || mono_type_is_generic_parameter (m_class_get_byval_arg (c)))
 
+/*
+ * We use this to pass context information to the row locator
+ */
+typedef struct {
+	// caller inputs
+	// note: we can't optimize around locator_t.idx yet because a few call sites mutate it
+	guint32 idx;			/* The index that we are trying to locate */
+	// no call sites mutate this so we can optimize around it
+	guint32 col_idx;		/* The index in the row where idx may be stored */
+	// no call sites mutate this so we can optimize around it
+	MonoTableInfo *t;		/* pointer to the table */
+
+	// optimization data
+	gboolean metadata_has_updates;
+	const char * t_base;
+	guint t_row_size;
+	guint32 t_rows;
+	guint32 column_size;
+	const char * first_column_data;
+
+	// result
+	guint32 result;
+} locator_t;
+
+MONO_ALWAYS_INLINE static locator_t
+locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
+{
+	locator_t result = { 0, };
+
+	result.idx = idx;
+	result.col_idx = col_idx;
+	result.t = t;
+
+	g_assert (t);
+	// FIXME: Callers shouldn't rely on this
+	if (!t->base)
+		return result;
+
+	// optimization data for decode_locator_row
+	result.metadata_has_updates = mono_metadata_has_updates ();
+	result.t_base = t->base;
+	result.t_row_size = t->row_size;
+	result.t_rows = table_info_get_rows (t);
+	g_assert (col_idx < mono_metadata_table_count (t->size_bitfield));
+	result.column_size = mono_metadata_table_size (t->size_bitfield, col_idx);
+	result.first_column_data = result.t_base + t->column_offsets [col_idx];
+
+	return result;
+}
+
 static inline gboolean
 m_image_is_raw_data_allocated (MonoImage *image)
 {

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1147,7 +1147,7 @@ typedef struct {
 	MonoTableInfo *t;		/* pointer to the table */
 
 	// optimization data
-	gboolean metadata_has_updates;
+	gint32 metadata_has_updates; // -1: uninitialized. 0/1: value
 	const char * t_base;
 	guint t_row_size;
 	guint32 t_rows;
@@ -1173,7 +1173,7 @@ locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
 		return result;
 
 	// optimization data for decode_locator_row
-	result.metadata_has_updates = mono_metadata_has_updates ();
+	result.metadata_has_updates = -1;
 	result.t_base = t->base;
 	result.t_row_size = t->row_size;
 	result.t_rows = table_info_get_rows (t);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4683,11 +4683,75 @@ mono_metadata_token_from_dor (guint32 dor_index)
  * We use this to pass context information to the row locator
  */
 typedef struct {
+	// caller inputs
+	// note: we can't optimize around locator_t.idx yet because a few call sites mutate it
 	guint32 idx;			/* The index that we are trying to locate */
+	// no call sites mutate this so we can optimize around it
 	guint32 col_idx;		/* The index in the row where idx may be stored */
+	// no call sites mutate this so we can optimize around it
 	MonoTableInfo *t;		/* pointer to the table */
+
+	// optimization data
+	gboolean metadata_has_updates;
+	const char * t_base;
+	guint t_row_size;
+	guint32 t_rows;
+	guint32 column_size;
+	const char * first_column_data;
+
+	// result
 	guint32 result;
 } locator_t;
+
+MONO_ALWAYS_INLINE static locator_t
+locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
+{
+	g_assert (t);
+
+	locator_t result;
+	result.idx = idx;
+	result.col_idx = col_idx;
+	result.t = t;
+	result.result = 0;
+
+	// optimization data for decode_locator_row
+	result.metadata_has_updates = mono_metadata_has_updates ();
+	result.t_base = t->base;
+	result.t_row_size = t->row_size;
+	result.t_rows = table_info_get_rows (t);
+	g_assert (col_idx < mono_metadata_table_count (t->size_bitfield));
+	result.column_size = mono_metadata_table_size (t->size_bitfield, col_idx);
+	result.first_column_data = result.t_base + t->column_offsets [col_idx];
+
+	return result;
+}
+
+static guint32
+decode_locator_row (locator_t *loc, int row_index)
+{
+	const char *data;
+
+	if (G_UNLIKELY (loc->metadata_has_updates))
+		return mono_metadata_decode_row_col_slow (loc->t, row_index, loc->col_idx);
+
+	// g_assert (col < mono_metadata_table_count (bitfield));
+	// data = t->base + idx * t->row_size + t->column_offsets [col];
+	// n = mono_metadata_table_size (bitfield, col);
+
+	g_assert (GINT_TO_UINT32(row_index) < loc->t_rows);
+	data = loc->first_column_data + (row_index * loc->t_row_size);
+	switch (loc->column_size) {
+	case 1:
+		return *data;
+	case 2:
+		return read16 (data);
+	case 4:
+		return read32 (data);
+	default:
+		g_assert_not_reached ();
+		return 0;
+	}
+}
 
 /*
  * How the row locator works.
@@ -4726,21 +4790,21 @@ typedef_locator (const void *a, const void *b)
 {
 	locator_t *loc = (locator_t *) a;
 	const char *bb = (const char *) b;
-	int typedef_index = GPTRDIFF_TO_INT ((bb - loc->t->base) / loc->t->row_size);
-	guint32 col, col_next;
+	int typedef_index = GPTRDIFF_TO_INT ((bb - loc->t_base) / loc->t_row_size);
+	guint32 col, col_next, target_idx = loc->idx;
 
-	col = mono_metadata_decode_row_col (loc->t, typedef_index, loc->col_idx);
+	col = decode_locator_row (loc, typedef_index);
 
-	if (loc->idx < col)
+	if (target_idx < col)
 		return -1;
 
 	/*
 	 * Need to check that the next row is valid.
 	 */
 	g_assert (typedef_index >= 0);
-	if (GINT_TO_UINT32(typedef_index) + 1 < table_info_get_rows (loc->t)) {
-		col_next = mono_metadata_decode_row_col (loc->t, typedef_index + 1, loc->col_idx);
-		if (loc->idx >= col_next)
+	if (GINT_TO_UINT32(typedef_index) + 1 < loc->t_rows) {
+		col_next = decode_locator_row (loc, typedef_index + 1);
+		if (target_idx >= col_next)
 			return 1;
 
 		if (col == col_next)
@@ -4757,16 +4821,16 @@ table_locator (const void *a, const void *b)
 {
 	locator_t *loc = (locator_t *) a;
 	const char *bb = (const char *) b;
-	guint32 table_index = GPTRDIFF_TO_INT ((bb - loc->t->base) / loc->t->row_size);
-	guint32 col;
+	guint32 table_index = GPTRDIFF_TO_INT ((bb - loc->t_base) / loc->t_row_size);
+	guint32 col, target_idx = loc->idx;
 
-	col = mono_metadata_decode_row_col (loc->t, table_index, loc->col_idx);
+	col = decode_locator_row (loc, table_index);
 
-	if (loc->idx == col) {
+	if (target_idx == col) {
 		loc->result = table_index;
 		return 0;
 	}
-	if (loc->idx < col)
+	if (target_idx < col)
 		return -1;
 	else
 		return 1;
@@ -4777,16 +4841,16 @@ declsec_locator (const void *a, const void *b)
 {
 	locator_t *loc = (locator_t *) a;
 	const char *bb = (const char *) b;
-	guint32 table_index = GPTRDIFF_TO_UINT32 ((bb - loc->t->base) / loc->t->row_size);
-	guint32 col;
+	guint32 table_index = GPTRDIFF_TO_UINT32 ((bb - loc->t_base) / loc->t_row_size);
+	guint32 col, target_index = loc->idx;
 
-	col = mono_metadata_decode_row_col (loc->t, table_index, loc->col_idx);
+	col = decode_locator_row (loc, table_index);
 
-	if (loc->idx == col) {
+	if (target_index == col) {
 		loc->result = table_index;
 		return 0;
 	}
-	if (loc->idx < col)
+	if (target_index < col)
 		return -1;
 	else
 		return 1;
@@ -4829,15 +4893,12 @@ guint32
 mono_metadata_typedef_from_field (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_TYPEDEF];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_FIELD_LIST);
 
 	if (!tdef->base)
 		return 0;
 
-	loc.idx = mono_metadata_token_index (index);
-	loc.col_idx = MONO_TYPEDEF_FIELD_LIST;
-	loc.t = tdef;
-
+	// FIXME: Modifies locator_t.idx
 	if (meta->uncompressed_metadata)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, loc.idx);
 
@@ -4866,15 +4927,12 @@ guint32
 mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_TYPEDEF];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_METHOD_LIST);
 
 	if (!tdef->base)
 		return 0;
 
-	loc.idx = mono_metadata_token_index (index);
-	loc.col_idx = MONO_TYPEDEF_METHOD_LIST;
-	loc.t = tdef;
-
+	// FIXME: Modifies locator_t.idx
 	if (meta->uncompressed_metadata)
 		loc.idx = search_ptr_table (meta, MONO_TABLE_METHOD_POINTER, loc.idx);
 
@@ -4924,10 +4982,7 @@ mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, Mono
 	if (!tdef->base && !meta->has_updates)
 		return TRUE;
 
-	loc.idx = mono_metadata_token_index (index);
-	loc.col_idx = MONO_INTERFACEIMPL_CLASS;
-	loc.t = tdef;
-	loc.result = 0;
+	loc = locator_init (tdef, mono_metadata_token_index (index), MONO_INTERFACEIMPL_CLASS);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -5026,15 +5081,10 @@ guint32
 mono_metadata_nested_in_typedef (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_NESTEDCLASS];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_NESTED_CLASS_NESTED);
 
 	if (!tdef->base && !meta->has_updates)
 		return 0;
-
-	loc.idx = mono_metadata_token_index (index);
-	loc.col_idx = MONO_NESTED_CLASS_NESTED;
-	loc.t = tdef;
-	loc.result = 0;
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !meta->has_updates)
@@ -5095,15 +5145,11 @@ guint32
 mono_metadata_packing_from_typedef (MonoImage *meta, guint32 index, guint32 *packing, guint32 *size)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_CLASSLAYOUT];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_CLASS_LAYOUT_PARENT);
 	guint32 cols [MONO_CLASS_LAYOUT_SIZE];
 
 	if (!tdef->base)
 		return 0;
-
-	loc.idx = mono_metadata_token_index (index);
-	loc.col_idx = MONO_CLASS_LAYOUT_PARENT;
-	loc.t = tdef;
 
 	/* FIXME: metadata-update */
 
@@ -5132,15 +5178,10 @@ guint32
 mono_metadata_custom_attrs_from_index (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_CUSTOMATTRIBUTE];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, index, MONO_CUSTOM_ATTR_PARENT);
 
 	if (!tdef->base && !meta->has_updates)
 		return 0;
-
-	loc.idx = index;
-	loc.col_idx = MONO_CUSTOM_ATTR_PARENT;
-	loc.t = tdef;
-	loc.result = 0;
 
 	/* FIXME: Index translation */
 
@@ -5178,14 +5219,10 @@ guint32
 mono_metadata_declsec_from_index (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_DECLSECURITY];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, index, MONO_DECL_SECURITY_PARENT);
 
 	if (!tdef->base)
 		return -1;
-
-	loc.idx = index;
-	loc.col_idx = MONO_DECL_SECURITY_PARENT;
-	loc.t = tdef;
 
 	/* FIXME: metadata-update */
 
@@ -5212,14 +5249,10 @@ guint32
 mono_metadata_localscope_from_methoddef (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_LOCALSCOPE];
-	locator_t loc;
+	locator_t loc = locator_init (tdef, index, MONO_LOCALSCOPE_METHOD);
 
 	if (!tdef->base)
 		return 0;
-
-	loc.idx = index;
-	loc.col_idx = MONO_LOCALSCOPE_METHOD;
-	loc.t = tdef;
 
 	/* FIXME: metadata-update */
 
@@ -6313,17 +6346,16 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 				       MonoMarshalSpec **marshal_spec, gboolean alloc_from_image)
 {
 	MonoTableInfo *tdef;
-	locator_t loc = {0,};
+	locator_t loc;
 
-	loc.idx = index + 1;
+	guint32 idx = index + 1;
 	if (meta->uncompressed_metadata)
-		loc.idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, loc.idx);
+		idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, loc.idx);
 
 	if (offset) {
 		tdef = &meta->tables [MONO_TABLE_FIELDLAYOUT];
 
-		loc.col_idx = MONO_FIELD_LAYOUT_FIELD;
-		loc.t = tdef;
+		loc = locator_init (tdef, idx, MONO_FIELD_LAYOUT_FIELD);
 
 		/* metadata-update: explicit layout not supported, just return -1 */
 
@@ -6336,15 +6368,14 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 	if (rva) {
 		tdef = &meta->tables [MONO_TABLE_FIELDRVA];
 
-		loc.col_idx = MONO_FIELD_RVA_FIELD;
-		loc.t = tdef;
+		loc = locator_init (tdef, idx, MONO_FIELD_RVA_FIELD);
 
-                gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator);
+		gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator);
 
-                if (G_UNLIKELY (meta->has_updates)) {
-                        if (!found)
-                                found = (mono_metadata_update_metadata_linear_search (meta, tdef, &loc, table_locator) != NULL);
-                }
+		if (G_UNLIKELY (meta->has_updates)) {
+			if (!found)
+				found = (mono_metadata_update_metadata_linear_search (meta, tdef, &loc, table_locator) != NULL);
+		}
 
 		if (found) {
 			/*
@@ -6398,9 +6429,8 @@ mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 		g_warning ("Not a valid token for the constant table: 0x%08x", token);
 		return 0;
 	}
-	loc.idx = index;
-	loc.col_idx = MONO_CONSTANT_PARENT;
-	loc.t = tdef;
+
+	loc = locator_init (tdef, index, MONO_CONSTANT_PARENT);
 
 	/* FIXME: Index translation */
 
@@ -6438,10 +6468,7 @@ mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_id
 	if (!tdef->base && !meta->has_updates)
 		return 0;
 
-	loc.t = tdef;
-	loc.col_idx = MONO_EVENT_MAP_PARENT;
-	loc.idx = index + 1;
-	loc.result = 0;
+	loc = locator_init (tdef, index + 1, MONO_EVENT_MAP_PARENT);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !meta->has_updates)
@@ -6499,10 +6526,12 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 	if (meta->uncompressed_metadata)
 	    index = search_ptr_table (meta, MONO_TABLE_EVENT_POINTER, index + 1) - 1;
 
-	loc.t = msemt;
-	loc.col_idx = MONO_METHOD_SEMA_ASSOCIATION;
-	loc.idx = ((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_EVENT; /* Method association coded index */
-	loc.result = 0;
+	loc = locator_init (
+		msemt,
+		/* Method association coded index */
+		((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_EVENT,
+		MONO_METHOD_SEMA_ASSOCIATION
+	);
 
 	gboolean found = msemt->base && mono_binary_search (&loc, msemt->base, table_info_get_rows (msemt), msemt->row_size, table_locator) != NULL;
 
@@ -6556,10 +6585,7 @@ mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *en
 	if (!tdef->base && !meta->has_updates)
 		return 0;
 
-	loc.t = tdef;
-	loc.col_idx = MONO_PROPERTY_MAP_PARENT;
-	loc.idx = index + 1;
-	loc.result = 0;
+	loc = locator_init (tdef, index + 1, MONO_PROPERTY_MAP_PARENT);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -6618,10 +6644,12 @@ mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *en
 	if (meta->uncompressed_metadata)
 	    index = search_ptr_table (meta, MONO_TABLE_PROPERTY_POINTER, index + 1) - 1;
 
-	loc.t = msemt;
-	loc.col_idx = MONO_METHOD_SEMA_ASSOCIATION;
-	loc.idx = ((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_PROPERTY; /* Method association coded index */
-	loc.result = 0;
+	loc = locator_init (
+		msemt,
+		/* Method association coded index */
+		((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_PROPERTY,
+		MONO_METHOD_SEMA_ASSOCIATION
+	);
 
 	gboolean found = msemt->base && mono_binary_search (&loc, msemt->base, table_info_get_rows (msemt), msemt->row_size, table_locator) != NULL;
 
@@ -6669,9 +6697,7 @@ mono_metadata_implmap_from_method (MonoImage *meta, guint32 method_idx)
 
 	/* No index translation seems to be needed */
 
-	loc.t = tdef;
-	loc.col_idx = MONO_IMPLMAP_MEMBER;
-	loc.idx = ((method_idx + 1) << MONO_MEMBERFORWD_BITS) | MONO_MEMBERFORWD_METHODDEF;
+	loc = locator_init (tdef, ((method_idx + 1) << MONO_MEMBERFORWD_BITS) | MONO_MEMBERFORWD_METHODDEF, MONO_IMPLMAP_MEMBER);
 
 	/* FIXME: metadata-update */
 
@@ -7085,12 +7111,14 @@ handle_enum:
 const char*
 mono_metadata_get_marshal_info (MonoImage *meta, guint32 idx, gboolean is_field)
 {
-	locator_t loc = {0,};
+	locator_t loc;
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_FIELDMARSHAL];
 
-	loc.t = tdef;
-	loc.col_idx = MONO_FIELD_MARSHAL_PARENT;
-	loc.idx = ((idx + 1) << MONO_HAS_FIELD_MARSHAL_BITS) | (is_field? MONO_HAS_FIELD_MARSHAL_FIELDSREF: MONO_HAS_FIELD_MARSHAL_PARAMDEF);
+	loc = locator_init (
+		tdef,
+		((idx + 1) << MONO_HAS_FIELD_MARSHAL_BITS) | (is_field? MONO_HAS_FIELD_MARSHAL_FIELDSREF: MONO_HAS_FIELD_MARSHAL_PARAMDEF),
+		MONO_FIELD_MARSHAL_PARENT
+	);
 
 	/* FIXME: Index translation */
 
@@ -7151,10 +7179,7 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 	if (!tdef->base && !image->has_updates)
 		return;
 
-	loc.t = tdef;
-	loc.col_idx = MONO_METHODIMPL_CLASS;
-	loc.idx = mono_metadata_token_index (type_token);
-	loc.result = 0;
+	loc = locator_init (tdef, mono_metadata_token_index (type_token), MONO_METHODIMPL_CLASS);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -7266,10 +7291,7 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 	/* FIXME: metadata-update */
 	guint32 rows = table_info_get_rows (tdef);
 
-	loc.idx = owner;
-	loc.col_idx = MONO_GENPARCONSTRAINT_GENERICPAR;
-	loc.t = tdef;
-	loc.result = 0;
+	loc = locator_init (tdef, owner, MONO_GENPARCONSTRAINT_GENERICPAR);
 
 	gboolean is_found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!is_found && !image->has_updates)
@@ -7342,10 +7364,7 @@ mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *o
 	}
 	*owner |= mono_metadata_token_index (token) << MONO_TYPEORMETHOD_BITS;
 
-	loc.idx = *owner;
-	loc.col_idx = MONO_GENERICPARAM_OWNER;
-	loc.t = tdef;
-	loc.result = 0;
+	loc = locator_init (tdef, *owner, MONO_GENERICPARAM_OWNER);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !image->has_updates)

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4679,56 +4679,6 @@ mono_metadata_token_from_dor (guint32 dor_index)
 	return 0;
 }
 
-/*
- * We use this to pass context information to the row locator
- */
-typedef struct {
-	// caller inputs
-	// note: we can't optimize around locator_t.idx yet because a few call sites mutate it
-	guint32 idx;			/* The index that we are trying to locate */
-	// no call sites mutate this so we can optimize around it
-	guint32 col_idx;		/* The index in the row where idx may be stored */
-	// no call sites mutate this so we can optimize around it
-	MonoTableInfo *t;		/* pointer to the table */
-
-	// optimization data
-	gboolean metadata_has_updates;
-	const char * t_base;
-	guint t_row_size;
-	guint32 t_rows;
-	guint32 column_size;
-	const char * first_column_data;
-
-	// result
-	guint32 result;
-} locator_t;
-
-MONO_ALWAYS_INLINE static locator_t
-locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
-{
-	locator_t result = { 0, };
-
-	result.idx = idx;
-	result.col_idx = col_idx;
-	result.t = t;
-
-	g_assert (t);
-	// FIXME: Callers shouldn't rely on this
-	if (!t->base)
-		return result;
-
-	// optimization data for decode_locator_row
-	result.metadata_has_updates = mono_metadata_has_updates ();
-	result.t_base = t->base;
-	result.t_row_size = t->row_size;
-	result.t_rows = table_info_get_rows (t);
-	g_assert (col_idx < mono_metadata_table_count (t->size_bitfield));
-	result.column_size = mono_metadata_table_size (t->size_bitfield, col_idx);
-	result.first_column_data = result.t_base + t->column_offsets [col_idx];
-
-	return result;
-}
-
 static guint32
 decode_locator_row (locator_t *loc, int row_index)
 {

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4680,7 +4680,7 @@ mono_metadata_token_from_dor (guint32 dor_index)
 }
 
 static guint32
-decode_locator_row (locator_t *loc, int row_index)
+decode_locator_row (mono_locator_t *loc, int row_index)
 {
 	const char *data;
 
@@ -4743,7 +4743,7 @@ decode_locator_row (locator_t *loc, int row_index)
 static int
 typedef_locator (const void *a, const void *b)
 {
-	locator_t *loc = (locator_t *) a;
+	mono_locator_t *loc = (mono_locator_t *) a;
 	const char *bb = (const char *) b;
 	int typedef_index = GPTRDIFF_TO_INT ((bb - loc->t_base) / loc->t_row_size);
 	guint32 col, col_next, target_idx = loc->idx;
@@ -4774,7 +4774,7 @@ typedef_locator (const void *a, const void *b)
 static int
 table_locator (const void *a, const void *b)
 {
-	locator_t *loc = (locator_t *) a;
+	mono_locator_t *loc = (mono_locator_t *) a;
 	const char *bb = (const char *) b;
 	guint32 table_index = GPTRDIFF_TO_INT ((bb - loc->t_base) / loc->t_row_size);
 	guint32 col, target_idx = loc->idx;
@@ -4794,7 +4794,7 @@ table_locator (const void *a, const void *b)
 static int
 declsec_locator (const void *a, const void *b)
 {
-	locator_t *loc = (locator_t *) a;
+	mono_locator_t *loc = (mono_locator_t *) a;
 	const char *bb = (const char *) b;
 	guint32 table_index = GPTRDIFF_TO_UINT32 ((bb - loc->t_base) / loc->t_row_size);
 	guint32 col, target_index = loc->idx;
@@ -4848,7 +4848,7 @@ guint32
 mono_metadata_typedef_from_field (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_TYPEDEF];
-	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_FIELD_LIST);
+	mono_locator_t loc = mono_locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_FIELD_LIST);
 
 	if (!tdef->base)
 		return 0;
@@ -4882,7 +4882,7 @@ guint32
 mono_metadata_typedef_from_method (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_TYPEDEF];
-	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_METHOD_LIST);
+	mono_locator_t loc = mono_locator_init (tdef, mono_metadata_token_index (index), MONO_TYPEDEF_METHOD_LIST);
 
 	if (!tdef->base)
 		return 0;
@@ -4924,7 +4924,7 @@ gboolean
 mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, MonoClass ***interfaces, guint *count, gboolean heap_alloc_result, MonoGenericContext *context, MonoError *error)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_INTERFACEIMPL];
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 start, pos;
 	guint32 cols [MONO_INTERFACEIMPL_SIZE];
 	MonoClass **result;
@@ -4937,7 +4937,7 @@ mono_metadata_interfaces_from_typedef_full (MonoImage *meta, guint32 index, Mono
 	if (!tdef->base && !meta->has_updates)
 		return TRUE;
 
-	loc = locator_init (tdef, mono_metadata_token_index (index), MONO_INTERFACEIMPL_CLASS);
+	loc = mono_locator_init (tdef, mono_metadata_token_index (index), MONO_INTERFACEIMPL_CLASS);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -5036,7 +5036,7 @@ guint32
 mono_metadata_nested_in_typedef (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_NESTEDCLASS];
-	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_NESTED_CLASS_NESTED);
+	mono_locator_t loc = mono_locator_init (tdef, mono_metadata_token_index (index), MONO_NESTED_CLASS_NESTED);
 
 	if (!tdef->base && !meta->has_updates)
 		return 0;
@@ -5100,7 +5100,7 @@ guint32
 mono_metadata_packing_from_typedef (MonoImage *meta, guint32 index, guint32 *packing, guint32 *size)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_CLASSLAYOUT];
-	locator_t loc = locator_init (tdef, mono_metadata_token_index (index), MONO_CLASS_LAYOUT_PARENT);
+	mono_locator_t loc = mono_locator_init (tdef, mono_metadata_token_index (index), MONO_CLASS_LAYOUT_PARENT);
 	guint32 cols [MONO_CLASS_LAYOUT_SIZE];
 
 	if (!tdef->base)
@@ -5133,7 +5133,7 @@ guint32
 mono_metadata_custom_attrs_from_index (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_CUSTOMATTRIBUTE];
-	locator_t loc = locator_init (tdef, index, MONO_CUSTOM_ATTR_PARENT);
+	mono_locator_t loc = mono_locator_init (tdef, index, MONO_CUSTOM_ATTR_PARENT);
 
 	if (!tdef->base && !meta->has_updates)
 		return 0;
@@ -5174,7 +5174,7 @@ guint32
 mono_metadata_declsec_from_index (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_DECLSECURITY];
-	locator_t loc = locator_init (tdef, index, MONO_DECL_SECURITY_PARENT);
+	mono_locator_t loc = mono_locator_init (tdef, index, MONO_DECL_SECURITY_PARENT);
 
 	if (!tdef->base)
 		return -1;
@@ -5204,7 +5204,7 @@ guint32
 mono_metadata_localscope_from_methoddef (MonoImage *meta, guint32 index)
 {
 	MonoTableInfo *tdef = &meta->tables [MONO_TABLE_LOCALSCOPE];
-	locator_t loc = locator_init (tdef, index, MONO_LOCALSCOPE_METHOD);
+	mono_locator_t loc = mono_locator_init (tdef, index, MONO_LOCALSCOPE_METHOD);
 
 	if (!tdef->base)
 		return 0;
@@ -6301,7 +6301,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 				       MonoMarshalSpec **marshal_spec, gboolean alloc_from_image)
 {
 	MonoTableInfo *tdef;
-	locator_t loc;
+	mono_locator_t loc;
 
 	guint32 idx = index + 1;
 	if (meta->uncompressed_metadata)
@@ -6310,7 +6310,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 	if (offset) {
 		tdef = &meta->tables [MONO_TABLE_FIELDLAYOUT];
 
-		loc = locator_init (tdef, idx, MONO_FIELD_LAYOUT_FIELD);
+		loc = mono_locator_init (tdef, idx, MONO_FIELD_LAYOUT_FIELD);
 
 		/* metadata-update: explicit layout not supported, just return -1 */
 
@@ -6323,7 +6323,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 	if (rva) {
 		tdef = &meta->tables [MONO_TABLE_FIELDRVA];
 
-		loc = locator_init (tdef, idx, MONO_FIELD_RVA_FIELD);
+		loc = mono_locator_init (tdef, idx, MONO_FIELD_RVA_FIELD);
 
 		gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator);
 
@@ -6365,7 +6365,7 @@ guint32
 mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 {
 	MonoTableInfo *tdef;
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 index = mono_metadata_token_index (token);
 
 	tdef = &meta->tables [MONO_TABLE_CONSTANT];
@@ -6385,7 +6385,7 @@ mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 		return 0;
 	}
 
-	loc = locator_init (tdef, index, MONO_CONSTANT_PARENT);
+	loc = mono_locator_init (tdef, index, MONO_CONSTANT_PARENT);
 
 	/* FIXME: Index translation */
 
@@ -6414,7 +6414,7 @@ mono_metadata_get_constant_index (MonoImage *meta, guint32 token, guint32 hint)
 guint32
 mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_idx)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 start, end;
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_EVENTMAP];
 
@@ -6423,7 +6423,7 @@ mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_id
 	if (!tdef->base && !meta->has_updates)
 		return 0;
 
-	loc = locator_init (tdef, index + 1, MONO_EVENT_MAP_PARENT);
+	loc = mono_locator_init (tdef, index + 1, MONO_EVENT_MAP_PARENT);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !meta->has_updates)
@@ -6469,7 +6469,7 @@ mono_metadata_events_from_typedef (MonoImage *meta, guint32 index, guint *end_id
 guint32
 mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_idx)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 start, end;
 	guint32 cols [MONO_METHOD_SEMA_SIZE];
 	MonoTableInfo *msemt = &meta->tables [MONO_TABLE_METHODSEMANTICS];
@@ -6481,7 +6481,7 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 	if (meta->uncompressed_metadata)
 	    index = search_ptr_table (meta, MONO_TABLE_EVENT_POINTER, index + 1) - 1;
 
-	loc = locator_init (
+	loc = mono_locator_init (
 		msemt,
 		/* Method association coded index */
 		((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_EVENT,
@@ -6531,7 +6531,7 @@ mono_metadata_methods_from_event   (MonoImage *meta, guint32 index, guint *end_i
 guint32
 mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *end_idx)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 start, end;
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_PROPERTYMAP];
 
@@ -6540,7 +6540,7 @@ mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *en
 	if (!tdef->base && !meta->has_updates)
 		return 0;
 
-	loc = locator_init (tdef, index + 1, MONO_PROPERTY_MAP_PARENT);
+	loc = mono_locator_init (tdef, index + 1, MONO_PROPERTY_MAP_PARENT);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -6587,7 +6587,7 @@ mono_metadata_properties_from_typedef (MonoImage *meta, guint32 index, guint *en
 guint32
 mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *end_idx)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 start, end;
 	guint32 cols [MONO_METHOD_SEMA_SIZE];
 	MonoTableInfo *msemt = &meta->tables [MONO_TABLE_METHODSEMANTICS];
@@ -6599,7 +6599,7 @@ mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *en
 	if (meta->uncompressed_metadata)
 	    index = search_ptr_table (meta, MONO_TABLE_PROPERTY_POINTER, index + 1) - 1;
 
-	loc = locator_init (
+	loc = mono_locator_init (
 		msemt,
 		/* Method association coded index */
 		((index + 1) << MONO_HAS_SEMANTICS_BITS) | MONO_HAS_SEMANTICS_PROPERTY,
@@ -6644,7 +6644,7 @@ mono_metadata_methods_from_property   (MonoImage *meta, guint32 index, guint *en
 guint32
 mono_metadata_implmap_from_method (MonoImage *meta, guint32 method_idx)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_IMPLMAP];
 
 	if (!tdef->base)
@@ -6652,7 +6652,7 @@ mono_metadata_implmap_from_method (MonoImage *meta, guint32 method_idx)
 
 	/* No index translation seems to be needed */
 
-	loc = locator_init (tdef, ((method_idx + 1) << MONO_MEMBERFORWD_BITS) | MONO_MEMBERFORWD_METHODDEF, MONO_IMPLMAP_MEMBER);
+	loc = mono_locator_init (tdef, ((method_idx + 1) << MONO_MEMBERFORWD_BITS) | MONO_MEMBERFORWD_METHODDEF, MONO_IMPLMAP_MEMBER);
 
 	/* FIXME: metadata-update */
 
@@ -7066,10 +7066,10 @@ handle_enum:
 const char*
 mono_metadata_get_marshal_info (MonoImage *meta, guint32 idx, gboolean is_field)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	MonoTableInfo *tdef  = &meta->tables [MONO_TABLE_FIELDMARSHAL];
 
-	loc = locator_init (
+	loc = mono_locator_init (
 		tdef,
 		((idx + 1) << MONO_HAS_FIELD_MARSHAL_BITS) | (is_field? MONO_HAS_FIELD_MARSHAL_FIELDSREF: MONO_HAS_FIELD_MARSHAL_PARAMDEF),
 		MONO_FIELD_MARSHAL_PARENT
@@ -7118,7 +7118,7 @@ mono_method_from_method_def_or_ref (MonoImage *m, guint32 tok, MonoGenericContex
 void
 mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod ***overrides, gint32 *num_overrides, MonoGenericContext *generic_context, MonoError *error)
 {
-	locator_t loc;
+	mono_locator_t loc;
 	MonoTableInfo *tdef  = &image->tables [MONO_TABLE_METHODIMPL];
 	guint32 start, end;
 	gint32 i, num;
@@ -7134,7 +7134,7 @@ mono_class_get_overrides_full (MonoImage *image, guint32 type_token, MonoMethod 
 	if (!tdef->base && !image->has_updates)
 		return;
 
-	loc = locator_init (tdef, mono_metadata_token_index (type_token), MONO_METHODIMPL_CLASS);
+	loc = mono_locator_init (tdef, mono_metadata_token_index (type_token), MONO_METHODIMPL_CLASS);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 
@@ -7233,7 +7233,7 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 {
 	MonoTableInfo *tdef  = &image->tables [MONO_TABLE_GENERICPARAMCONSTRAINT];
 	guint32 cols [MONO_GENPARCONSTRAINT_SIZE];
-	locator_t loc;
+	mono_locator_t loc;
 	guint32 i, token, found, start;
 	MonoClass *klass, **res;
 	GSList *cons = NULL, *tmp;
@@ -7246,7 +7246,7 @@ get_constraints (MonoImage *image, int owner, MonoClass ***constraints, MonoGene
 	/* FIXME: metadata-update */
 	guint32 rows = table_info_get_rows (tdef);
 
-	loc = locator_init (tdef, owner, MONO_GENPARCONSTRAINT_GENERICPAR);
+	loc = mono_locator_init (tdef, owner, MONO_GENPARCONSTRAINT_GENERICPAR);
 
 	gboolean is_found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!is_found && !image->has_updates)
@@ -7303,7 +7303,7 @@ guint32
 mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *owner)
 {
 	MonoTableInfo *tdef  = &image->tables [MONO_TABLE_GENERICPARAM];
-	locator_t loc;
+	mono_locator_t loc;
 
 	g_assert (owner);
 	if (!tdef->base && !image->has_updates)
@@ -7319,7 +7319,7 @@ mono_metadata_get_generic_param_row (MonoImage *image, guint32 token, guint32 *o
 	}
 	*owner |= mono_metadata_token_index (token) << MONO_TYPEORMETHOD_BITS;
 
-	loc = locator_init (tdef, *owner, MONO_GENERICPARAM_OWNER);
+	loc = mono_locator_init (tdef, *owner, MONO_GENERICPARAM_OWNER);
 
 	gboolean found = tdef->base && mono_binary_search (&loc, tdef->base, table_info_get_rows (tdef), tdef->row_size, table_locator) != NULL;
 	if (!found && !image->has_updates)

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4706,13 +4706,16 @@ typedef struct {
 MONO_ALWAYS_INLINE static locator_t
 locator_init (MonoTableInfo *t, guint32 idx, guint32 col_idx)
 {
-	g_assert (t);
+	locator_t result = { 0, };
 
-	locator_t result;
 	result.idx = idx;
 	result.col_idx = col_idx;
 	result.t = t;
-	result.result = 0;
+
+	g_assert (t);
+	// FIXME: Callers shouldn't rely on this
+	if (!t->base)
+		return result;
 
 	// optimization data for decode_locator_row
 	result.metadata_has_updates = mono_metadata_has_updates ();

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -6353,7 +6353,7 @@ mono_metadata_field_info_full (MonoImage *meta, guint32 index, guint32 *offset, 
 
 	guint32 idx = index + 1;
 	if (meta->uncompressed_metadata)
-		idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, loc.idx);
+		idx = search_ptr_table (meta, MONO_TABLE_FIELD_POINTER, idx);
 
 	if (offset) {
 		tdef = &meta->tables [MONO_TABLE_FIELDLAYOUT];

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -4684,7 +4684,9 @@ decode_locator_row (locator_t *loc, int row_index)
 {
 	const char *data;
 
-	if (G_UNLIKELY (loc->metadata_has_updates))
+	if (G_UNLIKELY (loc->metadata_has_updates < 0))
+		loc->metadata_has_updates = mono_metadata_has_updates ();
+	if (G_UNLIKELY (loc->metadata_has_updates > 0))
 		return mono_metadata_decode_row_col_slow (loc->t, row_index, loc->col_idx);
 
 	// g_assert (col < mono_metadata_table_count (bitfield));


### PR DESCRIPTION
Metadata loading does a bunch of table searches that contain redundant lookups and checks, this PR attempts to optimize them by hoisting most of the checking and computation outside of the binary search operation.

Profile with this in effect: https://share.firefox.dev/4aqtjUc