### PR TITLE
[RISC-V] Fix intermittent failures due to unalignment access

### DIFF
--- a/src/coreclr/gcinfo/CMakeLists.txt
+++ b/src/coreclr/gcinfo/CMakeLists.txt
@@ -77,8 +77,10 @@ if (CLR_CMAKE_TARGET_ARCH_RISCV64)
   create_gcinfo_lib(TARGET gcinfo_unix_riscv64 OS unix ARCH riscv64)
 endif (CLR_CMAKE_TARGET_ARCH_RISCV64)
 
-create_gcinfo_lib(TARGET gcinfo_universal_arm OS universal ARCH arm)
-create_gcinfo_lib(TARGET gcinfo_win_x86 OS win ARCH x86)
+if (NOT CLR_CMAKE_TARGET_ARCH_RISCV64)
+  create_gcinfo_lib(TARGET gcinfo_universal_arm OS universal ARCH arm)
+  create_gcinfo_lib(TARGET gcinfo_win_x86 OS win ARCH x86)
+endif (NOT CLR_CMAKE_TARGET_ARCH_RISCV64)
 
 if (CLR_CMAKE_TARGET_ARCH_I386 AND CLR_CMAKE_TARGET_UNIX)
   create_gcinfo_lib(TARGET gcinfo_unix_x86 OS unix ARCH x86)

--- a/src/coreclr/inc/stdmacros.h
+++ b/src/coreclr/inc/stdmacros.h
@@ -159,11 +159,9 @@
     #define DBG_ADDR(ptr)      (DWORD)((UINT_PTR)(ptr))
 #endif // HOST_64BIT
 
-#ifndef ALIGN_ACCESS
 #if defined(TARGET_ARM) || defined(TARGET_RISCV64)
     #define ALIGN_ACCESS        ((1<<LOG2_PTRSIZE)-1)
 #endif // TARGET_ARM || TARGET_RISCV64
-#endif // ALIGN_ACCESS
 
 
 #ifndef ALLOC_ALIGN_CONSTANT

--- a/src/coreclr/inc/stdmacros.h
+++ b/src/coreclr/inc/stdmacros.h
@@ -159,9 +159,11 @@
     #define DBG_ADDR(ptr)      (DWORD)((UINT_PTR)(ptr))
 #endif // HOST_64BIT
 
-#ifdef TARGET_ARM
+#ifndef ALIGN_ACCESS
+#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
     #define ALIGN_ACCESS        ((1<<LOG2_PTRSIZE)-1)
-#endif
+#endif // TARGET_ARM || TARGET_RISCV64
+#endif // ALIGN_ACCESS
 
 
 #ifndef ALLOC_ALIGN_CONSTANT

--- a/src/coreclr/inc/stdmacros.h
+++ b/src/coreclr/inc/stdmacros.h
@@ -159,9 +159,9 @@
     #define DBG_ADDR(ptr)      (DWORD)((UINT_PTR)(ptr))
 #endif // HOST_64BIT
 
-#if defined(TARGET_ARM) || defined(TARGET_RISCV64)
+#if defined(HOST_ARM) || defined(HOST_RISCV64)
     #define ALIGN_ACCESS        ((1<<LOG2_PTRSIZE)-1)
-#endif // TARGET_ARM || TARGET_RISCV64
+#endif // HOST_ARM || HOST_RISCV64
 
 
 #ifndef ALLOC_ALIGN_CONSTANT

--- a/src/coreclr/pal/inc/pal_endian.h
+++ b/src/coreclr/pal/inc/pal_endian.h
@@ -103,7 +103,8 @@ inline void SwapGuid(GUID *pGuid)
 #endif
 
 #ifdef HOST_RISCV64
-#define ALIGN_ACCESS    ((1<<3)-1)
+#define LOG2_PTRSIZE	3
+#define ALIGN_ACCESS    ((1<<LOG2_PTRSIZE)-1)
 #endif
 
 #if defined(ALIGN_ACCESS) && !defined(_MSC_VER)

--- a/src/coreclr/pal/inc/pal_endian.h
+++ b/src/coreclr/pal/inc/pal_endian.h
@@ -102,6 +102,10 @@ inline void SwapGuid(GUID *pGuid)
 #define ALIGN_ACCESS    ((1<<LOG2_PTRSIZE)-1)
 #endif
 
+#ifdef HOST_RISCV64
+#define ALIGN_ACCESS    ((1<<3)-1)
+#endif
+
 #if defined(ALIGN_ACCESS) && !defined(_MSC_VER)
 #ifdef __cplusplus
 extern "C++" {


### PR DESCRIPTION
Some tests fails intermittently on visionfive 2 board only. (not qemu)
It updates unalignment access.

Tests
```
JIT/jit64/hfa/main/testE/hfa_nf0E_d/hfa_nf0E_d.sh
JIT/jit64/hfa/main/testE/hfa_nf0E_d/hfa_nf0E_r.sh
JIT/jit64/hfa/main/testE/hfa_nf1E_d/hfa_nf1E_d.sh
JIT/jit64/hfa/main/testE/hfa_nf1E_d/hfa_nf1E_r.sh
JIT/jit64/hfa/main/testE/hfa_sf0E_d/hfa_sf0E_d.sh
JIT/jit64/hfa/main/testE/hfa_sf0E_d/hfa_sf0E_r.sh
JIT/jit64/hfa/main/testE/hfa_sf1E_d/hfa_sf1E_d.sh
JIT/jit64/hfa/main/testE/hfa_sf1E_d/hfa_sf1E_r.sh
```

Part of https://github.com/dotnet/runtime/issues/84834
cc @dotnet/samsung