### PR TITLE
Add managed blocking info for lock and monitor waits

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -32,6 +32,8 @@ namespace System.Threading
         private Waiter? _waitersHead;
         private Waiter? _waitersTail;
 
+        internal Lock AssociatedLock => _lock;
+
         private unsafe void AssertIsInList(Waiter waiter)
         {
             Debug.Assert(_waitersHead != null && _waitersTail != null);
@@ -105,6 +107,8 @@ namespace System.Threading
 
             if (!_lock.IsHeldByCurrentThread)
                 throw new SynchronizationLockException();
+
+            using ThreadBlockingInfo.Scope threadBlockingScope = new(this, millisecondsTimeout);
 
             Waiter waiter = GetWaiterForCurrentThread();
             AddWaiter(waiter);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -24,6 +24,12 @@ namespace System.Threading
         /// </summary>
         public Lock() => _spinCount = SpinCountNotInitialized;
 
+#pragma warning disable CA1822 // can be marked as static - varies between runtimes
+        internal ulong OwningOSThreadId => 0;
+#pragma warning restore CA1822
+
+        internal int OwningManagedThreadId => (int)_owningThreadId;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryEnterOneShot(int currentManagedThreadId)
         {

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -1158,6 +1158,13 @@ void SystemDomain::Init()
 
         // Finish loading CoreLib now.
         m_pSystemAssembly->GetDomainAssembly()->EnsureActive();
+
+        // Set AwareLock's offset of the holding OS thread ID field into ThreadBlockingInfo's static field. That can be used
+        // when doing managed debugging to get the OS ID of the thread holding the lock. The offset is currently not zero, and
+        // zero is used in managed code to determine if the static variable has been initialized.
+        _ASSERTE(AwareLock::GetOffsetOfHoldingOSThreadId() != 0);
+        CoreLibBinder::GetField(FIELD__THREAD_BLOCKING_INFO__OFFSET_OF_LOCK_OWNER_OS_THREAD_ID)
+            ->SetStaticValue32(AwareLock::GetOffsetOfHoldingOSThreadId());
     }
 
 #ifdef _DEBUG

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -583,6 +583,10 @@ END_ILLINK_FEATURE_SWITCH()
 DEFINE_CLASS(MONITOR,               Threading,              Monitor)
 DEFINE_METHOD(MONITOR,              ENTER,                  Enter,                      SM_Obj_RetVoid)
 
+DEFINE_CLASS(THREAD_BLOCKING_INFO,  Threading,              ThreadBlockingInfo)
+DEFINE_FIELD(THREAD_BLOCKING_INFO,  OFFSET_OF_LOCK_OWNER_OS_THREAD_ID, s_monitorObjectOffsetOfLockOwnerOSThreadId)
+DEFINE_FIELD(THREAD_BLOCKING_INFO,  FIRST,                  t_first)
+
 DEFINE_CLASS(PARAMETER,             Reflection,             ParameterInfo)
 
 DEFINE_CLASS(PARAMETER_MODIFIER,    Reflection,             ParameterModifier)

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -602,6 +602,12 @@ public:
         LIMITED_METHOD_CONTRACT;
         return m_HoldingThread;
     }
+
+    static int GetOffsetOfHoldingOSThreadId()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (int)offsetof(AwareLock, m_HoldingOSThreadId);
+    }
 };
 
 #ifdef FEATURE_COMINTEROP

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1266,6 +1266,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Thread.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ProcessorIdCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadAbortException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadBlockingInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadExceptionEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadInt64PersistentCounter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadInterruptedException.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
@@ -16,6 +16,12 @@ namespace System.Threading
         /// </summary>
         public Lock() => _spinCount = s_maxSpinCount;
 
+        internal ulong OwningOSThreadId => _owningThreadId;
+
+#pragma warning disable CA1822 // can be marked as static - varies between runtimes
+        internal int OwningManagedThreadId => 0;
+#pragma warning restore CA1822
+
         private static TryLockResult LazyInitializeOrEnter() => TryLockResult.Spin;
         private static bool IsSingleProcessor => Environment.IsSingleProcessor;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -477,6 +477,8 @@ namespace System.Threading
                     waitStartTimeTicks = Stopwatch.GetTimestamp();
                 }
 
+                using ThreadBlockingInfo.Scope threadBlockingScope = new(this, timeoutMs);
+
                 bool acquiredLock = false;
                 int waitStartTimeMs = timeoutMs < 0 ? 0 : Environment.TickCount;
                 int remainingTimeoutMs = timeoutMs;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Threading
+{
+    // Tracks some kinds of blocking on the thread, like waiting on locks where it may be useful to know when debugging which
+    // thread owns the lock.
+    //
+    // Notes:
+    // - The type, some fields, and some other members may be used by debuggers (noted specifically below), so take care when
+    //   renaming them
+    // - There is a native version of this struct in CoreCLR, used by Monitor to fold in its blocking info here. The struct is
+    //   blittable with sequential layout to support that.
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct ThreadBlockingInfo
+    {
+#if CORECLR
+        // In CoreCLR, for the Monitor object kinds, the object ptr will be a pointer to a native AwareLock object. This
+        // relative offset indicates the location of the field holding the lock owner OS thread ID (the field is of type
+        // size_t), and is used to get that info by the LockOwnerOSThreadId property. The offset is not zero currently, so zero
+        // is used to determine if the static field has been initialized.
+        //
+        // This mechanism is used instead of using an FCall in the property getter such that the property can be more easily
+        // evaluated by a debugger.
+        private static int s_monitorObjectOffsetOfLockOwnerOSThreadId;
+#endif
+
+        // Points to the first (most recent) blocking info for the thread. The _next field points to the next-most-recent
+        // blocking info for the thread, or null if there are no more. Blocking can be reentrant in some cases, such as on UI
+        // threads where reentrant waits are used, or if a SynchronizationContext wait override is set.
+        [ThreadStatic]
+        private static ThreadBlockingInfo* t_first; // may be used by debuggers
+
+        // This pointer can be used to obtain the object relevant to the blocking. For native object kinds, it points to the
+        // native object (for Monitor object kinds in CoreCLR, it points to a native AwareLock object). For managed object
+        // kinds, it points to a stack location containing the managed object reference.
+        private void* _objectPtr; // may be used by debuggers
+
+        // Indicates the type of object relevant to the blocking
+        private ObjectKind _objectKind; // may be used by debuggers
+
+        // The timeout in milliseconds for the wait, -1 for infinite timeout
+        private int _timeoutMs; // may be used by debuggers
+
+        // Points to the next-most-recent blocking info for the thread
+        private ThreadBlockingInfo* _next; // may be used by debuggers
+
+        private void Push(void* objectPtr, ObjectKind objectKind, int timeoutMs)
+        {
+            Debug.Assert(objectPtr != null);
+
+            _objectPtr = objectPtr;
+            _objectKind = objectKind;
+            _timeoutMs = timeoutMs;
+            _next = t_first;
+            t_first = (ThreadBlockingInfo*)Unsafe.AsPointer(ref this);
+        }
+
+        private void Pop()
+        {
+            Debug.Assert(_objectPtr != null);
+            Debug.Assert(t_first != null);
+            Debug.Assert(t_first->_next == _next);
+
+            t_first = _next;
+            _objectPtr = null;
+        }
+
+        // If the blocking is associated with a lock of some kind that has thread affinity and tracks the owner's OS thread ID,
+        // returns the OS thread ID of the thread that currently owns the lock. Otherwise, returns 0. A return value of 0 may
+        // indicate that the associated lock is currently not owned by a thread, or that the information could not be
+        // determined.
+        //
+        // Calls to native helpers are avoided in the property getter such that it can be more easily evaluated by a debugger.
+        public ulong LockOwnerOSThreadId // the getter may be used by debuggers
+        {
+            get
+            {
+                Debug.Assert(_objectPtr != null);
+
+                switch (_objectKind)
+                {
+                    case ObjectKind.MonitorLock:
+                    case ObjectKind.MonitorWait:
+                        // The Monitor object kinds are only used by CoreCLR, and only the OS thread ID is reported
+#if CORECLR
+                        if (s_monitorObjectOffsetOfLockOwnerOSThreadId != 0)
+                        {
+                            return *(nuint*)((nint)_objectPtr + s_monitorObjectOffsetOfLockOwnerOSThreadId);
+                        }
+#endif
+                        return 0;
+
+                    case ObjectKind.Lock:
+                        return ((Lock)Unsafe.AsRef<object>(_objectPtr)).OwningOSThreadId;
+
+                    default:
+                        Debug.Assert(_objectKind == ObjectKind.Condition);
+#if NATIVEAOT
+                        return ((Condition)Unsafe.AsRef<object>(_objectPtr)).AssociatedLock.OwningOSThreadId;
+#else
+                        return 0;
+#endif
+                }
+            }
+        }
+
+        // If the blocking is associated with a lock of some kind that has thread affinity and tracks the owner's managed thread
+        // ID, returns the managed thread ID of the thread that currently owns the lock. Otherwise, returns 0. A return value of
+        // 0 may indicate that the associated lock is currently not owned by a thread, or that the information could not be
+        // determined.
+        //
+        // Calls to native helpers are avoided in the property getter such that it can be more easily evaluated by a debugger.
+        public int LockOwnerManagedThreadId // the getter may be used by debuggers
+        {
+            get
+            {
+                Debug.Assert(_objectPtr != null);
+
+                switch (_objectKind)
+                {
+                    case ObjectKind.MonitorLock:
+                    case ObjectKind.MonitorWait:
+                        // The Monitor object kinds are only used by CoreCLR, and only the OS thread ID is reported
+                        return 0;
+
+                    case ObjectKind.Lock:
+                        return ((Lock)Unsafe.AsRef<object>(_objectPtr)).OwningManagedThreadId;
+
+                    default:
+                        Debug.Assert(_objectKind == ObjectKind.Condition);
+#if NATIVEAOT
+                        return ((Condition)Unsafe.AsRef<object>(_objectPtr)).AssociatedLock.OwningManagedThreadId;
+#else
+                        return 0;
+#endif
+                }
+            }
+        }
+
+        public unsafe ref struct Scope
+        {
+            private object? _object;
+            private ThreadBlockingInfo _blockingInfo;
+
+#pragma warning disable CS9216 // casting Lock to object
+            public Scope(Lock lockObj, int timeoutMs) : this(lockObj, ObjectKind.Lock, timeoutMs) { }
+#pragma warning restore CS9216
+
+#if NATIVEAOT
+            public Scope(Condition condition, int timeoutMs) : this(condition, ObjectKind.Condition, timeoutMs) { }
+#endif
+
+            private Scope(object obj, ObjectKind objectKind, int timeoutMs)
+            {
+                _object = obj;
+                _blockingInfo.Push(Unsafe.AsPointer(ref _object), objectKind, timeoutMs);
+            }
+
+            public void Dispose()
+            {
+                if (_object is not null)
+                {
+                    _blockingInfo.Pop();
+                    _object = null;
+                }
+            }
+        }
+
+        public enum ObjectKind // may be used by debuggers
+        {
+            MonitorLock, // maps to DebugBlockingItemType::DebugBlock_MonitorCriticalSection in coreclr
+            MonitorWait, // maps to DebugBlockingItemType::DebugBlock_MonitorEvent in coreclr
+            Lock,
+            Condition
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -15,6 +15,18 @@ namespace System.Threading
     //   renaming them
     // - There is a native version of this struct in CoreCLR, used by Monitor to fold in its blocking info here. The struct is
     //   blittable with sequential layout to support that.
+    //
+    // Debuggers may use this info by evaluating expressions to enumerate the blocking infos for a thread. For example:
+    // - Evaluate "System.Threading.ThreadBlockingInfo.t_first" to obtain the first pointer to a blocking info for the current
+    //   thread
+    // - While there is a non-null pointer to a blocking info:
+    //   - Evaluate "(*(System.Threading.ThreadBlockingInfo*)ptr).fieldOrProperty", where "ptr" is the blocking info pointer
+    //     value, to get the field and relevant property getter values below
+    //   - Use the _objectKind field value to determine what kind of blocking is occurring
+    //   - Get the LockOwnerOSThreadId and LockOwnerManagedThreadId property getter values. If the blocking is waiting for a
+    //     lock and the lock is currently owned by a thread, one of these properties will return a nonzero value that can be
+    //     used to identify the lock owner thread.
+    //   - Use the _next field value to obtain the next pointer to a blocking info for the thread
     [StructLayout(LayoutKind.Sequential)]
     internal unsafe struct ThreadBlockingInfo
     {


### PR DESCRIPTION
- Added a managed `ThreadBlockingInfo` struct that is similar to CoreCLR's `DebugBlockingItem`
- Updated `Lock`, `Condition`, and `Monitor` to record the info
- The `LockOwnerOSThreadId` and `LockOwnerManagedThreadId` properties can be used by debuggers to determine which thread owns a lock that the current thread is waiting on
  - In CoreCLR, `Monitor` records the info using the `Monitor` object kinds. In NativeAOT, `Lock` and `Condition` are used for `Monitor` waits, so the object kinds would be `Lock/Condition`. For now, Mono's `Monitor` does not record this info.