### PR TITLE
Add missing property to include native libraries for Apple mobile native linker

### DIFF
--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -212,6 +212,7 @@
 
   <PropertyGroup Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetsAppleMobile)' == 'true'">
     <_targetOS>$(TargetOS)</_targetOS>
+    <_targetArchitecture>$(TargetArchitecture)</_targetArchitecture>
     <UseNativeAOTRuntime>true</UseNativeAOTRuntime>
     <NativeLib>static</NativeLib>
     <CustomNativeMain>true</CustomNativeMain>


### PR DESCRIPTION
## Description

The `_targetArchitecture` is not being set correctly, leading to missing native libraries for the native linker. This is a hotfix for the CI failures. The Native AOT pipeline for Apple mobile will be reviewed and improved in subsequent PRs.

Fixes https://github.com/dotnet/runtime/issues/100632