### PR TITLE
Fix a compiler error on alpine-arm64

### DIFF
--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1248,7 +1248,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
         optReturnBlock = true;
     }
 
-    assert(m_cmpOp != NULL && m_c1 != nullptr && m_c2 != nullptr);
+    assert(m_cmpOp != GT_NONE && m_c1 != nullptr && m_c2 != nullptr);
 
     GenTree* cmpOp1 = m_foldOp == GT_NONE ? m_c1 : m_comp->gtNewOperNode(m_foldOp, m_foldType, m_c1, m_c2);
     if (m_testInfo1.isBool && m_testInfo2.isBool)


### PR DESCRIPTION
Attempt to fix this compilation error:

>  /runtime/src/coreclr/jit/optimizebools.cpp:1251:20: error: invalid operands to binary expression ('genTreeOps' and 'std::nullptr_t')