### PR TITLE
[NativeAOT/x86] Fix funclet unwinding

### DIFF
--- a/src/coreclr/gcdump/i386/gcdumpx86.cpp
+++ b/src/coreclr/gcdump/i386/gcdumpx86.cpp
@@ -456,10 +456,10 @@ size_t              GCDump::DumpGCTable(PTR_CBYTE      table,
                     /* non-ptr arg push */
 
                     curOffs += (val & 0x07);
-#ifndef UNIX_X86_ABI
+#ifndef FEATURE_EH_FUNCLETS
                     // For x86/Linux, non-ptr arg pushes can be reported even for EBP frames
                     _ASSERTE(!header.ebpFrame);
-#endif // UNIX_X86_ABI
+#endif // FEATURE_EH_FUNCLETS
                     argCnt++;
 
                     DumpEncoding(bp, table-bp); bp = table;

--- a/src/coreclr/gcdump/i386/gcdumpx86.cpp
+++ b/src/coreclr/gcdump/i386/gcdumpx86.cpp
@@ -457,7 +457,7 @@ size_t              GCDump::DumpGCTable(PTR_CBYTE      table,
 
                     curOffs += (val & 0x07);
 #ifndef FEATURE_EH_FUNCLETS
-                    // For x86/Linux, non-ptr arg pushes can be reported even for EBP frames
+                    // For funclets, non-ptr arg pushes can be reported even for EBP frames
                     _ASSERTE(!header.ebpFrame);
 #endif // FEATURE_EH_FUNCLETS
                     argCnt++;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6680,9 +6680,9 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
 
     emitFullyInt   = fullyInt;
     emitFullGCinfo = fullPtrMap;
-
-#ifndef UNIX_X86_ABI
-    emitFullArgInfo = !emitHasFramePtr;
+#if TARGET_X86
+    // On x86 with funclets we emit full ptr map even for EBP frames
+    emitFullArgInfo = comp->UsesFunclets() ? !emitHasFramePtr : fullPtrMap;
 #else
     emitFullArgInfo = fullPtrMap;
 #endif

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6682,9 +6682,9 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
     emitFullGCinfo = fullPtrMap;
 #if TARGET_X86
     // On x86 with funclets we emit full ptr map even for EBP frames
-    emitFullArgInfo = comp->UsesFunclets() ? !emitHasFramePtr : fullPtrMap;
+    emitFullArgInfo = comp->UsesFunclets() ? fullPtrMap : !emitHasFramePtr;
 #else
-    emitFullArgInfo = fullPtrMap;
+    emitFullArgInfo = !emitHasFramePtr;
 #endif
 
 #if EMITTER_STATS

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -2584,9 +2584,7 @@ size_t GCInfo::gcMakeRegPtrTable(BYTE* dest, int mask, const InfoHdr& header, un
 
                     assert((codeDelta & 0x7) == codeDelta);
                     *dest++ = 0xB0 | (BYTE)codeDelta;
-#ifndef UNIX_X86_ABI
-                    assert(!compiler->isFramePointerUsed());
-#endif
+                    assert(compiler->UsesFunclets() || !compiler->isFramePointerUsed());
 
                     /* Remember the new 'last' offset */
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14232,6 +14232,13 @@ void Compiler::fgSetOptions()
     if (info.compXcptnsCount > 0)
     {
         codeGen->setFramePointerRequiredEH(true);
+
+        if (UsesFunclets())
+        {
+            assert(!codeGen->isGCTypeFixed());
+            // Enforce fully interruptible codegen for funclet unwinding
+            SetInterruptible(true);
+        }
     }
 
 #else // !TARGET_X86
@@ -14242,15 +14249,6 @@ void Compiler::fgSetOptions()
     }
 
 #endif // TARGET_X86
-
-#ifdef UNIX_X86_ABI
-    if (info.compXcptnsCount > 0)
-    {
-        assert(!codeGen->isGCTypeFixed());
-        // Enforce fully interruptible codegen for funclet unwinding
-        SetInterruptible(true);
-    }
-#endif // UNIX_X86_ABI
 
     if (compMethodRequiresPInvokeFrame())
     {

--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -1519,10 +1519,10 @@ unsigned scanArgRegTableI(PTR_CBYTE    table,
 
     bool      hasPartialArgInfo;
 
-#ifndef UNIX_X86_ABI
+#ifndef FEATURE_EH_FUNCLETS
     hasPartialArgInfo = info->ebpFrame;
 #else
-    // For x86/Linux, interruptible code always has full arg info
+    // For x86/Funclets, interruptible code always has full arg info
     //
     // This should be aligned with emitFullArgInfo setting at
     // emitter::emitEndCodeGen (in JIT)

--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -1522,7 +1522,7 @@ unsigned scanArgRegTableI(PTR_CBYTE    table,
 #ifndef FEATURE_EH_FUNCLETS
     hasPartialArgInfo = info->ebpFrame;
 #else
-    // For x86/Funclets, interruptible code always has full arg info
+    // For funclets, interruptible code always has full arg info
     //
     // This should be aligned with emitFullArgInfo setting at
     // emitter::emitEndCodeGen (in JIT)


### PR DESCRIPTION
Fixes #100507

The x86 funclet unwinding code depends on `GetPushedArgSize` returning the correct value when there are any arguments pushed to the stack inside the funclet code. Normally that information is not recorded for methods with EBP frames. The ABI was modified in https://github.com/dotnet/coreclr/pull/10782 for x86/Linux to generate the additional information. However, it was guarded by `UNIX_X86_ABI` #define. This PR changes the guard to `UsesFunclets()` (for JIT) /  `FEATURE_EH_FUNCLETS` (for runtime code) so the same logic can be reused. 