### PR TITLE
[browser][MT] JSImport with DiscardNoWait is OK in the middle of pending synchronous call

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Interop/JavaScriptExports.cs
@@ -289,6 +289,7 @@ namespace System.Runtime.InteropServices.JavaScript
             try
             {
                 var ctx = arg_exc.AssertCurrentThreadContext();
+                // note that this method is only executed when the caller is on another thread, via mono_wasm_invoke_jsexport_sync -> mono_wasm_install_js_worker_interop_wrapper
                 ctx.IsPendingSynchronousCall = true;
                 if (ctx.IsMainThread)
                 {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/JSFunctionBinding.cs
@@ -307,7 +307,7 @@ namespace System.Runtime.InteropServices.JavaScript
 #if FEATURE_WASM_MANAGED_THREADS
             else
             {
-                if (targetContext.IsPendingSynchronousCall && targetContext.IsMainThread)
+                if (targetContext.IsPendingSynchronousCall && targetContext.IsMainThread && !signature.IsDiscardNoWait)
                 {
                     throw new PlatformNotSupportedException("Cannot call synchronous JS function from inside a synchronous call to a C# method.");
                 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/WebWorkerTestBase.cs
@@ -180,6 +180,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             new NamedCall { IsBlocking = false, Name = "new Timer", Call = delegate (CancellationToken ct) {
                 new Timer((_) => { }, null, 1, -1);
             }},
+            new NamedCall { IsBlocking = false, Name = "JSType.DiscardNoWait", Call = delegate (CancellationToken ct) {
+                WebWorkerTestHelper.Log("DiscardNoWait");
+            }},
 
             // things which should throw PNSE on sync JSExport and JSWebWorker
             new NamedCall { IsBlocking = true, Name = "Task.Wait", Call = delegate (CancellationToken ct) { Task.Delay(30, ct).Wait(ct); }},


### PR DESCRIPTION
JSImport with `DiscardNoWait` is OK to be called in the IsPendingSynchronousCall

See [Log](https://helixre107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-pull-101017-merge-f976c959a6804b4098/WasmTestOnBrowser-System.Runtime.InteropServices.JavaScript.Tests/1/console.34c407e9.log?helixlogtype=result)