### PR TITLE
Move first chance exception notification so the !pe works

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -5655,8 +5655,6 @@ VOID DECLSPEC_NORETURN DispatchManagedException(OBJECTREF throwable, CONTEXT* pE
     args[ARGNUM_0] = OBJECTREF_TO_ARGHOLDER(throwable);
     args[ARGNUM_1] = PTR_TO_ARGHOLDER(&exInfo);
 
-    FirstChanceExceptionNotification();
-
     pThread->IncPreventAbort();
 
     //Ex.RhThrowEx(throwable, &exInfo)
@@ -8127,6 +8125,7 @@ static void NotifyExceptionPassStarted(StackFrameIterator *pThis, Thread *pThrea
     {
         GCX_COOP();
         pThread->SafeSetThrowables(pExInfo->m_exception);
+        FirstChanceExceptionNotification();
         EEToProfilerExceptionInterfaceWrapper::ExceptionThrown(pThread);
     }
     else // pExInfo->m_passNumber == 2


### PR DESCRIPTION
The recent addition of first chance exception notification for the new EH was comming too early, so when the notification occurred, the !pe SOS command was not able to get the actual exception yet - it was not accessible via the Thread::ExceptionState

This change moves the notification to the first spot where the exception state points to the exception, so the !pe works.