### PR TITLE
[release/6.0] Avoid rooting X509Certificate2 in SslSessionCache

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -322,14 +322,13 @@ namespace System.Net.Security
     internal sealed class SafeFreeCredential_SECURITY : SafeFreeCredentials
     {
 #pragma warning disable 0649
-         // This is used only by SslStream but it is included elsewhere
-         public X509Certificate? LocalCertificate;
- #pragma warning restore 0649
+        // This is used only by SslStream but it is included elsewhere
+        public bool HasLocalCertificate;
+#pragma warning restore 0649
         public SafeFreeCredential_SECURITY() : base() { }
 
         protected override bool ReleaseHandle()
         {
-            LocalCertificate?.Dispose();
             return Interop.SspiCli.FreeCredentialsHandle(ref _handle) == 0;
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -101,7 +101,7 @@ namespace System.Net
                 // This is TLS Resumed session. Windows can fail to query the local cert bellow.
                 // Instead, we will determine the usage form used credentials.
                 SafeFreeCredential_SECURITY creds = (SafeFreeCredential_SECURITY)_credentialsHandle!;
-                return creds.LocalCertificate != null;
+                return creds.HasLocalCertificate;
             }
 
             SafeFreeCertContext? localContext = null;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -112,10 +112,10 @@ namespace System.Net.Security
             return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
         }
 
-        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer )
+        public static SecurityStatusPal Renegotiate(ref SafeFreeCredentials? credentialsHandle, ref SafeDeleteSslContext? context, SslAuthenticationOptions sslAuthenticationOptions, out byte[]? outputBuffer)
         {
             byte[]? output = Array.Empty<byte>();
-            SecurityStatusPal status =  AcceptSecurityContext(ref credentialsHandle, ref context, Span<byte>.Empty, ref output, sslAuthenticationOptions);
+            SecurityStatusPal status = AcceptSecurityContext(ref credentialsHandle, ref context, Span<byte>.Empty, ref output, sslAuthenticationOptions);
             outputBuffer = output;
             return status;
         }
@@ -139,8 +139,7 @@ namespace System.Net.Security
                 if (newCredentialsRequested && certificateContext != null)
                 {
                     SafeFreeCredential_SECURITY handle = (SafeFreeCredential_SECURITY)cred;
-                    // We need to create copy to avoid Disposal issue.
-                    handle.LocalCertificate = new X509Certificate2(certificateContext.Certificate);
+                    handle.HasLocalCertificate = true;
                 }
 
                 return cred;
@@ -270,11 +269,11 @@ namespace System.Net.Security
             Interop.SspiCli.SCH_CREDENTIALS credential = default;
             credential.dwVersion = Interop.SspiCli.SCH_CREDENTIALS.CurrentVersion;
             credential.dwFlags = flags;
-            Interop.Crypt32.CERT_CONTEXT *certificateHandle = null;
+            Interop.Crypt32.CERT_CONTEXT* certificateHandle = null;
             if (certificate != null)
             {
                 credential.cCreds = 1;
-                certificateHandle = (Interop.Crypt32.CERT_CONTEXT *)certificate.Handle;
+                certificateHandle = (Interop.Crypt32.CERT_CONTEXT*)certificate.Handle;
                 credential.paCred = &certificateHandle;
             }
 


### PR DESCRIPTION
Backport of #101120 to release/6.0-staging

Fixes #101090

/cc @rzikm

## Customer Impact

X509Certificates may be stored on disk. We extended their lifetime in .NET 6.0.27 (Feb release) (see details below) and they might not be deleted by the process. For short-lived processes, it may lead to disk space exhaustion.
Reported by a large service -- operating in environment with limited disk space and short-lived processes.

### Technical details

PR #79898 fixed `SslStream.IsMutuallyAuthenticated` property for scenarios with TLS resumed sessions -- we found out that in some older windows versions we cannot reliably query whether the resumed session used a client certificate (important information for the property to be accurate). As a workaround, we added a reference to the X509Certificate instance on the record in the internal TLS session cache, which prolongs the lifetime of the X509Certificate.

X509Certificates constructed by importing PFX certificate have their keys stored in a key file on disk. `Dispose()` of the certificate is implemented such that the key file is cleaned up. Keeping a reference to the certificate from TLS session cache prevents this cleanup to happen (regardless whether user properly disposed of the certificate). The key file will then outlive the process it was created in. In scenarios with many short-lived processes which do mutually-authenticated HTTPS requests with such certificates will lead to accumulation of those files, potentially exhausting disk space.

Since we don't use the value of the certificate in any part of the code, only the knowledge whether one was used or not, we can replace the cert reference by a simple `bool` flag which does not extend the lifetime of the certificate.

## Regression

Yes, introduced in **.NET 6.0.27 (Feb release)** - fixes to `SslStream.IsMutuallyAuthenticated` in servicing PR #92684. Original regression .NET 8 in PR #79898.

## Testing

Verified on the provided isolated repro from the original issue #101090.
E2E verification done by reporting customer via provided private bits.

## Risk

Low, the issue is well understood and the fix is small and contained to affected code path (using client certificates on Windows).