### PR TITLE
Remove support for non-indirect code headers

### DIFF
--- a/src/coreclr/debug/daccess/fntableaccess.h
+++ b/src/coreclr/debug/daccess/fntableaccess.h
@@ -16,12 +16,7 @@
 #ifndef TARGET_UNIX
 #define DEBUGSUPPORT_STUBS_HAVE_UNWIND_INFO
 #endif // !TARGET_UNIX
-
-#ifndef USE_INDIRECT_CODEHEADER
-#define USE_INDIRECT_CODEHEADER
-#endif  // USE_INDIRECT_CODEHEADER
 #endif
-
 
 struct FakeEEJitManager
 {

--- a/src/coreclr/inc/nibblemapmacros.h
+++ b/src/coreclr/inc/nibblemapmacros.h
@@ -26,7 +26,6 @@
 
 #if defined(HOST_64BIT)
 // TODO: bump up the windows CODE_ALIGN to 16 and iron out any nibble map bugs that exist.
-// TODO: there is something wrong with USE_INDIRECT_CODEHEADER with CODE_ALIGN=16
 # define CODE_ALIGN             4
 # define LOG2_CODE_ALIGN        2
 #else

--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -48,9 +48,6 @@ EXTERN_C void FastCallFinalizeWorker(Object *obj, PCODE funcPtr);
 #define SIZEOF_LOAD_AND_JUMP_THUNK              22   // # bytes to mov r10, X; jmp Z
 #define SIZEOF_LOAD2_AND_JUMP_THUNK             32   // # bytes to mov r10, X; mov r11, Y; jmp Z
 
-// Also in CorCompile.h, FnTableAccess.h
-#define USE_INDIRECT_CODEHEADER                 // use CodeHeader, RealCodeHeader construct
-
 #define HAS_NDIRECT_IMPORT_PRECODE              1
 #define HAS_FIXUP_PRECODE                       1
 

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -54,9 +54,6 @@ EXTERN_C void checkStack(void);
 
 #define HAS_NDIRECT_IMPORT_PRECODE              1
 
-#define USE_INDIRECT_CODEHEADER
-
-
 EXTERN_C void getFPReturn(int fpSize, INT64 *pRetVal);
 EXTERN_C void setFPReturn(int fpSize, INT64 retVal);
 

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -38,8 +38,6 @@ extern PCODE GetPreStubEntryPoint();
 
 #define HAS_NDIRECT_IMPORT_PRECODE              1
 
-#define USE_INDIRECT_CODEHEADER
-
 #define HAS_FIXUP_PRECODE                       1
 
 // ThisPtrRetBufPrecode one is necessary for closed delegates over static methods with return buffer

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2865,7 +2865,11 @@ void EEJitManager::allocCode(MethodDesc* pMD, size_t blockSize, size_t reserveFo
 #endif
     requestInfo.setReserveForJumpStubs(reserveForJumpStubs);
 
+#ifdef FEATURE_EH_FUNCLETS
     SIZE_T realHeaderSize = offsetof(RealCodeHeader, unwindInfos[0]) + (sizeof(T_RUNTIME_FUNCTION) * nUnwindInfos);
+#else
+    SIZE_T realHeaderSize = sizeof(RealCodeHeader);
+#endif
 
     // if this is a LCG method then we will be allocating the RealCodeHeader
     // following the code so that the code block can be removed easily by

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -69,10 +69,6 @@ Abstract:
 #include "gcinfo.h"
 #include "eexcp.h"
 
-#if defined(FEATURE_EH_FUNCLETS) && !defined(USE_INDIRECT_CODEHEADER)
-#error "FEATURE_EH_FUNCLETS requires USE_INDIRECT_CODEHEADER"
-#endif // FEATURE_EH_FUNCLETS && !USE_INDIRECT_CODEHEADER
-
 class MethodDesc;
 class ICorJitCompiler;
 class IJitManager;
@@ -125,20 +121,10 @@ enum StubCodeBlockKind : int
 // Today CodeHeader is used by the EEJitManager.
 // The GCInfo version is always current GCINFO_VERSION in this header.
 
-#ifdef USE_INDIRECT_CODEHEADER
 typedef DPTR(struct _hpRealCodeHdr) PTR_RealCodeHeader;
 typedef DPTR(struct _hpCodeHdr) PTR_CodeHeader;
 
-#else // USE_INDIRECT_CODEHEADER
-typedef DPTR(struct _hpCodeHdr) PTR_CodeHeader;
-
-#endif // USE_INDIRECT_CODEHEADER
-
-#ifdef USE_INDIRECT_CODEHEADER
 typedef struct _hpRealCodeHdr
-#else // USE_INDIRECT_CODEHEADER
-typedef struct _hpCodeHdr
-#endif // USE_INDIRECT_CODEHEADER
 {
 public:
     PTR_BYTE            phdrDebugInfo;
@@ -160,95 +146,9 @@ public:
 #endif // FEATURE_EH_FUNCLETS
 
 public:
-#ifndef USE_INDIRECT_CODEHEADER
-    //
-    // Note: that the JITted code follows immediately after the MethodDesc*
-    //
-    PTR_BYTE                GetDebugInfo()
-    {
-        SUPPORTS_DAC;
-
-        return phdrDebugInfo;
-    }
-    PTR_EE_ILEXCEPTION      GetEHInfo()
-    {
-        return phdrJitEHInfo;
-    }
-    PTR_BYTE                GetGCInfo()
-    {
-        SUPPORTS_DAC;
-        return phdrJitGCInfo;
-    }
-    PTR_MethodDesc          GetMethodDesc()
-    {
-        SUPPORTS_DAC;
-        return phdrMDesc;
-    }
-#if defined(FEATURE_GDBJIT)
-    VOID*                GetCalledMethods()
-    {
-        SUPPORTS_DAC;
-        return pCalledMethods;
-    }
-#endif
-    TADDR                   GetCodeStartAddress()
-    {
-        SUPPORTS_DAC;
-        return dac_cast<TADDR>(dac_cast<PTR_CodeHeader>(this) + 1);
-    }
-    StubCodeBlockKind       GetStubCodeBlockKind()
-    {
-        SUPPORTS_DAC;
-        return (StubCodeBlockKind)dac_cast<TADDR>(phdrMDesc);
-    }
-    BOOL                    IsStubCodeBlock()
-    {
-        SUPPORTS_DAC;
-        // Note that it is important for this comparison to be unsigned
-        return dac_cast<TADDR>(phdrMDesc) <= (TADDR)STUB_CODE_BLOCK_LAST;
-    }
-
-    void SetDebugInfo(PTR_BYTE pDI)
-    {
-        phdrDebugInfo = pDI;
-    }
-    void SetEHInfo(PTR_EE_ILEXCEPTION pEH)
-    {
-        phdrJitEHInfo = pEH;
-    }
-    void SetGCInfo(PTR_BYTE pGC)
-    {
-        phdrJitGCInfo = pGC;
-    }
-    void SetMethodDesc(PTR_MethodDesc pMD)
-    {
-        phdrMDesc = pMD;
-    }
-#if defined(FEATURE_GDBJIT)
-    void SetCalledMethods(VOID* pCM)
-    {
-        pCalledMethods = pCM;
-    }
-#endif
-    void SetStubCodeBlockKind(StubCodeBlockKind kind)
-    {
-        phdrMDesc = (PTR_MethodDesc)kind;
-    }
-#endif // !USE_INDIRECT_CODEHEADER
-
 // if we're using the indirect codeheaders then all enumeration is done by the code header
-#ifndef USE_INDIRECT_CODEHEADER
-#ifdef DACCESS_COMPILE
-    void EnumMemoryRegions(CLRDataEnumMemoryFlags flags, IJitManager* pJitMan);
-#endif  // DACCESS_COMPILE
-#endif  // USE_INDIRECT_CODEHEADER
-#ifdef USE_INDIRECT_CODEHEADER
 } RealCodeHeader;
-#else // USE_INDIRECT_CODEHEADER
-} CodeHeader;
-#endif // USE_INDIRECT_CODEHEADER
 
-#ifdef USE_INDIRECT_CODEHEADER
 typedef struct _hpCodeHdr
 {
     PTR_RealCodeHeader   pRealCodeHeader;
@@ -355,7 +255,6 @@ public:
 #endif  // DACCESS_COMPILE
 
 } CodeHeader;
-#endif // USE_INDIRECT_CODEHEADER
 
 
 //-----------------------------------------------------------------------------
@@ -1871,9 +1770,7 @@ public:
 
     void                allocCode(MethodDesc* pFD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, CodeHeader** ppCodeHeader, CodeHeader** ppCodeHeaderRW,
                                   size_t* pAllocatedSize, HeapList** ppCodeHeap
-#ifdef USE_INDIRECT_CODEHEADER
                                 , BYTE** ppRealHeader
-#endif
 #ifdef FEATURE_EH_FUNCLETS
                                 , UINT nUnwindInfos
 #endif

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -51,10 +51,6 @@ EXTERN_C void SinglecastDelegateInvokeStub();
 #define JUMP_ALLOCATE_SIZE                      8   // # bytes to allocate for a jump instruction
 #define BACK_TO_BACK_JUMP_ALLOCATE_SIZE         8   // # bytes to allocate for a back to back jump instruction
 
-#ifdef FEATURE_EH_FUNCLETS
-#define USE_INDIRECT_CODEHEADER
-#endif // FEATURE_EH_FUNCLETS
-
 #define HAS_COMPACT_ENTRYPOINTS                 1
 
 // Needed for PInvoke inlining in ngened images

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10851,14 +10851,12 @@ void CEEJitInfo::WriteCodeBytes()
 {
     LIMITED_METHOD_CONTRACT;
 
-#ifdef USE_INDIRECT_CODEHEADER
     if (m_pRealCodeHeader != NULL)
     {
         // Restore the read only version of the real code header
         m_CodeHeaderRW->SetRealCodeHeader(m_pRealCodeHeader);
         m_pRealCodeHeader = NULL;
     }
-#endif // USE_INDIRECT_CODEHEADER
 
     if (m_CodeHeaderRW != m_CodeHeader)
     {
@@ -12243,9 +12241,7 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
     }
 
     m_jitManager->allocCode(m_pMethodBeingCompiled, totalSize.Value(), GetReserveForJumpStubs(), pArgs->flag, &m_CodeHeader, &m_CodeHeaderRW, &m_codeWriteBufferSize, &m_pCodeHeap
-#ifdef USE_INDIRECT_CODEHEADER
                           , &m_pRealCodeHeader
-#endif
 #ifdef FEATURE_EH_FUNCLETS
                           , m_totalUnwindInfos
 #endif

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -688,9 +688,7 @@ public:
         m_CodeHeaderRW = NULL;
 
         m_codeWriteBufferSize = 0;
-#ifdef USE_INDIRECT_CODEHEADER
         m_pRealCodeHeader = NULL;
-#endif
         m_pCodeHeap = NULL;
 
         if (m_pOffsetMapping != NULL)
@@ -801,9 +799,7 @@ public:
           m_CodeHeader(NULL),
           m_CodeHeaderRW(NULL),
           m_codeWriteBufferSize(0),
-#ifdef USE_INDIRECT_CODEHEADER
           m_pRealCodeHeader(NULL),
-#endif
           m_pCodeHeap(NULL),
           m_ILHeader(header),
 #ifdef FEATURE_EH_FUNCLETS
@@ -951,9 +947,7 @@ protected :
     CodeHeader*             m_CodeHeader;   // descriptor for JITTED code - read/execute address
     CodeHeader*             m_CodeHeaderRW; // descriptor for JITTED code - code write scratch buffer address
     size_t                  m_codeWriteBufferSize;
-#ifdef USE_INDIRECT_CODEHEADER
     BYTE*                   m_pRealCodeHeader;
-#endif
     HeapList*               m_pCodeHeap;
     COR_ILMETHOD_DECODER *  m_ILHeader;     // the code header as exist in the file
 #ifdef FEATURE_EH_FUNCLETS

--- a/src/coreclr/vm/loongarch64/cgencpu.h
+++ b/src/coreclr/vm/loongarch64/cgencpu.h
@@ -36,8 +36,6 @@ extern PCODE GetPreStubEntryPoint();
 
 #define HAS_NDIRECT_IMPORT_PRECODE              1
 
-#define USE_INDIRECT_CODEHEADER
-
 #define HAS_FIXUP_PRECODE                       1
 #define HAS_FIXUP_PRECODE_CHUNKS                1
 

--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -36,8 +36,6 @@ extern PCODE GetPreStubEntryPoint();
 
 #define HAS_NDIRECT_IMPORT_PRECODE              1
 
-#define USE_INDIRECT_CODEHEADER
-
 #define HAS_FIXUP_PRECODE                       1
 
 // ThisPtrRetBufPrecode one is necessary for closed delegates over static methods with return buffer


### PR DESCRIPTION
- We use indirect code headers on all platforms (except for Windows X86, which has no particular reason to not use them)
  - Indirect code headers are required to support funclet style codegen, but work just fine in all cases.
- This removes one of the ways in which Windows X86 is different from all other platforms