### PR TITLE
PEReader throws exception when using PEStreamOptions.PrefetchMetadata for some assemblies

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -201,7 +201,11 @@ namespace System.Reflection.PortableExecutable
                     {
                         // The peImage is left null, but the lazyMetadataBlock is initialized up front.
                         _lazyPEHeaders = new PEHeaders(peStream, actualSize, IsLoadedImage);
-                        _lazyMetadataBlock = StreamMemoryBlockProvider.ReadMemoryBlockNoLock(peStream, _lazyPEHeaders.MetadataStartOffset, _lazyPEHeaders.MetadataSize);
+
+                        if (_lazyPEHeaders.MetadataStartOffset != -1)
+                        {
+                            _lazyMetadataBlock = StreamMemoryBlockProvider.ReadMemoryBlockNoLock(peStream, _lazyPEHeaders.MetadataStartOffset, _lazyPEHeaders.MetadataSize);
+                        }
                     }
                     // We read all we need, the stream is going to be closed.
                 }

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEReaderTests.cs
@@ -870,5 +870,15 @@ namespace System.Reflection.PortableExecutable.Tests
                 }
             }
         }
+
+        [Fact]
+        public void HasMetadataShouldReturnFalseWhenPrefetchingMetadataOfImageWithoutMetadata()
+        {
+            using (var fileStream = new MemoryStream(Misc.KeyPair))
+            using (var peReader = new PEReader(fileStream, PEStreamOptions.PrefetchMetadata | PEStreamOptions.LeaveOpen))
+            {
+                Assert.False(peReader.HasMetadata);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #46344