### PR TITLE
[release/6.0-staging] Remove Windows 7 helix queues

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -147,18 +147,15 @@ jobs:
       # netcoreapp
       - ${{ if notIn(parameters.jobParameters.framework, 'net48') }}:
         - ${{ if and(eq(parameters.jobParameters.testScope, 'outerloop'), eq(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
-          - Windows.7.Amd64.Open
           - Windows.10.Amd64.ServerRS5.Open
         - ${{ if or(ne(parameters.jobParameters.testScope, 'outerloop'), ne(parameters.jobParameters.runtimeFlavor, 'mono')) }}:
           - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-            - Windows.7.Amd64.Open
             - Windows.10.Amd64.ServerRS5.Open
             - Windows.Amd64.Server2022.Open
           - ${{ if ne(parameters.jobParameters.isFullMatrix, true) }}:
             - ${{ if eq(parameters.jobParameters.buildConfig, 'Release') }}:
               - Windows.Amd64.Server2022.Open
             - ${{ if eq(parameters.jobParameters.buildConfig, 'Debug') }}:
-              - Windows.7.Amd64.Open
               - Windows.Amd64.Server2022.Open
 
       # .NETFramework


### PR DESCRIPTION
Backport of #100981 to release/6.0-staging

## Customer Impact

- [ ] Customer reported
- [X] Found internally

Due to changing internal requirements, Helix is decomissioning the Win7 queues.

As a result, we need to stop sending work to them before they are turned off (as any build that uses them after that point will fail.

## Regression

- [ ] Yes
- [X] No

## Testing

Infrastructure-only removal of a queue, no testing necessary.

## Risk

Low: Simple removal of a Helix queue. We do lose some test coverage, but we can't keep the queue around.

**IMPORTANT**: If this backport is for a servicing release, please verify that:

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.