### PR TITLE
Fix NullReferenceException in FileSystemWatcher on Windows during dispose

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Win32.cs
@@ -105,8 +105,12 @@ namespace System.IO
             // increased, such that the disposal operation won't take effect and close the handle
             // until that P/Invoke returns; if during that time the FSW is restarted, the IsHandleInvalid
             // check will see a valid handle, unless we also null it out.
-            _directoryHandle.Dispose();
-            _directoryHandle = null;
+            SafeFileHandle? handle = _directoryHandle;
+            if (handle is not null)
+            {
+                _directoryHandle = null;
+                handle.Dispose();
+            }
         }
 
         private void FinalizeDispose()


### PR DESCRIPTION
Fix NullReferenceException in FileSystemWatcher on Windows if two threads try and dispose the instance at the same time.

Found in a failing test while running the CI in a PR against the OpenTelemetry libraries for net8.0 on Windows: [workflow logs](https://github.com/open-telemetry/opentelemetry-dotnet/actions/runs/8600318104/job/23565066419?pr=5520#step:6:3896)

```console
Failed OpenTelemetry.Instrumentation.AspNetCore.Tests.BasicTests.AddAspNetCoreInstrumentation_BadArgs [1 ms]
  Error Message:
   [Test Class Cleanup Failure (OpenTelemetry.Instrumentation.AspNetCore.Tests.BasicTests)]: System.NullReferenceException : Object reference not set to an instance of an object.
  Stack Trace:
     at System.IO.FileSystemWatcher.StopRaisingEvents()
   at System.IO.FileSystemWatcher.Dispose(Boolean disposing)
   at System.ComponentModel.Component.Dispose()
   at Microsoft.Extensions.FileProviders.Physical.PhysicalFilesWatcher.Dispose(Boolean disposing)
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider.Dispose(Boolean disposing)
   at Microsoft.Extensions.FileProviders.PhysicalFileProvider.Dispose()
   at Microsoft.Extensions.Hosting.Internal.Host.<DisposeAsync>g__DisposeAsync|21_0(Object o)
   at Microsoft.Extensions.Hosting.Internal.Host.DisposeAsync()
   at Microsoft.Extensions.Hosting.Internal.Host.Dispose()
   at Microsoft.AspNetCore.Mvc.Testing.DeferredHostBuilder.DeferredHost.Dispose()
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.Dispose(Boolean disposing)
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.Dispose()
```