### PR TITLE
Avoid IDE030X suggestions for collection expressions that could change semantics/perf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -92,6 +92,7 @@ dotnet_style_readonly_field = true:suggestion
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_exactly_match
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion


### PR DESCRIPTION
e.g. by default this will trigger IDE0300:
```C#
IEnumerable<int> source = new int[] { 0, 1, 2 };
```
but if that's changed to:
```C#
IEnumerable<int> source = [0, 1, 2];
```
the compiler tries to protect the readonly-ness of the enumerable from upcasting and emits something along the lines of:
```C#
IEnumerable<int> source = new ReadOnlyArray<int>(new int[] { 0, 1, 2 });
```
which is then both an extra allocation and hinders some downstream optimizations from code such as we have in LINQ that tests whether the source is a T[].

Putting this into the .editorconfig prevents the IDE from recommending switching to collection expressions in such cases.