### PR TITLE
Fix HalfNumberBufferLength

### DIFF
--- a/src/libraries/Common/src/System/Number.NumberBuffer.cs
+++ b/src/libraries/Common/src/System/Number.NumberBuffer.cs
@@ -17,7 +17,7 @@ namespace System
         internal const int Int64NumberBufferLength = 19 + 1;    // 19 for the longest input: 9,223,372,036,854,775,807
         internal const int Int128NumberBufferLength = 39 + 1;    // 39 for the longest input: 170,141,183,460,469,231,731,687,303,715,884,105,727
         internal const int SingleNumberBufferLength = 112 + 1 + 1;  // 112 for the longest input + 1 for rounding: 1.40129846E-45
-        internal const int HalfNumberBufferLength = 21; // 19 for the longest input + 1 for rounding (+1 for the null terminator)
+        internal const int HalfNumberBufferLength = 21 + 1 + 1; // 21 for the longest input + 1 for rounding: 0.000122010707855224609375
         internal const int UInt32NumberBufferLength = 10 + 1;   // 10 for the longest input: 4,294,967,295
         internal const int UInt64NumberBufferLength = 20 + 1;   // 20 for the longest input: 18,446,744,073,709,551,615
         internal const int UInt128NumberBufferLength = 39 + 1; // 39 for the longest input: 340,282,366,920,938,463,463,374,607,431,768,211,455

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
@@ -1125,6 +1125,14 @@ namespace System.Tests
             AssertExtensions.Equal((Half)value, result);
         }
 
+        [Fact] // https://github.com/dotnet/runtime/issues/98841
+        public static void ToString_MaxPrecision()
+        {
+            Half value = BitConverter.Int16BitsToHalf(0x07FF);
+            string str = value.ToString("F24");
+            Assert.Equal("0.000122010707855224609375", str);
+        }
+
         public static IEnumerable<object[]> RoundTripFloat_CornerCases()
         {
             // Magnitude smaller than 2^-24 maps to 0


### PR DESCRIPTION
Fixes #98841

I'm not sure where to add test. Should I create a single regression test, or add a case to Half.ToString tests?