### PR TITLE
Avoid possible null pointer exception when starting BackgroundService

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -174,12 +174,12 @@ namespace Microsoft.Extensions.Hosting.Internal
 
         private async Task TryExecuteBackgroundServiceAsync(BackgroundService backgroundService)
         {
-            // backgroundService.ExecuteTask may not be set (e.g. if the derived class doesn't call base.StartAsync)
-            Task? backgroundTask = backgroundService.ExecuteTask;
             if (backgroundTask is null)
             {
                 return;
             }
+            // backgroundService.ExecuteTask may not be set (e.g. if the derived class doesn't call base.StartAsync)
+            Task? backgroundTask = backgroundService.ExecuteTask;
 
             try
             {


### PR DESCRIPTION
Fixes: #100740 

When starting `IHostedServices` that are derivatives of `BackgroudService` the host should first check the nullability of the argument and then the nullability of the argument's property.