### PR TITLE
Fix ArgumentNullException in SecurityIdentifier.CompareTo(null)

### DIFF
--- a/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/libraries/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -861,7 +861,10 @@ namespace System.Security.Principal
 
         public int CompareTo(SecurityIdentifier? sid)
         {
-            ArgumentNullException.ThrowIfNull(sid);
+            if (sid is null)
+            {
+                return 1;
+            }
 
             if (this.IdentifierAuthority < sid.IdentifierAuthority)
             {

--- a/src/libraries/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
+++ b/src/libraries/System.Security.Principal.Windows/tests/WellKnownSidTypeTests.cs
@@ -152,4 +152,15 @@ public class WellKnownSidTypeTests
         Assert.Equal(WellKnownSidType.WinBuiltinTerminalServerLicenseServersSid, WellKnownSidType.MaxDefined);
 #pragma warning restore 0618
     }
+
+    [ConditionalTheory(nameof(AccountIsDomainJoined))]
+    [InlineData(WellKnownSidType.WorldSid)]
+    public void CompareTo_Null(WellKnownSidType sidType)
+    {
+        using (var identity = WindowsIdentity.GetCurrent())
+        {
+            var si = new SecurityIdentifier(sidType, identity.Owner.AccountDomainSid);
+            Assert.Equal(1, si.CompareTo(null));
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100990