### PR TITLE
[scouting] Reenable msvc vectorization in GC get_promoted_bytes

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -24244,9 +24244,6 @@ size_t gc_heap::get_promoted_bytes()
 
     dprintf (3, ("h%d getting surv", heap_number));
     size_t promoted = 0;
-#ifdef _MSC_VER
-#pragma loop(no_vector)
-#endif
     for (size_t i = 0; i < region_count; i++)
     {
         if (survived_per_region[i] > 0)


### PR DESCRIPTION
[This is expected to fail - double-checking my understanding of toolset selection]

Partially revert "Disable msvc vectorization in GC get_promoted_bytes (#100309)"

This partially reverts commit 765ca4e9f2dddca2005ffdb45863b7980247a886.

(reverts the workaround but keeps the test)