### PR TITLE
[Release/8.0] Remove preventing EH at shutdown

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1331,9 +1331,6 @@ part2:
                 // Shutdown finalizer before we suspend all background threads. Otherwise we
                 // never get to finalize anything.
 
-                // No longer process exceptions
-                g_fNoExceptions = true;
-
                 // <TODO>@TODO: This does things which shouldn't occur in part 2.  Namely,
                 // calling managed dll main callbacks (AppDomain::SignalProcessDetach), and
                 // RemoveAppDomainFromIPC.

--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -59,13 +59,6 @@ void SafeExitProcess(UINT exitCode, ShutdownCompleteAction sca = SCA_ExitProcess
         }
     }
 
-    // Turn off exception processing, because if some other random DLL has a
-    //  fault in DLL_PROCESS_DETACH, we could get called for exception handling.
-    //  Since we've turned off part of the runtime, we can't, for instance,
-    //  properly execute the GC that handling an exception might trigger.
-    g_fNoExceptions = true;
-    LOG((LF_EH, LL_INFO10, "SafeExitProcess: turning off exceptions\n"));
-
     if (sca == SCA_TerminateProcessWhenShutdownComplete)
     {
         // disabled because if we fault in this code path we will trigger our Watson code

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4623,12 +4623,6 @@ LONG InternalUnhandledExceptionFilter_Worker(
     }
 #endif
 
-    // This shouldn't be possible, but MSVC re-installs us... for now, just bail if this happens.
-    if (g_fNoExceptions)
-    {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
-
     // Are we looking at a stack overflow here?
     if ((pThread !=  NULL) && !pThread->DetermineIfGuardPagePresent())
     {
@@ -5532,8 +5526,6 @@ static LONG ThreadBaseExceptionFilter_Worker(PEXCEPTION_POINTERS pExceptionInfo,
 
     ThreadBaseExceptionFilterParam *pParam = (ThreadBaseExceptionFilterParam *) pvParam;
     UnhandledExceptionLocation location = pParam->location;
-
-    _ASSERTE(!g_fNoExceptions);
 
     Thread* pThread = GetThread();
 
@@ -7393,8 +7385,8 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
     // WARNING WARNING WARNING WARNING WARNING WARNING WARNING
     //
 
-    // If exceptions (or runtime) have been disabled, then simply return.
-    if (g_fForbidEnterEE || g_fNoExceptions)
+    // If runtime have been disabled, then simply return.
+    if (g_fForbidEnterEE)
     {
         return EXCEPTION_CONTINUE_SEARCH;
     }

--- a/src/coreclr/vm/i386/excepx86.cpp
+++ b/src/coreclr/vm/i386/excepx86.cpp
@@ -1571,9 +1571,6 @@ EXCEPTION_HANDLER_IMPL(COMPlusFrameHandler)
 
     _ASSERTE((pContext == NULL) || ((pContext->ContextFlags & CONTEXT_CONTROL) == CONTEXT_CONTROL));
 
-    if (g_fNoExceptions)
-        return ExceptionContinueSearch; // No EH during EE shutdown.
-
     // Check if the exception represents a GCStress Marker. If it does,
     // we shouldnt record its entry in the TLS as such exceptions are
     // continuable and can confuse the VM to treat them as CSE,

--- a/src/coreclr/vm/vars.cpp
+++ b/src/coreclr/vm/vars.cpp
@@ -193,7 +193,6 @@ GVAL_IMPL(SIZE_T, g_runtimeVirtualSize);
 
 Volatile<LONG> g_fForbidEnterEE = false;
 bool g_fManagedAttach = false;
-bool g_fNoExceptions = false;
 
 DWORD g_FinalizerWaiterStatus = 0;
 

--- a/src/coreclr/vm/vars.hpp
+++ b/src/coreclr/vm/vars.hpp
@@ -477,7 +477,6 @@ GVAL_DECL(bool, g_fProcessDetach);
 GVAL_DECL(bool, g_metadataUpdatesApplied);
 #endif
 EXTERN bool g_fManagedAttach;
-EXTERN bool g_fNoExceptions;
 
 // Indicates whether we're executing shut down as a result of DllMain
 // (DLL_PROCESS_DETACH). See comments at code:EEShutDown for details.


### PR DESCRIPTION
Backport of #100293 to release/8.0

## Customer Impact
During the runtime shutdown, we stop handling exceptions at all and we also prevent entering EE at few places. A customer has hit an issue with Watson dump being generated from a .NET app on every machine reboot due to that. That app was a networking app that was listening on a socket. Shutdown of the app resulted in a SocketException being thrown, but the exception handling was prevented and so the exception was reported as an unhandled exception which caused the dump to be taken.

## Testing
CI testing, local testing of a case equivalent to what the customer had - a grpc running as a service. Without the fix the issue reported by the customer can be reproduced, with the fix it is gone.

## Risk
Low - the change just enables exceptions handling during shutdown. So where previously the app would crash with an unhandled exception, it will now get proper handling of that exception upto the point the process is torn down by the OS.
