### PR TITLE
Do not warn when accessing fields on T constrained to be enum

### DIFF
--- a/src/coreclr/tools/Common/Compiler/Dataflow/GenericParameterProxy.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/GenericParameterProxy.cs
@@ -15,6 +15,17 @@ namespace ILLink.Shared.TypeSystemProxy
 
         internal partial bool HasDefaultConstructorConstraint() => GenericParameter.HasDefaultConstructorConstraint;
 
+        internal partial bool HasEnumConstraint()
+        {
+            foreach (TypeDesc constraint in GenericParameter.TypeConstraints)
+            {
+                if (constraint.IsWellKnownType(Internal.TypeSystem.WellKnownType.Enum))
+                    return true;
+            }
+
+            return false;
+        }
+
         public readonly GenericParameterDesc GenericParameter;
 
         public override string ToString() => GenericParameter.ToString();

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterProxy.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/GenericParameterProxy.cs
@@ -14,6 +14,16 @@ namespace ILLink.Shared.TypeSystemProxy
 			TypeParameterSymbol.HasValueTypeConstraint |
 			TypeParameterSymbol.HasUnmanagedTypeConstraint;
 
+		internal partial bool HasEnumConstraint ()
+		{
+			foreach (ITypeSymbol constraintType in TypeParameterSymbol.ConstraintTypes) {
+				if (constraintType.SpecialType == SpecialType.System_Enum)
+					return true;
+			}
+
+			return false;
+		}
+
 		public readonly ITypeParameterSymbol TypeParameterSymbol;
 
 		public override string ToString () => TypeParameterSymbol.ToString ();

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -28,6 +28,10 @@ namespace ILLink.Shared.TrimAnalysis
 					&& uniqueValue is GenericParameterValue genericParam
 					&& genericParam.GenericParameter.HasDefaultConstructorConstraint ()) {
 					// We allow a new() constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
+				} else if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.PublicFields
+					&& uniqueValue is GenericParameterValue maybeEnumConstrainedGenericParam
+					&& maybeEnumConstrainedGenericParam.GenericParameter.HasEnumConstraint ()) {
+					// We allow a System.Enum constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicFields
 				} else if (uniqueValue is ValueWithDynamicallyAccessedMembers valueWithDynamicallyAccessedMembers) {
 					if (uniqueValue is NullableValueWithDynamicallyAccessedMembers nullableValue) {
 						MarkTypeForDynamicallyAccessedMembers (nullableValue.NullableType, nullableValue.DynamicallyAccessedMemberTypes);

--- a/src/tools/illink/src/ILLink.Shared/TypeSystemProxy/GenericParameterProxy.cs
+++ b/src/tools/illink/src/ILLink.Shared/TypeSystemProxy/GenericParameterProxy.cs
@@ -9,5 +9,7 @@ namespace ILLink.Shared.TypeSystemProxy
 	internal readonly partial struct GenericParameterProxy
 	{
 		internal partial bool HasDefaultConstructorConstraint ();
+
+		internal partial bool HasEnumConstraint ();
 	}
 }

--- a/src/tools/illink/src/linker/Linker.Dataflow/GenericParameterProxy.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/GenericParameterProxy.cs
@@ -13,6 +13,18 @@ namespace ILLink.Shared.TypeSystemProxy
 
 		internal partial bool HasDefaultConstructorConstraint () => GenericParameter.HasDefaultConstructorConstraint;
 
+		internal partial bool HasEnumConstraint ()
+		{
+			if (GenericParameter.HasConstraints) {
+				foreach (GenericParameterConstraint? constraint in GenericParameter.Constraints) {
+					if (constraint.ConstraintType.Name == "Enum" && constraint.ConstraintType.Namespace == "System")
+						return true;
+				}
+			}
+
+			return false;
+		}
+
 		public readonly GenericParameter GenericParameter;
 
 		public override string ToString () => GenericParameter.ToString ();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterDataFlow.cs
@@ -37,6 +37,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			TestStructConstraintSatisfiesParameterlessConstructor<TestStruct> ();
 			TestUnmanagedConstraintSatisfiesParameterlessConstructor<byte> ();
 
+			TestEnumConstraintSatisfiesPublicFields<Enum> ();
+
 			TestGenericParameterFlowsToField ();
 			TestGenericParameterFlowsToReturnValue ();
 
@@ -796,6 +798,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		static void RequiresParameterlessConstructor<[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> ()
 		{
+		}
+
+		static void TestEnumConstraintSatisfiesPublicFields<T> () where T : Enum
+		{
+			typeof (T).RequiresPublicFields ();
 		}
 
 		// Warn about calls to static methods:


### PR DESCRIPTION
Fixes #97737.

Trimming ensures we keep all the public fields on enums. `typeof(T).GetFields()` is safe when the `T` is constrained to be `System.Enum` or a derived type.

Cc @dotnet/ilc-contrib 