### PR TITLE
Fix building x86 Windows native AOT runtime packs

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -65,6 +65,7 @@ extends:
           buildConfig: release
           platforms:
           - windows_x64
+          - windows_x86
           - windows_arm64
           jobParameters:
             templatePath: 'templates-official'
@@ -89,41 +90,6 @@ extends:
               parameters:
                 name: $(osGroup)$(osSubgroup)_$(archType)
 
-
-      #
-      # Build CoreCLR runtime packs
-      # Windows x86
-      # No NativeAOT as NativeAOT is not supported on x86
-      # Sign diagnostic files after native build
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x86
-          jobParameters:
-            templatePath: 'templates-official'
-            buildArgs: -s clr.runtime+clr.alljits -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
-            nameSuffix: CoreCLR
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            timeoutInMinutes: 120
-            postBuildSteps:
-            - template: /eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
-              parameters:
-                basePath: $(Build.SourcesDirectory)/artifacts/bin/coreclr
-                isOfficialBuild: ${{ variables.isOfficialBuild }}
-                timeoutInMinutes: 30
-            # Now that we've signed the diagnostic files, do the rest of the build.
-            - template: /eng/pipelines/common/templates/global-build-step.yml
-              parameters:
-                buildArgs: -s clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+host+packs -c $(_BuildConfig)
-                displayName: Build managed CoreCLR components, all libraries, hosts, and packs
-
-            # Upload the results.
-            - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
-              parameters:
-                name: $(osGroup)$(osSubgroup)_$(archType)
       #
       # Build CoreCLR runtime packs
       # Mac x64/arm64


### PR DESCRIPTION
Looks like we had a whole extra job definition just to avoid building the native AOT parts in the official build, so the x86 packages we produce are incomplete.

I'm in no rush getting this in, obviously the 1ES switchover is higher pri.

Cc @dotnet/ilc-contrib 