### PR TITLE
Avoid frequent calls to CertificateValidationPal.IsLocalCertificateUsed

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -362,7 +362,7 @@ namespace System.Net.Security
                 token.ReleasePayload();
 
                 // reset the cached flag which has potentially outdated value.
-                _localClientCertificateUsed = null;
+                _localClientCertificateUsed = -1;
             }
 
             if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -360,6 +360,9 @@ namespace System.Net.Security
                 }
 
                 token.ReleasePayload();
+
+                // reset the cached flag which has potentially outdated value.
+                _localClientCertificateUsed = null;
             }
 
             if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -56,7 +56,9 @@ namespace System.Net.Security
         private X509Certificate? _selectedClientCertificate;
         private X509Certificate2? _remoteCertificate;
         private bool _remoteCertificateExposed;
-        private bool? _localClientCertificateUsed;
+
+        // -1 for uninitialized, 0 for false, 1 for true, should be accessed via IsLocalClientCertificateUsed property
+        private int _localClientCertificateUsed = -1;
 
         // These are the MAX encrypt buffer output sizes, not the actual sizes.
         private int _headerSize = 5; //ATTN must be set to at least 5 by default
@@ -85,7 +87,20 @@ namespace System.Net.Security
 
         // IsLocalCertificateUsed is expensive, but it does not change during the lifetime of the SslStream except for renegotiation, so we
         // can cache the value.
-        private bool IsLocalClientCertificateUsed => _localClientCertificateUsed ??= CertificateValidationPal.IsLocalCertificateUsed(_credentialsHandle, _securityContext!);
+        private bool IsLocalClientCertificateUsed
+        {
+            get
+            {
+                if (_localClientCertificateUsed == -1)
+                {
+                    _localClientCertificateUsed = CertificateValidationPal.IsLocalCertificateUsed(_credentialsHandle, _securityContext!)
+                        ? 1
+                        : 0;
+                }
+
+                return _localClientCertificateUsed == 1;
+            }
+        }
 
         internal X509Certificate? LocalClientCertificate
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -56,6 +56,7 @@ namespace System.Net.Security
         private X509Certificate? _selectedClientCertificate;
         private X509Certificate2? _remoteCertificate;
         private bool _remoteCertificateExposed;
+        private bool? _localClientCertificateUsed;
 
         // These are the MAX encrypt buffer output sizes, not the actual sizes.
         private int _headerSize = 5; //ATTN must be set to at least 5 by default
@@ -82,11 +83,15 @@ namespace System.Net.Security
             }
         }
 
+        // IsLocalCertificateUsed is expensive, but it does not change during the lifetime of the SslStream except for renegotiation, so we
+        // can cache the value.
+        private bool IsLocalClientCertificateUsed => _localClientCertificateUsed ??= CertificateValidationPal.IsLocalCertificateUsed(_credentialsHandle, _securityContext!);
+
         internal X509Certificate? LocalClientCertificate
         {
             get
             {
-                if (_selectedClientCertificate != null && CertificateValidationPal.IsLocalCertificateUsed(_credentialsHandle, _securityContext!))
+                if (_selectedClientCertificate != null && IsLocalClientCertificateUsed)
                 {
                     return _selectedClientCertificate;
                 }


### PR DESCRIPTION
Closes #95687.

The affected code path is on Windows in mutually authenticated connections (i.e. with client certificate), and where client accesses either of:
- IsMutuallyAuthenticated
- LocalCertificate

Server side is unaffected, as well as client side without client certificate.

```

BenchmarkDotNet v0.13.11-nightly.20231126.107, Windows 11 (10.0.22631.3296/23H2/2023Update/SunValley3)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
.NET SDK 8.0.300-preview.24201.7
  [Host]     : .NET 8.0.2 (8.0.224.6711), X64 RyuJIT AVX2
  Job-JOWNWG : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2
  Job-UGFCLX : .NET 9.0.0 (42.42.42.42424), X64 RyuJIT AVX2

PowerPlanMode=00000000-0000-0000-0000-000000000000  IterationTime=250.0000 ms  MaxIterationCount=20  
MinIterationCount=15  WarmupCount=1  

```
| Method                  | Job        | Toolchain                                                                          | Mean          | Error         | StdDev      | Median        | Min           | Max           | Ratio | Allocated | Alloc Ratio |
|------------------------ |----------- |----------------------------------------------------------------------------------- |--------------:|--------------:|------------:|--------------:|--------------:|--------------:|------:|----------:|------------:|
| IsMutuallyAuthenticated | Job-JOWNWG | \95687-SslStreamIsMutuallyAuthenticated-calls-are-expensive-on-Windows\corerun.exe |      5.271 ns |     0.0428 ns |   0.0334 ns |      5.273 ns |      5.202 ns |      5.320 ns | 0.000 |         - |        0.00 |
| IsMutuallyAuthenticated | Job-UGFCLX | \main\corerun.exe                                                                  | 62,898.672 ns | 1,125.7018 ns | 997.9053 ns | 63,306.704 ns | 61,270.539 ns | 64,574.663 ns | 1.000 |      32 B |        1.00 |
