### PR TITLE
Commit Accounting related changes

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6017,7 +6017,18 @@ gc_heap::get_segment (size_t size, gc_oh_num oh)
 
             if (gc_heap::grow_brick_card_tables (start, end, size, result, __this, uoh_p) != 0)
             {
-                virtual_free (mem, size);
+                // release_segment needs the flags to decrement the proper bucket
+                size_t flags = 0;
+                if (oh == poh)
+                {
+                    flags = heap_segment_flags_poh;
+                }
+                else if (oh == loh)
+                {
+                    flags = heap_segment_flags_loh;
+                }
+                result->flags |= flags;
+                release_segment (result);
                 return 0;
             }
         }

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -6990,13 +6990,12 @@ void gc_heap::gc_thread_function ()
             bool wait_on_time_out_p = gradual_decommit_in_progress_p;
             uint32_t wait_time = DECOMMIT_TIME_STEP_MILLISECONDS;
 #ifdef DYNAMIC_HEAP_COUNT
-#ifdef BACKGROUND_GC
-            bool background_running_p = gc_heap::background_running_p ();
-#else
-            bool background_running_p = false;
-#endif
             // background_running_p can only change from false to true during suspension.
-            if (!background_running_p && dynamic_heap_count_data.should_change_heap_count)
+            if (
+#ifdef BACKGROUND_GC
+                !gc_heap::background_running_p () &&
+#endif
+                dynamic_heap_count_data.should_change_heap_count)
             {
                 assert (dynamic_adaptation_mode == dynamic_adaptation_to_application_sizes);
 

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1574,8 +1574,8 @@ private:
                           uint8_t* low, uint8_t* high);
 #endif //VERIFY_HEAP
 
-#ifdef USE_REGIONS
     PER_HEAP_METHOD void verify_committed_bytes_per_heap();
+#ifdef USE_REGIONS
     PER_HEAP_ISOLATED_METHOD void verify_committed_bytes();
 #endif //USE_REGIONS
 
@@ -1674,9 +1674,6 @@ private:
     // Compute the size committed for the mark array for this region.
     PER_HEAP_METHOD size_t get_mark_array_size(heap_segment* seg);
 
-    // Accumulate the committed bytes for both the region and the mark array for this list of regions.
-    PER_HEAP_METHOD void accumulate_committed_bytes(heap_segment* seg, size_t& committed_bytes, size_t& mark_array_committed_bytes, gc_oh_num oh = unknown);
-
     PER_HEAP_ISOLATED_METHOD void verify_region_to_generation_map();
 
     PER_HEAP_ISOLATED_METHOD void compute_gc_and_ephemeral_range (int condemned_gen_number, bool end_of_gc_p);
@@ -1684,6 +1681,9 @@ private:
     PER_HEAP_METHOD void pin_by_gc (uint8_t* object);
 #endif //STRESS_REGIONS
 #endif //USE_REGIONS
+
+    // Accumulate the committed bytes for both the region and the mark array for this list of regions.
+    PER_HEAP_METHOD void accumulate_committed_bytes(heap_segment* seg, size_t& committed_bytes, size_t& mark_array_committed_bytes, gc_oh_num oh = unknown);
 
     PER_HEAP_ISOLATED_METHOD gc_heap* make_gc_heap(
 #if defined (MULTIPLE_HEAPS)
@@ -3351,8 +3351,8 @@ private:
     PER_HEAP_ISOLATED_METHOD bool compute_memory_settings(bool is_initialization, uint32_t& nhp, uint32_t nhp_from_config, size_t& seg_size_from_config,
         size_t new_current_total_committed);
 
-#ifdef USE_REGIONS
     PER_HEAP_METHOD size_t compute_committed_bytes_per_heap(int oh, size_t& committed_bookkeeping);
+#ifdef USE_REGIONS
     PER_HEAP_ISOLATED_METHOD void compute_committed_bytes(size_t& total_committed, size_t& committed_decommit, size_t& committed_free, 
                                   size_t& committed_bookkeeping, size_t& new_current_total_committed, size_t& new_current_total_committed_bookkeeping, 
                                   size_t* new_committed_by_oh);

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1570,10 +1570,10 @@ private:
 
 #ifdef VERIFY_HEAP
     PER_HEAP_METHOD void verify_free_lists();
-#if defined (USE_REGIONS) && defined (_DEBUG)
+#if defined (USE_REGIONS)
     PER_HEAP_METHOD void verify_regions (int gen_number, bool can_verify_gen_num, bool can_verify_tail);
     PER_HEAP_METHOD void verify_regions (bool can_verify_gen_num, bool concurrent_p);
-#endif //USE_REGIONS && _DEBUG
+#endif //USE_REGIONS
     PER_HEAP_ISOLATED_METHOD void enter_gc_lock_for_verify_heap();
     PER_HEAP_ISOLATED_METHOD void leave_gc_lock_for_verify_heap();
     PER_HEAP_METHOD void verify_heap (BOOL begin_gc_p);
@@ -3900,11 +3900,10 @@ private:
     PER_HEAP_FIELD_DIAG_ONLY int gchist_index_per_heap;
     PER_HEAP_FIELD_DIAG_ONLY gc_history gchist_per_heap[max_history_count];
 
-#ifdef MULTIPLE_HEAPS
+#if defined(MULTIPLE_HEAPS) && defined(_DEBUG)
     PER_HEAP_FIELD_DIAG_ONLY size_t committed_by_oh_per_heap[total_oh_count];
     PER_HEAP_FIELD_DIAG_ONLY size_t committed_by_oh_per_heap_refresh[total_oh_count];
-#else //MULTIPLE_HEAPS
-#endif //MULTIPLE_HEAPS
+#endif // MULTIPLE_HEAPS && _DEBUG
 
 #ifdef BACKGROUND_GC
     PER_HEAP_FIELD_DIAG_ONLY gc_history_per_heap bgc_data_per_heap;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2385,6 +2385,7 @@ private:
     PER_HEAP_ISOLATED_METHOD bool virtual_alloc_commit_for_heap (void* addr, size_t size, int h_number);
     PER_HEAP_ISOLATED_METHOD bool virtual_commit (void* address, size_t size, int bucket, int h_number=-1, bool* hard_limit_exceeded_p=NULL);
     PER_HEAP_ISOLATED_METHOD bool virtual_decommit (void* address, size_t size, int bucket, int h_number=-1);
+    PER_HEAP_ISOLATED_METHOD void reduce_committed_bytes (void* address, size_t size, int bucket, int h_number, bool decommit_succeeded_p);
     friend void destroy_card_table (uint32_t*);
     PER_HEAP_ISOLATED_METHOD void destroy_card_table_helper (uint32_t* c_table);
     PER_HEAP_ISOLATED_METHOD void virtual_free (void* add, size_t size, heap_segment* sg=NULL);


### PR DESCRIPTION
1. When `heap_segment` are moved across heaps during `change_heap_count`, this change records them so that `committed_by_oh_per_heap` is still valid.
2. Keep track of the various `committed_by` values regardless of `heap_hard_limit`, which will allow us `refresh_memory_limit` for segments.
3. Various refactoring to avoid duplicating code for verification.
4. Moved `verify_regions` into `_DEBUG`.
5. When `release_segment`, heap_segment are released by `virtual_free`, we need to also decrement the committed counters when that happen.
6. When `get_segment`, we accidentally used `max_generation` as `oh` for UOH segments, this change will make it use the right `oh`.
7. If we failed to `grow_brick_card_table`, heap_segment are released by `virtual_free`, we need to also decrement the committed counters when that happen.
8. Compute the amount of memory spent on bookkeeping data for segments, and give up accounting for mark array

... to be continued.