### PR TITLE
[6.0] Force TLS1.2 in update-machine-certs.ps1

### DIFF
--- a/eng/pipelines/mono/update-machine-certs.ps1
+++ b/eng/pipelines/mono/update-machine-certs.ps1
@@ -5,7 +5,7 @@ Try {
   
     Try {
         $Stream = New-Object System.Net.Security.SslStream($Conn.GetStream())
-        $Stream.AuthenticateAsClient($WebsiteURL) 
+        $Stream.AuthenticateAsClient($WebsiteURL, $null, [System.Security.Authentication.SslProtocols]::Tls12, $true) 
    
         $Cert = $Stream.Get_RemoteCertificate()
  


### PR DESCRIPTION
The Windows image enforces TLS1.2 now so we need to make sure we're using that in the powershell script too.

Fixes https://github.com/dotnet/runtime/issues/100973