### PR TITLE
Remove defensive copies in `System.Reflection.MetadataLoadContext`

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Constructors/RoDefinitionConstructor.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Constructors/RoDefinitionConstructor.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.TypeLoading
     internal sealed class RoDefinitionConstructor<TMethodDecoder> : RoConstructor where TMethodDecoder : IMethodDecoder
     {
         private readonly RoInstantiationProviderType _declaringType;
-        private readonly TMethodDecoder _decoder;
+        private TMethodDecoder _decoder;
 
         internal RoDefinitionConstructor(RoInstantiationProviderType declaringType, TMethodDecoder decoder)
             : base()

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoDefinitionMethod.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoDefinitionMethod.cs
@@ -31,7 +31,7 @@ namespace System.Reflection.TypeLoading
     internal sealed partial class RoDefinitionMethod<TMethodDecoder> : RoDefinitionMethod where TMethodDecoder : IMethodDecoder
     {
         private readonly RoInstantiationProviderType _declaringType;
-        private readonly TMethodDecoder _decoder;
+        private TMethodDecoder _decoder;
 
         internal RoDefinitionMethod(RoInstantiationProviderType declaringType, Type reflectedType, TMethodDecoder decoder)
             : base(reflectedType)


### PR DESCRIPTION
These fields being marked `readonly` causes 25 uses to create a defensive copy in total (since it's generic, it has no such things as `readonly` members, meaning every access requires a defensive copy). Removing the `readonly` should resolve these.