### PR TITLE
Remove invalid `GCPROTECT` for duplicate slot

### DIFF
--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -4731,11 +4731,8 @@ void OleVariant::ConvertValueClassToVariant(OBJECTREF *pBoxedValueClass, VARIANT
     // Marshal the contents of the value class into the record.
     MethodDesc* pStructMarshalStub;
     {
-        GCPROTECT_BEGIN(*pBoxedValueClass);
         GCX_PREEMP();
-
         pStructMarshalStub = NDirect::CreateStructMarshalILStub(pValueClassMT);
-        GCPROTECT_END();
     }
 
     MarshalStructViaILStub(pStructMarshalStub, (*pBoxedValueClass)->GetData(), (BYTE*)V_RECORD(pRecHolder), StructMarshalStubs::MarshalOperation::Marshal);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100739

/cc @janvorli @dotnet/interop-contrib 