### PR TITLE
Update VS install requirements to bump Windows 10 SDK version

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -43,7 +43,7 @@
     "Microsoft.VisualStudio.Component.VC.Redist.14.Latest",
     "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.Component.Windows10SDK.20348",
     "Microsoft.VisualStudio.ComponentGroup.MSIX.Packaging",
     "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core",
     "Microsoft.VisualStudio.Workload.CoreEditor",

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -36,8 +36,7 @@ Note that Visual Studio and the development tools described below are required, 
 
 * It's recommended to use **Workloads** installation approach. The following are the minimum requirements:
   * **.NET Desktop Development** with all default components,
-  * **Desktop Development with C++** with all default components, plus:
-    * *Windows 10 SDK (10.0.20348)* or newer, instead of version 10.0.19041
+  * **Desktop Development with C++** with all default components.
 * To build for Arm64, make sure that you have the right architecture-specific compilers installed. In the **Individual components** window, in the **Compilers, build tools, and runtimes** section:
   * For Arm64, check the box for _MSVC v143* VS 2022 C++ ARM64 build tools (Latest)_.
 * To build the tests, you will need some additional components:

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -36,7 +36,8 @@ Note that Visual Studio and the development tools described below are required, 
 
 * It's recommended to use **Workloads** installation approach. The following are the minimum requirements:
   * **.NET Desktop Development** with all default components,
-  * **Desktop Development with C++** with all default components.
+  * **Desktop Development with C++** with all default components, plus:
+    * *Windows 10 SDK (10.0.20348)* or newer, instead of version 10.0.19041
 * To build for Arm64, make sure that you have the right architecture-specific compilers installed. In the **Individual components** window, in the **Compilers, build tools, and runtimes** section:
   * For Arm64, check the box for _MSVC v143* VS 2022 C++ ARM64 build tools (Latest)_.
 * To build the tests, you will need some additional components:


### PR DESCRIPTION
As was discovered in [#94106](https://github.com/dotnet/runtime/issues/94106#issuecomment-1827889500), our build now requires Windows 10 SDK 10.0.20348+. Using version 10.0.19041 results in the following build error when building mono.

    C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winbase.h(9531): error C2220: the following warning is treated as an error
    C:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\um\winbase.h(9531): warning C5105: macro expansion producing 'defined' has undefined behavior

I stumbled upon this while building clr+mono on a fresh machine. Updating the Windows 10 SDK version fixed my build.