### PR TITLE
Fix `Int128` checked-convert to signed IntX

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -265,6 +265,10 @@ namespace System
             if (~value._upper == 0)
             {
                 long lower = (long)value._lower;
+                if (lower >= 0)
+                {
+                    ThrowHelper.ThrowOverflowException();
+                }
                 return checked((short)lower);
             }
 
@@ -289,6 +293,10 @@ namespace System
             if (~value._upper == 0)
             {
                 long lower = (long)value._lower;
+                if (lower >= 0)
+                {
+                    ThrowHelper.ThrowOverflowException();
+                }
                 return checked((int)lower);
             }
 
@@ -313,6 +321,10 @@ namespace System
             if (~value._upper == 0)
             {
                 long lower = (long)value._lower;
+                if (lower >= 0)
+                {
+                    ThrowHelper.ThrowOverflowException();
+                }
                 return lower;
             }
 
@@ -337,6 +349,10 @@ namespace System
             if (~value._upper == 0)
             {
                 long lower = (long)value._lower;
+                if (lower >= 0)
+                {
+                    ThrowHelper.ThrowOverflowException();
+                }
                 return checked((nint)lower);
             }
 
@@ -363,6 +379,10 @@ namespace System
             if (~value._upper == 0)
             {
                 long lower = (long)value._lower;
+                if (lower >= 0)
+                {
+                    ThrowHelper.ThrowOverflowException();
+                }
                 return checked((sbyte)lower);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -262,21 +262,12 @@ namespace System
         /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <see cref="Int128" />.</exception>
         public static explicit operator checked short(Int128 value)
         {
-            if (~value._upper == 0)
-            {
-                long lower = (long)value._lower;
-                if (lower >= 0)
-                {
-                    ThrowHelper.ThrowOverflowException();
-                }
-                return checked((short)lower);
-            }
-
-            if (value._upper != 0)
+            long lower = (long)value._lower;
+            if ((long)value._upper != lower >> 63)
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return checked((short)value._lower);
+            return checked((short)lower);
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="int" /> value.</summary>
@@ -290,21 +281,12 @@ namespace System
         /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <see cref="Int128" />.</exception>
         public static explicit operator checked int(Int128 value)
         {
-            if (~value._upper == 0)
-            {
-                long lower = (long)value._lower;
-                if (lower >= 0)
-                {
-                    ThrowHelper.ThrowOverflowException();
-                }
-                return checked((int)lower);
-            }
-
-            if (value._upper != 0)
+            long lower = (long)value._lower;
+            if ((long)value._upper != lower >> 63)
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return checked((int)value._lower);
+            return checked((int)lower);
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="long" /> value.</summary>
@@ -318,21 +300,12 @@ namespace System
         /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <see cref="Int128" />.</exception>
         public static explicit operator checked long(Int128 value)
         {
-            if (~value._upper == 0)
-            {
-                long lower = (long)value._lower;
-                if (lower >= 0)
-                {
-                    ThrowHelper.ThrowOverflowException();
-                }
-                return lower;
-            }
-
-            if (value._upper != 0)
+            long lower = (long)value._lower;
+            if ((long)value._upper != lower >> 63)
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return checked((long)value._lower);
+            return lower;
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="IntPtr" /> value.</summary>
@@ -346,21 +319,12 @@ namespace System
         /// <exception cref="OverflowException"><paramref name="value" /> is not representable by <see cref="Int128" />.</exception>
         public static explicit operator checked nint(Int128 value)
         {
-            if (~value._upper == 0)
-            {
-                long lower = (long)value._lower;
-                if (lower >= 0)
-                {
-                    ThrowHelper.ThrowOverflowException();
-                }
-                return checked((nint)lower);
-            }
-
-            if (value._upper != 0)
+            long lower = (long)value._lower;
+            if ((long)value._upper != lower >> 63)
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return checked((nint)value._lower);
+            return checked((nint)lower);
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="sbyte" /> value.</summary>
@@ -376,21 +340,12 @@ namespace System
         [CLSCompliant(false)]
         public static explicit operator checked sbyte(Int128 value)
         {
-            if (~value._upper == 0)
-            {
-                long lower = (long)value._lower;
-                if (lower >= 0)
-                {
-                    ThrowHelper.ThrowOverflowException();
-                }
-                return checked((sbyte)lower);
-            }
-
-            if (value._upper != 0)
+            long lower = (long)value._lower;
+            if ((long)value._upper != lower >> 63)
             {
                 ThrowHelper.ThrowOverflowException();
             }
-            return checked((sbyte)value._lower);
+            return checked((sbyte)lower);
         }
 
         /// <summary>Explicitly converts a 128-bit signed integer to a <see cref="float" /> value.</summary>

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
@@ -107,6 +107,36 @@ namespace System.Tests
             Assert.Equal(expected, i1.Equals(obj));
         }
 
+        [Fact]
+        public static void CheckedConvertToInt64Overflow()
+        {
+            Assert.Throws<OverflowException>(() => checked((long)new Int128(ulong.MaxValue, 42)));
+        }
+
+        [Fact]
+        public static void CheckedConvertToInt32Overflow()
+        {
+            Assert.Throws<OverflowException>(() => checked((int)new Int128(ulong.MaxValue, 42)));
+        }
+
+        [Fact]
+        public static void CheckedConvertToInt16Overflow()
+        {
+            Assert.Throws<OverflowException>(() => checked((short)new Int128(ulong.MaxValue, 42)));
+        }
+
+        [Fact]
+        public static void CheckedConvertToSByteOverflow()
+        {
+            Assert.Throws<OverflowException>(() => checked((sbyte)new Int128(ulong.MaxValue, 42)));
+        }
+
+        [Fact]
+        public static void CheckedConvertToIntPtrOverflow()
+        {
+            Assert.Throws<OverflowException>(() => checked((nint)new Int128(ulong.MaxValue, 42)));
+        }
+
         public static IEnumerable<object[]> ToString_TestData()
         {
             foreach (NumberFormatInfo defaultFormat in new[] { null, NumberFormatInfo.CurrentInfo })

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
@@ -108,32 +108,47 @@ namespace System.Tests
         }
 
         [Fact]
-        public static void CheckedConvertToInt64Overflow()
+        public static void CheckedConvertToInt64()
         {
+            Assert.Equal(123L, checked((long)new Int128(0, 123)));
+            Assert.Equal(-123L, checked((long)(Int128)(-123)));
+            Assert.Throws<OverflowException>(() => checked((long)new Int128(1, 1)));
             Assert.Throws<OverflowException>(() => checked((long)new Int128(ulong.MaxValue, 42)));
         }
 
         [Fact]
-        public static void CheckedConvertToInt32Overflow()
+        public static void CheckedConvertToInt32()
         {
+            Assert.Equal(123, checked((int)new Int128(0, 123)));
+            Assert.Equal(-123, checked((int)(Int128)(-123)));
+            Assert.Throws<OverflowException>(() => checked((int)new Int128(1, 1)));
             Assert.Throws<OverflowException>(() => checked((int)new Int128(ulong.MaxValue, 42)));
         }
 
         [Fact]
-        public static void CheckedConvertToInt16Overflow()
+        public static void CheckedConvertToInt16()
         {
+            Assert.Equal((short)123, checked((short)new Int128(0, 123)));
+            Assert.Equal((short)(-123), checked((short)(Int128)(-123)));
+            Assert.Throws<OverflowException>(() => checked((short)new Int128(1, 1)));
             Assert.Throws<OverflowException>(() => checked((short)new Int128(ulong.MaxValue, 42)));
         }
 
         [Fact]
-        public static void CheckedConvertToSByteOverflow()
+        public static void CheckedConvertToSByte()
         {
+            Assert.Equal((sbyte)123, checked((sbyte)new Int128(0, 123)));
+            Assert.Equal((sbyte)(-123), checked((sbyte)(Int128)(-123)));
+            Assert.Throws<OverflowException>(() => checked((sbyte)new Int128(1, 1)));
             Assert.Throws<OverflowException>(() => checked((sbyte)new Int128(ulong.MaxValue, 42)));
         }
 
         [Fact]
-        public static void CheckedConvertToIntPtrOverflow()
+        public static void CheckedConvertToIntPtr()
         {
+            Assert.Equal((nint)123, checked((nint)new Int128(0, 123)));
+            Assert.Equal((nint)(-123), checked((nint)(Int128)(-123)));
+            Assert.Throws<OverflowException>(() => checked((nint)new Int128(1, 1)));
             Assert.Throws<OverflowException>(() => checked((nint)new Int128(ulong.MaxValue, 42)));
         }
 


### PR DESCRIPTION
Fix #99489 

Hope to add more tests for `Int128` in the future.