### PR TITLE
[release/8.0-staging] Special casing `System.Guid` for COM VARIANT marshalling

### DIFF
--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -4773,11 +4773,8 @@ void OleVariant::ConvertValueClassToVariant(OBJECTREF *pBoxedValueClass, VARIANT
     // Marshal the contents of the value class into the record.
     MethodDesc* pStructMarshalStub;
     {
-        GCPROTECT_BEGIN(*pBoxedValueClass);
         GCX_PREEMP();
-
         pStructMarshalStub = NDirect::CreateStructMarshalILStub(pValueClassMT);
-        GCPROTECT_END();
     }
 
     MarshalStructViaILStub(pStructMarshalStub, (*pBoxedValueClass)->GetData(), (BYTE*)V_RECORD(pRecHolder), StructMarshalStubs::MarshalOperation::Marshal);

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -2609,17 +2609,34 @@ void OleVariant::MarshalRecordVariantOleToCom(VARIANT *pOleVariant,
     if (!pRecInfo)
         COMPlusThrow(kArgumentException, IDS_EE_INVALID_OLE_VARIANT);
 
+    LPVOID pvRecord = V_RECORD(pOleVariant);
+    if (pvRecord == NULL)
+    {
+        pComVariant->SetObjRef(NULL);
+        return;
+    }
+
+    MethodTable* pValueClass = NULL;
+    {
+        GCX_PREEMP();
+        pValueClass = GetMethodTableForRecordInfo(pRecInfo);
+    }
+
+    if (pValueClass == NULL)
+    {
+        // This value type should have been registered through
+        // a TLB. CoreCLR doesn't support dynamic type mapping.
+        COMPlusThrow(kArgumentException, IDS_EE_CANNOT_MAP_TO_MANAGED_VC);
+    }
+    _ASSERTE(pValueClass->IsBlittable());
+
     OBJECTREF BoxedValueClass = NULL;
     GCPROTECT_BEGIN(BoxedValueClass)
     {
-        LPVOID pvRecord = V_RECORD(pOleVariant);
-        if (pvRecord)
-        {
-            // This value type should have been registered through
-            // a TLB. CoreCLR doesn't support dynamic type mapping.
-            COMPlusThrow(kArgumentException, IDS_EE_CANNOT_MAP_TO_MANAGED_VC);
-        }
-
+        // Now that we have a blittable value class, allocate an instance of the
+        // boxed value class and copy the contents of the record into it.
+        BoxedValueClass = AllocateObject(pValueClass);
+        memcpyNoGCRefs(BoxedValueClass->GetData(), (BYTE*)pvRecord, pValueClass->GetNativeSize());
         pComVariant->SetObjRef(BoxedValueClass);
     }
     GCPROTECT_END();

--- a/src/coreclr/vm/stdinterfaces.cpp
+++ b/src/coreclr/vm/stdinterfaces.cpp
@@ -611,6 +611,43 @@ HRESULT GetITypeLibForAssembly(_In_ Assembly *pAssembly, _Outptr_ ITypeLib **ppT
     return S_OK;
 } // HRESULT GetITypeLibForAssembly()
 
+// .NET Framework's mscorlib TLB GUID.
+static const GUID s_MscorlibGuid = { 0xBED7F4EA, 0x1A96, 0x11D2, { 0x8F, 0x08, 0x00, 0xA0, 0xC9, 0xA6, 0x18, 0x6D } };
+
+// Hard-coded GUID for System.Guid.
+static const GUID s_GuidForSystemGuid = { 0x9C5923E9, 0xDE52, 0x33EA, { 0x88, 0xDE, 0x7E, 0xBC, 0x86, 0x33, 0xB9, 0xCC } };
+
+// There are types that are helpful to provide that facilitate porting from
+// .NET Framework to .NET 8+. This function is used to acquire their ITypeInfo.
+// This should be used narrowly. Types at a minimum should be blittable.
+static bool TryDeferToMscorlib(MethodTable* pClass, ITypeInfo** ppTI)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+        PRECONDITION(pClass != NULL);
+        PRECONDITION(pClass->IsBlittable());
+        PRECONDITION(ppTI != NULL);
+    }
+    CONTRACTL_END;
+
+    // Marshalling of System.Guid is a common scenario that impacts many teams porting
+    // code to .NET 8+. Try to load the .NET Framework's TLB to support this scenario.
+    if (pClass == CoreLibBinder::GetClass(CLASS__GUID))
+    {
+        SafeComHolder<ITypeLib> pMscorlibTypeLib = NULL;
+        if (SUCCEEDED(::LoadRegTypeLib(s_MscorlibGuid, 2, 4, 0, &pMscorlibTypeLib)))
+        {
+            if (SUCCEEDED(pMscorlibTypeLib->GetTypeInfoOfGuid(s_GuidForSystemGuid, ppTI)))
+                return true;
+        }
+    }
+
+    return false;
+}
+
 HRESULT GetITypeInfoForEEClass(MethodTable *pClass, ITypeInfo **ppTI, bool bClassInfo)
 {
     CONTRACTL
@@ -625,6 +662,7 @@ HRESULT GetITypeInfoForEEClass(MethodTable *pClass, ITypeInfo **ppTI, bool bClas
     GUID clsid;
     GUID ciid;
     ComMethodTable *pComMT              = NULL;
+    MethodTable* pOriginalClass         = pClass;
     HRESULT                 hr          = S_OK;
     SafeComHolder<ITypeLib> pITLB       = NULL;
     SafeComHolder<ITypeInfo> pTI        = NULL;
@@ -770,11 +808,67 @@ ErrExit:
     {
         if (!FAILED(hr))
             hr = E_FAIL;
+
+        if (pOriginalClass->IsValueType() && pOriginalClass->IsBlittable())
+        {
+            if (TryDeferToMscorlib(pOriginalClass, ppTI))
+                hr = S_OK;
+        }
     }
 
 ReturnHR:
     return hr;
 } // HRESULT GetITypeInfoForEEClass()
+
+// Only a narrow set of types are supported.
+// See TryDeferToMscorlib() above.
+MethodTable* GetMethodTableForRecordInfo(IRecordInfo* recInfo)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_PREEMPTIVE;
+        PRECONDITION(recInfo != NULL);
+    }
+    CONTRACTL_END;
+
+    HRESULT hr;
+
+    // Verify the associated TypeLib attribute
+    SafeComHolder<ITypeInfo> typeInfo;
+    hr = recInfo->GetTypeInfo(&typeInfo);
+    if (FAILED(hr))
+        return NULL;
+
+    SafeComHolder<ITypeLib> typeLib;
+    UINT index;
+    hr = typeInfo->GetContainingTypeLib(&typeLib, &index);
+    if (FAILED(hr))
+        return NULL;
+
+    TLIBATTR* attrs;
+    hr = typeLib->GetLibAttr(&attrs);
+    if (FAILED(hr))
+        return NULL;
+
+    GUID libGuid = attrs->guid;
+    typeLib->ReleaseTLibAttr(attrs);
+    if (s_MscorlibGuid != libGuid)
+        return NULL;
+
+    // Verify the Guid of the associated type
+    GUID typeGuid;
+    hr = recInfo->GetGuid(&typeGuid);
+    if (FAILED(hr))
+        return NULL;
+
+    // Check for supported types.
+    if (s_GuidForSystemGuid == typeGuid)
+        return CoreLibBinder::GetClass(CLASS__GUID);
+
+    return NULL;
+}
 
 // Returns a NON-ADDREF'd ITypeInfo.
 HRESULT GetITypeInfoForMT(ComMethodTable *pMT, ITypeInfo **ppTI)

--- a/src/coreclr/vm/stdinterfaces.h
+++ b/src/coreclr/vm/stdinterfaces.h
@@ -183,4 +183,7 @@ IErrorInfo *GetSupportedErrorInfo(IUnknown *iface, REFIID riid);
 // Helpers to get the ITypeInfo* for a type.
 HRESULT GetITypeInfoForEEClass(MethodTable *pMT, ITypeInfo **ppTI, bool bClassInfo = false);
 
+// Gets the MethodTable for the associated IRecordInfo.
+MethodTable* GetMethodTableForRecordInfo(IRecordInfo* recInfo);
+
 #endif

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/GetNativeVariantForObjectTests.cs
@@ -189,7 +189,7 @@ namespace System.Runtime.InteropServices.Tests
 
                     var expectedBytes = new ReadOnlySpan<byte>(guid.ToByteArray());
                     var actualBytes = new ReadOnlySpan<byte>((void*)result.bstrVal, expectedBytes.Length);
-                    Assert.Equal(expectedBytes, actualBytes);
+                    Assert.True(expectedBytes.SequenceEqual(actualBytes));
 
                     object o = Marshal.GetObjectForNativeVariant(pNative);
                     Assert.Equal(guid, o);

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/GetObjectForNativeVariantTests.cs
@@ -246,14 +246,38 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled))]
-        public void GetObjectForNativeVariant_NoDataForRecord_ThrowsArgumentException()
+        public void GetObjectForNativeVariant_NoRecordInfo_ThrowsArgumentException()
         {
             Variant variant = CreateVariant(VT_RECORD, new UnionTypes { _record = new Record { _recordInfo = IntPtr.Zero } });
             AssertExtensions.Throws<ArgumentException>(null, () => GetObjectForNativeVariant(variant));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltInComEnabled))]
+        public void GetObjectForNativeVariant_NoRecordData_ReturnsNull()
+        {
+            var recordInfo = new RecordInfo();
+            IntPtr pRecordInfo = Marshal.GetComInterfaceForObject<RecordInfo, IRecordInfo>(recordInfo);
+            try
+            {
+                Variant variant = CreateVariant(VT_RECORD, new UnionTypes
+                {
+                    _record = new Record
+                    {
+                        _record = IntPtr.Zero,
+                        _recordInfo = pRecordInfo
+                    }
+                });
+                Assert.Null(GetObjectForNativeVariant(variant));
+            }
+            finally
+            {
+                Marshal.Release(pRecordInfo);
+            }
+        }
+
         public static IEnumerable<object[]> GetObjectForNativeVariant_NoSuchGuid_TestData()
         {
+            yield return new object[] { typeof(object).GUID };
             yield return new object[] { typeof(string).GUID };
             yield return new object[] { Guid.Empty };
         }

--- a/src/tests/Interop/CMakeLists.txt
+++ b/src/tests/Interop/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CLR_CMAKE_TARGET_WIN32)
     add_subdirectory(COM/NativeClients/DefaultInterfaces)
     add_subdirectory(COM/NativeClients/Dispatch)
     add_subdirectory(COM/NativeClients/Events)
+    add_subdirectory(COM/NativeClients/MiscTypes)
     add_subdirectory(COM/ComWrappers/MockReferenceTrackerRuntime)
     add_subdirectory(COM/ComWrappers/WeakReference)
 

--- a/src/tests/Interop/COM/Dynamic/BasicTest.cs
+++ b/src/tests/Interop/COM/Dynamic/BasicTest.cs
@@ -43,6 +43,7 @@ namespace Dynamic
 
             String();
             Date();
+            SpecialCasedValueTypes();
             ComObject();
             Null();
 
@@ -383,6 +384,16 @@ namespace Dynamic
 
             // Pass as variant
             Variant<DateTime>(val, expected);
+        }
+
+        private void SpecialCasedValueTypes()
+        {
+            {
+                var val = Guid.NewGuid();
+                var expected = val;
+                // Pass as variant
+                Variant<Guid>(val, expected);
+            }
         }
 
         private void ComObject()

--- a/src/tests/Interop/COM/NETClients/MiscTypes/App.manifest
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/App.manifest
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    type="win32"
+    name="NetClientMiscTypes"
+    version="1.0.0.0" />
+
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM -->
+      <assemblyIdentity
+          type="win32"
+          name="COMNativeServer.X"
+          version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+
+</assembly>

--- a/src/tests/Interop/COM/NETClients/MiscTypes/NetClientMiscTypes.csproj
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/NetClientMiscTypes.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CMakeProjectReference, GC.WaitForPendingFinalizers -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ApplicationManifest>App.manifest</ApplicationManifest>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="../../ServerContracts/Server.CoClasses.cs" />
+    <Compile Include="../../ServerContracts/Server.Contracts.cs" />
+    <Compile Include="../../ServerContracts/ServerGuids.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="../../NativeServer/CMakeLists.txt" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+namespace NetClient
+{
+    using System;
+    using System.Runtime.InteropServices;
+
+    using TestLibrary;
+    using Xunit;
+    using Server.Contract;
+    using Server.Contract.Servers;
+
+    struct Struct {}
+
+    public unsafe class Program
+    {
+        [Fact]
+        public static int TestEntryPoint()
+        {
+            // RegFree COM is not supported on Windows Nano
+            if (TestLibrary.Utilities.IsWindowsNanoServer)
+            {
+                return 100;
+            }
+
+            try
+            {
+                ValidationTests();
+                ValidateNegativeTests();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Test object interop failure: {e}");
+                return 101;
+            }
+
+            return 100;
+        }
+
+        private static void ValidationTests()
+        {
+            Console.WriteLine($"Running {nameof(ValidationTests)} ...");
+
+            var miscTypeTesting = (Server.Contract.Servers.MiscTypesTesting)new Server.Contract.Servers.MiscTypesTestingClass();
+
+            Console.WriteLine("-- Primitives <=> VARIANT...");
+            {
+                object expected = null;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = DBNull.Value;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = (sbyte)0x0f;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = (short)0x07ff;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = (int)0x07ffffff;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = (long)0x07ffffffffffffff;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = true;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+            {
+                var expected = false;
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+
+            Console.WriteLine("-- BSTR <=> VARIANT...");
+            {
+                var expected = "The quick Fox jumped over the lazy Dog.";
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+
+            Console.WriteLine("-- System.Guid <=> VARIANT...");
+            {
+                var expected = new Guid("{8EFAD956-B33D-46CB-90F4-45F55BA68A96}");
+                Assert.Equal(expected, miscTypeTesting.Marshal_Variant(expected));
+            }
+        }
+
+        private static void ValidateNegativeTests()
+        {
+            Console.WriteLine($"Running {nameof(ValidateNegativeTests)} ...");
+
+            var miscTypeTesting = (Server.Contract.Servers.MiscTypesTesting)new Server.Contract.Servers.MiscTypesTestingClass();
+
+            Console.WriteLine("-- User defined ValueType <=> VARIANT...");
+            {
+                Assert.Throws<NotSupportedException>(() => miscTypeTesting.Marshal_Variant(new Struct()));
+            }
+        }
+    }
+}

--- a/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
+++ b/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.MiscTypesTesting)]
+public class MiscTypesTesting : Server.Contract.IMiscTypesTesting
+{
+    object Server.Contract.IMiscTypesTesting.Marshal_Variant(object obj)
+    {
+        if (obj is null)
+        {
+            return null;
+        }
+
+        if (obj is DBNull)
+        {
+            return DBNull.Value;
+        }
+
+        if (obj.GetType().IsValueType)
+        {
+            return CallMemberwiseClone(obj);
+        }
+
+        if (obj is string)
+        {
+            return obj;
+        }
+
+        Environment.FailFast($"Arguments must be ValueTypes or strings: {obj.GetType()}");
+        return null;
+
+        // object.MemberwiseClone() will bitwise copy for ValueTypes.
+        // This is sufficient for the VARIANT marshalling scenario being
+        // tested here.
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "MemberwiseClone")]
+        static extern object CallMemberwiseClone(object obj);
+    }
+
+    object Server.Contract.IMiscTypesTesting.Marshal_Instance_Variant(string init)
+    {
+        if (Guid.TryParse(init, out Guid result))
+        {
+            return result;
+        }
+
+        Environment.FailFast($"Unknown init value: {init}");
+        return null;
+    }
+}

--- a/src/tests/Interop/COM/NativeClients/MiscTypes.csproj
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <CMakeProjectReference Include="MiscTypes/CMakeLists.txt" />
+    <ProjectReference Include="../NETServer/NETServer.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/App.manifest
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/App.manifest
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="COMClientMiscTypes"
+    version="1.0.0.0"/>
+
+  <dependency>
+    <dependentAssembly>
+      <!-- RegFree COM - CoreCLR Shim -->
+      <assemblyIdentity
+        type="win32"
+        name="CoreShim.X"
+        version="1.0.0.0"/>
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/CMakeLists.txt
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/CMakeLists.txt
@@ -1,0 +1,22 @@
+project (COMClientMiscTypes)
+include_directories( ${INC_PLATFORM_DIR} )
+include_directories( "../../ServerContracts" )
+include_directories( "../../NativeServer" )
+include_directories("../")
+set(SOURCES
+    MiscTypes.cpp
+    App.manifest)
+
+# add the executable
+add_executable (COMClientMiscTypes ${SOURCES})
+target_link_libraries(COMClientMiscTypes PRIVATE ${LINK_LIBRARIES_ADDITIONAL})
+
+# Copy CoreShim manifest to project output
+file(GENERATE OUTPUT $<TARGET_FILE_DIR:${PROJECT_NAME}>/CoreShim.X.manifest INPUT ${CMAKE_CURRENT_SOURCE_DIR}/CoreShim.X.manifest)
+
+# add the install targets
+install (TARGETS COMClientMiscTypes DESTINATION bin)
+# If there's a dynamic ASAN runtime, then copy it to project output.
+if (NOT "${ASAN_RUNTIME}" STREQUAL "")
+    file(COPY "${ASAN_RUNTIME}" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
+endif()

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/CoreShim.X.manifest
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/CoreShim.X.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+
+<assemblyIdentity
+  type="win32"
+  name="CoreShim.X"
+  version="1.0.0.0" />
+
+<file name="CoreShim.dll">
+  <!-- MiscTypesTesting -->
+  <comClass
+    clsid="{CCFF894B-A27C-45E0-9B30-6C88D722E843}"
+    threadingModel="Both" />
+</file>
+
+</assembly>

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <xplatform.h>
+#include <cassert>
+#include <Server.Contracts.h>
+#include <windows_version_helpers.h>
+
+// COM headers
+#include <objbase.h>
+#include <combaseapi.h>
+
+#define COM_CLIENT
+#include <Servers.h>
+
+#define THROW_IF_FAILED(exp) { hr = exp; if (FAILED(hr)) { ::printf("FAILURE: 0x%08x = %s\n", hr, #exp); throw hr; } }
+#define THROW_FAIL_IF_FALSE(exp) { if (!(exp)) { ::printf("FALSE: %s\n", #exp); throw E_FAIL; } }
+
+template<COINIT TM>
+struct ComInit
+{
+    const HRESULT Result;
+
+    ComInit()
+        : Result{ ::CoInitializeEx(nullptr, TM) }
+    { }
+
+    ~ComInit()
+    {
+        if (SUCCEEDED(Result))
+            ::CoUninitialize();
+    }
+};
+
+using ComMTA = ComInit<COINIT_MULTITHREADED>;
+void ValidationTests();
+
+int __cdecl main()
+{
+    if (is_windows_nano() == S_OK)
+    {
+        ::puts("RegFree COM is not supported on Windows Nano. Auto-passing this test.\n");
+        return 100;
+    }
+    ComMTA init;
+    if (FAILED(init.Result))
+        return -1;
+
+    try
+    {
+        CoreShimComActivation csact{ W("NETServer"), W("MiscTypesTesting") };
+        ValidationTests();
+    }
+    catch (HRESULT hr)
+    {
+        ::printf("Test Failure: 0x%08x\n", hr);
+        return 101;
+    }
+
+    return 100;
+}
+
+struct VariantMarshalTest
+{
+    VARIANT Input;
+    VARIANT Result;
+    VariantMarshalTest()
+    {
+        ::VariantInit(&Input);
+        ::VariantInit(&Result);
+    }
+    ~VariantMarshalTest()
+    {
+        ::VariantClear(&Input);
+        ::VariantClear(&Result);
+    }
+};
+
+void ValidationTests()
+{
+    ::printf(__FUNCTION__ "() through CoCreateInstance...\n");
+
+    HRESULT hr;
+
+    IMiscTypesTesting *miscTypesTesting;
+    THROW_IF_FAILED(::CoCreateInstance(CLSID_MiscTypesTesting, nullptr, CLSCTX_INPROC, IID_IMiscTypesTesting, (void**)&miscTypesTesting));
+
+    ::printf("-- Primitives <=> VARIANT...\n");
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_EMPTY;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_VT(&args.Input) == V_VT(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_NULL;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_VT(&args.Input) == V_VT(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_I1;
+        V_I1(&args.Input) = 0x0f;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_I1(&args.Input) == V_I1(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_I2;
+        V_I2(&args.Input) = 0x07ff;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_I2(&args.Input) == V_I2(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_I4;
+        V_I4(&args.Input) = 0x07ffffff;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_I4(&args.Input) == V_I4(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_I8;
+        V_I8(&args.Input) = 0x07ffffffffffffff;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_I8(&args.Input) == V_I8(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_BOOL;
+        V_BOOL(&args.Input) = VARIANT_TRUE;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_BOOL(&args.Input) == V_BOOL(&args.Result));
+    }
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_BOOL;
+        V_BOOL(&args.Input) = VARIANT_FALSE;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_BOOL(&args.Input) == V_BOOL(&args.Result));
+    }
+
+    ::printf("-- BSTR <=> VARIANT...\n");
+    {
+        VariantMarshalTest args{};
+        V_VT(&args.Input) = VT_BSTR;
+        V_BSTR(&args.Input) = ::SysAllocString(W("The quick Fox jumped over the lazy Dog."));
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(CompareStringOrdinal(V_BSTR(&args.Input), -1, V_BSTR(&args.Result), -1, FALSE) == CSTR_EQUAL);
+    }
+
+    ::printf("-- System.Guid <=> VARIANT...\n");
+    {
+        /* 8EFAD956-B33D-46CB-90F4-45F55BA68A96 */
+        const GUID expected = { 0x8EFAD956, 0xB33D, 0x46CB, { 0x90, 0xF4, 0x45, 0xF5, 0x5B, 0xA6, 0x8A, 0x96} };
+
+        // Get a System.Guid into native
+        VariantMarshalTest guidVar;
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Instance_Variant(W("{8EFAD956-B33D-46CB-90F4-45F55BA68A96}"), &guidVar.Result));
+        THROW_FAIL_IF_FALSE(V_VT(&guidVar.Result) == VT_RECORD);
+        THROW_FAIL_IF_FALSE(memcmp(V_RECORD(&guidVar.Result), &expected, sizeof(expected)) == 0);
+
+        // Use the Guid as input.
+        VariantMarshalTest args{};
+        THROW_IF_FAILED(::VariantCopy(&args.Input, &guidVar.Result));
+        THROW_IF_FAILED(miscTypesTesting->Marshal_Variant(args.Input, &args.Result));
+        THROW_FAIL_IF_FALSE(V_VT(&args.Input) == V_VT(&args.Result));
+        THROW_FAIL_IF_FALSE(memcmp(V_RECORD(&args.Input), V_RECORD(&args.Result), sizeof(expected)) == 0);
+    }
+}

--- a/src/tests/Interop/COM/NativeClients/Primitives/CoreShim.X.manifest
+++ b/src/tests/Interop/COM/NativeClients/Primitives/CoreShim.X.manifest
@@ -19,6 +19,10 @@
   <comClass
     clsid="{C73C83E8-51A2-47F8-9B5C-4284458E47A6}"
     threadingModel="Both" />
+  <!-- MiscTypesTesting -->
+  <comClass
+    clsid="{CCFF894B-A27C-45E0-9B30-6C88D722E843}"
+    threadingModel="Both" />
   <!-- ErrorMarshalTesting -->
   <comClass
     clsid="{71CF5C45-106C-4B32-B418-43A463C6041F}"

--- a/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
+++ b/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
@@ -22,6 +22,11 @@
     clsid="{C73C83E8-51A2-47F8-9B5C-4284458E47A6}"
     threadingModel="Both" />
 
+  <!-- MiscTypesTesting -->
+  <comClass
+    clsid="{CCFF894B-A27C-45E0-9B30-6C88D722E843}"
+    threadingModel="Both" />
+
   <!-- ErrorMarshalTesting -->
   <comClass
     clsid="{71CF5C45-106C-4B32-B418-43A463C6041F}"

--- a/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
+++ b/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include <xplatform.h>
+#include "Servers.h"
+
+class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting
+{
+public: // IMiscTypesTesting
+    DEF_FUNC(Marshal_Variant)(_In_ VARIANT obj, _Out_ VARIANT* result)
+    {
+        return ::VariantCopy(result, &obj);
+    }
+
+    DEF_FUNC(Marshal_Instance_Variant)(_In_ LPCWSTR init, _Out_ VARIANT* result)
+    {
+        return E_NOTIMPL;
+    }
+
+public: // IUnknown
+    STDMETHOD(QueryInterface)(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+    {
+        return DoQueryInterface(riid, ppvObject, static_cast<IMiscTypesTesting *>(this));
+    }
+
+    DEFINE_REF_COUNTING();
+};

--- a/src/tests/Interop/COM/NativeServer/Servers.cpp
+++ b/src/tests/Interop/COM/NativeServer/Servers.cpp
@@ -162,6 +162,7 @@ STDAPI DllRegisterServer(void)
     RETURN_IF_FAILED(RegisterClsid(__uuidof(NumericTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ArrayTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(StringTesting), L"Both"));
+    RETURN_IF_FAILED(RegisterClsid(__uuidof(MiscTypesTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ErrorMarshalTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(DispatchTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(EventTesting), L"Both"));
@@ -180,6 +181,7 @@ STDAPI DllUnregisterServer(void)
     RETURN_IF_FAILED(RemoveClsid(__uuidof(NumericTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ArrayTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(StringTesting)));
+    RETURN_IF_FAILED(RemoveClsid(__uuidof(MiscTypesTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ErrorMarshalTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(DispatchTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(EventTesting)));
@@ -201,6 +203,9 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Out_ LPVOID FA
 
     if (rclsid == __uuidof(StringTesting))
         return ClassFactoryBasic<StringTesting>::Create(riid, ppv);
+
+    if (rclsid == __uuidof(MiscTypesTesting))
+        return ClassFactoryBasic<MiscTypesTesting>::Create(riid, ppv);
 
     if (rclsid == __uuidof(ErrorMarshalTesting))
         return ClassFactoryBasic<ErrorMarshalTesting>::Create(riid, ppv);

--- a/src/tests/Interop/COM/NativeServer/Servers.h
+++ b/src/tests/Interop/COM/NativeServer/Servers.h
@@ -12,6 +12,7 @@
 class DECLSPEC_UUID("53169A33-E85D-4E3C-B668-24E438D0929B") NumericTesting;
 class DECLSPEC_UUID("B99ABE6A-DFF6-440F-BFB6-55179B8FE18E") ArrayTesting;
 class DECLSPEC_UUID("C73C83E8-51A2-47F8-9B5C-4284458E47A6") StringTesting;
+class DECLSPEC_UUID("CCFF894B-A27C-45E0-9B30-6C88D722E843") MiscTypesTesting;
 class DECLSPEC_UUID("71CF5C45-106C-4B32-B418-43A463C6041F") ErrorMarshalTesting;
 class DECLSPEC_UUID("0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726") DispatchTesting;
 class DECLSPEC_UUID("4DBD9B61-E372-499F-84DE-EFC70AA8A009") EventTesting;
@@ -25,6 +26,7 @@ class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesti
 #define CLSID_NumericTesting __uuidof(NumericTesting)
 #define CLSID_ArrayTesting __uuidof(ArrayTesting)
 #define CLSID_StringTesting __uuidof(StringTesting)
+#define CLSID_MiscTypesTesting __uuidof(MiscTypesTesting)
 #define CLSID_ErrorMarshalTesting __uuidof(ErrorMarshalTesting)
 #define CLSID_DispatchTesting __uuidof(DispatchTesting)
 #define CLSID_EventTesting __uuidof(EventTesting)
@@ -38,6 +40,7 @@ class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesti
 #define IID_INumericTesting __uuidof(INumericTesting)
 #define IID_IArrayTesting __uuidof(IArrayTesting)
 #define IID_IStringTesting __uuidof(IStringTesting)
+#define IID_IMiscTypesTesting __uuidof(IMiscTypesTesting)
 #define IID_IErrorMarshalTesting __uuidof(IErrorMarshalTesting)
 #define IID_IDispatchTesting __uuidof(IDispatchTesting)
 #define IID_TestingEvents __uuidof(TestingEvents)
@@ -82,6 +85,7 @@ private:
     #include "NumericTesting.h"
     #include "ArrayTesting.h"
     #include "StringTesting.h"
+    #include "MiscTypesTesting.h"
     #include "ErrorMarshalTesting.h"
     #include "DispatchTesting.h"
     #include "EventTesting.h"

--- a/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
@@ -10,7 +10,7 @@ namespace Server.Contract.Servers
     using System.Runtime.InteropServices;
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(NumericTestingClass))]
@@ -29,7 +29,7 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(ArrayTestingClass))]
@@ -48,7 +48,7 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(StringTestingClass))]
@@ -67,7 +67,26 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
+    /// </summary>
+    [ComImport]
+    [CoClass(typeof(MiscTypesTestingClass))]
+    [Guid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466")]
+    internal interface MiscTypesTesting : Server.Contract.IMiscTypesTesting
+    {
+    }
+
+    /// <summary>
+    /// Managed activation for CoClass
+    /// </summary>
+    [ComImport]
+    [Guid(Server.Contract.Guids.MiscTypesTesting)]
+    internal class MiscTypesTestingClass
+    {
+    }
+
+    /// <summary>
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(ErrorMarshalTestingClass))]
@@ -86,7 +105,7 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(DispatchTestingClass))]
@@ -105,7 +124,7 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(AggregationTestingClass))]
@@ -124,7 +143,7 @@ namespace Server.Contract.Servers
     }
 
     /// <summary>
-    /// Managed definition of CoClass 
+    /// Managed definition of CoClass
     /// </summary>
     [ComImport]
     [CoClass(typeof(ColorTestingClass))]

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -184,6 +184,17 @@ namespace Server.Contract
         void Pass_Through_LCID(out int lcid);
     }
 
+    [ComVisible(true)]
+    [Guid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IMiscTypesTesting
+    {
+        object Marshal_Variant(object obj);
+
+        // Test API for marshalling an arbitrary type via VARIANT
+        object Marshal_Instance_Variant([MarshalAs(UnmanagedType.LPWStr)] string init);
+    }
+
     public struct HResult
     {
         public int hr;

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -366,6 +366,18 @@ IStringTesting : IUnknown
         /*[out]*/ LCID* outLcid) = 0;
 };
 
+struct __declspec(uuid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466"))
+IMiscTypesTesting : IUnknown
+{
+      virtual HRESULT STDMETHODCALLTYPE Marshal_Variant (
+        /*[in]*/ VARIANT obj,
+        /*[out,retval]*/ VARIANT* result) = 0;
+
+      virtual HRESULT STDMETHODCALLTYPE Marshal_Instance_Variant (
+        /*[in]*/ LPCWSTR init,
+        /*[out,retval]*/ VARIANT* result) = 0;
+};
+
 struct __declspec(uuid("592386a5-6837-444d-9de3-250815d18556"))
 IErrorMarshalTesting : IUnknown
 {

--- a/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
+++ b/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
@@ -11,6 +11,7 @@ namespace Server.Contract
         public const string NumericTesting = "53169A33-E85D-4E3C-B668-24E438D0929B";
         public const string ArrayTesting = "B99ABE6A-DFF6-440F-BFB6-55179B8FE18E";
         public const string StringTesting = "C73C83E8-51A2-47F8-9B5C-4284458E47A6";
+        public const string MiscTypesTesting = "CCFF894B-A27C-45E0-9B30-6C88D722E843";
         public const string ErrorMarshalTesting = "71CF5C45-106C-4B32-B418-43A463C6041F";
         public const string DispatchTesting = "0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726";
         public const string EventTesting = "4DBD9B61-E372-499F-84DE-EFC70AA8A009";


### PR DESCRIPTION
Backport of #100377 to release/8.0-staging

## Customer Impact

- [x] Customer reported
- [ ] Found internally

* Support System.Guid marshalling via VARIANT

VARIANT marshalling in .NET 5+ requires a TLB
for COM records (i.e., ValueType instances). This
means that without a runtime provided TLB, users
must define their own TLB for runtime types or
define their own transfer types.

We address this here by deferring to the NetFX
mscorlib's TLB.

## Regression

- [ ] Yes
- [x] No

This support has never been in .NET Core 3.1/.NET 5+. This is helping porting efforts from .NET Framework to .NET 5+.

## Risk

Low, this is enabling a narrow feature that was present in .NET Framework.

