### PR TITLE
Guard against -1 Returned from sysconf for the Cache Sizes Causing Large Gen0 Sizes and Budgets for Certain Linux Distributions.

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,7 +868,7 @@ done:
     return result;
 }
 
-#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if ((NEW_CACHE_SIZE != UINTMAX_MAX) || NEW_CACHE_SIZE > cacheSize) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if ((NEW_CACHE_SIZE != UINTMAX_MAX) && (NEW_CACHE_SIZE > cacheSize)) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
 
 static size_t GetLogicalProcessorCacheSizeFromOS()
 {

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,7 +868,7 @@ done:
     return result;
 }
 
-#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if (NEW_CACHE_SIZE > cacheSize) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if ((NEW_CACHE_SIZE != UINTMAX_MAX) || NEW_CACHE_SIZE > cacheSize) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
 
 static size_t GetLogicalProcessorCacheSizeFromOS()
 {
@@ -885,12 +885,16 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
-    size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
+    size_t level3_dcache_size;
+    size = level3_dcache_size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 3)
+    printf("[GetLogicalProcessorCacheSizeFromOS]: size after Level3DCacheSize (%zu): %zu\n", level3_dcache_size,  size);
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
-    size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
+    size_t level4_dcache_size;
+    size = level4_dcache_size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 4)
+    printf("[GetLogicalProcessorCacheSizeFromOS]: size after Level4DCacheSize (%zu): %zu\n", level4_dcache_size,  size);
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -885,16 +885,12 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
-    size_t level3_dcache_size;
-    size = level3_dcache_size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
+    size = ( size_t) sysconf(_SC_LEVEL3_CACHE_SIZE);
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 3)
-    printf("[GetLogicalProcessorCacheSizeFromOS]: size after Level3DCacheSize (%zu): %zu\n", level3_dcache_size,  size);
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
-    size_t level4_dcache_size;
-    size = level4_dcache_size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
+    size = ( size_t) sysconf(_SC_LEVEL4_CACHE_SIZE);
     UPDATE_CACHE_SIZE_AND_LEVEL(size, 4)
-    printf("[GetLogicalProcessorCacheSizeFromOS]: size after Level4DCacheSize (%zu): %zu\n", level4_dcache_size,  size);
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -927,7 +927,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
                     UPDATE_CACHE_SIZE_AND_LEVEL(size, level)
                 }
 
-                else if (size > 0)
+                else
                 {
                     cacheSize = std::max((long)cacheSize, size);
                 }

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -932,7 +932,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if (defined(HOST_ARM64) || defined(HOST_LOONGARCH64)) && !defined(TARGET_APPLE)
-    if (cacheSize == 0 || cacheSize == SIZE_MAX)
+    if (cacheSize == 0)
     {
         // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
         // from most of the machines.
@@ -960,7 +960,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if HAVE_SYSCTLBYNAME
-    if (cacheSize == 0 || cacheSize == SIZE_MAX)
+    if (cacheSize == 0)
     {
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -894,7 +894,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
-    if (cacheSize == 0 || cacheSize == SIZE_MAX)
+    if (cacheSize == 0)
     {
         //
         // Fallback to retrieve cachesize via /sys/.. if sysconf was not available
@@ -912,7 +912,8 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         {
             path_to_size_file[index] = (char)(48 + i);
 
-            if (ReadMemoryValueFromFile(path_to_size_file, &size))
+            // Only accept reading cache sizes from size files if they are non-bogus values i.e., non-zero and != SIZE_MAX.
+            if (ReadMemoryValueFromFile(path_to_size_file, &size) && ((size != SIZE_MAX) || (size != 0)))
             {
                 path_to_level_file[index] = (char)(48 + i);
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -930,7 +930,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if (defined(HOST_ARM64) || defined(HOST_LOONGARCH64)) && !defined(TARGET_APPLE)
-    if (cacheSize == 0)
+    if (cacheSize == 0 || cacheSize == SIZE_MAX)
     {
         // We expect to get the L3 cache size for Arm64 but currently expected to be missing that info
         // from most of the machines.
@@ -958,7 +958,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if HAVE_SYSCTLBYNAME
-    if (cacheSize == 0)
+    if (cacheSize == 0 || cacheSize == SIZE_MAX)
     {
         int64_t cacheSizeFromSysctl = 0;
         size_t sz = sizeof(cacheSizeFromSysctl);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -894,7 +894,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
-    if (cacheSize == 0)
+    if (cacheSize == 0 || cacheSize == UINTMAX_MAX)
     {
         //
         // Fallback to retrieve cachesize via /sys/.. if sysconf was not available

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -912,7 +912,8 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         {
             path_to_size_file[index] = (char)(48 + i);
 
-            // Only accept reading cache sizes from size files if they are non-bogus values i.e., non-zero and != SIZE_MAX.
+            // Only accept reading cache sizes from size files if they are 
+            // non-bogus values i.e., non-zero and != SIZE_MAX.
             if (ReadMemoryValueFromFile(path_to_size_file, &size) && ((size != SIZE_MAX) || (size != 0)))
             {
                 path_to_level_file[index] = (char)(48 + i);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -976,6 +976,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         if (success)
         {
             assert(cacheSizeFromSysctl > 0);
+            assert(cacheSizeFromSysctl != SIZE_MAX);
             cacheSize = ( size_t) cacheSizeFromSysctl;
         }
     }
@@ -1013,6 +1014,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     }
 #endif
 
+    assert (cacheSize != SIZE_MAX);
     return cacheSize;
 }
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,7 +868,7 @@ done:
     return result;
 }
 
-#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if ((NEW_CACHE_SIZE != UINTMAX_MAX) && (NEW_CACHE_SIZE > cacheSize)) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if ((NEW_CACHE_SIZE != SIZE_MAX) && (NEW_CACHE_SIZE > cacheSize)) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
 
 static size_t GetLogicalProcessorCacheSizeFromOS()
 {
@@ -894,7 +894,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
-    if (cacheSize == 0 || cacheSize == UINTMAX_MAX)
+    if (cacheSize == 0 || cacheSize == SIZE_MAX)
     {
         //
         // Fallback to retrieve cachesize via /sys/.. if sysconf was not available

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -927,8 +927,6 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
                     UPDATE_CACHE_SIZE_AND_LEVEL(size, level)
                 }
 
-                // We guard against the case where the size = -1 or 0. 
-                // This isn't currently an issue but to be safe, we add this check.
                 else if (size > 0)
                 {
                     cacheSize = std::max((long)cacheSize, size);


### PR DESCRIPTION
## Issue Summary

- ``GetLogicalProcessorCacheSizeFromOS`` retrieves a bogus value of ``SIZE_MAX`` (-1 but type casted to a ``size_t``) from the ``sysconf`` call for the L4 Cache Size that's now recognized has the last cache size (as it's not 0) causing a significantly larger gen0 size and budget for Debian 12 vs. Debian 11 for the same hardware i.e., same cache sizes, architecture etc. This behavior also seems to show up for Ubuntu 22.04.
- This is confirmed by running ``getconf -a | grep LEVEL4_CACHE`` on a Debian 12 (and an Ubuntu 22.04) machine results in an empty string for the L4 cache size - this is different from the behavior of Debian 11 that returns a 0 for the L4 cache size. 
- ``SIZE_MAX`` from ``GetLogicalProcessorCacheSizeFromOS`` is also returned from ``GetCacheSizePerLogicalCpu`` and causes an extremely large gen0 size thereby affecting the gen0 budget for Server GC. 

### Further Details

Running ``getconf -a | grep LEVEL4_CACHE`` Outputs:

#### Debian 11

LEVEL4_CACHE_SIZE                  0
LEVEL4_CACHE_ASSOC                 0
LEVEL4_CACHE_LINESIZE              0

#### Debian 12

LEVEL4_CACHE_SIZE
LEVEL4_CACHE_ASSOC
LEVEL4_CACHE_LINESIZE

<hr>

#### Ubuntu 20.04

LEVEL4_CACHE_SIZE                  0
LEVEL4_CACHE_ASSOC                 0
LEVEL4_CACHE_LINESIZE              0

#### Ubuntu 22.04

LEVEL4_CACHE_SIZE
LEVEL4_CACHE_ASSOC
LEVEL4_CACHE_LINESIZE

#### How To Detect This Issue

Run ``getconf -a | grep LEVEL4_CACHE`` and observe if the value for the LEVEL4_CACHE is empty or 0. If it is empty, it indicates that sysconf will return -1 and therefore, we will be susceptible to a large gen0 size and not if it's 0.

## Solution

- Guard against ``-1`` from being returned from sysconf that we cast to a size_t and therefore becomes ``SIZE_MAX`` to prevent much larger gen0 sizes and budgets than if -1 wasn't returned from sysconf.

## Testing

First, we confirmed that running a standalone C program on Debian 11 vs. Debian 12 with code:

```c
#include <unistd.h>
#include <stdio.h>

int main (int argc, char **argv) {
    printf( " Raw LEVEL4 Cache Size: %lu \n",  sysconf( _SC_LEVEL4_CACHE_SIZE ));
    return 0;
}
```

Results in:

Debian 11:
Raw LEVEL4 Cache Size: 0
 
Debian 12:
Raw LEVEL4 Cache Size: 18446744073709551615 or SIZE_MAX

Ubuntu 22.04:
Raw L4 Cache Value: 18446744073709551615 or SIZE_MAX

Additionally, with this fix, the customer confirmed that this fix resulted in their memory going back to previous levels.