### PR TITLE
Reloading sources in ConfigurationManager should not dispose IConfigurationSources, only providers

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/tests/JsonConfigurationTest.cs
@@ -275,6 +275,29 @@ namespace Microsoft.Extensions.Configuration
             Assert.True(GetIsDisposed(fileProvider));
         }
 
+        [Fact]
+        public void AddJsonFile_FileProvider_Is_Not_Disposed_When_SourcesGetReloaded()
+        {
+            string filePath = Path.Combine(Path.GetTempPath(), $"{nameof(AddJsonFile_FileProvider_Is_Not_Disposed_When_SourcesGetReloaded)}.json");
+            File.WriteAllText(filePath, @"{ ""some"": ""value"" }");
+
+            IConfigurationBuilder builder = new ConfigurationManager();
+
+            builder.AddJsonFile(filePath, optional: false);
+
+            FileConfigurationSource fileConfigurationSource = (FileConfigurationSource)builder.Sources.Last();
+            PhysicalFileProvider fileProvider = (PhysicalFileProvider)fileConfigurationSource.FileProvider;
+
+            Assert.False(GetIsDisposed(fileProvider));
+
+            builder.Properties.Add("simplest", "repro");
+
+            Assert.False(GetIsDisposed(fileProvider));
+
+            fileProvider.Dispose();
+            Assert.True(GetIsDisposed(fileProvider));
+        }
+
         private static bool GetIsDisposed(PhysicalFileProvider fileProvider)
         {
             System.Reflection.FieldInfo isDisposedField = typeof(PhysicalFileProvider).GetField("_disposed", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);


### PR DESCRIPTION
This PR fixes #95745 with low risk (to allow backporting), but in an ugly way as the existing public APIs don't allow for a proper fix and introducing a new API would require breaking changes.