### PR TITLE
Remove obsolete CopySrcInsteadOfClone source-build property

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -21,10 +21,6 @@
     <_hostArch>$(_hostRid.Substring($(_hostRidPlatformIndex)).TrimStart('-'))</_hostArch>
 
     <LogVerbosity Condition="'$(LogVerbosity)' == ''">minimal</LogVerbosity>
-
-    <!-- When using the inner clone functionality in the repo build, copy the sources
-         directly as source-link doesn't support local path clones anymore. -->
-    <CopySrcInsteadOfClone>true</CopySrcInsteadOfClone>
   </PropertyGroup>
 
   <PropertyGroup Label="ShortStacks">


### PR DESCRIPTION
Copy is now the default/only behavior. This property was removed with https://github.com/dotnet/source-build/issues/4117