### PR TITLE
[NativeAOT] Remove TargetAbi.CppCodegen and TargetAbi.Jit

### DIFF
--- a/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Portable/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(PortableRuntime)
 
-# Portable version of the runtime is designed to be used with CppCodeGen or WASM.
+# Portable version of the runtime is designed to be used with WASM.
 # It should be written in pure C/C++, with no assembly code.
 
 add_definitions(-DUSE_PORTABLE_HELPERS)

--- a/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TargetDetails.cs
@@ -37,14 +37,6 @@ namespace Internal.TypeSystem
         /// model for armel execution model
         /// </summary>
         NativeAotArmel,
-        /// <summary>
-        /// Jit runtime ABI
-        /// </summary>
-        Jit,
-        /// <summary>
-        /// Cross-platform portable C++ codegen
-        /// </summary>
-        CppCodegen,
     }
 
     /// <summary>
@@ -102,7 +94,7 @@ namespace Internal.TypeSystem
         {
             get
             {
-                return (Abi != TargetAbi.CppCodegen) && (Architecture != TargetArchitecture.Wasm32);
+                return Architecture != TargetArchitecture.Wasm32;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CanonicalEETypeNode.cs
@@ -24,7 +24,7 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
             Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
             Debug.Assert(type == type.ConvertToCanonForm(CanonicalFormKind.Specific));
-            Debug.Assert(!type.IsMdArray || factory.Target.Abi == TargetAbi.CppCodegen);
+            Debug.Assert(!type.IsMdArray);
         }
 
         public override bool StaticDependenciesAreComputed => true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticEETypeNode.cs
@@ -64,7 +64,6 @@ namespace ILCompiler.DependencyAnalysis
             dataBuilder.AddSymbol(this);
 
             // +1 for SyncBlock (static size already includes MethodTable)
-            Debug.Assert(factory.Target.Abi == TargetAbi.NativeAot || factory.Target.Abi == TargetAbi.CppCodegen);
             int totalSize = (_gcMap.Size + 1) * _target.PointerSize;
 
             // We only need to check for containsPointers because ThreadStatics are always allocated

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NecessaryCanonicalEETypeNode.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(!type.IsCanonicalDefinitionType(CanonicalFormKind.Any));
             Debug.Assert(type.IsCanonicalSubtype(CanonicalFormKind.Any));
             Debug.Assert(type == type.ConvertToCanonForm(CanonicalFormKind.Specific));
-            Debug.Assert(!type.IsMdArray || factory.Target.Abi == TargetAbi.CppCodegen);
+            Debug.Assert(!type.IsMdArray);
         }
 
         protected override void OutputInterfaceMap(NodeFactory factory, ref ObjectDataBuilder objData)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectionFieldMapNode.cs
@@ -59,10 +59,6 @@ namespace ILCompiler.DependencyAnalysis
                 if (field.IsLiteral || field.HasRva)
                     continue;
 
-                // CppCodegen: implement thread statics
-                if (factory.Target.Abi == TargetAbi.CppCodegen && field.IsThreadStatic)
-                    continue;
-
                 FieldTableFlags flags;
                 if (field.IsStatic)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -950,9 +950,6 @@ namespace Internal.JitInterface
                                 RelocType.IMAGE_REL_BASED_ABSOLUTE :
                                 RelocType.IMAGE_REL_BASED_RELPTR32;
 
-                            if (_compilation.NodeFactory.Target.Abi == TargetAbi.Jit)
-                                rel = RelocType.IMAGE_REL_BASED_REL32;
-
                             builder.EmitReloc(typeSymbol, rel);
                         }
                         break;


### PR DESCRIPTION
CppCodegen was removed when CoreRT was transformed into NativeAOT, JIT support was never published.