### PR TITLE
Use invariant globalization in cdacreader project

### DIFF
--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Do not produce a public package. This ships as part of the runtime -->
     <IsShippingPackage>false</IsShippingPackage>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I assume cdacreader is not going to have globalization concerns. This speeds up the build a bit because we no longer need to compile things like the Korean calendar. Also makes output smaller (if output size is a concern, we can do a lot more).