### PR TITLE
Analyze generic parameter dataflow in `Type.GetType`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/RequireDynamicallyAccessedMembersAction.cs
@@ -29,6 +29,11 @@ namespace ILLink.Shared.TrimAnalysis
         {
             if (_reflectionMarker.TryResolveTypeNameAndMark(typeName, _diagnosticContext, needsAssemblyName, _reason, out TypeDesc? foundType))
             {
+                if (foundType.HasInstantiation && _reflectionMarker.Annotations.HasGenericParameterAnnotation(foundType))
+                {
+                    GenericArgumentDataFlow.ProcessGenericArgumentDataFlow(_diagnosticContext, _reflectionMarker, foundType);
+                }
+
                 type = new(foundType);
                 return true;
             }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterWarningLocation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/GenericParameterWarningLocation.cs
@@ -1373,16 +1373,14 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				static void MethodWithAnnotatedParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] string typeName) { }
 
 				// Analyzer: https://github.com/dotnet/runtime/issues/95118
-				// NativeAOT: https://github.com/dotnet/runtime/issues/95140
-				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer)]
+				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				static void AnnotatedParameter ()
 				{
 					MethodWithAnnotatedParameter ("Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithPrivateMethods`1[[Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithRUCMethod]]");
 				}
 
 				// Analyzer: https://github.com/dotnet/runtime/issues/95118
-				// NativeAOT: https://github.com/dotnet/runtime/issues/95140
-				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer)]
+				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 				static string AnnotatedReturnValue ()
 				{
@@ -1393,8 +1391,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				static string _annotatedField;
 
 				// Analyzer: https://github.com/dotnet/runtime/issues/95118
-				// NativeAOT: https://github.com/dotnet/runtime/issues/95140
-				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer)]
+				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				static void AnnotatedField ()
 				{
 					_annotatedField = "Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithPrivateMethods`1[[Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithRUCMethod]]";
@@ -1411,8 +1408,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			class TypeGetType
 			{
 				// Analyzer: https://github.com/dotnet/runtime/issues/95118
-				// NativeAOT: https://github.com/dotnet/runtime/issues/95140
-				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer)]
+				[ExpectedWarning ("IL2026", "TypeWithRUCMethod.PrivateRUCMethod", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
 				static void SpecificType ()
 				{
 					Type.GetType ("Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithPrivateMethods`1[[Mono.Linker.Tests.Cases.DataFlow.GenericParameterWarningLocation+MethodBody+TypeWithRUCMethod]]");

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeUsedViaReflection.cs
@@ -404,10 +404,9 @@ namespace Mono.Linker.Tests.Cases.Reflection
 		[Kept]
 		public class GenericTypeWithAnnotations_InnerType
 		{
-			// NativeAOT: https://github.com/dotnet/runtime/issues/95140
-			[Kept (By = Tool.Trimmer)]
+			[Kept]
 			[KeptBackingField]
-			private static bool PrivateProperty { [Kept (By = Tool.Trimmer)] get; [Kept (By = Tool.Trimmer)] set; }
+			private static bool PrivateProperty { [Kept] get; [Kept] set; }
 
 			private static void PrivateMethod () { }
 		}


### PR DESCRIPTION
Fixes #95140.

Dataflow wasn't looking at flow into annotated generic parameters in `Type.GetType` calls with known strings.

Cc @dotnet/ilc-contrib 