### PR TITLE
Remove preventing EH and entering EE at shutdown

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1345,31 +1345,8 @@ part2:
                 TerminateDebugger();
 #endif // DEBUGGING_SUPPORTED
 
-                StubManager::TerminateStubManagers();
-
-#ifdef FEATURE_INTERPRETER
-                Interpreter::Terminate();
-#endif // FEATURE_INTERPRETER
-
                 //@TODO: find the right place for this
                 VirtualCallStubManager::UninitStatic();
-
-                // Unregister our vectored exception and continue handlers from the OS.
-                // This will ensure that if any other DLL unload (after ours) has an exception,
-                // we wont attempt to process that exception (which could lead to various
-                // issues including AV in the runtime).
-                //
-                // This should be done:
-                //
-                // 1) As the last action during the shutdown so that any unexpected AVs
-                //    in the runtime during shutdown do result in FailFast in VEH.
-                //
-                // 2) Only when the runtime is processing DLL_PROCESS_DETACH.
-                CLRRemoveVectoredHandlers();
-
-#if USE_DISASSEMBLER
-                Disassembler::StaticClose();
-#endif // USE_DISASSEMBLER
 
                 WriteJitHelperCountToSTRESSLOG();
 
@@ -1693,10 +1670,6 @@ BOOL STDMETHODCALLTYPE EEDllMain( // TRUE on success, FALSE on error.
 
                     LOG((LF_STARTUP, INFO3, "EEShutDown invoked from EEDllMain"));
                     EEShutDown(TRUE); // shut down EE if it was started up
-                }
-                else
-                {
-                    CLRRemoveVectoredHandlers();
                 }
                 break;
             }

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1332,9 +1332,6 @@ part2:
                 // Shutdown finalizer before we suspend all background threads. Otherwise we
                 // never get to finalize anything.
 
-                // No longer process exceptions
-                g_fNoExceptions = true;
-
                 // <TODO>@TODO: This does things which shouldn't occur in part 2.  Namely,
                 // calling managed dll main callbacks (AppDomain::SignalProcessDetach), and
                 // RemoveAppDomainFromIPC.

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1329,9 +1329,6 @@ part2:
             {
                 g_fEEShutDown |= ShutDown_Phase2;
 
-                // Shutdown finalizer before we suspend all background threads. Otherwise we
-                // never get to finalize anything.
-
                 // <TODO>@TODO: This does things which shouldn't occur in part 2.  Namely,
                 // calling managed dll main callbacks (AppDomain::SignalProcessDetach), and
                 // RemoveAppDomainFromIPC.

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -103,7 +103,6 @@ extern DWORD g_fEEShutDown;
 #endif
 // Total count of Crst lock  of the type (Shutdown) that are currently in use
 extern Volatile<LONG> g_ShutdownCrstUsageCount;
-extern Volatile<LONG> g_fForbidEnterEE;
 
 // The CRST.
 class CrstBase

--- a/src/coreclr/vm/eehash.inl
+++ b/src/coreclr/vm/eehash.inl
@@ -346,7 +346,7 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::DeleteValue(KeyType p
     _ASSERTE (OwnLock());
 
     Thread *pThread = GetThreadNULLOk();
-    GCX_MAYBE_COOP_NO_THREAD_BROKEN(pThread ? !(pThread->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) : FALSE);
+    GCX_MAYBE_COOP_NO_THREAD_BROKEN(pThread != NULL);
 
     _ASSERTE(m_pVolatileBucketTable->m_dwNumBuckets != 0);
 
@@ -850,7 +850,7 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::
     _ASSERTE_IMPL(OwnLock());
 
     Thread *pThread = GetThreadNULLOk();
-    GCX_MAYBE_COOP_NO_THREAD_BROKEN(pThread ? !(pThread->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) : FALSE);
+    GCX_MAYBE_COOP_NO_THREAD_BROKEN(pThread != NULL);
 
     _ASSERTE(pIter->m_pTable == (void *) this);
 

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -41,8 +41,6 @@ void SafeExitProcess(UINT exitCode, ShutdownCompleteAction sca = SCA_ExitProcess
     // other DLLs call Release() on us in their detach [dangerous!], etc.
     GCX_PREEMP_NO_DTOR();
 
-    InterlockedExchange((LONG*)&g_fForbidEnterEE, TRUE);
-
     // Note that for free and retail builds StressLog must also be enabled
     if (g_pConfig && g_pConfig->StressLog())
     {
@@ -58,13 +56,6 @@ void SafeExitProcess(UINT exitCode, ShutdownCompleteAction sca = SCA_ExitProcess
             }
         }
     }
-
-    // Turn off exception processing, because if some other random DLL has a
-    //  fault in DLL_PROCESS_DETACH, we could get called for exception handling.
-    //  Since we've turned off part of the runtime, we can't, for instance,
-    //  properly execute the GC that handling an exception might trigger.
-    g_fNoExceptions = true;
-    LOG((LF_EH, LL_INFO10, "SafeExitProcess: turning off exceptions\n"));
 
     if (sca == SCA_TerminateProcessWhenShutdownComplete)
     {

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -7653,35 +7653,6 @@ void CLRAddVectoredHandlers(void)
 #endif // !TARGET_UNIX
 }
 
-// This function removes the vectored exception and continue handler registration
-// from the OS.
-void CLRRemoveVectoredHandlers(void)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-#ifndef TARGET_UNIX
-
-    // Unregister the vectored exception handler if one is registered (and we can).
-    if (g_hVectoredExceptionHandler != NULL)
-    {
-        // Unregister the vectored exception handler
-        if (RemoveVectoredExceptionHandler(g_hVectoredExceptionHandler) == FALSE)
-        {
-            LOG((LF_EH, LL_INFO100, "CLRRemoveVectoredHandlers: RemoveVectoredExceptionHandler() failed.\n"));
-        }
-        else
-        {
-            LOG((LF_EH, LL_INFO100, "CLRRemoveVectoredHandlers: RemoveVectoredExceptionHandler() succeeded.\n"));
-        }
-    }
-#endif // !TARGET_UNIX
-}
-
 //
 // This does the work of the Unwind and Continue Hanlder inside the catch clause of that handler. The stack has not
 // been unwound when this is called. Keep that in mind when deciding where to put new code :)

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4585,13 +4585,6 @@ LONG InternalUnhandledExceptionFilter_Worker(
     STRESS_LOG2(LF_EH, LL_INFO10, "In InternalUnhandledExceptionFilter_Worker, Exception = %x, sp = %p\n",
                                     pExceptionInfo->ExceptionRecord->ExceptionCode, GetCurrentSP());
 
-    // If we can't enter the EE, done.
-    if (g_fForbidEnterEE)
-    {
-        LOG((LF_EH, LL_INFO100, "InternalUnhandledExceptionFilter_Worker: g_fForbidEnterEE is TRUE\n"));
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
-
     // We don't do anything when this is called from an unmanaged thread.
     Thread *pThread = GetThreadNULLOk();
 
@@ -4622,18 +4615,6 @@ LONG InternalUnhandledExceptionFilter_Worker(
         }
     }
 #endif
-
-    // This shouldn't be possible, but MSVC re-installs us... for now, just bail if this happens.
-    if (g_fNoExceptions)
-    {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
-
-    // Are we looking at a stack overflow here?
-    if ((pThread !=  NULL) && !pThread->DetermineIfGuardPagePresent())
-    {
-        g_fForbidEnterEE = true;
-    }
 
 #ifdef DEBUGGING_SUPPORTED
 
@@ -5532,8 +5513,6 @@ static LONG ThreadBaseExceptionFilter_Worker(PEXCEPTION_POINTERS pExceptionInfo,
 
     ThreadBaseExceptionFilterParam *pParam = (ThreadBaseExceptionFilterParam *) pvParam;
     UnhandledExceptionLocation location = pParam->location;
-
-    _ASSERTE(!g_fNoExceptions);
 
     Thread* pThread = GetThread();
 
@@ -6737,14 +6716,6 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase3(PEXCEPTION_POINTERS pExcepti
 
 VEH_ACTION WINAPI CLRVectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
-    // It is not safe to execute code inside VM after we shutdown EE.  One example is DisablePreemptiveGC
-    // will block forever.
-    if (g_fForbidEnterEE)
-    {
-        return VEH_CONTINUE_SEARCH;
-    }
-
-
     //
     // DO NOT USE CONTRACTS HERE AS THIS ROUTINE MAY NEVER RETURN.  You can use
     // static contracts, but currently this is all WRAPPER_NO_CONTRACT.
@@ -7433,12 +7404,6 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
     //
     // WARNING WARNING WARNING WARNING WARNING WARNING WARNING
     //
-
-    // If exceptions (or runtime) have been disabled, then simply return.
-    if (g_fForbidEnterEE || g_fNoExceptions)
-    {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
 
 #ifdef FEATURE_EH_FUNCLETS
     pExceptionInfo->ContextRecord->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -107,7 +107,6 @@ struct EE_ILEXCEPTION_CLAUSE;
 
 void InitializeExceptionHandling();
 void CLRAddVectoredHandlers(void);
-void CLRRemoveVectoredHandlers(void);
 void TerminateExceptionHandling();
 
 // Prototypes

--- a/src/coreclr/vm/i386/excepx86.cpp
+++ b/src/coreclr/vm/i386/excepx86.cpp
@@ -1571,9 +1571,6 @@ EXCEPTION_HANDLER_IMPL(COMPlusFrameHandler)
 
     _ASSERTE((pContext == NULL) || ((pContext->ContextFlags & CONTEXT_CONTROL) == CONTEXT_CONTROL));
 
-    if (g_fNoExceptions)
-        return ExceptionContinueSearch; // No EH during EE shutdown.
-
     // Check if the exception represents a GCStress Marker. If it does,
     // we shouldnt record its entry in the TLS as such exceptions are
     // continuable and can confuse the VM to treat them as CSE,

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -1227,16 +1227,6 @@ HRESULT RCWCleanupList::ReleaseRCWListInCorrectCtx(LPVOID pData)
 
     LPVOID pCurrCtxCookie = GetCurrentCtxCookie();
 
-    // If we are releasing our IP's as a result of shutdown, we MUST not transition
-    // into cooperative GC mode. This "fix" will prevent us from doing so.
-    if (g_fEEShutDown & ShutDown_Finalize2)
-    {
-        Thread *pThread = GetThreadNULLOk();
-        if (pThread && !FinalizerThread::IsCurrentThreadFinalizer())
-            pThread->SetThreadStateNC(Thread::TSNC_UnsafeSkipEnterCooperative);
-    }
-
-
     // Make sure we're in the right context / apartment.
     // Also - if we've already transitioned once, we don't want to do so again.
     //  If the cookie exists in multiple MTA apartments, and the STA has gone away
@@ -1266,14 +1256,6 @@ HRESULT RCWCleanupList::ReleaseRCWListInCorrectCtx(LPVOID pData)
             // The only option we have left is to try and clean up the RCW's from the current context.
             ReleaseRCWListRaw(pHead);
         }
-    }
-
-    // Reset the bit indicating we cannot transition into cooperative GC mode.
-    if (g_fEEShutDown & ShutDown_Finalize2)
-    {
-        Thread *pThread = GetThreadNULLOk();
-        if (pThread && !FinalizerThread::IsCurrentThreadFinalizer())
-            pThread->ResetThreadStateNC(Thread::TSNC_UnsafeSkipEnterCooperative);
     }
 
     return S_OK;
@@ -1559,7 +1541,6 @@ void RCW::RemoveMemoryPressure()
         NOTHROW;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
-        PRECONDITION((GetThread()->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) == 0);
     }
     CONTRACTL_END;
 
@@ -1771,7 +1752,6 @@ void RCW::Cleanup()
     // if the wrapper is still in the cache.  Also, if we can't switch to coop mode,
     // we're guaranteed to have already decoupled the RCW from its object.
 #ifdef _DEBUG
-    if (!(GetThread()->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative))
     {
         GCX_COOP();
 
@@ -1789,9 +1769,7 @@ void RCW::Cleanup()
         ReleaseAllInterfacesCallBack(this);
 
         // Remove the memory pressure caused by this RCW (if present)
-        // If we're in a shutdown situation, we can ignore the memory pressure.
-        if ((GetThread()->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) == 0)
-            RemoveMemoryPressure();
+        RemoveMemoryPressure();
     }
 
 #ifdef _DEBUG

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -1790,7 +1790,7 @@ void RCW::Cleanup()
 
         // Remove the memory pressure caused by this RCW (if present)
         // If we're in a shutdown situation, we can ignore the memory pressure.
-        if ((GetThread()->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) == 0 && !g_fForbidEnterEE)
+        if ((GetThread()->m_StateNC & Thread::TSNC_UnsafeSkipEnterCooperative) == 0)
             RemoveMemoryPressure();
     }
 

--- a/src/coreclr/vm/stdinterfaces_wrapper.cpp
+++ b/src/coreclr/vm/stdinterfaces_wrapper.cpp
@@ -52,7 +52,7 @@ namespace
         LIMITED_METHOD_CONTRACT;
         // If we are finalizing all alive objects, or after this stage, we do not allow
         // a thread to enter EE.
-        return !((g_fEEShutDown & ShutDown_Finalize2) || g_fForbidEnterEE);
+        return !(g_fEEShutDown & ShutDown_Finalize2);
     }
 }
 

--- a/src/coreclr/vm/stdinterfaces_wrapper.cpp
+++ b/src/coreclr/vm/stdinterfaces_wrapper.cpp
@@ -45,17 +45,6 @@ struct IEnumConnectionPoints;
 // Common vtables for well-known COM interfaces
 // shared by all COM+ callable wrappers.
 
-namespace
-{
-    bool CanCallRuntimeInterfaceImplementations()
-    {
-        LIMITED_METHOD_CONTRACT;
-        // If we are finalizing all alive objects, or after this stage, we do not allow
-        // a thread to enter EE.
-        return !(g_fEEShutDown & ShutDown_Finalize2);
-    }
-}
-
 //-------------------------------------------------------------------------
 // IUnknown methods
 
@@ -73,9 +62,6 @@ HRESULT STDMETHODCALLTYPE Unknown_QueryInterface(IUnknown* pUnk, REFIID riid, vo
         PRECONDITION(CheckPointer(ppv, NULL_OK));
     }
     CONTRACTL_END;
-
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
 
     ComCallWrapper* pWrap = MapIUnknownToWrapper(pUnk);
     return Unknown_QueryInterface_Internal(pWrap, pUnk, riid, ppv);
@@ -268,9 +254,6 @@ HRESULT STDMETHODCALLTYPE Dispatch_GetTypeInfoCount_Wrapper(IDispatch* pDisp, un
     }
     CONTRACTL_END;
     
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
-
     return Dispatch_GetTypeInfoCount(pDisp, pctinfo);
 }
 
@@ -287,10 +270,6 @@ HRESULT STDMETHODCALLTYPE Dispatch_GetTypeInfo_Wrapper(IDispatch* pDisp, unsigne
         PRECONDITION(CheckPointer(pptinfo, NULL_OK));
     }
     CONTRACTL_END;
-    
-    
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
 
     return Dispatch_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
 }
@@ -310,9 +289,6 @@ HRESULT STDMETHODCALLTYPE Dispatch_GetIDsOfNames_Wrapper(IDispatch* pDisp, REFII
         PRECONDITION(CheckPointer(rgdispid, NULL_OK));
     }
     CONTRACTL_END;
-    
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
 
     return Dispatch_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
@@ -333,9 +309,6 @@ HRESULT STDMETHODCALLTYPE InternalDispatchImpl_GetIDsOfNames_Wrapper(IDispatch* 
     }
     CONTRACTL_END;
     
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
-
     return InternalDispatchImpl_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
 }
 
@@ -359,10 +332,6 @@ HRESULT STDMETHODCALLTYPE Dispatch_Invoke_Wrapper(IDispatch* pDisp, DISPID dispi
     }
     CONTRACTL_END;
     
-    
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
-
     return Dispatch_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
 }
 
@@ -385,10 +354,6 @@ HRESULT STDMETHODCALLTYPE InternalDispatchImpl_Invoke_Wrapper(IDispatch* pDisp, 
     }
     CONTRACTL_END;
     
-    
-    if (!CanCallRuntimeInterfaceImplementations())
-        return E_FAIL;
-
     return InternalDispatchImpl_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
 }
 
@@ -411,9 +376,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ClassInfo_GetClassInfo(pUnk, ppTI);
     }
 
@@ -435,9 +397,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return SupportsErroInfo_IntfSupportsErrorInfo(pUnk, riid);
     }
 
@@ -457,9 +416,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ErrorInfo_GetDescription(pUnk, pbstrDescription);
     }
 
@@ -477,9 +433,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ErrorInfo_GetGUID(pUnk, pguid);
     }
 
@@ -497,10 +450,6 @@ namespace
         }
         CONTRACTL_END;
     
-    
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ErrorInfo_GetHelpContext(pUnk, pdwHelpCtxt);
     }
 
@@ -518,9 +467,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ErrorInfo_GetHelpFile(pUnk, pbstrHelpFile);
     }
 
@@ -538,9 +484,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ErrorInfo_GetSource(pUnk, pbstrSource);
     }
 
@@ -561,9 +504,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetTypeInfoCount(pDisp, pctinfo);
     }
 
@@ -581,9 +521,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetTypeInfo(pDisp, itinfo, lcid, pptinfo);
     }
 
@@ -603,9 +540,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetIDsOfNames(pDisp, riid, rgszNames, cNames, lcid, rgdispid);
     }
 
@@ -628,9 +562,6 @@ namespace
         }
         CONTRACTL_END;
 
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_Invoke(pDisp, dispidMember, riid, lcid, wFlags, pdispparams, pvarResult, pexcepinfo, puArgErr);
     }
 
@@ -647,9 +578,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_DeleteMemberByDispID(pDisp, id);
     }
 
@@ -665,9 +593,6 @@ namespace
             PRECONDITION(CheckPointer(pDisp));
         }
         CONTRACTL_END;
-
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
 
         return DispatchEx_DeleteMemberByName(pDisp, bstrName, grfdex);
     }
@@ -686,9 +611,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetMemberName(pDisp, id, pbstrName);
     }
 
@@ -707,9 +629,6 @@ namespace
         }
         CONTRACTL_END;
 
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetDispID(pDisp, bstrName, grfdex, pid);
     }
 
@@ -727,9 +646,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetMemberProperties(pDisp, id, grfdexFetch, pgrfdex);
     }
 
@@ -747,9 +663,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetNameSpaceParent(pDisp, ppunk);
     }
 
@@ -767,9 +680,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_GetNextDispID(pDisp, grfdex, id, pid);
     }
 
@@ -791,9 +701,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return DispatchEx_InvokeEx(pDisp, id, lcid, wFlags, pdp, pVarRes, pei, pspCaller);
     }
 
@@ -817,9 +724,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_GetUnmarshalClass(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pclsid);
     }
 
@@ -840,9 +744,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_GetMarshalSizeMax(pMarsh, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize);
     }
 
@@ -862,9 +763,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_MarshalInterface(pMarsh, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags);
     }
 
@@ -883,9 +781,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_UnmarshalInterface(pMarsh, pStm, riid, ppvObj);
     }
 
@@ -903,9 +798,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_ReleaseMarshalData(pMarsh, pStm);
     }
 
@@ -922,9 +814,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return Marshal_DisconnectObject(pMarsh, dwReserved);
     }
 
@@ -945,9 +834,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ConnectionPointContainer_EnumConnectionPoints(pUnk, ppEnum);
     }
 
@@ -965,9 +851,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ConnectionPointContainer_FindConnectionPoint(pUnk, riid, ppCP);
     }
 
@@ -991,9 +874,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ObjectSafety_GetInterfaceSafetyOptions(pUnk, riid, pdwSupportedOptions, pdwEnabledOptions);
     }
 
@@ -1011,9 +891,6 @@ namespace
         }
         CONTRACTL_END;
     
-        if (!CanCallRuntimeInterfaceImplementations())
-            return E_FAIL;
-
         return ObjectSafety_SetInterfaceSafetyOptions(pUnk, riid, dwOptionSetMask, dwEnabledOptions);
     }
 }

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -718,22 +718,6 @@ void StubManager::InitializeStubManagers()
 #endif // !DACCESS_COMPILE
 }
 
-//-----------------------------------------------------------
-// Terminate the global stub manager service.
-//-----------------------------------------------------------
-void StubManager::TerminateStubManagers()
-{
-#if !defined(DACCESS_COMPILE)
-
-#if defined(_DEBUG)
-    DbgFinishLog();
-    s_DbgLogCrst.Destroy();
-#endif
-
-    s_StubManagerListCrst.Destroy();
-#endif // !DACCESS_COMPILE
-}
-
 #ifdef _DEBUG
 
 //-----------------------------------------------------------

--- a/src/coreclr/vm/stubmgr.h
+++ b/src/coreclr/vm/stubmgr.h
@@ -210,7 +210,6 @@ class StubManager
   public:
     // Startup and shutdown the global stubmanager service.
     static void InitializeStubManagers();
-    static void TerminateStubManagers();
 
     // Does any sub manager recognise this EIP?
     static BOOL IsStub(PCODE stubAddress)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -7767,7 +7767,7 @@ OBJECTREF Thread::GetCulture(BOOL bUICulture)
 
     // This is the case when we're building CoreLib and haven't yet created
     // the system assembly.
-    if (SystemDomain::System()->SystemAssembly()==NULL || g_fForbidEnterEE) {
+    if (SystemDomain::System()->SystemAssembly()==NULL) {
         return NULL;
     }
 

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -700,7 +700,7 @@ public:
         // unused                       = 0x00000040,
         TSNC_CLRCreatedThread           = 0x00000080, // The thread was created through Thread::CreateNewThread
         TSNC_ExistInThreadStore         = 0x00000100, // For dtor to know if it needs to be removed from ThreadStore
-        TSNC_UnsafeSkipEnterCooperative = 0x00000200, // This is a "fix" for deadlocks caused when cleaning up COM
+        // unused                       = 0x00000200,
         TSNC_OwnsSpinLock               = 0x00000400, // The thread owns a spinlock.
         TSNC_PreparingAbort             = 0x00000800, // Preparing abort.  This avoids recursive HandleThreadAbort call.
         TSNC_OSAlertableWait            = 0x00001000, // Preparing abort.  This avoids recursive HandleThreadAbort call.

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2099,9 +2099,6 @@ void Thread::RareDisablePreemptiveGC()
         goto Exit;
     }
 
-    // This should NEVER be called if the TSNC_UnsafeSkipEnterCooperative bit is set!
-    _ASSERTE(!(m_StateNC & TSNC_UnsafeSkipEnterCooperative) && "DisablePreemptiveGC called while the TSNC_UnsafeSkipEnterCooperative bit is set");
-
     // Holding a spin lock in preemp mode and switch to coop mode could cause other threads spinning
     // waiting for GC
     _ASSERTE ((m_StateNC & Thread::TSNC_OwnsSpinLock) == 0);

--- a/src/coreclr/vm/vars.cpp
+++ b/src/coreclr/vm/vars.cpp
@@ -194,9 +194,7 @@ GVAL_IMPL(SIZE_T, g_runtimeVirtualSize);
 
 #ifndef DACCESS_COMPILE
 
-Volatile<LONG> g_fForbidEnterEE = false;
 bool g_fManagedAttach = false;
-bool g_fNoExceptions = false;
 
 DWORD g_FinalizerWaiterStatus = 0;
 

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -480,13 +480,11 @@ EXTERN BOOL g_fComStarted;
 GVAL_DECL(DWORD, g_fEEShutDown);
 EXTERN DWORD g_fFastExitProcess;
 EXTERN BOOL g_fFatalErrorOccurredOnGCThread;
-EXTERN Volatile<LONG> g_fForbidEnterEE;
 GVAL_DECL(bool, g_fProcessDetach);
 #ifdef FEATURE_METADATA_UPDATER
 GVAL_DECL(bool, g_metadataUpdatesApplied);
 #endif
 EXTERN bool g_fManagedAttach;
-EXTERN bool g_fNoExceptions;
 
 // Indicates whether we're executing shut down as a result of DllMain
 // (DLL_PROCESS_DETACH). See comments at code:EEShutDown for details.


### PR DESCRIPTION
Historically, the runtime was trying to block handling exceptions, entering EE and other stuff during shutdown of the runtime. We have already removed most of that in the past, since it has been a deadlock farm. While debugging a customer issue, I have found that we are still preventing some things to happen during shutdown. We stop handling exceptions at all and we also prevent entering EE at few places. This change removes these, as the plan we've been on is to keep the runtime running until the OS itself stops the process. In the customer's case, the problem was that during a machine shutdown, .NET runtime was generating watson dump due to an unhandled exception stemming from a network socket related code that would otherwise be handled.