### PR TITLE
Fix VS user unhandled exception notification

### DIFF
--- a/src/coreclr/vm/amd64/cgencpu.h
+++ b/src/coreclr/vm/amd64/cgencpu.h
@@ -455,6 +455,14 @@ inline TADDR GetFP(const CONTEXT * context)
     return (TADDR)(context->Rbp);
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->Rbx);
+}
+
 extern "C" TADDR GetCurrentSP();
 
 // Emits:

--- a/src/coreclr/vm/arm/cgencpu.h
+++ b/src/coreclr/vm/arm/cgencpu.h
@@ -261,6 +261,14 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->R11);
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->R5);
+}
+
 inline void ClearITState(T_CONTEXT *context) {
     LIMITED_METHOD_DAC_CONTRACT;
     context->Cpsr = context->Cpsr & 0xf9ff03ff;

--- a/src/coreclr/vm/arm64/cgencpu.h
+++ b/src/coreclr/vm/arm64/cgencpu.h
@@ -279,6 +279,13 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->X19);
+}
 
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {

--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -206,6 +206,7 @@ void * DispatchCallSimple(
 #endif
     callDescrData.fpReturnSize = 0;
     callDescrData.pTarget = pTargetAddress;
+    callDescrData.rethrowManagedException = true;
 
     if ((dwDispatchCallSimpleFlags & DispatchCallSimple_CatchHandlerFoundNotification) != 0)
     {
@@ -540,6 +541,7 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
 #endif
     callDescrData.fpReturnSize = fpReturnSize;
     callDescrData.pTarget = m_pCallTarget;
+    callDescrData.rethrowManagedException = true;
 
 #ifdef FEATURE_INTERPRETER
     if (transitionToPreemptive)

--- a/src/coreclr/vm/callhelpers.h
+++ b/src/coreclr/vm/callhelpers.h
@@ -48,6 +48,12 @@ struct CallDescrData
 #else
     UINT64 returnValue;
 #endif
+    // True indicates that the new exception handling should rethrow managed exception
+    // using native EH / SEH when it reaches the CallDescrWorkerInternal.
+    // False means that the native code that called the CallDescrWorkerInternal will
+    // be skipped during EH. Please note that in this case destructors in that
+    // code won't be invoked, so extra care needs to be taken to avoid resource leaks.
+    bool rethrowManagedException;
 };
 
 #define NUMBER_RETURNVALUE_SLOTS (ENREGISTERED_RETURNTYPE_MAXSIZE / sizeof(ARG_SLOT))

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -8390,7 +8390,8 @@ extern "C" bool QCALLTYPE SfiNext(StackFrameIterator* pThis, uint* uExCollideCla
             size_t CallDescrWorkerInternalReturnAddress = (size_t)CallDescrWorkerInternal + CallDescrWorkerInternalReturnAddressOffset;
             if (GetIP(pThis->m_crawl.GetRegisterSet()->pCallerContext) == CallDescrWorkerInternalReturnAddress)
             {
-                invalidRevPInvoke = true;
+                CallDescrData* pCallDescrData = (CallDescrData*)GetCallDescrWorkerInternalCallDescrDataReg(pThis->m_crawl.GetRegisterSet()->pCallerContext);
+                invalidRevPInvoke = pCallDescrData->rethrowManagedException;
             }
             else if (pThis->m_crawl.IsFilterFunclet())
             {

--- a/src/coreclr/vm/i386/cgencpu.h
+++ b/src/coreclr/vm/i386/cgencpu.h
@@ -241,6 +241,15 @@ inline TADDR GetFP(const CONTEXT * context)
     return (TADDR)context->Ebp;
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->Ebx);
+}
+
+
 // Get Rel32 destination, emit jumpStub if necessary
 inline INT32 rel32UsingJumpStub(INT32 UNALIGNED * pRel32, PCODE target, MethodDesc *pMethod = NULL, LoaderAllocator *pLoaderAllocator = NULL)
 {

--- a/src/coreclr/vm/loongarch64/cgencpu.h
+++ b/src/coreclr/vm/loongarch64/cgencpu.h
@@ -234,6 +234,14 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->S0);
+}
+
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {
     TADDR mem;

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -558,6 +558,7 @@ FCIMPL4(Object*, RuntimeMethodHandle::InvokeMethod,
         pTarget = pMeth->GetSingleCallableAddrOfCode();
     }
     callDescrData.pTarget = pTarget;
+    callDescrData.rethrowManagedException = false;
 
     // Build the arguments on the stack
 

--- a/src/coreclr/vm/riscv64/cgencpu.h
+++ b/src/coreclr/vm/riscv64/cgencpu.h
@@ -239,6 +239,13 @@ inline TADDR GetFP(const T_CONTEXT * context)
     return (TADDR)(context->Fp);
 }
 
+// Get register that holds CallDescrData* in the GetCallDescrWorkerInternal
+inline TADDR GetCallDescrWorkerInternalCallDescrDataReg(CONTEXT * pContext)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    return (TADDR)(pContext->S1);
+}
 
 inline TADDR GetMem(PCODE address, SIZE_T size, bool signExtend)
 {


### PR DESCRIPTION
With the new EH enabled, VS is not breaking on user unhandled exceptions stemming from reflection invoked code. These are exceptions that are still handled, but not in the user code. The most frequent case when the VS issue occurs is in unit tests execution, where a unit test assert throws an exception that's caught by the xunit. With the old EH, VS breaks on such exception and pops out a dialog reporting it as user unhandled. With the new EH, it doesn't happen and the test execution completes with the failure reported into a console instead.

The reason is that VS is expecting to get a "catch handler found" notification when EH locates the catch handler for the exception so that it can decide whether the catch is in user code or not. We cannot provide it when there are two separate passes of EH - one inside of the reflected code and one in the caller of the reflected code.

This change fixes that by changing the way how exception is propagated over the native code that invokes the reflected code. Instead of throwing a native exception at the CallDescrWorkerInternal frame, it skips all the native frames upto the explicit frame at the boundary of the managed caller of the reflected code. That way, the exception is propagated in one go instead of two stages.

That also have a positive effect on the only failing dotnet-diagnostics test for exceptions from reflection. We were planning to rework the test to accomodate for the two stages of the exception propagation, but with this fix, it works as-is.

While this behavior was implemented for reflection invocation case only, it was made so that it would be easy to extend it for other calls through the CallDescrWorker if we discover that any other needs such a treatment too.