### PR TITLE
JIT: Fix mangleVarArgsType for SIMD types

### DIFF
--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -2817,8 +2817,8 @@ inline var_types Compiler::mangleVarArgsType(var_types type)
 
         if (varTypeIsSIMD(type))
         {
-            // Vectors also get passed in int registers. Use TYP_INT.
-            return TYP_INT;
+            // Vectors should be considered like passing a struct
+            return TYP_STRUCT;
         }
     }
 #endif // defined(TARGET_ARMARCH)


### PR DESCRIPTION
Returning `TYP_INT` from this function was causing `lvaInitUserArgs` to not set the "other reg" in `LclVarDsc` for SIMD types in varargs methods. This seemingly didn't usually cause issues, probably because we always DNER them and apparently `genFnPrologCalleeRegArgs` does not use `LclVarDsc::GetOtherArgReg()` in this case.

Split out from #100276