### PR TITLE
Fix Build Subset Help Not Displaying

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -138,7 +138,7 @@ if (-not $PSBoundParameters.ContainsKey("subset") -and $properties.Length -gt 0 
 }
 
 if ($subset -eq 'help') {
-  Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" -restore -build /p:subset=help /clp:nosummary"
+  Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" -restore -build /p:subset=help /clp:nosummary /tl:false"
   exit 0
 }
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -149,7 +149,7 @@ initDistroRid()
 
 showSubsetHelp()
 {
-  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary"
+  "$scriptroot/common/build.sh" "-restore" "-build" "/p:Subset=help" "/clp:nosummary /tl:false"
 }
 
 arguments=''


### PR DESCRIPTION
This PR fixes issue #100042. The problem is that a new terminal logger was added to MSBuild, and it has a problem in that it deletes output lines, and therefore ends up eating up all the subset help message. This is a known issue and is being discussed and tracked in detail over in issue #97211. Thanks @steveisok for the help in figuring this out.