### PR TITLE
[NativeAOT] Fix Activator.CreateInstance for shared generic structs

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
@@ -63,7 +63,7 @@ namespace System
                 else
                 {
                     t = default!;
-                    ((delegate* <ref byte, void>)defaultConstructor)(ref Unsafe.As<T, byte>(ref t));
+                    RawCalliHelper.CallDefaultStructConstructor(defaultConstructor, ref Unsafe.As<T, byte>(ref t));
 
                     // Debugger goo so that stepping in works. Only affects debug info generation.
                     // The call gets optimized away.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Activator.NativeAot.cs
@@ -63,7 +63,7 @@ namespace System
                 else
                 {
                     t = default!;
-                    RawCalliHelper.Call(defaultConstructor, ref Unsafe.As<T, byte>(ref t));
+                    ((delegate* <ref byte, void>)defaultConstructor)(ref Unsafe.As<T, byte>(ref t));
 
                     // Debugger goo so that stepping in works. Only affects debug info generation.
                     // The call gets optimized away.

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Array.NativeAot.cs
@@ -143,14 +143,14 @@ namespace System
             if (constructorEntryPoint == IntPtr.Zero)
                 return;
 
-            var constructorFtn = (delegate*<ref byte, void>)RuntimeAugments.TypeLoaderCallbacks.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(constructorEntryPoint, new RuntimeTypeHandle(pElementEEType));
+            IntPtr constructorFtn = RuntimeAugments.TypeLoaderCallbacks.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(constructorEntryPoint, new RuntimeTypeHandle(pElementEEType));
 
             ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(this);
             nuint elementSize = ElementSize;
 
             for (int i = 0; i < Length; i++)
             {
-                constructorFtn(ref arrayRef);
+                RawCalliHelper.CallDefaultStructConstructor(constructorFtn, ref arrayRef);
                 arrayRef = ref Unsafe.Add(ref arrayRef, elementSize);
             }
         }

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -10,6 +10,7 @@ using System.Threading;
 
 using Internal.Runtime;
 using Internal.Runtime.Augments;
+using Internal.Runtime.CompilerServices;
 
 namespace System.Runtime
 {
@@ -162,8 +163,20 @@ namespace System.Runtime
     internal static unsafe class RawCalliHelper
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void Call(System.IntPtr pfn, ref byte data)
-            => ((delegate*<ref byte, void>)pfn)(ref data);
+        public static void CallDefaultStructConstructor(System.IntPtr pfn, ref byte data)
+        {
+            // Manually expand call of the instance method fat pointer. We cannot use a regular C# function
+            // pointer call because it cannot express call of an instance method.
+            if (FunctionPointerOps.IsGenericMethodPointer(pfn))
+            {
+                GenericMethodDescriptor* gmd = FunctionPointerOps.ConvertToGenericDescriptor(pfn);
+                ((delegate*<ref byte, IntPtr, void>)gmd->MethodFunctionPointer)(ref data, gmd->InstantiationArgument);
+            }
+            else
+            {
+                ((delegate*<ref byte, void>)pfn)(ref data);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Call<T>(System.IntPtr pfn, IntPtr arg)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/TypeLoaderExports.cs
@@ -165,8 +165,8 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void CallDefaultStructConstructor(System.IntPtr pfn, ref byte data)
         {
-            // Manually expand call of the instance method fat pointer. We cannot use a regular C# function
-            // pointer call because it cannot express call of an instance method.
+            // Manually expand call of the instance method fat pointer. We cannot use a regular static C# function
+            // pointer call since it would not work for shared generic instance method.
             if (FunctionPointerOps.IsGenericMethodPointer(pfn))
             {
                 GenericMethodDescriptor* gmd = FunctionPointerOps.ConvertToGenericDescriptor(pfn);

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -340,10 +340,10 @@ namespace Internal.Runtime.TypeLoader
                 if (result != IntPtr.Zero)
                 {
                     if (Type.IsValueType)
-                        Environment.FailFast("Here!");
-
-                    // TODO
-                    //      result = TypeLoaderEnvironment.Instance.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(result, new RuntimeTypeHandle(pElementEEType));
+                    {
+                        result = TypeLoaderEnvironment.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(result,
+                            builder.GetRuntimeTypeHandle(Type));
+                    }
                 }
                 else
                 {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/Runtime/TypeLoader/GenericDictionaryCell.cs
@@ -337,9 +337,19 @@ namespace Internal.Runtime.TypeLoader
             {
                 IntPtr result = TypeLoaderEnvironment.TryGetDefaultConstructorForType(Type);
 
+                if (result != IntPtr.Zero)
+                {
+                    if (Type.IsValueType)
+                        Environment.FailFast("Here!");
 
-                if (result == IntPtr.Zero)
+                    // TODO
+                    //      result = TypeLoaderEnvironment.Instance.ConvertUnboxingFunctionPointerToUnderlyingNonUnboxingPointer(result, new RuntimeTypeHandle(pElementEEType));
+                }
+                else
+                {
                     result = RuntimeAugments.GetFallbackDefaultConstructor();
+                }
+
                 return result;
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -326,7 +326,7 @@ namespace ILCompiler
                     {
                         var type = (TypeDesc)targetOfLookup;
                         MethodDesc ctor = GetConstructorForCreateInstanceIntrinsic(type);
-                        return NodeFactory.CanonicalEntrypoint(ctor);
+                        return type.IsValueType ? NodeFactory.ExactCallableAddress(ctor) : NodeFactory.CanonicalEntrypoint(ctor);
                     }
                 case ReadyToRunHelperId.ObjectAllocator:
                     {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -781,7 +781,7 @@ namespace ILCompiler.DependencyAnalysis
         {
             TypeDesc instantiatedType = _type.GetNonRuntimeDeterminedTypeFromRuntimeDeterminedSubtypeViaSubstitution(dictionary.TypeInstantiation, dictionary.MethodInstantiation);
             MethodDesc defaultCtor = Compilation.GetConstructorForCreateInstanceIntrinsic(instantiatedType);
-            return factory.CanonicalEntrypoint(defaultCtor);
+            return instantiatedType.IsValueType ? factory.ExactCallableAddress(defaultCtor) : factory.CanonicalEntrypoint(defaultCtor);
         }
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -360,8 +360,9 @@ namespace Internal.IL
                     }
                     else
                     {
-                        MethodDesc ctor = Compilation.GetConstructorForCreateInstanceIntrinsic(method.Instantiation[0]);
-                        _dependencies.Add(_factory.CanonicalEntrypoint(ctor), reason);
+                        TypeDesc type = method.Instantiation[0];
+                        MethodDesc ctor = Compilation.GetConstructorForCreateInstanceIntrinsic(type);
+                        _dependencies.Add(type.IsValueType ? _factory.ExactCallableAddress(ctor) : _factory.CanonicalEntrypoint(ctor), reason);
                     }
 
                     return;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.Generic.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/ActivatorTests.Generic.cs
@@ -61,6 +61,22 @@ namespace System.Tests
         public void CreateInstanceT_StructWithDefaultConstructorThatThrows_ThrowsTargetInvocationException() =>
             Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance<StructWithDefaultConstructorThatThrows>());
 
+        [Fact]
+        public void CreateInstanceT_GenericTypes()
+        {
+            TestGenericClassWithDefaultConstructor<string>();
+            TestGenericClassWithDefaultConstructor<int>();
+
+            TestGenericStructWithDefaultConstructor<string>();
+            TestGenericStructWithDefaultConstructor<int>();
+
+            void TestGenericClassWithDefaultConstructor<T>()
+                => Assert.Equal(typeof(T), Activator.CreateInstance<GenericClassWithDefaultConstructor<T>>().TypeOfT);
+
+            void TestGenericStructWithDefaultConstructor<T>()
+                => Assert.Equal(typeof(T), Activator.CreateInstance<GenericStructWithDefaultConstructor<T>>().TypeOfT);
+        }
+
         private interface IInterface
         {
         }
@@ -95,6 +111,28 @@ namespace System.Tests
         {
             public ClassWithDefaultConstructorThatThrows() =>
                 throw new Exception();
+        }
+
+        public class GenericClassWithDefaultConstructor<T>
+        {
+            public GenericClassWithDefaultConstructor() =>
+                TypeOfT = typeof(T);
+
+            public Type TypeOfT { get; }
+        }
+
+        public struct StructWithDefaultConstructorThatThrows
+        {
+            public StructWithDefaultConstructorThatThrows() =>
+                throw new Exception();
+        }
+
+        public struct GenericStructWithDefaultConstructor<T>
+        {
+            public GenericStructWithDefaultConstructor() =>
+                TypeOfT = typeof(T);
+
+            public Type TypeOfT { get; }
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/TestStructs/System.TestStructs.il
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/TestStructs/System.TestStructs.il
@@ -57,18 +57,6 @@
             ret
         }
     }
-
-    .class public sequential sealed StructWithDefaultConstructorThatThrows
-        extends [System.Runtime]System.ValueType
-    {
-        .size 1
-
-        .method public hidebysig specialname rtspecialname instance void .ctor () cil managed 
-        {
-            newobj instance void [System.Runtime]System.Exception::.ctor()
-            throw
-        }
-    }
 }
 
 .class public sequential sealed '.GlobalStructStartingWithDot'

--- a/src/tests/nativeaot/SmokeTests/DynamicGenerics/activation.cs
+++ b/src/tests/nativeaot/SmokeTests/DynamicGenerics/activation.cs
@@ -131,6 +131,18 @@ public class My {
             return memberVar;
         }
     }
+    struct StructToString<T>
+    {
+        string memberVar;
+        public StructToString()
+        {
+            memberVar = typeof(T).Name;
+        }
+        public override string ToString()
+        {
+            return memberVar;
+        }
+    }
     class SomeUnrealtedType<T>
     {
         string memberVar;
@@ -195,5 +207,7 @@ public class My {
         AllocViaGVMBase typeWithGVM = AllocViaGVMDerived.Alloc();
         Assert.AreEqual("ToStringIsInteresting1", typeWithGVM.Alloc<ToStringIsInteresting1>().ToString());
         Assert.AreEqual("ToStringIsInteresting2", typeWithGVM.Alloc<ToStringIsInteresting2>().ToString());
+        Assert.AreEqual("ToStringIsInteresting1", typeWithGVM.Alloc<StructToString<ToStringIsInteresting1>>().ToString());
+        Assert.AreEqual("ToStringIsInteresting2", typeWithGVM.Alloc<StructToString<ToStringIsInteresting2>>().ToString());
     }
 }


### PR DESCRIPTION
The default constructor has to be invoked using fat pointer in shared generic structs.
