### PR TITLE
Clean up macro in GetLogicalProcessorCacheSizeFromOS to include cacheSize as a parameter via a new argument CURRENT_CACHE_SIZE

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -917,7 +917,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 
             if (ReadMemoryValueFromFile(path_to_size_file, &cache_size_from_sys_file))
             {
-                cacheSize = std::max((long)cacheSize, size);
+                cacheSize = std::max(cacheSize, (size_t)cache_size_from_sys_file);
 
                 path_to_level_file[index] = (char)(48 + i);
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,7 +868,7 @@ done:
     return result;
 }
 
-void SetLargestCacheSizeAndLevelFromSysConf(size_t* cache_size, size_t* cache_level)
+static void SetLargestCacheSizeAndLevelFromSysConf(size_t* cache_size, size_t* cache_level)
 {
     const int cacheLevelNames[] =
     {

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -892,7 +892,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
             break;
         }
     }
-#endif // HAVE_SYSCONF
+#endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
     if (cacheSize == 0)

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -872,7 +872,6 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cacheLevel = 0;
     size_t cacheSize = 0;
-    long size;
 
 #ifdef HAVE_SYSCONF
     const int cacheLevelNames[] =

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,7 +868,7 @@ done:
     return result;
 }
 
-#define UPDATE_CACHE_SIZE_AND_LEVEL(NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if (NEW_CACHE_SIZE > ((long)cacheSize)) { cacheSize = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
+#define UPDATE_CACHE_SIZE_AND_LEVEL(CURRENT_CACHE_SIZE, NEW_CACHE_SIZE, NEW_CACHE_LEVEL) if (NEW_CACHE_SIZE > ((long)CURRENT_CACHE_SIZE)) { CURRENT_CACHE_SIZE = NEW_CACHE_SIZE; cacheLevel = NEW_CACHE_LEVEL; }
 
 static size_t GetLogicalProcessorCacheSizeFromOS()
 {
@@ -880,19 +880,19 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     // UPDATE_CACHE_SIZE_AND_LEVEL should handle both the cases by not updating cacheSize if either of cases are met.
 #ifdef _SC_LEVEL1_DCACHE_SIZE
     size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
-    UPDATE_CACHE_SIZE_AND_LEVEL(size, 1)
+    UPDATE_CACHE_SIZE_AND_LEVEL(cacheSize, size, 1)
 #endif
 #ifdef _SC_LEVEL2_CACHE_SIZE
     size = sysconf(_SC_LEVEL2_CACHE_SIZE);
-    UPDATE_CACHE_SIZE_AND_LEVEL(size, 2)
+    UPDATE_CACHE_SIZE_AND_LEVEL(cacheSize, size, 2)
 #endif
 #ifdef _SC_LEVEL3_CACHE_SIZE
     size = sysconf(_SC_LEVEL3_CACHE_SIZE);
-    UPDATE_CACHE_SIZE_AND_LEVEL(size, 3)
+    UPDATE_CACHE_SIZE_AND_LEVEL(cacheSize, size, 3)
 #endif
 #ifdef _SC_LEVEL4_CACHE_SIZE
     size = sysconf(_SC_LEVEL4_CACHE_SIZE);
-    UPDATE_CACHE_SIZE_AND_LEVEL(size, 4)
+    UPDATE_CACHE_SIZE_AND_LEVEL(cacheSize, size, 4)
 #endif
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)
@@ -924,7 +924,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 
                 if (ReadMemoryValueFromFile(path_to_level_file, &level))
                 {
-                    UPDATE_CACHE_SIZE_AND_LEVEL(size, level)
+                    UPDATE_CACHE_SIZE_AND_LEVEL(cacheSize, size, level)
                 }
 
                 else
@@ -981,7 +981,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
         if (success)
         {
             assert(cacheSizeFromSysctl > 0);
-            cacheSize = ( size_t) cacheSizeFromSysctl;
+            cacheSize = (size_t) cacheSizeFromSysctl;
         }
     }
 #endif

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -873,7 +873,7 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
     size_t cacheLevel = 0;
     size_t cacheSize = 0;
 
-#ifdef HAVE_SYSCONF
+#if defined(_SC_LEVEL1_DCACHE_SIZE) || defined(_SC_LEVEL2_CACHE_SIZE) || defined(_SC_LEVEL3_CACHE_SIZE) || defined(_SC_LEVEL4_CACHE_SIZE)
     const int cacheLevelNames[] =
     {
         _SC_LEVEL1_DCACHE_SIZE,

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -883,7 +883,6 @@ void SetLargestCacheSizeAndLevelFromSysConf(size_t* cache_size, size_t* cache_le
         long size = sysconf(cacheLevelNames[i]);
         if (size > 0)
         {
-            printf ("Iterating over cache size: %ld, current cache size: %zu\n", size, *cache_size);
             *cache_size = (size_t)size;
             *cache_level = i + 1;
             break;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -918,7 +918,6 @@ static size_t GetLogicalProcessorCacheSizeFromOS()
 
             if (ReadMemoryValueFromFile(path_to_size_file, &cache_size_from_sys_file))
             {
-                size = (long)cache_size_from_sys_file;
                 cacheSize = std::max((long)cacheSize, size);
 
                 path_to_level_file[index] = (char)(48 + i);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -868,8 +868,13 @@ done:
     return result;
 }
 
-static void SetLargestCacheSizeAndLevelFromSysConf(size_t* cache_size, size_t* cache_level)
+static size_t GetLogicalProcessorCacheSizeFromOS()
 {
+    size_t cacheLevel = 0;
+    size_t cacheSize = 0;
+    long size;
+
+#ifdef HAVE_SYSCONF
     const int cacheLevelNames[] =
     {
         _SC_LEVEL1_DCACHE_SIZE,
@@ -883,21 +888,11 @@ static void SetLargestCacheSizeAndLevelFromSysConf(size_t* cache_size, size_t* c
         long size = sysconf(cacheLevelNames[i]);
         if (size > 0)
         {
-            *cache_size = (size_t)size;
-            *cache_level = i + 1;
+            cacheSize = (size_t)size;
+            cacheLevel = i + 1;
             break;
         }
     }
-}
-
-static size_t GetLogicalProcessorCacheSizeFromOS()
-{
-    size_t cacheLevel = 0;
-    size_t cacheSize = 0;
-    long size;
-
-#if HAVE_SYSCONF
-    SetLargestCacheSizeAndLevelFromSysConf(&cacheSize, &cacheLevel);
 #endif // HAVE_SYSCONF
 
 #if defined(TARGET_LINUX) && !defined(HOST_ARM) && !defined(HOST_X86)


### PR DESCRIPTION
## Testing

Added printf after the sysconf calls to discern which cache size is used and found that it correctly resolves to the L3 Cache Size on my machine with the following details after running ``getconf -a | grep CACHE``:

LEVEL1_ICACHE_SIZE                 32768
LEVEL1_ICACHE_ASSOC                
LEVEL1_ICACHE_LINESIZE             64
LEVEL1_DCACHE_SIZE                 32768
LEVEL1_DCACHE_ASSOC                8
LEVEL1_DCACHE_LINESIZE             64
LEVEL2_CACHE_SIZE                  524288
LEVEL2_CACHE_ASSOC                 8
LEVEL2_CACHE_LINESIZE              64
LEVEL3_CACHE_SIZE                  268435456
LEVEL3_CACHE_ASSOC                 0
LEVEL3_CACHE_LINESIZE              64
LEVEL4_CACHE_SIZE                  
LEVEL4_CACHE_ASSOC                 
LEVEL4_CACHE_LINESIZE              

Output of  printf( "Last Cache Size: %zu\n", cacheSize);: Last Cache Size: 268435456