### PR TITLE
Optimize `MemoryMarshal.Cast` for same type

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -113,7 +113,7 @@ namespace System.Runtime.InteropServices
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<TTo> Cast<TFrom, TTo>(Span<TFrom> span)
+        public static unsafe Span<TTo> Cast<TFrom, TTo>(Span<TFrom> span)
             where TFrom : struct
             where TTo : struct
         {
@@ -121,6 +121,9 @@ namespace System.Runtime.InteropServices
                 ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            if (typeof(TFrom) == typeof(TTo))
+                return *(Span<TTo>*)&span;
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.
@@ -168,7 +171,7 @@ namespace System.Runtime.InteropServices
         /// Thrown when <typeparamref name="TFrom"/> or <typeparamref name="TTo"/> contains pointers.
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> span)
+        public static unsafe ReadOnlySpan<TTo> Cast<TFrom, TTo>(ReadOnlySpan<TFrom> span)
             where TFrom : struct
             where TTo : struct
         {
@@ -176,6 +179,9 @@ namespace System.Runtime.InteropServices
                 ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TFrom));
             if (RuntimeHelpers.IsReferenceOrContainsReferences<TTo>())
                 ThrowHelper.ThrowInvalidTypeWithPointersNotSupported(typeof(TTo));
+
+            if (typeof(TFrom) == typeof(TTo))
+                return *(ReadOnlySpan<TTo>*)&span;
 
             // Use unsigned integers - unsigned division by constant (especially by power of 2)
             // and checked casts are faster and smaller.


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/99835.

### Diffs

- https://github.com/MihuBot/runtime-utils/issues/348
- https://github.com/MihuBot/runtime-utils/issues/349

Diffs looks mostly positive although there are some large code size regressions due to enablement of more inlining.

cc: @stephentoub