### PR TITLE
Add GC heap hard limit for 32 bit

### DIFF
--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -3476,6 +3476,8 @@ private:
 
     PER_HEAP_ISOLATED_METHOD BOOL dt_high_memory_load_p();
 
+    PER_HEAP_ISOLATED_METHOD bool compute_hard_limit_from_heap_limits();
+
     PER_HEAP_ISOLATED_METHOD bool compute_hard_limit();
 
     PER_HEAP_ISOLATED_METHOD bool compute_memory_settings(bool is_initialization, uint32_t& nhp, uint32_t nhp_from_config, size_t& seg_size_from_config,


### PR DESCRIPTION
This change enables heap hard limit on 32 bit.

Approach is similar to `DOTNET_GCSegmentSize` (`GCConfig::GetSegmentSize`), which allows to set size of segment for SOH/LOH/POH, and guarantees that there's no oveflow during computations (for example, during `size_t initial_heap_size = soh_segment_size + loh_segment_size + poh_segment_size;`). When `DOTNET_GCSegmentSize` is set on 32bit, it's rounded down to power of 2, so largest possible value of provided segment (SOH) is 2 Gb (`4Mb<=soh_segment_size<=2Gb`). For LOH/POH same value is divided by 2 and then also rounded down to power of 2, so largest possible value of LOH/POH segment is 1 Gb (`4Mb<=loh_segment_size<=1Gb, 0<=poh_segment_size<=1Gb`). So, segment size for SOH/LOH/POH never overflows, as well as `initial_heap_size` (except for oveflow of `initial_heap_size` to 0, which will lead to failed allocation later anyway).

Similar thing happens when `DOTNET_GCHeapHardLimit` or `DOTNET_GCHeapHardLimitSOH`/`DOTNET_GCHeapHardLimitLOH`/`DOTNET_GCHeapHardLimitPOH` are set on 32bit. There're limits on these values:
1) for heap-specific limits:
  `0 <= (heap_hard_limit = heap_hard_limit_oh[soh] + heap_hard_limit_oh[loh] + heap_hard_limit_oh[poh]) < 4Gb`
  `a) 0 <= heap_hard_limit_oh[soh] < 2Gb, 0 <= heap_hard_limit_oh[loh] <= 1Gb, 0 <= heap_hard_limit_oh[poh] <= 1Gb`
  `b) 0 <= heap_hard_limit_oh[soh] <= 1Gb, 0 <= heap_hard_limit_oh[loh] < 2Gb, 0 <= heap_hard_limit_oh[poh] <= 1Gb`
  `c) 0 <= heap_hard_limit_oh[soh] <= 1Gb, 0 <= heap_hard_limit_oh[loh] <= 1Gb, 0 <= heap_hard_limit_oh[poh] < 2Gb`
2) for same limit for all heaps:
  `0 <= heap_hard_limit <= 1Gb`

These ranges guarantee that calculation of soh_segment_size, loh_segment_size and poh_segment_size with alignment and round up won't overflow, as well as calculation of sum of them for allocation (overflow to 0 is allowed, same as for `DOTNET_GCSegmentSize`). When values specified by user with env variables don't meet the requirements above, runtime exits with `CLR_E_GC_BAD_HARD_LIMIT`. When allocation (with `mmap` on Linux) fails, runtime exits with same error as for large segment size specified with `DOTNET_GCSegmentSize`.

This patch doesn't enable heap hard limit on 32bit in containers (`is_restricted_physical_mem`), because current heap hard limit approach is to reserve one large GC heap segment with size equal to specified heap hard limit, and no new segments are reserved in future. On 64 bit in containers by default heap hard limit is set to 75% of total physical memory available, and this is fine, because virtual address space on 64 bit is much larger than actual physical size on devices. In contrast, on 32 bit virtual address space size might be the same as available physical size on device (e.g. 4 Gb for both). This means that reserving 75% of total physical mem will reserve 75% of whole virtual address space, which might be both undesirable (e.g. process later expects more available memory) and `mmap` on Linux will probably fail anyway. 

I've ran release CLR tests on armel Linux with this patch on top of f84d33 with different limits, there seems to be no issues with 4Mb/8Mb/16Mb and 512Mb heap hard limits (some tests fail with "Out of memory"/"OOM" and "System.OutOfMemoryException", as expected, or "System.InvalidOperationException: NoGCRegion mode must be set" when NoGC region is larger than limit). Same for GCStresss 0xc and 0x3 with 4 Mb heap hard limit, and same for debug CLR tests on armel Linux with 4Mb heap hard limit.

@Maoni0 @cshung please share what you think. Thank you.