### PR TITLE
Add arch_info for TARGET_RISCV64

### DIFF
--- a/src/native/eventpipe/ep-event-source.c
+++ b/src/native/eventpipe/ep-event-source.c
@@ -48,6 +48,8 @@ const ep_char8_t* _ep_arch_info = "s390x";
 const ep_char8_t* _ep_arch_info = "loongarch64";
 #elif defined(TARGET_POWERPC64)
 const ep_char8_t* _ep_arch_info = "ppc64le";
+#elif defined(TARGET_RISCV64)
+const ep_char8_t* _ep_arch_info = "riscv64";
 #else
 const ep_char8_t* _ep_arch_info = "Unknown";
 #endif


### PR DESCRIPTION
For `TARGET_RISCV64` value of `_ep_arch_info` set to `"riscv64"`.

Part of #84834, cc @dotnet/samsung