### PR TITLE
[mono][interp] Add missing GC wbarriers for static field stores with hotreload enabled

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4644,6 +4644,13 @@ interp_emit_sfld_access (TransformData *td, MonoClassField *field, MonoClass *fi
 			}
 			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
 		} else {
+			if (G_UNLIKELY (m_field_is_from_update (field)) && (mt == MINT_TYPE_VT || mt == MINT_TYPE_O)) {
+				interp_emit_ldsflda (td, field, error);
+				return_if_nok (error);
+				interp_emit_stobj (td, field_class, TRUE);
+				return;
+			}
+
 			if (G_LIKELY (!wide_data))
 				interp_add_ins (td, (mt == MINT_TYPE_VT) ? MINT_STSFLD_VT : (MINT_STSFLD_I1 + mt - MINT_TYPE_I1));
 			else

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4644,7 +4644,12 @@ interp_emit_sfld_access (TransformData *td, MonoClassField *field, MonoClass *fi
 			}
 			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
 		} else {
-			if (G_UNLIKELY (m_field_is_from_update (field)) && (mt == MINT_TYPE_VT || mt == MINT_TYPE_O)) {
+			// Fields from hotreload update and fields from collectible assemblies are not
+			// stored inside fixed gc roots but rather in other objects. This means that
+			// storing into these fields requires write barriers.
+			if ((mt == MINT_TYPE_VT || mt == MINT_TYPE_O) &&
+					(m_field_is_from_update (field) ||
+					mono_image_get_alc (m_class_get_image (m_field_get_parent (field)))->collectible)) {
 				interp_emit_ldsflda (td, field, error);
 				return_if_nok (error);
 				interp_emit_stobj (td, field_class, TRUE);


### PR DESCRIPTION
By default, static fields are stored in malloced memory that is registered and always scanned as roots. With hotreload, new static data is allocated inside newly created objects, so storing into it will require write barriers. In order to avoid slowing the normal execution, for fields from metadata updates, we will store into them via ldflda + stobj instead.

Fixes https://github.com/dotnet/runtime/issues/100065