### PR TITLE
Add RequiresProcessIsolation in testcase Runtime_100437

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100437/Runtime_100437.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- uses WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>


### PR DESCRIPTION
Test-only change. 

Fixes: https://github.com/dotnet/runtime/issues/100576
