### PR TITLE
JIT: Use new ABI representation for x86 varargs handling

### DIFF
--- a/src/coreclr/jit/abi.cpp
+++ b/src/coreclr/jit/abi.cpp
@@ -70,6 +70,16 @@ regMaskTP ABIPassingSegment::GetRegisterMask() const
 // Return Value:
 //   Offset relative to the first stack argument.
 //
+// Remarks:
+//   On x86, where arguments are pushed in order and thus come in reverse order
+//   in the callee, this is the offset to subtract from the top of the stack to
+//   get the argument's address. By top of the stack is meant esp on entry + 4
+//   for the return address + total size of stack arguments. In varargs methods
+//   the varargs cookie contains the information required to allow the
+//   computation of the total size of stack arguments.
+//
+//   Outside x86 this is the offset to add to the first argument's address.
+//
 unsigned ABIPassingSegment::GetStackOffset() const
 {
     assert(IsPassedOnStack());
@@ -206,6 +216,18 @@ bool ABIPassingInformation::HasAnyStackSegment() const
         }
     }
     return false;
+}
+
+//-----------------------------------------------------------------------------
+// HasExactlyOneRegisterSegment:
+//   Check if this value is passed as a single register segment.
+//
+// Return Value:
+//   True if so.
+//
+bool ABIPassingInformation::HasExactlyOneRegisterSegment() const
+{
+    return (NumSegments == 1) && Segments[0].IsPassedInRegister();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/abi.h
+++ b/src/coreclr/jit/abi.h
@@ -28,7 +28,7 @@ public:
     regMaskTP GetRegisterMask() const;
 
     // If this segment is passed on the stack then return the particular stack
-    // offset, relative to the first stack argument's offset.
+    // offset, relative to the base of stack arguments.
     unsigned GetStackOffset() const;
 
     var_types GetRegisterStoreType() const;
@@ -53,6 +53,7 @@ struct ABIPassingInformation
 
     bool HasAnyRegisterSegment() const;
     bool HasAnyStackSegment() const;
+    bool HasExactlyOneRegisterSegment() const;
     bool HasExactlyOneStackSegment() const;
     bool IsSplitAcrossRegistersAndStack() const;
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4988,7 +4988,7 @@ void CodeGen::genHomeSwiftStructParameters(bool handleStack)
         }
 
         JITDUMP("Homing Swift parameter V%02u: ", lclNum);
-        const ABIPassingInformation& abiInfo = compiler->lvaParameterPassingInfo[lclNum];
+        const ABIPassingInformation& abiInfo = compiler->lvaGetParameterABIInfo(lclNum);
         DBEXEC(VERBOSE, abiInfo.Dump());
 
         for (unsigned i = 0; i < abiInfo.NumSegments; i++)
@@ -6520,7 +6520,8 @@ void CodeGen::genFnProlog()
         noway_assert(compiler->info.compArgsCount > 0);
 
         // MOV EAX, <VARARGS HANDLE>
-        GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_EAX, compiler->info.compArgsCount - 1, 0);
+        assert(compiler->lvaVarargsHandleArg == compiler->info.compArgsCount - 1);
+        GetEmitter()->emitIns_R_S(ins_Load(TYP_I_IMPL), EA_PTRSIZE, REG_EAX, compiler->lvaVarargsHandleArg, 0);
         regSet.verifyRegUsed(REG_EAX);
 
         // MOV EAX, [EAX]
@@ -6529,7 +6530,7 @@ void CodeGen::genFnProlog()
         // EDX might actually be holding something here.  So make sure to only use EAX for this code
         // sequence.
 
-        const LclVarDsc* lastArg = compiler->lvaGetDesc(compiler->info.compArgsCount - 1);
+        const LclVarDsc* lastArg = compiler->lvaGetDesc(compiler->lvaVarargsHandleArg);
         noway_assert(!lastArg->lvRegister);
         signed offset = lastArg->GetStackOffset();
         assert(offset != BAD_STK_OFFS);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4023,6 +4023,12 @@ public:
         return lvaGetDesc(lclVar->GetLclNum());
     }
 
+    const ABIPassingInformation& lvaGetParameterABIInfo(unsigned lclNum)
+    {
+        assert(lclNum < info.compArgsCount);
+        return lvaParameterPassingInfo[lclNum];
+    }
+
     unsigned lvaTrackedIndexToLclNum(unsigned trackedIndex)
     {
         assert(trackedIndex < lvaTrackedCount);
@@ -4092,16 +4098,7 @@ public:
                                                 // that writes to arg0
 
 #ifdef TARGET_X86
-    bool lvaIsArgAccessedViaVarArgsCookie(unsigned lclNum)
-    {
-        if (!info.compIsVarArgs)
-        {
-            return false;
-        }
-
-        LclVarDsc* varDsc = lvaGetDesc(lclNum);
-        return varDsc->lvIsParam && !varDsc->lvIsRegArg && (lclNum != lvaVarargsHandleArg);
-    }
+    bool lvaIsArgAccessedViaVarArgsCookie(unsigned lclNum);
 #endif // TARGET_X86
 
     bool lvaIsImplicitByRefLocal(unsigned lclNum) const;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4097,9 +4097,7 @@ public:
     bool lvaIsOriginalThisReadOnly();           // return true if there is no place in the code
                                                 // that writes to arg0
 
-#ifdef TARGET_X86
     bool lvaIsArgAccessedViaVarArgsCookie(unsigned lclNum);
-#endif // TARGET_X86
 
     bool lvaIsImplicitByRefLocal(unsigned lclNum) const;
     bool lvaIsLocalImplicitlyAccessedByRef(unsigned lclNum) const;
@@ -8018,32 +8016,6 @@ protected:
 private:
     Lowering*            m_pLowering;   // Lowering; needed to Lower IR that's added or modified after Lowering.
     LinearScanInterface* m_pLinearScan; // Linear Scan allocator
-
-    /* raIsVarargsStackArg is called by raMaskStkVars and by
-       lvaComputeRefCounts.  It identifies the special case
-       where a varargs function has a parameter passed on the
-       stack, other than the special varargs handle.  Such parameters
-       require special treatment, because they cannot be tracked
-       by the GC (their offsets in the stack are not known
-       at compile time).
-    */
-
-    bool raIsVarargsStackArg(unsigned lclNum)
-    {
-#ifdef TARGET_X86
-
-        LclVarDsc* varDsc = lvaGetDesc(lclNum);
-
-        assert(varDsc->lvIsParam);
-
-        return (info.compIsVarArgs && !varDsc->lvIsRegArg && (lclNum != lvaVarargsHandleArg));
-
-#else // TARGET_X86
-
-        return false;
-
-#endif // TARGET_X86
-    }
 
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2303,7 +2303,7 @@ void LinearScan::buildIntervals()
                 continue;
             }
 
-            const ABIPassingInformation& abiInfo = compiler->lvaParameterPassingInfo[lclNum];
+            const ABIPassingInformation& abiInfo = compiler->lvaGetParameterABIInfo(lclNum);
             for (unsigned i = 0; i < abiInfo.NumSegments; i++)
             {
                 const ABIPassingSegment& seg = abiInfo.Segments[i];

--- a/src/coreclr/jit/regalloc.cpp
+++ b/src/coreclr/jit/regalloc.cpp
@@ -377,7 +377,7 @@ void Compiler::raMarkStkVars()
         // to the GC, as the frame offsets in these local variables would
         // not be correct.
 
-        if (varDsc->lvIsParam && raIsVarargsStackArg(lclNum))
+        if (varDsc->lvIsParam && lvaIsArgAccessedViaVarArgsCookie(lclNum))
         {
             if (!varDsc->lvPromoted && !varDsc->lvIsStructField)
             {

--- a/src/coreclr/jit/targetx86.cpp
+++ b/src/coreclr/jit/targetx86.cpp
@@ -113,8 +113,8 @@ ABIPassingInformation X86Classifier::Classify(Compiler*    comp,
     else
     {
         assert((m_stackArgSize % TARGET_POINTER_SIZE) == 0);
-        segment = ABIPassingSegment::OnStack(m_stackArgSize, 0, size);
         m_stackArgSize += roundUp(size, TARGET_POINTER_SIZE);
+        segment = ABIPassingSegment::OnStack(m_stackArgSize, 0, size);
     }
 
     return ABIPassingInformation::FromSegment(comp, segment);


### PR DESCRIPTION
One difference is that the old representation counts register arguments when assigning stack offsets, so it has to subtract that amount off. The new representation does not need to do this as stack offsets only account for stack arguments.

x86 is also different in that the managed calling convention pushes arguments in order and thus the parameters come in reverse order in the callee. That is, the first parameter is at the top of the stack arguments. The ABI representation therefore represents the stack offsets relative to the top of stack arguments instead of from the bottom on x86.

Also introduce `Compiler::lvaGetParameterABIInfo` and switch all uses to use it instead of directly accessing the array.