### PR TITLE
Rework ProbabilisticMap character checks in SearchValues

### DIFF
--- a/src/libraries/System.Memory/tests/Span/SearchValues.cs
+++ b/src/libraries/System.Memory/tests/Span/SearchValues.cs
@@ -68,9 +68,31 @@ namespace System.SpanTests
                 "\uFFFF\uFFFE\uFFFD\uFFFC\uFFFB\uFFFA",
                 "\uFFFF\uFFFE\uFFFD\uFFFC\uFFFB\uFFFB",
                 "\uFFFF\uFFFE\uFFFD\uFFFC\uFFFB\uFFF9",
+                new string('\u0080', 256) + '\u0082',
+                new string('\u0080', 100) + '\uF000',
+                new string('\u0080', 256) + '\uF000',
+                string.Concat(Enumerable.Range(128, 255).Select(i => (char)i)),
+                string.Concat(Enumerable.Range(128, 257).Select(i => (char)i)),
+                string.Concat(Enumerable.Range(128, 254).Select(i => (char)i)) + '\uF000',
+                string.Concat(Enumerable.Range(128, 256).Select(i => (char)i)) + '\uF000',
+                '\0' + string.Concat(Enumerable.Range(2, char.MaxValue - 1).Select(i => (char)i)),
             };
 
-            return values.Select(v => new object[] { v, Encoding.Latin1.GetBytes(v) });
+            foreach (string value in values)
+            {
+                yield return Pair(value);
+                yield return Pair('a' + value);
+
+                // Test some more duplicates
+                if (value.Length > 0)
+                {
+                    yield return Pair(value + value[0]);
+                    yield return Pair(value[0] + value);
+                    yield return Pair(value + value);
+                }
+            }
+
+            static object[] Pair(string value) => new object[] { value, Encoding.Latin1.GetBytes(value) };
         }
 
         [Theory]
@@ -192,10 +214,12 @@ namespace System.SpanTests
 
             static void Test<T>(ReadOnlySpan<T> needle, SearchValues<T> values) where T : struct, INumber<T>, IMinMaxValue<T>
             {
+                HashSet<T> needleSet = needle.ToArray().ToHashSet();
+
                 for (int i = int.CreateChecked(T.MaxValue); i >= 0; i--)
                 {
                     T t = T.CreateChecked(i);
-                    Assert.Equal(needle.Contains(t), values.Contains(t));
+                    Assert.Equal(needleSet.Contains(t), values.Contains(t));
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -435,6 +435,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Any2SearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Any3SearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\BitVector256.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\ProbabilisticMapState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\ProbabilisticWithAsciiCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Any4SearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Any5SearchValues.cs" />
@@ -445,7 +446,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\RangeByteSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\RangeCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\ProbabilisticCharSearchValues.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\Latin1CharSearchValues.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\BitmapCharSearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValues.T.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\SearchValues\SearchValuesDebugView.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
@@ -9,15 +9,14 @@ namespace System.Buffers
     internal sealed class ProbabilisticCharSearchValues : SearchValues<char>
     {
         private ProbabilisticMapState _map;
-        private readonly string _values;
 
         public ProbabilisticCharSearchValues(ReadOnlySpan<char> values, int maxInclusive)
         {
-            _values = new string(values);
             _map = new ProbabilisticMapState(values, maxInclusive);
         }
 
-        internal override char[] GetValues() => _values.ToCharArray();
+        internal override char[] GetValues() =>
+            _map.GetValues();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(char value) =>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticCharSearchValues.cs
@@ -8,31 +8,31 @@ namespace System.Buffers
 {
     internal sealed class ProbabilisticCharSearchValues : SearchValues<char>
     {
-        private ProbabilisticMap _map;
+        private ProbabilisticMapState _map;
         private readonly string _values;
 
-        public ProbabilisticCharSearchValues(scoped ReadOnlySpan<char> values)
+        public ProbabilisticCharSearchValues(ReadOnlySpan<char> values, int maxInclusive)
         {
             _values = new string(values);
-            _map = new ProbabilisticMap(_values);
+            _map = new ProbabilisticMapState(values, maxInclusive);
         }
 
         internal override char[] GetValues() => _values.ToCharArray();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(char value) =>
-            ProbabilisticMap.Contains(ref Unsafe.As<ProbabilisticMap, uint>(ref _map), _values, value);
+            _map.FastContains(value);
 
         internal override int IndexOfAny(ReadOnlySpan<char> span) =>
-            ProbabilisticMap.IndexOfAny(ref Unsafe.As<ProbabilisticMap, uint>(ref _map), ref MemoryMarshal.GetReference(span), span.Length, _values);
+            ProbabilisticMap.IndexOfAny<SearchValues.TrueConst>(ref MemoryMarshal.GetReference(span), span.Length, ref _map);
 
         internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            ProbabilisticMap.IndexOfAnySimpleLoop<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length, _values);
+            ProbabilisticMapState.IndexOfAnySimpleLoop<SearchValues.TrueConst, IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length, ref _map);
 
         internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>
-            ProbabilisticMap.LastIndexOfAny(ref Unsafe.As<ProbabilisticMap, uint>(ref _map), ref MemoryMarshal.GetReference(span), span.Length, _values);
+            ProbabilisticMap.LastIndexOfAny<SearchValues.TrueConst>(ref MemoryMarshal.GetReference(span), span.Length, ref _map);
 
         internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            ProbabilisticMap.LastIndexOfAnySimpleLoop<IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length, _values);
+            ProbabilisticMapState.LastIndexOfAnySimpleLoop<SearchValues.TrueConst, IndexOfAnyAsciiSearcher.Negate>(ref MemoryMarshal.GetReference(span), span.Length, ref _map);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -10,6 +10,8 @@ using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
 
+#pragma warning disable CS8500 // Takes the address of a managed type
+
 namespace System.Buffers
 {
     /// <summary>Data structure used to optimize checks for whether a char is in a set of chars.</summary>
@@ -97,7 +99,7 @@ namespace System.Buffers
             Contains(values, (char)ch);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool Contains(ReadOnlySpan<char> values, char ch) =>
+        internal static bool Contains(ReadOnlySpan<char> values, char ch) =>
             SpanHelpers.NonPackedContainsValueType(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(values)),
                 (short)ch,
@@ -343,78 +345,64 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static int ProbabilisticIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+        private static unsafe int ProbabilisticIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
-            var map = new ProbabilisticMap(valuesSpan);
-            ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
+            // ProbabilisticMapState can hold either a precomputed hash table or a pointer to the values.
+            // Precomputing the table is relatively expensive, so we only do it when using SearchValues where instances can be reused.
+            var state = new ProbabilisticMapState(&valuesSpan);
 
-            return IndexOfAny(ref charMap, ref searchSpace, searchSpaceLength, valuesSpan);
+            // The FalseConst here indicates that we can't use the fast character checks and must instead check the values span.
+            return IndexOfAny<SearchValues.FalseConst>(ref searchSpace, searchSpaceLength, ref state);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static int ProbabilisticLastIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
+        private static unsafe int ProbabilisticLastIndexOfAny(ref char searchSpace, int searchSpaceLength, ref char values, int valuesLength)
         {
             var valuesSpan = new ReadOnlySpan<char>(ref values, valuesLength);
 
-            var map = new ProbabilisticMap(valuesSpan);
-            ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
+            // ProbabilisticMapState can hold either a precomputed hash table or a pointer to the values.
+            // Precomputing the table is relatively expensive, so we only do it when using SearchValues where instances can be reused.
+            var state = new ProbabilisticMapState(&valuesSpan);
 
-            return LastIndexOfAny(ref charMap, ref searchSpace, searchSpaceLength, valuesSpan);
+            // The FalseConst here indicates that we can't use the fast character checks and must instead check the values span.
+            return LastIndexOfAny<SearchValues.FalseConst>(ref searchSpace, searchSpaceLength, ref state);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOfAny(ref uint charMap, ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
+        internal static int IndexOfAny<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             if ((Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && searchSpaceLength >= 16)
             {
                 return Vector512.IsHardwareAccelerated && Avx512Vbmi.VL.IsSupported
-                    ? IndexOfAnyVectorizedAvx512(ref charMap, ref searchSpace, searchSpaceLength, values)
-                    : IndexOfAnyVectorized(ref charMap, ref searchSpace, searchSpaceLength, values);
+                    ? IndexOfAnyVectorizedAvx512<TUseFastContains>(ref searchSpace, searchSpaceLength, ref state)
+                    : IndexOfAnyVectorized<TUseFastContains>(ref searchSpace, searchSpaceLength, ref state);
             }
 
-            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
-            ref char cur = ref searchSpace;
-
-            while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
-            {
-                int ch = cur;
-                if (Contains(ref charMap, values, ch))
-                {
-                    return MatchOffset(ref searchSpace, ref cur);
-                }
-
-                cur = ref Unsafe.Add(ref cur, 1);
-            }
-
-            return -1;
+            return ProbabilisticMapState.IndexOfAnySimpleLoop<TUseFastContains, IndexOfAnyAsciiSearcher.DontNegate>(ref searchSpace, searchSpaceLength, ref state);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LastIndexOfAny(ref uint charMap, ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
+        internal static int LastIndexOfAny<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
-            for (int i = searchSpaceLength - 1; i >= 0; i--)
-            {
-                int ch = Unsafe.Add(ref searchSpace, i);
-                if (Contains(ref charMap, values, ch))
-                {
-                    return i;
-                }
-            }
+            // TODO: Implement vectorized LastIndexOfAny.
 
-            return -1;
+            return ProbabilisticMapState.LastIndexOfAnySimpleLoop<TUseFastContains, IndexOfAnyAsciiSearcher.DontNegate>(ref searchSpace, searchSpaceLength, ref state);
         }
 
         [CompExactlyDependsOn(typeof(Avx512Vbmi.VL))]
-        private static int IndexOfAnyVectorizedAvx512(ref uint charMap, ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
+        private static int IndexOfAnyVectorizedAvx512<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             Debug.Assert(Avx512Vbmi.VL.IsSupported);
             Debug.Assert(searchSpaceLength >= 16);
 
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            Vector256<byte> charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<uint, byte>(ref charMap));
+            Vector256<byte> charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
 
             if (searchSpaceLength > 32)
             {
@@ -431,7 +419,7 @@ namespace System.Buffers
 
                         if (result != Vector512<byte>.Zero)
                         {
-                            if (TryFindMatch(ref cur, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), values, out int index))
+                            if (TryFindMatch<TUseFastContains>(ref cur, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), ref state, out int index))
                             {
                                 return MatchOffset(ref searchSpace, ref cur) + index;
                             }
@@ -461,7 +449,7 @@ namespace System.Buffers
 
                     if (result != Vector512<byte>.Zero)
                     {
-                        if (TryFindMatchOverlapped(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), values, out int index))
+                        if (TryFindMatchOverlapped<TUseFastContains>(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector512Result(result).ExtractMostSignificantBits(), ref state, out int index))
                         {
                             return index;
                         }
@@ -478,7 +466,7 @@ namespace System.Buffers
 
                 if (result != Vector256<byte>.Zero)
                 {
-                    if (TryFindMatchOverlapped(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), values, out int index))
+                    if (TryFindMatchOverlapped<TUseFastContains>(ref searchSpace, searchSpaceLength, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), ref state, out int index))
                     {
                         return index;
                     }
@@ -490,7 +478,8 @@ namespace System.Buffers
 
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Sse41))]
-        private static int IndexOfAnyVectorized(ref uint charMap, ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> values)
+        private static int IndexOfAnyVectorized<TUseFastContains>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             Debug.Assert(Sse41.IsSupported || AdvSimd.Arm64.IsSupported);
             Debug.Assert(searchSpaceLength >= 16);
@@ -498,8 +487,8 @@ namespace System.Buffers
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
             ref char cur = ref searchSpace;
 
-            Vector128<byte> charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<uint, byte>(ref charMap));
-            Vector128<byte> charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<uint, byte>(ref charMap), (nuint)Vector128<byte>.Count);
+            Vector128<byte> charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            Vector128<byte> charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map), (nuint)Vector128<byte>.Count);
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // In this case, we have an else clause which has the same semantic meaning whether or not Avx2 is considered supported or unsupported
             if (Avx2.IsSupported && searchSpaceLength >= 32)
@@ -516,7 +505,7 @@ namespace System.Buffers
 
                     if (result != Vector256<byte>.Zero)
                     {
-                        if (TryFindMatch(ref cur, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), values, out int index))
+                        if (TryFindMatch<TUseFastContains>(ref cur, PackedSpanHelpers.FixUpPackedVector256Result(result).ExtractMostSignificantBits(), ref state, out int index))
                         {
                             return MatchOffset(ref searchSpace, ref cur) + index;
                         }
@@ -556,7 +545,7 @@ namespace System.Buffers
 
                 if (result != Vector128<byte>.Zero)
                 {
-                    if (TryFindMatch(ref cur, result.ExtractMostSignificantBits(), values, out int index))
+                    if (TryFindMatch<TUseFastContains>(ref cur, result.ExtractMostSignificantBits(), ref state, out int index))
                     {
                         return MatchOffset(ref searchSpace, ref cur) + index;
                     }
@@ -584,13 +573,14 @@ namespace System.Buffers
             (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindMatch(ref char cur, uint mask, ReadOnlySpan<char> values, out int index)
+        private static bool TryFindMatch<TUseFastContains>(ref char cur, uint mask, ref ProbabilisticMapState state, out int index)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             do
             {
                 index = BitOperations.TrailingZeroCount(mask);
 
-                if (Contains(values, Unsafe.Add(ref cur, index)))
+                if (state.ConfirmProbabilisticMatch<TUseFastContains>(Unsafe.Add(ref cur, index)))
                 {
                     return true;
                 }
@@ -604,7 +594,8 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindMatchOverlapped(ref char cur, int searchSpaceLength, uint mask, ReadOnlySpan<char> values, out int index)
+        private static bool TryFindMatchOverlapped<TUseFastContains>(ref char cur, int searchSpaceLength, uint mask, ref ProbabilisticMapState state, out int index)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             do
             {
@@ -617,7 +608,7 @@ namespace System.Buffers
                     index += searchSpaceLength - (2 * Vector256<ushort>.Count);
                 }
 
-                if (Contains(values, Unsafe.Add(ref cur, index)))
+                if (state.ConfirmProbabilisticMatch<TUseFastContains>(Unsafe.Add(ref cur, index)))
                 {
                     return true;
                 }
@@ -631,13 +622,14 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindMatch(ref char cur, ulong mask, ReadOnlySpan<char> values, out int index)
+        private static bool TryFindMatch<TUseFastContains>(ref char cur, ulong mask, ref ProbabilisticMapState state, out int index)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             do
             {
                 index = BitOperations.TrailingZeroCount(mask);
 
-                if (Contains(values, Unsafe.Add(ref cur, index)))
+                if (state.ConfirmProbabilisticMatch<TUseFastContains>(Unsafe.Add(ref cur, index)))
                 {
                     return true;
                 }
@@ -651,7 +643,8 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindMatchOverlapped(ref char cur, int searchSpaceLength, ulong mask, ReadOnlySpan<char> values, out int index)
+        private static bool TryFindMatchOverlapped<TUseFastContains>(ref char cur, int searchSpaceLength, ulong mask, ref ProbabilisticMapState state, out int index)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
         {
             do
             {
@@ -664,7 +657,7 @@ namespace System.Buffers
                     index += searchSpaceLength - (2 * Vector512<ushort>.Count);
                 }
 
-                if (Contains(values, Unsafe.Add(ref cur, index)))
+                if (state.ConfirmProbabilisticMatch<TUseFastContains>(Unsafe.Add(ref cur, index)))
                 {
                     return true;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -61,6 +61,16 @@ namespace System.Buffers
             _slowContainsValuesPtr = valuesPtr;
         }
 
+        public char[] GetValues()
+        {
+            Debug.Assert(_hashEntries is not null);
+
+            var unique = new HashSet<char>(_hashEntries);
+            char[] values = new char[unique.Count];
+            unique.CopyTo(values);
+            return values;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool FastContains(char value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -1,0 +1,299 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+#pragma warning disable CS8500 // Takes the address of a managed type
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Stores the state necessary to call vectorized members on <see cref="ProbabilisticMap"/>,
+    /// as well as (optionally) a precomputed perfect hash table for faster single-character lookups/match confirmations.
+    /// When the hash table isn't available, the structure stores a pointer to the span of values in the set instead.
+    /// </summary>
+    internal unsafe struct ProbabilisticMapState
+    {
+        private const int MaxModulus = char.MaxValue + 1;
+
+        public ProbabilisticMap Map;
+
+        // Hash entries store each value from the set at the index determined by the remainder modulo the table size.
+        // As every value has a unique remainder, we can check if a value is contained in the set by checking
+        // _hashEntries[value % _hashEntries.Length] == value (see FastContains below).
+        // The multiplier is used for faster modulo operations when determining the hash table index.
+        // Exactly one of _hashEntries and _slowContainsValuesPtr may be initialized at the same time.
+        private readonly uint _multiplier;
+        private readonly char[]? _hashEntries;
+        private readonly ReadOnlySpan<char>* _slowContainsValuesPtr;
+
+        public ProbabilisticMapState(ReadOnlySpan<char> values, int maxInclusive)
+        {
+            Debug.Assert(!values.IsEmpty);
+
+            Map = new ProbabilisticMap(values);
+
+            uint modulus = FindModulus(values, maxInclusive);
+            _multiplier = GetFastModMultiplier(modulus);
+            _hashEntries = new char[modulus];
+
+            // Some hash entries will remain unused.
+            // We can't leave them uninitialized as that would lead to false positives for values divisible by modulus.
+            _hashEntries.AsSpan().Fill(values[0]);
+
+            foreach (char c in values)
+            {
+                _hashEntries[FastMod(c, modulus, _multiplier)] = c;
+            }
+        }
+
+        // valuesPtr must remain valid for as long as this ProbabilisticMapState is used.
+        public unsafe ProbabilisticMapState(ReadOnlySpan<char>* valuesPtr)
+        {
+            Debug.Assert((IntPtr)valuesPtr != IntPtr.Zero);
+
+            Map = new ProbabilisticMap(*valuesPtr);
+            _slowContainsValuesPtr = valuesPtr;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool FastContains(char value)
+        {
+            Debug.Assert(_hashEntries is not null);
+            Debug.Assert((IntPtr)_slowContainsValuesPtr == IntPtr.Zero);
+
+            return FastContains(_hashEntries, _multiplier, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool FastContains(char[] hashEntries, uint multiplier, char value)
+        {
+            ulong offset = FastMod(value, (uint)hashEntries.Length, multiplier);
+            Debug.Assert(offset < (ulong)hashEntries.Length);
+
+            return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(hashEntries), (nuint)offset) == value;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool SlowProbabilisticContains(char value)
+        {
+            Debug.Assert(_hashEntries is null);
+            Debug.Assert((IntPtr)_slowContainsValuesPtr != IntPtr.Zero);
+
+            return ProbabilisticMap.Contains(
+                ref Unsafe.As<ProbabilisticMap, uint>(ref Map),
+                *_slowContainsValuesPtr,
+                value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool SlowContains(char value)
+        {
+            Debug.Assert(_hashEntries is null);
+            Debug.Assert((IntPtr)_slowContainsValuesPtr != IntPtr.Zero);
+
+            return ProbabilisticMap.Contains(*_slowContainsValuesPtr, value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ConfirmProbabilisticMatch<TUseFastContains>(char value)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
+        {
+            if (TUseFastContains.Value)
+            {
+                return FastContains(value);
+            }
+            else
+            {
+                // We use SlowContains instead of SlowProbabilisticContains here as we've already checked
+                // the value against the probabilistic filter and are now confirming the potential match.
+                return SlowContains(value);
+            }
+        }
+
+        /// <summary>Finds a modulus where remainders for all values in the set are unique.</summary>
+        private static uint FindModulus(ReadOnlySpan<char> values, int maxInclusive)
+        {
+            Debug.Assert(maxInclusive <= char.MaxValue);
+
+            int modulus = HashHelpers.GetPrime(values.Length);
+            bool removedDuplicates = false;
+
+            if (modulus >= maxInclusive)
+            {
+                return (uint)(maxInclusive + 1);
+            }
+
+            while (true)
+            {
+                if (modulus >= maxInclusive)
+                {
+                    // Try to remove duplicates and try again.
+                    if (!removedDuplicates && TryRemoveDuplicates(values, out char[]? deduplicated))
+                    {
+                        removedDuplicates = true;
+                        values = deduplicated;
+                        modulus = HashHelpers.GetPrime(values.Length);
+                        continue;
+                    }
+
+                    return (uint)(maxInclusive + 1);
+                }
+
+                if (TestModulus(values, modulus))
+                {
+                    return (uint)modulus;
+                }
+
+                modulus = HashHelpers.GetPrime(modulus + 1);
+            }
+
+            static bool TestModulus(ReadOnlySpan<char> values, int modulus)
+            {
+                Debug.Assert(modulus < MaxModulus);
+
+                bool[] seen = ArrayPool<bool>.Shared.Rent(modulus);
+                seen.AsSpan(0, modulus).Clear();
+
+                uint multiplier = GetFastModMultiplier((uint)modulus);
+
+                foreach (char c in values)
+                {
+                    ulong index = FastMod(c, (uint)modulus, multiplier);
+
+                    if (seen[index])
+                    {
+                        ArrayPool<bool>.Shared.Return(seen);
+                        return false;
+                    }
+
+                    seen[index] = true;
+                }
+
+                // Saw no duplicates.
+                ArrayPool<bool>.Shared.Return(seen);
+                return true;
+            }
+
+            static bool TryRemoveDuplicates(ReadOnlySpan<char> values, [NotNullWhen(true)] out char[]? deduplicated)
+            {
+                HashSet<char> unique = [.. values];
+
+                if (unique.Count == values.Length)
+                {
+                    deduplicated = null;
+                    return false;
+                }
+
+                deduplicated = new char[unique.Count];
+                unique.CopyTo(deduplicated);
+                return true;
+            }
+        }
+
+        // This is a variant of HashHelpers.GetFastModMultiplier, specialized for smaller divisors (<= 65536).
+        private static uint GetFastModMultiplier(uint divisor)
+        {
+            Debug.Assert(divisor > 0);
+            Debug.Assert(divisor <= MaxModulus);
+
+            return uint.MaxValue / divisor + 1;
+        }
+
+        // This is a faster variant of HashHelpers.FastMod, specialized for smaller divisors (<= 65536).
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong FastMod(char value, uint divisor, uint multiplier)
+        {
+            Debug.Assert(multiplier == GetFastModMultiplier(divisor));
+
+            ulong result = ((ulong)(multiplier * value) * divisor) >> 32;
+
+            Debug.Assert(result == (value % divisor));
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOfAnySimpleLoop<TUseFastContains, TNegator>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
+            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
+        {
+            ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
+            ref char cur = ref searchSpace;
+
+            if (TUseFastContains.Value)
+            {
+                Debug.Assert(state._hashEntries is not null);
+
+                char[] hashEntries = state._hashEntries;
+                uint multiplier = state._multiplier;
+
+                while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
+                {
+                    char c = cur;
+                    if (TNegator.NegateIfNeeded(FastContains(hashEntries, multiplier, c)))
+                    {
+                        return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    }
+
+                    cur = ref Unsafe.Add(ref cur, 1);
+                }
+            }
+            else
+            {
+                while (!Unsafe.AreSame(ref cur, ref searchSpaceEnd))
+                {
+                    char c = cur;
+                    if (TNegator.NegateIfNeeded(state.SlowProbabilisticContains(c)))
+                    {
+                        return (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref cur) / sizeof(char));
+                    }
+
+                    cur = ref Unsafe.Add(ref cur, 1);
+                }
+            }
+
+            return -1;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int LastIndexOfAnySimpleLoop<TUseFastContains, TNegator>(ref char searchSpace, int searchSpaceLength, ref ProbabilisticMapState state)
+            where TUseFastContains : struct, SearchValues.IRuntimeConst
+            where TNegator : struct, IndexOfAnyAsciiSearcher.INegator
+        {
+            if (TUseFastContains.Value)
+            {
+                Debug.Assert(state._hashEntries is not null);
+
+                char[] hashEntries = state._hashEntries;
+                uint multiplier = state._multiplier;
+
+                while (--searchSpaceLength >= 0)
+                {
+                    char c = Unsafe.Add(ref searchSpace, searchSpaceLength);
+                    if (TNegator.NegateIfNeeded(FastContains(hashEntries, multiplier, c)))
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                while (--searchSpaceLength >= 0)
+                {
+                    char c = Unsafe.Add(ref searchSpace, searchSpaceLength);
+                    if (TNegator.NegateIfNeeded(state.SlowProbabilisticContains(c)))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return searchSpaceLength;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -43,7 +43,8 @@ namespace System.Buffers
             _hashEntries = new char[modulus];
 
             // Some hash entries will remain unused.
-            // We can't leave them uninitialized as that would lead to false positives for values divisible by modulus.
+            // We can't leave them uninitialized as we would otherwise erroneously match (char)0.
+            // The exact value doesn't matter, as long as it's in the set of our values.
             _hashEntries.AsSpan().Fill(values[0]);
 
             foreach (char c in values)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -16,7 +16,6 @@ namespace System.Buffers
         private IndexOfAnyAsciiSearcher.AsciiState _asciiState;
         private IndexOfAnyAsciiSearcher.AsciiState _inverseAsciiState;
         private ProbabilisticMapState _map;
-        private readonly string _values;
 
         public ProbabilisticWithAsciiCharSearchValues(ReadOnlySpan<char> values, int maxInclusive)
         {
@@ -26,11 +25,11 @@ namespace System.Buffers
             IndexOfAnyAsciiSearcher.ComputeAsciiState(values, out _asciiState);
             _inverseAsciiState = _asciiState.CreateInverse();
 
-            _values = new string(values);
-            _map = new ProbabilisticMapState(_values, maxInclusive);
+            _map = new ProbabilisticMapState(values, maxInclusive);
         }
 
-        internal override char[] GetValues() => _values.ToCharArray();
+        internal override char[] GetValues() =>
+            _map.GetValues();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override bool ContainsCore(char value) =>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -3,9 +3,7 @@
 
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.Wasm;
 using System.Runtime.Intrinsics.X86;
@@ -159,36 +157,52 @@ namespace System.Buffers
                 return new Any5SearchValues<char, short>(shortValues);
             }
 
-            scoped ReadOnlySpan<char> probabilisticValues = values;
-
-            if (Vector128.IsHardwareAccelerated && values.Length < 8)
-            {
-                // ProbabilisticMap does a Span.Contains check to confirm potential matches.
-                // If we have fewer than 8 values, pad them with existing ones to make the verification faster.
-                Span<char> newValues = stackalloc char[8];
-                newValues.Fill(values[0]);
-                values.CopyTo(newValues);
-                probabilisticValues = newValues;
-            }
-
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && minInclusive < 128)
             {
                 // If we have both ASCII and non-ASCII characters, use an implementation that
                 // does an optimistic ASCII fast-path and then falls back to the ProbabilisticMap.
 
-                return (Ssse3.IsSupported || PackedSimd.IsSupported) && probabilisticValues.Contains('\0')
-                    ? new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(probabilisticValues)
-                    : new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(probabilisticValues);
+                return (Ssse3.IsSupported || PackedSimd.IsSupported) && values.Contains('\0')
+                    ? new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle>(values, maxInclusive)
+                    : new ProbabilisticWithAsciiCharSearchValues<IndexOfAnyAsciiSearcher.Default>(values, maxInclusive);
             }
 
-            // We prefer using the ProbabilisticMap over Latin1CharSearchValues if the former is vectorized.
-            if (!(Sse41.IsSupported || AdvSimd.Arm64.IsSupported) && maxInclusive < 256)
+            if (ShouldUseProbabilisticMap(values.Length, maxInclusive))
             {
-                // This will also match ASCII values when IndexOfAnyAsciiSearcher is not supported.
-                return new Latin1CharSearchValues(values);
+                return new ProbabilisticCharSearchValues(values, maxInclusive);
             }
 
-            return new ProbabilisticCharSearchValues(probabilisticValues);
+            // This will also match ASCII values when IndexOfAnyAsciiSearcher is not supported.
+            return new BitmapCharSearchValues(values, maxInclusive);
+
+            static bool ShouldUseProbabilisticMap(int valuesLength, int maxInclusive)
+            {
+                // *Rough estimates*. The current implementation uses 256 bits for the bloom filter.
+                // If the implementation is vectorized we can get away with a decent false positive rate.
+                const int MaxValuesForProbabilisticMap = 256;
+
+                if (valuesLength > MaxValuesForProbabilisticMap)
+                {
+                    // If the number of values is too high, we won't see any benefits from the 'probabilistic' part.
+                    return false;
+                }
+
+                if (Sse41.IsSupported || AdvSimd.Arm64.IsSupported)
+                {
+                    // If the probabilistic map is vectorized, we prefer it.
+                    return true;
+                }
+
+                // The probabilistic map is more memory efficient for spare sets, while the bitmap is more efficient for dense sets.
+                int bitmapFootprintBytesEstimate = 64 + (maxInclusive / 8);
+                int probabilisticFootprintBytesEstimate = 128 + (valuesLength * 6);
+
+                // The bitmap is a bit faster than the perfect hash checks employed by the probabilistic map.
+                // Sacrifice some memory usage for faster lookups.
+                const int AcceptableSizeMultiplier = 2;
+
+                return AcceptableSizeMultiplier * probabilisticFootprintBytesEstimate < bitmapFootprintBytesEstimate;
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -195,7 +195,7 @@ namespace System.Buffers
 
                 // The probabilistic map is more memory efficient for spare sets, while the bitmap is more efficient for dense sets.
                 int bitmapFootprintBytesEstimate = 64 + (maxInclusive / 8);
-                int probabilisticFootprintBytesEstimate = 128 + (valuesLength * 6);
+                int probabilisticFootprintBytesEstimate = 128 + (valuesLength * 4);
 
                 // The bitmap is a bit faster than the perfect hash checks employed by the probabilistic map.
                 // Sacrifice some memory usage for faster lookups.


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/pull/100315#issuecomment-2048108027

The probabilistic map uses an `O(i * m)` fallback for `-Except` methods (scan all the values for each character in the input).
We use the same `O(m)` helper (scan the values) to confirm potential matches in the vectorized helper.

This PR adds support for the probmap to use an `O(1)` contains check for `-Except` methods and match confirmations.
The check is effectively a perfect hash check `entries[value % entries.Length] == value`, but implemented using a variant of `FastMod`. These checks can be inlined into the vectorized methods while not consuming too much memory.
We use this only when the probmap is computed as part of `SearchValues` as finding an optimal modulus is relatively expensive (see `ProbabilisticMapState.FindModulus` - there are probably smarter ways to go about it). When the probabilistic map is created for single-use `IndexOfAny` operations, we still use the same `O(m)` checks as before.

This PR also replaces the `Latin1CharSearchValues` implementation with `BitmapCharSearchValues`, which can use a bitmap of arbitrary size (not limited to `[0, 255]`). We use this when we guess that it'll be faster than the `ProbabilisticMap` (e.g. there are a lot of values in the set, or the set is dense and the probmap isn't vectorized).
I haven't changed the condition when we use `ProbabilisticWithAsciiCharSearchValues` as there are plausible cases where the ASCII fast path may still be useful even if the probabilistic path could be a bitmap instead.

<details>
<summary>Improvements for early matches (cheaper confirmation step)</summary>

```c#
public class IndexOfAnyMixedAsciiNonAscii
{
    private static readonly SearchValues<char> s_charsWithNonAscii = SearchValues.Create("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzK");
    private const string Text = "űaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";

    [Benchmark] // This one will do the confirmation inside the vectorized path
    public int IndexOfAny() => Text.AsSpan().IndexOfAny(s_charsWithNonAscii);
}
```

| Method           | Toolchain | Mean      | Error     | Ratio |
|----------------- |---------- |----------:|----------:|------:|
| IndexOfAny       | main      | 11.236 ns | 0.0375 ns |  1.00 |
| IndexOfAny       | pr        |  7.768 ns | 0.0412 ns |  0.69 |

</details>


<details>
<summary>Improvements for IndexOfAnyExcept (O(1) instead of O(m) character checks)</summary>

```c#
public class IndexOfAnyMixedAsciiNonAscii
{
    private static readonly SearchValues<char> s_charsWithNonAscii = SearchValues.Create("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzK");
    private static readonly string _textExcept = new string('K', 1000);

    [Benchmark]
    public int IndexOfAnyExcept() => _textExcept.AsSpan().IndexOfAnyExcept(s_charsWithNonAscii);
}
```

| Method           | Toolchain | Mean       | Error    | Ratio |
|----------------- |-----------|-----------:|---------:|------:|
| IndexOfAnyExcept | main      | 2,832.7 ns | 10.65 ns |  1.00 |
| IndexOfAnyExcept | pr        |   675.2 ns |  2.39 ns |  0.24 |

Speedup factor is going to depend on how many values are in the set and how early in the `values` each input character matched with the previous implementation.
With the new implementation, the throughput is less dependent on the haystack.

</details>

<details>
<summary>The bitmap vs probmap hash O(1) checks</summary>

```c#
public class IndexOfAnyMixedAsciiNonAscii
{
    private static readonly SearchValues<char> s_bitmap = SearchValues.Create(new string('\u0080', 256) + '\u0082');
    private static readonly SearchValues<char> s_probmap = SearchValues.Create(new string('\u0080', 100) + '\uF000');
    private static readonly string TextExcept = new string('\u0080', 1000);

    [Benchmark]
    public int Bitmap() => TextExcept.AsSpan().IndexOfAnyExcept(s_bitmap);

    [Benchmark]
    public int Probmap() => TextExcept.AsSpan().IndexOfAnyExcept(s_probmap);
}
```

| Method  | Mean     | Error    |
|-------- |---------:|---------:|
| Bitmap  | 754.2 ns | 14.42 ns |
| Probmap | 868.3 ns |  0.11 ns |

</details>

This happens to bring all `SearchValues<char>` implementations to an `O(i)` worst-case (from `O(i * m)`).