### PR TITLE
JIT: Generalize `hasFixedRetBuffReg` for ARM64

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -1806,11 +1806,7 @@ regNumber CallArgs::GetCustomRegister(Compiler* comp, CorInfoCallConvExtension c
         case WellKnownArg::RetBuffer:
             if (hasFixedRetBuffReg(cc))
             {
-                // Windows does not use fixed ret buff arg for instance calls, but does otherwise.
-                if (!TargetOS::IsWindows || !callConvIsInstanceMethodCallConv(cc))
-                {
-                    return theFixedRetBuffReg(cc);
-                }
+                return theFixedRetBuffReg(cc);
             }
 
             break;

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -422,7 +422,8 @@ inline bool genIsValidDoubleReg(regNumber reg)
 inline bool hasFixedRetBuffReg(CorInfoCallConvExtension callConv)
 {
 #if defined(TARGET_ARM64)
-    return true;
+    // Windows does not use fixed ret buff arg for instance calls, but does otherwise.
+    return !TargetOS::IsWindows || !callConvIsInstanceMethodCallConv(cc);
 #elif defined(TARGET_AMD64) && defined(SWIFT_SUPPORT)
     return callConv == CorInfoCallConvExtension::Swift;
 #else

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -423,7 +423,7 @@ inline bool hasFixedRetBuffReg(CorInfoCallConvExtension callConv)
 {
 #if defined(TARGET_ARM64)
     // Windows does not use fixed ret buff arg for instance calls, but does otherwise.
-    return !TargetOS::IsWindows || !callConvIsInstanceMethodCallConv(cc);
+    return !TargetOS::IsWindows || !callConvIsInstanceMethodCallConv(callConv);
 #elif defined(TARGET_AMD64) && defined(SWIFT_SUPPORT)
     return callConv == CorInfoCallConvExtension::Swift;
 #else


### PR DESCRIPTION
Move a check from `CallArgs::GetCustomRegister` to `hasFixedRetBuffReg`.

Split out from #100276.