### PR TITLE
JIT: Add peephole for reversing BBJ_COND condition and removing false jump

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -390,33 +390,15 @@ void CodeGen::genMarkLabelsForCodegen()
                 break;
 
             case BBJ_COND:
-                // Check if reversing the condition will allow us to fall into the false target
-                if (block->CanRemoveJumpToTarget(block->GetTrueTarget(), compiler))
+                JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
+                block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
+
+                // If we need a jump to the false target, give it a label
+                if (!block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler))
                 {
-                    compiler->gtReverseCond(block->lastNode());
-                    FlowEdge* const oldTrueEdge  = block->GetTrueEdge();
-                    FlowEdge* const oldFalseEdge = block->GetFalseEdge();
-                    block->SetTrueEdge(oldFalseEdge);
-                    block->SetFalseEdge(oldTrueEdge);
-
-                    // Only true target needs a label
-                    assert(block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler));
-                    JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
-                    block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
+                    JITDUMP("  " FMT_BB " : branch target\n", block->GetFalseTarget()->bbNum);
+                    block->GetFalseTarget()->SetFlags(BBF_HAS_LABEL);
                 }
-                else
-                {
-                    JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
-                    block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
-
-                    // If we need a jump to the false target, give it a label
-                    if (!block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler))
-                    {
-                        JITDUMP("  " FMT_BB " : branch target\n", block->GetFalseTarget()->bbNum);
-                        block->GetFalseTarget()->SetFlags(BBF_HAS_LABEL);
-                    }
-                }
-
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -390,15 +390,33 @@ void CodeGen::genMarkLabelsForCodegen()
                 break;
 
             case BBJ_COND:
-                JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
-                block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
-
-                // If we need a jump to the false target, give it a label
-                if (!block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler))
+                // Check if reversing the condition will allow us to fall into the false target
+                if (block->CanRemoveJumpToTarget(block->GetTrueTarget(), compiler))
                 {
-                    JITDUMP("  " FMT_BB " : branch target\n", block->GetFalseTarget()->bbNum);
-                    block->GetFalseTarget()->SetFlags(BBF_HAS_LABEL);
+                    compiler->gtReverseCond(block->lastNode());
+                    FlowEdge* const oldTrueEdge  = block->GetTrueEdge();
+                    FlowEdge* const oldFalseEdge = block->GetFalseEdge();
+                    block->SetTrueEdge(oldFalseEdge);
+                    block->SetFalseEdge(oldTrueEdge);
+
+                    // Only true target needs a label
+                    assert(block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler));
+                    JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
+                    block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
                 }
+                else
+                {
+                    JITDUMP("  " FMT_BB " : branch target\n", block->GetTrueTarget()->bbNum);
+                    block->GetTrueTarget()->SetFlags(BBF_HAS_LABEL);
+
+                    // If we need a jump to the false target, give it a label
+                    if (!block->CanRemoveJumpToTarget(block->GetFalseTarget(), compiler))
+                    {
+                        JITDUMP("  " FMT_BB " : branch target\n", block->GetFalseTarget()->bbNum);
+                        block->GetFalseTarget()->SetFlags(BBF_HAS_LABEL);
+                    }
+                }
+
                 break;
 
             case BBJ_SWITCH:

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5270,6 +5270,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Copied from rpPredictRegUse()
     SetFullPtrRegMapRequired(codeGen->GetInterruptible() || !codeGen->isFramePointerUsed());
 
+    if (opts.OptimizationEnabled())
+    {
+        // LSRA and stack level setting can modify the flowgraph.
+        // Now that it won't change, run post-layout optimizations.
+        DoPhase(this, PHASE_OPTIMIZE_POST_LAYOUT, &Compiler::optOptimizePostLayout);
+    }
+
 #if FEATURE_LOOP_ALIGN
     // Place loop alignment instructions
     DoPhase(this, PHASE_ALIGN_LOOPS, &Compiler::placeLoopAlignInstructions);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6858,6 +6858,7 @@ public:
     PhaseStatus optInvertLoops();    // Invert loops so they're entered at top and tested at bottom.
     PhaseStatus optOptimizeFlow();   // Simplify flow graph and do tail duplication
     PhaseStatus optOptimizeLayout(); // Optimize the BasicBlock layout of the method
+    PhaseStatus optOptimizePostLayout(); // Run optimizations after block layout is finalized
     PhaseStatus optSetBlockWeights();
     PhaseStatus optFindLoopsPhase(); // Finds loops and records them in the loop table
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -64,6 +64,7 @@ CompPhaseNameMacro(PHASE_INVERT_LOOPS,               "Invert loops",            
 CompPhaseNameMacro(PHASE_HEAD_TAIL_MERGE2,           "Post-morph head and tail merge", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_FLOW,              "Optimize control flow",          false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LAYOUT,            "Optimize layout",                false, -1, false)
+CompPhaseNameMacro(PHASE_OPTIMIZE_POST_LAYOUT,       "Optimize post-layout",           false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_DOMINATORS,         "Compute dominators",             false, -1, false)
 CompPhaseNameMacro(PHASE_CANONICALIZE_ENTRY,         "Canonicalize entry",             false, -1, false)
 CompPhaseNameMacro(PHASE_SET_BLOCK_WEIGHTS,          "Set block weights",              false, -1, false)


### PR DESCRIPTION
Various flowgraph transformations may lead to a `BBJ_COND` block's true target being the next block. In such cases, if we reverse the block's condition right before emitting instructions, we can remove the jump to the false target. I think this peephole optimization will become increasingly useful as we strip out preliminary condition reversals in earlier phases, as part of #93020.