### PR TITLE
[release/8.0][mono][HybridGlobalization] Fix ShortDatePattern year format to be "yyyy" 

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
@@ -8,6 +8,13 @@ namespace System.Globalization.Tests
 {
     public class DateTimeFormatInfoShortDatePattern
     {
+        public static IEnumerable<object[]> ShortDatePattern_Get_TestData()
+        {
+            yield return new object[] { DateTimeFormatInfo.InvariantInfo, "MM/dd/yyyy", "invariant" };
+            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, "M/d/yyyy", "en-US" };
+            yield return new object[] { new CultureInfo("fr-FR").DateTimeFormat, "dd/MM/yyyy", "fr-FR" };
+        }
+
         public static IEnumerable<object[]> ShortDatePattern_Get_TestData_HybridGlobalization()
         {
             // see the comments on the right to check the non-Hybrid result, if it differs
@@ -131,7 +138,6 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("en-ZA").DateTimeFormat, "yyyy/MM/dd" };
             yield return new object[] { new CultureInfo("en-ZM").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("en-ZW").DateTimeFormat, "d/M/yyyy" };
-            yield return new object[] { new CultureInfo("en-US").DateTimeFormat, "M/d/yyyy" };
             yield return new object[] { new CultureInfo("es-419").DateTimeFormat, "d/M/yyyy" };
             yield return new object[] { new CultureInfo("es-ES").DateTimeFormat, "d/M/yyyy" };
             yield return new object[] { new CultureInfo("es-MX").DateTimeFormat, "dd/MM/yyyy" };
@@ -198,6 +204,13 @@ namespace System.Globalization.Tests
             yield return new object[] { new CultureInfo("zh-SG").DateTimeFormat, "dd/MM/yyyy" };
             yield return new object[] { new CultureInfo("zh-HK").DateTimeFormat, "d/M/yyyy" };
             yield return new object[] { new CultureInfo("zh-TW").DateTimeFormat, "yyyy/M/d" };
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnOSX))]
+        [MemberData(nameof(ShortDatePattern_Get_TestData))]
+        public void ShortDatePattern_Get_ReturnsExpected(DateTimeFormatInfo format, string expected, string cultureName)
+        {
+            Assert.True(expected == format.ShortDatePattern, $"Failed for culture: {cultureName}. Expected: {expected}, Actual: {format.ShortDatePattern}");
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsHybridGlobalizationOnBrowser))]

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.iOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.iOS.cs
@@ -18,6 +18,15 @@ namespace System.Globalization
             sNativeName = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.NativeName);
             sMonthDay = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.MonthDay);
             saShortDates = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.ShortDates).Split("||");
+            // Handle ShortDatePattern to have "yyyy" year format
+            List<string> shortDatePatternList = new List<string>(saShortDates);
+            for (int i = 0; i < shortDatePatternList.Count; i++)
+            {
+                shortDatePatternList[i] = NormalizeDatePattern(shortDatePatternList[i]);
+            }
+            FixDefaultShortDatePattern(shortDatePatternList);
+            saShortDates = shortDatePatternList.ToArray();
+
             saLongDates = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.LongDates).Split("||");
             saYearMonths = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.YearMonths).Split("||");
             saDayNames = GetCalendarInfoNative(localeName, calendarId, CalendarDataType.DayNames).Split("||");


### PR DESCRIPTION
## Customer Impact

- [X] Customer reported
- [ ] Found internally

When using Hybrid Globalization mode on Apple mobile platforms with .NET 8, we are returning `ShortDatePattern` in ICU-like format instead of .NET-like format. This PR fixes this by normalizing the short date format returned from Apple ICU and converting "yy" year format to the expected "yyyy"

Hybrid Globalization mode in .NET 8 is off by default, so this only affects applications where the developer explicitly opted into using this mode.

NOTE: This is a .NET 8 version of https://github.com/dotnet/runtime/pull/99908.

## Regression
- [x] Yes - only when user opts into hybrid globalization
- [ ] No

## Testing
We added a small set of tests to verify the correct functionality of the fix.

## Risk
Low, only affects scenarios where Hybrid Globalization mode on Apple mobile platforms is enabled.

---

fyi: @vitek-karas @mkhamoyan @ilonatommy @akoeplinger @steveisok 