### PR TITLE
Fix erroneous readonly on a mutable struct

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -35,7 +35,7 @@ namespace System.Runtime
         private const int MaximumCacheSize = 4096; // 4096 * sizeof(CastCacheEntry) is 98304 bytes on 64bit. We will rarely need this much though.
 #endif // DEBUG
 
-        private static readonly CastCache s_castCache = new CastCache(InitialCacheSize, MaximumCacheSize);
+        private static CastCache s_castCache = new CastCache(InitialCacheSize, MaximumCacheSize);
 
         [Flags]
         internal enum AssignmentVariation


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/100995#issuecomment-2052686664