### PR TITLE
Make InstallRuntimeComponentToFinalDestination use NativeOutputPath for copying to runtime output

### DIFF
--- a/src/native/managed/native-library.targets
+++ b/src/native/managed/native-library.targets
@@ -69,7 +69,7 @@
 
     <Target Name="InstallRuntimeComponentToFinalDestination"
             AfterTargets="CopyNativeBinary"
-            DependsOnTargets="CopyNativeBinary;StripLibraryLikeCoreCLRBuild" Condition="'$(IsRuntimeComponent)' == 'true'">
+            DependsOnTargets="CopyNativeBinary;_CopyAotSymbols;StripLibraryLikeCoreCLRBuild" Condition="'$(IsRuntimeComponent)' == 'true'">
         <Error Text="Set at least one @InstallRuntimeComponentDestination item" Condition="@(InstallRuntimeComponentDestination->Count()) == 0" />
 
         <PropertyGroup>
@@ -88,7 +88,7 @@
 
         <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
             <CopyFinalFiles Include="$(PublishDir)$(TargetName)$(NativeBinaryExt)" />
-            <CopyFinalFilesPDB Include="$(PublishDir)$(TargetName).pdb" />
+            <CopyFinalFilesPDB Include="$(PublishDir)$(TargetName).pdb" Condition="Exists('$(PublishDir)$(TargetName).pdb')" />
         </ItemGroup>
 
         <Message Importance="Normal" Text="Installing @(CopyFinalFiles) into %(_NormalizedInstallRuntimeComponentDest.Identity)"/>

--- a/src/native/managed/native-library.targets
+++ b/src/native/managed/native-library.targets
@@ -39,16 +39,16 @@
     </Target>
 
     <Target Name="StripLibraryLikeCoreCLRBuild"
-            DependsOnTargets="SetupOSSpecificProps;CopyNativeBinary;StripLibraryLikeCoreCLRSetupPaths"
+            DependsOnTargets="SetupOSSpecificProps;LinkNative;StripLibraryLikeCoreCLRSetupPaths"
             Condition="'$(IsRuntimeComponent)' == 'true' and '$(TargetsWindows)' != 'true'"
-            Inputs="$(PublishDir)$(TargetName)$(NativeBinaryExt)"
+            Inputs="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)"
             Outputs="$(StripSourceFile);$(StripDestinationFile)">
         <Error Text="Do not set StripSymbols to true - runtime components stripping is controlled by native-library.targets" Condition="'$(StripSymbols)' == 'true'" />
 
-        <Message Importance="Normal" Text="Stripping $(PublishDir)$(TargetName)$(NativeBinaryExt) into $(StripSourceFile) and $(StripDestinationFile)" />
+        <Message Importance="Normal" Text="Stripping $(NativeOutputPath)$(TargetName)$(NativeBinaryExt) into $(StripSourceFile) and $(StripDestinationFile)" />
 
-        <!-- copy from the published/ subfolder to the stripped/ subfolder -->
-        <Copy SourceFiles="$(PublishDir)$(TargetName)$(NativeBinaryExt)"
+        <!-- copy from the native/ subfolder to the stripped/ subfolder -->
+        <Copy SourceFiles="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)"
               DestinationFolder="$(StrippedOutputPath)"
               SkipUnchangedFiles="true" />
 
@@ -68,8 +68,8 @@
     </Target>
 
     <Target Name="InstallRuntimeComponentToFinalDestination"
-            AfterTargets="CopyNativeBinary"
-            DependsOnTargets="CopyNativeBinary;_CopyAotSymbols;StripLibraryLikeCoreCLRBuild" Condition="'$(IsRuntimeComponent)' == 'true'">
+            AfterTargets="LinkNative"
+            DependsOnTargets="LinkNative;StripLibraryLikeCoreCLRBuild" Condition="'$(IsRuntimeComponent)' == 'true'">
         <Error Text="Set at least one @InstallRuntimeComponentDestination item" Condition="@(InstallRuntimeComponentDestination->Count()) == 0" />
 
         <PropertyGroup>
@@ -87,8 +87,8 @@
         </ItemGroup>
 
         <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-            <CopyFinalFiles Include="$(PublishDir)$(TargetName)$(NativeBinaryExt)" />
-            <CopyFinalFilesPDB Include="$(PublishDir)$(TargetName).pdb" Condition="Exists('$(PublishDir)$(TargetName).pdb')" />
+            <CopyFinalFiles Include="$(NativeOutputPath)$(TargetName)$(NativeBinaryExt)" />
+            <CopyFinalFilesPDB Include="$(NativeOutputPath)$(TargetName).pdb" />
         </ItemGroup>
 
         <Message Importance="Normal" Text="Installing @(CopyFinalFiles) into %(_NormalizedInstallRuntimeComponentDest.Identity)"/>


### PR DESCRIPTION
The `InstallRuntimeComponentToFinalDestination` target from infrastructure for NativeAOT-ed runtime components (#98565) copies the component and symbol files to the runtime output directory. Make the target use `NativeOutputPath` for the for the library and symbol path instead of the ones copied to the publish directory. They should be available after `LinkNative`.

This should unblock https://github.com/dotnet/installer/pull/19333

This was working in the runtime repo because the projects under src/native/managed are currently using the ILCompiler package corresponding to the SDK being used to build the repo. That version of the package doesn't have https://github.com/dotnet/runtime/pull/98342 - the native-library.targets were relying the symbols already being copied before `_CopyAotSymbols` was run.

I think the infrastructure should use the live ILCompiler if possible, otherwise the version in Version.Details.xml/Version.props instead. This PR does not try to do that - will look into it separately.