### PR TITLE
Remove IDE0060 suppressions

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetSecurityTelemetry.cs
@@ -164,7 +164,6 @@ namespace System.Net.Security
             HandshakeStop(SslProtocols.None);
         }
 
-#pragma warning disable IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
         [NonEvent]
         public void HandshakeCompleted(SslProtocols protocol, long startingTimestamp, bool connectionOpen)
         {
@@ -213,7 +212,6 @@ namespace System.Net.Security
 
             HandshakeStop(protocol);
         }
-#pragma warning restore IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
 
         [NonEvent]
         public void ConnectionClosed(SslProtocols protocol)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -10,7 +10,6 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
-
 namespace System.Buffers
 {
     /// <summary>Data structure used to optimize checks for whether a char is in a set of chars.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -7,7 +7,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 
-
 #pragma warning disable 8500 // sizeof of managed types
 
 namespace System

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
-
 #pragma warning disable 8500 // sizeof of managed types
 
 namespace System


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/99113.

- Remove double new lines introduced by the previous PR.
- Fix for `System.Net.Security`