### PR TITLE
[release/8.0-staging] Support building against clang 18

### DIFF
--- a/eng/common/native/init-compiler.sh
+++ b/eng/common/native/init-compiler.sh
@@ -63,7 +63,7 @@ if [ -z "$CLR_CC" ]; then
     # Set default versions
     if [ -z "$majorVersion" ]; then
         # note: gcc (all versions) and clang versions higher than 6 do not have minor version in file name, if it is zero.
-        if [ "$compiler" = "clang" ]; then versions="17 16 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5"
+        if [ "$compiler" = "clang" ]; then versions="18 17 16 15 14 13 12 11 10 9 8 7 6.0 5.0 4.0 3.9 3.8 3.7 3.6 3.5"
         elif [ "$compiler" = "gcc" ]; then versions="13 12 11 10 9 8 7 6 5 4.9"; fi
 
         for version in $versions; do

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -590,6 +590,9 @@ if (CLR_CMAKE_HOST_UNIX)
     # other clang 16.0 suppressions
     add_compile_options(-Wno-single-bit-bitfield-constant-conversion)
     add_compile_options(-Wno-cast-function-type-strict)
+
+    # clang 18.1 supressions
+    add_compile_options(-Wno-switch-default)
   else()
     add_compile_options(-Wno-uninitialized)
     add_compile_options(-Wno-strict-aliasing)

--- a/src/coreclr/pal/src/include/pal/palinternal.h
+++ b/src/coreclr/pal/src/include/pal/palinternal.h
@@ -426,6 +426,7 @@ function_name() to call the system's implementation
 #undef va_start
 #undef va_end
 #undef va_copy
+#undef va_arg
 #undef stdin
 #undef stdout
 #undef stderr


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [ ] Found internally

Build breaks when building with clang 18 (affects source build)

This is a targeted backport from a few other PRs that makes it possible to build dotnet/runtme's 8.0 branch on Fedora 40 which includes clang 18.

- https://github.com/dotnet/arcade/pull/14572
- https://github.com/dotnet/runtime/pull/94782
- https://github.com/dotnet/runtime/pull/99811

## Regression

- [ ] Yes
- [x] No

## Testing

Verified by customer.

## Risk

Low. 