### PR TITLE
Fix VS user unhandled exception notification

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodInvokerCommon.cs
@@ -113,9 +113,10 @@ namespace System.Reflection
                 // If ByRefs are used, we can't use this strategy.
                 strategy |= InvokerStrategy.StrategyDetermined_ObjSpanArgs;
             }
-            else if ((strategy & InvokerStrategy.HasBeenInvoked_ObjSpanArgs) == 0)
+            else if (((strategy & InvokerStrategy.HasBeenInvoked_ObjSpanArgs) == 0) && !Debugger.IsAttached)
             {
-                // The first time, ignoring race conditions, use the slow path.
+                // The first time, ignoring race conditions, use the slow path, except for the case when running under a debugger.
+                // This is a workaround for the debugger issues with understanding exceptions propagation over the slow path.
                 strategy |= InvokerStrategy.HasBeenInvoked_ObjSpanArgs;
             }
             else
@@ -141,9 +142,10 @@ namespace System.Reflection
                 // If ByRefs are used, we can't use this strategy.
                 strategy |= InvokerStrategy.StrategyDetermined_Obj4Args;
             }
-            else if ((strategy & InvokerStrategy.HasBeenInvoked_Obj4Args) == 0)
+            else if (((strategy & InvokerStrategy.HasBeenInvoked_Obj4Args) == 0) && !Debugger.IsAttached)
             {
-                // The first time, ignoring race conditions, use the slow path.
+                // The first time, ignoring race conditions, use the slow path, except for the case when running under a debugger.
+                // This is a workaround for the debugger issues with understanding exceptions propagation over the slow path.
                 strategy |= InvokerStrategy.HasBeenInvoked_Obj4Args;
             }
             else
@@ -163,9 +165,10 @@ namespace System.Reflection
             MethodBase method,
             bool backwardsCompat)
         {
-            if ((strategy & InvokerStrategy.HasBeenInvoked_RefArgs) == 0)
+            if (((strategy & InvokerStrategy.HasBeenInvoked_RefArgs) == 0) && !Debugger.IsAttached)
             {
-                // The first time, ignoring race conditions, use the slow path.
+                // The first time, ignoring race conditions, use the slow path, except for the case when running under a debugger.
+                // This is a workaround for the debugger issues with understanding exceptions propagation over the slow path.
                 strategy |= InvokerStrategy.HasBeenInvoked_RefArgs;
             }
             else


### PR DESCRIPTION
With the new EH enabled, VS is not breaking on user unhandled exceptions stemming from reflection invoked code. These are exceptions that are still handled, but not in the user code. The most frequent case when the VS issue occurs is in unit tests execution, where a unit test assert throws an exception that's caught by the xunit. With the old EH, VS breaks on such exception and pops out a dialog reporting it as user unhandled. With the new EH, it doesn't happen and the test execution completes with the failure reported into a console instead.

The reason is that VS is expecting to get a "catch handler found" notification when EH locates the catch handler for the exception so that it can decide whether the catch is in user code or not. We cannot provide it when there are two separate passes of EH - one inside of the reflected code and one in the caller of the reflected code.

This change fixes it by turning off the path of reflection invocation that uses the RuntimeMethodHandle::InvokeMethod when a debugger is attached. In that case, it always uses the dynamically generated managed code path.