### PR TITLE
Support SSLKEYLOGFILE in Release builds

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -21,8 +21,6 @@ internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-        private static readonly string? s_keyLogFile = Environment.GetEnvironmentVariable("SSLKEYLOGFILE");
-        private static readonly FileStream? s_fileStream = s_keyLogFile != null ? File.Open(s_keyLogFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite) : null;
         private const string TlsCacheSizeCtxName = "System.Net.Security.TlsCacheSize";
         private const string TlsCacheSizeEnvironmentVariable = "DOTNET_SYSTEM_NET_SECURITY_TLSCACHESIZE";
         private const SslProtocols FakeAlpnSslProtocol = (SslProtocols)1;   // used to distinguish server sessions with ALPN
@@ -207,7 +205,7 @@ internal static partial class Interop
                         Ssl.SslCtxSetDefaultOcspCallback(sslCtx);
                     }
                 }
-                if (s_fileStream != null)
+                if (SslKeyLogger.IsEnabled)
                 {
                     Ssl.SslCtxSetKeylogCallback(sslCtx, &KeyLogCallback);
                 }
@@ -756,17 +754,8 @@ internal static partial class Interop
         [UnmanagedCallersOnly]
         private static unsafe void KeyLogCallback(IntPtr ssl, char* line)
         {
-            Debug.Assert(s_fileStream != null);
             ReadOnlySpan<byte> data = MemoryMarshal.CreateReadOnlySpanFromNullTerminated((byte*)line);
-            if (data.Length > 0)
-            {
-                lock (s_fileStream)
-                {
-                    s_fileStream.Write(data);
-                    s_fileStream.WriteByte((byte)'\n');
-                    s_fileStream.Flush();
-                }
-            }
+            SslKeyLogger.WriteLineRaw(data);
         }
 
         private static int BioRead(SafeBioHandle bio, Span<byte> buffer, int count)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -21,10 +21,8 @@ internal static partial class Interop
 {
     internal static partial class OpenSsl
     {
-#if DEBUG
         private static readonly string? s_keyLogFile = Environment.GetEnvironmentVariable("SSLKEYLOGFILE");
         private static readonly FileStream? s_fileStream = s_keyLogFile != null ? File.Open(s_keyLogFile, FileMode.Append, FileAccess.Write, FileShare.ReadWrite) : null;
-#endif
         private const string TlsCacheSizeCtxName = "System.Net.Security.TlsCacheSize";
         private const string TlsCacheSizeEnvironmentVariable = "DOTNET_SYSTEM_NET_SECURITY_TLSCACHESIZE";
         private const SslProtocols FakeAlpnSslProtocol = (SslProtocols)1;   // used to distinguish server sessions with ALPN
@@ -209,12 +207,10 @@ internal static partial class Interop
                         Ssl.SslCtxSetDefaultOcspCallback(sslCtx);
                     }
                 }
-#if DEBUG
                 if (s_fileStream != null)
                 {
                     Ssl.SslCtxSetKeylogCallback(sslCtx, &KeyLogCallback);
                 }
-#endif
             }
             catch
             {
@@ -757,7 +753,6 @@ internal static partial class Interop
             ctxHandle.RemoveSession(name);
         }
 
-#if DEBUG
         [UnmanagedCallersOnly]
         private static unsafe void KeyLogCallback(IntPtr ssl, char* line)
         {
@@ -773,7 +768,6 @@ internal static partial class Interop
                 }
             }
         }
-#endif
 
         private static int BioRead(SafeBioHandle bio, Span<byte> buffer, int count)
         {

--- a/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
@@ -18,7 +18,11 @@ internal static class SslKeyLogger
 
         try
         {
+#if DEBUG
+            bool isEnabled = true;
+#else
             bool isEnabled = AppContext.TryGetSwitch("System.Net.Security.EnableSslKeyLogging", out bool enabled) && enabled;
+#endif
 
             if (isEnabled && s_keyLogFile != null)
             {

--- a/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
@@ -106,6 +106,8 @@ internal static class SslKeyLogger
             return;
         }
 
+        // write the secret line in the format {label} {client_random (hex)} {secret (hex)} e.g.
+        // SERVER_HANDSHAKE_TRAFFIC_SECRET bae582227f0f46ca663cb8c3d62e68cec38c2b947e7c4a9ec6f4e262b5ed5354 48f6bd5b0c8447d97129c6dad080f34c7f9f11ade8eeabb011f33811543411d7ab1013b1374bcd81bfface6a2deef539
         int totalLength = labelUtf8.Length + 1 + clientRandomUtf8.Length + 1 + 2 * secret.Length + 1;
         Span<byte> line = totalLength <= 1024 ? stackalloc byte[totalLength] : new byte[totalLength];
 

--- a/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
@@ -67,7 +67,15 @@ internal static class SslKeyLogger
         Debug.Assert(s_fileStream != null);
         Debug.Assert(!clientRandom.IsEmpty);
 
-        if (s_fileStream == null || clientRandom.IsEmpty)
+        if (s_fileStream == null ||
+            clientRandom.IsEmpty ||
+
+            // return early if there is nothing to log
+            (clientHandshakeTrafficSecret.IsEmpty &&
+            serverHandshakeTrafficSecret.IsEmpty &&
+            clientTrafficSecret0.IsEmpty &&
+            serverTrafficSecret0.IsEmpty &&
+            clientEarlyTrafficSecret.IsEmpty))
         {
             return;
         }
@@ -89,7 +97,6 @@ internal static class SslKeyLogger
 
     private static void WriteSecretCore(ReadOnlySpan<byte> labelUtf8, ReadOnlySpan<byte> clientRandomUtf8, ReadOnlySpan<byte> secret)
     {
-        Debug.Assert(s_fileStream != null);
         if (secret.Length == 0)
         {
             return;
@@ -107,7 +114,7 @@ internal static class SslKeyLogger
         HexEncode(secret, line.Slice(labelUtf8.Length + 1 + clientRandomUtf8.Length + 1));
         line[^1] = (byte)'\n';
 
-        s_fileStream.Write(line);
+        s_fileStream!.Write(line);
     }
 
     private static void HexEncode(ReadOnlySpan<byte> source, Span<byte> destination)

--- a/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
+++ b/src/libraries/Common/src/System/Net/Security/SslKeyLogger.cs
@@ -21,7 +21,7 @@ internal static class SslKeyLogger
 #if DEBUG
             bool isEnabled = true;
 #else
-            bool isEnabled = AppContext.TryGetSwitch("System.Net.Security.EnableSslKeyLogging", out bool enabled) && enabled;
+            bool isEnabled = AppContext.TryGetSwitch("System.Net.EnableSslKeyLogging", out bool enabled) && enabled;
 #endif
 
             if (isEnabled && s_keyLogFile != null)

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -38,6 +38,8 @@
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs" Link="Common\System\Net\Security\TlsAlertMessage.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs" Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\SslKeyLogger.cs"
+      Link="Common\System\Net\Security\SslKeyLogger.cs" />
     <!-- IP parser -->
     <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs" Link="System\Net\IPv4AddressHelper.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs" Link="System\Net\IPv6AddressHelper.Common.cs" />

--- a/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
+++ b/src/libraries/System.Net.Quic/src/System.Net.Quic.csproj
@@ -38,8 +38,7 @@
     <Compile Include="$(CommonPath)System\Net\Security\TlsAlertMessage.cs" Link="Common\System\Net\Security\TlsAlertMessage.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\TargetHostNameHelper.cs" Link="Common\System\Net\Security\TargetHostNameHelper.cs" />
-    <Compile Include="$(CommonPath)System\Net\Security\SslKeyLogger.cs"
-      Link="Common\System\Net\Security\SslKeyLogger.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\SslKeyLogger.cs" Link="Common\System\Net\Security\SslKeyLogger.cs" />
     <!-- IP parser -->
     <Compile Include="$(CommonPath)System\Net\IPv4AddressHelper.Common.cs" Link="System\Net\IPv4AddressHelper.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\IPv6AddressHelper.Common.cs" Link="System\Net\IPv6AddressHelper.Common.cs" />

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -187,13 +187,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// </summary>
     private SslApplicationProtocol _negotiatedApplicationProtocol;
 
-#if DEBUG
     /// <summary>
     /// Will contain TLS secret after CONNECTED event is received and store it into SSLKEYLOGFILE.
     /// MsQuic holds the underlying pointer so this object can be disposed only after connection native handle gets closed.
     /// </summary>
     private readonly MsQuicTlsSecret? _tlsSecret;
-#endif
 
     /// <summary>
     /// The remote endpoint used for this connection.
@@ -254,9 +252,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
             throw;
         }
 
-#if DEBUG
         _tlsSecret = MsQuicTlsSecret.Create(_handle);
-#endif
     }
 
     /// <summary>
@@ -284,9 +280,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         _remoteEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(info->RemoteAddress);
         _localEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(info->LocalAddress);
-#if DEBUG
         _tlsSecret = MsQuicTlsSecret.Create(_handle);
-#endif
     }
 
     private async ValueTask FinishConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
@@ -510,9 +504,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
         QuicAddr localAddress = MsQuicHelpers.GetMsQuicParameter<QuicAddr>(_handle, QUIC_PARAM_CONN_LOCAL_ADDRESS);
         _localEndPoint = MsQuicHelpers.QuicAddrToIPEndPoint(&localAddress);
 
-#if DEBUG
         _tlsSecret?.WriteSecret();
-#endif
 
         if (NetEventSource.Log.IsEnabled())
         {

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -23,11 +23,6 @@ namespace System.Net.Quic.Tests
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void SslKeyLogFile_IsCreatedAndFilled()
         {
-            if (PlatformDetection.IsReleaseLibrary(typeof(QuicConnection).Assembly))
-            {
-                throw new SkipTestException("Retrieving SSL secrets is not supported in Release mode.");
-            }
-
             var psi = new ProcessStartInfo();
             var tempFile = Path.GetTempFileName();
             psi.Environment.Add("SSLKEYLOGFILE", tempFile);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -25,6 +25,11 @@ namespace System.Net.Quic.Tests
         [InlineData(false)]
         public void SslKeyLogFile_IsCreatedAndFilled(bool enabledBySwitch)
         {
+            if (PlatformDetection.IsDebugLibrary(typeof(QuicConnection).Assembly) && !enabledBySwitch)
+            {
+                throw new SkipTestException("AppCtxSwitch is not necessary for SSLKEYLOGFILE in Debug.");
+            }
+
             var psi = new ProcessStartInfo();
             var tempFile = Path.GetTempFileName();
             psi.Environment.Add("SSLKEYLOGFILE", tempFile);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -27,7 +27,9 @@ namespace System.Net.Quic.Tests
         {
             if (PlatformDetection.IsDebugLibrary(typeof(QuicConnection).Assembly) && !enabledBySwitch)
             {
-                throw new SkipTestException("AppCtxSwitch is not necessary for SSLKEYLOGFILE in Debug.");
+                // AppCtxSwitch is not checked for SSLKEYLOGFILE in Debug builds, the same code path
+                // will be tested by the enabledBySwitch = true case. Skip it here.
+                return;
             }
 
             var psi = new ProcessStartInfo();

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -49,13 +49,11 @@ namespace System.Net.Quic.Tests
 
             if (enabledBySwitch)
             {
-                Assert.True(File.Exists(tempFile));
-                var text = File.ReadAllText(tempFile);
-                Assert.True(text.Length > 0);
+                Assert.True(File.ReadAllText(tempFile).Length > 0);
             }
             else
             {
-                Assert.True(!File.Exists(tempFile) || File.ReadAllText(tempFile).Length == 0);
+                Assert.True(File.ReadAllText(tempFile).Length == 0);
             }
         }
     }

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicRemoteExecutorTests.cs
@@ -40,7 +40,7 @@ namespace System.Net.Quic.Tests
             {
                 if (bool.Parse(enabledBySwitch))
                 {
-                    AppContext.SetSwitch("System.Net.Security.EnableSslKeyLogging", true);
+                    AppContext.SetSwitch("System.Net.EnableSslKeyLogging", true);
                 }
 
                 (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -387,6 +387,8 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteSslContext.cs"
              Link="Common\System\Net\Security\Unix\SafeDeleteSslContext.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\SslKeyLogger.cs"
+             Link="Common\System\Net\Security\SslKeyLogger.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true'">

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -27,6 +27,11 @@ namespace System.Net.Security.Tests
         [InlineData(false)]
         public void SslKeyLogFile_IsCreatedAndFilled(bool enabledBySwitch)
         {
+            if (PlatformDetection.IsDebugLibrary(typeof(SslStream).Assembly) && !enabledBySwitch)
+            {
+                throw new SkipTestException("AppCtxSwitch is not necessary for SSLKEYLOGFILE in Debug.");
+            }
+
             var psi = new ProcessStartInfo();
             var tempFile = Path.GetTempFileName();
             psi.Environment.Add("SSLKEYLOGFILE", tempFile);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -66,12 +66,11 @@ namespace System.Net.Security.Tests
 
             if (enabledBySwitch)
             {
-                Assert.True(File.Exists(tempFile));
                 Assert.True(File.ReadAllText(tempFile).Length > 0);
             }
             else
             {
-                Assert.True(!File.Exists(tempFile) || File.ReadAllText(tempFile).Length == 0);
+                Assert.True(File.ReadAllText(tempFile).Length == 0);
             }
         }
     }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -22,14 +22,9 @@ namespace System.Net.Security.Tests
         { }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/94843", ~TestPlatforms.Linux)]
+        [PlatformSpecific(TestPlatforms.Linux)] // SSLKEYLOGFILE is only supported on Linux for SslStream
         public void SslKeyLogFile_IsCreatedAndFilled()
         {
-            if (PlatformDetection.IsReleaseLibrary(typeof(SslStream).Assembly))
-            {
-                throw new SkipTestException("Retrieving SSL secrets is not supported in Release mode.");
-            }
-
             var psi = new ProcessStartInfo();
             var tempFile = Path.GetTempFileName();
             psi.Environment.Add("SSLKEYLOGFILE", tempFile);

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -29,7 +29,9 @@ namespace System.Net.Security.Tests
         {
             if (PlatformDetection.IsDebugLibrary(typeof(SslStream).Assembly) && !enabledBySwitch)
             {
-                throw new SkipTestException("AppCtxSwitch is not necessary for SSLKEYLOGFILE in Debug.");
+                // AppCtxSwitch is not checked for SSLKEYLOGFILE in Debug builds, the same code path
+                // will be tested by the enabledBySwitch = true case. Skip it here.
+                return;
             }
 
             var psi = new ProcessStartInfo();

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamRemoteExecutorTests.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security.Tests
             {
                 if (bool.Parse(enabledBySwitch))
                 {
-                    AppContext.SetSwitch("System.Net.Security.EnableSslKeyLogging", true);
+                    AppContext.SetSwitch("System.Net.EnableSslKeyLogging", true);
                 }
 
                 (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -121,6 +121,8 @@
              Link="Common\Microsoft\Win32\SafeHandles\SafeHandleCache.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\Unix\SafeDeleteSslContext.cs"
              Link="Common\System\Net\Security\Unix\SafeDeleteSslContext.cs" />
+    <Compile Include="$(CommonPath)System\Net\Security\SslKeyLogger.cs"
+             Link="Common\System\Net\Security\SslKeyLogger.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios'">


### PR DESCRIPTION
Closes #37915.

This PR unifies existing SSLKEYLOGFILE exporting between SslStream and QuicConnection to use same shared code, and enables the feature in Release builds of libraries. This makes the feature available to consumers without needing to compile Debug builds of .NET Runtime.

Note that the SSLKEYLOGFILE feature is currently supported for:

| OS | SslStream | QuicConnection |
|---|----|----|
| Windows | Not possible | Yes |
| Linux | Yes | Yes |
| OSX | Not possible? | Yes* |

*MsQuic is not yet officially supported on OSX, but once it is, no changes should be necessary from .NET side.

For security concerns, in addition to setting SSLKEYLOGFILE environment variable, setting `System.Net.EnableSslKeyLogging` AppContext switch to `true` is required. This can be done either via code

```cs
AppContext.SetSwitch("System.Net.EnableSslKeyLogging", true);
```

or via {project}.runtimeconfig.json

```
{
  "runtimeOptions": {
    "configProperties": {
      "System.Net.EnableSslKeyLogging": true
    }
  }
}
```

Debug runtime libraires (= local development builds of .NET Runtime) don't require the AppContext switch for the feature.