### PR TITLE
[release/8.0] Avoid allocating collectible instances in the frozen heap (#100444)

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9393,7 +9393,8 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                             CORINFO_FIELD_INFO fi;
                             eeGetFieldInfo(&fldToken, CORINFO_ACCESS_SET, &fi);
                             unsigned flagsToCheck = CORINFO_FLG_FIELD_STATIC | CORINFO_FLG_FIELD_FINAL;
-                            if ((fi.fieldFlags & flagsToCheck) == flagsToCheck)
+                            if (((fi.fieldFlags & flagsToCheck) == flagsToCheck) &&
+                                ((info.compCompHnd->getClassAttribs(info.compClassHnd) & CORINFO_FLG_SHAREDINST) == 0))
                             {
 #ifdef FEATURE_READYTORUN
                                 if (opts.IsReadyToRun())

--- a/src/coreclr/vm/frozenobjectheap.cpp
+++ b/src/coreclr/vm/frozenobjectheap.cpp
@@ -47,6 +47,7 @@ Object* FrozenObjectHeapManager::TryAllocateObject(PTR_MethodTable type, size_t 
 
             _ASSERT(type != nullptr);
             _ASSERT(FOH_COMMIT_SIZE >= MIN_OBJECT_SIZE);
+            _ASSERT(!type->Collectible());
 
             // Currently we don't support frozen objects with special alignment requirements
             // TODO: We should also give up on arrays of doubles on 32-bit platforms.

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using Xunit;
+
+public class Runtime_100437
+{
+    [Fact]
+    [SkipOnMono("PlatformDetection.IsPreciseGcSupported false on mono", TestPlatforms.Any)]
+    public static void TestNonCollectibleType() => TestCollectibleReadOnlyStatics(nameof(NonCollectibleType));
+
+    [Fact]
+    [SkipOnMono("PlatformDetection.IsPreciseGcSupported false on mono", TestPlatforms.Any)]
+    public static void TestNonCollectibleTypeInSharedGenericCode() => TestCollectibleReadOnlyStatics(nameof(NonCollectibleTypeInSharedGenericCode));
+
+    [Fact]
+    [SkipOnMono("PlatformDetection.IsPreciseGcSupported false on mono", TestPlatforms.Any)]
+    public static void TestNonCollectibleArrayTypeInSharedGenericCode() => TestCollectibleReadOnlyStatics(nameof(NonCollectibleArrayTypeInSharedGenericCode));
+
+    [Fact]
+    [SkipOnMono("PlatformDetection.IsPreciseGcSupported false on mono", TestPlatforms.Any)]
+    public static void TestCollectibleEmptyArray() => TestCollectibleReadOnlyStatics(nameof(CollectibleEmptyArray));
+
+    private static void TestCollectibleReadOnlyStatics(string methodName)
+    {
+        string assemblyPath = typeof(Runtime_100437).Assembly.Location;
+
+        // Skip this test for single file
+        if (string.IsNullOrEmpty(assemblyPath))
+            return;
+
+        WeakReference wr = CreateReadOnlyStaticWeakReference();
+
+        for (int i = 0; i < 10; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            if (!IsTargetAlive(wr))
+                return;
+        }
+
+        throw new Exception("Test failed - readonly static has not been collected.");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        WeakReference CreateReadOnlyStaticWeakReference()
+        {
+            AssemblyLoadContext alc = new CollectibleAssemblyLoadContext();
+            Assembly a = alc.LoadFromAssemblyPath(assemblyPath);
+            return (WeakReference)a.GetType(nameof(Runtime_100437)).GetMethod(methodName).Invoke(null, new object[] { typeof(Runtime_100437).Assembly });
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        bool IsTargetAlive(WeakReference wr)
+        {
+            return wr.Target != null;
+        }
+    }
+
+    public static WeakReference NonCollectibleType(Assembly assemblyInDefaultContext)
+    {
+        return new WeakReference(Holder.Singleton, trackResurrection: true);
+    }
+
+    public static WeakReference NonCollectibleTypeInSharedGenericCode(Assembly assemblyInDefaultContext)
+    {
+        // Create instance of a non-collectible generic type definition over a collectible type
+        var type = assemblyInDefaultContext.GetType("Runtime_100437+GenericHolder`1", throwOnError: true).MakeGenericType(typeof(Runtime_100437));
+        var field = type.GetField("Singleton", BindingFlags.Static | BindingFlags.Public);
+        return new WeakReference(field.GetValue(null), trackResurrection: true);
+    }
+
+    public static WeakReference NonCollectibleArrayTypeInSharedGenericCode(Assembly assemblyInDefaultContext)
+    {
+        // Create instance of a non-collectible generic type definition over a collectible type
+        var type = assemblyInDefaultContext.GetType("Runtime_100437+GenericArrayHolder`1", throwOnError: true).MakeGenericType(typeof(Runtime_100437));
+        var field = type.GetField("Singleton", BindingFlags.Static | BindingFlags.Public);
+        return new WeakReference(field.GetValue(null), trackResurrection: true);
+    }
+
+    public static WeakReference CollectibleEmptyArray(Assembly assemblyInDefaultContext)
+    {
+        return new WeakReference(Array.Empty<Runtime_100437>(), trackResurrection: true);
+    }
+
+    private class CollectibleAssemblyLoadContext : AssemblyLoadContext
+    {
+        public CollectibleAssemblyLoadContext()
+            : base(isCollectible: true)
+        {
+        }
+    }
+
+    private class Holder
+    {
+        public static readonly object Singleton = new object();
+    }
+
+    private class GenericHolder<T>
+    {
+        public static readonly object Singleton = new object();
+    }
+
+    private class GenericArrayHolder<T>
+    {
+        public static readonly int[] Singleton = new int[0];
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/100444 to release/8.0-staging

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Intermittent crashes and memory leaks in complex scenarios involving collectible assemblies.

## Regression

- [x] Yes
- [ ] No

Regression introduced by new JIT optimization in .NET 8.

## Testing

Targeted test crashing or failing before the fix, passing with the fix. Also, customer verified the fix.

## Risk

Low. The fix is to suppress the new JIT optimization for shared generic code.