### PR TITLE
Fix KeyInfoX509Data encoding negative serial numbers

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/KeyInfoX509Data.cs
@@ -160,6 +160,15 @@ namespace System.Security.Cryptography.Xml
             if (!BigInteger.TryParse(serialNumber, NumberStyles.AllowHexSpecifier, NumberFormatInfo.CurrentInfo, out h))
                 throw new ArgumentException(SR.Cryptography_Xml_InvalidX509IssuerSerialNumber, nameof(serialNumber));
 
+            // NetFx compat: .NET Framework treats the input as unsigned and we need to write down the X509SerialNumber
+            // as a positive number.
+            if (h < BigInteger.Zero)
+            {
+                byte[] bytes = h.ToByteArray();
+                Array.Resize(ref bytes, bytes.Length + 1);
+                h = new BigInteger(bytes);
+            }
+
             _issuerSerials ??= new ArrayList();
             _issuerSerials.Add(Utils.CreateX509IssuerSerial(issuerName, h.ToString()));
         }

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
@@ -335,5 +335,14 @@ namespace System.Security.Cryptography.Xml.Tests
             KeyInfoX509Data data1 = new KeyInfoX509Data();
             Assert.Throws<CryptographicException>(() => data1.LoadXml(doc.DocumentElement));
         }
+
+        [Fact]
+        public void AddIssuerSerial_NegativeSerial()
+        {
+            KeyInfoX509Data data = new KeyInfoX509Data();
+            data.AddIssuerSerial("CN=Vince", "FF");
+            X509IssuerSerial serial = (X509IssuerSerial)Assert.Single(data.IssuerSerials);
+            Assert.Equal("255", serial.SerialNumber);
+        }
     }
 }


### PR DESCRIPTION
.NET Framework treats the serial number from an X509Certificate as unsigned, and encodes the serial number as a positive integer. This changes the managed implementation to encode the serial number in the same way.

Fixes #91064