### PR TITLE
[NativeAOT] Always zero-init if object contains pointers

### DIFF
--- a/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/GCHelpers.cpp
@@ -476,6 +476,12 @@ static Object* GcAllocInternal(MethodTable* pEEType, uint32_t uFlags, uintptr_t 
     ASSERT(!pThread->IsDoNotTriggerGcSet());
     ASSERT(pThread->IsCurrentThreadInCooperativeMode());
 
+    if (pEEType->ContainsPointers())
+    {
+        uFlags |= GC_ALLOC_CONTAINS_REF;
+        uFlags &= ~GC_ALLOC_ZEROING_OPTIONAL;
+    }
+
     size_t cbSize = pEEType->GetBaseSize();
 
     if (pEEType->HasComponentSize())

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1099,6 +1099,8 @@ namespace System.Tests
             byte* pointer = (byte*)Unsafe.AsPointer(ref array[0]); // Unsafe.AsPointer is safe since array is pinned
             var size = Unsafe.SizeOf<EmbeddedValueType<string>>();
 
+            GC.Collect();
+
             for(int i = 0; i < length; ++i)
             {
                 int idx = rng.Next(length);


### PR DESCRIPTION
`GC_ALLOC_ZEROING_OPTIONAL` flag should be unset when the object contains GC references. Otherwise, random values in object slots may break heap tracing.  

It looks like NativeAOT never had a check for this condition, but the combination was not reachable, thus was not causing problems.

https://github.com/dotnet/runtime/pull/89293 has made this scenario reachable, but the check was not introduced. It resulted in (relatively rare) crashes in run-to-failure test runs.
