### PR TITLE
Disable binder tracing test under gcstress

### DIFF
--- a/src/tests/Loader/binding/tracing/BinderTracingTest.Basic.csproj
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.Basic.csproj
@@ -1,10 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <!-- TestAssemblyLoadContext.Load called from the finalizer -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- Dynamic assembly loads -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.Basic.cs" />
     <Compile Include="BinderTracingTest.DefaultProbing.cs" />

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
@@ -1,10 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Test creates non-collectible AssemblyLoadContext -->
-    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <!-- Dynamic assembly loads -->
-    <NativeAotIncompatible>true</NativeAotIncompatible>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.cs
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.cs
@@ -85,9 +85,6 @@ namespace BinderTracingTests
             foreach (var method in methods)
             {
                 BinderTestAttribute attribute = method.GetCustomAttribute<BinderTestAttribute>();
-                if (attribute.Isolate && Environment.GetEnvironmentVariable("DOTNET_GCStress") != null)
-                    continue;
-
                 bool success = attribute.Isolate
                     ? RunTestInSeparateProcess(method)
                     : RunSingleTest(method);

--- a/src/tests/Loader/binding/tracing/BinderTracingTest.targets
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.targets
@@ -4,6 +4,12 @@
     <!-- Requires explicit Main as it implements command-line parameters for local testing purposes. -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <!-- Test creates non-collectible AssemblyLoadContext -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <!-- Dynamic assembly loads -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- Tracing tests routinely time out with gcstress -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.cs" />


### PR DESCRIPTION
Tests depending on event tracing intermittently time out under gcstress. Disable binder tracing tests for that configuration. This is similar to what was done for other tracing tests in https://github.com/dotnet/runtime/pull/85186.

Fixes https://github.com/dotnet/runtime/issues/94390