### PR TITLE
Allow for setting of isOfficialBuild when uploading intermediate artifacts

### DIFF
--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -2,6 +2,7 @@ parameters:
   name: ''
   publishPackagesCondition: always()
   publishVSSetupCondition: false
+  isOfficialBuild: true
 
 steps:
 - task: CopyFiles@2
@@ -27,7 +28,7 @@ steps:
 
 - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
   parameters:
-    isOfficialBuild: true
+    isOfficialBuild: ${{ parameters.isOfficialBuild }}
     displayName: Publish intermediate artifacts
     inputs:
       PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'

--- a/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
+++ b/eng/pipelines/coreclr/perf-non-wasm-jobs.yml
@@ -288,7 +288,7 @@ jobs:
         runKind: micro
         runJobTemplate: /eng/pipelines/coreclr/templates/run-performance-job.yml
         logicalmachine: 'perfowl'
-  
+
   # run coreclr perfviper microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
@@ -376,6 +376,7 @@ jobs:
           - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
             parameters:
               name: MonoRuntimePacks
+              isOfficialBuild: false
 
   # build PerfBDN app
   - template: /eng/pipelines/common/platform-matrix.yml


### PR DESCRIPTION
Allow for setting of isOfficialBuild when uploading intermediate artifacts. 

After the update https://github.com/dotnet/runtime/pull/99433, the performance pipeline runs started failing due to not being able to find `1ES.PublishBuildArtifacts`, example run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2420076&view=results. This was due to the `upload-intermediate-artifacts-step` setting the job as an official build for the actual upload, where we use it as part of non-official builds. As such, I added the parameter isOfficialBuild with the default of true to allow for non-official build uses of the upload-intermediate-artifacts-step.yml.

Test run showing that this fixes the yaml parsing error: https://dev.azure.com/dnceng/internal/_build/results?buildId=2420143&view=results