### PR TITLE
[PERF] Update dependson for mono perf jobs

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -43,28 +43,6 @@ extends:
       jobs:
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(in(variables['Build.Reason'], 'Schedule'), parameters.runScheduledJobs)) }}:
-        # build coreclr and libraries
-        - template: /eng/pipelines/common/platform-matrix.yml
-          parameters:
-            jobTemplate: /eng/pipelines/common/global-build-job.yml
-            buildConfig: release
-            platforms:
-            - linux_arm64
-            jobParameters:
-              nameSuffix: coreclr
-              buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
-              isOfficialBuild: false
-              postBuildSteps:
-              - template: /eng/pipelines/common/upload-artifact-step.yml
-                parameters:
-                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
-                  includeRootFolder: false
-                  archiveType: $(archiveType)
-                  archiveExtension: $(archiveExtension)
-                  tarCompression: $(tarCompression)
-                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
-                  displayName: Build Assets
-
         # build mono
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -35,13 +35,34 @@ extends:
       jobs:
 
       - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+        # build coreclr and libraries
+        - template: /eng/pipelines/common/platform-matrix.yml
+          parameters:
+            jobTemplate: /eng/pipelines/common/global-build-job.yml
+            buildConfig: release
+            platforms:
+            - linux_arm64
+            jobParameters:
+              nameSuffix: coreclr
+              buildArgs: -s clr+libs+host+packs -c $(_BuildConfig)
+              isOfficialBuild: false
+              postBuildSteps:
+              - template: /eng/pipelines/common/upload-artifact-step.yml
+                parameters:
+                  rootFolder: $(Build.SourcesDirectory)/artifacts/bin
+                  includeRootFolder: false
+                  archiveType: $(archiveType)
+                  archiveExtension: $(archiveExtension)
+                  tarCompression: $(tarCompression)
+                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
+                  displayName: Build Assets
 
+        # build mono
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
             jobTemplate: /eng/pipelines/common/global-build-job.yml
             buildConfig: release
             runtimeFlavor: mono
-            runtimeVariant: monointerpreter
             platforms:
             - linux_arm64
             jobParameters:

--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -1,3 +1,11 @@
+parameters:
+- name: runPrivateJobs
+  type: boolean
+  default: false
+- name: runScheduledJobs
+  type: boolean
+  default: false
+
 trigger:
   batch: true
   branches:
@@ -34,7 +42,7 @@ extends:
     - stage: Build
       jobs:
 
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'Schedule')) }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(in(variables['Build.Reason'], 'Schedule'), parameters.runScheduledJobs)) }}:
         # build coreclr and libraries
         - template: /eng/pipelines/common/platform-matrix.yml
           parameters:
@@ -99,7 +107,7 @@ extends:
               logicalmachine: 'perfampere'
               timeoutInMinutes: 720
 
-      - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'Schedule')) }}:
+      - ${{ if and(ne(variables['System.TeamProject'], 'public'), or(notin(variables['Build.Reason'], 'Schedule', 'Manual'), parameters.runPrivateJobs)) }}:
 
         # build coreclr and libraries
         - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/coreclr/templates/perf-job.yml
+++ b/eng/pipelines/coreclr/templates/perf-job.yml
@@ -77,7 +77,7 @@ jobs:
     # Test job depends on the corresponding build job
     ${{ if eq(parameters.downloadSpecificBuild.buildId, '') }}:
       dependsOn:
-      - ${{ if not(in(parameters.runtimeType, 'AndroidMono', 'iOSMono', 'iOSNativeAOT', 'wasm')) }}:
+      - ${{ if not(or(in(parameters.runtimeType, 'AndroidMono', 'iOSMono', 'iOSNativeAOT', 'wasm'), and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')))) }}:
         - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'coreclr') }}
       - ${{ if and(eq(parameters.runtimeType, 'mono'), ne(parameters.codeGenType, 'AOT')) }}:
         - ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, 'mono') }}


### PR DESCRIPTION
Update dependson for mono perf jobs to fix the runs and add run parameters for easier manually started verification. The steps were broken with this commit: https://github.com/dotnet/runtime/commit/663839e21ce38f41ce27c0ab6506a05e6d6f723b, due to the simplification to one build step, while perf-job.yml was expecting both the mono and coreclr builds separately. Failing build example: [Failing build](https://dev.azure.com/dnceng/internal/_build/results?buildId=2416734)

Test run: [Test Run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2417474&view=results). I also checked and only the monoAOT pulls in coreclr in the main pipeline runs. This canceled run shows that the yaml still starts successfully and doesn't have any unknown dependencies between steps: [dotnet-runtime-perf runnable verification](https://dev.azure.com/dnceng/internal/_build/results?buildId=2417477&view=results)