### PR TITLE
Delay MsQuicSendBuffers disposal to QuicStream safe handle closing.

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -170,6 +170,7 @@ public sealed partial class QuicStream
                 &handle),
                 "StreamOpen failed");
             _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
+            _handle.Disposable = _sendBuffers;
         }
         catch
         {
@@ -201,6 +202,7 @@ public sealed partial class QuicStream
         try
         {
             _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
+            _handle.Disposable = _sendBuffers;
             delegate* unmanaged[Cdecl]<QUIC_HANDLE*, void*, QUIC_STREAM_EVENT*, int> nativeCallback = &NativeCallback;
             MsQuicApi.Api.SetCallbackHandler(
                 _handle,
@@ -714,9 +716,6 @@ public sealed partial class QuicStream
         }
         Debug.Assert(_startedTcs.IsCompleted);
         _handle.Dispose();
-
-        // TODO: memory leak if not disposed
-        _sendBuffers.Dispose();
 
         unsafe void StreamShutdown(QUIC_STREAM_SHUTDOWN_FLAGS flags, long errorCode)
         {


### PR DESCRIPTION
Fixes ASAN violation found in https://github.com/dotnet/runtime/pull/100023#issuecomment-2012023713.

It may happen that there is an outstanding call to MsQuicStreamSend (where we pass native allocated buffers), while another thread initiates (and completes) QuicStream.Dispose().

This PR makes sure the native memory is live until we close the QuicStream safe handle. This also gets rid of small memory leak if QuicStream is never disposed and is left for finalizer.