### PR TITLE
[mono] Migrate various GHashTables to dn_simdhash

### DIFF
--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -45,7 +45,10 @@ endif()
 set(imported_native_sources
     ../../../native/containers/dn-simdhash.c
     ../../../native/containers/dn-simdhash-string-ptr.c
-    ../../../native/containers/dn-simdhash-u32-ptr.c)
+    ../../../native/containers/dn-simdhash-u32-ptr.c
+    ../../../native/containers/dn-simdhash-u32-ptr.c
+    ../../../native/containers/dn-simdhash-ptr-ptr.c
+    ../../../native/containers/dn-simdhash-ght-compatible.c)
 
 set(metadata_common_sources
     appdomain.c

--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -46,7 +46,6 @@ set(imported_native_sources
     ../../../native/containers/dn-simdhash.c
     ../../../native/containers/dn-simdhash-string-ptr.c
     ../../../native/containers/dn-simdhash-u32-ptr.c
-    ../../../native/containers/dn-simdhash-u32-ptr.c
     ../../../native/containers/dn-simdhash-ptr-ptr.c
     ../../../native/containers/dn-simdhash-ght-compatible.c)
 

--- a/src/mono/mono/metadata/bundled-resources-internals.h
+++ b/src/mono/mono/metadata/bundled-resources-internals.h
@@ -17,6 +17,7 @@ typedef enum {
 
 typedef void (*free_bundled_resource_func)(void *, void*);
 
+// WARNING: The layout of these structs cannot change because EmitBundleBase.cs depends on it!
 typedef struct _MonoBundledResource {
 	MonoBundledResourceType type;
 	const char *id;

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -163,7 +163,7 @@ mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t 
 		dn_simdhash_ptr_ptr_try_add (bundled_resource_key_lookup_table, (void *)resource_to_bundle->id, key);
 
 		g_assert (dn_simdhash_ght_try_add (bundled_resources, (gpointer) key, resource_to_bundle));
-		g_assert (bundled_resources_get (resource_to_bundle->id) == resource_to_bundle);
+		// g_assert (bundled_resources_get (resource_to_bundle->id) == resource_to_bundle);
 	}
 
 	if (assemblyAdded)

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -73,6 +73,17 @@ bundled_resources_is_known_assembly_extension (const char *ext)
 #endif
 }
 
+// strrchr calls strlen, so we need to do a search with known length instead
+// for some reason memrchr is defined in a header but the build fails when we try to use it
+static const char *
+g_memrchr (const char *s, char c, size_t n)
+{
+	while (n--)
+		if (s[n] == c)
+			return (void *)(s + n);
+	return NULL;
+}
+
 // If a bundled resource has a known assembly extension, we strip the extension from its name
 // This ensures that lookups for foo.dll will work even if the assembly is in a webcil container
 static char *
@@ -80,12 +91,12 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 {
 	size_t id_length = strlen (id),
 		extension_offset = -1;
-	const char *extension = strrchr (id, '.');
+	const char *extension = g_memrchr (id, '.', id_length);
 	if (extension)
 		extension_offset = extension - id;
 	if (!buffer) {
 		buffer_len = (guint)(id_length + 1);
-		buffer = g_malloc(buffer_len);
+		buffer = g_malloc (buffer_len);
 	}
 	buffer[0] = 0;
 

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -87,13 +87,12 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 		buffer_len = (guint)(id_length + 1);
 		buffer = g_malloc(buffer_len);
 	}
+	buffer[0] = 0;
 
 	if (extension_offset && bundled_resources_is_known_assembly_extension (extension))
-		strncpy(buffer, id, MIN(buffer_len - 1, extension_offset + 1));
+		g_strlcpy(buffer, id, MIN(buffer_len, extension_offset + 1));
 	else
-		strncpy(buffer, id, MIN(buffer_len - 1, id_length));
-
-	buffer[buffer_len - 1] = 0;
+		g_strlcpy(buffer, id, MIN(buffer_len, id_length + 1));
 
 	return buffer;
 }
@@ -163,7 +162,7 @@ mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t 
 		char *key = key_from_id (resource_to_bundle->id, NULL, 0);
 		dn_simdhash_ptr_ptr_try_add (bundled_resource_key_lookup_table, (void *)resource_to_bundle->id, key);
 
-		dn_simdhash_ght_try_add (bundled_resources, (gpointer) key, resource_to_bundle);
+		g_assert (dn_simdhash_ght_try_add (bundled_resources, (gpointer) key, resource_to_bundle));
 		g_assert (bundled_resources_get (resource_to_bundle->id) == resource_to_bundle);
 	}
 

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -8,8 +8,11 @@
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/bundled-resources-internals.h>
 #include <mono/metadata/webcil-loader.h>
+#include "../native/containers/dn-simdhash-specializations.h"
+#include "../native/containers/dn-simdhash-utils.h"
 
-static GHashTable *bundled_resources = NULL;
+static dn_simdhash_ght_t *bundled_resources = NULL;
+static dn_simdhash_ptr_ptr_t *bundled_resource_key_lookup_table = NULL;
 static bool bundled_resources_contains_assemblies = false;
 static bool bundled_resources_contains_satellite_assemblies = false;
 
@@ -31,8 +34,10 @@ mono_bundled_resources_free (void)
 {
 	g_assert (mono_runtime_is_shutting_down ());
 
-	g_hash_table_destroy (bundled_resources);
+	dn_simdhash_free (bundled_resources);
+	dn_simdhash_free (bundled_resource_key_lookup_table);
 	bundled_resources = NULL;
+	bundled_resource_key_lookup_table = NULL;
 
 	bundled_resources_contains_assemblies = false;
 	bundled_resources_contains_satellite_assemblies = false;
@@ -50,6 +55,12 @@ bundled_resources_value_destroy_func (void *resource)
 	MonoBundledResource *value = (MonoBundledResource *)resource;
 	if (value->free_func)
 		value->free_func (resource, value->free_data);
+
+	char *key;
+	if (dn_simdhash_ptr_ptr_try_get_value (bundled_resource_key_lookup_table, (void *)value->id, (void **)&key)) {
+		dn_simdhash_ptr_ptr_try_remove (bundled_resource_key_lookup_table, (void *)value->id);
+		g_free (key);
+	}
 }
 
 static bool
@@ -62,47 +73,47 @@ bundled_resources_is_known_assembly_extension (const char *ext)
 #endif
 }
 
+// If a bundled resource has a known assembly extension, we strip the extension from its name
+// This ensures that lookups for foo.dll will work even if the assembly is in a webcil container
+static char *
+key_from_id (const char *id, char *buffer, guint buffer_len)
+{
+	size_t id_length = strlen (id),
+		extension_offset = -1;
+	const char *extension = strrchr (id, '.');
+	if (extension)
+		extension_offset = extension - id;
+	if (!buffer) {
+		buffer_len = (guint)(id_length + 1);
+		buffer = g_malloc0(buffer_len);
+	}
+
+	if (extension_offset && bundled_resources_is_known_assembly_extension (extension))
+		strncpy(buffer, id, MIN(buffer_len - 1, extension_offset + 1));
+	else
+		strncpy(buffer, id, MIN(buffer_len - 1, id_length));
+
+	buffer[buffer_len - 1] = 0;
+
+	return buffer;
+}
+
 static gboolean
-bundled_resources_resource_id_equal (const char *id_one, const char *id_two)
+bundled_resources_resource_id_equal (const char *key_one, const char *key_two)
 {
-	const char *extension_one = strrchr (id_one, '.');
-	const char *extension_two = strrchr (id_two, '.');
-	if (extension_one && extension_two && bundled_resources_is_known_assembly_extension (extension_one) && bundled_resources_is_known_assembly_extension (extension_two)) {
-		size_t len_one = extension_one - id_one;
-		size_t len_two = extension_two - id_two;
-		return (len_one == len_two) && !strncmp (id_one, id_two, len_one);
-	}
-
-	return !strcmp (id_one, id_two);
+	return strcmp (key_one, key_two) == 0;
 }
 
-static guint
-bundled_resources_resource_id_hash (const char *id)
+static guint32
+bundled_resources_resource_id_hash (const char *key)
 {
-	const char *current = id;
-	const char *extension = NULL;
-	guint previous_hash = 0;
-	guint hash = 0;
-
-	while (*current) {
-		hash = (hash << 5) - (hash + *current);
-		if (*current == '.') {
-			extension = current;
-			previous_hash = hash;
-		}
-		current++;
-	}
-
-	// alias all extensions to .dll
-	if (extension && bundled_resources_is_known_assembly_extension (extension)) {
-		hash = previous_hash;
-		hash = (hash << 5) - (hash + 'd');
-		hash = (hash << 5) - (hash + 'l');
-		hash = (hash << 5) - (hash + 'l');
-	}
-
-	return hash;
+	// FIXME: Seed
+	// FIXME: We should cache the hash code so rehashes are cheaper
+	return MurmurHash3_32_streaming ((const uint8_t *)key, 0);
 }
+
+static MonoBundledResource *
+bundled_resources_get (const char *id);
 
 //---------------------------------------------------------------------------------------
 //
@@ -130,7 +141,11 @@ mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t 
 	g_assert (!domain);
 
 	if (!bundled_resources)
-		bundled_resources = g_hash_table_new_full ((GHashFunc)bundled_resources_resource_id_hash, (GEqualFunc)bundled_resources_resource_id_equal, NULL, bundled_resources_value_destroy_func);
+		// FIXME: Choose a good initial capacity to avoid rehashes during startup. I picked one at random
+		bundled_resources = dn_simdhash_ght_new_full ((GHashFunc)bundled_resources_resource_id_hash, (GEqualFunc)bundled_resources_resource_id_equal, NULL, bundled_resources_value_destroy_func, 2048, NULL);
+
+	if (!bundled_resource_key_lookup_table)
+		bundled_resource_key_lookup_table = dn_simdhash_ptr_ptr_new (2048, NULL);
 
 	bool assemblyAdded = false;
 	bool satelliteAssemblyAdded = false;
@@ -143,7 +158,13 @@ mono_bundled_resources_add (MonoBundledResource **resources_to_bundle, uint32_t 
 		if (resource_to_bundle->type == MONO_BUNDLED_SATELLITE_ASSEMBLY)
 			satelliteAssemblyAdded = true;
 
-		g_hash_table_insert (bundled_resources, (gpointer) resource_to_bundle->id, resource_to_bundle);
+		// Generate the hash key for the id (strip certain extensions) and store it
+		//  so that we can free it later when freeing the bundled data
+		char *key = key_from_id (resource_to_bundle->id, NULL, 0);
+		dn_simdhash_ptr_ptr_try_add (bundled_resource_key_lookup_table, (void *)resource_to_bundle->id, key);
+
+		dn_simdhash_ght_try_add (bundled_resources, (gpointer) key, resource_to_bundle);
+		g_assert (bundled_resources_get (resource_to_bundle->id) == resource_to_bundle);
 	}
 
 	if (assemblyAdded)
@@ -172,7 +193,13 @@ bundled_resources_get (const char *id)
 	if (!bundled_resources)
 		return NULL;
 
-	return g_hash_table_lookup (bundled_resources, id);
+	char key_buffer[1024];
+	memset(key_buffer, 0, 1024);
+	key_from_id(id, key_buffer, 1024);
+
+	MonoBundledResource *result = NULL;
+	dn_simdhash_ght_try_get_value (bundled_resources, key_buffer, (void **)&result);
+	return result;
 }
 
 //---------------------------------------------------------------------------------------
@@ -364,9 +391,7 @@ bool
 mono_bundled_resources_get_data_resource_values (const char *id, const uint8_t **data_out, uint32_t *size_out)
 {
 	MonoBundledDataResource *bundled_data_resource = bundled_resources_get_data_resource (id);
-	if (!bundled_data_resource ||
-		!bundled_data_resource->data.data ||
-		bundled_data_resource->data.size == 0)
+	if (!bundled_data_resource || !bundled_data_resource->data.data)
 		return false;
 
 	if (data_out)

--- a/src/mono/mono/metadata/bundled-resources.c
+++ b/src/mono/mono/metadata/bundled-resources.c
@@ -85,7 +85,7 @@ key_from_id (const char *id, char *buffer, guint buffer_len)
 		extension_offset = extension - id;
 	if (!buffer) {
 		buffer_len = (guint)(id_length + 1);
-		buffer = g_malloc0(buffer_len);
+		buffer = g_malloc(buffer_len);
 	}
 
 	if (extension_offset && bundled_resources_is_known_assembly_extension (extension))
@@ -194,7 +194,6 @@ bundled_resources_get (const char *id)
 		return NULL;
 
 	char key_buffer[1024];
-	memset(key_buffer, 0, 1024);
 	key_from_id(id, key_buffer, 1024);
 
 	MonoBundledResource *result = NULL;

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -2120,9 +2120,9 @@ mono_image_close_except_pools (MonoImage *image)
 	}
 
 	if (image->method_cache)
-		g_hash_table_destroy (image->method_cache);
+		dn_simdhash_free (image->method_cache);
 	if (image->methodref_cache)
-		g_hash_table_destroy (image->methodref_cache);
+		dn_simdhash_free (image->methodref_cache);
 	mono_internal_hash_table_destroy (&image->class_cache);
 	mono_conc_hashtable_destroy (image->field_cache);
 	if (image->array_cache) {

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -18,6 +18,8 @@
 #include <mono/utils/mono-error.h>
 #include <mono/utils/mono-forward.h>
 #include <mono/utils/mono-conc-hashtable.h>
+// for dn_simdhash_ght_t
+#include "../native/containers/dn-simdhash-specializations.h"
 
 #if defined(TARGET_OSX)
 #define MONO_LOADER_LIBRARY_NAME "libcoreclr.dylib"
@@ -174,7 +176,7 @@ struct _MonoMemoryManager {
 	MonoAssemblyLoadContext **alcs;
 
 	// Generic-specific caches
-	GHashTable *ginst_cache, *gmethod_cache, *gsignature_cache;
+	dn_simdhash_ght_t *ginst_cache, *gmethod_cache, *gsignature_cache;
 	MonoConcurrentHashTable *gclass_cache;
 
 	/* mirror caches of ones already on MonoImage. These ones contain generics */

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1182,12 +1182,14 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 
 	if (mono_metadata_token_table (token) == MONO_TABLE_METHOD) {
 		if (!image->method_cache)
-			image->method_cache = g_hash_table_new (NULL, NULL);
-		result = (MonoMethod *)g_hash_table_lookup (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)));
+			// FIXME: Pick a better initial size
+			image->method_cache = dn_simdhash_u32_ptr_new (512, NULL);
+		dn_simdhash_u32_ptr_try_get_value (image->method_cache, mono_metadata_token_index (token), (void **)&result);
 	} else if (!image_is_dynamic (image)) {
 		if (!image->methodref_cache)
-			image->methodref_cache = g_hash_table_new (NULL, NULL);
-		result = (MonoMethod *)g_hash_table_lookup (image->methodref_cache, GINT_TO_POINTER (token));
+			// FIXME: Pick a better initial size
+			image->methodref_cache = dn_simdhash_u32_ptr_new (512, NULL);
+		dn_simdhash_u32_ptr_try_get_value (image->methodref_cache, token, (void **)&result);
 	}
 	mono_image_unlock (image);
 
@@ -1204,9 +1206,9 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 		MonoMethod *result2 = NULL;
 
 		if (mono_metadata_token_table (token) == MONO_TABLE_METHOD)
-			result2 = (MonoMethod *)g_hash_table_lookup (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)));
+			dn_simdhash_u32_ptr_try_get_value (image->method_cache, mono_metadata_token_index (token), (void **)&result2);
 		else if (!image_is_dynamic (image))
-			result2 = (MonoMethod *)g_hash_table_lookup (image->methodref_cache, GINT_TO_POINTER (token));
+			dn_simdhash_u32_ptr_try_get_value (image->methodref_cache, token, (void **)&result2);
 
 		if (result2) {
 			mono_image_unlock (image);
@@ -1214,9 +1216,9 @@ mono_get_method_checked (MonoImage *image, guint32 token, MonoClass *klass, Mono
 		}
 
 		if (mono_metadata_token_table (token) == MONO_TABLE_METHOD)
-			g_hash_table_insert (image->method_cache, GINT_TO_POINTER (mono_metadata_token_index (token)), result);
+			dn_simdhash_u32_ptr_try_add (image->method_cache, mono_metadata_token_index (token), result);
 		else if (!image_is_dynamic (image))
-			g_hash_table_insert (image->methodref_cache, GINT_TO_POINTER (token), result);
+			dn_simdhash_u32_ptr_try_add (image->methodref_cache, token, result);
 	}
 
 	mono_image_unlock (image);
@@ -1514,7 +1516,7 @@ mono_method_get_param_token (MonoMethod *method, int index)
 	idx = mono_method_get_index (method);
 	if (idx > 0) {
 		guint param_index = mono_metadata_get_method_params (klass_image, idx, NULL);
-		
+
 		if (index == -1)
 			/* Return value */
 			return mono_metadata_make_token (MONO_TABLE_PARAM, 0);

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -204,6 +204,14 @@ free_hash (GHashTable **hash)
 	*hash = NULL;
 }
 
+static void
+free_simdhash (dn_simdhash_t **hash)
+{
+	if (*hash)
+		dn_simdhash_free (*hash);
+	*hash = NULL;
+}
+
 // Full deletion
 static void
 memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
@@ -230,9 +238,9 @@ memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
 	MonoMemoryManager *mm = memory_manager;
 	if (mm->gclass_cache)
 		mono_conc_hashtable_destroy (mm->gclass_cache);
-	free_hash (&mm->ginst_cache);
-	free_hash (&mm->gmethod_cache);
-	free_hash (&mm->gsignature_cache);
+	free_simdhash (&mm->ginst_cache);
+	free_simdhash (&mm->gmethod_cache);
+	free_simdhash (&mm->gsignature_cache);
 	free_hash (&mm->szarray_cache);
 	free_hash (&mm->array_cache);
 	free_hash (&mm->ptr_cache);

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -418,11 +418,11 @@ struct _MonoImage {
 	/*
 	 * Indexed by method tokens and typedef tokens.
 	 */
-	GHashTable *method_cache; /*protected by the image lock*/
+	dn_simdhash_u32_ptr_t *method_cache; /*protected by the image lock*/
 	MonoInternalHashTable class_cache;
 
 	/* Indexed by memberref + methodspec tokens */
-	GHashTable *methodref_cache; /*protected by the image lock*/
+	dn_simdhash_u32_ptr_t *methodref_cache; /*protected by the image lock*/
 
 	/*
 	 * Indexed by fielddef and memberref tokens

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3402,8 +3402,8 @@ decode_exception_debug_info (MonoAotModule *amodule,
 			jit_mm_lock (jit_mm);
 			/* This could be set already since this function can be called more than once for the same method */
 			MonoSeqPointInfo *existing_seq_points = NULL;
-			if (!g_hash_table_lookup_extended (jit_mm->seq_points, method, NULL, (gpointer *)&existing_seq_points)) {
-				g_hash_table_insert (jit_mm->seq_points, method, seq_points);
+			if (!dn_simdhash_ght_try_get_value (jit_mm->seq_points, method, (void **)&existing_seq_points)) {
+				dn_simdhash_ght_insert (jit_mm->seq_points, method, seq_points);
 			} else {
 				mono_seq_point_info_free (seq_points);
 				seq_points = existing_seq_points;

--- a/src/mono/mono/mini/interp/tiering.c
+++ b/src/mono/mono/mini/interp/tiering.c
@@ -1,14 +1,16 @@
 #include "tiering.h"
 
 static mono_mutex_t tiering_mutex;
-static GHashTable *patch_sites_table;
+// FIXME: The add/remove traffic on this table may require dn_simdhash to implement cascade flag cleanup
+//  and compaction
+static dn_simdhash_ptr_ptr_t *patch_sites_table;
 static gboolean enable_tiering;
 
 void
 mono_interp_tiering_init (void)
 {
 	mono_os_mutex_init_recursive (&tiering_mutex);
-	patch_sites_table = g_hash_table_new (NULL, NULL);
+	patch_sites_table = dn_simdhash_ptr_ptr_new (0, NULL);
 	enable_tiering = TRUE;
 }
 
@@ -61,11 +63,12 @@ patch_imethod_site (gpointer data, gpointer user_data)
 static void
 patch_interp_data_items (InterpMethod *old_imethod, InterpMethod *new_imethod)
 {
-	GSList *sites = g_hash_table_lookup (patch_sites_table, old_imethod);
-	g_slist_foreach (sites, patch_imethod_site, new_imethod);
-
-	g_hash_table_remove (patch_sites_table, old_imethod);
-	g_slist_free (sites);
+	GSList *sites = NULL;
+	if (dn_simdhash_ptr_ptr_try_get_value (patch_sites_table, old_imethod, (void **)&sites)) {
+		g_slist_foreach (sites, patch_imethod_site, new_imethod);
+		dn_simdhash_ptr_ptr_try_remove (patch_sites_table, old_imethod);
+		g_slist_free (sites);
+	}
 }
 
 static InterpMethod*
@@ -100,9 +103,13 @@ static void
 register_imethod_patch_site (InterpMethod *imethod, gpointer *ptr)
 {
 	g_assert (!imethod->optimized);
-	GSList *sites = g_hash_table_lookup (patch_sites_table, imethod);
+	GSList *sites = NULL;
+	guint8 found = dn_simdhash_ptr_ptr_try_get_value (patch_sites_table, imethod, (void **)&sites);
 	sites = g_slist_prepend (sites, ptr);
-	g_hash_table_insert_replace (patch_sites_table, imethod, sites, TRUE);
+	if (found)
+		dn_simdhash_ptr_ptr_try_replace_value (patch_sites_table, imethod, sites);
+	else
+		dn_simdhash_ptr_ptr_try_add (patch_sites_table, imethod, sites);
 }
 
 static void

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -311,10 +311,12 @@ typedef struct
 	int n_data_items;
 	int max_data_items;
 	void **data_items;
-	GHashTable *data_hash;
+	// FIXME: ptr_u32
+	dn_simdhash_ptr_ptr_t *data_hash;
 	GSList *imethod_items;
 #ifdef ENABLE_EXPERIMENT_TIERED
-	GHashTable *patchsite_hash;
+	// FIXME: ptr_u32
+	dn_simdhash_ptr_ptr_t *patchsite_hash;
 #endif
 	int *clause_indexes;
 	int *clause_vars;
@@ -504,7 +506,7 @@ interp_dump_ins (InterpInst *ins, gpointer *data_items);
 InterpInst*
 interp_get_ldc_i4_from_const (TransformData *td, InterpInst *ins, gint32 ct, int dreg);
 
-gint32 
+gint32
 interp_get_const_from_ldc_i4 (InterpInst *ins);
 
 int

--- a/src/mono/mono/mini/interp/whitebox.c
+++ b/src/mono/mono/mini/interp/whitebox.c
@@ -165,7 +165,7 @@ transform_method (MonoDomain *domain, MonoImage *image, TestItem *ti)
 	td->rtm = rtm;
 	td->clause_indexes = (int*)g_malloc (header->code_size * sizeof (int));
 	td->data_items = NULL;
-	td->data_hash = g_hash_table_new (NULL, NULL);
+	td->data_hash = dn_simdhash_ptr_ptr_new (0, NULL);
 	/* TODO: init more fields of `td` */
 
 	mono_test_interp_method_compute_offsets (td, rtm, signature, header);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3027,7 +3027,7 @@ mono_jit_free_method (MonoMethod *method)
 	//seq_points are always on get_default_jit_mm
 	jit_mm = get_default_jit_mm ();
 	jit_mm_lock (jit_mm);
-	g_hash_table_remove (jit_mm->seq_points, method);
+	dn_simdhash_ght_try_remove (jit_mm->seq_points, method);
 	jit_mm_unlock (jit_mm);
 
 	jit_mm = jit_mm_for_method (method);
@@ -3043,7 +3043,7 @@ mono_jit_free_method (MonoMethod *method)
 	mono_conc_hashtable_remove (jit_mm->runtime_invoke_hash, method);
 	g_hash_table_remove (jit_mm->dynamic_code_hash, method);
 	g_hash_table_remove (jit_mm->jump_trampoline_hash, method);
-	g_hash_table_remove (jit_mm->seq_points, method);
+	dn_simdhash_ght_try_remove (jit_mm->seq_points, method);
 
 	g_hash_table_iter_init (&iter, jit_mm->jump_target_hash);
 	while (g_hash_table_iter_next (&iter, NULL, (void**)&jlist)) {
@@ -4380,7 +4380,7 @@ init_jit_mem_manager (MonoMemoryManager *mem_manager)
 	info->jump_target_hash = g_hash_table_new (NULL, NULL);
 	info->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->delegate_info_hash = g_hash_table_new (delegate_class_method_pair_hash, delegate_class_method_pair_equal);
-	info->seq_points = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free);
+	info->seq_points = dn_simdhash_ght_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free, 0, NULL);
 	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
 	info->arch_seq_points = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	mono_jit_code_hash_init (&info->jit_code_hash);
@@ -4453,7 +4453,7 @@ free_jit_mem_manager (MonoMemoryManager *mem_manager)
 	g_hash_table_destroy (info->static_rgctx_trampoline_hash);
 	g_hash_table_destroy (info->mrgctx_hash);
 	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
-	g_hash_table_destroy (info->seq_points);
+	dn_simdhash_free (info->seq_points);
 	g_hash_table_destroy (info->arch_seq_points);
 	if (info->agent_info)
 		mono_component_debugger ()->free_mem_manager (info);
@@ -5602,4 +5602,11 @@ mono_jit_call_can_be_supported_by_interp (MonoMethod *method, MonoMethodSignatur
 		return FALSE;
 
 	return TRUE;
+}
+
+void
+mono_jit_memory_manager_foreach_seq_point (dn_simdhash_ght_t *seq_points, dn_simdhash_ght_foreach_func func, gpointer user_data)
+{
+	g_assert (seq_points);
+	dn_simdhash_ght_foreach (seq_points, func, user_data);
 }

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -37,7 +37,7 @@ typedef struct {
 	MonoConcurrentHashTable *runtime_invoke_hash;
 	/* Maps MonoMethod to a GPtrArray containing sequence point locations */
 	/* Protected by the domain lock */
-	GHashTable *seq_points;
+	dn_simdhash_ght_t *seq_points;
 	/* Debugger agent data */
 	gpointer agent_info;
 	/* Maps MonoMethod to an arch-specific structure */
@@ -659,6 +659,9 @@ mono_is_addr_implicit_null_check (void *addr);
 
 gboolean
 mono_jit_call_can_be_supported_by_interp (MonoMethod *method, MonoMethodSignature *sig, gboolean is_llvm_only);
+
+MONO_COMPONENT_API void
+mono_jit_memory_manager_foreach_seq_point (dn_simdhash_ght_t *seq_points, dn_simdhash_ght_foreach_func func, gpointer user_data);
 
 /*
  * Signal handling

--- a/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
+++ b/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
@@ -318,6 +318,7 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
             string resourceId = tuple.registeredName;
 
             // Generate Preloaded MonoBundled*Resource structs
+            // See bundled-resources-internals.h
             string preloadedStruct;
             switch (tuple.resourceType)
             {


### PR DESCRIPTION
Migrates various GHashTables in the mono runtime over to dn_simdhash, and optimizes a couple specific spots in the process - in particular bundled resources, which had a very expensive compare function and hash function for keys.

Opening now to run CI tests so I can investigate any broken tests locally. I probably did other stuff in this branch that I can't remember, but it'll be obvious once the parent branch is squashed and I review the diff again...

There are more hash tables in mono that might be profitable to migrate based on profiling, but they're more complex scenarios, i.e. internal hash tables or concurrent hash tables, so I opted not to do them in this PR. In one case when I tried migrating one of them, things actually got slower.