### PR TITLE
Implement RuntimeHelpers.Box

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -422,18 +422,19 @@ namespace System.Runtime.CompilerServices
             if (type.IsNullHandle())
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.type);
 
-            RuntimeType rtType = (RuntimeType)Type.GetTypeFromHandle(type)!;
+            TypeHandle handle = type.GetNativeTypeHandle();
 
-            if (rtType.IsByRefLike)
-                throw new NotSupportedException(SR.NotSupported_ByRefLike);
+            if (handle.IsTypeDesc)
+                throw new ArgumentException(SR.Arg_TypeNotSupported);
 
-            if (rtType.IsPointer || rtType.IsFunctionPointer)
-                throw new NotSupportedException(SR.NotSupported_BoxedPointer);
+            MethodTable* pMT = handle.AsMethodTable();
 
-            if (rtType.IsActualValueType)
+            if (pMT->IsValueType)
             {
-                object? result = Box(rtType.GetNativeTypeHandle().AsMethodTable(), ref target);
-                GC.KeepAlive(rtType);
+                if (pMT->IsByRefLike)
+                    throw new NotSupportedException(SR.NotSupported_ByRefLike);
+                object? result = Box(pMT, ref target);
+                GC.KeepAlive(type);
                 return result;
             }
             else

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -417,6 +417,15 @@ namespace System.Runtime.CompilerServices
             }
         }
 
+        /// <summary>
+        /// Create a boxed object of the specified type from the data located at the target reference.
+        /// </summary>
+        /// <param name="target">The target data</param>
+        /// <param name="type">The type of box to create.</param>
+        /// <returns>A boxed object containing the specified data.</returns>
+        /// <exception cref="ArgumentNullException">The specified type handle is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The specified type cannot have a boxed instance of itself created.</exception>
+        /// <exception cref="NotSupportedException">The passed in type is a by-ref-like type.</exception>
         public static unsafe object? Box(ref byte target, RuntimeTypeHandle type)
         {
             if (type.IsNullHandle())

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -429,7 +429,7 @@ namespace System.Runtime.CompilerServices
 
             MethodTable* pMT = handle.AsMethodTable();
 
-            if (pMT->IsGenericTypeDefinition)
+            if (pMT->ContainsGenericVariables)
                 throw new ArgumentException(SR.Arg_TypeNotSupported);
 
             if (pMT->IsValueType)
@@ -556,6 +556,7 @@ namespace System.Runtime.CompilerServices
 
         // WFLAGS_HIGH_ENUM
         private const uint enum_flag_ContainsPointers = 0x01000000;
+        private const uint enum_flag_ContainsGenericVariables = 0x20000000;
         private const uint enum_flag_HasComponentSize = 0x80000000;
         private const uint enum_flag_HasTypeEquivalence = 0x02000000;
         private const uint enum_flag_Category_Mask = 0x000F0000;
@@ -662,6 +663,8 @@ namespace System.Runtime.CompilerServices
                 return genericsFlags == enum_flag_GenericsMask_GenericInst || genericsFlags == enum_flag_GenericsMask_SharedInst;
             }
         }
+
+        public bool ContainsGenericVariables => (Flags & enum_flag_ContainsGenericVariables) != 0;
 
         /// <summary>
         /// Gets a <see cref="TypeHandle"/> for the element type of the current type.

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -429,10 +429,17 @@ namespace System.Runtime.CompilerServices
 
             MethodTable* pMT = handle.AsMethodTable();
 
+            if (pMT->IsGenericTypeDefinition)
+                throw new ArgumentException(SR.Arg_TypeNotSupported);
+
             if (pMT->IsValueType)
             {
                 if (pMT->IsByRefLike)
                     throw new NotSupportedException(SR.NotSupported_ByRefLike);
+
+                if (MethodTable.AreSameType(pMT, (MethodTable*)RuntimeTypeHandle.ToIntPtr(typeof(void).TypeHandle)))
+                    throw new ArgumentException(SR.Arg_TypeNotSupported);
+
                 object? result = Box(pMT, ref target);
                 GC.KeepAlive(type);
                 return result;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -87,6 +87,11 @@ namespace System
             return m_type == null;
         }
 
+        internal TypeHandle GetNativeTypeHandle()
+        {
+            return m_type.GetNativeTypeHandle();
+        }
+
         internal static bool IsTypeDefinition(RuntimeType type)
         {
             CorElementType corElemType = GetCorElementType(type);

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -121,6 +121,16 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
+        /// Reads a value of type <typeparamref name="T"/> from the given location.
+        /// </summary>
+        [Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T ReadUnaligned<T>(ref readonly byte source)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>
         /// Copies bytes from the source address to the destination address.
         /// </summary>
         [Intrinsic]

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -76,8 +76,7 @@ namespace System.Runtime
         public static unsafe object RhBox(MethodTable* pEEType, ref byte data)
         {
             // A null can be passed for boxing of a null ref.
-            if (Unsafe.IsNullRef(ref data))
-                throw new NullReferenceException();
+            _ = Unsafe.ReadUnaligned<byte>(ref data);
 
             ref byte dataAdjustedForNullable = ref data;
 

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -75,6 +75,10 @@ namespace System.Runtime
         [RuntimeExport("RhBox")]
         public static unsafe object RhBox(MethodTable* pEEType, ref byte data)
         {
+            // Compatibility with CoreCLR, throw on a null reference to the unboxed data.
+            if (Unsafe.IsNullRef(ref target))
+                throw new NullReferenceException();
+
             ref byte dataAdjustedForNullable = ref data;
 
             // Can box non-ByRefLike value types only (which also implies no finalizers).

--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/RuntimeExports.cs
@@ -75,8 +75,8 @@ namespace System.Runtime
         [RuntimeExport("RhBox")]
         public static unsafe object RhBox(MethodTable* pEEType, ref byte data)
         {
-            // Compatibility with CoreCLR, throw on a null reference to the unboxed data.
-            if (Unsafe.IsNullRef(ref target))
+            // A null can be passed for boxing of a null ref.
+            if (Unsafe.IsNullRef(ref data))
                 throw new NullReferenceException();
 
             ref byte dataAdjustedForNullable = ref data;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -374,7 +374,7 @@ namespace System.Runtime.CompilerServices
 
             if (!eeType->IsValueType)
             {
-                return Unsafe.As<byte, object>>(ref target);
+                return Unsafe.As<byte, object>(ref target);
             }
             
             if (eeType->IsByRefLike)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -376,7 +376,7 @@ namespace System.Runtime.CompilerServices
             {
                 return Unsafe.As<byte, object>(ref target);
             }
-            
+
             if (eeType->IsByRefLike)
                 throw new NotSupportedException(SR.NotSupported_ByRefLike);
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -380,7 +380,7 @@ namespace System.Runtime.CompilerServices
             if (eeType->IsByRefLike)
                 throw new NotSupportedException(SR.NotSupported_ByRefLike);
 
-            return RuntimeImports.RhBox(ref target, eeType);
+            return RuntimeImports.RhBox(eeType, ref target);
         }
     }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.NativeAot.cs
@@ -362,6 +362,15 @@ namespace System.Runtime.CompilerServices
             return RuntimeImports.RhNewObject(mt);
         }
 
+        /// <summary>
+        /// Create a boxed object of the specified type from the data located at the target reference.
+        /// </summary>
+        /// <param name="target">The target data</param>
+        /// <param name="type">The type of box to create.</param>
+        /// <returns>A boxed object containing the specified data.</returns>
+        /// <exception cref="ArgumentNullException">The specified type handle is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The specified type cannot have a boxed instance of itself created.</exception>
+        /// <exception cref="NotSupportedException">The passed in type is a by-ref-like type.</exception>
         public static unsafe object? Box(ref byte target, RuntimeTypeHandle type)
         {
             if (type.IsNull)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
@@ -50,23 +50,15 @@ namespace System
 
         public static unsafe object ToObject(TypedReference value)
         {
-            RuntimeTypeHandle typeHandle = value._typeHandle;
-            if (typeHandle.IsNull)
-                ThrowHelper.ThrowArgumentException_ArgumentNull_TypedRefType();
+            RuntimeTypeHandle handle = RawTargetTypeToken(value);
 
-            MethodTable* eeType = typeHandle.ToMethodTable();
-            if (eeType->IsValueType)
+            MethodTable* mt = handle.ToMethodTable();
+            if (mt->IsPointer || mt->IsFunctionPointer)
             {
-                return RuntimeImports.RhBox(eeType, ref value.Value);
+                handle = typeof(UIntPtr).TypeHandle;
             }
-            else if (eeType->IsPointer || eeType->IsFunctionPointer)
-            {
-                return RuntimeImports.RhBox(MethodTable.Of<UIntPtr>(), ref value.Value);
-            }
-            else
-            {
-                return Unsafe.As<byte, object>(ref value.Value);
-            }
+
+            return RuntimeHelpers.Box(ref value.Value, handle);
         }
 
         public static void SetTypedReference(TypedReference target, object? value) { throw new NotSupportedException(); }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/TypedReference.cs
@@ -52,6 +52,9 @@ namespace System
         {
             RuntimeTypeHandle handle = RawTargetTypeToken(value);
 
+            if (handle.IsNull)
+                ThrowHelper.ThrowArgumentException_ArgumentNull_TypedRefType();
+
             MethodTable* mt = handle.ToMethodTable();
             if (mt->IsPointer || mt->IsFunctionPointer)
             {

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2954,6 +2954,9 @@
   <data name="NotSupported_AssemblyLoadFromHash" xml:space="preserve">
     <value>Assembly.LoadFrom with hashValue is not supported.</value>
   </data>
+  <data name="NotSupported_BoxedPointer" xml:space="preserve">
+    <value>Cannot create boxed pointer values.</value>
+  </data>
   <data name="NotSupported_ByRefLike" xml:space="preserve">
     <value>Cannot create boxed ByRef-like values.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2954,9 +2954,6 @@
   <data name="NotSupported_AssemblyLoadFromHash" xml:space="preserve">
     <value>Assembly.LoadFrom with hashValue is not supported.</value>
   </data>
-  <data name="NotSupported_BoxedPointer" xml:space="preserve">
-    <value>Cannot create boxed pointer values.</value>
-  </data>
   <data name="NotSupported_ByRefLike" xml:space="preserve">
     <value>Cannot create boxed ByRef-like values.</value>
   </data>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13149,6 +13149,7 @@ namespace System.Runtime.CompilerServices
         [System.ObsoleteAttribute("OffsetToStringData has been deprecated. Use string.GetPinnableReference() instead.")]
         public static int OffsetToStringData { get { throw null; } }
         public static System.IntPtr AllocateTypeAssociatedMemory(System.Type type, int size) { throw null; }
+        public static object? Box(ref byte target, System.RuntimeTypeHandle type) { throw null; }
         public static System.ReadOnlySpan<T> CreateSpan<T>(System.RuntimeFieldHandle fldHandle) { throw null; }
         public static void EnsureSufficientExecutionStack() { }
         public static new bool Equals(object? o1, object? o2) { throw null; }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -567,6 +567,26 @@ namespace System.Runtime.CompilerServices.Tests
                 RuntimeHelpers.Box(ref value, t.TypeHandle);
             });
         }
+
+        [Fact]
+        public static void BoxGenericTypeDefinition()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                byte value = 3;
+                RuntimeHelpers.Box(ref value, typeof(List<>).TypeHandle);
+            });
+        }
+
+        [Fact]
+        public static void BoxVoid()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                byte value = 3;
+                RuntimeHelpers.Box(ref value, typeof(void).TypeHandle);
+            });
+        }
     }
 
     public struct Age

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -571,6 +571,20 @@ namespace System.Runtime.CompilerServices.Tests
             });
         }
 
+        // We can't even get a RuntimeTypeHandle for a partially instantiated generic type on NativeAOT,
+        // so we don't even get to the method we're testing.
+        // So, let's not even waste time running this test on NativeAOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
+        public static void BoxPartiallyOpenGeneric()
+        {
+            Type t = typeof(Dictionary<,>).MakeGenericType(typeof(object), typeof(Dictionary<,>).GetGenericArguments()[1]);
+            Assert.Throws<ArgumentException>(() =>
+            {
+                byte value = 3;
+                RuntimeHelpers.Box(ref value, t.TypeHandle);
+            });
+        }
+
         [Fact]
         public static void BoxGenericTypeDefinition()
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -557,7 +557,10 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.Same(arr, RuntimeHelpers.Box(ref Unsafe.As<string[], byte>(ref arr), typeof(string[]).TypeHandle));
         }
 
-        [Fact]
+        // We can't even get a RuntimeTypeHandle for a generic parameter type on NativeAOT,
+        // so we don't even get to the method we're testing.
+        // So, let's not even waste time running this test on NativeAOT
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         public static void BoxGenericParameterType()
         {
             Type t = typeof(List<>).GetGenericArguments()[0];

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -437,6 +437,110 @@ namespace System.Runtime.CompilerServices.Tests
 
             Assert.Equal(fixedPtr1, fixedPtr2);
         }
+
+        [Fact]
+        public static void BoxPrimitive()
+        {
+            int value = 4;
+            object result = RuntimeHelpers.Box(ref Unsafe.As<int, byte>(ref value), typeof(int).TypeHandle);
+            Assert.Equal(value, Assert.IsType<int>(result));
+        }
+
+        [Fact]
+        public static void BoxPointer()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                nint value = 3;
+                object result = RuntimeHelpers.Box(ref Unsafe.As<nint, byte>(ref value), typeof(void*).TypeHandle);
+            });
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private ref struct ByRefLikeType
+        {
+            public int i;
+        }
+
+        [Fact]
+        public static void BoxByRefLike()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+            {
+                int value = 3;
+                object result = RuntimeHelpers.Box(ref Unsafe.As<int, byte>(ref value), typeof(ByRefLikeType).TypeHandle);
+            });
+        }
+
+        [Fact]
+        public static void BoxStruct()
+        {
+            Span<int> buffer = [0, 42, int.MaxValue];
+            StructWithoutReferences expected = new()
+            {
+                a = buffer[0],
+                b = buffer[1],
+                c = buffer[2]
+            };
+            object result = RuntimeHelpers.Box(ref MemoryMarshal.AsBytes(buffer)[0], typeof(StructWithoutReferences).TypeHandle);
+
+            Assert.Equal(expected, Assert.IsType<StructWithoutReferences>(result));
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct GenericStruct<T>
+        {
+            public T data;
+        }
+
+        [Fact]
+        public static void BoxUnmanagedGenericStruct()
+        {
+            int value = 3;
+            object result = RuntimeHelpers.Box(ref Unsafe.As<int, byte>(ref value), typeof(GenericStruct<int>).TypeHandle);
+            
+            Assert.Equal(value, Assert.IsType<GenericStruct<int>>(result).data);
+        }
+
+        [Fact]
+        public static void BoxManagedGenericStruct()
+        {
+            object value = new();
+            object result = RuntimeHelpers.Box(ref Unsafe.As<object, byte>(ref value), typeof(GenericStruct<object>).TypeHandle);
+            
+            Assert.Same(value, Assert.IsType<GenericStruct<object>>(result).data);
+        }
+
+        [Fact]
+        public static void BoxNullable()
+        {
+            float? value = 3.14f;
+            object result = RuntimeHelpers.Box(ref Unsafe.As<float?, byte>(ref value), typeof(float?).TypeHandle);
+            Assert.Equal(value, Assert.IsType<float>(result));
+        }
+
+        [Fact]
+        public static void NullBox()
+        {
+            Assert.Throws<NullReferenceException>(() => RuntimeHelpers.Box(ref Unsafe.NullRef<byte>(), typeof(byte).TypeHandle));
+        }
+
+        [Fact]
+        public static void BoxInvalidType()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                byte value = 3;
+                RuntimeHelpers.Box(ref value, default(RuntimeTypeHandle));
+            });
+        }
+
+        [Fact]
+        public static void BoxReferenceType()
+        {
+            string str = "ABC";
+            Assert.Same(str, RuntimeHelpers.Box(ref Unsafe.As<string, byte>(ref str), typeof(string).TypeHandle));
+        }
     }
 
     public struct Age

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -449,7 +449,7 @@ namespace System.Runtime.CompilerServices.Tests
         [Fact]
         public static void BoxPointer()
         {
-            Assert.Throws<NotSupportedException>(() =>
+            Assert.Throws<ArgumentException>(() =>
             {
                 nint value = 3;
                 object result = RuntimeHelpers.Box(ref Unsafe.As<nint, byte>(ref value), typeof(void*).TypeHandle);
@@ -520,13 +520,21 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         [Fact]
+        public static void BoxNullNullable()
+        {
+            float? value = null;
+            object? result = RuntimeHelpers.Box(ref Unsafe.As<float?, byte>(ref value), typeof(float?).TypeHandle);
+            Assert.Null(result);
+        }
+
+        [Fact]
         public static void NullBox()
         {
             Assert.Throws<NullReferenceException>(() => RuntimeHelpers.Box(ref Unsafe.NullRef<byte>(), typeof(byte).TypeHandle));
         }
 
         [Fact]
-        public static void BoxInvalidType()
+        public static void BoxNullTypeHandle()
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -540,6 +548,24 @@ namespace System.Runtime.CompilerServices.Tests
         {
             string str = "ABC";
             Assert.Same(str, RuntimeHelpers.Box(ref Unsafe.As<string, byte>(ref str), typeof(string).TypeHandle));
+        }
+
+        [Fact]
+        public static void BoxArrayType()
+        {
+            string[] arr = ["a", "b", "c"];
+            Assert.Same(arr, RuntimeHelpers.Box(ref Unsafe.As<string[], byte>(ref arr), typeof(string[]).TypeHandle));
+        }
+
+        [Fact]
+        public static void BoxGenericParameterType()
+        {
+            Type t = typeof(List<>).GetGenericArguments()[0];
+            Assert.Throws<ArgumentException>(() =>
+            {
+                byte value = 3;
+                RuntimeHelpers.Box(ref value, t.TypeHandle);
+            });
         }
     }
 

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -226,8 +226,15 @@ namespace System.Runtime.CompilerServices
 
             RuntimeType rtType = (RuntimeType)Type.GetTypeFromHandle(type)!;
 
-            if (rtType.IsPointer || rtType.IsFunctionPointer || rtType.IsByRef || rtType.IsGenericParameter)
+            if (rtType.IsGenericTypeDefinition
+                || rtType.IsPointer
+                || rtType.IsFunctionPointer
+                || rtType.IsByRef
+                || rtType.IsGenericParameter
+                || rtType == typeof(void))
+            {
                 throw new ArgumentException(SR.Arg_TypeNotSupported);
+            }
 
             if (!rtType.IsValueType)
             {

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -226,23 +226,20 @@ namespace System.Runtime.CompilerServices
 
             RuntimeType rtType = (RuntimeType)Type.GetTypeFromHandle(type)!;
 
-            if (rtType.IsByRefLike)
-                throw new NotSupportedException(SR.NotSupported_ByRefLike);
+            if (rtType.IsPointer || rtType.IsFunctionPointer || rtType.IsByRef || rtType.IsGenericParameter)
+                throw new ArgumentException(SR.Arg_TypeNotSupported);
 
-            if (rtType.IsPointer || rtType.IsFunctionPointer)
-                throw new NotSupportedException(SR.NotSupported_BoxedPointer);
-
-
-            if (rtType.IsValueType)
-            {
-                object? result = null;
-                InternalBox(new QCallTypeHandle(ref rtType), ref target, ObjectHandleOnStack.Create(ref result));
-                return result;
-            }
-            else
+            if (!rtType.IsValueType)
             {
                 return Unsafe.As<byte, object?>(ref target);
             }
+
+            if (rtType.IsByRefLike)
+                throw new NotSupportedException(SR.NotSupported_ByRefLike);
+
+            object? result = null;
+            InternalBox(new QCallTypeHandle(ref rtType), ref target, ObjectHandleOnStack.Create(ref result));
+            return result;
         }
     }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -224,6 +224,7 @@ namespace System.Runtime.CompilerServices
         /// <exception cref="ArgumentNullException">The specified type handle is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">The specified type cannot have a boxed instance of itself created.</exception>
         /// <exception cref="NotSupportedException">The passed in type is a by-ref-like type.</exception>
+        /// <remarks>This returns an object that is equivalent to executing the IL box instruction with the provided target address and type.</remarks>
         public static object? Box(ref byte target, RuntimeTypeHandle type)
         {
             if (type.Value is 0)

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -226,7 +226,7 @@ namespace System.Runtime.CompilerServices
 
             RuntimeType rtType = (RuntimeType)Type.GetTypeFromHandle(type)!;
 
-            if (rtType.IsGenericTypeDefinition
+            if (rtType.ContainsGenericParameters
                 || rtType.IsPointer
                 || rtType.IsFunctionPointer
                 || rtType.IsByRef

--- a/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.Mono.cs
@@ -215,6 +215,15 @@ namespace System.Runtime.CompilerServices
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void InternalBox(QCallTypeHandle type, ref byte target, ObjectHandleOnStack result);
 
+        /// <summary>
+        /// Create a boxed object of the specified type from the data located at the target reference.
+        /// </summary>
+        /// <param name="target">The target data</param>
+        /// <param name="type">The type of box to create.</param>
+        /// <returns>A boxed object containing the specified data.</returns>
+        /// <exception cref="ArgumentNullException">The specified type handle is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">The specified type cannot have a boxed instance of itself created.</exception>
+        /// <exception cref="NotSupportedException">The passed in type is a by-ref-like type.</exception>
         public static object? Box(ref byte target, RuntimeTypeHandle type)
         {
             if (type.Value is 0)

--- a/src/mono/mono/metadata/icall-def.h
+++ b/src/mono/mono/metadata/icall-def.h
@@ -435,6 +435,7 @@ HANDLES(RUNH_1, "GetObjectValue", ves_icall_System_Runtime_CompilerServices_Runt
 HANDLES(RUNH_6, "GetSpanDataFrom", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetSpanDataFrom, gpointer, 3, (MonoClassField_ptr, MonoType_ptr, gpointer))
 HANDLES(RUNH_2, "GetUninitializedObjectInternal", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_GetUninitializedObjectInternal, MonoObject, 1, (MonoType_ptr))
 HANDLES(RUNH_3, "InitializeArray", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InitializeArray, void, 2, (MonoArray, MonoClassField_ptr))
+HANDLES(RUNH_8, "InternalBox", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalBox, void, 3, (MonoQCallTypeHandle, char_ref, MonoObjectHandleOnStack))
 HANDLES(RUNH_7, "InternalGetHashCode", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalGetHashCode, int, 1, (MonoObject))
 HANDLES(RUNH_3a, "PrepareMethod", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_PrepareMethod, void, 3, (MonoMethod_ptr, gpointer, int))
 HANDLES(RUNH_4, "RunClassConstructor", ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_RunClassConstructor, void, 1, (MonoType_ptr))

--- a/src/mono/mono/metadata/icall-table.h
+++ b/src/mono/mono/metadata/icall-table.h
@@ -71,6 +71,7 @@ typedef mono_unichar2 *mono_unichar2_ptr;
 typedef mono_unichar4 *mono_unichar4_ptr;
 typedef MonoSpanOfObjects *MonoSpanOfObjects_ref;
 
+typedef char    *char_ref;
 typedef char **char_ptr_ref;
 typedef gint32  *gint32_ref;
 typedef gint64  *gint64_ref;
@@ -173,6 +174,7 @@ typedef MonoStringHandle MonoStringOutHandle;
 #define MONO_HANDLE_TYPE_WRAP_int_ref  			ICALL_HANDLES_WRAP_VALUETYPE_REF
 #define MONO_HANDLE_TYPE_WRAP_gint32_ref  			ICALL_HANDLES_WRAP_VALUETYPE_REF
 #define MONO_HANDLE_TYPE_WRAP_int_ptr_ref  		ICALL_HANDLES_WRAP_VALUETYPE_REF
+#define MONO_HANDLE_TYPE_WRAP_char_ref		ICALL_HANDLES_WRAP_VALUETYPE_REF
 #define MONO_HANDLE_TYPE_WRAP_char_ptr_ref		ICALL_HANDLES_WRAP_VALUETYPE_REF
 #define MONO_HANDLE_TYPE_WRAP_guint8_ptr_ref		ICALL_HANDLES_WRAP_VALUETYPE_REF
 #define MONO_HANDLE_TYPE_WRAP_MonoResolveTokenError_ref	ICALL_HANDLES_WRAP_VALUETYPE_REF

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1210,6 +1210,26 @@ ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_PrepareMethod (MonoMeth
 	// FIXME: Implement
 }
 
+void
+ves_icall_System_Runtime_CompilerServices_RuntimeHelpers_InternalBox (MonoQCallTypeHandle type_handle, char* data, MonoObjectHandleOnStack obj, MonoError *error)
+{
+	MonoType *type = type_handle.type;
+	MonoClass *klass = mono_class_from_mono_type_internal (type);
+
+	g_assert (m_class_is_valuetype (klass));
+
+	mono_class_init_checked (klass, error);
+	goto_if_nok (error, error_ret);
+
+	MonoObject* raw_obj = mono_value_box_checked (klass, data, error);
+	goto_if_nok (error, error_ret);
+
+	HANDLE_ON_STACK_SET(obj, raw_obj);
+	return;
+error_ret:
+	HANDLE_ON_STACK_SET (obj, NULL);
+}
+
 MonoObjectHandle
 ves_icall_System_Object_MemberwiseClone (MonoObjectHandle this_obj, MonoError *error)
 {


### PR DESCRIPTION
Fixes #97341 

Implement RuntimeHelpers.Box with the same semantics as the `box` IL instruction. It creates a new box for value types, returns the existing object for reference types, and throws for byref types and pointers. It also throws a NullReferenceException when boxing a null by-ref (matching CoreCLR's existing behavior).