### PR TITLE
[cdac] Add basic cdacreader project

### DIFF
--- a/src/native/managed/cdacreader/cmake/CMakeLists.txt
+++ b/src/native/managed/cdacreader/cmake/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(cdacreader_api INTERFACE)
+target_include_directories(cdacreader_api INTERFACE ${CLR_SRC_NATIVE_DIR}/managed/cdacreader/inc)

--- a/src/native/managed/cdacreader/inc/cdac_reader.h
+++ b/src/native/managed/cdacreader/inc/cdac_reader.h
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef CDAC_READER_H
+#define CDAC_READER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int cdac_reader_init(intptr_t descriptor, intptr_t* handle);
+int cdac_reader_free(intptr_t handle);
+int cdac_reader_get_sos_interface(intptr_t handle, IUnknown** obj);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CDAC_READER_H

--- a/src/native/managed/cdacreader/src/Entrypoints.cs
+++ b/src/native/managed/cdacreader/src/Entrypoints.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+internal static class Entrypoints
+{
+    private const string CDAC = "cdac_reader_";
+
+    [UnmanagedCallersOnly(EntryPoint = $"{CDAC}init")]
+    private static unsafe int Init(nint descriptor, IntPtr* handle)
+    {
+        Target target = new(descriptor);
+        GCHandle gcHandle = GCHandle.Alloc(target);
+        *handle = GCHandle.ToIntPtr(gcHandle);
+        return 0;
+    }
+
+    [UnmanagedCallersOnly(EntryPoint = $"{CDAC}free")]
+    private static unsafe int Free(IntPtr handle)
+    {
+        GCHandle h = GCHandle.FromIntPtr(handle);
+        h.Free();
+        return 0;
+    }
+
+    /// <summary>
+    /// Get the SOS-DAC interface implementation.
+    /// </summary>
+    /// <param name="handle">Handle crated via cdac initialization</param>
+    /// <param name="obj"><c>IUnknown</c> pointer that can be queried for ISOSDacInterface*</param>
+    /// <returns></returns>
+    [UnmanagedCallersOnly(EntryPoint = $"{CDAC}get_sos_interface")]
+    private static unsafe int GetSOSInterface(IntPtr handle, nint* obj)
+    {
+        ComWrappers cw = new StrategyBasedComWrappers();
+        Target? target = GCHandle.FromIntPtr(handle).Target as Target;
+        if (target == null)
+            return -1;
+
+        SOSDacImpl impl = new(target);
+        nint ptr = cw.GetOrCreateComInterfaceForObject(impl, CreateComInterfaceFlags.None);
+        *obj = ptr;
+        return 0;
+    }
+}

--- a/src/native/managed/cdacreader/src/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/SOSDacImpl.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+[GeneratedComInterface]
+[Guid("4eca42d8-7e7b-4c8a-a116-7bfbf6929267")]
+internal partial interface ISOSDacInterface9
+{
+    void GetBreakingChangeVersion(out int version);
+}
+
+/// <summary>
+/// Implementation of ISOSDacInterface* interfaces intended to be passed out to consumers
+/// interacting with the DAC via those COM interfaces.
+/// </summary>
+[GeneratedComClass]
+internal sealed partial class SOSDacImpl : ISOSDacInterface9
+{
+    private readonly Target _target;
+
+    public SOSDacImpl(Target target)
+    {
+        _target = target;
+    }
+
+    public void GetBreakingChangeVersion(out int version)
+    {
+        // TODO: Return non-hard-coded version
+        version = 4;
+    }
+}

--- a/src/native/managed/cdacreader/src/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/SOSDacImpl.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Diagnostics.DataContractReader;
 [Guid("4eca42d8-7e7b-4c8a-a116-7bfbf6929267")]
 internal partial interface ISOSDacInterface9
 {
-    void GetBreakingChangeVersion(out int version);
+    int GetBreakingChangeVersion();
 }
 
 /// <summary>
@@ -28,9 +28,9 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface9
         _target = target;
     }
 
-    public void GetBreakingChangeVersion(out int version)
+    public int GetBreakingChangeVersion()
     {
         // TODO: Return non-hard-coded version
-        version = 4;
+        return 4;
     }
 }

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+internal sealed class Target
+{
+    public Target(nint _)
+    {
+    }
+}

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Do not produce a public package. This ships as part of the runtime -->
+    <IsShippingPackage>false</IsShippingPackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InstallRuntimeComponentDestination Include="." />
+    <!-- TODO: [cdac] Output to sharedFramework and add PlatformManifestFileEntry for Microsoft.NETCore.App once ready to include in shipping package -->
+    <!-- <InstallRuntimeComponentDestination Include="sharedFramework" Condition="'$(RuntimeFlavor)' == 'coreclr'"/> -->
+  </ItemGroup>
+
+</Project>

--- a/src/native/managed/compile-native.proj
+++ b/src/native/managed/compile-native.proj
@@ -12,6 +12,7 @@
     <ItemGroup>
         <!-- add new projects here -->
         <!-- NativeLibsProjectsToBuild Include="$(MSBuildThisFileDirectory)libhellomanaged/src/libhellomanaged.csproj" -->
+        <NativeLibsProjectsToBuild Include="$(MSBuildThisFileDirectory)cdacreader/src/cdacreader.csproj" />
     </ItemGroup>
 
     <!-- Decide if we're going to do the NativeAOT builds -->


### PR DESCRIPTION
This change adds a basic `cdacreader` project under src/native/managed.
- Built as part of the clr subset (via runtime-prereqs referencing compile-native.proj)
- Not yet integrated into anything in the product (that is, the dac doesn't try to use it yet)
- Can return a class that can implement the ISOSDacInterface* interfaces - currently does ISOSDacInterface9

Contributes to https://github.com/dotnet/runtime/issues/99298
cc @AaronRobinsonMSFT @davidwrighton @jkotas @mikem8361 @noahfalk

Manually tested with:
```c++
intptr_t handle;
cdac_reader_init_fn(0, &handle);

IUnknown* unk;
cdac_reader_get_sos_interface_fn(handle, &unk);
ISOSDacInterface9* sos_dac;
HRESULT hr = unk->QueryInterface<ISOSDacInterface9>(&sos_dac);
unk->Release();
if (FAILED(hr))
    return hr;

int version;
int ret = sos_dac->GetBreakingChangeVersion(&version);
sos_dac->Release();
if (ret == 0)
    std::cout << "Version: " << version << std::endl;

cdac_reader_free_fn(handle);
```