### PR TITLE
[wasm][debugger] Cleaning CI

### DIFF
--- a/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
+++ b/src/mono/browser/debugger/DebuggerTestSuite/EvaluateOnCallFrameTests.cs
@@ -216,7 +216,7 @@ namespace DebuggerTests
                    ($"local_dt.Date.Year * 10", TNumber(10)));
            });
 
-        [Theory]
+        [ConditionalTheory(nameof(RunningOnChrome))]
         [InlineData("")]
         [InlineData("this.")]
         public async Task InheritedAndPrivateMembersInAClass(string prefix)


### PR DESCRIPTION
Disabling this test on Firefox.
Fixes https://github.com/dotnet/runtime/issues/75013

Removing this test because it's flaky and this will not be responsability of BrowserDebugProxy anymore.
Fixes https://github.com/dotnet/runtime/issues/98215