### PR TITLE
Remove defensive copies in `System.Collections.Immutable`

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSetInternalBase.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSetInternalBase.cs
@@ -19,7 +19,7 @@ namespace System.Collections.Frozen
         where TThisWrapper : struct, FrozenSetInternalBase<T, TThisWrapper>.IGenericSpecializedWrapper
     {
         /// <summary>A wrapper around this that enables access to important members without making virtual calls.</summary>
-        private readonly TThisWrapper _thisSet;
+        private TThisWrapper _thisSet;
 
         protected FrozenSetInternalBase(IEqualityComparer<T> comparer) : base(comparer)
         {


### PR DESCRIPTION
The field being marked `readonly` causes 26 uses of it in this file to create a defensive copy (since it's generic, it has no such things as `readonly` members, meaning every access requires a defensive copy). Removing the `readonly` should resolve these.