### PR TITLE
Skip cleanup of eventpipe for mono to prevent crashes on shutdown

### DIFF
--- a/src/mono/mono/eventpipe/ep-rt-mono-profiler-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-profiler-provider.c
@@ -3030,9 +3030,6 @@ void
 ep_rt_mono_profiler_provider_fini (void)
 {
 	if (_mono_profiler_provider_enabled) {
-		if (_mono_profiler_provider_callspec.enabled)
-			mono_callspec_cleanup (&_mono_profiler_provider_callspec);
-
 		if (_mono_profiler_provider) {
 			mono_profiler_set_gc_root_register_callback (_mono_profiler_provider, NULL);
 			mono_profiler_set_gc_root_unregister_callback (_mono_profiler_provider, NULL);
@@ -3100,7 +3097,6 @@ ep_rt_mono_profiler_provider_fini (void)
 
 			mono_profiler_set_call_instrumentation_filter_callback (_mono_profiler_provider, NULL);
 		}
-		_mono_profiler_provider = NULL;
 
 		if (_mono_heap_dump_profiler_provider) {
 			mono_profiler_set_gc_root_register_callback (_mono_heap_dump_profiler_provider, NULL);
@@ -3110,21 +3106,16 @@ ep_rt_mono_profiler_provider_fini (void)
 			mono_profiler_set_gc_resize_callback (_mono_heap_dump_profiler_provider, NULL);
 			mono_profiler_set_gc_finalized_callback (_mono_heap_dump_profiler_provider, NULL);
 		}
-		_mono_heap_dump_profiler_provider = NULL;
 
 		_gc_heap_dump_requests = 0;
 		_gc_heap_dump_in_progress = 0;
 		_gc_heap_dump_trigger_count = 0;
 		_gc_state = 0;
-
-		_mono_profiler_provider_enabled = DEFAULT_MONO_PROFILER_PROVIDER_ENABLED;
-
-		gc_heap_dump_mem_block_free_all ();
-
-		gc_heap_dump_request_params_free ();
-		provider_params_free ();
-
-		ep_rt_spin_lock_free (&_gc_lock);
+		
+		// We were cleaning up resources (mutexes, tls data, etc) here but it races with
+		// other threads on shutdown. Skipping cleanup to prevent failures. If unloading
+		// and not leaking these threads becomes a priority we will have to reimplement
+		// cleanup here.
 	}
 }
 

--- a/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono-runtime-provider.c
@@ -4630,26 +4630,10 @@ ep_rt_mono_runtime_provider_init (void)
 void
 ep_rt_mono_runtime_provider_fini (void)
 {
-	if (_sampled_thread_callstacks)
-		g_array_free (_sampled_thread_callstacks, TRUE);
-	_sampled_thread_callstacks = NULL;
-
-	_max_sampled_thread_count = 32;
-
-	g_free (_runtime_helper_compile_method_jitinfo);
-	_runtime_helper_compile_method_jitinfo = NULL;
-
-	if (_runtime_helper_compile_method)
-		mono_free_method (_runtime_helper_compile_method);
-	_runtime_helper_compile_method = NULL;
-
-	g_free (_monitor_enter_method_jitinfo);
-	_monitor_enter_method_jitinfo = NULL;
-	_monitor_enter_method = NULL;
-
-	g_free (_monitor_enter_v4_method_jitinfo);
-	_monitor_enter_v4_method_jitinfo = NULL;
-	_monitor_enter_v4_method = NULL;
+	// We were cleaning up resources (mutexes, tls data, etc) here but it races with
+	// other threads on shutdown. Skipping cleanup to prevent failures. If unloading
+	// and not leaking these threads becomes a priority we will have to reimplement
+	// cleanup here.
 
 	if (_ep_rt_mono_default_profiler_provider) {
 		mono_profiler_set_jit_begin_callback (_ep_rt_mono_default_profiler_provider, NULL);
@@ -4680,14 +4664,6 @@ ep_rt_mono_runtime_provider_fini (void)
 	_gc_heap_dump_requests = 0;
 	_gc_heap_dump_count = 0;
 	_gc_heap_dump_trigger_count = 0;
-
-	dn_vector_dispose (&_gc_heap_dump_requests_data);
-	memset (&_gc_heap_dump_requests_data, 0, sizeof (_gc_heap_dump_requests_data));
-
-	dn_umap_dispose (&_gc_roots_table);
-	memset (&_gc_roots_table, 0, sizeof (_gc_roots_table));
-
-	ep_rt_spin_lock_free (&_gc_lock);
 }
 
 void

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -850,6 +850,24 @@ ep_rt_mono_init_finish (void)
 }
 
 void
+ep_rt_mono_fini (void)
+{
+	ep_rt_mono_runtime_provider_fini ();
+	ep_rt_mono_profiler_provider_fini ();
+
+	if (_ep_rt_mono_default_profiler_provider) {
+		mono_profiler_set_runtime_initialized_callback (_ep_rt_mono_default_profiler_provider, NULL);
+		mono_profiler_set_thread_started_callback (_ep_rt_mono_default_profiler_provider, NULL);
+		mono_profiler_set_thread_stopped_callback (_ep_rt_mono_default_profiler_provider, NULL);
+	}
+	
+	// We were cleaning up resources (mutexes, tls data, etc) here but it races with
+	// other threads on shutdown. Skipping cleanup to prevent failures. If unloading
+	// and not leaking these threads becomes a priority we will have to reimplement
+	// cleanup here.
+}
+
+void
 EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeRundown (
 	const uint8_t *source_id,

--- a/src/mono/mono/eventpipe/ep-rt-mono.c
+++ b/src/mono/mono/eventpipe/ep-rt-mono.c
@@ -850,49 +850,6 @@ ep_rt_mono_init_finish (void)
 }
 
 void
-ep_rt_mono_fini (void)
-{
-	// Avoid cleaning up resources to prevent cleaning up out from under running
-	// threads.
-	if (!mono_runtime_is_shutting_down ())
-		return;
-
-	ep_rt_mono_runtime_provider_fini ();
-	ep_rt_mono_profiler_provider_fini ();
-
-	if (_eventpipe_initialized)
-		mono_rand_close (_rand_provider);
-
-	_rand_provider = NULL;
-	_eventpipe_initialized = FALSE;
-
-	_ep_rt_mono_runtime_initialized = FALSE;
-
-	if (_ep_rt_mono_default_profiler_provider) {
-		mono_profiler_set_runtime_initialized_callback (_ep_rt_mono_default_profiler_provider, NULL);
-		mono_profiler_set_thread_started_callback (_ep_rt_mono_default_profiler_provider, NULL);
-		mono_profiler_set_thread_stopped_callback (_ep_rt_mono_default_profiler_provider, NULL);
-	}
-	_ep_rt_mono_default_profiler_provider = NULL;
-
-	if (_ep_rt_mono_thread_holder_tls_id)
-		mono_native_tls_free (_ep_rt_mono_thread_holder_tls_id);
-	_ep_rt_mono_thread_holder_tls_id = 0;
-
-	if (_thread_data_tls_id)
-		mono_native_tls_free (_thread_data_tls_id);
-	_thread_data_tls_id = 0;
-
-	_ep_rt_mono_os_cmd_line_init = MONO_LAZY_INIT_STATUS_NOT_INITIALIZED;
-	_ep_rt_mono_os_cmd_line = NULL;
-
-	_ep_rt_mono_managed_cmd_line_init = MONO_LAZY_INIT_STATUS_NOT_INITIALIZED;
-	_ep_rt_mono_managed_cmd_line = NULL;
-
-	ep_rt_spin_lock_free (&_ep_rt_mono_config_lock);
-}
-
-void
 EP_CALLBACK_CALLTYPE
 EventPipeEtwCallbackDotNETRuntimeRundown (
 	const uint8_t *source_id,

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -402,7 +402,10 @@ ep_rt_shutdown (void)
 	mono_lazy_cleanup (managed_command_line_get_init (), managed_command_line_lazy_clean);
 	mono_lazy_cleanup (os_command_line_get_init (), os_command_line_lazy_clean);
 
-	ep_rt_mono_fini ();
+	// We were cleaning up resources (mutexes, tls data, etc) here but it races with
+	// other threads on shutdown. Skipping cleanup to prevent failures. If unloading
+	// and not leaking these threads becomes a priority we will have to reimplement
+	// cleanup here.
 }
 
 static

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -62,6 +62,7 @@ extern void ep_rt_mono_thread_detach (void);
 extern void ep_rt_mono_component_init (void);
 extern void ep_rt_mono_init (void);
 extern void ep_rt_mono_init_finish (void);
+extern void ep_rt_mono_fini (void);
 extern bool ep_rt_mono_walk_managed_stack_for_thread (ep_rt_thread_handle_t thread, EventPipeStackContents *stack_contents);
 extern bool ep_rt_mono_method_get_simple_assembly_name (ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);
 extern bool ep_rt_mono_method_get_full_name (ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);
@@ -401,10 +402,7 @@ ep_rt_shutdown (void)
 	mono_lazy_cleanup (managed_command_line_get_init (), managed_command_line_lazy_clean);
 	mono_lazy_cleanup (os_command_line_get_init (), os_command_line_lazy_clean);
 
-	// We were cleaning up resources (mutexes, tls data, etc) here but it races with
-	// other threads on shutdown. Skipping cleanup to prevent failures. If unloading
-	// and not leaking these threads becomes a priority we will have to reimplement
-	// cleanup here.
+	ep_rt_mono_fini ();
 }
 
 static

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -62,7 +62,6 @@ extern void ep_rt_mono_thread_detach (void);
 extern void ep_rt_mono_component_init (void);
 extern void ep_rt_mono_init (void);
 extern void ep_rt_mono_init_finish (void);
-extern void ep_rt_mono_fini (void);
 extern bool ep_rt_mono_walk_managed_stack_for_thread (ep_rt_thread_handle_t thread, EventPipeStackContents *stack_contents);
 extern bool ep_rt_mono_method_get_simple_assembly_name (ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);
 extern bool ep_rt_mono_method_get_full_name (ep_rt_method_desc_t *method, ep_char8_t *name, size_t name_len);


### PR DESCRIPTION
fixes #99609