### PR TITLE
remove test references to obsolete OSes

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -20,13 +20,13 @@ namespace System
         public static bool IsUbuntu2004 => IsDistroAndVersion("ubuntu", 20, 4);
         public static bool IsDebian => IsDistroAndVersion("debian");
         public static bool IsAlpine => IsDistroAndVersion("alpine");
-        public static bool IsDebian10 => IsDistroAndVersion("debian", 10);
         public static bool IsRaspbian10 => IsDistroAndVersion("raspbian", 10);
         public static bool IsMariner => IsDistroAndVersion("mariner");
         public static bool IsSLES => IsDistroAndVersion("sles");
         public static bool IsTizen => IsDistroAndVersion("tizen");
         public static bool IsFedora => IsDistroAndVersion("fedora");
         public static bool IsLinuxBionic => IsBionic();
+        public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;
@@ -39,14 +39,6 @@ namespace System
         public static bool IsNotMacOsAppleSilicon => !IsMacOsAppleSilicon;
         public static bool IsAppSandbox => Environment.GetEnvironmentVariable("APP_SANDBOX_CONTAINER_ID") != null;
         public static bool IsNotAppSandbox => !IsAppSandbox;
-
-        // RedHat family covers RedHat and CentOS
-        public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
-        public static bool IsNotRedHatFamily => !IsRedHatFamily;
-        public static bool IsRedHatFamily7 => IsRedHatFamilyAndVersion(7);
-        public static bool IsCentos7 => IsDistroAndVersion("centos", 7);
-        public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
-        public static bool IsNotDebian10 => !IsDebian10;
 
         public static Version OpenSslVersion => !IsApplePlatform && !IsWindows && !IsAndroid ?
             GetOpenSslVersion() :

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -125,12 +125,6 @@ namespace System.Net.Sockets.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/52124", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public async Task MulticastInterface_Set_IPv6_AnyInterface_Succeeds()
         {
-            if (PlatformDetection.IsRedHatFamily7)
-            {
-                // RH7 seems to have issues with multicast in Azure. Same code and setup can pass when executed outside of Azure.
-                throw new SkipTestException("IPv6 multicast environment not available");
-            }
-
             // On all platforms, index 0 means "any interface"
             await MulticastInterface_Set_IPv6_Helper(0);
         }


### PR DESCRIPTION
RH7  and Centos 7 are out of support. Small cleanup to remove old and unused properties.