### PR TITLE
[browser] System.Runtime.InteropServices.JavaScript change should trigger full wasm run

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -22,6 +22,7 @@ parameters:
         src/libraries/sendtohelix-browser.targets
         src/libraries/sendtohelix-wasi.targets
         src/libraries/sendtohelix-wasm.targets
+        src/libraries/System.Runtime.InteropServices.JavaScript/*
         src/mono/mono/**/*wasm*
         src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Sdk/*
         src/mono/nuget/Microsoft.NET.Runtime.WebAssembly.Wasi.Sdk/*


### PR DESCRIPTION
Because https://github.com/dotnet/runtime/pull/101078/ triggered only smoke test for MT