### PR TITLE
Globbing - Use GetFullPath for normalization on relative files

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -51,13 +51,14 @@ namespace Microsoft.Extensions.FileSystemGlobbing
                 // normalize
                 foreach (string file in files)
                 {
+                    string fileWithNormalSeparators = file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
                     if (Path.IsPathRooted(file))
                     {
-                        fileList.Add(Path.GetFullPath(file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                        fileList.Add(Path.GetFullPath(fileWithNormalSeparators));
                     }
                     else
                     {
-                        fileList.Add(Path.Combine(normalizedRoot, file.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)));
+                        fileList.Add(Path.GetFullPath(Path.Combine(normalizedRoot, fileWithNormalSeparators)));
                     }
                 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100762.

For context: 

> What's causing `file` (in `matcher.Match("./sdk/9.0.100-preview.4.24207.1/.version")` to not match is the leading `./`. I excluded relative paths from using GetFullPath (In https://github.com/dotnet/runtime/pull/94528) in order to decouple them from CWD. However, GetFullPath should still be used on relative paths (combined with rootDir, instead of CWD) so normalization provided by GetFullPath can remove those redundant segments, which are not accounted for in subsequent code.