### PR TITLE
Fix missing explicit frame pop on arm32

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -867,7 +867,7 @@ UINT_PTR ExceptionTracker::FinishSecondPass(
 
 void CleanUpForSecondPass(Thread* pThread, bool fIsSO, LPVOID MemoryStackFpForFrameChain, LPVOID MemoryStackFp);
 
-static void PopExplicitFrames(Thread *pThread, void *targetSp)
+static void PopExplicitFrames(Thread *pThread, void *targetSp, void *targetCallerSp)
 {
     Frame* pFrame = pThread->GetFrame();
     while (pFrame < targetSp)
@@ -875,6 +875,39 @@ static void PopExplicitFrames(Thread *pThread, void *targetSp)
         pFrame->ExceptionUnwind();
         pFrame->Pop(pThread);
         pFrame = pThread->GetFrame();
+    }
+
+    // Check if the pFrame is an active InlinedCallFrame inside of the target frame. It needs to be popped or inactivated depending
+    // on the target architecture / ready to run
+    if ((pFrame < targetCallerSp) && InlinedCallFrame::FrameHasActiveCall(pFrame))
+    {
+        InlinedCallFrame* pInlinedCallFrame = (InlinedCallFrame*)pFrame;
+        // When unwinding an exception in ReadyToRun, the JIT_PInvokeEnd helper which unlinks the ICF from
+        // the thread will be skipped. This is because unlike jitted code, each pinvoke is wrapped by calls
+        // to the JIT_PInvokeBegin and JIT_PInvokeEnd helpers, which push and pop the ICF on the thread. The
+        // ICF is not linked at the method prolog and unlined at the epilog when running R2R code. Since the
+        // JIT_PInvokeEnd helper will be skipped, we need to unlink the ICF here. If the executing method
+        // has another pinvoke, it will re-link the ICF again when the JIT_PInvokeBegin helper is called.
+        TADDR returnAddress = pInlinedCallFrame->m_pCallerReturnAddress;
+#ifdef USE_PER_FRAME_PINVOKE_INIT
+        // If we're setting up the frame for each P/Invoke for the given platform,
+        // then we do this for all P/Invokes except ones in IL stubs.
+        // IL stubs link the frame in for the whole stub, so if an exception is thrown during marshalling,
+        // the ICF will be on the frame chain and inactive.
+        if (!ExecutionManager::GetCodeMethodDesc(returnAddress)->IsILStub())
+#else
+        // If we aren't setting up the frame for each P/Invoke (instead setting up once per method),
+        // then ReadyToRun code is the only code using the per-P/Invoke logic.
+        if (ExecutionManager::IsReadyToRunCode(returnAddress))
+#endif
+        {
+            pFrame->ExceptionUnwind();
+            pFrame->Pop(pThread);
+        }
+        else
+        {
+            pInlinedCallFrame->Reset();
+        }
     }
 
     GCFrame* pGCFrame = pThread->GetGCFrame();
@@ -907,8 +940,8 @@ ProcessCLRExceptionNew(IN     PEXCEPTION_RECORD   pExceptionRecord,
         if ((pExceptionRecord->ExceptionFlags & EXCEPTION_UNWINDING))
         {
             GCX_COOP();
-            PopExplicitFrames(pThread, (void*)GetSP(pContextRecord));
-            ExInfo::PopExInfos(pThread, (void*)GetSP(pContextRecord));
+            PopExplicitFrames(pThread, (void*)pDispatcherContext->EstablisherFrame, (void*)GetSP(pDispatcherContext->ContextRecord));
+            ExInfo::PopExInfos(pThread, (void*)pDispatcherContext->EstablisherFrame);
         }
         return ExceptionContinueSearch;
     }
@@ -7663,6 +7696,7 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
     HandlerFn* pfnHandler = (HandlerFn*)pHandlerIP;
     exInfo->m_ScannedStackRange.ExtendUpperBound(exInfo->m_frameIter.m_crawl.GetRegisterSet()->SP);
     DWORD_PTR dwResumePC = 0;
+    UINT_PTR callerTargetSp = 0;
 
     if (pHandlerIP != NULL)
     {
@@ -7696,10 +7730,11 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
         // Profiler, debugger and ETW events
         exInfo->MakeCallbacksRelatedToHandler(false, pThread, pMD, &exInfo->m_ClauseForCatch, (DWORD_PTR)pHandlerIP, spForDebugger);
         SetIP(pvRegDisplay->pCurrentContext, dwResumePC);
+        callerTargetSp = CallerStackFrame::FromRegDisplay(pvRegDisplay).SP;
     }
 
     UINT_PTR targetSp = GetSP(pvRegDisplay->pCurrentContext);
-    PopExplicitFrames(pThread, (void*)targetSp);
+    PopExplicitFrames(pThread, (void*)targetSp, (void*)callerTargetSp);
 
     ExInfo* pExInfo = (PTR_ExInfo)pThread->GetExceptionState()->GetCurrentExceptionTracker();
 
@@ -7858,7 +7893,8 @@ extern "C" void QCALLTYPE ResumeAtInterceptionLocation(REGDISPLAY* pvRegDisplay)
 
     pExInfo->m_ScannedStackRange.ExtendUpperBound(targetSp);
 
-    PopExplicitFrames(pThread, (void*)targetSp);
+    EECodeManager::EnsureCallerContextIsValid(pvRegDisplay);
+    PopExplicitFrames(pThread, (void*)targetSp, (void*)CallerStackFrame::FromRegDisplay(pvRegDisplay).SP);
 
     // This must be done before we pop the ExInfos.
     BOOL fIntercepted = pThread->GetExceptionState()->GetFlags()->DebuggerInterceptInfo();

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -100,10 +100,6 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
         echo $2 >> $__ResponseFile
 
-
-        if [ "$(Optimize)" == "True" ]%3B then
-            echo -O>>$__ResponseFile
-        fi
         echo -o:$__OutputFile>>$__ResponseFile
         echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
         echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
@@ -259,9 +255,6 @@ if defined RunCrossGen2 (
     set __Command=!__Command! @"!__ResponseFile!"
     set __Command=!__Command! !ExtraCrossGen2Args!
     echo !__InputFile!>>!__ResponseFile!
-    if /i "$(Optimize)" == "True" (
-        echo -O>>!__ResponseFile!
-    )
     echo -o:!__OutputFile!>>!__ResponseFile!
     echo --targetarch:$(TargetArchitecture)>>!__ResponseFile!
     echo --targetos:$(TargetOS)>>!__ResponseFile!

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -100,6 +100,10 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
         echo $2 >> $__ResponseFile
 
+
+        if [ "$(Optimize)" == "True" ]%3B then
+            echo -O>>$__ResponseFile
+        fi
         echo -o:$__OutputFile>>$__ResponseFile
         echo -r:$CORE_ROOT/System.*.dll>>$__ResponseFile
         echo -r:$CORE_ROOT/Microsoft.*.dll>>$__ResponseFile
@@ -255,6 +259,9 @@ if defined RunCrossGen2 (
     set __Command=!__Command! @"!__ResponseFile!"
     set __Command=!__Command! !ExtraCrossGen2Args!
     echo !__InputFile!>>!__ResponseFile!
+    if /i "$(Optimize)" == "True" (
+        echo -O>>!__ResponseFile!
+    )
     echo -o:!__OutputFile!>>!__ResponseFile!
     echo --targetarch:$(TargetArchitecture)>>!__ResponseFile!
     echo --targetos:$(TargetOS)>>!__ResponseFile!

--- a/src/tests/Regressions/coreclr/GitHub_100536/test100536.cs
+++ b/src/tests/Regressions/coreclr/GitHub_100536/test100536.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class Test100536
+{
+    [DllImport("__test", CallingConvention = CallingConvention.Cdecl, EntryPoint = "Nonexistent")]
+    private static extern IntPtr Nonexistent();
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    private static void GarbleStack()
+    {
+        Span<byte> local = stackalloc byte[4096];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Test()
+    {
+        try
+        {
+            Nonexistent();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Expected exception {ex} caught");
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Test();
+        GarbleStack();
+        GC.Collect();
+    }
+}
+

--- a/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Optimize>True</Optimize>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- The issue this test is for can only occur on targets that allow inlining pinvokes in the same frame as the frame of the continuation of catch handler -->
-    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' AND '$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
-    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <Optimize>True</Optimize>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>

--- a/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_100536/test100536.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- The issue this test is for can only occur on targets that allow inlining pinvokes in the same frame as the frame of the continuation of catch handler -->
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' AND '$(TargetArchitecture)' != 'x86'">true</CLRTestTargetUnsupported>
+    <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
+    <Optimize>True</Optimize>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test100536.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
There is an edge case during exception handling on arm32 where an active `InlinedCallFrame` is not popped from the explicit frame list. That later leads to various kinds of failures / crashes. For example, the on Alpine arm32, the `dotnet help` hangs eating 100% of one CPU core. That happens due to code executing after the exception was handled and its stack overwriting the explicit frame contents.

This can only occur when the pinvoke is inlined in a method that calls it inside of a try region with catch in the same method and exception occurs e.g. due to the target native function or the shared library not existing.

What happens is that when we pop the explicit frame, we pop frames that are below the SP of the resume location after catch. But the `InlinedCallFrame` is in this case above that SP, as it was created in the prolog of the method.

To fix that, we need to pop that frame too. The fix uses the same condition as the old EH was using.

While fixing the issue, I've also found that an incorrect SP limit was passed to the `PopExplicitFrames` in the `ProcessCLRExceptionNew` in case of an unhandled exception. This doesn't probably cause any bad effect due to the fact that the process is going down, but it should still be correct.

Closes #100536