### PR TITLE
Make src/native/managed projects use Microsoft.DotNet.ILCompiler version from Version.props

### DIFF
--- a/src/native/managed/compile-native.proj
+++ b/src/native/managed/compile-native.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.Traversal" DefaultTargets="Publish">
+<Project Sdk="Microsoft.Build.Traversal">
     <PropertyGroup>
         <!-- We always want to use release for publishing using NativeAOT -->
         <NativeLibsPublishConfiguration>Release</NativeLibsPublishConfiguration>
@@ -58,6 +58,7 @@
         <ProjectReference Include="@(NativeLibsProjectsToBuild)"
                           ReferenceOutputAssembly="false"
                           AdditionalProperties="%(AdditionalProperties);$(SplitSubprojectProps)"
-			  Condition="$(SupportsNativeAotComponents)"/>
+                          Targets="LinkNative"
+                          Condition="$(SupportsNativeAotComponents)"/>
     </ItemGroup>
 </Project>

--- a/src/native/managed/native-library.props
+++ b/src/native/managed/native-library.props
@@ -6,6 +6,7 @@
          the same way as eng/native/functions.cmake strip_symbols
     -->
     <StripSymbols>false</StripSymbols>
+    <SuppressGenerateILCompilerExplicitPackageReferenceWarning>true</SuppressGenerateILCompilerExplicitPackageReferenceWarning>
   </PropertyGroup>
 
   <!-- set the shared library name.  this helps the native linker correctly reference this shared
@@ -31,5 +32,10 @@
   <ItemGroup>
     <!-- passed by compile-native.proj to set - -gcc-toolchain=$(ROOTFS_DIR)/usr -->
     <CustomLinkerArg Condition="'$(CustomLinkerArgToolchainArg)' != ''" Include="$(CustomLinkerArgToolchainArg)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
+    <PackageReference Include="runtime.$(ToolsRID).Microsoft.DotNet.ILCompiler" Version="$(MicrosoftDotNetILCompilerVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use the version of Microsoft.DotNet.ILCompiler specified in Version.props when producing runtime components in src/native/managed via NativeAOT
  - This is the same version that `ILCompiler.csproj` / `ilc` itself uses to publish as NativeAOT
- Reduce the number of copies of the output by avoiding publishing and just running `LinkNative` - per https://github.com/dotnet/runtime/pull/100782#discussion_r1556446453

I also tried making it use the live build ([elinor-fung/runtimeComponent-nativeaotLive](https://github.com/elinor-fung/runtime/tree/runtimeComponent-nativeaotLive)). Works fine locally, but it would require having clr.aot+libs built before being able to build the cdac. We have cdac parented under the clr build now - I don't know that we'd want to pull it into a separate thing that requires subsets from multiple sub-partitions to have been built already.