### PR TITLE
[PERF] Remove lttng-modules-dkms package at beginning of microbenchmark runs

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -69,7 +69,6 @@ jobs:
       # nodejs installation steps from https://github.com/nodesource/distributions
       - HelixPreCommandsWasmOnLinux: >-
           export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets &&
-          sudo apt-get remove -y lttng-modules-dkms &&
           sudo apt-get -y remove nodejs &&
           sudo apt-get update &&
           sudo apt-get install -y ca-certificates curl gnupg &&

--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -69,6 +69,7 @@ jobs:
       # nodejs installation steps from https://github.com/nodesource/distributions
       - HelixPreCommandsWasmOnLinux: >-
           export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets &&
+          sudo apt-get remove -y lttng-modules-dkms &&
           sudo apt-get -y remove nodejs &&
           sudo apt-get update &&
           sudo apt-get install -y ca-certificates curl gnupg &&
@@ -93,6 +94,7 @@ jobs:
         echo "** Installing prerequistes **";
         echo "** Waiting for dpkg to unlock (up to 2 minutes) **" &&
         timeout 2m bash -c 'while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do if [ -z "$printed" ]; then echo "Waiting for dpkg lock to be released... Lock is held by: $(ps -o cmd= -p $(sudo fuser /var/lib/dpkg/lock-frontend))"; printed=1; fi; echo "Waiting 5 seconds to check again"; sleep 5; done;' &&
+        sudo apt-get remove -y lttng-modules-dkms &&
         sudo apt-get -y install python3-pip &&
         python3 -m pip install --user -U pip &&
         sudo apt-get -y install python3-venv &&


### PR DESCRIPTION
Add removal of lttng-modules-dkms package as it is currently causing microbenchmarking runs to fail.
Should fix: https://github.com/dotnet/performance/issues/4149

The removal of the lttng-modules-dkms package using the set command causes the python3-pip package install command to succeed instead of failing as it currently is. This will likely have an impact on our scenario testing that uses Lttng (non-microbenchmarks) as I was unable to get a clean install of the lttng-modules-dkms package on both the 6.5.0-27 and -26 kernels.