### PR TITLE
Fix official build: disable compile-native runtime component libraries for linux-bionic

### DIFF
--- a/src/native/managed/compile-native.proj
+++ b/src/native/managed/compile-native.proj
@@ -19,6 +19,8 @@
     <PropertyGroup>
         <!-- disable on Mono, for now -->
         <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(RuntimeFlavor)' == 'Mono'">false</SupportsNativeAotComponents>
+        <!-- disable on linux-bionic, for now -->
+        <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(TargetsLinuxBionic)' == 'true'">false</SupportsNativeAotComponents>
         <!-- NativeAOT doesn't support cross-OS compilation. disable for crossdac-->
         <SupportsNativeAotComponents Condition="'$(SupportsNativeAotComponents)' == '' and '$(HostOS)' != '$(TargetOS)'">false</SupportsNativeAotComponents>
         <!-- unsupported targets -->


### PR DESCRIPTION
After https://github.com/dotnet/runtime/pull/100623, the official build is broken. Our infrastructure for building native runtime component libraries using NativeAOT is failing for linux-bionic. Disable building on linux-bionic for now to unblock the build.

cc @steveisok @lambdageek 