### PR TITLE
Switch from array to collection expression in OidLookup

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidLookup.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/OidLookup.cs
@@ -133,17 +133,14 @@ namespace System.Security.Cryptography
 
         private static void InitializeLookupDictionaries()
         {
-            static void AddEntry(string oid, string primaryFriendlyName, string[]? additionalFriendlyNames = null)
+            static void AddEntry(string oid, string primaryFriendlyName, ReadOnlySpan<string> additionalFriendlyNames = default)
             {
                 s_oidToFriendlyName.Add(oid, primaryFriendlyName);
                 s_friendlyNameToOid.Add(primaryFriendlyName, oid);
 
-                if (additionalFriendlyNames != null)
+                foreach (string additionalName in additionalFriendlyNames)
                 {
-                    foreach (var additionalName in additionalFriendlyNames)
-                    {
-                        s_friendlyNameToOid.Add(additionalName, oid);
-                    }
+                    s_friendlyNameToOid.Add(additionalName, oid);
                 }
             }
 
@@ -200,10 +197,9 @@ namespace System.Security.Cryptography
             AddEntry("1.3.133.16.840.63.0.2", "ECDH_STD_SHA1_KDF");
             AddEntry("1.3.132.1.11.1", "ECDH_STD_SHA256_KDF");
             AddEntry("1.3.132.1.11.2", "ECDH_STD_SHA384_KDF");
-#pragma warning disable CA1861 // Avoid constant arrays as arguments. Loaded by static constructor
-            AddEntry("1.2.840.10045.3.1.7", "ECDSA_P256", new[] { "nistP256", "secP256r1", "x962P256v1", "ECDH_P256" });
-            AddEntry("1.3.132.0.34", "ECDSA_P384", new[] { "nistP384", "secP384r1", "ECDH_P384" });
-            AddEntry("1.3.132.0.35", "ECDSA_P521", new[] { "nistP521", "secP521r1", "ECDH_P521" });
+            AddEntry("1.2.840.10045.3.1.7", "ECDSA_P256", ["nistP256", "secP256r1", "x962P256v1", "ECDH_P256"]);
+            AddEntry("1.3.132.0.34", "ECDSA_P384", ["nistP384", "secP384r1", "ECDH_P384"]);
+            AddEntry("1.3.132.0.35", "ECDSA_P521", ["nistP521", "secP521r1", "ECDH_P521"]);
             AddEntry("1.2.840.113549.1.9.16.3.5", "ESDH");
             AddEntry("2.5.4.42", "G");
             AddEntry("2.5.4.43", "I");
@@ -230,8 +226,7 @@ namespace System.Security.Cryptography
             AddEntry("1.2.840.113549.1.1.1", "RSA");
             AddEntry("1.2.840.113549.1.1.7", "RSAES_OAEP");
             AddEntry("1.2.840.113549.1.1.10", "RSASSA-PSS");
-            AddEntry("2.5.4.8", "S", new[] { "ST" });
-#pragma warning restore CA1861 // Avoid constant arrays as arguments
+            AddEntry("2.5.4.8", "S", ["ST"]);
             AddEntry("1.3.132.0.9", "secP160k1");
             AddEntry("1.3.132.0.8", "secP160r1");
             AddEntry("1.3.132.0.30", "secP160r2");


### PR DESCRIPTION
This removes four array allocations on initialization and allows removing a warning suppression.