### PR TITLE
Don't ignore the case when dataflow doesn't know what's going on

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -656,6 +656,12 @@ namespace ILCompiler.Dataflow
                         if (Intrinsics.GetIntrinsicIdForMethod(callingMethodDefinition) == IntrinsicId.RuntimeReflectionExtensions_GetMethodInfo)
                             break;
 
+                        if (param.IsEmpty())
+                        {
+                            // The static value is unknown and the below `foreach` won't execute
+                            reflectionMarker.Dependencies.Add(reflectionMarker.Factory.ReflectedDelegate(null), "Delegate.Method access on unknown delegate type");
+                        }
+
                         foreach (var valueNode in param.AsEnumerable())
                         {
                             TypeDesc? staticType = (valueNode as IValueWithStaticType)?.StaticType?.Type;


### PR DESCRIPTION
Fixes #101026.

TIL that when dataflow doesn't know something, it will model it as no value at all.