### PR TITLE
Update CI builds to not use VS Previews

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -1,4 +1,3 @@
-parameters:
   jobTemplate: ''
   hostedOs: ''
   hostedArch: ''
@@ -181,12 +180,12 @@ jobs:
         # Official Build Windows Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.jobParameters.hostedOs, 'windows')), ne(variables['System.TeamProject'], 'public')) }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64
+          demands: ImageOverride -equals windows.vs2022.amd64
 
         # Public Windows Build Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.jobParameters.hostedOs, 'windows')), eq(variables['System.TeamProject'], 'public')) }}:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64.open
+          demands: ImageOverride -equals windows.vs2022.amd64.open
 
 
     ${{ if eq(parameters.helixQueuesTemplate, '') }}:

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -1,3 +1,4 @@
+parameters:
   jobTemplate: ''
   hostedOs: ''
   hostedArch: ''


### PR DESCRIPTION
Moving CI builds to use VS2022 Release images. 