### PR TITLE
Fix more diagnostics with CA2263

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             try
             {
-                return (ComTypes.TYPEATTR)Marshal.PtrToStructure(pAttrs, typeof(ComTypes.TYPEATTR));
+                return Marshal.PtrToStructure<ComTypes.TYPEATTR>(pAttrs);
             }
             finally
             {
@@ -200,7 +200,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             try
             {
-                return (ComTypes.TYPELIBATTR)Marshal.PtrToStructure(pAttrs, typeof(ComTypes.TYPELIBATTR));
+                return Marshal.PtrToStructure<ComTypes.TYPELIBATTR>(pAttrs);
             }
             finally
             {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComRuntimeHelpers.cs
@@ -166,7 +166,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             return typeInfo;
         }
 
-        internal static ComTypes.TYPEATTR GetTypeAttrForTypeInfo(ComTypes.ITypeInfo typeInfo)
+        internal static unsafe ComTypes.TYPEATTR GetTypeAttrForTypeInfo(ComTypes.ITypeInfo typeInfo)
         {
             IntPtr pAttrs;
             typeInfo.GetTypeAttr(out pAttrs);
@@ -179,7 +179,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             try
             {
-                return Marshal.PtrToStructure<ComTypes.TYPEATTR>(pAttrs);
+                return *(ComTypes.TYPEATTR*)pAttrs;
             }
             finally
             {
@@ -187,7 +187,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             }
         }
 
-        internal static ComTypes.TYPELIBATTR GetTypeAttrForTypeLib(ComTypes.ITypeLib typeLib)
+        internal static unsafe ComTypes.TYPELIBATTR GetTypeAttrForTypeLib(ComTypes.ITypeLib typeLib)
         {
             IntPtr pAttrs;
             typeLib.GetLibAttr(out pAttrs);
@@ -200,7 +200,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             try
             {
-                return Marshal.PtrToStructure<ComTypes.TYPELIBATTR>(pAttrs);
+                return *(ComTypes.TYPELIBATTR*)pAttrs;
             }
             finally
             {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComTypeEnumDesc.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
                 try
                 {
-                    varDesc = (ComTypes.VARDESC)Marshal.PtrToStructure(p, typeof(ComTypes.VARDESC));
+                    varDesc = Marshal.PtrToStructure<ComTypes.VARDESC>(p);
 
                     if (varDesc.varkind == ComTypes.VARKIND.VAR_CONST)
                     {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ExcepInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 #if DEBUG
         static ExcepInfo()
         {
-            Debug.Assert(Marshal.SizeOf(typeof(ExcepInfo)) == Marshal.SizeOf(typeof(ComTypes.EXCEPINFO)));
+            Debug.Assert(Marshal.SizeOf<ExcepInfo>() == Marshal.SizeOf<ComTypes.EXCEPINFO>());
         }
 #endif
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
@@ -328,7 +328,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
             return new IDispatchMetaObject(parameter, this);
         }
 
-        private static void GetFuncDescForDescIndex(ComTypes.ITypeInfo typeInfo, int funcIndex, out ComTypes.FUNCDESC funcDesc, out IntPtr funcDescHandle)
+        private static unsafe void GetFuncDescForDescIndex(ComTypes.ITypeInfo typeInfo, int funcIndex, out ComTypes.FUNCDESC funcDesc, out IntPtr funcDescHandle)
         {
             IntPtr pFuncDesc;
             typeInfo.GetFuncDesc(funcIndex, out pFuncDesc);
@@ -339,7 +339,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 throw Error.CannotRetrieveTypeInformation();
             }
 
-            funcDesc = Marshal.PtrToStructure<ComTypes.FUNCDESC>(pFuncDesc);
+            funcDesc = *(ComTypes.FUNCDESC*)pFuncDesc;
             funcDescHandle = pFuncDesc;
         }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/IDispatchComObject.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 throw Error.CannotRetrieveTypeInformation();
             }
 
-            funcDesc = (ComTypes.FUNCDESC)Marshal.PtrToStructure(pFuncDesc, typeof(ComTypes.FUNCDESC));
+            funcDesc = Marshal.PtrToStructure<ComTypes.FUNCDESC>(pFuncDesc);
             funcDescHandle = pFuncDesc;
         }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -1439,7 +1439,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             if (parameters.Length > 0)
             {
                 // See if we have a param array.
-                if (parameters[parameters.Length - 1].GetCustomAttribute(typeof(ParamArrayAttribute), false) != null)
+                if (parameters[parameters.Length - 1].GetCustomAttribute<ParamArrayAttribute>(false) != null)
                 {
                     methProp.isParamArray = true;
                 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedTransient(collection, typeof(TService), serviceKey, typeof(TService));
+            TryAddKeyedTransient<TService, TService>(collection, serviceKey);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedScoped(collection, typeof(TService), serviceKey, typeof(TService));
+            TryAddKeyedScoped<TService, TService>(collection, serviceKey);
         }
 
         /// <summary>
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedSingleton(collection, typeof(TService), serviceKey, typeof(TService));
+            TryAddKeyedSingleton<TService, TService>(collection, serviceKey);
         }
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             ThrowHelper.ThrowIfNull(collection);
             ThrowHelper.ThrowIfNull(instance);
 
-            var descriptor = ServiceDescriptor.KeyedSingleton(serviceType: typeof(TService), serviceKey, implementationInstance: instance);
+            var descriptor = ServiceDescriptor.KeyedSingleton(serviceKey, implementationInstance: instance);
             ServiceCollectionDescriptorExtensions.TryAdd(collection, descriptor);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.Keyed.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedTransient<TService, TService>(collection, serviceKey);
+            TryAddKeyedTransient(collection, typeof(TService), serviceKey, typeof(TService));
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedScoped<TService, TService>(collection, serviceKey);
+            TryAddKeyedScoped(collection, typeof(TService), serviceKey, typeof(TService));
         }
 
         /// <summary>
@@ -318,7 +318,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddKeyedSingleton<TService, TService>(collection, serviceKey);
+            TryAddKeyedSingleton(collection, typeof(TService), serviceKey, typeof(TService));
         }
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             ThrowHelper.ThrowIfNull(collection);
             ThrowHelper.ThrowIfNull(instance);
 
-            var descriptor = ServiceDescriptor.KeyedSingleton(serviceKey, implementationInstance: instance);
+            var descriptor = ServiceDescriptor.KeyedSingleton(serviceType: typeof(TService), serviceKey, implementationInstance: instance);
             ServiceCollectionDescriptorExtensions.TryAdd(collection, descriptor);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddTransient(collection, typeof(TService), typeof(TService));
+            TryAddTransient<TService, TService>(collection);
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddScoped(collection, typeof(TService), typeof(TService));
+            TryAddScoped<TService, TService>(collection);
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddSingleton(collection, typeof(TService), typeof(TService));
+            TryAddSingleton<TService, TService>(collection);
         }
 
         /// <summary>
@@ -412,7 +412,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             ThrowHelper.ThrowIfNull(collection);
             ThrowHelper.ThrowIfNull(instance);
 
-            var descriptor = ServiceDescriptor.Singleton(serviceType: typeof(TService), implementationInstance: instance);
+            var descriptor = ServiceDescriptor.Singleton(implementationInstance: instance);
             TryAdd(collection, descriptor);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddTransient<TService, TService>(collection);
+            TryAddTransient(collection, typeof(TService), typeof(TService));
         }
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddScoped<TService, TService>(collection);
+            TryAddScoped(collection, typeof(TService), typeof(TService));
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         {
             ThrowHelper.ThrowIfNull(collection);
 
-            TryAddSingleton<TService, TService>(collection);
+            TryAddSingleton(collection, typeof(TService), typeof(TService));
         }
 
         /// <summary>
@@ -412,7 +412,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             ThrowHelper.ThrowIfNull(collection);
             ThrowHelper.ThrowIfNull(instance);
 
-            var descriptor = ServiceDescriptor.Singleton(implementationInstance: instance);
+            var descriptor = ServiceDescriptor.Singleton(serviceType: typeof(TService), implementationInstance: instance);
             TryAdd(collection, descriptor);
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.Keyed.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.Keyed.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedTransient<TService>(serviceKey, implementationFactory);
+            return services.AddKeyedTransient(typeof(TService), serviceKey, implementationFactory);
         }
 
         /// <summary>
@@ -324,9 +324,8 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedScoped<TService>(serviceKey, implementationFactory);
+            return services.AddKeyedScoped(typeof(TService), serviceKey, implementationFactory);
         }
-
 
         /// <summary>
         /// Adds a singleton service of the type specified in <paramref name="serviceType"/> with an
@@ -434,7 +433,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ThrowHelper.ThrowIfNull(services);
 
-            return services.AddKeyedSingleton<TService, TService>(serviceKey);
+            return services.AddKeyedSingleton(typeof(TService), serviceKey, typeof(TService));
         }
 
         /// <summary>
@@ -483,7 +482,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedSingleton<TService>(serviceKey, implementationFactory);
+            return services.AddKeyedSingleton(typeof(TService), serviceKey, implementationFactory);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.Keyed.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.Keyed.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedTransient(typeof(TService), serviceKey, implementationFactory);
+            return services.AddKeyedTransient<TService>(serviceKey, implementationFactory);
         }
 
         /// <summary>
@@ -324,7 +324,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedScoped(typeof(TService), serviceKey, implementationFactory);
+            return services.AddKeyedScoped<TService>(serviceKey, implementationFactory);
         }
 
 
@@ -434,7 +434,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             ThrowHelper.ThrowIfNull(services);
 
-            return services.AddKeyedSingleton(typeof(TService), serviceKey, typeof(TService));
+            return services.AddKeyedSingleton<TService, TService>(serviceKey);
         }
 
         /// <summary>
@@ -483,7 +483,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddKeyedSingleton(typeof(TService), serviceKey, implementationFactory);
+            return services.AddKeyedSingleton<TService>(serviceKey, implementationFactory);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddTransient(typeof(TService), implementationFactory);
+            return services.AddTransient<TService>(implementationFactory);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddScoped(typeof(TService), implementationFactory);
+            return services.AddScoped<TService>(implementationFactory);
         }
 
 
@@ -435,7 +435,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddSingleton(typeof(TService), implementationFactory);
+            return services.AddSingleton<TService>(implementationFactory);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddTransient<TService>(implementationFactory);
+            return services.AddTransient(typeof(TService), implementationFactory);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddScoped<TService>(implementationFactory);
+            return services.AddScoped(typeof(TService), implementationFactory);
         }
 
 
@@ -435,7 +435,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ThrowHelper.ThrowIfNull(services);
             ThrowHelper.ThrowIfNull(implementationFactory);
 
-            return services.AddSingleton<TService>(implementationFactory);
+            return services.AddSingleton(typeof(TService), implementationFactory);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
+++ b/src/libraries/Microsoft.VisualBasic.Core/src/Microsoft/VisualBasic/FileIO/FileSystem.vb
@@ -892,7 +892,7 @@ Namespace Microsoft.VisualBasic.FileIO
         Private Shared Sub CopyOrMoveDirectory(ByVal operation As CopyOrMove,
                                                ByVal sourceDirectoryName As String, ByVal destinationDirectoryName As String,
                                                ByVal overwrite As Boolean, ByVal showUI As UIOptionInternal, ByVal onUserCancel As UICancelOption)
-            Debug.Assert(System.Enum.IsDefined(GetType(CopyOrMove), operation), "Invalid Operation")
+            Debug.Assert([Enum].IsDefined(operation), "Invalid Operation")
 
             ' Verify enums.
             VerifyUICancelOption("onUserCancel", onUserCancel)
@@ -961,7 +961,7 @@ Namespace Microsoft.VisualBasic.FileIO
         Private Shared Sub FxCopyOrMoveDirectory(ByVal operation As CopyOrMove,
                                                  ByVal sourceDirectoryPath As String, ByVal targetDirectoryPath As String, ByVal overwrite As Boolean)
 
-            Debug.Assert(System.Enum.IsDefined(GetType(CopyOrMove), operation), "Invalid Operation")
+            Debug.Assert([Enum].IsDefined(operation), "Invalid Operation")
             Debug.Assert(sourceDirectoryPath <> "" And IO.Path.IsPathRooted(sourceDirectoryPath), "Invalid Source")
             Debug.Assert(targetDirectoryPath <> "" And IO.Path.IsPathRooted(targetDirectoryPath), "Invalid Target")
 
@@ -1010,7 +1010,7 @@ Namespace Microsoft.VisualBasic.FileIO
         Private Shared Sub CopyOrMoveDirectoryNode(ByVal Operation As CopyOrMove,
                                                    ByVal SourceDirectoryNode As DirectoryNode, ByVal Overwrite As Boolean, ByVal Exceptions As ListDictionary)
 
-            Debug.Assert(System.Enum.IsDefined(GetType(CopyOrMove), Operation), "Invalid Operation")
+            Debug.Assert([Enum].IsDefined(Operation), "Invalid Operation")
             Debug.Assert(Exceptions IsNot Nothing, "Null exception list")
             Debug.Assert(SourceDirectoryNode IsNot Nothing, "Null source node")
 
@@ -1092,7 +1092,7 @@ Namespace Microsoft.VisualBasic.FileIO
                                           ByVal sourceFileName As String, ByVal destinationFileName As String,
                                           ByVal overwrite As Boolean, ByVal showUI As UIOptionInternal, ByVal onUserCancel As UICancelOption
                                           )
-            Debug.Assert(System.Enum.IsDefined(GetType(CopyOrMove), operation), "Invalid Operation")
+            Debug.Assert([Enum].IsDefined(operation), "Invalid Operation")
 
             ' Verify enums.
             VerifyUICancelOption("onUserCancel", onUserCancel)
@@ -1597,8 +1597,8 @@ Namespace Microsoft.VisualBasic.FileIO
         ''' </remarks>
         Private Shared Sub ShellCopyOrMove(ByVal Operation As CopyOrMove, ByVal TargetType As FileOrDirectory,
             ByVal FullSourcePath As String, ByVal FullTargetPath As String, ByVal ShowUI As UIOptionInternal, ByVal OnUserCancel As UICancelOption)
-            Debug.Assert(System.Enum.IsDefined(GetType(CopyOrMove), Operation))
-            Debug.Assert(System.Enum.IsDefined(GetType(FileOrDirectory), TargetType))
+            Debug.Assert([Enum].IsDefined(Operation))
+            Debug.Assert([Enum].IsDefined(TargetType))
             Debug.Assert(FullSourcePath <> "" And IO.Path.IsPathRooted(FullSourcePath), "Invalid FullSourcePath")
             Debug.Assert(FullTargetPath <> "" And IO.Path.IsPathRooted(FullTargetPath), "Invalid FullTargetPath")
             Debug.Assert(ShowUI <> UIOptionInternal.NoUI, "Why call ShellDelete if ShowUI is NoUI???")
@@ -1693,7 +1693,7 @@ Namespace Microsoft.VisualBasic.FileIO
         Private Shared Sub ShellFileOperation(ByVal OperationType As SHFileOperationType, ByVal OperationFlags As ShFileOperationFlags,
             ByVal FullSource As String, ByVal FullTarget As String, ByVal OnUserCancel As UICancelOption, ByVal FileOrDirectory As FileOrDirectory)
 
-            Debug.Assert(System.Enum.IsDefined(GetType(SHFileOperationType), OperationType))
+            Debug.Assert([Enum].IsDefined(OperationType))
             Debug.Assert(OperationType <> SHFileOperationType.FO_RENAME, "Don't call Shell to rename")
             Debug.Assert(FullSource <> "" And IO.Path.IsPathRooted(FullSource), "Invalid FullSource path")
             Debug.Assert(OperationType = SHFileOperationType.FO_DELETE OrElse (FullTarget <> "" And IO.Path.IsPathRooted(FullTarget)), "Invalid FullTarget path")
@@ -1750,7 +1750,7 @@ Namespace Microsoft.VisualBasic.FileIO
         Private Shared Function GetShellOperationInfo(
                             ByVal OperationType As SHFileOperationType, ByVal OperationFlags As ShFileOperationFlags,
                             ByVal SourcePaths() As String, Optional ByVal TargetPath As String = Nothing) As SHFILEOPSTRUCT
-            Debug.Assert(System.Enum.IsDefined(GetType(SHFileOperationType), OperationType), "Invalid OperationType")
+            Debug.Assert([Enum].IsDefined(OperationType), "Invalid OperationType")
             Debug.Assert(TargetPath = "" Or IO.Path.IsPathRooted(TargetPath), "Invalid TargetPath")
             Debug.Assert(SourcePaths IsNot Nothing AndAlso SourcePaths.Length > 0, "Invalid SourcePaths")
 

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BindingList.cs
@@ -312,7 +312,7 @@ namespace System.ComponentModel
         {
             // Allow event handler to supply the new item for us
             // If event handler did not supply new item, create one ourselves
-            object? newItem = FireAddingNew() ?? Activator.CreateInstance(typeof(T));
+            object? newItem = FireAddingNew() ?? Activator.CreateInstance<T>();
 
             // Add item to end of list. Note: If event handler returned an item not of type T,
             // the cast below will trigger an InvalidCastException. This is by design.

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SidList.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SidList.cs
@@ -157,8 +157,8 @@ namespace System.DirectoryServices.AccountManagement
 
                 for (int i = 0; i < domainCount; i++)
                 {
-                    domains[i] = (Interop.LSA_TRUST_INFORMATION)Marshal.PtrToStructure(pCurrentDomain, typeof(Interop.LSA_TRUST_INFORMATION));
-                    pCurrentDomain = new IntPtr(pCurrentDomain.ToInt64() + Marshal.SizeOf(typeof(Interop.LSA_TRUST_INFORMATION)));
+                    domains[i] = Marshal.PtrToStructure<Interop.LSA_TRUST_INFORMATION>(pCurrentDomain);
+                    pCurrentDomain = new IntPtr(pCurrentDomain.ToInt64() + Marshal.SizeOf<Interop.LSA_TRUST_INFORMATION>());
                 }
 
                 GlobalDebug.WriteLineIf(GlobalDebug.Info, "AuthZSet", "SidList: got {0} groups in {1} domains", sidCount, domainCount);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SidList.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/SidList.cs
@@ -62,7 +62,7 @@ namespace System.DirectoryServices.AccountManagement
             TranslateSids(null, pSids);
         }
 
-        private void TranslateSids(string target, IntPtr[] pSids)
+        private unsafe void TranslateSids(string target, IntPtr[] pSids)
         {
             GlobalDebug.WriteLineIf(GlobalDebug.Info, "AuthZSet", "SidList: processing {0} SIDs", pSids.Length);
 
@@ -157,8 +157,8 @@ namespace System.DirectoryServices.AccountManagement
 
                 for (int i = 0; i < domainCount; i++)
                 {
-                    domains[i] = Marshal.PtrToStructure<Interop.LSA_TRUST_INFORMATION>(pCurrentDomain);
-                    pCurrentDomain = new IntPtr(pCurrentDomain.ToInt64() + Marshal.SizeOf<Interop.LSA_TRUST_INFORMATION>());
+                    domains[i] = *(Interop.LSA_TRUST_INFORMATION*)pCurrentDomain;
+                    pCurrentDomain += sizeof(Interop.LSA_TRUST_INFORMATION);
                 }
 
                 GlobalDebug.WriteLineIf(GlobalDebug.Info, "AuthZSet", "SidList: got {0} groups in {1} domains", sidCount, domainCount);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
@@ -131,7 +131,7 @@ namespace System.DirectoryServices.AccountManagement
 
                                 // Extract TOKEN_GROUPS.GroupCount
 
-                                Interop.TOKEN_GROUPS tokenGroups = Marshal.PtrToStructure<Interop.TOKEN_GROUPS>(pBuffer);
+                                Interop.TOKEN_GROUPS tokenGroups = *(Interop.TOKEN_GROUPS*)pBuffer;
 
                                 uint groupCount = tokenGroups.GroupCount;
 
@@ -141,13 +141,13 @@ namespace System.DirectoryServices.AccountManagement
                                 // each native SID_AND_ATTRIBUTES into a managed SID_AND_ATTR.
                                 Interop.SID_AND_ATTRIBUTES[] groups = new Interop.SID_AND_ATTRIBUTES[groupCount];
 
-                                IntPtr currentItem = new IntPtr(pBuffer.ToInt64() + Marshal.SizeOf<Interop.TOKEN_GROUPS>() - sizeof(Interop.SID_AND_ATTRIBUTES));
+                                IntPtr currentItem = pBuffer + sizeof(Interop.TOKEN_GROUPS) - sizeof(Interop.SID_AND_ATTRIBUTES);
 
                                 for (int i = 0; i < groupCount; i++)
                                 {
-                                    groups[i] = Marshal.PtrToStructure<Interop.SID_AND_ATTRIBUTES>(currentItem);
+                                    groups[i] = *(Interop.SID_AND_ATTRIBUTES*)currentItem;
 
-                                    currentItem = new IntPtr(currentItem.ToInt64() + Marshal.SizeOf<Interop.SID_AND_ATTRIBUTES>());
+                                    currentItem += sizeof(Interop.SID_AND_ATTRIBUTES);
                                 }
 
                                 _groupSidList = new SidList(groups);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AuthZSet.cs
@@ -131,7 +131,7 @@ namespace System.DirectoryServices.AccountManagement
 
                                 // Extract TOKEN_GROUPS.GroupCount
 
-                                Interop.TOKEN_GROUPS tokenGroups = (Interop.TOKEN_GROUPS)Marshal.PtrToStructure(pBuffer, typeof(Interop.TOKEN_GROUPS));
+                                Interop.TOKEN_GROUPS tokenGroups = Marshal.PtrToStructure<Interop.TOKEN_GROUPS>(pBuffer);
 
                                 uint groupCount = tokenGroups.GroupCount;
 
@@ -141,13 +141,13 @@ namespace System.DirectoryServices.AccountManagement
                                 // each native SID_AND_ATTRIBUTES into a managed SID_AND_ATTR.
                                 Interop.SID_AND_ATTRIBUTES[] groups = new Interop.SID_AND_ATTRIBUTES[groupCount];
 
-                                IntPtr currentItem = new IntPtr(pBuffer.ToInt64() + Marshal.SizeOf(typeof(Interop.TOKEN_GROUPS)) - sizeof(Interop.SID_AND_ATTRIBUTES));
+                                IntPtr currentItem = new IntPtr(pBuffer.ToInt64() + Marshal.SizeOf<Interop.TOKEN_GROUPS>() - sizeof(Interop.SID_AND_ATTRIBUTES));
 
                                 for (int i = 0; i < groupCount; i++)
                                 {
-                                    groups[i] = (Interop.SID_AND_ATTRIBUTES)Marshal.PtrToStructure(currentItem, typeof(Interop.SID_AND_ATTRIBUTES));
+                                    groups[i] = Marshal.PtrToStructure<Interop.SID_AND_ATTRIBUTES>(currentItem);
 
-                                    currentItem = new IntPtr(currentItem.ToInt64() + Marshal.SizeOf(typeof(Interop.SID_AND_ATTRIBUTES)));
+                                    currentItem = new IntPtr(currentItem.ToInt64() + Marshal.SizeOf<Interop.SID_AND_ATTRIBUTES>());
                                 }
 
                                 _groupSidList = new SidList(groups);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/SAM/SAMStoreCtx.cs
@@ -1053,7 +1053,7 @@ namespace System.DirectoryServices.AccountManagement
                 if (err == 0)
                 {
                     UnsafeNativeMethods.WKSTA_INFO_100 wkstaInfo =
-                        (UnsafeNativeMethods.WKSTA_INFO_100)Marshal.PtrToStructure(buffer, typeof(UnsafeNativeMethods.WKSTA_INFO_100));
+                        Marshal.PtrToStructure<UnsafeNativeMethods.WKSTA_INFO_100>(buffer);
 
                     _machineFlatName = wkstaInfo.wki100_computername;
                     GlobalDebug.WriteLineIf(GlobalDebug.Info, "SAMStoreCtx", "LoadComputerInfo: machineFlatName={0}", _machineFlatName);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
@@ -198,15 +198,14 @@ namespace System.DirectoryServices.AccountManagement
         }
 
 
-        internal static SidType ClassifySID(IntPtr pSid)
+        internal static unsafe SidType ClassifySID(IntPtr pSid)
         {
             Debug.Assert(Interop.Advapi32.IsValidSid(pSid));
 
             // Get the issuing authority and the first RID
             IntPtr pIdentAuth = Interop.Advapi32.GetSidIdentifierAuthority(pSid);
 
-            Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth =
-                Marshal.PtrToStructure<Interop.Advapi32.SID_IDENTIFIER_AUTHORITY>(pIdentAuth);
+            Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth = *(Interop.Advapi32.SID_IDENTIFIER_AUTHORITY*)pIdentAuth;
 
             IntPtr pRid = Interop.Advapi32.GetSidSubAuthority(pSid, 0);
             int rid = Marshal.ReadInt32(pRid);
@@ -333,7 +332,7 @@ namespace System.DirectoryServices.AccountManagement
         }
 
 
-        internal static IntPtr GetCurrentUserSid()
+        internal static unsafe IntPtr GetCurrentUserSid()
         {
             SafeTokenHandle tokenHandle = null;
             IntPtr pBuffer = IntPtr.Zero;
@@ -425,7 +424,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 // Retrieve the user's SID from the user info
-                Interop.TOKEN_USER tokenUser = Marshal.PtrToStructure<Interop.TOKEN_USER>(pBuffer);
+                Interop.TOKEN_USER tokenUser = *(Interop.TOKEN_USER*)pBuffer;
                 IntPtr pUserSid = tokenUser.sidAndAttributes.Sid;   // this is a reference into the NATIVE memory (into pBuffer)
 
                 Debug.Assert(Interop.Advapi32.IsValidSid(pUserSid));
@@ -457,7 +456,7 @@ namespace System.DirectoryServices.AccountManagement
         }
 
 
-        internal static IntPtr GetMachineDomainSid()
+        internal static unsafe IntPtr GetMachineDomainSid()
         {
             SafeLsaPolicyHandle policyHandle = null;
             IntPtr pBuffer = IntPtr.Zero;
@@ -496,7 +495,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 Debug.Assert(pBuffer != IntPtr.Zero);
-                UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO info = Marshal.PtrToStructure<UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO>(pBuffer);
+                UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO info = *(UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO*)pBuffer;
 
                 Debug.Assert(Interop.Advapi32.IsValidSid(info.DomainSid));
 

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/Utils.cs
@@ -206,7 +206,7 @@ namespace System.DirectoryServices.AccountManagement
             IntPtr pIdentAuth = Interop.Advapi32.GetSidIdentifierAuthority(pSid);
 
             Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth =
-                (Interop.Advapi32.SID_IDENTIFIER_AUTHORITY)Marshal.PtrToStructure(pIdentAuth, typeof(Interop.Advapi32.SID_IDENTIFIER_AUTHORITY));
+                Marshal.PtrToStructure<Interop.Advapi32.SID_IDENTIFIER_AUTHORITY>(pIdentAuth);
 
             IntPtr pRid = Interop.Advapi32.GetSidSubAuthority(pSid, 0);
             int rid = Marshal.ReadInt32(pRid);
@@ -425,7 +425,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 // Retrieve the user's SID from the user info
-                Interop.TOKEN_USER tokenUser = (Interop.TOKEN_USER)Marshal.PtrToStructure(pBuffer, typeof(Interop.TOKEN_USER));
+                Interop.TOKEN_USER tokenUser = Marshal.PtrToStructure<Interop.TOKEN_USER>(pBuffer);
                 IntPtr pUserSid = tokenUser.sidAndAttributes.Sid;   // this is a reference into the NATIVE memory (into pBuffer)
 
                 Debug.Assert(Interop.Advapi32.IsValidSid(pUserSid));
@@ -496,8 +496,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 Debug.Assert(pBuffer != IntPtr.Zero);
-                UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO info = (UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO)
-                                    Marshal.PtrToStructure(pBuffer, typeof(UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO));
+                UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO info = Marshal.PtrToStructure<UnsafeNativeMethods.POLICY_ACCOUNT_DOMAIN_INFO>(pBuffer);
 
                 Debug.Assert(Interop.Advapi32.IsValidSid(info.DomainSid));
 
@@ -570,7 +569,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 UnsafeNativeMethods.DomainControllerInfo domainControllerInfo =
-                    (UnsafeNativeMethods.DomainControllerInfo)Marshal.PtrToStructure(domainControllerInfoPtr, typeof(UnsafeNativeMethods.DomainControllerInfo));
+                    Marshal.PtrToStructure<UnsafeNativeMethods.DomainControllerInfo>(domainControllerInfoPtr);
 
                 return domainControllerInfo;
             }
@@ -802,7 +801,7 @@ namespace System.DirectoryServices.AccountManagement
                 }
 
                 UnsafeNativeMethods.DSROLE_PRIMARY_DOMAIN_INFO_BASIC dsRolePrimaryDomainInfo =
-                    (UnsafeNativeMethods.DSROLE_PRIMARY_DOMAIN_INFO_BASIC)Marshal.PtrToStructure(dsRoleInfoPtr, typeof(UnsafeNativeMethods.DSROLE_PRIMARY_DOMAIN_INFO_BASIC));
+                    Marshal.PtrToStructure<UnsafeNativeMethods.DSROLE_PRIMARY_DOMAIN_INFO_BASIC>(dsRoleInfoPtr);
 
                 return (dsRolePrimaryDomainInfo.MachineRole == UnsafeNativeMethods.DSROLE_MACHINE_ROLE.DsRole_RoleBackupDomainController ||
                              dsRolePrimaryDomainInfo.MachineRole == UnsafeNativeMethods.DSROLE_MACHINE_ROLE.DsRole_RolePrimaryDomainController);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/BerConverter.cs
@@ -527,7 +527,7 @@ namespace System.DirectoryServices.Protocols
                 {
                     int i = 0;
                     berValArray = Utility.AllocHGlobalIntPtrArray(tempValue.Length + 1);
-                    int structSize = Marshal.SizeOf(typeof(BerVal));
+                    int structSize = Marshal.SizeOf<BerVal>();
                     managedBervalArray = new BerVal[tempValue.Length];
                     void** pBerValArray = (void**)berValArray;
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/common/DirectoryControl.cs
@@ -716,7 +716,7 @@ namespace System.DirectoryServices.Protocols
             }
 
             IntPtr control = IntPtr.Zero;
-            int structSize = Marshal.SizeOf(typeof(SortKeyInterop));
+            int structSize = Marshal.SizeOf<SortKeyInterop>();
             int keyCount = nativeSortKeys.Length;
             IntPtr memHandle = Utility.AllocHGlobalIntPtrArray(keyCount + 1);
 

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -544,7 +544,7 @@ namespace System.DirectoryServices.Protocols
             {
                 // Build server control.
                 managedServerControls = BuildControlArray(request.Controls, true);
-                int structSize = Marshal.SizeOf(typeof(LdapControl));
+                int structSize = Marshal.SizeOf<LdapControl>();
 
                 if (managedServerControls != null)
                 {
@@ -658,7 +658,7 @@ namespace System.DirectoryServices.Protocols
                     addModCount = (modifications == null ? 1 : modifications.Length + 1);
                     modArray = Utility.AllocHGlobalIntPtrArray(addModCount);
                     void** pModArray = (void**)modArray;
-                    int modStructSize = Marshal.SizeOf(typeof(LdapMod));
+                    int modStructSize = Marshal.SizeOf<LdapMod>();
                     int i = 0;
                     for (i = 0; i < addModCount - 1; i++)
                     {
@@ -918,12 +918,12 @@ namespace System.DirectoryServices.Protocols
             var list = new ArrayList();
             if (CAs != IntPtr.Zero)
             {
-                SecPkgContext_IssuerListInfoEx trustedCAs = (SecPkgContext_IssuerListInfoEx)Marshal.PtrToStructure(CAs, typeof(SecPkgContext_IssuerListInfoEx));
+                SecPkgContext_IssuerListInfoEx trustedCAs = Marshal.PtrToStructure<SecPkgContext_IssuerListInfoEx>(CAs);
                 int issuerNumber = trustedCAs.cIssuers;
                 for (int i = 0; i < issuerNumber; i++)
                 {
-                    IntPtr tempPtr = (IntPtr)((byte*)trustedCAs.aIssuers + Marshal.SizeOf(typeof(CRYPTOAPI_BLOB)) * (nint)i);
-                    CRYPTOAPI_BLOB info = (CRYPTOAPI_BLOB)Marshal.PtrToStructure(tempPtr, typeof(CRYPTOAPI_BLOB));
+                    IntPtr tempPtr = (IntPtr)((byte*)trustedCAs.aIssuers + Marshal.SizeOf<CRYPTOAPI_BLOB>() * (nint)i);
+                    CRYPTOAPI_BLOB info = Marshal.PtrToStructure<CRYPTOAPI_BLOB>(tempPtr);
                     int dataLength = info.cbData;
 
                     byte[] context = new byte[dataLength];
@@ -1077,7 +1077,7 @@ namespace System.DirectoryServices.Protocols
                 var cred = new SEC_WINNT_AUTH_IDENTITY_EX()
                 {
                     version = Interop.SEC_WINNT_AUTH_IDENTITY_VERSION,
-                    length = Marshal.SizeOf(typeof(SEC_WINNT_AUTH_IDENTITY_EX)),
+                    length = Marshal.SizeOf<SEC_WINNT_AUTH_IDENTITY_EX>(),
                     flags = Interop.SEC_WINNT_AUTH_IDENTITY_UNICODE
                 };
                 if (AuthType == AuthType.Kerberos)
@@ -1342,7 +1342,7 @@ namespace System.DirectoryServices.Protocols
 
                     attributes[i].values = Utility.AllocHGlobalIntPtrArray(valuesCount + 1);
                     void** pAttributesValues = (void**)attributes[i].values;
-                    int structSize = Marshal.SizeOf(typeof(BerVal));
+                    int structSize = Marshal.SizeOf<BerVal>();
                     IntPtr controlPtr;
 
                     int m;

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -918,12 +918,12 @@ namespace System.DirectoryServices.Protocols
             var list = new ArrayList();
             if (CAs != IntPtr.Zero)
             {
-                SecPkgContext_IssuerListInfoEx trustedCAs = Marshal.PtrToStructure<SecPkgContext_IssuerListInfoEx>(CAs);
+                SecPkgContext_IssuerListInfoEx trustedCAs = *(SecPkgContext_IssuerListInfoEx*)CAs;
                 int issuerNumber = trustedCAs.cIssuers;
                 for (int i = 0; i < issuerNumber; i++)
                 {
-                    IntPtr tempPtr = (IntPtr)((byte*)trustedCAs.aIssuers + Marshal.SizeOf<CRYPTOAPI_BLOB>() * (nint)i);
-                    CRYPTOAPI_BLOB info = Marshal.PtrToStructure<CRYPTOAPI_BLOB>(tempPtr);
+                    IntPtr tempPtr = (IntPtr)((byte*)trustedCAs.aIssuers + sizeof(CRYPTOAPI_BLOB) * (nint)i);
+                    CRYPTOAPI_BLOB info = *(CRYPTOAPI_BLOB*)tempPtr;
                     int dataLength = info.cbData;
 
                     byte[] context = new byte[dataLength];

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.cs
@@ -555,7 +555,7 @@ namespace System.DirectoryServices.Protocols
             {
                 // build server control
                 managedServerControls = LdapConnection.BuildControlArray(controls, true);
-                int structSize = Marshal.SizeOf(typeof(LdapControl));
+                int structSize = Marshal.SizeOf<LdapControl>();
                 if (managedServerControls != null)
                 {
                     serverControlArray = Utility.AllocHGlobalIntPtrArray(managedServerControls.Length + 1);
@@ -848,7 +848,7 @@ namespace System.DirectoryServices.Protocols
         {
             LdapReferralCallback value = new LdapReferralCallback()
             {
-                sizeofcallback = Marshal.SizeOf(typeof(LdapReferralCallback)),
+                sizeofcallback = Marshal.SizeOf<LdapReferralCallback>(),
                 query = tempCallback.QueryForConnection == null ? null : _queryDelegate,
                 notify = tempCallback.NotifyNewConnection == null ? null : _notifiyDelegate,
                 dereference = tempCallback.DereferenceConnection == null ? null : _dereferenceDelegate

--- a/src/libraries/System.DirectoryServices/src/Interop/EnumVariant.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/EnumVariant.cs
@@ -58,10 +58,10 @@ namespace System.DirectoryServices
             /// Moves the pointer to the next value In the contained IEnumVariant, and
             /// stores the current value In currentValue.
             /// </devdoc>
-            private void Advance()
+            private unsafe void Advance()
             {
                 _currentValue = s_noMoreValues;
-                IntPtr addr = Marshal.AllocCoTaskMem(Marshal.SizeOf<Variant>());
+                IntPtr addr = Marshal.AllocCoTaskMem(sizeof(Variant));
                 try
                 {
                     int[] numRead = new int[] { 0 };

--- a/src/libraries/System.DirectoryServices/src/Interop/EnumVariant.cs
+++ b/src/libraries/System.DirectoryServices/src/Interop/EnumVariant.cs
@@ -61,7 +61,7 @@ namespace System.DirectoryServices
             private void Advance()
             {
                 _currentValue = s_noMoreValues;
-                IntPtr addr = Marshal.AllocCoTaskMem(Marshal.SizeOf(typeof(Variant)));
+                IntPtr addr = Marshal.AllocCoTaskMem(Marshal.SizeOf<Variant>());
                 try
                 {
                     int[] numRead = new int[] { 0 };

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectoryReplicationMetaData.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectoryReplicationMetaData.cs
@@ -64,14 +64,14 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 if (advanced)
                 {
-                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_ATTR_META_DATA_2)));
+                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_ATTR_META_DATA_2>());
 
                     AttributeMetadata managedMetaData = new AttributeMetadata(addr, true, _server, _nameTable);
                     Add(managedMetaData.Name, managedMetaData);
                 }
                 else
                 {
-                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_ATTR_META_DATA)));
+                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_ATTR_META_DATA>());
 
                     AttributeMetadata managedMetaData = new AttributeMetadata(addr, false, _server, _nameTable);
                     Add(managedMetaData.Name, managedMetaData);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
@@ -1302,7 +1302,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 DomainController dc = DomainController.GetDomainController(Utils.GetNewDirectoryContext(serverName, DirectoryContextType.DirectoryServer, context));
                 IntPtr handle = dc.Handle;
 
-                Debug.Assert(handle != (IntPtr)0);
+                Debug.Assert(handle != 0);
 
                 void* pDomains = null;
                 // call DsReplicaSyncAllW
@@ -1327,8 +1327,8 @@ namespace System.DirectoryServices.ActiveDirectory
                     IntPtr val = names.rItems;
                     if (count > 0)
                     {
-                        Debug.Assert(val != (IntPtr)0);
-                        IntPtr tmpPtr = (IntPtr)0;
+                        Debug.Assert(val != 0);
+                        IntPtr tmpPtr = 0;
                         for (int i = 0; i < count; i++)
                         {
                             tmpPtr = IntPtr.Add(val, Marshal.SizeOf<DS_NAME_RESULT_ITEM>() * i);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ActiveDirectorySite.cs
@@ -1331,7 +1331,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         IntPtr tmpPtr = (IntPtr)0;
                         for (int i = 0; i < count; i++)
                         {
-                            tmpPtr = IntPtr.Add(val, Marshal.SizeOf(typeof(DS_NAME_RESULT_ITEM)) * i);
+                            tmpPtr = IntPtr.Add(val, Marshal.SizeOf<DS_NAME_RESULT_ITEM>() * i);
                             DS_NAME_RESULT_ITEM nameResult = new DS_NAME_RESULT_ITEM();
                             Marshal.PtrToStructure(tmpPtr, nameResult);
                             if (nameResult.status == DS_NAME_ERROR.DS_NAME_NO_ERROR || nameResult.status == DS_NAME_ERROR.DS_NAME_ERROR_DOMAIN_ONLY)

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
@@ -692,8 +692,8 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal unsafe void SyncReplicaHelper(IntPtr dsHandle, bool isADAM, string partition, string? sourceServer, int option, SafeLibraryHandle libHandle)
         {
-            int structSize = Marshal.SizeOf<Guid>();
-            IntPtr unmanagedGuid = (IntPtr)0;
+            int structSize = sizeof(Guid);
+            IntPtr unmanagedGuid = 0;
             Guid guid = Guid.Empty;
             AdamInstance? adamServer = null;
             DomainController? dcServer = null;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/DirectoryServer.cs
@@ -692,7 +692,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
         internal unsafe void SyncReplicaHelper(IntPtr dsHandle, bool isADAM, string partition, string? sourceServer, int option, SafeLibraryHandle libHandle)
         {
-            int structSize = Marshal.SizeOf(typeof(Guid));
+            int structSize = Marshal.SizeOf<Guid>();
             IntPtr unmanagedGuid = (IntPtr)0;
             Guid guid = Guid.Empty;
             AdamInstance? adamServer = null;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -114,7 +114,7 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 try
                 {
-                    IntPtr ptr = (IntPtr)0;
+                    IntPtr ptr = 0;
                     fileTime = Marshal.AllocHGlobal(Marshal.SizeOf<FileTime>());
                     Interop.Kernel32.GetSystemTimeAsFileTime(fileTime);
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ForestTrustRelationshipInformation.cs
@@ -115,7 +115,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 try
                 {
                     IntPtr ptr = (IntPtr)0;
-                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileTime)));
+                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf<FileTime>());
                     Interop.Kernel32.GetSystemTimeAsFileTime(fileTime);
 
                     // set the time
@@ -134,7 +134,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         ptrList.Add(ptr);
                         Interop.NtDll.RtlInitUnicodeString(out record.TopLevelName, ptr);
 
-                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
+                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_FOREST_TRUST_RECORD>());
                         ptrList.Add(tmpPtr);
                         Marshal.StructureToPtr(record, tmpPtr, false);
 
@@ -163,7 +163,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         ptr = Marshal.StringToHGlobalUni(_excludedNames[i]);
                         ptrList.Add(ptr);
                         Interop.NtDll.RtlInitUnicodeString(out record.TopLevelName, ptr);
-                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
+                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_FOREST_TRUST_RECORD>());
                         ptrList.Add(tmpPtr);
                         Marshal.StructureToPtr(record, tmpPtr, false);
 
@@ -196,7 +196,7 @@ namespace System.DirectoryServices.ActiveDirectory
                         ptrList.Add(record.DomainInfo.NetBIOSNameBuffer);
                         record.DomainInfo.NetBIOSNameLength = (short)(tmp.NetBiosName == null ? 0 : tmp.NetBiosName.Length * 2);
                         record.DomainInfo.NetBIOSNameMaximumLength = (short)(tmp.NetBiosName == null ? 0 : tmp.NetBiosName.Length * 2);
-                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
+                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_FOREST_TRUST_RECORD>());
                         ptrList.Add(tmpPtr);
                         Marshal.StructureToPtr(record, tmpPtr, false);
 
@@ -222,7 +222,7 @@ namespace System.DirectoryServices.ActiveDirectory
                             ptrList.Add(record.Data.Buffer);
                             Marshal.Copy((byte[])_binaryData[i]!, 0, record.Data.Buffer, record.Data.Length);
                         }
-                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_RECORD)));
+                        tmpPtr = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_FOREST_TRUST_RECORD>());
                         ptrList.Add(tmpPtr);
                         Marshal.StructureToPtr(record, tmpPtr, false);
 
@@ -235,7 +235,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     LSA_FOREST_TRUST_INFORMATION trustInformation = new LSA_FOREST_TRUST_INFORMATION();
                     trustInformation.RecordCount = count;
                     trustInformation.Entries = records;
-                    forestInfo = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_FOREST_TRUST_INFORMATION)));
+                    forestInfo = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_FOREST_TRUST_INFORMATION>());
                     Marshal.StructureToPtr(trustInformation, forestInfo, false);
 
                     // get policy server name

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationCursorCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationCursorCollection.cs
@@ -49,7 +49,7 @@ namespace System.DirectoryServices.ActiveDirectory
             else
                 count = ((DS_REPL_CURSORS)cursors).cNumCursors;
 
-            IntPtr addr = (IntPtr)0;
+            IntPtr addr = 0;
 
             for (int i = 0; i < count; i++)
             {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationCursorCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationCursorCollection.cs
@@ -55,7 +55,7 @@ namespace System.DirectoryServices.ActiveDirectory
             {
                 if (advanced)
                 {
-                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_CURSOR_3)));
+                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_CURSOR_3>());
                     DS_REPL_CURSOR_3 cursor = new DS_REPL_CURSOR_3();
                     Marshal.PtrToStructure(addr, cursor);
 
@@ -69,7 +69,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
                 else
                 {
-                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_CURSOR)));
+                    addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_CURSOR>());
                     DS_REPL_CURSOR cursor = new DS_REPL_CURSOR();
                     Marshal.PtrToStructure(addr, cursor);
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationFailureCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationFailureCollection.cs
@@ -52,7 +52,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
             for (int i = 0; i < count; i++)
             {
-                addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_KCC_DSA_FAILURE)));
+                addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_KCC_DSA_FAILURE>());
 
                 ReplicationFailure managedFailure = new ReplicationFailure(addr, _server, _nameTable);
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationFailureCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationFailureCollection.cs
@@ -48,7 +48,7 @@ namespace System.DirectoryServices.ActiveDirectory
             // get the count
             int count = failures.cNumEntries;
 
-            IntPtr addr = (IntPtr)0;
+            IntPtr addr = 0;
 
             for (int i = 0; i < count; i++)
             {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationNeighborCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationNeighborCollection.cs
@@ -48,7 +48,7 @@ namespace System.DirectoryServices.ActiveDirectory
             // get the count
             int count = neighbors.cNumNeighbors;
 
-            IntPtr addr = (IntPtr)0;
+            IntPtr addr = 0;
 
             for (int i = 0; i < count; i++)
             {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationNeighborCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationNeighborCollection.cs
@@ -52,7 +52,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
             for (int i = 0; i < count; i++)
             {
-                addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf(typeof(DS_REPL_NEIGHBOR)));
+                addr = IntPtr.Add(info, sizeof(int) * 2 + i * Marshal.SizeOf<DS_REPL_NEIGHBOR>());
 
                 ReplicationNeighbor managedNeighbor = new ReplicationNeighbor(addr, _server, _nameTable);
 

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationOperationCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationOperationCollection.cs
@@ -52,7 +52,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
             for (int i = 0; i < count; i++)
             {
-                addr = IntPtr.Add(info, Marshal.SizeOf(typeof(DS_REPL_PENDING_OPS)) + i * Marshal.SizeOf(typeof(DS_REPL_OP)));
+                addr = IntPtr.Add(info, Marshal.SizeOf<DS_REPL_PENDING_OPS>() + i * Marshal.SizeOf<DS_REPL_OP>());
                 ReplicationOperation managedOperation = new ReplicationOperation(addr, _server, _nameTable);
 
                 Add(managedOperation);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationOperationCollection.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/ReplicationOperationCollection.cs
@@ -48,7 +48,7 @@ namespace System.DirectoryServices.ActiveDirectory
             // get the count
             int count = operations.cNumPendingOps;
 
-            IntPtr addr = (IntPtr)0;
+            IntPtr addr = 0;
 
             for (int i = 0; i < count; i++)
             {

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
@@ -220,7 +220,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     }
 
                     // reconstruct the unmanaged structure to set it back
-                    newInfo = Marshal.AllocHGlobal(Marshal.SizeOf<Interop.Advapi32.TRUSTED_DOMAIN_INFORMATION_EX>());
+                    newInfo = Marshal.AllocHGlobal(sizeof(Interop.Advapi32.TRUSTED_DOMAIN_INFORMATION_EX));
                     Marshal.StructureToPtr(domainInfo, newInfo, false);
 
                     result = Interop.Advapi32.LsaSetTrustedDomainInfoByName(handle, trustedDomainName, Interop.Advapi32.TRUSTED_INFORMATION_CLASS.TrustedDomainInformationEx, newInfo);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/TrustHelper.cs
@@ -220,7 +220,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     }
 
                     // reconstruct the unmanaged structure to set it back
-                    newInfo = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(Interop.Advapi32.TRUSTED_DOMAIN_INFORMATION_EX)));
+                    newInfo = Marshal.AllocHGlobal(Marshal.SizeOf<Interop.Advapi32.TRUSTED_DOMAIN_INFORMATION_EX>());
                     Marshal.StructureToPtr(domainInfo, newInfo, false);
 
                     result = Interop.Advapi32.LsaSetTrustedDomainInfoByName(handle, trustedDomainName, Interop.Advapi32.TRUSTED_INFORMATION_CLASS.TrustedDomainInformationEx, newInfo);
@@ -462,7 +462,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     Marshal.PtrToStructure(info, domainInfo);
 
                     AuthData = new LSA_AUTH_INFORMATION();
-                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileTime)));
+                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf<FileTime>());
                     Interop.Kernel32.GetSystemTimeAsFileTime(fileTime);
 
                     // set the time
@@ -477,7 +477,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     AuthData.AuthInfo = unmanagedPassword;
                     AuthData.AuthInfoLength = password.Length * 2;          // sizeof(WCHAR)
 
-                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_AUTH_INFORMATION)));
+                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_AUTH_INFORMATION>());
                     Marshal.StructureToPtr(AuthData, unmanagedAuthData, false);
 
                     Interop.Advapi32.TRUSTED_DOMAIN_AUTH_INFORMATION AuthInfoEx = default;
@@ -616,7 +616,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
                     // change the attribute value properly
                     AuthData = new LSA_AUTH_INFORMATION();
-                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileTime)));
+                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf<FileTime>());
                     Interop.Kernel32.GetSystemTimeAsFileTime(fileTime);
 
                     // set the time
@@ -631,7 +631,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     AuthData.AuthInfo = unmanagedPassword;
                     AuthData.AuthInfoLength = password.Length * 2;
 
-                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_AUTH_INFORMATION)));
+                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_AUTH_INFORMATION>());
                     Marshal.StructureToPtr(AuthData, unmanagedAuthData, false);
 
                     Interop.Advapi32.TRUSTED_DOMAIN_AUTH_INFORMATION AuthInfoEx = default;
@@ -743,7 +743,7 @@ namespace System.DirectoryServices.ActiveDirectory
 
                     // change the attribute value properly
                     AuthData = new LSA_AUTH_INFORMATION();
-                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(FileTime)));
+                    fileTime = Marshal.AllocHGlobal(Marshal.SizeOf<FileTime>());
                     Interop.Kernel32.GetSystemTimeAsFileTime(fileTime);
 
                     // set the time
@@ -758,7 +758,7 @@ namespace System.DirectoryServices.ActiveDirectory
                     AuthData.AuthInfo = unmanagedPassword;
                     AuthData.AuthInfoLength = password.Length * 2;
 
-                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(LSA_AUTH_INFORMATION)));
+                    unmanagedAuthData = Marshal.AllocHGlobal(Marshal.SizeOf<LSA_AUTH_INFORMATION>());
                     Marshal.StructureToPtr(AuthData, unmanagedAuthData, false);
 
                     Interop.Advapi32.TRUSTED_DOMAIN_AUTH_INFORMATION AuthInfoEx;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -2120,7 +2120,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 // Retrieve the user's SID from the user info
-                global::Interop.TOKEN_USER tokenUser = (global::Interop.TOKEN_USER)Marshal.PtrToStructure(pBuffer, typeof(global::Interop.TOKEN_USER))!;
+                global::Interop.TOKEN_USER tokenUser = Marshal.PtrToStructure<Interop.TOKEN_USER>(pBuffer)!;
                 IntPtr pUserSid = tokenUser.sidAndAttributes.Sid;   // this is a reference into the NATIVE memory (into pBuffer)
 
                 Debug.Assert(global::Interop.Advapi32.IsValidSid(pUserSid));
@@ -2178,8 +2178,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 Debug.Assert(pBuffer != IntPtr.Zero);
-                POLICY_ACCOUNT_DOMAIN_INFO info = (POLICY_ACCOUNT_DOMAIN_INFO)
-                                    Marshal.PtrToStructure(pBuffer, typeof(POLICY_ACCOUNT_DOMAIN_INFO))!;
+                POLICY_ACCOUNT_DOMAIN_INFO info = Marshal.PtrToStructure<POLICY_ACCOUNT_DOMAIN_INFO>(pBuffer)!;
 
                 Debug.Assert(global::Interop.Advapi32.IsValidSid(info.DomainSid));
 
@@ -2226,7 +2225,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 DSROLE_PRIMARY_DOMAIN_INFO_BASIC dsRolePrimaryDomainInfo =
-                    (DSROLE_PRIMARY_DOMAIN_INFO_BASIC)Marshal.PtrToStructure(dsRoleInfoPtr, typeof(DSROLE_PRIMARY_DOMAIN_INFO_BASIC))!;
+                    Marshal.PtrToStructure<DSROLE_PRIMARY_DOMAIN_INFO_BASIC>(dsRoleInfoPtr)!;
 
                 return (dsRolePrimaryDomainInfo.MachineRole == DSROLE_MACHINE_ROLE.DsRole_RoleBackupDomainController ||
                              dsRolePrimaryDomainInfo.MachineRole == DSROLE_MACHINE_ROLE.DsRole_RolePrimaryDomainController);
@@ -2246,7 +2245,7 @@ namespace System.DirectoryServices.ActiveDirectory
             IntPtr pIdentAuth = global::Interop.Advapi32.GetSidIdentifierAuthority(pSid);
 
             global::Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth =
-                (global::Interop.Advapi32.SID_IDENTIFIER_AUTHORITY)Marshal.PtrToStructure(pIdentAuth, typeof(global::Interop.Advapi32.SID_IDENTIFIER_AUTHORITY))!;
+                Marshal.PtrToStructure<Interop.Advapi32.SID_IDENTIFIER_AUTHORITY>(pIdentAuth)!;
 
             IntPtr pRid = global::Interop.Advapi32.GetSidSubAuthority(pSid, 0);
             int rid = Marshal.ReadInt32(pRid);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/ActiveDirectory/Utils.cs
@@ -2038,7 +2038,7 @@ namespace System.DirectoryServices.ActiveDirectory
         }
 
 
-        internal static IntPtr GetCurrentUserSid()
+        internal static unsafe IntPtr GetCurrentUserSid()
         {
             SafeTokenHandle? tokenHandle = null;
             IntPtr pBuffer = IntPtr.Zero;
@@ -2120,7 +2120,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 // Retrieve the user's SID from the user info
-                global::Interop.TOKEN_USER tokenUser = Marshal.PtrToStructure<Interop.TOKEN_USER>(pBuffer)!;
+                Interop.TOKEN_USER tokenUser = *(Interop.TOKEN_USER*)pBuffer;
                 IntPtr pUserSid = tokenUser.sidAndAttributes.Sid;   // this is a reference into the NATIVE memory (into pBuffer)
 
                 Debug.Assert(global::Interop.Advapi32.IsValidSid(pUserSid));
@@ -2147,7 +2147,7 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        internal static IntPtr GetMachineDomainSid()
+        internal static unsafe IntPtr GetMachineDomainSid()
         {
             SafeLsaPolicyHandle? policyHandle = null;
             IntPtr pBuffer = IntPtr.Zero;
@@ -2178,7 +2178,7 @@ namespace System.DirectoryServices.ActiveDirectory
                 }
 
                 Debug.Assert(pBuffer != IntPtr.Zero);
-                POLICY_ACCOUNT_DOMAIN_INFO info = Marshal.PtrToStructure<POLICY_ACCOUNT_DOMAIN_INFO>(pBuffer)!;
+                POLICY_ACCOUNT_DOMAIN_INFO info = *(POLICY_ACCOUNT_DOMAIN_INFO*)pBuffer;
 
                 Debug.Assert(global::Interop.Advapi32.IsValidSid(info.DomainSid));
 
@@ -2237,15 +2237,14 @@ namespace System.DirectoryServices.ActiveDirectory
             }
         }
 
-        internal static SidType ClassifySID(IntPtr pSid)
+        internal static unsafe SidType ClassifySID(IntPtr pSid)
         {
             Debug.Assert(global::Interop.Advapi32.IsValidSid(pSid));
 
             // Get the issuing authority and the first RID
             IntPtr pIdentAuth = global::Interop.Advapi32.GetSidIdentifierAuthority(pSid);
 
-            global::Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth =
-                Marshal.PtrToStructure<Interop.Advapi32.SID_IDENTIFIER_AUTHORITY>(pIdentAuth)!;
+            Interop.Advapi32.SID_IDENTIFIER_AUTHORITY identAuth = *(Interop.Advapi32.SID_IDENTIFIER_AUTHORITY*)pIdentAuth;
 
             IntPtr pRid = global::Interop.Advapi32.GetSidSubAuthority(pSid, 0);
             int rid = Marshal.ReadInt32(pRid);

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
@@ -892,10 +892,10 @@ namespace System.DirectoryServices
             }
         }
 
-        private static void DoSetSearchPrefs(UnsafeNativeMethods.IDirectorySearch adsSearch, AdsSearchPreferenceInfo[] prefs)
+        private static unsafe void DoSetSearchPrefs(UnsafeNativeMethods.IDirectorySearch adsSearch, AdsSearchPreferenceInfo[] prefs)
         {
-            int structSize = Marshal.SizeOf<AdsSearchPreferenceInfo>();
-            IntPtr ptr = Marshal.AllocHGlobal((IntPtr)(structSize * prefs.Length));
+            int structSize = sizeof(AdsSearchPreferenceInfo);
+            IntPtr ptr = Marshal.AllocHGlobal(structSize * prefs.Length);
             try
             {
                 IntPtr tempPtr = ptr;

--- a/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
+++ b/src/libraries/System.DirectoryServices/src/System/DirectoryServices/DirectorySearcher.cs
@@ -844,7 +844,7 @@ namespace System.DirectoryServices
                         ptrVLVContexToFree = vlvValue.contextID;
                         Marshal.Copy(_vlv.DirectoryVirtualListViewContext._context, 0, vlvValue.contextID, vlvValue.contextIDlength);
                     }
-                    IntPtr vlvPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(AdsVLV)));
+                    IntPtr vlvPtr = Marshal.AllocHGlobal(Marshal.SizeOf<AdsVLV>());
                     byte[] vlvBytes = new byte[Marshal.SizeOf(vlvValue)];
                     try
                     {
@@ -894,7 +894,7 @@ namespace System.DirectoryServices
 
         private static void DoSetSearchPrefs(UnsafeNativeMethods.IDirectorySearch adsSearch, AdsSearchPreferenceInfo[] prefs)
         {
-            int structSize = Marshal.SizeOf(typeof(AdsSearchPreferenceInfo));
+            int structSize = Marshal.SizeOf<AdsSearchPreferenceInfo>();
             IntPtr ptr = Marshal.AllocHGlobal((IntPtr)(structSize * prefs.Length));
             try
             {

--- a/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComponentModel/DefaultValueAttribute.cs
@@ -73,7 +73,7 @@ namespace System.ComponentModel
                     {
                         Type? typeDescriptorType = Type.GetType("System.ComponentModel.TypeDescriptor, System.ComponentModel.TypeConverter", throwOnError: false);
                         MethodInfo? mi = typeDescriptorType?.GetMethod("ConvertFromInvariantString", BindingFlags.NonPublic | BindingFlags.Static);
-                        Volatile.Write(ref s_convertFromInvariantString, mi == null ? new object() : mi.CreateDelegate(typeof(Func<Type, string, object>)));
+                        Volatile.Write(ref s_convertFromInvariantString, mi == null ? new object() : mi.CreateDelegate<Func<Type, string, object>>());
                     }
 
                     if (!(s_convertFromInvariantString is Func<Type, string?, object> convertFromInvariantString))

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -1516,8 +1516,8 @@ namespace System.Runtime.Serialization.DataContracts
         {
             string? clrNs = type.Namespace ?? string.Empty;
             string? ns =
-                GetGlobalDataContractNamespace(clrNs, type.Module.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray()) ??
-                GetGlobalDataContractNamespace(clrNs, type.Assembly.GetCustomAttributes(typeof(ContractNamespaceAttribute)).ToArray());
+                GetGlobalDataContractNamespace(clrNs, type.Module.GetCustomAttributes<ContractNamespaceAttribute>().ToArray()) ??
+                GetGlobalDataContractNamespace(clrNs, type.Assembly.GetCustomAttributes<ContractNamespaceAttribute>().ToArray());
 
             if (ns == null)
             {
@@ -2228,7 +2228,7 @@ namespace System.Runtime.Serialization.DataContracts
         /// </SecurityNote>
         internal static bool IsAssemblyFriendOfSerialization(Assembly assembly)
         {
-            InternalsVisibleToAttribute[] internalsVisibleAttributes = (InternalsVisibleToAttribute[])assembly.GetCustomAttributes(typeof(InternalsVisibleToAttribute));
+            InternalsVisibleToAttribute[] internalsVisibleAttributes = (InternalsVisibleToAttribute[])assembly.GetCustomAttributes<InternalsVisibleToAttribute>();
             foreach (InternalsVisibleToAttribute internalsVisibleAttribute in internalsVisibleAttributes)
             {
                 string internalsVisibleAttributeAssemblyName = internalsVisibleAttribute.AssemblyName;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -651,7 +651,7 @@ namespace System.Xml.Serialization
 
                         MethodInfo getSetMemberValueDelegateWithTypeGenericMi = typeof(ReflectionXmlSerializationReaderHelper).GetMethod("GetSetMemberValueDelegateWithType", BindingFlags.Static | BindingFlags.Public)!;
                         MethodInfo getSetMemberValueDelegateWithTypeMi = getSetMemberValueDelegateWithTypeGenericMi.MakeGenericMethod(o.GetType(), memberType);
-                        var getSetMemberValueDelegateWithType = (Func<MemberInfo, ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate>)getSetMemberValueDelegateWithTypeMi.CreateDelegate(typeof(Func<MemberInfo, ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate>));
+                        var getSetMemberValueDelegateWithType = getSetMemberValueDelegateWithTypeMi.CreateDelegate<Func<MemberInfo, ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate>>();
                         result = getSetMemberValueDelegateWithType(memberInfo);
                         delegateCacheForType[memberName] = result;
                     }
@@ -2121,7 +2121,7 @@ namespace System.Xml.Serialization
                         return propInfo.SetValue;
                     }
 
-                    setTypedDelegate = (Action<TObj, TParam>)setMethod.CreateDelegate(typeof(Action<TObj, TParam>));
+                    setTypedDelegate = setMethod.CreateDelegate<Action<TObj, TParam>>();
                 }
                 else if (memberInfo is FieldInfo fieldInfo)
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xslt/XslCompiledTransform.cs
@@ -229,7 +229,7 @@ namespace System.Xml.Xsl
 
             Delegate delExec = executeMethod is DynamicMethod dm
                 ? dm.CreateDelegate(typeof(ExecuteDelegate))
-                : executeMethod.CreateDelegate(typeof(ExecuteDelegate));
+                : executeMethod.CreateDelegate<ExecuteDelegate>();
 
             _command = new XmlILCommand((ExecuteDelegate)delExec, new XmlQueryStaticData(queryData, earlyBoundTypes));
             OutputSettings = _command.StaticData.DefaultWriterSettings;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
@@ -107,7 +107,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf(typeof(JSMarshalerArgument));
+            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
             slot.Type = MarshalerType.Array;
             slot.ElementType = MarshalerType.JSObject;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.JSObject.cs
@@ -107,7 +107,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
+            int bytes = value.Length * sizeof(JSMarshalerArgument);
             slot.Type = MarshalerType.Array;
             slot.ElementType = MarshalerType.JSObject;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
@@ -373,7 +373,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
+            int bytes = value.Length * sizeof(JSMarshalerArgument);
             slot.Type = MarshalerType.Array;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);
             Unsafe.InitBlock(payload, 0, (uint)bytes);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.Object.cs
@@ -373,7 +373,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf(typeof(JSMarshalerArgument));
+            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
             slot.Type = MarshalerType.Array;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);
             Unsafe.InitBlock(payload, 0, (uint)bytes);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.String.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.String.cs
@@ -115,7 +115,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf(typeof(JSMarshalerArgument));
+            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
             slot.Type = MarshalerType.Array;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);
             Unsafe.InitBlock(payload, 0, (uint)bytes);

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.String.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.String.cs
@@ -115,7 +115,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 return;
             }
             slot.Length = value.Length;
-            int bytes = value.Length * Marshal.SizeOf<JSMarshalerArgument>();
+            int bytes = value.Length * sizeof(JSMarshalerArgument);
             slot.Type = MarshalerType.Array;
             JSMarshalerArgument* payload = (JSMarshalerArgument*)Marshal.AllocHGlobal(bytes);
             Unsafe.InitBlock(payload, 0, (uint)bytes);

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
@@ -709,7 +709,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
                         // A field on the type isn't found. See if the field has OptionalFieldAttribute.  We only throw
                         // when the assembly format is set appropriately.
                         if (!_isSimpleAssembly &&
-                            _cache._memberInfos[i].GetCustomAttribute(typeof(OptionalFieldAttribute), inherit: false) == null)
+                            _cache._memberInfos[i].GetCustomAttribute<OptionalFieldAttribute>(inherit: false) == null)
                         {
                             Debug.Assert(_cache._memberNames != null);
                             throw new SerializationException(SR.Format(SR.Serialization_MissingMember, _cache._memberNames[i], objectType, typeof(OptionalFieldAttribute).FullName));

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHash.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHash.Apple.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography
                 throw new PlatformNotSupportedException(
                     SR.Format(
                         SR.Cryptography_UnknownHashAlgorithm,
-                        Enum.GetName(typeof(PAL_HashAlgorithm), algorithm)));
+                        Enum.GetName(algorithm)));
             }
 
             if (_ctx.IsInvalid)
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography
                 throw new PlatformNotSupportedException(
                     SR.Format(
                         SR.Cryptography_UnknownHashAlgorithm,
-                        Enum.GetName(typeof(Interop.AppleCrypto.PAL_HashAlgorithm), algorithm)));
+                        Enum.GetName(algorithm)));
             }
 
             if (_ctx.IsInvalid)

--- a/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -582,9 +582,9 @@ namespace System.Media
                         if (waveFormat == null)
                         {
                             int dw = ck.cksize;
-                            if (dw < Marshal.SizeOf(typeof(Interop.WinMM.WAVEFORMATEX)))
+                            if (dw < Marshal.SizeOf<Interop.WinMM.WAVEFORMATEX>())
                             {
-                                dw = Marshal.SizeOf(typeof(Interop.WinMM.WAVEFORMATEX));
+                                dw = Marshal.SizeOf<Interop.WinMM.WAVEFORMATEX>();
                             }
 
                             waveFormat = new Interop.WinMM.WAVEFORMATEX();


### PR DESCRIPTION
Fix more diagnostics found with `CA2263: Prefer generic overload when type is known`

Excluded fixing diagnostics for 
- Projects that build on lower versions like `netstandard`
- Excluded findings in Test projects like `Microsoft.Extensions.DependencyInjection.Specification.Tests`
- Excluded diagnostics on `Linq.Expressions` 

Related to https://github.com/dotnet/runtime/pull/99343#discussion_r1520477488