### PR TITLE
Define _TIME_BITS=64 globally

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -443,6 +443,8 @@ endif(CLR_CMAKE_HOST_WIN32)
 
 # Unconditionally define _FILE_OFFSET_BITS as 64 on all platforms.
 add_definitions(-D_FILE_OFFSET_BITS=64)
+# Unconditionally define _TIME_BITS as 64 on all platforms.
+add_definitions(-D_TIME_BITS=64)
 
 # Architecture specific files folder name
 if (CLR_CMAKE_TARGET_ARCH_AMD64)


### PR DESCRIPTION
I wasn't able to test it with docker (https://github.com/wolfcw/libfaketime/issues/437#issuecomment-2027835437), and attempts to emulate arm32 failed on osx-arm64 and win-x64. However, I can confirm that size of st_atime on Debian armel goes from 4 to 8 with _TIME_BITS=64 using this C program:

```c
// FILE: time.c
// COMMAND: cc -D_TIME_BITS=64 time.c
// PLATFORM: Debian armel

#include <sys/types.h>
#include <sys/stat.h>

#include <stdio.h>
#include <unistd.h>

int main(void)
{
    struct stat sb;

    printf("sizeof time_t: %zu\n", sizeof(time_t));
    printf("sizeof stat timestamp: %zu\n", sizeof(sb.st_atime));

    return 0;
}
``` 

Contributes to #96460 (pending confirmation once daily build is available)