### PR TITLE
Delete odd definition of VolatileLoad/Store

### DIFF
--- a/src/coreclr/nativeaot/Runtime/stressLog.cpp
+++ b/src/coreclr/nativeaot/Runtime/stressLog.cpp
@@ -29,9 +29,7 @@
 #include "threadstore.h"
 #include "threadstore.inl"
 #include "thread.inl"
-
-template<typename T> inline T VolatileLoad(T const * pt) { return *(T volatile const *)pt; }
-template<typename T> inline void VolatileStore(T* pt, T val) { *(T volatile *)pt = val; }
+#include "volatile.h"
 
 #ifdef STRESS_LOG
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/100627#issuecomment-2037392935

Cc @dotnet/ilc-contrib 