### PR TITLE
Keep our System.Text.Json version used in HostModel in sync with MSBuild

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -86,9 +86,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- when building from source we need to use the current version of MetadataLoadContext as the toolset version, but source-build imports
-         another props file which overrides the SystemReflectionMetadataLoadContextVersion from Version.props so we can't set it there -->
+    <!-- when building from source we need to use the current version of various packages as the toolset version, but source-build imports
+         another props file which overrides the versions from Version.props so we can't set it there -->
     <SystemReflectionMetadataLoadContextToolsetVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SystemReflectionMetadataLoadContextVersion)</SystemReflectionMetadataLoadContextToolsetVersion>
+    <SystemTextJsonToolsetVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(SystemTextJsonVersion)</SystemTextJsonToolsetVersion>
   </PropertyGroup>
 
   <Target Name="ValidateTargetOSLowercase"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -134,6 +134,7 @@
     <runtimenativeSystemIOPortsVersion>9.0.0-preview.4.24215.1</runtimenativeSystemIOPortsVersion>
     <!-- Keep toolset versions in sync with dotnet/msbuild and dotnet/sdk -->
     <SystemCollectionsImmutableToolsetVersion>8.0.0</SystemCollectionsImmutableToolsetVersion>
+    <SystemTextJsonToolsetVersion>8.0.0</SystemTextJsonToolsetVersion>
     <SystemReflectionMetadataToolsetVersion>8.0.0</SystemReflectionMetadataToolsetVersion>
     <SystemReflectionMetadataLoadContextToolsetVersion>8.0.0</SystemReflectionMetadataLoadContextToolsetVersion>
     <!-- Runtime-Assets dependencies -->

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataToolsetVersion)" />
-    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonToolsetVersion)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,5 +35,3 @@
 
 
 </Project>
-
-


### PR DESCRIPTION
This follows the same pattern as Roslyn, and ensures that the binding redirects in MSBuild kick in on .NET Framework.

This also happens to help unblock https://github.com/dotnet/installer/pull/19491 by working around the downgrade problem.