### PR TITLE
JIT: Add support for bounds check no throw assertions in range check and make overflow check more precise

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -769,9 +769,9 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
     }
     else if (curAssertion->op1.kind == O1K_ARR_BND)
     {
-        printf("[idx:");
+        printf("[idx: " FMT_VN, curAssertion->op1.bnd.vnIdx);
         vnStore->vnDump(this, curAssertion->op1.bnd.vnIdx);
-        printf(";len:");
+        printf("; len: " FMT_VN, curAssertion->op1.bnd.vnLen);
         vnStore->vnDump(this, curAssertion->op1.bnd.vnLen);
         printf("]");
     }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1312,7 +1312,7 @@ bool RangeCheck::DoesVarDefOverflow(BasicBlock* block, GenTreeLclVarCommon* lcl,
     // We can use intermediate assertions about the local to prove that any
     // overflow on this path does not matter for the range computed.
     Range assertionRange = Range(Limit(Limit::keUnknown));
-    MergeAssertion(block, lcl, &assertionRange, 0);
+    MergeAssertion(block, lcl, &assertionRange DEBUGARG(0));
 
     // But only if the range from the assertion is more strict than the global
     // range computed; otherwise we might still have used the def's value to

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -199,7 +199,7 @@ struct Limit
         return false;
     }
 
-    bool Equals(Limit& l)
+    bool Equals(const Limit& l) const
     {
         switch (type)
         {
@@ -262,9 +262,19 @@ struct Range
     {
     }
 
+    const Limit& UpperLimit() const
+    {
+        return uLimit;
+    }
+
     Limit& UpperLimit()
     {
         return uLimit;
+    }
+
+    const Limit& LowerLimit() const
+    {
+        return lLimit;
     }
 
     Limit& LowerLimit()
@@ -440,12 +450,12 @@ struct RangeOps
 
     // Given two ranges "r1" and "r2", do a Phi merge. If "monIncreasing" is true,
     // then ignore the dependent variables for the lower bound but not for the upper bound.
-    static Range Merge(Range& r1, Range& r2, bool monIncreasing)
+    static Range Merge(const Range& r1, const Range& r2, bool monIncreasing)
     {
-        Limit& r1lo = r1.LowerLimit();
-        Limit& r1hi = r1.UpperLimit();
-        Limit& r2lo = r2.LowerLimit();
-        Limit& r2hi = r2.UpperLimit();
+        const Limit& r1lo = r1.LowerLimit();
+        const Limit& r1hi = r1.UpperLimit();
+        const Limit& r2lo = r2.LowerLimit();
+        const Limit& r2hi = r2.UpperLimit();
 
         // Take care of lo part.
         Range result = Limit(Limit::keUnknown);
@@ -689,19 +699,19 @@ public:
     bool MultiplyOverflows(Limit& limit1, Limit& limit2);
 
     // Does the binary operation between the operands overflow? Check recursively.
-    bool DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop);
+    bool DoesBinOpOverflow(BasicBlock* block, GenTreeOp* binop, const Range& range);
 
     // Do the phi operands involve a definition that could overflow?
-    bool DoesPhiOverflow(BasicBlock* block, GenTree* expr);
+    bool DoesPhiOverflow(BasicBlock* block, GenTree* expr, const Range& range);
 
     // Find the def of the "expr" local and recurse on the arguments if any of them involve a
     // calculation that overflows.
-    bool DoesVarDefOverflow(GenTreeLclVarCommon* lcl);
+    bool DoesVarDefOverflow(BasicBlock* block, GenTreeLclVarCommon* lcl, const Range& range);
 
-    bool ComputeDoesOverflow(BasicBlock* block, GenTree* expr);
+    bool ComputeDoesOverflow(BasicBlock* block, GenTree* expr, const Range& range);
 
-    // Does the current "expr" which is a use involve a definition, that overflows.
-    bool DoesOverflow(BasicBlock* block, GenTree* tree);
+    // Does the current "expr", which is a use, involve a definition that overflows.
+    bool DoesOverflow(BasicBlock* block, GenTree* tree, const Range& range);
 
     // Widen the range by first checking if the induction variable is monotonically increasing.
     // Requires "pRange" to be partially computed.

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -418,7 +418,6 @@ namespace System.Collections.Generic
                     i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                     do
                     {
-                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
                         // Test in if to drop range check for following array access
                         if ((uint)i >= (uint)entries.Length)
                         {
@@ -450,7 +449,6 @@ namespace System.Collections.Generic
                     i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
                     do
                     {
-                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
                         // Test in if to drop range check for following array access
                         if ((uint)i >= (uint)entries.Length)
                         {
@@ -535,15 +533,8 @@ namespace System.Collections.Generic
                 comparer == null)
             {
                 // ValueType: Devirtualize with EqualityComparer<TKey>.Default intrinsic
-                while (true)
+                while ((uint)i < (uint)entries.Length)
                 {
-                    // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                    // Test uint in if rather than loop condition to drop range check for following array access
-                    if ((uint)i >= (uint)entries.Length)
-                    {
-                        break;
-                    }
-
                     if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
                     {
                         if (behavior == InsertionBehavior.OverwriteExisting)
@@ -574,15 +565,8 @@ namespace System.Collections.Generic
             else
             {
                 Debug.Assert(comparer is not null);
-                while (true)
+                while ((uint)i < (uint)entries.Length)
                 {
-                    // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                    // Test uint in if rather than loop condition to drop range check for following array access
-                    if ((uint)i >= (uint)entries.Length)
-                    {
-                        break;
-                    }
-
                     if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
                     {
                         if (behavior == InsertionBehavior.OverwriteExisting)
@@ -690,15 +674,8 @@ namespace System.Collections.Generic
                     comparer == null)
                 {
                     // ValueType: Devirtualize with EqualityComparer<TKey>.Default intrinsic
-                    while (true)
+                    while ((uint)i < (uint)entries.Length)
                     {
-                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                        // Test uint in if rather than loop condition to drop range check for following array access
-                        if ((uint)i >= (uint)entries.Length)
-                        {
-                            break;
-                        }
-
                         if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key, key))
                         {
                             exists = true;
@@ -720,15 +697,8 @@ namespace System.Collections.Generic
                 else
                 {
                     Debug.Assert(comparer is not null);
-                    while (true)
+                    while ((uint)i < (uint)entries.Length)
                     {
-                        // Should be a while loop https://github.com/dotnet/runtime/issues/9422
-                        // Test uint in if rather than loop condition to drop range check for following array access
-                        if ((uint)i >= (uint)entries.Length)
-                        {
-                            break;
-                        }
-
                         if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
                         {
                             exists = true;


### PR DESCRIPTION
Fix #9422
Fix #83349

Example:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
public static int Foo(int i, int[] indices)
{
    while ((uint)i < (uint)indices.Length)
    {
        i = indices[i];
    }

    return i;
}
```
Before:
```asm
G_M9328_IG02:  ;; offset=0x0004
       mov      eax, dword ptr [rdx+0x08]
       cmp      eax, ecx
       jbe      SHORT G_M9328_IG04
       align    [0 bytes for IG03]
						;; size=7 bbWeight=1 PerfScore 3.25

G_M9328_IG03:  ;; offset=0x000B
       cmp      ecx, eax
       jae      SHORT G_M9328_IG06
       mov      ecx, ecx
       mov      ecx, dword ptr [rdx+4*rcx+0x10]
       cmp      eax, ecx
       ja       SHORT G_M9328_IG03
						;; size=14 bbWeight=4 PerfScore 19.00

G_M9328_IG04:  ;; offset=0x0019
       mov      eax, ecx
						;; size=2 bbWeight=1 PerfScore 0.25

G_M9328_IG05:  ;; offset=0x001B
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25

G_M9328_IG06:  ;; offset=0x0020
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
						;; size=6 bbWeight=0 PerfScore 0.00
; Total bytes of code: 38
```
After:
```asm
G_M9328_IG02:  ;; offset=0x0004
       mov      eax, dword ptr [rdx+0x08]
       cmp      eax, ecx
       jbe      SHORT G_M9328_IG04
       align    [0 bytes for IG03]
						;; size=7 bbWeight=1 PerfScore 3.25
G_M9328_IG03:  ;; offset=0x000B
       mov      ecx, ecx
       mov      ecx, dword ptr [rdx+4*rcx+0x10]
       cmp      eax, ecx
       ja       SHORT G_M9328_IG03
						;; size=10 bbWeight=4 PerfScore 14.00
G_M9328_IG04:  ;; offset=0x0015
       mov      eax, ecx
						;; size=2 bbWeight=1 PerfScore 0.25
G_M9328_IG05:  ;; offset=0x0017
       add      rsp, 40
       ret      
						;; size=5 bbWeight=1 PerfScore 1.25

; Total bytes of code 28, prolog size 4, PerfScore 19.00, instruction count 12, allocated bytes for code 28 (MethodHash=e6badb8f) for method Program:Foo(int,int[]):int (FullOpts)
; ============================================================
```