### PR TITLE
The layout of the `ITypeLib2` interface is incorrect.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComTypes/ITypeLib2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComTypes/ITypeLib2.cs
@@ -25,9 +25,9 @@ namespace System.Runtime.InteropServices.ComTypes
         [PreserveSig]
         new void ReleaseTLibAttr(IntPtr pTLibAttr);
         void GetCustData(ref Guid guid, out object pVarVal);
+        void GetLibStatistics(IntPtr pcUniqueNames, out int pcchUniqueNames);
         [LCIDConversion(1)]
         void GetDocumentation2(int index, out string pbstrHelpString, out int pdwHelpStringContext, out string pbstrHelpStringDll);
-        void GetLibStatistics(IntPtr pcUniqueNames, out int pcchUniqueNames);
         void GetAllCustData(IntPtr pCustData);
     }
 }


### PR DESCRIPTION
Fixes #99946

Since build-in COM marshalling relies on the declaration order to build the RCW vtable, this is and has almost always resulted in an A/V or undefined behavior.