### PR TITLE
JIT: fix count reconstruction when a natural loop contains an improper loop

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2091,6 +2091,9 @@ class FlowGraphNaturalLoop
     // Can be used to store additional annotations for this loop on the side.
     unsigned m_index = 0;
 
+    // True if this loop contains an improper loop header
+    bool m_containsImproperHeader = false;
+
     FlowGraphNaturalLoop(const FlowGraphDfsTree* dfsTree, BasicBlock* head);
 
     unsigned LoopBlockBitVecIndex(BasicBlock* block);
@@ -2178,6 +2181,11 @@ public:
 
     bool ContainsBlock(BasicBlock* block);
     bool ContainsLoop(FlowGraphNaturalLoop* childLoop);
+
+    bool ContainsImproperHeader() const
+    {
+        return m_containsImproperHeader;
+    }
 
     unsigned NumLoopBlocks();
 

--- a/src/coreclr/jit/fgprofilesynthesis.cpp
+++ b/src/coreclr/jit/fgprofilesynthesis.cpp
@@ -1193,12 +1193,14 @@ void ProfileSynthesis::GaussSeidelSolver()
             //
             if (block->bbPreds != nullptr)
             {
-                // Leverage Cp for existing loop headers.
+                // Leverage Cp for existing loop headers, provided that
+                // all contained loops are proper.
+                //
                 // This is an optimization to speed convergence.
                 //
                 FlowGraphNaturalLoop* const loop = m_loops->GetLoopByHeader(block);
 
-                if (loop != nullptr)
+                if ((loop != nullptr) && !loop->ContainsImproperHeader())
                 {
                     // Sum all entry edges that aren't EH flow
                     //

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4386,6 +4386,15 @@ FlowGraphNaturalLoops* FlowGraphNaturalLoops::Find(const FlowGraphDfsTree* dfsTr
         if (!FindNaturalLoopBlocks(loop, worklist))
         {
             loops->m_improperLoopHeaders++;
+
+            for (FlowGraphNaturalLoop* const otherLoop : loops->InPostOrder())
+            {
+                if (otherLoop->ContainsBlock(header))
+                {
+                    otherLoop->m_containsImproperHeader = true;
+                }
+            }
+
             continue;
         }
 


### PR DESCRIPTION
If a natural loop contains an improper loop, the cyclic probability computation for the natural loop will be an underestimate, as the cyclic probability computation assumes one pass convergence.

In such cases count reconstruction may report convergence when it has not in fact converged, as any natural loop header ignores flow from its back edges, assuming their impact has been accounted for by the cyclic probability.

So, when a loop contains improper loops, fall back to normal iterative computation for the loop. We could use the cyclic probability initially as a convergence accelerator but would need to switch over to not using it to guarantee full convergence. But that complicates the logic, and these cases are rare.