### PR TITLE
Deduplicate header Separator logic

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderDescriptor.cs
@@ -277,5 +277,9 @@ namespace System.Net.Http.Headers
             decoded = null;
             return false;
         }
+
+        public string Separator => Parser is { } parser ? parser.Separator : HttpHeaderParser.DefaultSeparator;
+
+        public byte[] SeparatorBytes => Parser is { } parser ? parser.SeparatorBytes : HttpHeaderParser.DefaultSeparatorBytes;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderStringValues.cs
@@ -45,7 +45,7 @@ namespace System.Net.Http.Headers
         public override string ToString() => _value switch
         {
             string value => value,
-            string[] values => string.Join(_header.Parser is HttpHeaderParser parser && parser.SupportsMultipleValues ? parser.Separator : HttpHeaderParser.DefaultSeparator, values),
+            string[] values => string.Join(_header.Separator, values),
             _ => string.Empty,
         };
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaderParser.cs
@@ -4,53 +4,42 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace System.Net.Http.Headers
 {
     internal abstract class HttpHeaderParser
     {
-        internal const string DefaultSeparator = ", ";
+        public const string DefaultSeparator = ", ";
+        public static readonly byte[] DefaultSeparatorBytes = ", "u8.ToArray();
 
-        private readonly bool _supportsMultipleValues;
-        private readonly string? _separator;
+        public bool SupportsMultipleValues { get; private set; }
 
-        public bool SupportsMultipleValues
-        {
-            get { return _supportsMultipleValues; }
-        }
+        public string Separator { get; private set; }
 
-        public string? Separator
-        {
-            get
-            {
-                Debug.Assert(_supportsMultipleValues);
-                return _separator;
-            }
-        }
+        public byte[] SeparatorBytes { get; private set; }
 
         // If ValueType implements Equals() as required, there is no need to provide a comparer. A comparer is needed
         // e.g. if we want to compare strings using case-insensitive comparison.
-        public virtual IEqualityComparer? Comparer
-        {
-            get { return null; }
-        }
+        public virtual IEqualityComparer? Comparer => null;
 
         protected HttpHeaderParser(bool supportsMultipleValues)
         {
-            _supportsMultipleValues = supportsMultipleValues;
+            SupportsMultipleValues = supportsMultipleValues;
+            Separator = DefaultSeparator;
+            SeparatorBytes = DefaultSeparatorBytes;
+        }
+
+        protected HttpHeaderParser(bool supportsMultipleValues, string separator) : this(supportsMultipleValues)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(separator));
+            Debug.Assert(Ascii.IsValid(separator));
 
             if (supportsMultipleValues)
             {
-                _separator = DefaultSeparator;
+                Separator = separator;
+                SeparatorBytes = Encoding.ASCII.GetBytes(separator);
             }
-        }
-
-        protected HttpHeaderParser(bool supportsMultipleValues, string separator)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(separator));
-
-            _supportsMultipleValues = supportsMultipleValues;
-            _separator = separator;
         }
 
         // If a parser supports multiple values, a call to ParseValue/TryParseValue should return a value for 'index'

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -258,7 +258,7 @@ namespace System.Net.Http.Headers
                 {
                     // Note that if we get multiple values for a header that doesn't support multiple values, we'll
                     // just separate the values using a comma (default separator).
-                    string? separator = entry.Key.Parser is HttpHeaderParser parser && parser.SupportsMultipleValues ? parser.Separator : HttpHeaderParser.DefaultSeparator;
+                    string separator = entry.Key.Separator;
 
                     Debug.Assert(multiValue is not null && multiValue.Length > 0);
                     vsb.Append(multiValue[0]);
@@ -289,8 +289,7 @@ namespace System.Net.Http.Headers
 
                 // Note that if we get multiple values for a header that doesn't support multiple values, we'll
                 // just separate the values using a comma (default separator).
-                string? separator = descriptor.Parser != null && descriptor.Parser.SupportsMultipleValues ? descriptor.Parser.Separator : HttpHeaderParser.DefaultSeparator;
-                return string.Join(separator, multiValue!);
+                return string.Join(descriptor.Separator, multiValue!);
             }
 
             return string.Empty;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -708,19 +708,8 @@ namespace System.Net.Http
 
                         // For all other known headers, send them via their pre-encoded name and the associated value.
                         BufferBytes(knownHeader.Http3EncodedName);
-                        string? separator = null;
-                        if (headerValues.Length > 1)
-                        {
-                            HttpHeaderParser? parser = header.Key.Parser;
-                            if (parser != null && parser.SupportsMultipleValues)
-                            {
-                                separator = parser.Separator;
-                            }
-                            else
-                            {
-                                separator = HttpHeaderParser.DefaultSeparator;
-                            }
-                        }
+
+                        byte[]? separator = headerValues.Length > 1 ? header.Key.SeparatorBytes : null;
 
                         BufferLiteralHeaderValues(headerValues, separator, valueEncoding);
                     }
@@ -728,7 +717,7 @@ namespace System.Net.Http
                 else
                 {
                     // The header is not known: fall back to just encoding the header name and value(s).
-                    BufferLiteralHeaderWithoutNameReference(header.Key.Name, headerValues, HttpHeaderParser.DefaultSeparator, valueEncoding);
+                    BufferLiteralHeaderWithoutNameReference(header.Key.Name, headerValues, HttpHeaderParser.DefaultSeparatorBytes, valueEncoding);
                 }
             }
 
@@ -755,7 +744,7 @@ namespace System.Net.Http
             _sendBuffer.Commit(bytesWritten);
         }
 
-        private void BufferLiteralHeaderWithoutNameReference(string name, ReadOnlySpan<string> values, string separator, Encoding? valueEncoding)
+        private void BufferLiteralHeaderWithoutNameReference(string name, ReadOnlySpan<string> values, byte[] separator, Encoding? valueEncoding)
         {
             int bytesWritten;
             while (!QPackEncoder.EncodeLiteralHeaderFieldWithoutNameReference(name, values, separator, valueEncoding, _sendBuffer.AvailableSpan, out bytesWritten))
@@ -775,7 +764,7 @@ namespace System.Net.Http
             _sendBuffer.Commit(bytesWritten);
         }
 
-        private void BufferLiteralHeaderValues(ReadOnlySpan<string> values, string? separator, Encoding? valueEncoding)
+        private void BufferLiteralHeaderValues(ReadOnlySpan<string> values, byte[]? separator, Encoding? valueEncoding)
         {
             int bytesWritten;
             while (!QPackEncoder.EncodeValueString(values, separator, valueEncoding, _sendBuffer.AvailableSpan, out bytesWritten))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -417,16 +417,11 @@ namespace System.Net.Http
                 // Some headers such as User-Agent and Server use space as a separator (see: ProductInfoHeaderParser)
                 if (headerValuesCount > 1)
                 {
-                    HttpHeaderParser? parser = header.Key.Parser;
-                    string separator = HttpHeaderParser.DefaultSeparator;
-                    if (parser != null && parser.SupportsMultipleValues)
-                    {
-                        separator = parser.Separator!;
-                    }
+                    byte[] separator = header.Key.SeparatorBytes;
 
                     for (int i = 1; i < headerValuesCount; i++)
                     {
-                        WriteAsciiString(separator);
+                        WriteBytes(separator);
                         WriteString(headerValues[i], valueEncoding);
                     }
                 }

--- a/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HPack/HPackRoundtripTests.cs
@@ -71,19 +71,8 @@ namespace System.Net.Http.Unit.Tests.HPack
                 {
                     // For all other known headers, send them via their pre-encoded name and the associated value.
                     WriteBytes(knownHeader.Http2EncodedName);
-                    string separator = null;
-                    if (headerValuesSpan.Length > 1)
-                    {
-                        HttpHeaderParser parser = header.Key.Parser;
-                        if (parser != null && parser.SupportsMultipleValues)
-                        {
-                            separator = parser.Separator;
-                        }
-                        else
-                        {
-                            separator = HttpHeaderParser.DefaultSeparator;
-                        }
-                    }
+
+                    byte[]? separator = headerValuesSpan.Length > 1 ? header.Key.SeparatorBytes : null;
 
                     WriteLiteralHeaderValues(headerValuesSpan, separator);
                 }
@@ -105,7 +94,7 @@ namespace System.Net.Http.Unit.Tests.HPack
                 buffer.Commit(bytes.Length);
             }
 
-            void WriteLiteralHeaderValues(ReadOnlySpan<string> values, string separator)
+            void WriteLiteralHeaderValues(ReadOnlySpan<string> values, byte[]? separator)
             {
                 int bytesWritten;
                 while (!HPackEncoder.EncodeStringLiterals(values, separator, valueEncoding, buffer.AvailableSpan, out bytesWritten))
@@ -120,7 +109,7 @@ namespace System.Net.Http.Unit.Tests.HPack
             void WriteLiteralHeader(string name, ReadOnlySpan<string> values)
             {
                 int bytesWritten;
-                while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, valueEncoding, buffer.AvailableSpan, out bytesWritten))
+                while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparatorBytes, valueEncoding, buffer.AvailableSpan, out bytesWritten))
                 {
                     buffer.Grow();
                     FillAvailableSpaceWithOnes(buffer);


### PR DESCRIPTION
We have logic like this duplicated in 7 places:
```c#
string? separator = null;
if (headerValues.Length > 1)
{
    HttpHeaderParser? parser = header.Key.Parser;
    if (parser != null && parser.SupportsMultipleValues)
    {
        separator = parser.Separator;
    }
    else
    {
        separator = HttpHeaderParser.DefaultSeparator;
    }
}
```

This PR adds helpers that hide this. I also avoided the overhead of checking `SupportsMultipleValues` and doing the transcoding on the hot path.

As far as I can tell neither we nor Kestrel are using the HPack/QPack methods I removed which don't accept a value encoding.