### PR TITLE
Fix comments in ZipFileExtensions.ZipArchiveEntry.Extract.cs

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -6,8 +6,8 @@ namespace System.IO.Compression
     public static partial class ZipFileExtensions
     {
         /// <summary>
-        /// Creates a file on the file system with the entry?s contents and the specified name. The last write time of the file is set to the
-        /// entry?s last write time. This method does not allow overwriting of an existing file with the same name. Attempting to extract explicit
+        /// Creates a file on the file system with the entry's contents and the specified name. The last write time of the file is set to the
+        /// entry's last write time. This method does not allow overwriting of an existing file with the same name. Attempting to extract explicit
         /// directories (entries with names that end in directory separator characters) will not result in the creation of a directory.
         /// </summary>
         ///
@@ -34,8 +34,8 @@ namespace System.IO.Compression
             ExtractToFile(source, destinationFileName, false);
 
         /// <summary>
-        /// Creates a file on the file system with the entry?s contents and the specified name.
-        /// The last write time of the file is set to the entry?s last write time.
+        /// Creates a file on the file system with the entry's contents and the specified name.
+        /// The last write time of the file is set to the entry's last write time.
         /// This method does allows overwriting of an existing file with the same name.
         /// </summary>
         ///


### PR DESCRIPTION
There seems to be a minor encoding problem with the apostrophe character.