### PR TITLE
Add three-stage enqueuer/dispatcher scheme to SocketAsyncEngine, ThreadPoolWorkQueue and ThreadPoolTypedWorkItemQueue

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -87,12 +87,14 @@ namespace System.Net.Sockets
         //
         private readonly ConcurrentQueue<SocketIOEvent> _eventQueue = new ConcurrentQueue<SocketIOEvent>();
 
-        //
-        // This field is set to 1 to indicate that a thread pool work item is scheduled to process events in _eventQueue. It is
-        // set to 0 when the scheduled work item starts running, to indicate that a thread pool work item to process events is
-        // not scheduled. Changes are protected by atomic operations as appropriate.
-        //
-        private int _eventQueueProcessingRequested;
+        private enum EventQueueProcessingStage
+        {
+            NotScheduled,
+            Determining,
+            Scheduled
+        }
+
+        private int _eventQueueProcessingStage;
 
         //
         // Registers the Socket with a SocketAsyncEngine, and returns the associated engine.
@@ -190,9 +192,12 @@ namespace System.Net.Sockets
                     // The native shim is responsible for ensuring this condition.
                     Debug.Assert(numEvents > 0, $"Unexpected numEvents: {numEvents}");
 
-                    if (handler.HandleSocketEvents(numEvents))
+                    if (handler.HandleSocketEvents(numEvents) &&
+                        Interlocked.Exchange(
+                            ref _eventQueueProcessingStage,
+                            (int)EventQueueProcessingStage.Scheduled) == (int)EventQueueProcessingStage.NotScheduled)
                     {
-                        ScheduleToProcessEvents();
+                        ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
                     }
                 }
             }
@@ -202,45 +207,60 @@ namespace System.Net.Sockets
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ScheduleToProcessEvents()
+        private void UpdateEventQueueProcessingStage(bool isEventQueueEmpty)
         {
-            // Schedule a thread pool work item to process events. Only one work item is scheduled at any given time to avoid
-            // over-parallelization. When the work item begins running, this field is reset to 0, allowing for another work item
-            // to be scheduled for parallelizing processing of events.
-            if (Interlocked.CompareExchange(ref _eventQueueProcessingRequested, 1, 0) == 0)
+            if (!isEventQueueEmpty)
             {
-                ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+                _eventQueueProcessingStage = (int)EventQueueProcessingStage.Scheduled;
             }
+            else
+            {
+                int stageBeforeUpdate =
+                    Interlocked.CompareExchange(
+                        ref _eventQueueProcessingStage,
+                        (int)EventQueueProcessingStage.NotScheduled,
+                        (int)EventQueueProcessingStage.Determining);
+                Debug.Assert(stageBeforeUpdate != (int)EventQueueProcessingStage.NotScheduled);
+                if (stageBeforeUpdate == (int)EventQueueProcessingStage.Determining)
+                {
+                    return;
+                }
+            }
+
+            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
         }
 
         void IThreadPoolWorkItem.Execute()
         {
-            // Indicate that a work item is no longer scheduled to process events. The change needs to be visible to enqueuer
-            // threads (only for EventLoop() currently) before an event is attempted to be dequeued. In particular, if an
-            // enqueuer queues an event and does not schedule a work item because it is already scheduled, and this thread is
-            // the last thread processing events, it must see the event queued by the enqueuer.
-            Interlocked.Exchange(ref _eventQueueProcessingRequested, 0);
-
             ConcurrentQueue<SocketIOEvent> eventQueue = _eventQueue;
-            if (!eventQueue.TryDequeue(out SocketIOEvent ev))
+            SocketIOEvent ev;
+            while (true)
             {
-                return;
+                Debug.Assert(_eventQueueProcessingStage == (int)EventQueueProcessingStage.Scheduled);
+                _eventQueueProcessingStage = (int)EventQueueProcessingStage.Determining;
+                Interlocked.MemoryBarrier();
+
+                if (eventQueue.TryDequeue(out ev))
+                {
+                    break;
+                }
+
+                int stageBeforeUpdate =
+                    Interlocked.CompareExchange(
+                        ref _eventQueueProcessingStage,
+                        (int)EventQueueProcessingStage.NotScheduled,
+                        (int)EventQueueProcessingStage.Determining);
+                Debug.Assert(stageBeforeUpdate != (int)EventQueueProcessingStage.NotScheduled);
+                if (stageBeforeUpdate == (int)EventQueueProcessingStage.Determining)
+                {
+                    return;
+                }
             }
+
+            UpdateEventQueueProcessingStage(eventQueue.IsEmpty);
 
             int startTimeMs = Environment.TickCount;
-
-            if (!eventQueue.IsEmpty)
-            {
-                // An event was successfully dequeued, and there may be more events to process. Schedule a work item to parallelize
-                // processing of events, before processing more events. Following this, it is the responsibility of the new work
-                // item and the epoll thread to schedule more work items as necessary. The parallelization may be necessary here if
-                // the user callback as part of handling the event blocks for some reason that may have a dependency on other queued
-                // socket events.
-                ScheduleToProcessEvents();
-            }
-
-            while (true)
+            do
             {
                 ev.Context.HandleEvents(ev.Events);
 
@@ -256,19 +276,7 @@ namespace System.Net.Sockets
                 // using Stopwatch instead (like 1 ms, 5 ms, etc.), from quick tests they appeared to have a slightly greater
                 // impact on throughput compared to the threshold chosen below, though it is slight enough that it may not
                 // matter much. Higher thresholds didn't seem to have any noticeable effect.
-                if (Environment.TickCount - startTimeMs >= 15)
-                {
-                    break;
-                }
-
-                if (!eventQueue.TryDequeue(out ev))
-                {
-                    return;
-                }
-            }
-
-            // The queue was not observed to be empty, schedule another work item before yielding the thread
-            ScheduleToProcessEvents();
+            } while (Environment.TickCount - startTimeMs < 15 && eventQueue.TryDequeue(out ev));
         }
 
         private void FreeNativeResources()

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -238,6 +238,7 @@ namespace System.Net.Sockets
             {
                 Debug.Assert(_eventQueueProcessingStage == (int)EventQueueProcessingStage.Scheduled);
                 _eventQueueProcessingStage = (int)EventQueueProcessingStage.Determining;
+                Interlocked.MemoryBarrier();
 
                 if (eventQueue.TryDequeue(out ev))
                 {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -238,7 +238,6 @@ namespace System.Net.Sockets
             {
                 Debug.Assert(_eventQueueProcessingStage == (int)EventQueueProcessingStage.Scheduled);
                 _eventQueueProcessingStage = (int)EventQueueProcessingStage.Determining;
-                Interlocked.MemoryBarrier();
 
                 if (eventQueue.TryDequeue(out ev))
                 {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -230,12 +230,15 @@ namespace System.Net.Sockets
 
             int startTimeMs = Environment.TickCount;
 
-            // An event was successfully dequeued, and there may be more events to process. Schedule a work item to parallelize
-            // processing of events, before processing more events. Following this, it is the responsibility of the new work
-            // item and the epoll thread to schedule more work items as necessary. The parallelization may be necessary here if
-            // the user callback as part of handling the event blocks for some reason that may have a dependency on other queued
-            // socket events.
-            ScheduleToProcessEvents();
+            if (!eventQueue.IsEmpty)
+            {
+                // An event was successfully dequeued, and there may be more events to process. Schedule a work item to parallelize
+                // processing of events, before processing more events. Following this, it is the responsibility of the new work
+                // item and the epoll thread to schedule more work items as necessary. The parallelization may be necessary here if
+                // the user callback as part of handling the event blocks for some reason that may have a dependency on other queued
+                // socket events.
+                ScheduleToProcessEvents();
+            }
 
             while (true)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -87,11 +87,11 @@ namespace System.Net.Sockets
         //
         private readonly ConcurrentQueue<SocketIOEvent> _eventQueue = new ConcurrentQueue<SocketIOEvent>();
 
-        // The scheme works as following:
-        // From NotScheduled, the only transition is to Scheduled when new events are enqueued and a work item is enqueued to process them.
-        // From Scheduled, the only transition is to Determining right before trying to dequeue an event.
-        // From Determining, it can go to either NotScheduled when no events are present in the queue (the previous work item processed all of them)
-        // or Scheduled if the queue is still not empty (let the current work item handle parallelization as convinient).
+        // The scheme works as follows:
+        // - From NotScheduled, the only transition is to Scheduled when new events are enqueued and a work item is enqueued to process them.
+        // - From Scheduled, the only transition is to Determining right before trying to dequeue an event.
+        // - From Determining, it can go to either NotScheduled when no events are present in the queue (the previous work item processed all of them)
+        //   or Scheduled if the queue is still not empty (let the current work item handle parallelization as convinient).
         //
         // The goal is to avoid enqueueing more work items than necessary, while still ensuring that all events are processed.
         // Another work item isn't enqueued to the thread pool hastily while the state is Determining,
@@ -229,7 +229,7 @@ namespace System.Net.Sockets
             {
                 // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
                 // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                // would not have scheduled a work item to process the work, so try to dequeue a work item again.
+                // would not have scheduled a work item to process the work, so schedule one now.
                 int stageBeforeUpdate =
                     Interlocked.CompareExchange(
                         ref _eventQueueProcessingStage,

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -88,14 +88,14 @@ namespace System.Net.Sockets
         private readonly ConcurrentQueue<SocketIOEvent> _eventQueue = new ConcurrentQueue<SocketIOEvent>();
 
         // The scheme works as following:
-        // From NotScheduled, the only transition is to Scheduled when new events are enqueued and a work item is enqueued to process them
-        // From Scheduled, the only transition is to Determining right before trying to dequeue an event
-        // From Determining, it can go to either NotScheduled (when no events are present in the queue (the previous work item processed all of them)
-        // or Scheduled if the queue is still not empty (let the current work item handle parallelization as convinient)
+        // From NotScheduled, the only transition is to Scheduled when new events are enqueued and a work item is enqueued to process them.
+        // From Scheduled, the only transition is to Determining right before trying to dequeue an event.
+        // From Determining, it can go to either NotScheduled when no events are present in the queue (the previous work item processed all of them)
+        // or Scheduled if the queue is still not empty (let the current work item handle parallelization as convinient).
         //
-        // The goal is to avoid enqueueing more work items than necessary, while still ensuring that all events are processed
+        // The goal is to avoid enqueueing more work items than necessary, while still ensuring that all events are processed.
         // Another work item isn't enqueued to the thread pool hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time
+        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum EventQueueProcessingStage
         {
             NotScheduled,
@@ -201,8 +201,8 @@ namespace System.Net.Sockets
                     // The native shim is responsible for ensuring this condition.
                     Debug.Assert(numEvents > 0, $"Unexpected numEvents: {numEvents}");
 
-                    // Only enqueue a work item if the stage is NotScheduled
-                    // Otherwise there must be a work item already queued or executing, let it handle parallelization
+                    // Only enqueue a work item if the stage is NotScheduled.
+                    // Otherwise there must be a work item already queued or another thread already handling parallelization.
                     if (handler.HandleSocketEvents(numEvents) &&
                         Interlocked.Exchange(
                             ref _eventQueueProcessingStage,
@@ -222,7 +222,7 @@ namespace System.Net.Sockets
         {
             if (!isEventQueueEmpty)
             {
-                // There are more events to process, set stage to Scheduled and enqueue a work item
+                // There are more events to process, set stage to Scheduled and enqueue a work item.
                 _eventQueueProcessingStage = (int)EventQueueProcessingStage.Scheduled;
             }
             else

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -252,6 +252,12 @@ namespace System.Net.Sockets
             while (true)
             {
                 Debug.Assert(_eventQueueProcessingStage == (int)EventQueueProcessingStage.Scheduled);
+
+                // The change needs to be visible to other threads that may request a worker thread before a work item is attempted
+                // to be dequeued by the current thread. In particular, if an enqueuer queues a work item and does not request a
+                // thread because it sees a Determining or Scheduled stage, and the current thread is the last thread processing
+                // work items, the current thread must either see the work item queued by the enqueuer, or it must see a stage of
+                // Scheduled, and try to dequeue again or request another thread.
                 _eventQueueProcessingStage = (int)EventQueueProcessingStage.Determining;
                 Interlocked.MemoryBarrier();
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -227,8 +227,9 @@ namespace System.Net.Sockets
             }
             else
             {
-                // The stage before update would naturally be Determining, in that case there is no more work to do
-                // However the event enqueuer may have set it to Scheduled if more events arrived so enqueue another work item to handle them
+                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
+                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
+                // would not have scheduled a work item to process the work, so try to dequeue a work item again.
                 int stageBeforeUpdate =
                     Interlocked.CompareExchange(
                         ref _eventQueueProcessingStage,
@@ -259,8 +260,9 @@ namespace System.Net.Sockets
                     break;
                 }
 
-                // The stage before update would naturally be Determining, in that case there is no more work to do
-                // However the event enqueuer may have set it to Scheduled if more events were enqueued so let the work item try to dequeue again
+                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
+                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
+                // would not have scheduled a work item to process the work, so try to dequeue a work item again.
                 int stageBeforeUpdate =
                     Interlocked.CompareExchange(
                         ref _eventQueueProcessingStage,

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -823,9 +823,12 @@ namespace System.Threading
             object? workItem = null;
             if (_nextWorkItemToProcess != null)
             {
-                TryDequeue(out workItem, out anyMissedSteal, workQueue, tl);
+                workItem = Interlocked.Exchange(ref _nextWorkItemToProcess, null);
 
-                workItem ??= Interlocked.Exchange(ref _nextWorkItemToProcess, null);
+                if (workItem == null)
+                {
+                    TryDequeue(out workItem, out anyMissedSteal, workQueue, tl);
+                }
             }
 
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -824,6 +824,7 @@ namespace System.Threading
             {
                 Debug.Assert(workQueue._separated.queueProcessingStage == (int)QueueProcessingStage.Scheduled);
                 workQueue._separated.queueProcessingStage = (int)QueueProcessingStage.Determining;
+                Interlocked.MemoryBarrier();
 
                 if ((workItem = DequeueWithPriorityAlternation(workQueue, tl, out bool missedSteal)) != null)
                 {
@@ -1189,6 +1190,7 @@ namespace System.Threading
             {
                 Debug.Assert(_queueProcessingStage == (int)QueueProcessingStage.Scheduled);
                 _queueProcessingStage = (int)QueueProcessingStage.Determining;
+                Interlocked.MemoryBarrier();
 
                 if (_workItems.TryDequeue(out workItem))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1110,12 +1110,15 @@ namespace System.Threading
                 return;
             }
 
-            // An work item was successfully dequeued, and there may be more work items to process. Schedule a work item to
-            // parallelize processing of work items, before processing more work items. Following this, it is the responsibility
-            // of the new work item and the poller thread to schedule more work items as necessary. The parallelization may be
-            // necessary here if the user callback as part of handling the work item blocks for some reason that may have a
-            // dependency on other queued work items.
-            ScheduleForProcessing();
+            if (!_workItems.IsEmpty)
+            {
+                // An work item was successfully dequeued, and there may be more work items to process. Schedule a work item to
+                // parallelize processing of work items, before processing more work items. Following this, it is the responsibility
+                // of the new work item and the poller thread to schedule more work items as necessary. The parallelization may be
+                // necessary here if the user callback as part of handling the work item blocks for some reason that may have a
+                // dependency on other queued work items.
+                ScheduleForProcessing();
+            }
 
             ThreadPoolWorkQueueThreadLocals tl = ThreadPoolWorkQueueThreadLocals.threadLocals!;
             Debug.Assert(tl != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -648,8 +648,6 @@ namespace System.Threading
 
         public object? Dequeue(ThreadPoolWorkQueueThreadLocals tl, ref bool missedSteal)
         {
-            ThreadPoolWorkQueue workQueue = ThreadPool.s_workQueue;
-
             // Check for local work items
             object? workItem = tl.workStealingQueue.LocalPop();
             if (workItem != null)
@@ -657,9 +655,9 @@ namespace System.Threading
                 return workItem;
             }
 
-            if (workQueue._nextWorkItemToProcess != null)
+            if (_nextWorkItemToProcess != null)
             {
-                workItem = Interlocked.Exchange(ref workQueue._nextWorkItemToProcess, null);
+                workItem = Interlocked.Exchange(ref _nextWorkItemToProcess, null);
                 if (workItem != null)
                 {
                     return workItem;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1252,6 +1252,12 @@ namespace System.Threading
             while (true)
             {
                 Debug.Assert(_queueProcessingStage == (int)QueueProcessingStage.Scheduled);
+
+                // The change needs to be visible to other threads that may request a worker thread before a work item is attempted
+                // to be dequeued by the current thread. In particular, if an enqueuer queues a work item and does not request a
+                // thread because it sees a Determining or Scheduled stage, and the current thread is the last thread processing
+                // work items, the current thread must either see the work item queued by the enqueuer, or it must see a stage of
+                // Scheduled, and try to dequeue again or request another thread.
                 _queueProcessingStage = (int)QueueProcessingStage.Determining;
                 Interlocked.MemoryBarrier();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -407,14 +407,14 @@ namespace System.Threading
         private object? _nextWorkItemToProcess;
 
         // The scheme works as following:
-        // From NotScheduled, the only transition is to Scheduled when new items are enqueued and a thread is requested to process them
-        // From Scheduled, the only transition is to Determining right before trying to dequeue an item
+        // From NotScheduled, the only transition is to Scheduled when new items are enqueued and a thread is requested to process them.
+        // From Scheduled, the only transition is to Determining right before trying to dequeue an item.
         // From Determining, it can go to either NotScheduled when no items are present in the queue (the previous thread processed all of them)
-        // or Scheduled if the queue is still not empty (let the current thread handle parallelization as convinient)
+        // or Scheduled if the queue is still not empty (let the current thread handle parallelization as convinient).
         //
-        // The goal is to avoid requesting more threads than necessary, while still ensuring that all items are processed
+        // The goal is to avoid requesting more threads than necessary, while still ensuring that all items are processed.
         // Another thread isn't requested hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time
+        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum QueueProcessingStage
         {
             NotScheduled,
@@ -591,8 +591,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void EnsureThreadRequested()
         {
-            // Only request a thread if the stage is NotScheduled
-            // Otherwise let the current requested thread handle parallelization
+            // Only request a thread if the stage is NotScheduled.
+            // Otherwise let the current requested thread handle parallelization.
             if (Interlocked.Exchange(
                 ref _separated.queueProcessingStage,
                 (int)QueueProcessingStage.Scheduled) == (int)QueueProcessingStage.NotScheduled)
@@ -1178,14 +1178,14 @@ namespace System.Threading
         where TCallback : struct, IThreadPoolTypedWorkItemQueueCallback<T>
     {
         // The scheme works as following:
-        // From NotScheduled, the only transition is to Scheduled when new items are enqueued and a TP work item is enqueued to process them
-        // From Scheduled, the only transition is to Determining right before trying to dequeue an item
+        // From NotScheduled, the only transition is to Scheduled when new items are enqueued and a TP work item is enqueued to process them.
+        // From Scheduled, the only transition is to Determining right before trying to dequeue an item.
         // From Determining, it can go to either NotScheduled when no items are present in the queue (the previous TP work item processed all of them)
-        // or Scheduled if the queue is still not empty (let the current TP work item handle parallelization as convinient)
+        // or Scheduled if the queue is still not empty (let the current TP work item handle parallelization as convinient).
         //
-        // The goal is to avoid enqueueing more TP work items than necessary, while still ensuring that all items are processed
+        // The goal is to avoid enqueueing more TP work items than necessary, while still ensuring that all items are processed.
         // Another TP work item isn't enqueued to the thread pool hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time
+        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum QueueProcessingStage
         {
             NotScheduled,
@@ -1207,8 +1207,8 @@ namespace System.Threading
         public void BatchEnqueue(T workItem) => _workItems.Enqueue(workItem);
         public void CompleteBatchEnqueue()
         {
-            // Only enqueue a work item if the stage is NotScheduled
-            //Otherwise there must be a work item already queued or another thread already handling parallelization
+            // Only enqueue a work item if the stage is NotScheduled.
+            //Otherwise there must be a work item already queued or another thread already handling parallelization.
             if (Interlocked.Exchange(
                 ref _queueProcessingStage,
                 (int)QueueProcessingStage.Scheduled) == (int)QueueProcessingStage.NotScheduled)
@@ -1221,7 +1221,7 @@ namespace System.Threading
         {
             if (!isQueueEmpty)
             {
-                // There are more items to process, set stage to Scheduled and enqueue a TP work item
+                // There are more items to process, set stage to Scheduled and enqueue a TP work item.
                 _queueProcessingStage = (int)QueueProcessingStage.Scheduled;
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -404,7 +404,7 @@ namespace System.Threading
         private readonly int[] _assignedWorkItemQueueThreadCounts =
             s_assignableWorkItemQueueCount > 0 ? new int[s_assignableWorkItemQueueCount] : Array.Empty<int>();
 
-        private object? _nextWorkItemToProcess;
+        private static object? _nextWorkItemToProcess;
 
         // The scheme works as following:
         // From NotScheduled, the only transition is to Scheduled when new items are enqueued and a thread is requested to process them.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/93028.

In these scenarios, we currently handle two states: Scheduled and NotScheduled. 

This change introduces the "Determining" state, which avoids requesting another resource (thread or TP work item) hastily when more items are enqueued while in this state. Instead, the parallelizer takes care of that. This change ensures that only one thread can be parallelizing at any time.

The transitions are as following:
- From NotScheduled, the only transition is to Scheduled if new items are enqueued (a resource to process them is requested).
- From Scheduled, the only transition is to Determining right before trying to dequeue an item.
- From Determining, it'll transition to NotScheduled if it's determined that there are no more items to process. Otherwise, it'll transition to Scheduled if either new items were enqueued or it's determined that another resource is needed to guarantee all items are processed (in both cases a new resource is requested).