### PR TITLE
Process.OSX: fix thread safety

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.OSX.cs
@@ -117,8 +117,8 @@ namespace System.Diagnostics
             if (denom == default)
             {
                 Interop.libSystem.mach_timebase_info_data_t timeBase = GetTimeBase();
-                s_timeBase_denom = denom = timeBase.denom;
                 s_timeBase_numer = timeBase.numer;
+                s_timeBase_denom = denom = timeBase.denom;
             }
             uint numer = s_timeBase_numer;
 


### PR DESCRIPTION
Fixes an issue correctly outlined by @jkotas: https://github.com/dotnet/runtime/pull/100122#discussion_r1536727982

Without this fix, it was possible for another thread to see an incorrect (zero) value of `s_timeBase_numer` because of a race condition.