### PR TITLE
Ensure Array.CreateInstance for reference types works

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -536,7 +536,7 @@ namespace ILCompiler.Dataflow
                     {
                         // We could try to analyze if the type is known, but for now making sure this works for canonical arrays is enough.
                         TypeDesc canonArrayType = reflectionMarker.Factory.TypeSystemContext.CanonType.MakeArrayType();
-                        reflectionMarker.Dependencies.Add(reflectionMarker.Factory.NativeLayout.TemplateTypeLayout(canonArrayType), "Array.CreateInstance was called");
+                        reflectionMarker.MarkType(diagnosticContext.Origin, canonArrayType, "Array.CreateInstance was called");
                         goto case IntrinsicId.None;
                     }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedTypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ReflectedTypeNode.cs
@@ -34,10 +34,17 @@ namespace ILCompiler.DependencyAnalysis
 
         public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory)
         {
-            return new DependencyListEntry[]
-                {
-                    new DependencyListEntry(factory.MaximallyConstructableType(_type), "Reflection target"),
-                };
+            var result = new DependencyList
+            {
+                new DependencyListEntry(factory.MaximallyConstructableType(_type), "Reflection target"),
+            };
+
+            if (_type.IsCanonicalSubtype(CanonicalFormKind.Any))
+            {
+                GenericTypesTemplateMap.GetTemplateTypeDependencies(ref result, factory, _type);
+            }
+
+            return result;
         }
         protected override string GetName(NodeFactory factory)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -1030,7 +1030,12 @@ namespace ILCompiler
                 case TypeFlags.Array:
                 case TypeFlags.Pointer:
                 case TypeFlags.ByRef:
-                    return IsReflectionBlocked(((ParameterizedType)type).ParameterType);
+                    TypeDesc parameterType = ((ParameterizedType)type).ParameterType;
+
+                    if (parameterType.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                        return false;
+
+                    return IsReflectionBlocked(parameterType);
 
                 case TypeFlags.FunctionPointer:
                     MethodSignature pointerSignature = ((FunctionPointerType)type).Signature;


### PR DESCRIPTION
Follow up to #100626. The original fix only worked for unoptimized builds because the list of templates doesn't survive from scanning phase (when we do dataflow) to codegen phase (when we no longer do dataflow).

The test that this was supposed to fix is still failing in #100331.

Cc @dotnet/ilc-contrib 