### PR TITLE
[browser][mt] Fix `SignalRClientTests` timeouts

### DIFF
--- a/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Program.cs
+++ b/src/mono/wasm/testassets/BlazorHostedApp/BlazorHosted.Client/Program.cs
@@ -10,4 +10,5 @@ builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
+Helper.TestOutputWriteLine($"Starting the app");
 await builder.Build().RunAsync().ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100388 and fixes https://github.com/dotnet/runtime/issues/100445. The tests are supposed to check signalR connection in MT runtime and the timeouts occur before any connection is even made (`OnAfterRender` is not triggered), so adding retries does not obscure the objective of the test.