### PR TITLE
Exclude unhandledTester test on native AOT

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -712,6 +712,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/RuntimeConfiguration/TestConfigTester/*">
             <Issue>Test expects being run with corerun</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/unhandled/unhandledTester/*">
+            <Issue>Test expects being run with corerun</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/debugging/debuginfo/tester/*">
             <Issue>Just-in-time compilation test</Issue>
         </ExcludeList>


### PR DESCRIPTION
This is unfortunate because it was added for native AOT sake in #91415.

Then Tomas rewrote the test to execute corerun.exe in #91560 making it 100% unsupportable with native AOT.

What the test is doing doesn't look supportable with the merged runner infra and runs into the same issues I saw in #100269, I assume that's why Tomas took the easy way out by using corerun. Then we conveniently didn't detect it's broken because process isolation testing is busted with native AOT (found this regression in my local re-baselining run. it's not the only regression)