### PR TITLE
Streamline Guid.NewGuid on Windows

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoCreateGuid.cs
+++ b/src/libraries/Common/src/Interop/Windows/Ole32/Interop.CoCreateGuid.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Ole32
     {
         [LibraryImport(Libraries.Ole32)]
-        internal static partial int CoCreateGuid(out Guid guid);
+        internal static unsafe partial int CoCreateGuid(Guid* guid);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.Windows.cs
@@ -5,22 +5,26 @@ namespace System
 {
     public partial struct Guid
     {
-        public static Guid NewGuid()
+        public static unsafe Guid NewGuid()
         {
-            // CoCreateGuid should never return Guid.Empty, since it attempts to maintain some
-            // uniqueness guarantees.
+            // CoCreateGuid should never return Guid.Empty, since it attempts to maintain some uniqueness guarantees.
 
-            int hr = Interop.Ole32.CoCreateGuid(out Guid g);
+            Guid g;
+            int hr = Interop.Ole32.CoCreateGuid(&g);
+            if (hr != 0)
+            {
+                ThrowForHr(hr);
+            }
+
+            return g;
+        }
+
+        private static void ThrowForHr(int hr)
+        {
             // We don't expect that this will ever throw an error, none are even documented, and so we don't want to pull
             // in the HR to ComException mappings into the core library just for this so we will try a generic exception if
             // we ever hit this condition.
-            if (hr != 0)
-            {
-                Exception ex = new Exception();
-                ex.HResult = hr;
-                throw ex;
-            }
-            return g;
+            throw new Exception() { HResult = hr };
         }
     }
 }


### PR DESCRIPTION
Enable it to be inlined automatically and remove an extra LibraryImport helper