### PR TITLE
Perform manual intermediate certificate lookup when creating MsQuicConfiguration

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -132,13 +132,6 @@ internal static partial class MsQuicConfiguration
         }
 #pragma warning restore SYSLIB0040
 
-        if (!MsQuicApi.UsesSChannelBackend && certificate is X509Certificate2 cert && intermediates is null)
-        {
-            // MsQuic will not lookup intermediates in local CA store if not explicitly provided, so we need to do it here to have parity with SslStream.
-            SslStreamCertificateContext context = SslStreamCertificateContext.Create(cert, additionalCertificates: null, offline: true, trust: null);
-            intermediates = context.IntermediateCertificates;
-        }
-
         QUIC_SETTINGS settings = default(QUIC_SETTINGS);
 
         settings.IsSet.PeerUnidiStreamCount = 1;
@@ -206,6 +199,15 @@ internal static partial class MsQuicConfiguration
 
     private static unsafe MsQuicConfigurationSafeHandle CreateInternal(QUIC_SETTINGS settings, QUIC_CREDENTIAL_FLAGS flags, X509Certificate? certificate, ReadOnlyCollection<X509Certificate2>? intermediates, List<SslApplicationProtocol> alpnProtocols, QUIC_ALLOWED_CIPHER_SUITE_FLAGS allowedCipherSuites)
     {
+        if (!MsQuicApi.UsesSChannelBackend && certificate is X509Certificate2 cert && intermediates is null)
+        {
+            // MsQuic will not lookup intermediates in local CA store if not explicitly provided,
+            // so we build the cert context to get on feature parity with SslStream. Note that this code
+            // path runs after the MsQuicConfigurationCache check.
+            SslStreamCertificateContext context = SslStreamCertificateContext.Create(cert, additionalCertificates: null, offline: true, trust: null);
+            intermediates = context.IntermediateCertificates;
+        }
+
         QUIC_HANDLE* handle;
 
         using MsQuicBuffers msquicBuffers = new MsQuicBuffers();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicConfiguration.cs
@@ -132,6 +132,13 @@ internal static partial class MsQuicConfiguration
         }
 #pragma warning restore SYSLIB0040
 
+        if (!MsQuicApi.UsesSChannelBackend && certificate is X509Certificate2 cert && intermediates is null)
+        {
+            // MsQuic will not lookup intermediates in local CA store if not explicitly provided, so we need to do it here to have parity with SslStream.
+            SslStreamCertificateContext context = SslStreamCertificateContext.Create(cert, additionalCertificates: null, offline: true, trust: null);
+            intermediates = context.IntermediateCertificates;
+        }
+
         QUIC_SETTINGS settings = default(QUIC_SETTINGS);
 
         settings.IsSet.PeerUnidiStreamCount = 1;


### PR DESCRIPTION
Fixes #100530.

The issue does not seem to reproduce on Windows/SChannel, so I scoped the change to OpenSSL-MsQuic only.

Unfortunately, I didn't find a way to write unit test for this, as we don't have access to what exactly was sent over the wire from user code and reproducing this otherwise needs a 2 machine setup.

Test program

<details>

```
using System;
using System.Net;
using System.Net.Sockets;
using System.Net.Security;
using System.Security.Cryptography.X509Certificates;
using RuntimeSandbox;
using System.Security.Cryptography.X509Certificates.Tests.Common;
using System.Runtime.InteropServices;
using System.Security.Cryptography;

X509KeyUsageExtension s_eeKeyUsage = new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment, critical: false);
X509EnhancedKeyUsageExtension s_tlsServerEku = new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.1", null) },
        false);
X509EnhancedKeyUsageExtension s_tlsClientEku = new X509EnhancedKeyUsageExtension(new OidCollection { new Oid("1.3.6.1.5.5.7.3.2", null) }, false);
X509BasicConstraintsExtension s_eeConstraints = new X509BasicConstraintsExtension(false, false, 0, false);

CertificateAuthority.BuildPrivatePki(PkiOptions.None,
    out var responder,
    out var rootCa,
    out var intermediateCa,
    out var serverCert,
    "QuicSendingIntermediatesTest",
    true,
    true,
    "localhost",
    2048,
    BuildTlsCertExtensions("localhost", true));

using var intermediateCert = intermediateCa.CloneIssuerCert();

using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
{
    store.Open(OpenFlags.ReadWrite);
    store.Add(intermediateCert);
    store.Close();
}

if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
{
    X509Certificate2 temp = new X509Certificate2(serverCert.Export(X509ContentType.Pkcs12));
    serverCert.Dispose();
    serverCert = temp;
}


var (clientOptions, serverOptions, listenerOptions) = Helpers.GetDefaultOptions();
serverOptions.ServerAuthenticationOptions.ServerCertificateContext = null;

clientOptions.ClientAuthenticationOptions.ClientCertificates = new X509CertificateCollection();
clientOptions.ClientAuthenticationOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
{
    DumpChain(false, chain);
    return true;
};

// serverOptions.ServerAuthenticationOptions.ServerCertificateContext = SslStreamCertificateContext.Create(serverCert, new X509Certificate2Collection { intermediateCert }, offline: true);
serverOptions.ServerAuthenticationOptions.ServerCertificate = serverCert;
serverOptions.ServerAuthenticationOptions.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) =>
{
    DumpChain(true, chain);
    return true;
};

await using var pair = await Helpers.GetConnectedPair(clientOptions, listenerOptions);
System.Console.WriteLine("Connected");

using (var store = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser))
{
    store.Open(OpenFlags.ReadWrite);
    store.Remove(intermediateCert);
    store.Close();
}

X509ExtensionCollection BuildTlsCertExtensions(string targetName, bool serverCertificate)
{
    X509ExtensionCollection extensions = new X509ExtensionCollection();

    SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
    builder.AddDnsName(targetName);
    builder.AddIpAddress(IPAddress.Loopback);
    builder.AddIpAddress(IPAddress.IPv6Loopback);
    extensions.Add(builder.Build());
    extensions.Add(s_eeConstraints);
    extensions.Add(s_eeKeyUsage);
    extensions.Add(serverCertificate ? s_tlsServerEku : s_tlsClientEku);

    return extensions;
}

void DumpChain(bool server, X509Chain chain)
{
    System.Console.WriteLine(server ? "Server chain" : "Client chain");
    System.Console.WriteLine($"Chain elements: {chain.ChainElements.Count}");
    foreach (var element in chain.ChainElements)
    {
        System.Console.WriteLine($"  {element.Certificate.Subject}");
    }
}

```

</details>

Wireshark capture before
![image](https://github.com/dotnet/runtime/assets/32671551/34ac45b0-4d30-44fa-a2dc-899c0e122ef4)

Wireshark capture after
![image](https://github.com/dotnet/runtime/assets/32671551/b2f47ca9-b620-480d-b7bb-83f795c07882)
