### PR TITLE
Make JitOptRepeat available in Release builds

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -2902,10 +2902,7 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     opts.disAlignment = false;
     opts.disCodeBytes = false;
 
-#ifdef OPT_CONFIG
-    opts.optRepeat = false;
-#endif // OPT_CONFIG
-
+    opts.optRepeat          = false;
     opts.optRepeatIteration = 0;
     opts.optRepeatCount     = 1;
     opts.optRepeatActive    = false;
@@ -3084,6 +3081,13 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
     {
         opts.disAsm = true;
     }
+
+    if ((JitConfig.JitEnableOptRepeat() != 0) &&
+        (JitConfig.JitOptRepeat().contains(info.compMethodHnd, info.compClassHnd, &info.compMethodInfo->args)))
+    {
+        opts.optRepeat      = true;
+        opts.optRepeatCount = JitConfig.JitOptRepeatCount();
+    }
 #endif // !DEBUG
 
 #ifndef DEBUG
@@ -3109,8 +3113,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
         }
     }
 
-#ifdef OPT_CONFIG
-
     if (opts.optRepeat)
     {
         // Defer printing this until now, after the "START" line printed above.
@@ -3132,7 +3134,6 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
             JITDUMP("\n*************** JitOptRepeat enabled by JitOptRepeatRange; repetition count: %d\n\n",
                     opts.optRepeatCount);
         }
-#endif // DEBUG
 
         if (!opts.optRepeat && compStressCompile(STRESS_OPT_REPEAT, 10))
         {
@@ -3146,9 +3147,8 @@ void Compiler::compInitOptions(JitFlags* jitFlags)
 
             JITDUMP("\n*************** JitOptRepeat for stress; repetition count: %d\n\n", opts.optRepeatCount);
         }
+#endif // DEBUG
     }
-
-#endif // OPT_CONFIG
 
 #ifdef DEBUG
     assert(!codeGen->isGCTypeFixed());
@@ -5012,12 +5012,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         doVNBasedDeadStoreRemoval = doValueNum && (JitConfig.JitDoVNBasedDeadStoreRemoval() != 0);
 #endif // defined(OPT_CONFIG)
 
-#ifdef DEBUG
         if (opts.optRepeat)
         {
             opts.optRepeatActive = true;
         }
-#endif // DEBUG
 
         while (++opts.optRepeatIteration <= opts.optRepeatCount)
         {
@@ -5166,12 +5164,10 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
 #endif // DEBUG
         }
 
-#ifdef DEBUG
         if (opts.optRepeat)
         {
             opts.optRepeatActive = false;
         }
-#endif // DEBUG
     }
 
     optLoopsCanonical = false;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9874,15 +9874,12 @@ public:
         bool genFPopt;   // Can we do frame-pointer-omission optimization?
         bool altJit;     // True if we are an altjit and are compiling this method
 
-#ifdef OPT_CONFIG
-        bool optRepeat; // Repeat optimizer phases k times
-#endif
-
-        int optRepeatIteration; // The current optRepeat iteration: from 0 to optRepeatCount. optRepeatCount can be
-                                // zero, in which case no optimizations in the set of repeated optimizations are
-                                // performed. optRepeatIteration will only be zero if optRepeatCount is zero.
-        int  optRepeatCount;    // How many times to repeat. By default, comes from JitConfig.JitOptRepeatCount().
-        bool optRepeatActive;   // `true` if we are in the range of phases being repeated.
+        bool optRepeat;          // Repeat optimizer phases k times
+        int  optRepeatIteration; // The current optRepeat iteration: from 0 to optRepeatCount. optRepeatCount can be
+                                 // zero, in which case no optimizations in the set of repeated optimizations are
+                                 // performed. optRepeatIteration will only be zero if optRepeatCount is zero.
+        int  optRepeatCount;     // How many times to repeat. By default, comes from JitConfig.JitOptRepeatCount().
+        bool optRepeatActive;    // `true` if we are in the range of phases being repeated.
 
         bool disAsm;       // Display native code as it is generated
         bool disTesting;   // Display BEGIN METHOD/END METHOD anchors for disasm testing

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -521,14 +521,15 @@ CONFIG_STRING(JitEnableInductionVariableOptsRange, W("JitEnableInductionVariable
 CONFIG_INTEGER(JitDoSsa, W("JitDoSsa"), 1) // Perform Static Single Assignment (SSA) numbering on the variables
 CONFIG_INTEGER(JitDoValueNumber, W("JitDoValueNumber"), 1) // Perform value numbering on method expressions
 
-CONFIG_INTEGER(JitEnableOptRepeat, W("JitEnableOptRepeat"), 1) // If zero, do not allow JitOptRepeat
-CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))              // Runs optimizer multiple times on specified methods
-CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2)   // Number of times to repeat opts when repeating
-CONFIG_STRING(JitOptRepeatRange, W("JitOptRepeatRange"))       // Enable JitOptRepeat based on method hash range
+CONFIG_STRING(JitOptRepeatRange, W("JitOptRepeatRange")) // Enable JitOptRepeat based on method hash range
 
 CONFIG_INTEGER(JitDoIfConversion, W("JitDoIfConversion"), 1) // Perform If conversion
 
 #endif // defined(OPT_CONFIG)
+
+CONFIG_INTEGER(JitEnableOptRepeat, W("JitEnableOptRepeat"), 1) // If zero, do not allow JitOptRepeat
+CONFIG_METHODSET(JitOptRepeat, W("JitOptRepeat"))              // Runs optimizer multiple times on specified methods
+CONFIG_INTEGER(JitOptRepeatCount, W("JitOptRepeatCount"), 2)   // Number of times to repeat opts when repeating
 
 // Max # of MapSelect's considered for a particular top-level invocation.
 CONFIG_INTEGER(JitVNMapSelBudget, W("JitVNMapSelBudget"), DEFAULT_MAP_SELECT_BUDGET)

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -503,14 +503,12 @@ bool Compiler::optExtractInitTestIncr(
         if (initStmt->GetRootNode()->OperIs(GT_JTRUE))
         {
             bool doGetPrev = true;
-#ifdef OPT_CONFIG
             if (opts.optRepeat)
             {
                 // Previous optimization passes may have inserted compiler-generated
                 // statements other than duplicated loop conditions.
                 doGetPrev = (initStmt->GetPrevStmt() != nullptr);
             }
-#endif // OPT_CONFIG
             if (doGetPrev)
             {
                 initStmt = initStmt->GetPrevStmt();

--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2345,8 +2345,9 @@ class SuperPMIReplayAsmDiffs:
                         diff_perfscore = diff_metrics["Overall"]["Diffed PerfScore"]
                         logging.info("Total PerfScore of base: {}".format(base_perfscore))
                         logging.info("Total PerfScore of diff: {}".format(diff_perfscore))
-                        delta_perfscore = diff_perfscore - base_perfscore
-                        logging.info("Total PerfScore of delta: {} ({:.2%} of base)".format(delta_perfscore, delta_perfscore / base_perfscore))
+                        if base_perfscore != 0:
+                            delta_perfscore = diff_perfscore - base_perfscore
+                            logging.info("Total PerfScore of delta: {} ({:.2%} of base)".format(delta_perfscore, delta_perfscore / base_perfscore))
                         logging.info("")
 
                         relative_perfscore_geomean = diff_metrics["Overall"]["Relative PerfScore Geomean"]


### PR DESCRIPTION
Also, fix a problem in superpmi.py asmdiffs for Release builds where we got a divide by zero because release builds don't have PerfScore.