### PR TITLE
Use number of slots intead of size in BuildBlockStore

### DIFF
--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -691,14 +691,14 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                     allRegs(TYP_INT) & ~(RBM_WRITE_BARRIER_DST_BYREF | RBM_WRITE_BARRIER_SRC_BYREF);
                 buildInternalIntRegisterDefForNode(blkNode, internalIntCandidates);
 
-                if (size >= 2 * REGSIZE_BYTES)
+                const unsigned slots = blkNode->GetLayout()->GetSlotCount();
+                if (slots >= 2)
                 {
                     // We will use ldp/stp to reduce code size and improve performance
                     // so we need to reserve an extra internal register
                     buildInternalIntRegisterDefForNode(blkNode, internalIntCandidates);
                 }
-
-                if (size >= 4 * REGSIZE_BYTES && compiler->IsBaselineSimdIsaSupported())
+                if ((slots >= 4) && compiler->IsBaselineSimdIsaSupported())
                 {
                     // We can use 128-bit SIMD ldp/stp for larger block sizes
                     buildInternalFloatRegisterDefForNode(blkNode, internalFloatRegCandidates());


### PR DESCRIPTION
Proper fix for https://github.com/dotnet/runtime/issues/99611

The https://github.com/dotnet/runtime/issues/99611 crash was caused by a semi-valid struct defined in `Microsoft.macOS.dll`:
```cs
    [StructLayout(LayoutKind.Explicit, Size = 28)]
    private struct sockaddr_in
    {
      [FieldOffset(0)]
      private byte sin_len;
      [FieldOffset(1)]
      private byte sin_family;
      [FieldOffset(2)]
      private short sin_port;
      [FieldOffset(4)]
      private int sin_addr;
      [FieldOffset(4)]
      private uint sin6_flowinfo;
      [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
      [FieldOffset(8)]
      public byte[] sin6_addr8;
      [FieldOffset(24)]
      private uint sin6_scope_id;
    }
```
the size was explicitly set to 28 while in fact it's rounded to 32 anyway due to GC ref. 
The bug basically is:
1) LSRA: size is 28? then you don't need SIMD regs to copy it
2) Codegen: struct has 4 slots, give me 2 SIMD regs
