### PR TITLE
Don't emit analyzer warnings for MakeGeneric understood by ILC

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresAnalyzerBase.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace ILLink.RoslynAnalyzer
 {
@@ -341,6 +342,15 @@ namespace ILLink.RoslynAnalyzer
 				containingSymbol,
 				incompatibleMembers,
 				out diagnostic);
+		}
+
+		internal virtual bool IsIntrinsicallyHandled (
+			IMethodSymbol calledMethod,
+			MultiValue instance,
+			ImmutableArray<MultiValue> arguments
+			)
+		{
+			return false;
 		}
 	}
 }

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/RequiresDynamicCodeAnalyzer.cs
@@ -5,8 +5,11 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using ILLink.Shared;
+using ILLink.Shared.TrimAnalysis;
+using ILLink.Shared.TypeSystemProxy;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using MultiValue = ILLink.Shared.DataFlow.ValueSet<ILLink.Shared.DataFlow.SingleValue>;
 
 namespace ILLink.RoslynAnalyzer
 {
@@ -37,6 +40,77 @@ namespace ILLink.RoslynAnalyzer
 
 		internal override bool IsAnalyzerEnabled (AnalyzerOptions options) =>
 			options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableAotAnalyzer);
+
+		internal override bool IsIntrinsicallyHandled (IMethodSymbol calledMethod, MultiValue instance, ImmutableArray<MultiValue> arguments) {
+			MethodProxy method = new (calledMethod);
+			var intrinsicId = Intrinsics.GetIntrinsicIdForMethod (method);
+
+			switch (intrinsicId) {
+			case IntrinsicId.Type_MakeGenericType: {
+					if (!instance.IsEmpty ()) {
+						foreach (var value in instance.AsEnumerable ()) {
+							if (value is SystemTypeValue) {
+								if (!IsKnownInstantiation (arguments[0])) {
+									return false;
+								}
+							} else {
+								return false;
+							}
+						}
+					}
+					return true;
+				}
+			case IntrinsicId.MethodInfo_MakeGenericMethod: {
+					if (!instance.IsEmpty ()) {
+						foreach (var methodValue in instance.AsEnumerable ()) {
+							if (methodValue is SystemReflectionMethodBaseValue methodBaseValue) {
+								if (!IsKnownInstantiation (arguments[0])) {
+									return false;
+								}
+							} else {
+								return false;
+							}
+						}
+					}
+					return true;
+				}
+			}
+
+			return false;
+
+			static bool IsKnownInstantiation(MultiValue genericParametersArray) {
+				var typesValue = genericParametersArray.AsSingleValue ();
+				if (typesValue is NullValue) {
+					// This will fail at runtime but no warning needed
+					return true;
+				}
+
+				// Is this an array we model?
+				if (typesValue is not ArrayValue array) {
+					return false;
+				}
+
+				int? size = array.Size.AsConstInt ();
+				if (size == null) {
+					return false;
+				}
+
+				for (int i = 0; i < size.Value; i++) {
+					// Go over each element of the array. If the value is unknown, bail.
+					if (!array.TryGetValueByIndex (i, out MultiValue value)) {
+						return false;
+					}
+
+					var singleValue = value.AsSingleValue ();
+
+					if (singleValue is not SystemTypeValue and not GenericParameterValue and not NullableSystemTypeValue) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+		}
 
 		private protected override bool IsRequiresCheck (IPropertySymbol propertySymbol, Compilation compilation) {
 			var runtimeFeaturesType = compilation.GetTypeByMetadataName ("System.Runtime.CompilerServices.RuntimeFeature");

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisMethodCallPattern.cs
@@ -84,8 +84,11 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 
 			foreach (var requiresAnalyzer in context.EnabledRequiresAnalyzers)
 			{
-				if (requiresAnalyzer.CheckAndCreateRequiresDiagnostic(Operation, CalledMethod, OwningSymbol, context, FeatureContext, out Diagnostic? diag))
-					diagnosticContext.AddDiagnostic(diag);
+				if (requiresAnalyzer.CheckAndCreateRequiresDiagnostic (Operation, CalledMethod, OwningSymbol, context, FeatureContext, out Diagnostic? diag)
+					&& !requiresAnalyzer.IsIntrinsicallyHandled (CalledMethod, Instance, Arguments))
+				{
+					diagnosticContext.AddDiagnostic (diag);
+				}
 			}
 
 			return diagnosticContext.Diagnostics;

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -198,6 +198,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task MakeGenericDataflowIntrinsics ()
+		{
+			return RunTest ();
+		}
+
+		[Fact]
 		public Task MethodByRefReturnDataFlow ()
 		{
 			return RunTest ();

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresDynamicCodeAnalyzerTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ILLink.Shared;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -33,6 +35,19 @@ namespace System.Diagnostics.CodeAnalysis
 		public string? Url { get; set; }
 	}
 }";
+
+		static async Task VerifyRequiresDynamicCodeAnalyzer (
+			string source,
+			params DiagnosticResult[] expected)
+		{
+
+			await VerifyCS.VerifyAnalyzerAsync (
+				source,
+				consoleApplication: false,
+				TestCaseUtils.UseMSBuildProperties (MSBuildPropertyOptionNames.EnableAotAnalyzer),
+				Array.Empty<MetadataReference> (),
+				expected);
+		}
 
 		static Task VerifyRequiresDynamicCodeCodeFix (
 			string source,
@@ -331,6 +346,134 @@ build_property.{MSBuildPropertyOptionNames.EnableAotAnalyzer} = true")));
 				VerifyCS.Diagnostic(DiagnosticId.RequiresDynamicCode).WithSpan(13, 17, 13, 21).WithArguments("C.M1()", " message.", "")
 			};
 			return VerifyRequiresDynamicCodeCodeFix (src, fix, diag, Array.Empty<DiagnosticResult> ());
+		}
+
+		[Fact]
+		public Task MakeGenericTypeWithAllKnownTypes ()
+		{
+			const string src = $$"""
+			class C
+			{
+				public void M() => typeof(Gen<>).MakeGenericType(typeof(object));
+			}
+			class Gen<T> { }
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
+		public Task MakeGenericTypeWithAllKnownTypesInGenericContext ()
+		{
+			const string src = $$"""
+			class C
+			{
+				public void M<T>() => typeof(Gen<>).MakeGenericType(typeof(T));
+			}
+			class Gen<T> { }
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
+		public Task MakeGenericTypeWithUnknownDefinition ()
+		{
+			const string src = $$"""
+			using System;
+			class C
+			{
+				public void M() => GetDefinition().MakeGenericType(typeof(object));
+				static Type GetDefinition() => typeof(Gen<>);
+			}
+			class Gen<T> { }
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src,
+				// (4,21): warning IL3050: Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
+				VerifyCS.Diagnostic (DiagnosticId.RequiresDynamicCode).WithSpan (4, 21, 4, 68).WithArguments ("System.Type.MakeGenericType(params Type[])", " The native code for this instantiation might not be available at runtime.", ""));
+		}
+
+		[Fact]
+		public Task MakeGenericTypeWithUnknownArgument ()
+		{
+			const string src = $$"""
+			using System;
+			class C
+			{
+				public void M() => typeof(Gen<>).MakeGenericType(GetObject());
+				static Type GetObject() => typeof(object);
+			}
+			class Gen<T> { }
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src,
+				// (4,21): warning IL3050: Using member 'System.Type.MakeGenericType(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
+				VerifyCS.Diagnostic (DiagnosticId.RequiresDynamicCode).WithSpan (4, 21, 4, 63).WithArguments ("System.Type.MakeGenericType(params Type[])", " The native code for this instantiation might not be available at runtime.", ""));
+		}
+
+		[Fact]
+		public Task MakeGenericMethodWithAllKnownTypes ()
+		{
+			const string src = $$"""
+			class C
+			{
+				public void M() => typeof(C).GetMethod(nameof(N)).MakeGenericMethod(typeof(object));
+				public void N<T>() { }
+			}
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
+		public Task MakeGenericMethodWithAllKnownTypesInGenericContext ()
+		{
+			const string src = $$"""
+			class C
+			{
+				public void M<T>() => typeof(C).GetMethod(nameof(N)).MakeGenericMethod(typeof(T));
+				public void N<T>() { }
+			}
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src);
+		}
+
+		[Fact]
+		public Task MakeGenericMethodWithUnknownDefinition ()
+		{
+			const string src = $$"""
+			using System.Reflection;
+			class C
+			{
+				public void M() => GetMethodInfo().MakeGenericMethod(typeof(object));
+				public void N<T>() { }
+				public MethodInfo GetMethodInfo() => typeof(C).GetMethod(nameof(N));
+			}
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src,
+				// (4,21): warning IL3050: Using member 'System.Reflection.MethodInfo.MakeGenericMethod(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
+				VerifyCS.Diagnostic (DiagnosticId.RequiresDynamicCode).WithSpan (4, 21, 4, 70).WithArguments ("System.Reflection.MethodInfo.MakeGenericMethod(params Type[])", " The native code for this instantiation might not be available at runtime.", ""));
+		}
+
+		[Fact]
+		public Task MakeGenericMethodWithUnknownArgument ()
+		{
+			const string src = $$"""
+			using System;
+			class C
+			{
+				public void M() => typeof(C).GetMethod(nameof(N)).MakeGenericMethod(GetObject());
+				public void N<T>() { }
+				static Type GetObject() => typeof(object);
+			}
+			""";
+
+			return VerifyRequiresDynamicCodeAnalyzer (src,
+				// (4,21): warning IL3050: Using member 'System.Reflection.MethodInfo.MakeGenericMethod(params Type[])' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The native code for this instantiation might not be available at runtime.
+				VerifyCS.Diagnostic (DiagnosticId.RequiresDynamicCode).WithSpan (4, 21, 4, 82).WithArguments ("System.Reflection.MethodInfo.MakeGenericMethod(params Type[])", " The native code for this instantiation might not be available at runtime.", ""));
 		}
 	}
 }

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/DataFlowTests.g.cs
@@ -20,6 +20,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
+		public Task MakeGenericDataflowIntrinsics ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task MethodByRefParameterDataFlow ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.DataFlow
+{
+	[SkipKeptItemsValidation]
+	[ExpectedNoWarnings]
+	class MakeGenericDataflowIntrinsics
+	{
+		public static void Main ()
+		{
+			MakeGenericType.Test ();
+			MakeGenericMethod.Test ();
+		}
+
+		class MakeGenericType
+		{
+			class Gen<T> { }
+
+			static Type GrabUnknownType () => null;
+
+			public static void Test ()
+			{
+				TestRecognizedIntrinsic ();
+				TestRecognizedGenericIntrinsic<object> ();
+				TestUnknownOwningType ();
+				TestUnknownArgument ();
+			}
+
+			public static void TestRecognizedIntrinsic () => typeof (Gen<>).MakeGenericType (typeof (object));
+
+			public static void TestRecognizedGenericIntrinsic<T> () => typeof (Gen<>).MakeGenericType (typeof (T));
+
+			[ExpectedWarning ("IL2055", nameof (Type.MakeGenericType))]
+			[ExpectedWarning ("IL3050", nameof (Type.MakeGenericType), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			public static void TestUnknownOwningType () => GrabUnknownType ().MakeGenericType (typeof (object));
+
+			[ExpectedWarning ("IL3050", nameof (Type.MakeGenericType), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			public static void TestUnknownArgument () => typeof (Gen<>).MakeGenericType (GrabUnknownType ());
+		}
+
+		class MakeGenericMethod
+		{
+			public static void Gen<T> () { }
+
+			static MethodInfo GrabUnknownMethod () => null;
+
+			static Type GrabUnknownType () => null;
+
+			public static void Test ()
+			{
+				TestRecognizedIntrinsic ();
+				TestRecognizedGenericIntrinsic<object> ();
+				TestUnknownOwningMethod ();
+				TestUnknownArgument ();
+			}
+
+			public static void TestRecognizedIntrinsic () => typeof (MakeGenericMethod).GetMethod (nameof (Gen)).MakeGenericMethod (typeof (object));
+
+			public static void TestRecognizedGenericIntrinsic<T> () => typeof (MakeGenericMethod).GetMethod (nameof (Gen)).MakeGenericMethod (typeof (T));
+
+			[ExpectedWarning ("IL2060", nameof (MethodInfo.MakeGenericMethod))]
+			[ExpectedWarning ("IL3050", nameof (MethodInfo.MakeGenericMethod), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			public static void TestUnknownOwningMethod () => GrabUnknownMethod ().MakeGenericMethod (typeof (object));
+
+			[ExpectedWarning ("IL3050", nameof (MethodInfo.MakeGenericMethod), ProducedBy = Tool.Analyzer | Tool.NativeAot)]
+			public static void TestUnknownArgument () => typeof (MakeGenericMethod).GetMethod (nameof (Gen)).MakeGenericMethod (GrabUnknownType());
+		}
+	}
+}


### PR DESCRIPTION
Follow up to #99037.
Resolves #81204.

When `MakeGenericXXX` API is used in the "bridging constraints" pattern and all types/members involved are statically known, don't emit warning from the Roslyn analyzer since ILC will do the right thing and ensure this works.

Cc @dotnet/ilc-contrib 