### PR TITLE
Enable tail call generation for coreclr test Runtime_87393

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fsproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fsproj
@@ -7,6 +7,7 @@
     <Optimize>True</Optimize>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <GCStressIncompatible>True</GCStressIncompatible>
+    <OtherFlags>--tailcalls+</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).fs" />


### PR DESCRIPTION
In `Debug` configuration the coreclr test `Runtime_87393` fails with `StackOverflow` exception.

To pass, the test needs to be built with `--tailcalls` compiler flag enabled.

Part of #84834, cc @dotnet/samsung