### PR TITLE
Allow debuggers to see first chance exceptions

### DIFF
--- a/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/amd64/AsmMacros.inc
@@ -388,6 +388,7 @@ EXTERN RhExceptionHandling_FailedAllocation     : PROC
 EXTERN RhThrowHwEx                              : PROC
 EXTERN RhThrowEx                                : PROC
 EXTERN RhRethrow                                : PROC
+EXTERN PalRaiseFirstChanceExceptionEvent        : PROC
 EXTERN RhpGcPoll2                               : PROC
 ifdef FEATURE_GC_STRESS
 EXTERN RhpStressGc                              : PROC

--- a/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
+++ b/src/coreclr/nativeaot/Runtime/amd64/ExceptionHandling.asm
@@ -182,6 +182,13 @@ NESTED_ENTRY RhpThrowEx, _TEXT
 
         ;; rcx still contains the exception object
         ;; rdx contains the address of the ExInfo
+        mov     r12, rcx
+        mov     r13, rdx
+        call    PalRaiseFirstChanceExceptionEvent
+
+        ; restore exception object and ExInfo
+        mov     rcx, r12
+        mov     rdx, r13
         call    RhThrowEx
 
 ALTERNATE_ENTRY RhpThrowEx2

--- a/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalRedhawkMinWin.cpp
@@ -792,6 +792,23 @@ REDHAWK_PALEXPORT void* REDHAWK_PALAPI PalAddVectoredExceptionHandler(uint32_t f
     return AddVectoredExceptionHandler(firstHandler, vectoredHandler);
 }
 
+REDHAWK_PALEXPORT void REDHAWK_PALAPI PalRaiseFirstChanceExceptionEvent()
+{
+
+#define EXCEPTION_COMPLUS 0xe0434352    // 0xe0000000 | 'CCR'
+
+    if (IsDebuggerPresent())
+    {
+        __try
+        {
+            RaiseException(EXCEPTION_COMPLUS, 0, 0, NULL);
+        }
+        __except(EXCEPTION_EXECUTE_HANDLER)
+        {
+        }
+    }
+}
+
 REDHAWK_PALEXPORT void PalPrintFatalError(const char* message)
 {
     // Write the message using lowest-level OS API available. This is used to print the stack overflow


### PR DESCRIPTION
Port of #100714 to native AOT.

Any reason why we shouldn't do this for native AOT too?

Only did x64 for now for discussion.

Cc @dotnet/ilc-contrib @janvorli 