### PR TITLE
Don't try building Mono in default subsets on known-broken config

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -41,6 +41,8 @@
     <DefaultSubsets Condition="'$(TargetsLinuxBionic)' == 'true'">mono+libs+host+packs</DefaultSubsets>
     <!-- In source build, mono is only supported as primary runtime flavor. On Windows mono is supported for x86/x64 only. -->
     <DefaultSubsets Condition="('$(DotNetBuildSourceOnly)' == 'true' and '$(PrimaryRuntimeFlavor)' != 'Mono') or ('$(TargetOS)' == 'windows' and '$(TargetArchitecture)' != 'x86' and '$(TargetArchitecture)' != 'x64')">clr+libs+tools+host+packs</DefaultSubsets>
+    <!-- Mono Musl ARM32 build fails, see https://github.com/dotnet/runtime/issues/100772 -->
+    <DefaultSubsets Condition="'$(TargetsLinuxMusl)' == 'true' and '$(TargetArchitecture)' == 'arm'">clr+libs+tools+host+packs</DefaultSubsets>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is a prerequisite for https://github.com/dotnet/source-build/issues/3843 