### PR TITLE
[browser] dont trim fail fast message

### DIFF
--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -32,6 +32,7 @@ declare interface EmscriptenModule {
     UTF8ToString(ptr: CharPtr, maxBytesToRead?: number): string;
     UTF8ArrayToString(u8Array: Uint8Array, idx?: number, maxBytesToRead?: number): string;
     stringToUTF8Array(str: string, heap: Uint8Array, outIdx: number, maxBytesToWrite: number): void;
+    lengthBytesUTF8(str: string): number;
     FS_createPath(parent: string, path: string, canRead?: boolean, canWrite?: boolean): string;
     FS_createDataFile(parent: string, name: string, data: TypedArray, canRead: boolean, canWrite: boolean, canOwn?: boolean): string;
     addFunction(fn: Function, signature: string): number;

--- a/src/mono/browser/runtime/exports.ts
+++ b/src/mono/browser/runtime/exports.ts
@@ -24,6 +24,8 @@ import { jiterpreter_dump_stats } from "./jiterpreter";
 import { forceDisposeProxies } from "./gc-handles";
 import { mono_wasm_dump_threads } from "./pthreads";
 
+import { threads_c_functions as tcwraps } from "./cwraps";
+
 export let runtimeList: RuntimeList;
 
 function initializeExports (globalObjects: GlobalObjects): RuntimeAPI {
@@ -43,6 +45,7 @@ function initializeExports (globalObjects: GlobalObjects): RuntimeAPI {
     };
     if (WasmEnableThreads) {
         rh.dumpThreads = mono_wasm_dump_threads;
+        rh.mono_wasm_print_thread_dump = () => tcwraps.mono_wasm_print_thread_dump();
     }
     Object.assign(runtimeHelpers, rh);
 

--- a/src/mono/browser/runtime/loader/exit.ts
+++ b/src/mono/browser/runtime/loader/exit.ts
@@ -69,7 +69,11 @@ function onAbort (reason: any) {
         originalOnAbort(reason || loaderHelpers.exitReason);
     }
     if (WasmEnableThreads && loaderHelpers.config?.dumpThreadsOnNonZeroExit && runtimeHelpers.mono_wasm_print_thread_dump && loaderHelpers.exitCode === undefined) {
-        runtimeHelpers.mono_wasm_print_thread_dump();
+        try {
+            runtimeHelpers.mono_wasm_print_thread_dump();
+        } catch (e) {
+            // ignore
+        }
     }
     mono_exit(1, reason || loaderHelpers.exitReason);
 }

--- a/src/mono/browser/runtime/loader/exit.ts
+++ b/src/mono/browser/runtime/loader/exit.ts
@@ -68,6 +68,9 @@ function onAbort (reason: any) {
     if (originalOnAbort) {
         originalOnAbort(reason || loaderHelpers.exitReason);
     }
+    if (WasmEnableThreads && loaderHelpers.config?.dumpThreadsOnNonZeroExit && runtimeHelpers.mono_wasm_print_thread_dump && loaderHelpers.exitCode === undefined) {
+        runtimeHelpers.mono_wasm_print_thread_dump();
+    }
     mono_exit(1, reason || loaderHelpers.exitReason);
 }
 

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -237,6 +237,7 @@ export type RuntimeHelpers = {
     jiterpreter_dump_stats?: (concise?: boolean) => void,
     forceDisposeProxies: (disposeMethods: boolean, verbose: boolean) => void,
     dumpThreads: () => void,
+    mono_wasm_print_thread_dump: () => void,
 }
 
 export type AOTProfilerOptions = {

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -759,6 +759,7 @@ const char *   g_get_assertion_message (void);
 #define g_message(...)  g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE, __FILE__, __LINE__)
 #define g_debug(...)    g_log_disabled (G_LOG_DOMAIN, G_LOG_LEVEL_DEBUG, __FILE__, __LINE__)
 #endif
+#define g_warning_dont_trim(...)  g_log (G_LOG_DOMAIN, G_LOG_LEVEL_WARNING, __VA_ARGS__)
 
 typedef void (*GLogFunc) (const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data);
 typedef void (*GPrintFunc) (const gchar *string);

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -6164,16 +6164,16 @@ void
 ves_icall_System_Environment_FailFast (MonoStringHandle message, MonoExceptionHandle exception, MonoStringHandle errorSource, MonoError *error)
 {
 	if (MONO_HANDLE_IS_NULL (errorSource)) {
-		g_warning ("Process terminated.");
+		g_warning_dont_trim ("Process terminated.");
 	} else {
 		char *errorSourceMsg = mono_string_handle_to_utf8 (errorSource, error);
-		g_warning ("Process terminated. %s", errorSourceMsg);
+		g_warning_dont_trim ("Process terminated. %s", errorSourceMsg);
 		g_free (errorSourceMsg);
 	}
 
 	if (!MONO_HANDLE_IS_NULL (message)) {
 		char *msg = mono_string_handle_to_utf8 (message, error);
-		g_warning (msg);
+		g_warning_dont_trim (msg);
 		g_free (msg);
 	}
 


### PR DESCRIPTION
- don't trim `Environment.FailFast` message - because it's on heap not a constant
- call `mono_wasm_print_thread_dump` on the thread with `onAbort`