### PR TITLE
Fix SslStreamCertificateContext OCSP test failures

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -10,6 +10,7 @@ using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
@@ -115,6 +116,7 @@ namespace System.Net.Security
 
                 if (task.IsCompletedSuccessfully)
                 {
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Got OCSP response.");
                     return task.Result;
                 }
             }
@@ -122,6 +124,7 @@ namespace System.Net.Security
             {
             }
 
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "No OCSP response available.");
             return null;
         }
 
@@ -136,11 +139,13 @@ namespace System.Net.Security
 
             if (now > _ocspExpiration)
             {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Cached OCSP response expired, fetching fresh staple.");
                 return DownloadOcspAsync();
             }
 
             if (now > _nextDownload)
             {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Starting async refresh of OCSP staple");
                 // Calling DownloadOcsp will activate a Task to initiate
                 // in the background.  Further calls will attach to the
                 // same Task if it's still running.
@@ -171,6 +176,7 @@ namespace System.Net.Security
 
             if (pending is not null && !pending.IsFaulted)
             {
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Pending download task exists.");
                 return new ValueTask<byte[]?>(pending);
             }
 
@@ -208,14 +214,15 @@ namespace System.Net.Security
 
                 if (pending is null || pending.IsFaulted)
                 {
-                    _pendingDownload = pending = FetchOcspAsync();
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Starting new OCSP download task.");
+                    pending = FetchOcspAsync();
                 }
             }
 
             return new ValueTask<byte[]?>(pending);
         }
 
-        private async Task<byte[]?> FetchOcspAsync()
+        private Task<byte[]?> FetchOcspAsync()
         {
             Debug.Assert(_rootCertificate != null);
             X509Certificate2? caCert = _privateIntermediateCertificates.Length > 0 ? _privateIntermediateCertificates[0] : _rootCertificate;
@@ -235,7 +242,7 @@ namespace System.Net.Security
             if (subject == 0 || issuer == 0)
             {
                 _staplingForbidden = true;
-                return null;
+                return Task.FromResult<byte[]?>(null);
             }
 
             IntPtr[] issuerHandles = ArrayPool<IntPtr>.Shared.Rent(_privateIntermediateCertificates.Length + 1);
@@ -245,64 +252,82 @@ namespace System.Net.Security
             }
             issuerHandles[_privateIntermediateCertificates.Length] = _rootCertificate.Handle;
 
-            using (SafeOcspRequestHandle ocspRequest = Interop.Crypto.X509BuildOcspRequest(subject, issuer))
+            TaskCompletionSource<byte[]?> completionSource = new TaskCompletionSource<byte[]?>();
+
+            _pendingDownload = completionSource.Task;
+            FetchOcspAsyncCore(completionSource);
+            return completionSource.Task;
+
+            async void FetchOcspAsyncCore(TaskCompletionSource<byte[]?> completionSource)
             {
-                byte[] rentedBytes = ArrayPool<byte>.Shared.Rent(Interop.Crypto.GetOcspRequestDerSize(ocspRequest));
-                int encodingSize = Interop.Crypto.EncodeOcspRequest(ocspRequest, rentedBytes);
-                ArraySegment<byte> encoded = new ArraySegment<byte>(rentedBytes, 0, encodingSize);
-
-                ArraySegment<char> rentedChars = UrlBase64Encoding.RentEncode(encoded);
-                byte[]? ret = null;
-
-                for (int i = 0; i < _ocspUrls.Count; i++)
+                try
                 {
-                    string url = MakeUrl(_ocspUrls[i], rentedChars);
-                    ret = await System.Net.Http.X509ResourceClient.DownloadAssetAsync(url, TimeSpan.MaxValue).ConfigureAwait(false);
+                    using SafeOcspRequestHandle ocspRequest = Interop.Crypto.X509BuildOcspRequest(subject, issuer);
+                    byte[] rentedBytes = ArrayPool<byte>.Shared.Rent(Interop.Crypto.GetOcspRequestDerSize(ocspRequest));
+                    int encodingSize = Interop.Crypto.EncodeOcspRequest(ocspRequest, rentedBytes);
+                    ArraySegment<byte> encoded = new ArraySegment<byte>(rentedBytes, 0, encodingSize);
 
-                    if (ret is not null)
+                    ArraySegment<char> rentedChars = UrlBase64Encoding.RentEncode(encoded);
+                    byte[]? ret = null;
+
+                    for (int i = 0; i < _ocspUrls.Count; i++)
                     {
-                        if (!Interop.Crypto.X509DecodeOcspToExpiration(ret, ocspRequest, subject, issuerHandles.AsSpan(0, _privateIntermediateCertificates.Length + 1), out DateTimeOffset expiration))
+                        string url = MakeUrl(_ocspUrls[i], rentedChars);
+                        ret = await System.Net.Http.X509ResourceClient.DownloadAssetAsync(url, TimeSpan.MaxValue).ConfigureAwait(false);
+
+                        if (ret is not null)
                         {
-                            ret = null;
-                            continue;
+                            if (!Interop.Crypto.X509DecodeOcspToExpiration(ret, ocspRequest, subject, issuerHandles.AsSpan(0, _privateIntermediateCertificates.Length + 1), out DateTimeOffset expiration))
+                            {
+                                ret = null;
+                                continue;
+                            }
+
+                            // Swap the working URL in as the first one we'll try next time.
+                            if (i != 0)
+                            {
+                                string tmp = _ocspUrls[0];
+                                _ocspUrls[0] = _ocspUrls[i];
+                                _ocspUrls[i] = tmp;
+                            }
+
+                            DateTimeOffset nextCheckA = DateTimeOffset.UtcNow.Add(DefaultOcspRefreshInterval);
+                            DateTimeOffset nextCheckB = expiration.Subtract(MinRefreshBeforeExpirationInterval);
+
+                            _ocspResponse = ret;
+                            _ocspExpiration = expiration;
+                            _nextDownload = nextCheckA < nextCheckB ? nextCheckA : nextCheckB;
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Received {ret.Length} B OCSP response, Expiration: {_ocspExpiration}, Next refresh: {_nextDownload}");
+                            break;
                         }
-
-                        // Swap the working URL in as the first one we'll try next time.
-                        if (i != 0)
-                        {
-                            string tmp = _ocspUrls[0];
-                            _ocspUrls[0] = _ocspUrls[i];
-                            _ocspUrls[i] = tmp;
-                        }
-
-                        DateTimeOffset nextCheckA = DateTimeOffset.UtcNow.Add(DefaultOcspRefreshInterval);
-                        DateTimeOffset nextCheckB = expiration.Subtract(MinRefreshBeforeExpirationInterval);
-
-                        _ocspResponse = ret;
-                        _ocspExpiration = expiration;
-                        _nextDownload = nextCheckA < nextCheckB ? nextCheckA : nextCheckB;
-                        break;
                     }
+
+                    issuerHandles.AsSpan().Clear();
+                    ArrayPool<IntPtr>.Shared.Return(issuerHandles);
+                    ArrayPool<byte>.Shared.Return(rentedBytes);
+                    ArrayPool<char>.Shared.Return(rentedChars.Array!);
+                    GC.KeepAlive(TargetCertificate);
+                    GC.KeepAlive(_privateIntermediateCertificates);
+                    GC.KeepAlive(_rootCertificate);
+                    GC.KeepAlive(caCert);
+
+                    if (ret == null)
+                    {
+                        // All download attempts failed, don't try again for 5 seconds.
+                        // This backoff will be applied only if the OCSP staple is not expired.
+                        // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
+                        _nextDownload = DateTimeOffset.UtcNow.Add(RefreshAfterFailureBackOffInterval);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"OCSP response fetch failed, backing off, Next refresh = {_nextDownload}");
+                    }
+
+                    _pendingDownload = null;
+                    completionSource.SetResult(ret);
                 }
-
-                issuerHandles.AsSpan().Clear();
-                ArrayPool<IntPtr>.Shared.Return(issuerHandles);
-                ArrayPool<byte>.Shared.Return(rentedBytes);
-                ArrayPool<char>.Shared.Return(rentedChars.Array!);
-                GC.KeepAlive(TargetCertificate);
-                GC.KeepAlive(_privateIntermediateCertificates);
-                GC.KeepAlive(_rootCertificate);
-                GC.KeepAlive(caCert);
-
-                _pendingDownload = null;
-                if (ret == null)
+                catch (Exception ex)
                 {
-                    // All download attempts failed, don't try again for 5 seconds.
-                    // This backoff will be applied only if the OCSP staple is not expired.
-                    // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
-                    _nextDownload = DateTimeOffset.UtcNow.Add(RefreshAfterFailureBackOffInterval);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"OCSP refresh failed: {ex}");
+                    completionSource.SetException(ex);
                 }
-                return ret;
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -116,7 +116,10 @@ namespace System.Net.Security
 
                 if (task.IsCompletedSuccessfully)
                 {
-                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Got OCSP response.");
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        NetEventSource.Info(this, $"Got OCSP response.");
+                    }
                     return task.Result;
                 }
             }
@@ -124,7 +127,10 @@ namespace System.Net.Security
             {
             }
 
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "No OCSP response available.");
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(this, "No OCSP response available.");
+            }
             return null;
         }
 
@@ -139,13 +145,19 @@ namespace System.Net.Security
 
             if (now > _ocspExpiration)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Cached OCSP response expired, fetching fresh staple.");
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(this, "Cached OCSP response expired, fetching fresh staple.");
+                }
                 return DownloadOcspAsync();
             }
 
             if (now > _nextDownload)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Starting async refresh of OCSP staple");
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(this, "Starting async refresh of OCSP staple");
+                }
                 // Calling DownloadOcsp will activate a Task to initiate
                 // in the background.  Further calls will attach to the
                 // same Task if it's still running.
@@ -176,7 +188,10 @@ namespace System.Net.Security
 
             if (pending is not null && !pending.IsFaulted)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Pending download task exists.");
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Info(this, $"Pending download task exists.");
+                }
                 return new ValueTask<byte[]?>(pending);
             }
 
@@ -214,7 +229,10 @@ namespace System.Net.Security
 
                 if (pending is null || pending.IsFaulted)
                 {
-                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Starting new OCSP download task.");
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        NetEventSource.Info(this, $"Starting new OCSP download task.");
+                    }
                     pending = FetchOcspAsync();
                 }
             }
@@ -297,7 +315,10 @@ namespace System.Net.Security
                             _ocspResponse = ret;
                             _ocspExpiration = expiration;
                             _nextDownload = nextCheckA < nextCheckB ? nextCheckA : nextCheckB;
-                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Received {ret.Length} B OCSP response, Expiration: {_ocspExpiration}, Next refresh: {_nextDownload}");
+                            if (NetEventSource.Log.IsEnabled())
+                            {
+                                NetEventSource.Info(this, $"Received {ret.Length} B OCSP response, Expiration: {_ocspExpiration}, Next refresh: {_nextDownload}");
+                            }
                             break;
                         }
                     }
@@ -317,7 +338,10 @@ namespace System.Net.Security
                         // This backoff will be applied only if the OCSP staple is not expired.
                         // If it is expired, we will force-refresh it during next GetOcspResponseAsync call.
                         _nextDownload = DateTimeOffset.UtcNow.Add(RefreshAfterFailureBackOffInterval);
-                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"OCSP response fetch failed, backing off, Next refresh = {_nextDownload}");
+                        if (NetEventSource.Log.IsEnabled())
+                        {
+                            NetEventSource.Info(this, $"OCSP response fetch failed, backing off, Next refresh = {_nextDownload}");
+                        }
                     }
 
                     _pendingDownload = null;
@@ -325,7 +349,10 @@ namespace System.Net.Security
                 }
                 catch (Exception ex)
                 {
-                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"OCSP refresh failed: {ex}");
+                    if (NetEventSource.Log.IsEnabled())
+                    {
+                        NetEventSource.Error(this, $"OCSP refresh failed: {ex}");
+                    }
                     completionSource.SetException(ex);
                 }
             }

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -13,23 +13,12 @@ using System.Net.Security;
 
 using Xunit;
 using Xunit.Abstractions;
-using TestUtilities;
 
 namespace System.Net.Security.Tests;
 
 [PlatformSpecific(TestPlatforms.Linux)]
 public class SslStreamCertificateContextOcspLinuxTests : IDisposable
 {
-    TestEventListener _listener;
-
-    public SslStreamCertificateContextOcspLinuxTests(ITestOutputHelper output) => _listener = new TestEventListener(output, new[] { "Private.InternalDiagnostics.System.Net.Security" });
-
-    public void Dispose()
-    {
-        _listener.Dispose();
-    }
-
-
     [Fact]
     public async Task OfflineContext_NoFetchOcspResponse()
     {

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 namespace System.Net.Security.Tests;
 
 [PlatformSpecific(TestPlatforms.Linux)]
-public class SslStreamCertificateContextOcspLinuxTests : IDisposable
+public class SslStreamCertificateContextOcspLinuxTests
 {
     [Fact]
     public async Task OfflineContext_NoFetchOcspResponse()

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -12,12 +12,24 @@ using System.Threading.Tasks;
 using System.Net.Security;
 
 using Xunit;
+using Xunit.Abstractions;
+using TestUtilities;
 
 namespace System.Net.Security.Tests;
 
 [PlatformSpecific(TestPlatforms.Linux)]
-public class SslStreamCertificateContextOcspLinuxTests
+public class SslStreamCertificateContextOcspLinuxTests : IDisposable
 {
+    TestEventListener _listener;
+
+    public SslStreamCertificateContextOcspLinuxTests(ITestOutputHelper output) => _listener = new TestEventListener(output, new[] { "Private.InternalDiagnostics.System.Net.Security" });
+
+    public void Dispose()
+    {
+        _listener.Dispose();
+    }
+
+
     [Fact]
     public async Task OfflineContext_NoFetchOcspResponse()
     {
@@ -77,7 +89,6 @@ public class SslStreamCertificateContextOcspLinuxTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/97836")]
     public async Task FetchOcspResponse_FirstInvalidThenValid()
     {
         await SimpleTest(PkiOptions.OcspEverywhere, async (root, intermediate, endEntity, ctxFactory, responder) =>
@@ -95,7 +106,6 @@ public class SslStreamCertificateContextOcspLinuxTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/97779")]
     public async Task RefreshOcspResponse_BeforeExpiration()
     {
         await SimpleTest(PkiOptions.OcspEverywhere, async (root, intermediate, endEntity, ctxFactory, responder) =>
@@ -110,12 +120,12 @@ public class SslStreamCertificateContextOcspLinuxTests
 
             intermediate.RevocationExpiration = DateTimeOffset.UtcNow.AddDays(1);
 
-            // first call will dispatch a download and return the cached response, the first call after
-            // the pending download finishes will return the updated response
-            byte[] ocsp2 = ctx.GetOcspResponseNoWaiting();
-            Assert.Equal(ocsp, ocsp2);
+            // First call will dispatch a download. It most likely will return the
+            // previous cached response, but if the current thread gets delayed
+            // it may actually return the fresh OCSP staple so we won't check the result
+            ctx.GetOcspResponseNoWaiting();
 
-            // The download should succeed
+            // The pending download should eventually succeed
             byte[] ocsp3 = await ctx.WaitForPendingOcspFetchAsync();
             Assert.NotNull(ocsp3);
             Assert.NotEqual(ocsp, ocsp3);
@@ -123,7 +133,6 @@ public class SslStreamCertificateContextOcspLinuxTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/97779")]
     public async Task RefreshOcspResponse_AfterExpiration()
     {
         await SimpleTest(PkiOptions.OcspEverywhere, async (root, intermediate, endEntity, ctxFactory, responder) =>
@@ -139,13 +148,14 @@ public class SslStreamCertificateContextOcspLinuxTests
 
             intermediate.RevocationExpiration = DateTimeOffset.UtcNow.AddDays(1);
 
-            // The cached OCSP is expired, so the first call will dispatch a download and return the cached response,
-            byte[] ocsp = ctx.GetOcspResponseNoWaiting();
-            Assert.Null(ocsp);
+            // The cached OCSP is expired, so the first call will dispatch a download.
+            // It most likely will return null, but if the current thread gets delayed
+            // it may actually return the fresh OCSP staple so we won't check the result
+            ctx.GetOcspResponseNoWaiting();
 
-            // The download should succeed
-            byte[] ocsp2 = await ctx.WaitForPendingOcspFetchAsync();
-            Assert.NotNull(ocsp2);
+            // The pending download should eventually succeed
+            byte[] ocsp = await ctx.WaitForPendingOcspFetchAsync();
+            Assert.NotNull(ocsp);
         });
     }
 

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslStreamCertificateContextOcspLinuxTests.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using System.Net.Security;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Net.Security.Tests;
 


### PR DESCRIPTION
Fixes #97836.
Fixes #97779.

This PR fixes two data races and adds some internal logging (leftover from debugging, but I figured they can become useful in case we need to debug issues in this area in the future).

First data race was because of following pattern

```cs
if (_pendingTask == null)
{
    _pendingTask = DoStuffAsync();
}

//...
Task DoStuffAsync()
{
    // ....
    await SomeOtherTaskThatNeverCompletesSynchronously()
    // ...
    // done, remove the pending task
    _pendingTask = null;
}
```

Both assignments to `_pendingTask` are racing and some of the test failures in the past were due to `_pendingTask = null` assignment finishing first.

Second data race was test-only. Consider the function

```cs
        internal byte[]? GetOcspResponseNoWaiting()
        {
            try
            {
                ValueTask<byte[]?> task = GetOcspResponseAsync();

                if (task.IsCompletedSuccessfully)
                {
                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Got OCSP response.");
                    return task.Result;
                }
            }
            catch
            {
            }

            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "No OCSP response available.");
            return null;
        }
```

The test assumed that if `GetOcspResponseAsync` does not finish synchronously (e.g. no cached OCSP response and new one is being downloaded), the method will always return null. However, it is possible that the task finishes between returning from `GetOcspResponseAsync` and checking `task.IsCompletedSuccessfully`. The tests were adjusted to not depend on this.