### PR TITLE
Run MsQuic tests in parallel.

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -4024,7 +4024,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version20;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Http3 : HttpClientHandlerTest
     {
@@ -4032,7 +4031,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandlerTest_Cookies_Http3 : HttpClientHandlerTest_Cookies
     {
@@ -4040,7 +4038,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3 : HttpClientHandlerTest_Headers
     {
@@ -4048,7 +4045,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3 : SocketsHttpHandler_Cancellation_Test
     {
@@ -4056,7 +4052,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3 : HttpClientHandler_AltSvc_Test
     {
@@ -4064,7 +4059,6 @@ namespace System.Net.Http.Functional.Tests
         protected override Version UseVersion => HttpVersion.Version30;
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http3 : HttpClientHandler_Finalization_Test
     {
@@ -4328,7 +4322,7 @@ namespace System.Net.Http.Functional.Tests
                     };
 
                     policy.ExtraStore.AddRange(caCerts);
-                    policy.CustomTrustStore.Add(caCerts[caCerts.Count -1]);
+                    policy.CustomTrustStore.Add(caCerts[caCerts.Count - 1]);
                     socketsHandler.SslOptions = new SslClientAuthenticationOptions() { CertificateChainPolicy = policy };
 
                     using HttpClient client = CreateHttpClient(handler);
@@ -4490,7 +4484,7 @@ namespace System.Net.Http.Functional.Tests
             options: new GenericLoopbackOptions() { UseSsl = true });
         }
 
-        
+
     }
 
     public sealed class SocketsHttpHandler_HttpRequestErrorTest_Http11 : SocketsHttpHandler_HttpRequestErrorTest
@@ -4533,7 +4527,6 @@ namespace System.Net.Http.Functional.Tests
         }
     }
 
-    [Collection(nameof(DisableParallelization))]
     [ConditionalClass(typeof(HttpClientHandlerTestBase), nameof(IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpRequestErrorTest_Http30 : SocketsHttpHandler_HttpRequestErrorTest
     {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicApi.cs
@@ -62,7 +62,7 @@ internal sealed unsafe partial class MsQuicApi
     internal static string? NotSupportedReason { get; }
 
     // workaround for https://github.com/microsoft/msquic/issues/4132
-    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 4, 0);
+    internal static bool SupportsAsyncCertValidation => Version >= new Version(2, 3, 5);
 
     internal static bool UsesSChannelBackend { get; }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -360,7 +360,7 @@ namespace System.Net.Quic.Tests
         static bool SupportsAsyncCertValidation => QuicTestCollection.MsQuicVersion >= new Version(2, 4);
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074", typeof(MsQuicTests), nameof(SupportsAsyncCertValidation))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/99074")]
         public async Task CertificateCallbackThrowPropagates()
         {
             using CancellationTokenSource cts = new CancellationTokenSource(PassingTestTimeout);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/MsQuicTests.cs
@@ -357,8 +357,6 @@ namespace System.Net.Quic.Tests
             }
         }
 
-        static bool SupportsAsyncCertValidation => QuicTestCollection.MsQuicVersion >= new Version(2, 4);
-
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/99074")]
         public async Task CertificateCallbackThrowPropagates()

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicTestCollection.cs
@@ -15,7 +15,7 @@ using static Microsoft.Quic.MsQuic;
 
 namespace System.Net.Quic.Tests;
 
-[CollectionDefinition(nameof(QuicTestCollection), DisableParallelization = true)]
+[CollectionDefinition(nameof(QuicTestCollection))]
 public unsafe class QuicTestCollection : ICollectionFixture<QuicTestCollection>, IDisposable
 {
     public static bool IsSupported => QuicListener.IsSupported && QuicConnection.IsSupported;


### PR DESCRIPTION
Closes #55979.

Past work in https://github.com/dotnet/runtime/pull/98361 resolved the issue and all CI images have picked up https://github.com/microsoft/msquic/pull/4164.