### PR TITLE
Avoid 0-length array allocation for empty Distinct/Union.ToArray

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Distinct.SpeedOpt.cs
@@ -9,7 +9,7 @@ namespace System.Linq
     {
         private sealed partial class DistinctIterator<TSource>
         {
-            public override TSource[] ToArray() => HashSetToArray(new HashSet<TSource>(_source, _comparer));
+            public override TSource[] ToArray() => ICollectionToArray(new HashSet<TSource>(_source, _comparer));
 
             public override List<TSource> ToList() => new List<TSource>(new HashSet<TSource>(_source, _comparer));
 

--- a/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/libraries/System.Linq/src/System/Linq/ToCollection.cs
@@ -11,11 +11,6 @@ namespace System.Linq
     {
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
-            if (source is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-            }
-
 #if !OPTIMIZE_FOR_SIZE
             if (source is Iterator<TSource> iterator)
             {
@@ -25,15 +20,7 @@ namespace System.Linq
 
             if (source is ICollection<TSource> collection)
             {
-                int count = collection.Count;
-                if (count != 0)
-                {
-                    var result = new TSource[count];
-                    collection.CopyTo(result, 0);
-                    return result;
-                }
-
-                return [];
+                return ICollectionToArray(collection);
             }
 
             return EnumerableToArray(source);
@@ -41,6 +28,11 @@ namespace System.Linq
             [MethodImpl(MethodImplOptions.NoInlining)] // avoid large stack allocation impacting other paths
             static TSource[] EnumerableToArray(IEnumerable<TSource> source)
             {
+                if (source is null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+                }
+
                 SegmentedArrayBuilder<TSource>.ScratchBuffer scratch = default;
                 SegmentedArrayBuilder<TSource> builder = new(scratch);
 
@@ -50,6 +42,19 @@ namespace System.Linq
                 builder.Dispose();
                 return result;
             }
+        }
+
+        private static TSource[] ICollectionToArray<TSource>(ICollection<TSource> collection)
+        {
+            int count = collection.Count;
+            if (count != 0)
+            {
+                var result = new TSource[count];
+                collection.CopyTo(result, 0);
+                return result;
+            }
+
+            return [];
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
@@ -259,12 +264,5 @@ namespace System.Linq
         /// <summary>Default initial capacity to use when creating sets for internal temporary storage.</summary>
         /// <remarks>This is based on the implicit size used in previous implementations, which used a custom Set type.</remarks>
         private const int DefaultInternalSetCapacity = 7;
-
-        private static TSource[] HashSetToArray<TSource>(HashSet<TSource> set)
-        {
-            var result = new TSource[set.Count];
-            set.CopyTo(result);
-            return result;
-        }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Union.SpeedOpt.cs
@@ -24,7 +24,7 @@ namespace System.Linq
                 }
             }
 
-            public override TSource[] ToArray() => HashSetToArray(FillSet());
+            public override TSource[] ToArray() => ICollectionToArray(FillSet());
 
             public override List<TSource> ToList() => new List<TSource>(FillSet());
 


### PR DESCRIPTION
This also makes Enumerable.ToArray more inlineable and removes a bit of duplicated code.