### PR TITLE
Pass existing credscan suppression file to SDL scan

### DIFF
--- a/eng/pipelines/common/templates/template1es.yml
+++ b/eng/pipelines/common/templates/template1es.yml
@@ -20,6 +20,9 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)/.config/CredScanSuppressions.json
     pool:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022


### PR DESCRIPTION
Avoids duplicate findings in the Guardian tools.