### PR TITLE
Add span detection in Enumerable.First(predicate)

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -114,6 +114,19 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
+            {
+                for (int i = 0; i < span.Length; i++)
+                {
+                    TSource element = span[i];
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
+                }
+            }
+
             foreach (TSource element in source)
             {
                 if (predicate(element))


### PR DESCRIPTION
Proof of concept using the benchmark from https://github.com/dotnet/runtime/issues/100378

| Method                  | Branch | Count   | Mean           | Error        | StdDev       | Ratio | RatioSD |
|------------------------ |------- |-------- |---------------:|-------------:|-------------:|------:|--------:|
| WhereThenFirstOrDefault | main   | 100     |       191.4 ns |      1.30 ns |      1.21 ns |  1.00 |    0.00 |
| FirstOrDefault          | main   | 100     |       529.2 ns |      6.99 ns |      6.54 ns |  2.77 |    0.04 |
| WhereThenFirstOrDefault | PR     | 100     |       194.2 ns |      1.49 ns |      1.32 ns |  1.01 |    0.01 |
| FirstOrDefault          | PR     | 100     |       130.6 ns |      1.27 ns |      1.12 ns |  0.68 |    0.01 |
|                         |        |         |                |              |              |       |         |
| WhereThenFirstOrDefault | main   | 1000000 | 3,073,354.0 ns | 60,036.59 ns | 96,947.90 ns |  1.00 |    0.00 |
| FirstOrDefault          | main   | 1000000 | 6,240,425.2 ns | 44,984.93 ns | 42,078.93 ns |  2.02 |    0.06 |
| WhereThenFirstOrDefault | PR     | 1000000 | 3,022,626.9 ns | 54,269.78 ns | 62,497.16 ns |  0.98 |    0.03 |
| FirstOrDefault          | PR     | 1000000 | 3,068,601.1 ns | 59,960.37 ns | 77,965.41 ns |  0.99 |    0.03 |


Fix https://github.com/dotnet/runtime/issues/100378