### PR TITLE
Insert a breakpoint instruction after throwing calls

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -394,7 +394,7 @@
       Test="true" Category="tools"/>
   </ItemGroup>
 
-  <ItemGroup Condition="$(_subset.Contains('+clr.nativecorelib+'))">
+  <ItemGroup Condition="$(_subset.Contains('+clr.nativecorelib+')) and '$(TargetArchitecture)' != 'arm'">
     <ProjectToBuild Include="$(CoreClrProjectRoot)crossgen-corelib.proj" Category="clr" />
   </ItemGroup>
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3411,6 +3411,18 @@ void CodeGen::genCall(GenTreeCall* call)
     assert((gcInfo.gcRegByrefSetCur & killMask) == 0);
 #endif
 
+    if (call->IsNoReturn())
+    {
+        // There are several situations when we need to add another instruction
+        // after a throwing call to help the OS unwinder determine the correct context during unwind.
+        // It also ensures that the gc register liveness doesn't change across throwing call instructions
+        // in fully-interruptible mode.
+        instGen(INS_BREAKPOINT);
+
+        // nothing else needs to be emitted for this call
+        return;
+    }
+
     var_types returnType = call->TypeGet();
     if (returnType != TYP_VOID)
     {

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -6419,6 +6419,18 @@ void CodeGen::genCall(GenTreeCall* call)
     assert((gcInfo.gcRegByrefSetCur & killMask) == 0);
 #endif
 
+    if (call->IsNoReturn())
+    {
+        // There are several situations when we need to add another instruction
+        // after a throwing call to help the OS unwinder determine the correct context during unwind.
+        // It also ensures that the gc register liveness doesn't change across throwing call instructions
+        // in fully-interruptible mode.
+        instGen(INS_BREAKPOINT);
+
+        // nothing else needs to be emitted for this call
+        return;
+    }
+
     var_types returnType = call->TypeGet();
     if (returnType != TYP_VOID)
     {

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -6495,6 +6495,18 @@ void CodeGen::genCall(GenTreeCall* call)
     assert((gcInfo.gcRegByrefSetCur & killMask) == 0);
 #endif
 
+    if (call->IsNoReturn())
+    {
+        // There are several situations when we need to add another instruction
+        // after a throwing call to help the OS unwinder determine the correct context during unwind.
+        // It also ensures that the gc register liveness doesn't change across throwing call instructions
+        // in fully-interruptible mode.
+        instGen(INS_BREAKPOINT);
+
+        // nothing else needs to be emitted for this call
+        return;
+    }
+
     var_types returnType = call->TypeGet();
     if (returnType != TYP_VOID)
     {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2569,6 +2569,17 @@ bool emitter::emitHasEpilogEnd()
 
 #endif // JIT32_GCENCODER
 
+// Is the last instruction emitted a breakpoint instruction?
+bool emitter::emitIsLastInsBreakpoint()
+{
+    if (emitHasLastIns() && (emitLastIns->idIns() == INS_BREAKPOINT))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 #ifdef TARGET_XARCH
 
 /*****************************************************************************

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2757,6 +2757,9 @@ private:
         return (emitLastIns != nullptr);
     }
 
+    // Is the last instruction emitted a breakpoint instruction?
+    bool emitIsLastInsBreakpoint();
+
     // Checks to see if we can cross between the two given IG boundaries.
     //
     // We have the following checks:


### PR DESCRIPTION
A follow up for https://github.com/dotnet/runtime/pull/100900

See discussion at: https://github.com/dotnet/runtime/pull/100900#discussion_r1562851304

Instead of inserting a breakpoint at the end of `BBJ_THROW` blocks that end on a throwing call, we insert a breakpoint after throwing calls.

The change should end up with roughly the same number of added breakpoint instructions, since a BBJ_THROW nearly always ends with a throwing call anyways. However, this approach would be more robust in rare situations when a throwing call is followed by some extra code, which may potentially be removed at later phases.
