### PR TITLE
Remove _ASSERTE(!m_pMethodBeingCompiled->IsDynamicMethod());

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -5405,12 +5405,8 @@ void CEEInfo::getCallInfo(
         //    (c) constraint calls that require runtime context lookup are never resolved
         //        to underlying shared generic code
 
-        bool unresolvedLdVirtFtn = (flags & CORINFO_CALLINFO_LDFTN) && (flags & CORINFO_CALLINFO_CALLVIRT) && !resolvedCallVirt;
-
         if (((pResult->exactContextNeedsRuntimeLookup && pTargetMD->IsInstantiatingStub() && (!allowInstParam || fResolvedConstraint)) || fForceUseRuntimeLookup))
         {
-            _ASSERTE(!m_pMethodBeingCompiled->IsDynamicMethod());
-
             pResult->kind = CORINFO_CALL_CODE_POINTER;
 
             DictionaryEntryKind entryKind;
@@ -5477,8 +5473,6 @@ void CEEInfo::getCallInfo(
 
         if (pResult->exactContextNeedsRuntimeLookup)
         {
-            _ASSERTE(!m_pMethodBeingCompiled->IsDynamicMethod());
-
             ComputeRuntimeLookupForSharedGenericToken(fIsStaticVirtualMethod ? ConstrainedMethodEntrySlot : DispatchStubAddrSlot,
                                                         pResolvedToken,
                                                         pConstrainedResolvedToken,


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/99928

I reproed this assert locally, it seems to be happening when a dynamic method `dynamicclass::lambda_method139` is requesting call info for `System.Collections.Generic.ICollection'1[__Canon]::get_Count` and I don't see why it couldn't work. So I presume Andy and Jan are correct that inline in shared generics + PGO GDV exposed this path.

I assume it should be possible to create a simple repro with Expressions Trees where we call a method that inlines a callee with a runtime lookup.