### PR TITLE
[release/8.0-staging] Always zero-init if object contains pointers

### DIFF
--- a/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcrhenv.cpp
@@ -129,6 +129,12 @@ Object* GcAllocInternal(MethodTable *pEEType, uint32_t uFlags, uintptr_t numElem
     ASSERT(!pThread->IsDoNotTriggerGcSet());
     ASSERT(pThread->IsCurrentThreadInCooperativeMode());
 
+    if (pEEType->ContainsPointers())
+    {
+        uFlags |= GC_ALLOC_CONTAINS_REF;
+        uFlags &= ~GC_ALLOC_ZEROING_OPTIONAL;
+    }
+
     size_t cbSize = pEEType->get_BaseSize();
 
     if (pEEType->HasComponentSize())

--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -1100,6 +1100,8 @@ namespace System.Tests
             byte* pointer = (byte*)Unsafe.AsPointer(ref array[0]);
             var size = Unsafe.SizeOf<EmbeddedValueType<string>>();
 
+            GC.Collect();
+
             for(int i = 0; i < length; ++i)
             {
                 int idx = rng.Next(length);


### PR DESCRIPTION
Backport of #100265 to release/8.0-staging

## Customer Impact

- [ ] Customer reported
- [x] Found internally

This was seen to cause failures due to heap corruption in local run-to-failure runs. 

Using `GC.AllocateUninitializedArray()` API with reference-containing element types on NativeAOT would introduce silent heap corruptions and eventually cause a crash at the next full GC.

Such failures would be extremely difficult to diagnose if happen in a real application.
 
## Regression

- [ ] Yes
- [x] No

Allowing reference types for pinned `GC.AllocateUninitializedArray()` was a new addition to the public API.
The intended semantics of  AllocateUninitializedArray with reference containing element types is to ignore the "Unintialized" part as GC heap does not expect uninitialized object references. 

Historically, the check for this combination (reference-containing+uninitialized) was present in CoreCLR, but was not ported to NativeAOT as a part of the above change.

## Testing

Regular tests + a test scenario that is sensitive to this scenario was added.

## Risk

Low: This is matching the long existing behavior on CoreCLR.
