### PR TITLE
JIT: Track sideness of arrOp in GetCheckedBoundArithInfo

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -4813,8 +4813,12 @@ void CSE_HeuristicCommon::PerformCSE(CSE_Candidate* successfulCandidate)
 
                             assert(vnStore->IsVNCompareCheckedBoundArith(oldCmpVN));
                             vnStore->GetCompareCheckedBoundArithInfo(oldCmpVN, &info);
-                            newCmpArgVN = vnStore->VNForFunc(vnStore->TypeOfVN(info.arrOp), (VNFunc)info.arrOper,
-                                                             info.arrOp, theConservativeVN);
+
+                            ValueNum arrOp1 = info.arrOpLHS ? info.arrOp : theConservativeVN;
+                            ValueNum arrOp2 = info.arrOpLHS ? theConservativeVN : info.arrOp;
+
+                            newCmpArgVN =
+                                vnStore->VNForFunc(vnStore->TypeOfVN(info.arrOp), (VNFunc)info.arrOper, arrOp1, arrOp2);
                         }
                         ValueNum newCmpVN = vnStore->VNForFunc(vnStore->TypeOfVN(oldCmpVN), (VNFunc)info.cmpOper,
                                                                info.cmpOp, newCmpArgVN);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6675,9 +6675,10 @@ void ValueNumStore::GetCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundAri
     }
     else
     {
-        info->arrOper = funcArith.m_func;
-        info->arrOp   = funcArith.m_args[1];
-        info->vnBound = funcArith.m_args[0];
+        info->arrOper  = funcArith.m_func;
+        info->arrOp    = funcArith.m_args[1];
+        info->vnBound  = funcArith.m_args[0];
+        info->arrOpLHS = false;
     }
 }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -6669,9 +6669,10 @@ void ValueNumStore::GetCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundAri
     bool isOp1CheckedBound = IsVNCheckedBound(funcArith.m_args[1]);
     if (isOp1CheckedBound)
     {
-        info->arrOper = funcArith.m_func;
-        info->arrOp   = funcArith.m_args[0];
-        info->vnBound = funcArith.m_args[1];
+        info->arrOper  = funcArith.m_func;
+        info->arrOp    = funcArith.m_args[0];
+        info->vnBound  = funcArith.m_args[1];
+        info->arrOpLHS = true;
     }
     else
     {

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -939,9 +939,9 @@ public:
             : vnBound(NoVN)
             , arrOper(GT_NONE)
             , arrOp(NoVN)
+            , arrOpLHS(false)
             , cmpOper(GT_NONE)
             , cmpOp(NoVN)
-            , arrOpLHS(false)
         {
         }
 #ifdef DEBUG

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -941,6 +941,7 @@ public:
             , arrOp(NoVN)
             , cmpOper(GT_NONE)
             , cmpOp(NoVN)
+            , arrOpLHS(false)
         {
         }
 #ifdef DEBUG

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -932,6 +932,7 @@ public:
         ValueNum vnBound;
         unsigned arrOper;
         ValueNum arrOp;
+        bool     arrOpLHS; // arrOp is on the left side of cmpOp expression
         unsigned cmpOper;
         ValueNum cmpOp;
         CompareCheckedBoundArithInfo()

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100809/Runtime_100809.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100809/Runtime_100809.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static class Runtime_100809
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        return AlwaysFalse(96) ? -1 : 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AlwaysFalse(int x)
+    {
+        var result = new byte[x];
+        int count = result.Length - 2;
+        return (x < 0 || result.Length - count < 0);
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_100809/Runtime_100809.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_100809/Runtime_100809.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100809

Minimal repro:
```cs
using System.Runtime.CompilerServices;

AlwaysFalse(10);

[MethodImpl(MethodImplOptions.NoInlining | 
            MethodImplOptions.AggressiveOptimization)]
bool AlwaysFalse(int x)
{
    var result = new byte[x];
    int count = result.Length - 2;
    return (x < 0 || result.Length - count < 0);
}
```
It prints `False` in Debug and `True` in Release.

Here we have `((arr_len - (arr_len + -2)) >= 0)` expression which should evaluate into `2 >= 0`  -> `true`. But instead, we evaluate it as `-2 >= 0` -> `false`. It happens because `GetCheckedBoundArithInfo` looses track where it took arrOp in cmpOp - from op1 or op2? the order is important since we don't guarantee that arrOper is commutative.