### PR TITLE
Marked FixCasing to be always inlined

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
+++ b/src/libraries/System.Text.Json/Common/JsonCamelCaseNamingPolicy.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Text.Json
 {
     internal sealed class JsonCamelCaseNamingPolicy : JsonNamingPolicy
@@ -25,6 +27,7 @@ namespace System.Text.Json
 #endif
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void FixCasing(Span<char> chars)
         {
             for (int i = 0; i < chars.Length; i++)


### PR DESCRIPTION
# Description

Since `FixCasing` is invoked only from a single place it makes sense to always inline it. The method's body isn't written inside `ConvertName` just because there's a conditional compiation logic, and `FixCasing` needs in both branches there without cop pasting.

# Customer Impact

A bit less instructions.

# Regression

Nope.

# Testing

There's no behavior change at all, so the existing tests are enought.
