### PR TITLE
[browser] reduce use of wrap_error_root

### DIFF
--- a/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
+++ b/src/libraries/Common/src/Interop/Browser/Interop.Runtime.cs
@@ -58,7 +58,7 @@ internal static partial class Interop
         public static extern void CancelPromisePost(nint targetNativeTID, nint taskHolderGCHandle);
 #else
         [MethodImpl(MethodImplOptions.InternalCall)]
-        public static extern unsafe void BindJSImport(void* signature, out int is_exception, out object result);
+        public static extern unsafe nint BindJSImportST(void* signature);
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern void InvokeJSImportST(int importHandle, nint args);
         [MethodImpl(MethodImplOptions.InternalCall)]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -449,9 +449,13 @@ namespace System.Runtime.InteropServices.JavaScript
 
 #if !FEATURE_WASM_MANAGED_THREADS
 
-            Interop.Runtime.BindJSImport(signature.Header, out int isException, out object exceptionMessage);
-            if (isException != 0)
-                throw new JSException((string)exceptionMessage);
+            nint exceptionPtr = Interop.Runtime.BindJSImportST(signature.Header);
+            if (exceptionPtr != IntPtr.Zero)
+            {
+                var message = Marshal.PtrToStringUni(exceptionPtr)!;
+                Marshal.FreeHGlobal(exceptionPtr);
+                throw new JSException(message);
+            }
 
             JSHostImplementation.FreeMethodSignatureBuffer(signature);
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -36,6 +36,13 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             instance1.Dispose();
         }
 
+        [Fact]
+        public void MissingImport()
+        {
+            var ex = Assert.Throws<JSException>(() => JavaScriptTestHelper.IntentionallyMissingImport());
+            Assert.Contains("intentionallyMissingImport must be a Function but was undefined", ex.Message);
+        }
+
 #if !FEATURE_WASM_MANAGED_THREADS // because in MT JSHost.ImportAsync is really async, it will finish before the caller could cancel it
         [Fact]
         public async Task CancelableImportAsync()

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -37,6 +37,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("delay", "JavaScriptTestHelper")]
         public static partial Task Delay(int ms);
 
+        [JSImport("intentionallyMissingImport", "JavaScriptTestHelper")]
+        public static partial void IntentionallyMissingImport();
+
         [JSImport("catch1toString", "JavaScriptTestHelper")]
         public static partial string catch1toString(string message, string functionName);
 

--- a/src/mono/browser/runtime/corebindings.c
+++ b/src/mono/browser/runtime/corebindings.c
@@ -52,7 +52,7 @@ extern void mono_threads_wasm_async_run_in_target_thread_vi (pthread_t target_th
 extern void mono_threads_wasm_async_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer user_data2);
 extern void mono_threads_wasm_sync_run_in_target_thread_vii (pthread_t target_thread, void (*func) (gpointer, gpointer), gpointer user_data1, gpointer args);
 #else
-extern void mono_wasm_bind_js_import (void *signature, int *is_exception, MonoObject **result);
+extern void* mono_wasm_bind_js_import_ST (void *signature);
 extern void mono_wasm_invoke_jsimport_ST (int function_handle, void *args);
 #endif /* DISABLE_THREADS */
 
@@ -87,7 +87,7 @@ void bindings_initialize_internals (void)
 	mono_add_internal_call ("Interop/Runtime::InvokeJSFunctionSend", mono_wasm_invoke_js_function_send);
 	mono_add_internal_call ("Interop/Runtime::CancelPromisePost", mono_wasm_cancel_promise_post);
 #else
-	mono_add_internal_call ("Interop/Runtime::BindJSImport", mono_wasm_bind_js_import);
+	mono_add_internal_call ("Interop/Runtime::BindJSImportST", mono_wasm_bind_js_import_ST);
 	mono_add_internal_call ("Interop/Runtime::InvokeJSImportST", mono_wasm_invoke_jsimport_ST);
 #endif /* DISABLE_THREADS */
 

--- a/src/mono/browser/runtime/exports-binding.ts
+++ b/src/mono/browser/runtime/exports-binding.ts
@@ -5,7 +5,7 @@ import WasmEnableThreads from "consts:wasmEnableThreads";
 
 import { mono_wasm_debugger_log, mono_wasm_add_dbg_command_received, mono_wasm_set_entrypoint_breakpoint, mono_wasm_fire_debugger_agent_message_with_data, mono_wasm_fire_debugger_agent_message_with_data_to_pause } from "./debug";
 import { mono_wasm_release_cs_owned_object } from "./gc-handles";
-import { mono_wasm_bind_js_import, mono_wasm_invoke_js_function, mono_wasm_invoke_jsimport_MT, mono_wasm_invoke_jsimport_ST } from "./invoke-js";
+import { mono_wasm_bind_js_import_ST, mono_wasm_invoke_js_function, mono_wasm_invoke_jsimport_MT, mono_wasm_invoke_jsimport_ST } from "./invoke-js";
 import { mono_interp_tier_prepare_jiterpreter, mono_jiterp_free_method_data_js } from "./jiterpreter";
 import { mono_interp_jit_wasm_entry_trampoline, mono_interp_record_interp_entry } from "./jiterpreter-interp-entry";
 import { mono_interp_jit_wasm_jit_call_trampoline, mono_interp_invoke_wasm_jit_call_trampoline, mono_interp_flush_jitcall_queue } from "./jiterpreter-jit-call";
@@ -94,7 +94,7 @@ export const mono_wasm_imports = [
     // corebindings.c
     mono_wasm_console_clear,
     mono_wasm_release_cs_owned_object,
-    mono_wasm_bind_js_import,
+    mono_wasm_bind_js_import_ST,
     mono_wasm_invoke_js_function,
     mono_wasm_invoke_jsimport_ST,
     mono_wasm_resolve_or_reject_promise,

--- a/src/mono/browser/runtime/hybrid-globalization/calendar.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/calendar.ts
@@ -6,7 +6,7 @@ import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString, stringToUTF16 } from "../strings";
 import { MonoObject, MonoObjectRef, MonoString, MonoStringRef } from "../types/internal";
 import { Int32Ptr } from "../types/emscripten";
-import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "./helpers";
 import { INNER_SEPARATOR, OUTER_SEPARATOR, normalizeSpaces } from "./helpers";
 
 const MONTH_CODE = "MMMM";

--- a/src/mono/browser/runtime/hybrid-globalization/change-case.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/change-case.ts
@@ -5,7 +5,7 @@ import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString, utf16ToStringLoop, stringToUTF16 } from "../strings";
 import { MonoObject, MonoObjectRef, MonoString, MonoStringRef } from "../types/internal";
 import { Int32Ptr } from "../types/emscripten";
-import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "./helpers";
 import { localHeapViewU16, setU16_local } from "../memory";
 import { isSurrogate } from "./helpers";
 

--- a/src/mono/browser/runtime/hybrid-globalization/collations.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/collations.ts
@@ -5,7 +5,7 @@ import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString, utf16ToString } from "../strings";
 import { MonoObject, MonoObjectRef, MonoString, MonoStringRef } from "../types/internal";
 import { Int32Ptr } from "../types/emscripten";
-import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "./helpers";
 import { GraphemeSegmenter } from "./grapheme-segmenter";
 
 const COMPARISON_ERROR = -2;

--- a/src/mono/browser/runtime/hybrid-globalization/culture-info.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/culture-info.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "./helpers";
 import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString, stringToUTF16 } from "../strings";
 import { Int32Ptr } from "../types/emscripten";

--- a/src/mono/browser/runtime/hybrid-globalization/helpers.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/helpers.ts
@@ -1,6 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import { normalize_exception } from "../invoke-js";
+import { receiveWorkerHeapViews, setI32_unchecked } from "../memory";
+import { stringToMonoStringRoot } from "../strings";
+import { Int32Ptr } from "../types/emscripten";
+import { MonoObject, WasmRoot } from "../types/internal";
+
 const SURROGATE_HIGHER_START = "\uD800";
 const SURROGATE_HIGHER_END = "\uDBFF";
 const SURROGATE_LOWER_START = "\uDC00";
@@ -41,4 +47,30 @@ export function isSurrogate (str: string, startIdx: number): boolean {
         startIdx + 1 < str.length &&
         SURROGATE_LOWER_START <= str[startIdx + 1] &&
         str[startIdx + 1] <= SURROGATE_LOWER_END;
+}
+
+function _wrap_error_flag (is_exception: Int32Ptr | null, ex: any): string {
+    const res = normalize_exception(ex);
+    if (is_exception) {
+        receiveWorkerHeapViews();
+        setI32_unchecked(is_exception, 1);
+    }
+    return res;
+}
+
+export function wrap_error_root (is_exception: Int32Ptr | null, ex: any, result: WasmRoot<MonoObject>): void {
+    const res = _wrap_error_flag(is_exception, ex);
+    stringToMonoStringRoot(res, <any>result);
+}
+
+// TODO replace it with replace it with UTF8 char*, no GC root needed
+// https://github.com/dotnet/runtime/issues/98365
+export function wrap_no_error_root (is_exception: Int32Ptr | null, result?: WasmRoot<MonoObject>): void {
+    if (is_exception) {
+        receiveWorkerHeapViews();
+        setI32_unchecked(is_exception, 0);
+    }
+    if (result) {
+        result.clear();
+    }
 }

--- a/src/mono/browser/runtime/hybrid-globalization/helpers.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/helpers.ts
@@ -63,7 +63,7 @@ export function wrap_error_root (is_exception: Int32Ptr | null, ex: any, result:
     stringToMonoStringRoot(res, <any>result);
 }
 
-// TODO replace it with replace it with UTF8 char*, no GC root needed
+// TODO replace it with replace it with UTF16 char*, no GC root needed
 // https://github.com/dotnet/runtime/issues/98365
 export function wrap_no_error_root (is_exception: Int32Ptr | null, result?: WasmRoot<MonoObject>): void {
     if (is_exception) {

--- a/src/mono/browser/runtime/hybrid-globalization/locales.ts
+++ b/src/mono/browser/runtime/hybrid-globalization/locales.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import { wrap_error_root, wrap_no_error_root } from "../invoke-js";
+import { wrap_error_root, wrap_no_error_root } from "./helpers";
 import { mono_wasm_new_external_root } from "../roots";
 import { monoStringToString, stringToUTF16 } from "../strings";
 import { Int32Ptr } from "../types/emscripten";

--- a/src/mono/browser/runtime/strings.ts
+++ b/src/mono/browser/runtime/strings.ts
@@ -6,7 +6,7 @@ import { MonoString, MonoStringNull, WasmRoot, WasmRootBuffer } from "./types/in
 import { Module } from "./globals";
 import cwraps from "./cwraps";
 import { isSharedArrayBuffer, localHeapViewU8, getU32_local, setU16_local, localHeapViewU32, getU16_local, localHeapViewU16, _zero_region } from "./memory";
-import { NativePointer, CharPtr } from "./types/emscripten";
+import { NativePointer, CharPtr, VoidPtr } from "./types/emscripten";
 
 export const interned_js_string_table = new Map<string, MonoString>();
 export const mono_wasm_empty_string = "";
@@ -106,6 +106,15 @@ export function stringToUTF16 (dstPtr: number, endPtr: number, text: string) {
         dstPtr += 2;
         if (dstPtr >= endPtr) break;
     }
+}
+
+export function stringToUTF16Ptr (str: string): VoidPtr {
+    const bytes = (str.length + 1) * 2;
+    const ptr = Module._malloc(bytes) as any;
+    _zero_region(ptr, str.length * 2);
+    stringToUTF16(ptr, ptr + bytes, str);
+    return ptr;
+
 }
 
 export function monoStringToString (root: WasmRoot<MonoString>): string | null {

--- a/src/mono/browser/runtime/strings.ts
+++ b/src/mono/browser/runtime/strings.ts
@@ -45,7 +45,7 @@ export function stringToUTF8 (str: string): Uint8Array {
 }
 
 export function stringToUTF8Ptr (str: string): CharPtr {
-    const bytes = str.length * 2;
+    const bytes = (str.length + 1) * 2;
     const ptr = Module._malloc(bytes) as any;
     _zero_region(ptr, str.length * 2);
     const buffer = localHeapViewU8().subarray(ptr, ptr + bytes);


### PR DESCRIPTION
- renamed `BindJSImport` to `BindJSImportST` and changed signature
    - it now returns null pointer to UTF16 buffer when there is no error
    - or zero terminated UTF16 buffer with error message, freed by receiver
- renamed `mono_wasm_bind_js_import` to `mono_wasm_bind_js_import_ST`
- implemented `stringToUTF16Ptr`
- moved `wrap_error_root` to `hybrid-globalization`
- makes failed binding `JSException` rather than `abort`

Contributes to https://github.com/dotnet/runtime/issues/98365

