### PR TITLE
Disallow frozen `RuntimeType` for canonical types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -1484,7 +1484,8 @@ namespace ILCompiler.DependencyAnalysis
                 // If the whole program view contains a reference to a preallocated RuntimeType
                 // instance for this type, generate a reference to it.
                 // Otherwise, generate as zero to save size.
-                if (_type.GetFrozenRuntimeTypeNode(factory) is { Marked: true } runtimeTypeObject)
+                if (!_type.Type.IsCanonicalSubtype(CanonicalFormKind.Any)
+                    && _type.GetFrozenRuntimeTypeNode(factory) is { Marked: true } runtimeTypeObject)
                 {
                     builder.EmitPointerReloc(runtimeTypeObject);
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/FrozenRuntimeTypeNode.cs
@@ -16,6 +16,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public FrozenRuntimeTypeNode(TypeDesc type, bool constructed)
         {
+            Debug.Assert(!type.IsCanonicalSubtype(CanonicalFormKind.Any));
             _type = type;
             _constructed = constructed;
         }

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2404,6 +2404,9 @@ namespace Internal.JitInterface
         private CORINFO_OBJECT_STRUCT_* getRuntimeTypePointer(CORINFO_CLASS_STRUCT_* cls)
         {
             TypeDesc type = HandleToObject(cls);
+            if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
+                return null;
+            
             return ObjectToHandle(_compilation.NecessaryRuntimeTypeIfPossible(type));
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2406,7 +2406,7 @@ namespace Internal.JitInterface
             TypeDesc type = HandleToObject(cls);
             if (type.IsCanonicalSubtype(CanonicalFormKind.Any))
                 return null;
-            
+
             return ObjectToHandle(_compilation.NecessaryRuntimeTypeIfPossible(type));
         }
 

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101175/Runtime_101175.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101175/Runtime_101175.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public static class Runtime_101175
+{
+    [Fact]
+    public static void Test()
+    {
+        Activator.CreateInstance(typeof(Foo<>).MakeGenericType(typeof(object)));
+    }
+
+    class Foo<T>
+    {
+        public Foo()
+        {
+            if (new T[0].ToString() != "System.Object[]")
+                throw new Exception();
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101175/Runtime_101175.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101175/Runtime_101175.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`__Canon` is a compile-time concept.

Fixes #101175