### PR TITLE
Remove Win7 Helix queues

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -146,7 +146,6 @@ jobs:
       - ${{ if notIn(parameters.jobParameters.framework, 'net48') }}:
         # mono outerloop
         - ${{ if and(eq(parameters.jobParameters.testScope, 'outerloop'), eq(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
-          - Windows.7.Amd64.Open
           - Windows.11.Amd64.Client.Open
         # libraries on coreclr (outerloop and innerloop), or libraries on mono innerloop
         - ${{ if or(ne(parameters.jobParameters.testScope, 'outerloop'), ne(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
@@ -155,7 +154,6 @@ jobs:
             - Windows.Amd64.Server2022.Open
           - ${{ if or(ne(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
             - Windows.Amd64.Server2022.Open
-            - Windows.7.Amd64.Open
 
       # .NETFramework
       - ${{ if eq(parameters.jobParameters.framework, 'net48') }}:


### PR DESCRIPTION
Due to changing internal requirements, Helix is decomissioning the Win7 queues.

As a result, we need to stop sending work to them before they are turned off (as any build that uses them after that point will fail.

This will need to be backported.