### PR TITLE
Add -cross flag to build.ps1

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -12,6 +12,7 @@ Param(
   [string]$testscope,
   [switch]$testnobuild,
   [ValidateSet("x86","x64","arm","arm64","wasm")][string[]][Alias('a')]$arch = @([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString().ToLowerInvariant()),
+  [switch]$cross = $false,
   [string][Alias('s')]$subset,
   [ValidateSet("Debug","Release","Checked")][string][Alias('rc')]$runtimeConfiguration,
   [ValidateSet("Debug","Release")][string][Alias('lc')]$librariesConfiguration,


### PR DESCRIPTION
Fixes VMR build error on Windows after https://github.com/dotnet/installer/pull/19321

We haven't used or passed this on Windows before and a bunch of logic is conditioned based on the `CrossBuild` property (which is what `-cross` is turned into in build.sh) so ignore it for now.