### PR TITLE
Tar: support GNU numeric format.

### DIFF
--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -193,8 +193,8 @@
   <data name="TarEntryFieldExceedsMaxLength" xml:space="preserve">
     <value>The field '{0}' exceeds the maximum allowed length for this format.</value>
   </data>
-  <data name="TarSizeFieldTooLargeForEntryFormat" xml:space="preserve">
-    <value>The value of the size field for the current entry of format '{0}' is greater than the format allows.</value>
+  <data name="TarFieldTooLargeForEntryFormat" xml:space="preserve">
+    <value>The value of the field for the current entry of format '{0}' is greater than the format allows.</value>
   </data>
   <data name="TarExtAttrDisallowedKeyChar" xml:space="preserve">
     <value>The extended attribute key '{0}' contains a disallowed '{1}' character.</value>

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -193,9 +193,6 @@
   <data name="TarEntryFieldExceedsMaxLength" xml:space="preserve">
     <value>The field '{0}' exceeds the maximum allowed length for this format.</value>
   </data>
-  <data name="TarSizeFieldTooLargeForEntryFormat" xml:space="preserve">
-    <value>The value of the size field for the current entry of format '{0}' is greater than the format allows.</value>
-  </data>
   <data name="TarExtAttrDisallowedKeyChar" xml:space="preserve">
     <value>The extended attribute key '{0}' contains a disallowed '{1}' character.</value>
   </data>

--- a/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Tar/src/Resources/Strings.resx
@@ -193,6 +193,9 @@
   <data name="TarEntryFieldExceedsMaxLength" xml:space="preserve">
     <value>The field '{0}' exceeds the maximum allowed length for this format.</value>
   </data>
+  <data name="TarSizeFieldTooLargeForEntryFormat" xml:space="preserve">
+    <value>The value of the size field for the current entry of format '{0}' is greater than the format allows.</value>
+  </data>
   <data name="TarExtAttrDisallowedKeyChar" xml:space="preserve">
     <value>The extended attribute key '{0}' contains a disallowed '{1}' character.</value>
   </data>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/GnuTarEntry.cs
@@ -98,7 +98,6 @@ namespace System.Formats.Tar
             get => _header._aTime;
             set
             {
-                ArgumentOutOfRangeException.ThrowIfLessThan(value, DateTimeOffset.UnixEpoch);
                 _header._aTime = value;
             }
         }
@@ -112,7 +111,6 @@ namespace System.Formats.Tar
             get => _header._cTime;
             set
             {
-                ArgumentOutOfRangeException.ThrowIfLessThan(value, DateTimeOffset.UnixEpoch);
                 _header._cTime = value;
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -62,7 +62,6 @@ namespace System.Formats.Tar
                 }
 
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0x1FFFFF); // 7777777 in octal
 
                 _header._devMajor = value;
             }
@@ -85,7 +84,6 @@ namespace System.Formats.Tar
                 }
 
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
-                ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0x1FFFFF); // 7777777 in octal
 
                 _header._devMinor = value;
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -62,6 +62,10 @@ namespace System.Formats.Tar
                 }
 
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
+                if (FormatIsOctalOnly)
+                {
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0x1FFFFF); // 7777777 in octal
+                }
 
                 _header._devMajor = value;
             }
@@ -84,6 +88,10 @@ namespace System.Formats.Tar
                 }
 
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
+                if (FormatIsOctalOnly)
+                {
+                    ArgumentOutOfRangeException.ThrowIfGreaterThan(value, 0x1FFFFF); // 7777777 in octal
+                }
 
                 _header._devMinor = value;
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/PosixTarEntry.cs
@@ -50,7 +50,7 @@ namespace System.Formats.Tar
         /// </summary>
         /// <remarks>Character and block devices are Unix-specific entry types.</remarks>
         /// <exception cref="InvalidOperationException">The entry does not represent a block device or a character device.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The value is negative, or larger than 2097151.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The value is negative, or larger than 2097151 when using <see cref="TarEntryFormat.V7"/> or <see cref="TarEntryFormat.Ustar"/>.</exception>
         public int DeviceMajor
         {
             get => _header._devMajor;
@@ -76,7 +76,7 @@ namespace System.Formats.Tar
         /// </summary>
         /// <remarks>Character and block devices are Unix-specific entry types.</remarks>
         /// <exception cref="InvalidOperationException">The entry does not represent a block device or a character device.</exception>
-        /// <exception cref="ArgumentOutOfRangeException">The value is negative, or larger than 2097151.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The value is negative, or larger than 2097151 when using <see cref="TarEntryFormat.V7"/> or <see cref="TarEntryFormat.Ustar"/>.</exception>
         public int DeviceMinor
         {
             get => _header._devMinor;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -98,7 +98,6 @@ namespace System.Formats.Tar
             get => _header._mTime;
             set
             {
-                ArgumentOutOfRangeException.ThrowIfLessThan(value, DateTimeOffset.UnixEpoch);
                 _header._mTime = value;
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -20,6 +20,9 @@ namespace System.Formats.Tar
         // Used to access the data section of this entry in an unseekable file
         private TarReader? _readerOfOrigin;
 
+        // These formats have a limited numeric range due to the octal number representation.
+        protected bool FormatIsOctalOnly => _header._format is TarEntryFormat.V7 or TarEntryFormat.Ustar;
+
         // Constructor called when reading a TarEntry from a TarReader.
         internal TarEntry(TarHeader header, TarReader readerOfOrigin, TarEntryFormat format)
         {
@@ -98,6 +101,10 @@ namespace System.Formats.Tar
             get => _header._mTime;
             set
             {
+                if (FormatIsOctalOnly)
+                {
+                    ArgumentOutOfRangeException.ThrowIfLessThan(value, DateTimeOffset.UnixEpoch);
+                }
                 _header._mTime = value;
             }
         }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -95,7 +95,7 @@ namespace System.Formats.Tar
         /// A timestamps that represents the last time the contents of the file represented by this entry were modified.
         /// </summary>
         /// <remarks>In Unix platforms, this timestamp is commonly known as <c>mtime</c>.</remarks>
-        /// <exception cref="ArgumentOutOfRangeException">The specified value is larger than <see cref="DateTimeOffset.UnixEpoch"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The specified value is larger than <see cref="DateTimeOffset.UnixEpoch"/> when using <see cref="TarEntryFormat.V7"/> or <see cref="TarEntryFormat.Ustar"/>.</exception>
         public DateTimeOffset ModificationTime
         {
             get => _header._mTime;

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -374,8 +374,7 @@ namespace System.Formats.Tar
                 return null;
             }
 
-            long size = (long)TarHelpers.ParseOctal<ulong>(buffer.Slice(FieldLocations.Size, FieldLengths.Size));
-            Debug.Assert(size <= TarHelpers.MaxSizeLength, "size exceeded the max value possible with 11 octal digits. Actual size " + size);
+            long size = TarHelpers.ParseNumeric<long>(buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             if (size < 0)
             {
                 throw new InvalidDataException(SR.Format(SR.TarSizeFieldNegative));
@@ -384,14 +383,14 @@ namespace System.Formats.Tar
             // Continue with the rest of the fields that require no special checks
             TarHeader header = new(initialFormat,
                 name: TarHelpers.GetTrimmedUtf8String(buffer.Slice(FieldLocations.Name, FieldLengths.Name)),
-                mode: (int)TarHelpers.ParseOctal<uint>(buffer.Slice(FieldLocations.Mode, FieldLengths.Mode)),
-                mTime: TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch((long)TarHelpers.ParseOctal<ulong>(buffer.Slice(FieldLocations.MTime, FieldLengths.MTime))),
+                mode: TarHelpers.ParseNumeric<int>(buffer.Slice(FieldLocations.Mode, FieldLengths.Mode)),
+                mTime: TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(TarHelpers.ParseNumeric<long>(buffer.Slice(FieldLocations.MTime, FieldLengths.MTime))),
                 typeFlag: (TarEntryType)buffer[FieldLocations.TypeFlag])
             {
                 _checksum = checksum,
                 _size = size,
-                _uid = (int)TarHelpers.ParseOctal<uint>(buffer.Slice(FieldLocations.Uid, FieldLengths.Uid)),
-                _gid = (int)TarHelpers.ParseOctal<uint>(buffer.Slice(FieldLocations.Gid, FieldLengths.Gid)),
+                _uid = TarHelpers.ParseNumeric<int>(buffer.Slice(FieldLocations.Uid, FieldLengths.Uid)),
+                _gid = TarHelpers.ParseNumeric<int>(buffer.Slice(FieldLocations.Gid, FieldLengths.Gid)),
                 _linkName = TarHelpers.GetTrimmedUtf8String(buffer.Slice(FieldLocations.LinkName, FieldLengths.LinkName))
             };
 
@@ -524,10 +523,10 @@ namespace System.Formats.Tar
             if (_typeFlag is TarEntryType.CharacterDevice or TarEntryType.BlockDevice)
             {
                 // Major number for a character device or block device entry.
-                _devMajor = (int)TarHelpers.ParseOctal<uint>(buffer.Slice(FieldLocations.DevMajor, FieldLengths.DevMajor));
+                _devMajor = TarHelpers.ParseNumeric<int>(buffer.Slice(FieldLocations.DevMajor, FieldLengths.DevMajor));
 
                 // Minor number for a character device or block device entry.
-                _devMinor = (int)TarHelpers.ParseOctal<uint>(buffer.Slice(FieldLocations.DevMinor, FieldLengths.DevMinor));
+                _devMinor = TarHelpers.ParseNumeric<int>(buffer.Slice(FieldLocations.DevMinor, FieldLengths.DevMinor));
             }
         }
 
@@ -536,10 +535,10 @@ namespace System.Formats.Tar
         private void ReadGnuAttributes(Span<byte> buffer)
         {
             // Convert byte arrays
-            long aTime = (long)TarHelpers.ParseOctal<ulong>(buffer.Slice(FieldLocations.ATime, FieldLengths.ATime));
+            long aTime = TarHelpers.ParseNumeric<long>(buffer.Slice(FieldLocations.ATime, FieldLengths.ATime));
             _aTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(aTime);
 
-            long cTime = (long)TarHelpers.ParseOctal<ulong>(buffer.Slice(FieldLocations.CTime, FieldLengths.CTime));
+            long cTime = TarHelpers.ParseNumeric<long>(buffer.Slice(FieldLocations.CTime, FieldLengths.CTime));
             _cTime = TarHelpers.GetDateTimeOffsetFromSecondsSinceEpoch(cTime);
 
             // TODO: Read the bytes of the currently unsupported GNU fields, in case user wants to write this entry into another GNU archive, they need to be preserved. https://github.com/dotnet/runtime/issues/68230

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,6 +16,9 @@ namespace System.Formats.Tar
     // Writes header attributes of a tar archive entry.
     internal sealed partial class TarHeader
     {
+        private const long Octal12ByteFieldMaxValue = (1L << (3 * 11)) - 1; // Max value of 11 octal digits.
+        private const int Octal8ByteFieldMaxValue = (1 << (3 * 7)) - 1;     // Max value of 7 octal digits.
+
         private static ReadOnlySpan<byte> UstarMagicBytes => "ustar\0"u8;
         private static ReadOnlySpan<byte> UstarVersionBytes => "00"u8;
 
@@ -606,35 +610,22 @@ namespace System.Formats.Tar
 
             if (_mode > 0)
             {
-                checksum += FormatOctal(_mode, buffer.Slice(FieldLocations.Mode, FieldLengths.Mode));
+                checksum += FormatNumeric(_mode, buffer.Slice(FieldLocations.Mode, FieldLengths.Mode));
             }
 
             if (_uid > 0)
             {
-                checksum += FormatOctal(_uid, buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
+                checksum += FormatNumeric(_uid, buffer.Slice(FieldLocations.Uid, FieldLengths.Uid));
             }
 
             if (_gid > 0)
             {
-                checksum += FormatOctal(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
+                checksum += FormatNumeric(_gid, buffer.Slice(FieldLocations.Gid, FieldLengths.Gid));
             }
 
             if (_size > 0)
             {
-                if (_size <= TarHelpers.MaxSizeLength)
-                {
-                    checksum += FormatOctal(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
-                }
-                else if (_format is not TarEntryFormat.Pax)
-                {
-                    throw new ArgumentException(SR.Format(SR.TarSizeFieldTooLargeForEntryFormat, _format));
-                }
-                else
-                {
-                    // No writing, just verifications
-                    Debug.Assert(_typeFlag is not TarEntryType.ExtendedAttributes and not TarEntryType.GlobalExtendedAttributes);
-                    Debug.Assert(Convert.ToInt64(ExtendedAttributes[PaxEaSize]) > TarHelpers.MaxSizeLength);
-                }
+                checksum += FormatNumeric(_size, buffer.Slice(FieldLocations.Size, FieldLengths.Size));
             }
 
             checksum += WriteAsTimestamp(_mTime, buffer.Slice(FieldLocations.MTime, FieldLengths.MTime));
@@ -739,12 +730,12 @@ namespace System.Formats.Tar
 
             if (_devMajor > 0)
             {
-                checksum += FormatOctal(_devMajor, buffer.Slice(FieldLocations.DevMajor, FieldLengths.DevMajor));
+                checksum += FormatNumeric(_devMajor, buffer.Slice(FieldLocations.DevMajor, FieldLengths.DevMajor));
             }
 
             if (_devMinor > 0)
             {
-                checksum += FormatOctal(_devMinor, buffer.Slice(FieldLocations.DevMinor, FieldLengths.DevMinor));
+                checksum += FormatNumeric(_devMinor, buffer.Slice(FieldLocations.DevMinor, FieldLengths.DevMinor));
             }
 
             return checksum;
@@ -916,13 +907,49 @@ namespace System.Formats.Tar
                 ExtendedAttributes[PaxEaLinkName] = _linkName;
             }
 
-            if (_size > TarHelpers.MaxSizeLength)
+            if (_size > Octal12ByteFieldMaxValue)
             {
                 ExtendedAttributes[PaxEaSize] = _size.ToString();
             }
             else
             {
                 ExtendedAttributes.Remove(PaxEaSize);
+            }
+
+            if (_uid > Octal8ByteFieldMaxValue)
+            {
+                ExtendedAttributes[PaxEaUid] = _uid.ToString();
+            }
+            else
+            {
+                ExtendedAttributes.Remove(PaxEaUid);
+            }
+
+            if (_gid > Octal8ByteFieldMaxValue)
+            {
+                ExtendedAttributes[PaxEaGid] = _gid.ToString();
+            }
+            else
+            {
+                ExtendedAttributes.Remove(PaxEaGid);
+            }
+
+            if (_devMajor > Octal8ByteFieldMaxValue)
+            {
+                ExtendedAttributes[PaxEaDevMajor] = _devMajor.ToString();
+            }
+            else
+            {
+                ExtendedAttributes.Remove(PaxEaDevMajor);
+            }
+
+            if (_devMinor > Octal8ByteFieldMaxValue)
+            {
+                ExtendedAttributes[PaxEaDevMinor] = _devMinor.ToString();
+            }
+            else
+            {
+                ExtendedAttributes.Remove(PaxEaDevMinor);
             }
 
             // Sets the specified string to the dictionary if it's longer than the specified max byte length; otherwise, remove it.
@@ -1022,6 +1049,60 @@ namespace System.Formats.Tar
             return checksum;
         }
 
+        private int FormatNumeric(int value, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == 8, "8 byte field expected.");
+
+            // Prefer the octal format. For non-PAX, use GNU format to widen the range.
+            bool useOctal = (value >= 0 && value <= Octal8ByteFieldMaxValue) || _format is TarEntryFormat.Pax;
+
+            if (useOctal)
+            {
+                return FormatOctal(value, destination);
+            }
+            else if (value < 0)
+            {
+                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
+                BinaryPrimitives.WriteInt64BigEndian(destination, value);
+                return Checksum(destination);
+            }
+            else
+            {
+                // GNU format: store positive numbers in big endian format with leading '0x80' byte.
+                BinaryPrimitives.WriteUInt64BigEndian(destination, (1UL << 63) | (uint)value);
+                return Checksum(destination);
+            }
+        }
+
+        private int FormatNumeric(long value, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == 12, "12 byte field expected.");
+            const int Offset = 4; // 4 bytes before the long.
+
+            // Prefer the octal format. For non-PAX, use GNU format to widen the range.
+            bool useOctal = (value >= 0 && value <= Octal12ByteFieldMaxValue) || _format is TarEntryFormat.Pax;
+
+            if (useOctal)
+            {
+                return FormatOctal(value, destination);
+            }
+            else if (value < 0)
+            {
+                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
+                destination.Slice(0, Offset).Fill(0xff);
+                BinaryPrimitives.WriteInt64BigEndian(destination.Slice(Offset), value);
+                return Checksum(destination);
+            }
+            else
+            {
+                // GNU format: store positive numbers in big endian format with leading '0x80' byte.
+                destination.Slice(0, Offset).Fill(0);
+                destination[0] = 0x80;
+                BinaryPrimitives.WriteInt64BigEndian(destination.Slice(Offset), value);
+                return Checksum(destination);
+            }
+        }
+
         // Writes the specified decimal number as a right-aligned octal number and returns its checksum.
         private static int FormatOctal(long value, Span<byte> destination)
         {
@@ -1040,11 +1121,11 @@ namespace System.Formats.Tar
             return WriteRightAlignedBytesAndGetChecksum(digits.Slice(i), destination);
         }
 
-        // Writes the specified DateTimeOffset's Unix time seconds as a right-aligned octal number, and returns its checksum.
-        private static int WriteAsTimestamp(DateTimeOffset timestamp, Span<byte> destination)
+        // Writes the specified DateTimeOffset's Unix time seconds, and returns its checksum.
+        private int WriteAsTimestamp(DateTimeOffset timestamp, Span<byte> destination)
         {
             long unixTimeSeconds = timestamp.ToUnixTimeSeconds();
-            return FormatOctal(unixTimeSeconds, destination);
+            return FormatNumeric(unixTimeSeconds, destination);
         }
 
         // Writes the specified text as an UTF8 string aligned to the left, and returns its checksum.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1065,10 +1065,7 @@ namespace System.Formats.Tar
                 // GNU format: store negative numbers in big endian format with leading '0xff' byte.
                 //             store positive numbers in big endian format with leading '0x80' byte.
                 long destinationValue = value;
-                if (value >= 0)
-                {
-                    destinationValue |= 1L << 63;
-                }
+                destinationValue |= 1L << 63;
                 BinaryPrimitives.WriteInt64BigEndian(destination, destinationValue);
                 return Checksum(destination);
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1060,16 +1060,16 @@ namespace System.Formats.Tar
             {
                 return FormatOctal(value, destination);
             }
-            else if (value < 0)
-            {
-                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
-                BinaryPrimitives.WriteInt64BigEndian(destination, value);
-                return Checksum(destination);
-            }
             else
             {
-                // GNU format: store positive numbers in big endian format with leading '0x80' byte.
-                BinaryPrimitives.WriteUInt64BigEndian(destination, (1UL << 63) | (uint)value);
+                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
+                //             store positive numbers in big endian format with leading '0x80' byte.
+                long destinationValue = value;
+                if (value >= 0)
+                {
+                    destinationValue |= 1L << 63;
+                }
+                BinaryPrimitives.WriteInt64BigEndian(destination, destinationValue);
                 return Checksum(destination);
             }
         }
@@ -1086,18 +1086,11 @@ namespace System.Formats.Tar
             {
                 return FormatOctal(value, destination);
             }
-            else if (value < 0)
-            {
-                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
-                destination.Slice(0, Offset).Fill(0xff);
-                BinaryPrimitives.WriteInt64BigEndian(destination.Slice(Offset), value);
-                return Checksum(destination);
-            }
             else
             {
-                // GNU format: store positive numbers in big endian format with leading '0x80' byte.
-                destination.Slice(0, Offset).Fill(0);
-                destination[0] = 0x80;
+                // GNU format: store negative numbers in big endian format with leading '0xff' byte.
+                //             store positive numbers in big endian format with leading '0x80' byte.
+                BinaryPrimitives.WriteUInt32BigEndian(destination, value < 0 ? 0xffffffff : 1U << 31);
                 BinaryPrimitives.WriteInt64BigEndian(destination.Slice(Offset), value);
                 return Checksum(destination);
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1089,7 +1089,7 @@ namespace System.Formats.Tar
             {
                 // GNU format: store negative numbers in big endian format with leading '0xff' byte.
                 //             store positive numbers in big endian format with leading '0x80' byte.
-                BinaryPrimitives.WriteUInt32BigEndian(destination, value < 0 ? 0xffffffff : 1U << 31);
+                BinaryPrimitives.WriteUInt32BigEndian(destination, value < 0 ? 0xffffffff : 0x80000000);
                 BinaryPrimitives.WriteInt64BigEndian(destination.Slice(Offset), value);
                 return Checksum(destination);
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -1053,10 +1053,13 @@ namespace System.Formats.Tar
         {
             Debug.Assert(destination.Length == 8, "8 byte field expected.");
 
-            // Use GNU format to widen the range.
-            bool useGnuFormat = (value < 0 || value > Octal8ByteFieldMaxValue) && _format == TarEntryFormat.Gnu;
+            bool isOctalRange = value >= 0 && value <= Octal8ByteFieldMaxValue;
 
-            if (useGnuFormat)
+            if (isOctalRange || _format == TarEntryFormat.Pax)
+            {
+                return FormatOctal(value, destination);
+            }
+            else if (_format == TarEntryFormat.Gnu)
             {
                 // GNU format: store negative numbers in big endian format with leading '0xff' byte.
                 //             store positive numbers in big endian format with leading '0x80' byte.
@@ -1067,7 +1070,7 @@ namespace System.Formats.Tar
             }
             else
             {
-                return FormatOctal(value, destination);
+                throw new ArgumentException(SR.Format(SR.TarFieldTooLargeForEntryFormat, _format));
             }
         }
 
@@ -1076,10 +1079,13 @@ namespace System.Formats.Tar
             Debug.Assert(destination.Length == 12, "12 byte field expected.");
             const int Offset = 4; // 4 bytes before the long.
 
-            // Use GNU format to widen the range.
-            bool useGnuFormat = (value < 0 || value > Octal12ByteFieldMaxValue) && _format == TarEntryFormat.Gnu;
+            bool isOctalRange = value >= 0 && value <= Octal12ByteFieldMaxValue;
 
-            if (useGnuFormat)
+            if (isOctalRange || _format == TarEntryFormat.Pax)
+            {
+                return FormatOctal(value, destination);
+            }
+            else if (_format == TarEntryFormat.Gnu)
             {
                 // GNU format: store negative numbers in big endian format with leading '0xff' byte.
                 //             store positive numbers in big endian format with leading '0x80' byte.
@@ -1089,7 +1095,7 @@ namespace System.Formats.Tar
             }
             else
             {
-                return FormatOctal(value, destination);
+                throw new ArgumentException(SR.Format(SR.TarFieldTooLargeForEntryFormat, _format));
             }
         }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -19,7 +19,6 @@ namespace System.Formats.Tar
     {
         internal const short RecordSize = 512;
         internal const int MaxBufferLength = 4096;
-        internal const long MaxSizeLength = (1L << 33) - 1; // Max value of 11 octal digits = 2^33 - 1 or 8 Gb.
 
         internal const UnixFileMode ValidUnixFileModes =
             UnixFileMode.UserRead |
@@ -213,6 +212,28 @@ namespace System.Formats.Tar
             }
 
             return entryType;
+        }
+
+        /// <summary>Parses a numeric field.</summary>
+        internal static T ParseNumeric<T>(ReadOnlySpan<byte> buffer) where T : struct, INumber<T>, IBinaryInteger<T>
+        {
+            // The tar standard specifies that numeric fields are stored using an octal representation.
+            // This limits the range of values that can be stored in the fields.
+            // To increase the supported range, a GNU extension defines that when the leading byte is
+            // '0xff'/'0x80' the remaining bytes are a negative/positive big formatted endian value.
+            byte leadingByte = buffer[0];
+            if (leadingByte == 0xff)
+            {
+                return T.ReadBigEndian(buffer, isUnsigned: false);
+            }
+            else if (leadingByte == 0x80)
+            {
+                return T.ReadBigEndian(buffer.Slice(1), isUnsigned: true);
+            }
+            else
+            {
+                return ParseOctal<T>(buffer);
+            }
         }
 
         /// <summary>Parses a byte span that represents an ASCII string containing a number in octal base.</summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHelpers.cs
@@ -221,6 +221,7 @@ namespace System.Formats.Tar
             // This limits the range of values that can be stored in the fields.
             // To increase the supported range, a GNU extension defines that when the leading byte is
             // '0xff'/'0x80' the remaining bytes are a negative/positive big formatted endian value.
+            // Like the 'tar' tool we are permissive when encountering this representation in non GNU formats.
             byte leadingByte = buffer[0];
             if (leadingByte == 0xff)
             {

--- a/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
+++ b/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
@@ -20,10 +20,8 @@ public class ManualTests : TarTestsBase
             foreach (TarEntryFormat entryFormat in new[] { TarEntryFormat.V7, TarEntryFormat.Ustar, TarEntryFormat.Gnu, TarEntryFormat.Pax })
             {
                 yield return new object[] { entryFormat, LegacyMaxFileSize, unseekableStream };
+                yield return new object[] { entryFormat, LegacyMaxFileSize + 1, unseekableStream };
             }
-
-            // Pax supports unlimited size files.
-            yield return new object[] { TarEntryFormat.Pax, LegacyMaxFileSize + 1, unseekableStream };
         }
     }
 

--- a/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
+++ b/src/libraries/System.Formats.Tar/tests/Manual/ManualTests.cs
@@ -20,8 +20,11 @@ public class ManualTests : TarTestsBase
             foreach (TarEntryFormat entryFormat in new[] { TarEntryFormat.V7, TarEntryFormat.Ustar, TarEntryFormat.Gnu, TarEntryFormat.Pax })
             {
                 yield return new object[] { entryFormat, LegacyMaxFileSize, unseekableStream };
-                yield return new object[] { entryFormat, LegacyMaxFileSize + 1, unseekableStream };
             }
+
+            // Pax and Gnu supports unlimited size files.
+            yield return new object[] { TarEntryFormat.Pax, LegacyMaxFileSize + 1, unseekableStream };
+            yield return new object[] { TarEntryFormat.Gnu, LegacyMaxFileSize + 1, unseekableStream };
         }
     }
 

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -263,7 +263,6 @@ namespace System.Formats.Tar.Tests
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
         [InlineData("issue11169")] // Checksum with null in the middle
         [InlineData("issue10968")] // Garbage chars
-        [InlineData("writer-big")] // The size field contains an euro char
         public async Task Throw_ArchivesWithRandomCharsAsync(string testCaseName)
         {
             await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Async.Tests.cs
@@ -271,6 +271,16 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
+        public async Task Throw_ArchiveIsShortAsync()
+        {
+            // writer-big has a header for a 16G file but not its contents.
+            using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "writer-big");
+            using TarReader reader = new TarReader(archiveStream);
+            // MemoryStream throws when we try to change its Position past its Length.
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await reader.GetNextEntryAsync());
+        }
+
+        [Fact]
         public async Task GarbageEntryChecksumZeroReturnNullAsync()
         {
             await using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -271,7 +271,6 @@ namespace System.Formats.Tar.Tests
         [InlineData("invalid-go17")] // Many octal fields are all zero chars
         [InlineData("issue11169")] // Checksum with null in the middle
         [InlineData("issue10968")] // Garbage chars
-        [InlineData("writer-big")] // The size field contains an euro char
         public void Throw_ArchivesWithRandomChars(string testCaseName)
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", testCaseName);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.File.Tests.cs
@@ -279,6 +279,16 @@ namespace System.Formats.Tar.Tests
         }
 
         [Fact]
+        public void Throw_ArchiveIsShort()
+        {
+            // writer-big has a header for a 16G file but not its contents.
+            using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "writer-big");
+            using TarReader reader = new TarReader(archiveStream);
+            // MemoryStream throws when we try to change its Position past its Length.
+            Assert.Throws<ArgumentOutOfRangeException>(() => reader.GetNextEntry());
+        }
+
+        [Fact]
         public void GarbageEntryChecksumZeroReturnNull()
         {
             using MemoryStream archiveStream = GetTarMemoryStream(CompressionMethod.Uncompressed, "golang_tar", "issue12435");

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Gnu.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Gnu.cs
@@ -60,12 +60,10 @@ namespace System.Formats.Tar.Tests
 
             // ATime: Verify the default value was approximately "now"
             Assert.True(entry.AccessTime > approxNow);
-            Assert.Throws<ArgumentOutOfRangeException>(() => entry.AccessTime = DateTimeOffset.MinValue);
             entry.AccessTime = TestAccessTime;
 
             // CTime: Verify the default value was approximately "now"
             Assert.True(entry.ChangeTime > approxNow);
-            Assert.Throws<ArgumentOutOfRangeException>(() => entry.ChangeTime = DateTimeOffset.MinValue);
             entry.ChangeTime = TestChangeTime;
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Gnu.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Gnu.cs
@@ -56,14 +56,33 @@ namespace System.Formats.Tar.Tests
 
         protected void SetGnuProperties(GnuTarEntry entry)
         {
+            // The octal format limits the representable range.
+            bool formatIsOctalOnly = entry.Format is not TarEntryFormat.Pax and not TarEntryFormat.Gnu;
+
             DateTimeOffset approxNow = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(6));
 
             // ATime: Verify the default value was approximately "now"
             Assert.True(entry.AccessTime > approxNow);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => entry.AccessTime = DateTimeOffset.MinValue);
+            }
+            else
+            {
+                entry.AccessTime = DateTimeOffset.MinValue;
+            }
             entry.AccessTime = TestAccessTime;
 
             // CTime: Verify the default value was approximately "now"
             Assert.True(entry.ChangeTime > approxNow);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => entry.ChangeTime = DateTimeOffset.MinValue);
+            }
+            else
+            {
+                entry.ChangeTime = DateTimeOffset.MinValue;
+            }
             entry.ChangeTime = TestChangeTime;
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Posix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Posix.cs
@@ -27,13 +27,11 @@ namespace System.Formats.Tar.Tests
             // DeviceMajor
             Assert.Equal(DefaultDeviceMajor, device.DeviceMajor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = -1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = 2097152);
             device.DeviceMajor = TestBlockDeviceMajor;
 
             // DeviceMinor
             Assert.Equal(DefaultDeviceMinor, device.DeviceMinor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = -1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = 2097152);
             device.DeviceMinor = TestBlockDeviceMinor;
         }
 
@@ -47,13 +45,11 @@ namespace System.Formats.Tar.Tests
             // DeviceMajor
             Assert.Equal(DefaultDeviceMajor, device.DeviceMajor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = -1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = 2097152);
             device.DeviceMajor = TestCharacterDeviceMajor;
 
             // DeviceMinor
             Assert.Equal(DefaultDeviceMinor, device.DeviceMinor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = -1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = 2097152);
             device.DeviceMinor = TestCharacterDeviceMinor;
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.Posix.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.Posix.cs
@@ -19,6 +19,9 @@ namespace System.Formats.Tar.Tests
 
         private void SetBlockDeviceProperties(PosixTarEntry device)
         {
+            // The octal format limits the representable range.
+            bool formatIsOctalOnly = device.Format is not TarEntryFormat.Pax and not TarEntryFormat.Gnu;
+
             Assert.NotNull(device);
             Assert.Equal(TarEntryType.BlockDevice, device.EntryType);
             SetCommonProperties(device);
@@ -27,16 +30,35 @@ namespace System.Formats.Tar.Tests
             // DeviceMajor
             Assert.Equal(DefaultDeviceMajor, device.DeviceMajor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = -1);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = 2097152);
+            }
+            else
+            {
+                device.DeviceMajor = 2097152;
+            }
             device.DeviceMajor = TestBlockDeviceMajor;
 
             // DeviceMinor
             Assert.Equal(DefaultDeviceMinor, device.DeviceMinor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = -1);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = 2097152);
+            }
+            else
+            {
+                device.DeviceMinor = 2097152;
+            }
             device.DeviceMinor = TestBlockDeviceMinor;
         }
 
         private void SetCharacterDeviceProperties(PosixTarEntry device)
         {
+            // The octal format limits the representable range.
+            bool formatIsOctalOnly = device.Format is not TarEntryFormat.Pax and not TarEntryFormat.Gnu;
+
             Assert.NotNull(device);
             Assert.Equal(TarEntryType.CharacterDevice, device.EntryType);
             SetCommonProperties(device);
@@ -45,11 +67,27 @@ namespace System.Formats.Tar.Tests
             // DeviceMajor
             Assert.Equal(DefaultDeviceMajor, device.DeviceMajor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = -1);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMajor = 2097152);
+            }
+            else
+            {
+                device.DeviceMajor = 2097152;
+            }
             device.DeviceMajor = TestCharacterDeviceMajor;
 
             // DeviceMinor
             Assert.Equal(DefaultDeviceMinor, device.DeviceMinor);
             Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = -1);
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => device.DeviceMinor = 2097152);
+            }
+            else
+            {
+                device.DeviceMinor = 2097152;
+            }
             device.DeviceMinor = TestCharacterDeviceMinor;
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -329,7 +329,6 @@ namespace System.Formats.Tar.Tests
             DateTimeOffset approxNow = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(6));
             Assert.True(entry.ModificationTime > approxNow);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => entry.ModificationTime = DateTime.MinValue); // Minimum allowed is UnixEpoch, not MinValue
             entry.ModificationTime = TestModificationTime;
 
             // Name

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -311,6 +311,9 @@ namespace System.Formats.Tar.Tests
 
         protected void SetCommonProperties(TarEntry entry, bool isDirectory = false)
         {
+            // The octal format limits the range.
+            bool formatIsOctalOnly = entry.Format is not TarEntryFormat.Pax and not TarEntryFormat.Gnu;
+
             // Length (Data is checked outside this method)
             Assert.Equal(0, entry.Length);
 
@@ -329,6 +332,14 @@ namespace System.Formats.Tar.Tests
             DateTimeOffset approxNow = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(6));
             Assert.True(entry.ModificationTime > approxNow);
 
+            if (formatIsOctalOnly)
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => entry.ModificationTime = DateTime.MinValue); // Minimum allowed is UnixEpoch, not MinValue
+            }
+            else
+            {
+                entry.ModificationTime = DateTimeOffset.MinValue;
+            }
             entry.ModificationTime = TestModificationTime;
 
             // Name

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Base.cs
@@ -48,5 +48,59 @@ namespace System.Formats.Tar.Tests
                 Assert.Equal(value, gea.GlobalExtendedAttributes[key]);
             }
         }
+
+        public static IEnumerable<object[]> WriteIntField_TheoryData()
+        {
+            foreach (TarEntryFormat format in new[] { TarEntryFormat.V7, TarEntryFormat.Ustar, TarEntryFormat.Pax, TarEntryFormat.Gnu })
+            {
+                // Min value.
+                yield return new object[] { format, 0 };
+                // Max value.
+                yield return new object[] { format, int.MaxValue }; // This doesn't fit an 8-byte field with octal representation.
+
+                yield return new object[] { format, 1 };
+                yield return new object[] { format, 42 };
+            }
+        }
+
+        public static IEnumerable<object[]> WriteTimeStampsWithFormats_TheoryData()
+        {
+            foreach (TarEntryFormat entryFormat in new[] { TarEntryFormat.V7, TarEntryFormat.Ustar, TarEntryFormat.Gnu, TarEntryFormat.Pax })
+            {
+                foreach (DateTimeOffset timestamp in GetWriteTimeStamps())
+                {
+                    yield return new object[] { entryFormat, timestamp };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> WriteTimeStamps_TheoryData()
+        {
+            foreach (DateTimeOffset timestamp in GetWriteTimeStamps())
+            {
+                yield return new object[] { timestamp };
+            }
+        }
+
+        private static IEnumerable<DateTimeOffset> GetWriteTimeStamps()
+        {
+            // One second past Y2K38
+            yield return new DateTimeOffset(2038, 1, 19, 3, 14, 8, TimeSpan.Zero);
+
+            // One second past what a 12-byte field can store with octal representation
+            yield return new DateTimeOffset(2242, 3, 16, 12, 56, 33, TimeSpan.Zero);
+
+            // Min value
+            yield return DateTimeOffset.MinValue;
+
+            // Max value. Everything below seconds is set to zero for test equality comparison.
+            yield return new DateTimeOffset(new DateTime(DateTime.MaxValue.Year,
+                                                         DateTime.MaxValue.Month,
+                                                         DateTime.MaxValue.Day,
+                                                         DateTime.MaxValue.Hour,
+                                                         DateTime.MaxValue.Minute,
+                                                         DateTime.MaxValue.Second,
+                                                         DateTime.MaxValue.Kind), TimeSpan.Zero);
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Base.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Base.cs
@@ -84,7 +84,7 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        public static IEnumerable<object[]> WriteTimeStamps_TheoryData()
+        public static IEnumerable<object[]> WriteTimeStamp_Pax_TheoryData()
         {
             foreach (DateTimeOffset timestamp in GetWriteTimeStamps(TarEntryFormat.Pax))
             {

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -375,36 +375,30 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        [Fact]
-        // Y2K38 will happen one second after "2038/19/01 03:14:07 +00:00". This timestamp represents the seconds since the Unix epoch with a
-        // value of int.MaxValue: 2,147,483,647.
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // All our entry types should survive the Epochalypse because we internally use long to represent the seconds since Unix epoch, not int.
-        // So if the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591, which
-        // is way past int MaxValue, but still within the long limits. That number represents the date "2242/16/03 12:56:32 +00:00".
-        public void WriteTimestampsBeyondEpochalypseInPax()
+        [Theory]
+        [MemberData(nameof(WriteTimeStamps_TheoryData))]
+        public void WriteTimestampsInPax(DateTimeOffset timestamp)
         {
-            DateTimeOffset epochalypse = new DateTimeOffset(2038, 1, 19, 3, 14, 8, TimeSpan.Zero);
-            string strEpochalypse = GetTimestampStringFromDateTimeOffset(epochalypse);
+            string strTimestamp = GetTimestampStringFromDateTimeOffset(timestamp);
 
             Dictionary<string, string> ea = new Dictionary<string, string>()
             {
-                { PaxEaATime, strEpochalypse },
-                { PaxEaCTime, strEpochalypse }
+                { PaxEaATime, strTimestamp },
+                { PaxEaCTime, strTimestamp }
             };
 
             PaxTarEntry entry = new PaxTarEntry(TarEntryType.Directory, "dir", ea);
 
-            entry.ModificationTime = epochalypse;
-            Assert.Equal(epochalypse, entry.ModificationTime);
+            entry.ModificationTime = timestamp;
+            Assert.Equal(timestamp, entry.ModificationTime);
 
             Assert.Contains(PaxEaATime, entry.ExtendedAttributes);
             DateTimeOffset atime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaATime);
-            Assert.Equal(epochalypse, atime);
+            Assert.Equal(timestamp, atime);
 
             Assert.Contains(PaxEaCTime, entry.ExtendedAttributes);
             DateTimeOffset ctime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaCTime);
-            Assert.Equal(epochalypse, ctime);
+            Assert.Equal(timestamp, ctime);
 
             using MemoryStream archiveStream = new MemoryStream();
             using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
@@ -418,71 +412,15 @@ namespace System.Formats.Tar.Tests
                 PaxTarEntry readEntry = reader.GetNextEntry() as PaxTarEntry;
                 Assert.NotNull(readEntry);
 
-                Assert.Equal(epochalypse, readEntry.ModificationTime);
+                Assert.Equal(timestamp, readEntry.ModificationTime);
 
                 Assert.Contains(PaxEaATime, readEntry.ExtendedAttributes);
                 DateTimeOffset actualATime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaATime);
-                Assert.Equal(epochalypse, actualATime);
+                Assert.Equal(timestamp, actualATime);
 
                 Assert.Contains(PaxEaCTime, readEntry.ExtendedAttributes);
                 DateTimeOffset actualCTime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaCTime);
-                Assert.Equal(epochalypse, actualCTime);
-            }
-        }
-
-        [Fact]
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // We internally use long to represent the seconds since Unix epoch, not int.
-        // If the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591,
-        // which represents the date "2242/03/16 12:56:32 +00:00".
-        // Pax should survive after this date because it stores the timestamps in the extended attributes dictionary
-        // without size restrictions.
-        public void WriteTimestampsBeyondOctalLimitInPax()
-        {
-            DateTimeOffset overLimitTimestamp = new DateTimeOffset(2242, 3, 16, 12, 56, 33, TimeSpan.Zero); // One second past the octal limit
-
-            string strOverLimitTimestamp = GetTimestampStringFromDateTimeOffset(overLimitTimestamp);
-
-            Dictionary<string, string> ea = new Dictionary<string, string>()
-            {
-                { PaxEaATime, strOverLimitTimestamp },
-                { PaxEaCTime, strOverLimitTimestamp }
-            };
-
-            PaxTarEntry entry = new PaxTarEntry(TarEntryType.Directory, "dir", ea);
-
-            entry.ModificationTime = overLimitTimestamp;
-            Assert.Equal(overLimitTimestamp, entry.ModificationTime);
-
-            Assert.Contains(PaxEaATime, entry.ExtendedAttributes);
-            DateTimeOffset atime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaATime);
-            Assert.Equal(overLimitTimestamp, atime);
-
-            Assert.Contains(PaxEaCTime, entry.ExtendedAttributes);
-            DateTimeOffset ctime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaCTime);
-            Assert.Equal(overLimitTimestamp, ctime);
-
-            using MemoryStream archiveStream = new MemoryStream();
-            using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
-            {
-                writer.WriteEntry(entry);
-            }
-
-            archiveStream.Position = 0;
-            using (TarReader reader = new TarReader(archiveStream))
-            {
-                PaxTarEntry readEntry = reader.GetNextEntry() as PaxTarEntry;
-                Assert.NotNull(readEntry);
-
-                Assert.Equal(overLimitTimestamp, readEntry.ModificationTime);
-
-                Assert.Contains(PaxEaATime, readEntry.ExtendedAttributes);
-                DateTimeOffset actualATime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaATime);
-                Assert.Equal(overLimitTimestamp, actualATime);
-
-                Assert.Contains(PaxEaCTime, readEntry.ExtendedAttributes);
-                DateTimeOffset actualCTime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaCTime);
-                Assert.Equal(overLimitTimestamp, actualCTime);
+                Assert.Equal(timestamp, actualCTime);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntry.Entry.Pax.Tests.cs
@@ -376,7 +376,7 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [MemberData(nameof(WriteTimeStamps_TheoryData))]
+        [MemberData(nameof(WriteTimeStamp_Pax_TheoryData))]
         public void WriteTimestampsInPax(DateTimeOffset timestamp)
         {
             string strTimestamp = GetTimestampStringFromDateTimeOffset(timestamp);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -397,36 +397,30 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        [Fact]
-        // Y2K38 will happen one second after "2038/19/01 03:14:07 +00:00". This timestamp represents the seconds since the Unix epoch with a
-        // value of int.MaxValue: 2,147,483,647.
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // All our entry types should survive the Epochalypse because we internally use long to represent the seconds since Unix epoch, not int.
-        // So if the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591, which
-        // is way past int MaxValue, but still within the long limits. That number represents the date "2242/16/03 12:56:32 +00:00".
-        public async Task WriteTimestampsBeyondEpochalypseInPax_Async()
+        [Theory]
+        [MemberData(nameof(WriteTimeStamps_TheoryData))]
+        public async Task WriteTimestampsInPax_Async(DateTimeOffset timestamp)
         {
-            DateTimeOffset epochalypse = new DateTimeOffset(2038, 1, 19, 3, 14, 8, TimeSpan.Zero);
-            string strEpochalypse = GetTimestampStringFromDateTimeOffset(epochalypse);
+            string strTimestamp = GetTimestampStringFromDateTimeOffset(timestamp);
 
             Dictionary<string, string> ea = new Dictionary<string, string>()
             {
-                { PaxEaATime, strEpochalypse },
-                { PaxEaCTime, strEpochalypse }
+                { PaxEaATime, strTimestamp },
+                { PaxEaCTime, strTimestamp }
             };
 
             PaxTarEntry entry = new PaxTarEntry(TarEntryType.Directory, "dir", ea);
 
-            entry.ModificationTime = epochalypse;
-            Assert.Equal(epochalypse, entry.ModificationTime);
+            entry.ModificationTime = timestamp;
+            Assert.Equal(timestamp, entry.ModificationTime);
 
             Assert.Contains(PaxEaATime, entry.ExtendedAttributes);
             DateTimeOffset atime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaATime);
-            Assert.Equal(epochalypse, atime);
+            Assert.Equal(timestamp, atime);
 
             Assert.Contains(PaxEaCTime, entry.ExtendedAttributes);
             DateTimeOffset ctime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaCTime);
-            Assert.Equal(epochalypse, ctime);
+            Assert.Equal(timestamp, ctime);
 
             using MemoryStream archiveStream = new MemoryStream();
             await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
@@ -440,71 +434,15 @@ namespace System.Formats.Tar.Tests
                 PaxTarEntry readEntry = await reader.GetNextEntryAsync() as PaxTarEntry;
                 Assert.NotNull(readEntry);
 
-                Assert.Equal(epochalypse, readEntry.ModificationTime);
+                Assert.Equal(timestamp, readEntry.ModificationTime);
 
                 Assert.Contains(PaxEaATime, readEntry.ExtendedAttributes);
                 DateTimeOffset actualATime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaATime);
-                Assert.Equal(epochalypse, actualATime);
+                Assert.Equal(timestamp, actualATime);
 
                 Assert.Contains(PaxEaCTime, readEntry.ExtendedAttributes);
                 DateTimeOffset actualCTime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaCTime);
-                Assert.Equal(epochalypse, actualCTime);
-            }
-        }
-
-        [Fact]
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // We internally use long to represent the seconds since Unix epoch, not int.
-        // If the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591,
-        // which represents the date "2242/03/16 12:56:32 +00:00".
-        // Pax should survive after this date because it stores the timestamps in the extended attributes dictionary
-        // without size restrictions.
-        public async Task WriteTimestampsBeyondOctalLimitInPax_Async()
-        {
-            DateTimeOffset overLimitTimestamp = new DateTimeOffset(2242, 3, 16, 12, 56, 33, TimeSpan.Zero); // One second past the octal limit
-
-            string strOverLimitTimestamp = GetTimestampStringFromDateTimeOffset(overLimitTimestamp);
-
-            Dictionary<string, string> ea = new Dictionary<string, string>()
-            {
-                { PaxEaATime, strOverLimitTimestamp },
-                { PaxEaCTime, strOverLimitTimestamp }
-            };
-
-            PaxTarEntry entry = new PaxTarEntry(TarEntryType.Directory, "dir", ea);
-
-            entry.ModificationTime = overLimitTimestamp;
-            Assert.Equal(overLimitTimestamp, entry.ModificationTime);
-
-            Assert.Contains(PaxEaATime, entry.ExtendedAttributes);
-            DateTimeOffset atime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaATime);
-            Assert.Equal(overLimitTimestamp, atime);
-
-            Assert.Contains(PaxEaCTime, entry.ExtendedAttributes);
-            DateTimeOffset ctime = GetDateTimeOffsetFromTimestampString(entry.ExtendedAttributes, PaxEaCTime);
-            Assert.Equal(overLimitTimestamp, ctime);
-
-            using MemoryStream archiveStream = new MemoryStream();
-            await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
-            {
-                await writer.WriteEntryAsync(entry);
-            }
-
-            archiveStream.Position = 0;
-            await using (TarReader reader = new TarReader(archiveStream))
-            {
-                PaxTarEntry readEntry = await reader.GetNextEntryAsync() as PaxTarEntry;
-                Assert.NotNull(readEntry);
-
-                Assert.Equal(overLimitTimestamp, readEntry.ModificationTime);
-
-                Assert.Contains(PaxEaATime, readEntry.ExtendedAttributes);
-                DateTimeOffset actualATime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaATime);
-                Assert.Equal(overLimitTimestamp, actualATime);
-
-                Assert.Contains(PaxEaCTime, readEntry.ExtendedAttributes);
-                DateTimeOffset actualCTime = GetDateTimeOffsetFromTimestampString(readEntry.ExtendedAttributes, PaxEaCTime);
-                Assert.Equal(overLimitTimestamp, actualCTime);
+                Assert.Equal(timestamp, actualCTime);
             }
         }
 

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Entry.Pax.Tests.cs
@@ -398,7 +398,7 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [MemberData(nameof(WriteTimeStamps_TheoryData))]
+        [MemberData(nameof(WriteTimeStamp_Pax_TheoryData))]
         public async Task WriteTimestampsInPax_Async(DateTimeOffset timestamp)
         {
             string strTimestamp = GetTimestampStringFromDateTimeOffset(timestamp);

--- a/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarWriter/TarWriter.WriteEntryAsync.Tests.cs
@@ -237,31 +237,22 @@ namespace System.Formats.Tar.Tests
             }
         }
 
-        // Y2K38 will happen one second after "2038/19/01 03:14:07 +00:00". This timestamp represents the seconds since the Unix epoch with a
-        // value of int.MaxValue: 2,147,483,647.
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // All our entry types should survive the Epochalypse because we internally use long to represent the seconds since Unix epoch, not int.
-        // So if the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591, which
-        // is way past int MaxValue, but still within the long limits. That number represents the date "2242/16/03 12:56:32 +00:00".
         [Theory]
-        [InlineData(TarEntryFormat.V7)]
-        [InlineData(TarEntryFormat.Ustar)]
-        [InlineData(TarEntryFormat.Gnu)]
-        public async Task WriteTimestampsBeyondEpochalypse_Async(TarEntryFormat format)
+        [MemberData(nameof(WriteTimeStampsWithFormats_TheoryData))]
+        public async Task WriteTimeStamps_Async(TarEntryFormat format, DateTimeOffset timestamp)
         {
-            DateTimeOffset epochalypse = new DateTimeOffset(2038, 1, 19, 3, 14, 8, TimeSpan.Zero); // One second past Y2K38
             TarEntry entry = InvokeTarEntryCreationConstructor(format, TarEntryType.Directory, "dir");
 
-            entry.ModificationTime = epochalypse;
-            Assert.Equal(epochalypse, entry.ModificationTime);
+            entry.ModificationTime = timestamp;
+            Assert.Equal(timestamp, entry.ModificationTime);
 
             if (entry is GnuTarEntry gnuEntry)
             {
-                gnuEntry.AccessTime = epochalypse;
-                Assert.Equal(epochalypse, gnuEntry.AccessTime);
+                gnuEntry.AccessTime = timestamp;
+                Assert.Equal(timestamp, gnuEntry.AccessTime);
 
-                gnuEntry.ChangeTime = epochalypse;
-                Assert.Equal(epochalypse, gnuEntry.ChangeTime);
+                gnuEntry.ChangeTime = timestamp;
+                Assert.Equal(timestamp, gnuEntry.ChangeTime);
             }
 
             using MemoryStream archiveStream = new MemoryStream();
@@ -276,43 +267,24 @@ namespace System.Formats.Tar.Tests
                 TarEntry readEntry = await reader.GetNextEntryAsync();
                 Assert.NotNull(readEntry);
 
-                Assert.Equal(epochalypse, readEntry.ModificationTime);
+                Assert.Equal(timestamp, readEntry.ModificationTime);
 
                 if (readEntry is GnuTarEntry gnuReadEntry)
                 {
-                    Assert.Equal(epochalypse, gnuReadEntry.AccessTime);
-                    Assert.Equal(epochalypse, gnuReadEntry.ChangeTime);
+                    Assert.Equal(timestamp, gnuReadEntry.AccessTime);
+                    Assert.Equal(timestamp, gnuReadEntry.ChangeTime);
                 }
             }
         }
 
-        // The fixed size fields for mtime, atime and ctime can fit 12 ASCII characters, but the last character is reserved for an ASCII space.
-        // We internally use long to represent the seconds since Unix epoch, not int.
-        // If the max allowed value is 77,777,777,777 in octal, then the max allowed seconds since the Unix epoch are 8,589,934,591,
-        // which represents the date "2242/03/16 12:56:32 +00:00".
-        // V7, Ustar and GNU would not survive after this date because they only have the fixed size fields to store timestamps.
         [Theory]
-        [InlineData(TarEntryFormat.V7)]
-        [InlineData(TarEntryFormat.Ustar)]
-        [InlineData(TarEntryFormat.Gnu)]
-        public async Task WriteTimestampsBeyondOctalLimit_Async(TarEntryFormat format)
+        [MemberData(nameof(WriteIntField_TheoryData))]
+        public async Task WriteUid_Async(TarEntryFormat format, int value)
         {
-            DateTimeOffset overLimitTimestamp = new DateTimeOffset(2242, 3, 16, 12, 56, 33, TimeSpan.Zero); // One second past the octal limit
-
             TarEntry entry = InvokeTarEntryCreationConstructor(format, TarEntryType.Directory, "dir");
 
-            // Before writing the entry, the timestamps should have no issue
-            entry.ModificationTime = overLimitTimestamp;
-            Assert.Equal(overLimitTimestamp, entry.ModificationTime);
-
-            if (entry is GnuTarEntry gnuEntry)
-            {
-                gnuEntry.AccessTime = overLimitTimestamp;
-                Assert.Equal(overLimitTimestamp, gnuEntry.AccessTime);
-
-                gnuEntry.ChangeTime = overLimitTimestamp;
-                Assert.Equal(overLimitTimestamp, gnuEntry.ChangeTime);
-            }
+            entry.Uid = value;
+            Assert.Equal(value, entry.Uid);
 
             using MemoryStream archiveStream = new MemoryStream();
             await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
@@ -326,14 +298,94 @@ namespace System.Formats.Tar.Tests
                 TarEntry readEntry = await reader.GetNextEntryAsync();
                 Assert.NotNull(readEntry);
 
-                // The timestamps get stored as '{1970-01-01 12:00:00 AM +00:00}' due to the +1 overflow
-                Assert.NotEqual(overLimitTimestamp, readEntry.ModificationTime);
+                Assert.Equal(value, readEntry.Uid);
+            }
+        }
 
-                if (readEntry is GnuTarEntry gnuReadEntry)
-                {
-                    Assert.NotEqual(overLimitTimestamp, gnuReadEntry.AccessTime);
-                    Assert.NotEqual(overLimitTimestamp, gnuReadEntry.ChangeTime);
-                }
+        [Theory]
+        [MemberData(nameof(WriteIntField_TheoryData))]
+        public async Task WriteGid_Async(TarEntryFormat format, int value)
+        {
+            TarEntry entry = InvokeTarEntryCreationConstructor(format, TarEntryType.Directory, "dir");
+
+            entry.Gid = value;
+            Assert.Equal(value, entry.Gid);
+
+            using MemoryStream archiveStream = new MemoryStream();
+            await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archiveStream.Position = 0;
+            await using (TarReader reader = new TarReader(archiveStream))
+            {
+                TarEntry readEntry = await reader.GetNextEntryAsync();
+                Assert.NotNull(readEntry);
+
+                Assert.Equal(value, readEntry.Gid);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteIntField_TheoryData))]
+        public async Task WriteDeviceMajor_Async(TarEntryFormat format, int value)
+        {
+            if (format == TarEntryFormat.V7)
+            {
+                return; // No DeviceMajor
+            }
+
+            PosixTarEntry? entry = InvokeTarEntryCreationConstructor(format, TarEntryType.BlockDevice, "dir") as PosixTarEntry;
+            Assert.NotNull(entry);
+
+            entry.DeviceMajor = value;
+            Assert.Equal(value, entry.DeviceMajor);
+
+            using MemoryStream archiveStream = new MemoryStream();
+            await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archiveStream.Position = 0;
+            await using (TarReader reader = new TarReader(archiveStream))
+            {
+                PosixTarEntry? readEntry = await reader.GetNextEntryAsync() as PosixTarEntry;
+                Assert.NotNull(readEntry);
+
+                Assert.Equal(value, readEntry.DeviceMajor);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(WriteIntField_TheoryData))]
+        public async Task WriteDeviceMinor_Async(TarEntryFormat format, int value)
+        {
+            if (format == TarEntryFormat.V7)
+            {
+                return; // No DeviceMinor
+            }
+
+            PosixTarEntry? entry = InvokeTarEntryCreationConstructor(format, TarEntryType.BlockDevice, "dir") as PosixTarEntry;
+            Assert.NotNull(entry);
+
+            entry.DeviceMinor = value;
+            Assert.Equal(value, entry.DeviceMinor);
+
+            using MemoryStream archiveStream = new MemoryStream();
+            await using (TarWriter writer = new TarWriter(archiveStream, leaveOpen: true))
+            {
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archiveStream.Position = 0;
+            await using (TarReader reader = new TarReader(archiveStream))
+            {
+                PosixTarEntry? readEntry = await reader.GetNextEntryAsync() as PosixTarEntry;
+                Assert.NotNull(readEntry);
+
+                Assert.Equal(value, readEntry.DeviceMinor);
             }
         }
 
@@ -421,30 +473,6 @@ namespace System.Formats.Tar.Tests
             }
 
             AssertExtensions.SequenceEqual(msSource.ToArray(), msDestination.ToArray());
-        }
-
-        [Theory]
-        [InlineData(TarEntryFormat.V7, false)]
-        [InlineData(TarEntryFormat.Ustar, false)]
-        [InlineData(TarEntryFormat.Gnu, false)]
-        [InlineData(TarEntryFormat.V7, true)]
-        [InlineData(TarEntryFormat.Ustar, true)]
-        [InlineData(TarEntryFormat.Gnu, true)]
-        public async Task WriteEntry_FileSizeOverLegacyLimit_Throws_Async(TarEntryFormat entryFormat, bool unseekableStream)
-        {
-            const long FileSizeOverLimit = LegacyMaxFileSize + 1;
-
-            await using MemoryStream ms = new();
-            await using Stream s = unseekableStream ? new WrappedStream(ms, ms.CanRead, ms.CanWrite, canSeek: false) : ms;
-
-            string tarFilePath = GetTestFilePath();
-            await using TarWriter writer = new(File.Create(tarFilePath));
-            TarEntry writeEntry = InvokeTarEntryCreationConstructor(entryFormat, entryFormat is TarEntryFormat.V7 ? TarEntryType.V7RegularFile : TarEntryType.RegularFile, "foo");
-            writeEntry.DataStream = new SimulatedDataStream(FileSizeOverLimit);
-
-            Assert.Equal(FileSizeOverLimit, writeEntry.Length);
-
-            await Assert.ThrowsAsync<ArgumentException>(() => writer.WriteEntryAsync(writeEntry));
         }
 
         [Theory]


### PR DESCRIPTION
The tar specification stores numeric fields using an octal representation. This limits the range of values that can be stored.

To increase the supported range, a GNU extension defines that when the leading byte is 0xff/0x80 the remaining bytes are a negative/positive big endian formatted value.

When writing under the PAX format, we continue to only use the only octal representation in the header fields. The values are overridden using extended attributes.

Fixes https://github.com/dotnet/runtime/issues/93763.

@dotnet/area-system-formats-tar ptal.