### PR TITLE
JIT: fix count reconstruction problem

### DIFF
--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1289,6 +1289,12 @@ void ProfileSynthesis::GaussSeidelSolver()
                 residual      = change;
                 residualBlock = block;
             }
+
+            if (newWeight >= maxCount)
+            {
+                JITDUMP("count overflow in " FMT_BB ": " FMT_WT "\n", block->bbNum, newWeight);
+                m_overflow = true;
+            }
         }
 
         // If there were no improper headers, we will have converged in one pass.
@@ -1309,6 +1315,12 @@ void ProfileSynthesis::GaussSeidelSolver()
         if ((residual < stopResidual) || (relResidual < stopRelResidual))
         {
             converged = true;
+            break;
+        }
+
+        if (m_overflow)
+        {
+            printf("*** Overflowed counts in %s\n", m_comp->info.compFullName);
             break;
         }
 

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1320,7 +1320,6 @@ void ProfileSynthesis::GaussSeidelSolver()
 
         if (m_overflow)
         {
-            printf("*** Overflowed counts in %s\n", m_comp->info.compFullName);
             break;
         }
 

--- a/src/coreclr/jit/fgprofilesynthesis.h
+++ b/src/coreclr/jit/fgprofilesynthesis.h
@@ -51,6 +51,7 @@ private:
     static constexpr weight_t ilNextLikelihood   = 0.52;
     static constexpr weight_t loopBackLikelihood = 0.9;
     static constexpr weight_t loopExitLikelihood = 0.9;
+    static constexpr weight_t maxCount           = 1e12;
 
     void Run(ProfileSynthesisOption option);
 
@@ -84,6 +85,7 @@ private:
     unsigned               m_improperLoopHeaders       = 0;
     unsigned               m_cappedCyclicProbabilities = 0;
     bool                   m_approximate               = false;
+    bool                   m_overflow                  = false;
 };
 
 #endif // !_FGPROFILESYNTHESIS_H_


### PR DESCRIPTION
In large methods with lots of irreducible loops we may find reconstructed counts reaching very large values.

Since profile counts in practice won't ever be much larger than say 10^12, detect when reconstructed counts exceed this value, and stop the algorithm.

We may eventually decide to rerun in "hard blend" mode where we intentionally limit the edge likelihood ranges. But this should do for now.

Closes #100350.