### PR TITLE
Add OptRepeat phase start/end indications

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2903,9 +2903,12 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disCodeBytes = false;
 
 #ifdef OPT_CONFIG
-    opts.optRepeat      = false;
-    opts.optRepeatCount = 1;
+    opts.optRepeat = false;
 #endif // OPT_CONFIG
+
+    opts.optRepeatIteration = 0;
+    opts.optRepeatCount     = 1;
+    opts.optRepeatActive    = false;
 
 #ifdef DEBUG
     opts.dspInstrs       = false;
@@ -4993,7 +4996,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         bool doVNBasedIntrinExpansion  = true;
         bool doRangeAnalysis           = true;
         bool doVNBasedDeadStoreRemoval = true;
-        int  iterations                = 1;
 
 #if defined(OPT_CONFIG)
         doSsa                     = (JitConfig.JitDoSsa() != 0);
@@ -5008,15 +5010,25 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         doVNBasedIntrinExpansion  = doValueNum;
         doRangeAnalysis           = doAssertionProp && (JitConfig.JitDoRangeAnalysis() != 0);
         doVNBasedDeadStoreRemoval = doValueNum && (JitConfig.JitDoVNBasedDeadStoreRemoval() != 0);
-
-        if (opts.optRepeat)
-        {
-            iterations = opts.optRepeatCount;
-        }
 #endif // defined(OPT_CONFIG)
 
-        while (iterations > 0)
+#ifdef DEBUG
+        if (opts.optRepeat)
         {
+            opts.optRepeatActive = true;
+        }
+#endif // DEBUG
+
+        while (++opts.optRepeatIteration <= opts.optRepeatCount)
+        {
+#ifdef DEBUG
+            if (verbose && opts.optRepeat)
+            {
+                printf("\n*************** JitOptRepeat: iteration %d of %d\n\n", opts.optRepeatIteration,
+                       opts.optRepeatCount);
+            }
+#endif // DEBUG
+
             fgModified = false;
 
             if (doSsa)
@@ -5128,18 +5140,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
                 DoPhase(this, PHASE_COMPUTE_EDGE_WEIGHTS2, &Compiler::fgComputeEdgeWeights);
             }
 
-#ifdef DEBUG
-            if (verbose && opts.optRepeat)
-            {
-                printf("\n*************** JitOptRepeat: iterations remaining: %d\n\n", iterations - 1);
-            }
-#endif // DEBUG
-
             // Iterate if requested, resetting annotations first.
-            if (--iterations == 0)
+            if (opts.optRepeatIteration == opts.optRepeatCount)
             {
                 break;
             }
+
+            assert(opts.optRepeat);
 
             // We may have optimized away the canonical entry BB that SSA
             // depends on above, so if we are going for another iteration then
@@ -5158,6 +5165,13 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             }
 #endif // DEBUG
         }
+
+#ifdef DEBUG
+        if (opts.optRepeat)
+        {
+            opts.optRepeatActive = false;
+        }
+#endif // DEBUG
     }
 
     optLoopsCanonical = false;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9867,9 +9867,14 @@ public:
         bool altJit;     // True if we are an altjit and are compiling this method
 
 #ifdef OPT_CONFIG
-        bool optRepeat;      // Repeat optimizer phases k times
-        int  optRepeatCount; // How many times to repeat. By default, comes from JitConfig.JitOptRepeatCount().
+        bool optRepeat; // Repeat optimizer phases k times
 #endif
+
+        int optRepeatIteration; // The current optRepeat iteration: from 0 to optRepeatCount. optRepeatCount can be
+                                // zero, in which case no optimizations in the set of repeated optimizations are
+                                // performed. optRepeatIteration will only be zero if optRepeatCount is zero.
+        int  optRepeatCount;    // How many times to repeat. By default, comes from JitConfig.JitOptRepeatCount().
+        bool optRepeatActive;   // `true` if we are in the range of phases being repeated.
 
         bool disAsm;       // Display native code as it is generated
         bool disTesting;   // Display BEGIN METHOD/END METHOD anchors for disasm testing

--- a/src/coreclr/jit/phase.cpp
+++ b/src/coreclr/jit/phase.cpp
@@ -80,7 +80,15 @@ void Phase::PrePhase()
         }
         else
         {
-            printf("\n*************** Starting PHASE %s\n", m_name);
+            if (comp->opts.optRepeatActive)
+            {
+                printf("\n*************** Starting PHASE %s (OptRepeat iteration %d of %d)\n", m_name,
+                       comp->opts.optRepeatIteration, comp->opts.optRepeatCount);
+            }
+            else
+            {
+                printf("\n*************** Starting PHASE %s\n", m_name);
+            }
         }
     }
 #endif // DEBUG
@@ -124,7 +132,15 @@ void Phase::PostPhase(PhaseStatus status)
         }
         else
         {
-            printf("\n*************** Finishing PHASE %s%s\n", m_name, statusMessage);
+            if (comp->opts.optRepeatActive)
+            {
+                printf("\n*************** Finishing PHASE %s%s (OptRepeat iteration %d of %d)\n", m_name, statusMessage,
+                       comp->opts.optRepeatIteration, comp->opts.optRepeatCount);
+            }
+            else
+            {
+                printf("\n*************** Finishing PHASE %s%s\n", m_name, statusMessage);
+            }
         }
 
         if (doPostPhase && doPostPhaseDumps)


### PR DESCRIPTION
When OptRepeat is active, for phases that are being repeated, annotate the JitDump phase start/end output with the OptRepeat iteration number.