### PR TITLE
[mini] Use atomics, instead of loader lock, for JIT wrappers

### DIFF
--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -587,8 +587,8 @@ typedef struct {
 	// have both of them to be non-NULL.
 	const char *name;
 	gconstpointer func;
-	gconstpointer wrapper;
-	gconstpointer trampoline;
+	gconstpointer wrapper__;
+	gconstpointer trampoline__;
 	MonoMethodSignature *sig;
 	const char *c_symbol;
 	MonoMethod *wrapper_method;

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -7198,6 +7198,8 @@ mono_create_icall_signatures (void)
 	}
 }
 
+/* LOCKING: does not take locks. does not use an atomic write to info->wrapper
+ */
 void
 mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const char *name, MonoMethodSignature *sig, gboolean avoid_wrapper, const char *c_symbol)
 {
@@ -7211,7 +7213,7 @@ mono_register_jit_icall_info (MonoJitICallInfo *info, gconstpointer func, const 
 	// Fill in wrapper ahead of time, to just be func, to avoid
 	// later initializing it to anything else. So therefore, no wrapper.
 	if (avoid_wrapper) {
-		info->wrapper = func;
+		info->wrapper__ = func;
 	} else {
 		// Leave it alone in case of a race.
 	}

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6942,7 +6942,7 @@ emit_and_reloc_code (MonoAotCompile *acfg, MonoMethod *method, guint8 *code, gui
 					}
 				} else if (patch_info->type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 					MonoJitICallInfo * const info = mono_find_jit_icall_info (patch_info->data.jit_icall_id);
-					if (!got_only && info->func == info->wrapper) {
+					if (!got_only && info->func == info->wrapper__) {
 						const char * sym = NULL;
 						if (patch_info->data.jit_icall_id == MONO_JIT_ICALL_mono_dummy_runtime_init_callback) {
 							g_assert (acfg->aot_opts.static_link && acfg->aot_opts.runtime_init_callback != NULL);
@@ -10583,7 +10583,7 @@ mono_aot_get_direct_call_symbol (MonoJumpInfoType type, gconstpointer data)
 			sym = lookup_direct_pinvoke_symbol_name_aot (llvm_acfg, method);
 	} else if (type == MONO_PATCH_INFO_JIT_ICALL_ID && (direct_calls || (MonoJitICallId)(gsize)data == MONO_JIT_ICALL_mono_dummy_runtime_init_callback)) {
 		MonoJitICallInfo const * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
-		if (info->func == info->wrapper) {
+		if (info->func == info->wrapper__) {
 			if ((MonoJitICallId)(gsize)data == MONO_JIT_ICALL_mono_dummy_runtime_init_callback) {
 				sym = llvm_acfg->aot_opts.runtime_init_callback;
 			} else {

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -3161,7 +3161,7 @@ emit_call (MonoCompile *cfg, MonoCallInst *call, guint8 *code, MonoJitICallId ji
 					patch.type = MONO_PATCH_INFO_JIT_ICALL_ID;
 					patch.target = GUINT_TO_POINTER (jit_icall_id);
 
-					if (info->func == info->wrapper) {
+					if (info->func == info->wrapper__) {
 						/* No wrapper */
 						if ((((guint64)info->func) >> 32) == 0)
 							near_call = TRUE;

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -2168,7 +2168,7 @@ get_callee_llvmonly (EmitContext *ctx, LLVMTypeRef llvm_sig, MonoJumpInfoType ty
 		if (type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 			MonoJitICallInfo * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
 			g_assert (info);
-			if (info->func != info->wrapper) {
+			if (info->func != info->wrapper__) {
 				type = MONO_PATCH_INFO_METHOD;
 				data = mono_icall_get_wrapper_method (info);
 				callee_name = mono_aot_get_mangled_method_name ((MonoMethod*)data);
@@ -2211,7 +2211,7 @@ get_callee_llvmonly (EmitContext *ctx, LLVMTypeRef llvm_sig, MonoJumpInfoType ty
 	if (ctx->module->assembly->image == mono_get_corlib () && type == MONO_PATCH_INFO_JIT_ICALL_ID) {
 		MonoJitICallInfo * const info = mono_find_jit_icall_info ((MonoJitICallId)(gsize)data);
 
-		if (info->func != info->wrapper) {
+		if (info->func != info->wrapper__) {
 			type = MONO_PATCH_INFO_METHOD;
 			data = mono_icall_get_wrapper_method (info);
 		}

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -2853,7 +2853,7 @@ lookup_start:
 	p = mono_create_ftnptr (code);
 
 	if (callinfo) {
-		mono_atomic_cas_ptr ((volatile void*)&callinfo->wrapper__, NULL, p);
+		mono_atomic_cas_ptr ((volatile void*)&callinfo->wrapper__, p, NULL);
 		p = mono_atomic_load_ptr((volatile gpointer*)&callinfo->wrapper__);
 	}
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/93686

While this doesn't eliminate all deadlocks related to the global loader lock and managed locks, it removes one unneeded use of the loader lock.

The wrapper (and trampoline) of a JIT icall are only ever set from NULL to non-NULL.  We can use atomics to deal with races instad of double checked locking.  This was not the case historically, because the JIT info was dynamically allocated - so we used the loader lock to protect the integrity of the hash table