### PR TITLE
Disable msvc vectorization in GC get_promoted_bytes

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -24211,6 +24211,9 @@ size_t gc_heap::get_promoted_bytes()
 
     dprintf (3, ("h%d getting surv", heap_number));
     size_t promoted = 0;
+#ifdef _MSC_VER
+#pragma loop(no_vector)
+#endif
     for (size_t i = 0; i < region_count; i++)
     {
         if (survived_per_region[i] > 0)

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -17,9 +17,6 @@
         <ExcludeList Include = "$(XunitTestBinBase)/JIT/opt/SSA/MemorySsa/**">
             <Issue>https://github.com/dotnet/runtime/issues/86112</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/GC/API/NoGCRegion/Callback_Svr/**">
-            <Issue>https://github.com/dotnet/runtime/issues/100149</Issue>
-        </ExcludeList>    
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->


### PR DESCRIPTION
This fixes the code generation rather than trying to address the symptoms of tests failing.  Therefore, test Callback_Svr can be enabled again.

See https://developercommunity.visualstudio.com/t/Bad-codegen-in-coreclr-GC-code/10625094.  Issue may have been fixed already as later toolsets don't seem to show the issue, but this hasn't been verified.