### PR TITLE
Fix official build break

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -124,7 +124,7 @@
     <NativeAotSupported Condition="'$(_NativeAotSupportedOS)' == 'true' and $(_NativeAotSupportedArch) == 'true'">true</NativeAotSupported>
 
     <!-- If we're building clr.nativeaotlibs and not building the CLR runtime, compile libraries against NativeAOT CoreLib -->
-    <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')))">true</UseNativeAotCoreLib>
+    <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#100512 caused an official build break by exposing a latent issue in how we build the managed artifacts. Official builds split managed and native builds for some reason. This is throwing off the heuristic that decides whether to use native AOT's corelib in build.

We were always using the native AOT's corelib in x64 and arm64 legs because of the thrown off heuristic. This apparently didn't cause an immediate problem there.

It causes a problem on x86 because crossgen2 is a trimmed+r2r+singlefile executable on x86 (and nowhere else) and ILLink execution doesn't like the layouts with `UseNativeAotCoreLib`.

Tweak the heuristic to not use native AOT corelib if we're building JIT corelib.