### PR TITLE
Remove true randomness from a libraries test

### DIFF
--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
@@ -22,7 +22,7 @@ namespace System.Xml.XslCompiledTransformApiTests
             _output = output;
         }
 
-        private Random _rand = new Random(unchecked((int)DateTime.Now.Ticks));
+        private Random _rand = new Random(12345678);
 
         #region private const string xmlDocTemplate = ...
 


### PR DESCRIPTION
I spent a good while not understanding why a JIT bug was only reproing intermittently in this test until I noticed this source of randomness.