### PR TITLE
fix building error for `error: fallthrough annotation in unreachable code`

### DIFF
--- a/src/coreclr/interop/comwrappers.cpp
+++ b/src/coreclr/interop/comwrappers.cpp
@@ -736,7 +736,9 @@ HRESULT ManagedObjectWrapper::QueryInterface(
                     return E_NOINTERFACE;
 
                 default:
+#if !defined(__clang__) || (__clang_major__ > 13) // Workaround bug in old clang
                     _ASSERTE(false && "Unknown result value");
+#endif
                     FALLTHROUGH;
                 case TryInvokeICustomQueryInterfaceResult::FailedToInvoke:
                     // Set the 'lacks' flag since our attempt to use ICustomQueryInterface

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -184,14 +184,6 @@ extern bool g_arm64_atomics_present;
 #define __has_cpp_attribute(x) (0)
 #endif
 
-#ifndef FALLTHROUGH
-#if __has_cpp_attribute(fallthrough)
-#define FALLTHROUGH [[fallthrough]]
-#else // __has_cpp_attribute(fallthrough)
-#define FALLTHROUGH
-#endif // __has_cpp_attribute(fallthrough)
-#endif // FALLTHROUGH
-
 /******************* PAL-Specific Entrypoints *****************************/
 
 #define IsDebuggerPresent PAL_IsDebuggerPresent


### PR DESCRIPTION
```
/home/qiao/work_qiao/runtime/src/coreclr/interop/comwrappers.cpp:740:21: error: fallthrough annotation in unreachable code [-Werror,-Wimplicit-fallthrough]
                    FALLTHROUGH;
                    ^
/home/qiao/work_qiao/runtime/src/native/minipal/utils.h:25:25: note: expanded from macro 'FALLTHROUGH'
#    define FALLTHROUGH [[fallthrough]]
```