### PR TITLE
Cleanup of `fx_resolver_t` and tests in `NativeHostApis`

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/BundleProbe.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/BundleProbe.cs
@@ -35,8 +35,7 @@ namespace AppHost.Bundle.Tests
             };
 
             var result = Command.Create(singleFile, $"host_runtime_contract.bundle_probe {string.Join(" ", itemsToProbe.Select(i => i.Path))}")
-                .CaptureStdErr()
-                .CaptureStdOut()
+                .EnableTracingAndCaptureOutputs()
                 .Execute();
 
             result.Should().Pass();

--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
@@ -106,62 +106,48 @@ namespace HostApiInvokerApp
         /// <summary>
         /// Test invoking the native hostfxr api hostfxr_resolve_sdk2
         /// </summary>
-        /// <param name="args[0]">hostfxr_get_available_sdks</param>
-        /// <param name="args[1]">Directory of dotnet executable</param>
-        /// <param name="args[2]">Working directory where search for global.json begins</param>
-        /// <param name="args[3]">Flags</param>
+        /// <param name="args[0]">Directory of dotnet executable</param>
+        /// <param name="args[1]">Working directory where search for global.json begins</param>
+        /// <param name="args[2]">Flags</param>
         static void Test_hostfxr_resolve_sdk2(string[] args)
         {
-            if (args.Length != 4)
+            if (args.Length != 3)
             {
                 throw new ArgumentException("Invalid number of arguments passed");
             }
 
             var data = new List<(hostfxr.hostfxr_resolve_sdk2_result_key_t, string)>();
             int rc = hostfxr.hostfxr_resolve_sdk2(
-                exe_dir: args[1],
-                working_dir: args[2],
-                flags: Enum.Parse<hostfxr.hostfxr_resolve_sdk2_flags_t>(args[3]),
+                exe_dir: args[0],
+                working_dir: args[1],
+                flags: Enum.Parse<hostfxr.hostfxr_resolve_sdk2_flags_t>(args[2]),
                 result: (key, value) => data.Add((key, value)));
 
-            if (rc == 0)
-            {
-                Console.WriteLine("hostfxr_resolve_sdk2:Success");
-            }
-            else
-            {
-                Console.WriteLine($"hostfxr_resolve_sdk2:Fail[{rc}]");
-            }
-
-            Console.WriteLine($"hostfxr_resolve_sdk2 data:[{string.Join(';', data)}]");
+            string api = nameof(hostfxr.hostfxr_resolve_sdk2);
+            LogResult(api, rc);
+            Console.WriteLine($"{api} data:[{string.Join(';', data)}]");
         }
 
         /// <summary>
         /// Test invoking the native hostfxr api hostfxr_get_available_sdks
         /// </summary>
-        /// <param name="args[0]">hostfxr_get_available_sdks</param>
-        /// <param name="args[1]">Directory of dotnet executable</param>
+        /// <param name="args[0]">Directory of dotnet executable</param>
         static void Test_hostfxr_get_available_sdks(string[] args)
         {
-            if (args.Length != 2)
+            if (args.Length != 1)
             {
                 throw new ArgumentException("Invalid number of arguments passed");
             }
 
             string[] sdks = null;
             int rc = hostfxr.hostfxr_get_available_sdks(
-                exe_dir: args[1],
+                exe_dir: args[0],
                 (sdk_count, sdk_dirs) => sdks = sdk_dirs);
 
-            if (rc == 0)
-            {
-                Console.WriteLine("hostfxr_get_available_sdks:Success");
-                Console.WriteLine($"hostfxr_get_available_sdks sdks:[{string.Join(';', sdks)}]");
-            }
-            else
-            {
-                Console.WriteLine($"hostfxr_get_available_sdks:Fail[{rc}]");
-            }
+            string api = nameof(hostfxr.hostfxr_get_available_sdks);
+            LogResult(api, rc);
+            if (sdks != null)
+                Console.WriteLine($"{api} sdks:[{string.Join(';', sdks)}]");
         }
 
         static void Test_hostfxr_set_error_writer(string[] args)
@@ -193,13 +179,12 @@ namespace HostApiInvokerApp
         /// <summary>
         /// Test that invokes native api hostfxr_get_dotnet_environment_info.
         /// </summary>
-        /// <param name="args[0]">hostfxr_get_dotnet_environment_info</param>
-        /// <param name="args[1]">(Optional) Path to the directory with dotnet.exe</param>
+        /// <param name="args[0]">(Optional) Path to the directory with dotnet.exe</param>
         static void Test_hostfxr_get_dotnet_environment_info(string[] args)
         {
             string dotnetExeDir = null;
-            if (args.Length >= 2)
-                dotnetExeDir = args[1];
+            if (args.Length >= 1)
+                dotnetExeDir = args[0];
 
             string hostfxr_version;
             string hostfxr_commit_hash;
@@ -254,20 +239,19 @@ namespace HostApiInvokerApp
                 result: result_fn,
                 result_context: new IntPtr(42));
 
-            if (rc != 0)
-            {
-                Console.WriteLine($"hostfxr_get_dotnet_environment_info:Fail[{rc}]");
-            }
+            string api = nameof(hostfxr.hostfxr_get_dotnet_environment_info);
+            LogResult(api, rc);
 
-            Console.WriteLine($"hostfxr_get_dotnet_environment_info sdk versions:[{string.Join(";", sdks.Select(s => s.version).ToList())}]");
-            Console.WriteLine($"hostfxr_get_dotnet_environment_info sdk paths:[{string.Join(";", sdks.Select(s => s.path).ToList())}]");
+            Console.WriteLine($"{api} sdk versions:[{string.Join(";", sdks.Select(s => s.version).ToList())}]");
+            Console.WriteLine($"{api} sdk paths:[{string.Join(";", sdks.Select(s => s.path).ToList())}]");
 
-            Console.WriteLine($"hostfxr_get_dotnet_environment_info framework names:[{string.Join(";", frameworks.Select(f => f.name).ToList())}]");
-            Console.WriteLine($"hostfxr_get_dotnet_environment_info framework versions:[{string.Join(";", frameworks.Select(f => f.version).ToList())}]");
-            Console.WriteLine($"hostfxr_get_dotnet_environment_info framework paths:[{string.Join(";", frameworks.Select(f => f.path).ToList())}]");
-
-            Console.WriteLine("hostfxr_get_dotnet_environment_info:Success");
+            Console.WriteLine($"{api} framework names:[{string.Join(";", frameworks.Select(f => f.name).ToList())}]");
+            Console.WriteLine($"{api} framework versions:[{string.Join(";", frameworks.Select(f => f.version).ToList())}]");
+            Console.WriteLine($"{api} framework paths:[{string.Join(";", frameworks.Select(f => f.path).ToList())}]");
         }
+
+        private static void LogResult(string apiName, int rc)
+            => Console.WriteLine(rc == 0 ? $"{apiName}:Success" : $"{apiName}:Fail[0x{rc:x}]");
 
         public static bool RunTest(string apiToTest, string[] args)
         {

--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostRuntimeContract.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostRuntimeContract.cs
@@ -113,10 +113,10 @@ namespace HostApiInvokerApp
             switch (apiToTest)
             {
                 case $"{nameof(host_runtime_contract)}.{nameof(host_runtime_contract.get_runtime_property)}":
-                    Test_get_runtime_property(args[1..]);
+                    Test_get_runtime_property(args);
                     break;
                 case $"{nameof(host_runtime_contract)}.{nameof(host_runtime_contract.bundle_probe)}":
-                    Test_bundle_probe(args[1..]);
+                    Test_bundle_probe(args);
                     break;
                 default:
                     return false;

--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/Program.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/Program.cs
@@ -31,9 +31,6 @@ namespace HostApiInvokerApp
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
 
-            // Enable tracing so that test assertion failures are easier to diagnose.
-            Environment.SetEnvironmentVariable("COREHOST_TRACE", "1");
-
             // If requested, test multilevel lookup using fake Global SDK directories:
             //     1. using a fake ProgramFiles location
             //     2. using a fake SDK Self-Registered location
@@ -61,13 +58,13 @@ namespace HostApiInvokerApp
             }
 
             string apiToTest = args[0];
-            if (HostFXR.RunTest(apiToTest, args))
+            if (HostFXR.RunTest(apiToTest, args[1..]))
                 return;
 
-            if (HostPolicy.RunTest(apiToTest, args))
+            if (HostPolicy.RunTest(apiToTest, args[1..]))
                 return;
 
-            if (HostRuntimeContract.RunTest(apiToTest, args))
+            if (HostRuntimeContract.RunTest(apiToTest, args[1..]))
                 return;
 
             throw new ArgumentException($"Invalid API to test passed as args[0]): {apiToTest}");

--- a/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
+++ b/src/installer/tests/TestUtils/Assertions/CommandResultAssertions.cs
@@ -112,14 +112,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
         public AndConstraint<CommandResultAssertions> NotHaveStdOut()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(Result.StdOut))
-                .FailWith($"Expected command to not output to stdout but it was not:{GetDiagnosticsInfo()}");
+                .FailWith($"Expected command to not output to stdout but it did:{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
         public AndConstraint<CommandResultAssertions> NotHaveStdErr()
         {
             Execute.Assertion.ForCondition(string.IsNullOrEmpty(Result.StdErr))
-                .FailWith($"Expected command to not output to stderr but it was not:{GetDiagnosticsInfo()}");
+                .FailWith($"Expected command to not output to stderr but it did:{GetDiagnosticsInfo()}");
             return new AndConstraint<CommandResultAssertions>(this);
         }
 

--- a/src/installer/tests/TestUtils/Constants.cs
+++ b/src/installer/tests/TestUtils/Constants.cs
@@ -113,6 +113,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
 
         public static class ErrorCode
         {
+            public const int Success = 0;
             public const int InvalidArgFailure = unchecked((int)0x80008081);
             public const int CoreHostLibMissingFailure = unchecked((int)0x80008083);
             public const int ResolverInitFailure = unchecked((int)0x8000808b);

--- a/src/native/corehost/fxr/fx_resolver.h
+++ b/src/native/corehost/fxr/fx_resolver.h
@@ -27,7 +27,7 @@ public:
         const std::unordered_map<pal::string_t, const fx_ver_t> &existing_framework_versions_by_name);
 
 private:
-    fx_resolver_t();
+    fx_resolver_t() = default;
 
     void update_newest_references(
         const runtime_config_t& config);
@@ -40,10 +40,6 @@ private:
         fx_definition_vector_t& fx_definitions,
         const pal::char_t* app_display_name);
 
-    static StatusCode reconcile_fx_references_helper(
-        const fx_reference_t& lower_fx_ref,
-        const fx_reference_t& higher_fx_ref,
-        /*out*/ fx_reference_t& effective_fx_ref);
     static StatusCode reconcile_fx_references(
         const fx_reference_t& fx_ref_a,
         const fx_reference_t& fx_ref_b,


### PR DESCRIPTION
Slight cleanup of `fx_resolver_t` and `NativeHostApis` tests in preparation for #99027:
- Collapse `reconcile_fx_references_helper` into `reconcile_fx_references`
- Make `NativeHostApis` tests / `HostApiInvokerApp` more consistent in how they log and validate results