### PR TITLE
[release/8.0-staging] Ensure that Sse3.MoveAndDuplicate correctly tracks supporting SIMD scalar loads

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.cs
@@ -6,10 +6,11 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Xunit;
 
-public static class Runtime_98068
+public static class Runtime_100404
 {
     [Fact]
-    public static void Main(string[] args)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TestMultiplyVector128DoubleByConstant()
     {
         Vector128<double> result = Map(Vector128<double>.One, new FloatPoint(2.0, 3.0));
         Assert.Equal(2.0, result[0]);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+public static class Runtime_98068
+{
+    [Fact]
+    public static void Main(string[] args)
+    {
+        Vector128<double> result = Map(Vector128<double>.One, new FloatPoint(2.0, 3.0));
+        Assert.Equal(2.0, result[0]);
+        Assert.Equal(2.0, result[1]);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector128<double> Map(Vector128<double> m0, FloatPoint point)
+    {
+        return m0 * Vector128.Create(point.X);
+    }
+
+    private struct FloatPoint(double x, double y)
+    {
+        public double X = x;
+        public double Y = y;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100404/Runtime_100404.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/97783 to release/8.0-staging

/cc @tannergooding 

## Customer Impact

- [x] Customer reported
- [ ] Found internally

This was reported by a customer in https://github.com/dotnet/runtime/issues/100404 and was internally found via https://github.com/dotnet/runtime/issues/97688, where the containment checks around `Sse3.MoveAndDuplicate` weren't sufficient and so we missed an opportunity that another code path (related to the AVX-512 embedded broadcast support) was assuming would be made.
 
## Regression

- [ ] Yes
- [x] No

Prior to AVX-512 there was a missed containment opportunity, but this wasn't functionally incorrect, just less efficient. With the introduction of AVX-512 support in .NET 8, a new issue was introduced due to us missing the containment opportunity.

## Testing

The fix was verified on the customer provided example in https://github.com/dotnet/runtime/issues/100404 and a minimal regression test was added that validates the fix. The fix has been in .NET 9 for a couple months now with no additional issues having been found.

## Risk

Low: This is a net new scenario in .NET 8 and only impacts customers with AVX-512 capable hardware.
