### PR TITLE
[PERF] Add apt -y autoremove to our setup steps to keep machines clean.

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -79,6 +79,7 @@ jobs:
           echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list &&
           sudo apt-get update &&
           sudo apt-get install nodejs -y &&
+          sudo apt-get -y autoremove &&
           test -n "$(V8Version)" &&
           npm install --prefix $HELIX_WORKITEM_PAYLOAD jsvu -g &&
           $HELIX_WORKITEM_PAYLOAD/bin/jsvu --os=linux64 v8@$(V8Version) &&
@@ -105,6 +106,7 @@ jobs:
         pip3 install --user azure.storage.queue==12.0.0 &&
         sudo apt-get update &&
         sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates &&
+        sudo apt -y autoremove &&
         $(HelixPreCommandsWasmOnLinux) &&
         export PERFLAB_UPLOAD_TOKEN="$(HelixPerfUploadTokenValue)"
         || export PERF_PREREQS_INSTALL_FAILED=1;


### PR DESCRIPTION
Add apt -y autoremove to our setup steps to keep machines clean. This was found/noted in: https://github.com/dotnet/runtime/issues/100910#issuecomment-2049674920.