### PR TITLE
Fix shutdown on foreign thread

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -544,7 +544,11 @@ void EESocketCleanupHelper(bool isExecutingOnAltStack)
 
     if (isExecutingOnAltStack)
     {
-        GetThread()->SetExecutingOnAltStack();
+        Thread *pThread = GetThreadNULLOk();
+        if (pThread)
+        {
+             pThread->SetExecutingOnAltStack();
+        }
     }
 
     // Close the debugger transport socket first


### PR DESCRIPTION
When a foreign thread running in .NET process is killed or crashes due to some hardware exception, the .NET code that performs shutdown gets called and incorrectly expects the thread to be a thread that's registered with the runtime. It calls `GetThread` on it and then calls a method on the thread. That leads to an assert in debug builds and crash in release ones.

The function that is called is not needed for foreign threads though, so the fix is to skip calling it if the `GetThreadNULLOk` returns NULL (that means the thread is foreign and never registered with the runtime).

Close #95419