### PR TITLE
Ensure Array.CreateInstance over reference types works

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -528,6 +528,19 @@ namespace ILCompiler.Dataflow
                     break;
 
                 //
+                // System.Array
+                //
+                // CreateInstance (Type, Int32)
+                //
+                case IntrinsicId.Array_CreateInstance:
+                    {
+                        // We could try to analyze if the type is known, but for now making sure this works for canonical arrays is enough.
+                        TypeDesc canonArrayType = reflectionMarker.Factory.TypeSystemContext.CanonType.MakeArrayType();
+                        reflectionMarker.Dependencies.Add(reflectionMarker.Factory.NativeLayout.TemplateTypeLayout(canonArrayType), "Array.CreateInstance was called");
+                        goto case IntrinsicId.None;
+                    }
+
+                //
                 // System.Enum
                 //
                 // static GetValues (Type)

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/IntrinsicId.cs
@@ -54,6 +54,10 @@ namespace ILLink.Shared.TrimAnalysis
 		// the reflection body scanner.
 		RequiresReflectionBodyScanner_Sentinel = 1000,
 		/// <summary>
+		/// <see cref="System.Array.CreateInstance(System.Type, int)"/>
+		/// </summary>
+		Array_CreateInstance,
+		/// <summary>
 		/// <see cref="System.Type.MakeGenericType(System.Type[])"/>
 		/// </summary>
 		Type_MakeGenericType,

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/Intrinsics.cs
@@ -293,6 +293,12 @@ namespace ILLink.Shared.TrimAnalysis
 				"Empty" when calledMethod.IsDeclaredOnType ("System.Array")
 					=> IntrinsicId.Array_Empty,
 
+				// static System.Array.CreateInstance (System.Type type, int length)
+				"CreateInstance" when calledMethod.IsDeclaredOnType ("System.Array")
+					&& calledMethod.HasMetadataParametersCount (2)
+					&& calledMethod.HasParameterOfType ((ParameterIndex) 1, "System.Int32")
+					=> IntrinsicId.Array_CreateInstance,
+
 				// static System.Activator.CreateInstance (System.Type type)
 				// static System.Activator.CreateInstance (System.Type type, bool nonPublic)
 				// static System.Activator.CreateInstance (System.Type type, params object?[]? args)

--- a/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ReflectionMethodBodyScanner.cs
@@ -263,6 +263,7 @@ namespace Mono.Linker.Dataflow
 				}
 				break;
 
+			case IntrinsicId.Array_CreateInstance:
 			case IntrinsicId.Enum_GetValues:
 			case IntrinsicId.Marshal_SizeOf:
 			case IntrinsicId.Marshal_OffsetOf:


### PR DESCRIPTION
We have warning suppressions in place assuming `Array.CreateInstance` will succeed if it's over reference types, same as `MakeGeneric`. There's however no analysis to ensure we have the type loader template for `__Canon[]`. This adds the analysis.

The `reflection\GenericAttribute` test is currently failing because of this but we don't see it because it's marked RequiresProcessIsolation and we have a bug that we don't look at those tests at all.

We had this bug for a while, but the test regression is more recent because we're getting better at not generating useless stuff. Template for `__Canon[]` is probably part of any bigger test because it's common.

cc @dotnet/ilc-contrib 