### PR TITLE
Revert "[wasm] Bump chrome for testing - linux: 123.0.6312.58, windows: 123.0.6312.58"

### DIFF
--- a/eng/testing/ChromeVersions.props
+++ b/eng/testing/ChromeVersions.props
@@ -3,10 +3,10 @@
     <linux_ChromeVersion>122.0.6261.69</linux_ChromeVersion>
     <linux_ChromeRevision>1250580</linux_ChromeRevision>
     <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1250580</linux_ChromeBaseSnapshotUrl>
-    <linux_V8Version>12.2.281</linux_V8Version>
+    <linux_V8Version>12.3.219</linux_V8Version>
     <win_ChromeVersion>122.0.6261.69</win_ChromeVersion>
     <win_ChromeRevision>1250580</win_ChromeRevision>
     <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1250586</win_ChromeBaseSnapshotUrl>
-    <win_V8Version>12.2.281</win_V8Version>
+    <win_V8Version>12.3.219</win_V8Version>
   </PropertyGroup>
 </Project>

--- a/eng/testing/ChromeVersions.props
+++ b/eng/testing/ChromeVersions.props
@@ -1,12 +1,12 @@
 <Project>
   <PropertyGroup>
-    <linux_ChromeVersion>123.0.6312.58</linux_ChromeVersion>
-    <linux_ChromeRevision>1262506</linux_ChromeRevision>
-    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1262506</linux_ChromeBaseSnapshotUrl>
-    <linux_V8Version>12.3.219</linux_V8Version>
-    <win_ChromeVersion>123.0.6312.58</win_ChromeVersion>
-    <win_ChromeRevision>1262506</win_ChromeRevision>
-    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1262514</win_ChromeBaseSnapshotUrl>
-    <win_V8Version>12.3.219</win_V8Version>
+    <linux_ChromeVersion>122.0.6261.69</linux_ChromeVersion>
+    <linux_ChromeRevision>1250580</linux_ChromeRevision>
+    <linux_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/1250580</linux_ChromeBaseSnapshotUrl>
+    <linux_V8Version>12.2.281</linux_V8Version>
+    <win_ChromeVersion>122.0.6261.69</win_ChromeVersion>
+    <win_ChromeRevision>1250580</win_ChromeRevision>
+    <win_ChromeBaseSnapshotUrl>https://storage.googleapis.com/chromium-browser-snapshots/Win_x64/1250586</win_ChromeBaseSnapshotUrl>
+    <win_V8Version>12.2.281</win_V8Version>
   </PropertyGroup>
 </Project>

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -271,12 +271,12 @@ public partial class UpdateChromeVersions : MBU.Task
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)
     {
-        string baseUrlForRevision = $"{s_snapshotBaseUrl}?prefix={osPrefix}";
+        string baseUrl = $"{s_snapshotBaseUrl}/{osPrefix}";
 
         int branchPosition = int.Parse(version.branch_base_position);
         for (int i = 0; i < MaxBranchPositionsToCheck; i++)
         {
-            string branchUrl = $"{baseUrlForRevision}/{branchPosition}";
+            string branchUrl = $"{baseUrl}/{branchPosition}";
             string url = $"{branchUrl}/REVISIONS";
 
             Log.LogMessage(MessageImportance.Low, $"Checking if {url} exists ..");
@@ -285,16 +285,14 @@ public partial class UpdateChromeVersions : MBU.Task
                                                     .ConfigureAwait(false);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                string baseUrlForDownload = $"{s_snapshotBaseUrl}/{osPrefix}";
-                string snapshotUrl = $"{baseUrlForDownload}/{branchPosition}";
-                Log.LogMessage(MessageImportance.Low, $"Found {url}. Snapshots should be under ${snapshotUrl}");
-                return snapshotUrl;
+                Log.LogMessage(MessageImportance.Low, $"Found url = {url} with branchUrl = ${branchUrl}");
+                return branchUrl;
             }
 
             branchPosition += 1;
         }
 
-        string message = $"Could not find a chrome snapshot folder under {baseUrlForRevision}, " +
+        string message = $"Could not find a chrome snapshot folder under {baseUrl}, " +
                             $"for branch positions {version.branch_base_position} to " +
                             $"{branchPosition}, for version {version.version}. " +
                             "A fixed version+url can be set in eng/testing/ProvisioningVersions.props .";

--- a/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
+++ b/src/tasks/WasmBuildTasks/UpdateChromeVersions.cs
@@ -271,12 +271,12 @@ public partial class UpdateChromeVersions : MBU.Task
 
     private async Task<string?> FindSnapshotUrlFromBasePositionAsync(string osPrefix, ChromeVersionSpec version, bool throwIfNotFound = true)
     {
-        string baseUrl = $"{s_snapshotBaseUrl}/{osPrefix}";
+        string baseUrlForRevision = $"{s_snapshotBaseUrl}?prefix={osPrefix}";
 
         int branchPosition = int.Parse(version.branch_base_position);
         for (int i = 0; i < MaxBranchPositionsToCheck; i++)
         {
-            string branchUrl = $"{baseUrl}/{branchPosition}";
+            string branchUrl = $"{baseUrlForRevision}/{branchPosition}";
             string url = $"{branchUrl}/REVISIONS";
 
             Log.LogMessage(MessageImportance.Low, $"Checking if {url} exists ..");
@@ -285,14 +285,16 @@ public partial class UpdateChromeVersions : MBU.Task
                                                     .ConfigureAwait(false);
             if (response.StatusCode == HttpStatusCode.OK)
             {
-                Log.LogMessage(MessageImportance.Low, $"Found url = {url} with branchUrl = ${branchUrl}");
-                return branchUrl;
+                string baseUrlForDownload = $"{s_snapshotBaseUrl}/{osPrefix}";
+                string snapshotUrl = $"{baseUrlForDownload}/{branchPosition}";
+                Log.LogMessage(MessageImportance.Low, $"Found {url}. Snapshots should be under ${snapshotUrl}");
+                return snapshotUrl;
             }
 
             branchPosition += 1;
         }
 
-        string message = $"Could not find a chrome snapshot folder under {baseUrl}, " +
+        string message = $"Could not find a chrome snapshot folder under {baseUrlForRevision}, " +
                             $"for branch positions {version.branch_base_position} to " +
                             $"{branchPosition}, for version {version.version}. " +
                             "A fixed version+url can be set in eng/testing/ProvisioningVersions.props .";


### PR DESCRIPTION
Partially reverts dotnet/runtime#100084

The later version of chrome is crashing with MT WASM runtime. This avoids it.