### PR TITLE
Fix bug in virtual annotation logic for RequiresUnreferencedCode

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -40,10 +40,11 @@ namespace Mono.Linker.Steps
 		void ValidateMethodRequiresUnreferencedCodeAreSame (MethodDefinition method, MethodDefinition baseMethod)
 		{
 			var annotations = Context.Annotations;
-			bool methodHasAttribute = annotations.IsInRequiresUnreferencedCodeScope (method, out _);
-			if (methodHasAttribute != annotations.IsInRequiresUnreferencedCodeScope (baseMethod, out _)) {
-				string message = MessageFormat.FormatRequiresAttributeMismatch (methodHasAttribute,
-					baseMethod.DeclaringType.IsInterface, nameof (RequiresUnreferencedCodeAttribute), method.GetDisplayName (), baseMethod.GetDisplayName ());
+			bool methodSatisfies = annotations.IsInRequiresUnreferencedCodeScope (method, out _);
+			bool baseRequires = annotations.DoesMethodRequireUnreferencedCode (baseMethod, out _);
+			if ((baseRequires && !methodSatisfies) || (!baseRequires && annotations.DoesMethodRequireUnreferencedCode (method, out _))) {
+				string message = MessageFormat.FormatRequiresAttributeMismatch (methodSatisfies,
+				baseMethod.DeclaringType.IsInterface, nameof (RequiresUnreferencedCodeAttribute), method.GetDisplayName (), baseMethod.GetDisplayName ());
 				Context.LogWarning (method, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, message);
 			}
 		}

--- a/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -44,11 +44,11 @@ namespace Mono.Linker.Steps
 			bool baseRequires = annotations.DoesMethodRequireUnreferencedCode (baseMethod, out _);
 			if ((baseRequires && !methodSatisfies) || (!baseRequires && annotations.DoesMethodRequireUnreferencedCode (method, out _))) {
 				string message = MessageFormat.FormatRequiresAttributeMismatch (
-				    methodSatisfies,
-				    baseMethod.DeclaringType.IsInterface,
-				    nameof (RequiresUnreferencedCodeAttribute),
-				    method.GetDisplayName (),
-				    baseMethod.GetDisplayName ());
+					methodSatisfies,
+					baseMethod.DeclaringType.IsInterface,
+					nameof (RequiresUnreferencedCodeAttribute),
+					method.GetDisplayName (),
+					baseMethod.GetDisplayName ());
 				Context.LogWarning (method, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, message);
 			}
 		}

--- a/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/ValidateVirtualMethodAnnotationsStep.cs
@@ -43,8 +43,12 @@ namespace Mono.Linker.Steps
 			bool methodSatisfies = annotations.IsInRequiresUnreferencedCodeScope (method, out _);
 			bool baseRequires = annotations.DoesMethodRequireUnreferencedCode (baseMethod, out _);
 			if ((baseRequires && !methodSatisfies) || (!baseRequires && annotations.DoesMethodRequireUnreferencedCode (method, out _))) {
-				string message = MessageFormat.FormatRequiresAttributeMismatch (methodSatisfies,
-				baseMethod.DeclaringType.IsInterface, nameof (RequiresUnreferencedCodeAttribute), method.GetDisplayName (), baseMethod.GetDisplayName ());
+				string message = MessageFormat.FormatRequiresAttributeMismatch (
+				    methodSatisfies,
+				    baseMethod.DeclaringType.IsInterface,
+				    nameof (RequiresUnreferencedCodeAttribute),
+				    method.GetDisplayName (),
+				    baseMethod.GetDisplayName ());
 				Context.LogWarning (method, DiagnosticId.RequiresUnreferencedCodeAttributeMismatch, message);
 			}
 		}


### PR DESCRIPTION
The following virtual methods are correctly annotated and do not warn:

```csharp
class Base {
  virtual void M() {}
}

[RequiresUnreferencedCode("Derived")]
class Derived : Base {
  override void M() {}
}
```

However, if the method also happens to have DynamicallyAccessedMembers annotations, there's a bug in the logic that causes this to produce warnings in illink. This change fixes the bug.

Hit this while experimenting with ComponentModel annotations.