### PR TITLE
[browser] unhandled exceptions

### DIFF
--- a/src/mono/browser/runtime/invoke-js.ts
+++ b/src/mono/browser/runtime/invoke-js.ts
@@ -59,8 +59,8 @@ export function mono_wasm_invoke_jsimport_MT (signature: JSFunctionSignature, ar
                     }
                 }
                 return;
-            } catch (ex2: any) {
-                runtimeHelpers.nativeAbort(ex2);
+            } catch (ex: any) {
+                loaderHelpers.mono_exit(1, ex);
                 return;
             }
         }

--- a/src/mono/browser/runtime/pthreads/shared.ts
+++ b/src/mono/browser/runtime/pthreads/shared.ts
@@ -77,7 +77,11 @@ export function exec_synchronization_context_pump (): void {
         return;
     }
     forceThreadMemoryViewRefresh();
-    tcwraps.mono_wasm_synchronization_context_pump();
+    try {
+        tcwraps.mono_wasm_synchronization_context_pump();
+    } catch (ex) {
+        loaderHelpers.mono_exit(1, ex);
+    }
 }
 
 export function mono_wasm_schedule_synchronization_context (): void {

--- a/src/mono/browser/runtime/scheduling.ts
+++ b/src/mono/browser/runtime/scheduling.ts
@@ -35,20 +35,28 @@ function prevent_timer_throttling_tick () {
     if (!loaderHelpers.is_runtime_running()) {
         return;
     }
-    cwraps.mono_wasm_execute_timer();
-    pump_count++;
+    try {
+        cwraps.mono_wasm_execute_timer();
+        pump_count++;
+    } catch (ex) {
+        loaderHelpers.mono_exit(1, ex);
+    }
     mono_background_exec_until_done();
 }
 
 function mono_background_exec_until_done () {
     if (WasmEnableThreads) return;
     Module.maybeExit();
-    if (!loaderHelpers.is_runtime_running()) {
-        return;
-    }
-    while (pump_count > 0) {
-        --pump_count;
-        cwraps.mono_background_exec();
+    try {
+        while (pump_count > 0) {
+            --pump_count;
+            if (!loaderHelpers.is_runtime_running()) {
+                return;
+            }
+            cwraps.mono_background_exec();
+        }
+    } catch (ex) {
+        loaderHelpers.mono_exit(1, ex);
     }
 }
 
@@ -78,5 +86,10 @@ function mono_wasm_schedule_timer_tick () {
         return;
     }
     lastScheduledTimeoutId = undefined;
-    cwraps.mono_wasm_execute_timer();
+    try {
+        cwraps.mono_wasm_execute_timer();
+        pump_count++;
+    } catch (ex) {
+        loaderHelpers.mono_exit(1, ex);
+    }
 }


### PR DESCRIPTION
To address [Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-99829-merge-e53fbda7b1db41c4ac/WasmTestOnBrowser-System.Text.Encodings.Web.Tests/1/console.37f05dbd.log?helixlogtype=result)

Contributes to https://github.com/dotnet/runtime/issues/98309
Contributes to https://github.com/dotnet/runtime/issues/97546