### PR TITLE
Mark managed/Compilation test as NativeAotIncompatible

### DIFF
--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1084,9 +1084,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/tailcalls_do/**">
             <Issue>https://github.com/dotnet/runtimelab/issues/155: Reflection.Emit</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/managed/Compilation/Compilation/**">
-            <Issue>expects to see System.Private.CoreLib in CORE_ROOT</Issue>
-        </ExcludeList>
 
         <!-- Complex constrained calls -->
         <!-- https://github.com/dotnet/runtimelab/issues/1431 -->

--- a/src/tests/managed/Compilation/Compilation.csproj
+++ b/src/tests/managed/Compilation/Compilation.csproj
@@ -4,6 +4,9 @@
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+
+    <!-- Expects to find a corelib it can compile against -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The issues.targets exclusion doesn't seem to kick in with the merged wrapper, but whatever: this test compiles into a 100 MB executable because it includes a fully rooted Roslyn, and then doesn't work anyway. Stop building it instead of excluding it from runs.