### PR TITLE
[wasm] Microsoft.NET.Sdk.WebAssembly.Pack as library pack

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
+++ b/src/mono/nuget/Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest/WorkloadManifest.json.in
@@ -8,6 +8,7 @@
       "description": ".NET WebAssembly build tools",
       "packs": [
         "Microsoft.NET.Runtime.WebAssembly.Sdk",
+        "Microsoft.NET.Sdk.WebAssembly.Pack",
         "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",
         "Microsoft.NETCore.App.Runtime.AOT.Cross.browser-wasm"
       ],
@@ -175,6 +176,10 @@
     },
     "Microsoft.NET.Runtime.WebAssembly.Sdk": {
       "kind": "Sdk",
+      "version": "${PackageVersion}"
+    },
+    "Microsoft.NET.Sdk.WebAssembly.Pack": {
+      "kind": "library",
       "version": "${PackageVersion}"
     },
     "Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk": {


### PR DESCRIPTION
Include `Microsoft.NET.Sdk.WebAssembly.Pack` as library pack in workload. The nuget package will be downloaded to SDK as part of workload installation. We still can override the version if we change the `KnownWebAssemblySdkPack` version

From binlog https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-100672-merge-9b6799bef8f44457b3/Workloads-Wasm.Build.Tests.TestAppScenarios.DebugLevelTests/1/xharness-output/logs/DebugLevelTests_BuildWithDefaultLevel_Debug_qlnpzlih_ub5/DebugLevelTests_BuildWithDefaultLevel_Debug_qlnpzlih_ub5-build.binlog?helixlogtype=result

![image](https://github.com/dotnet/runtime/assets/10020471/bffdfec8-9467-40e5-9e15-c53c8ab83637)
