### PR TITLE
[wasm] Optimize jiterpreter option table updates

### DIFF
--- a/src/mono/browser/runtime/cwraps.ts
+++ b/src/mono/browser/runtime/cwraps.ts
@@ -99,6 +99,7 @@ const fn_signatures: SigLine[] = [
     [true, "mono_jiterp_get_size_of_stackval", "number", []],
     [true, "mono_jiterp_parse_option", "number", ["string"]],
     [true, "mono_jiterp_get_options_as_json", "number", []],
+    [true, "mono_jiterp_get_option_as_int", "number", ["string"]],
     [true, "mono_jiterp_get_options_version", "number", []],
     [true, "mono_jiterp_adjust_abort_count", "number", ["number", "number"]],
     [true, "mono_jiterp_register_jit_call_thunk", "void", ["number", "number"]],
@@ -228,6 +229,7 @@ export interface t_Cwraps {
     mono_jiterp_type_get_raw_value_size(type: MonoType): number;
     mono_jiterp_parse_option(name: string): number;
     mono_jiterp_get_options_as_json(): number;
+    mono_jiterp_get_option_as_int(name: string): number;
     mono_jiterp_get_options_version(): number;
     mono_jiterp_adjust_abort_count(opcode: number, delta: number): number;
     mono_jiterp_register_jit_call_thunk(cinfo: number, func: number): void;

--- a/src/mono/browser/runtime/jiterpreter-support.ts
+++ b/src/mono/browser/runtime/jiterpreter-support.ts
@@ -9,7 +9,6 @@ import { MintOpcode } from "./mintops";
 import cwraps from "./cwraps";
 import { mono_log_error, mono_log_info } from "./logging";
 import { localHeapViewU8, localHeapViewU32 } from "./memory";
-import { utf8ToString } from "./strings";
 import {
     JiterpNumberMode, BailoutReason, JiterpreterTable,
     JiterpCounter, JiterpMember, OpcodeInfoType
@@ -2015,15 +2014,13 @@ export function getOptions () {
 }
 
 function updateOptions () {
-    const pJson = cwraps.mono_jiterp_get_options_as_json();
-    const json = utf8ToString(<any>pJson);
-    Module._free(<any>pJson);
-    const blob = JSON.parse(json);
-
     optionTable = <any>{};
     for (const k in optionNames) {
-        const info = optionNames[k];
-        (<any>optionTable)[k] = blob[info];
+        const value = cwraps.mono_jiterp_get_option_as_int(optionNames[k]);
+        if (value > -2147483647)
+            (<any>optionTable)[k] = value;
+        else
+            mono_log_info(`Failed to retrieve value of option ${optionNames[k]}`);
     }
 }
 

--- a/src/mono/mono/mini/interp/jiterpreter.c
+++ b/src/mono/mono/mini/interp/jiterpreter.c
@@ -1021,8 +1021,28 @@ mono_jiterp_get_options_as_json ()
 	return mono_options_get_as_json ();
 }
 
+EMSCRIPTEN_KEEPALIVE gint32
+mono_jiterp_get_option_as_int (const char *name)
+{
+	MonoOptionType type;
+	void *value_address;
+
+	if (!mono_options_get (name, &type, &value_address))
+		return INT32_MIN;
+
+	switch (type) {
+		case MONO_OPTION_BOOL:
+		case MONO_OPTION_BOOL_READONLY:
+			return (*(guint8 *)value_address) != 0;
+		case MONO_OPTION_INT:
+			return *(gint32 *)value_address;
+		default:
+			return INT32_MIN;
+	}
+}
+
 EMSCRIPTEN_KEEPALIVE int
-mono_jiterp_object_has_component_size (MonoObject ** ppObj)
+mono_jiterp_object_has_component_size (MonoObject **ppObj)
 {
 	MonoObject *obj = *ppObj;
 	if (!obj)

--- a/src/mono/mono/utils/options.c
+++ b/src/mono/mono/utils/options.c
@@ -10,13 +10,6 @@
 #include "options.h"
 #include "mono/utils/mono-error-internals.h"
 
-typedef enum {
-	MONO_OPTION_BOOL,
-	MONO_OPTION_BOOL_READONLY,
-	MONO_OPTION_INT,
-	MONO_OPTION_STRING
-} MonoOptionType;
-
 /* Define flags */
 #define DEFINE_OPTION_FULL(option_type, ctype, c_name, cmd_name, def_value, comment) \
 	ctype mono_opt_##c_name = def_value;
@@ -332,4 +325,23 @@ mono_options_get_as_json (void)
 	result_str = result->str;
 	g_string_free(result, FALSE);
 	return result_str;
+}
+
+gboolean
+mono_options_get (const char *name, MonoOptionType *type, void **value_address)
+{
+	GHashTable *hash = get_option_hash ();
+	OptionData *meta = (OptionData *)g_hash_table_lookup (hash, name);
+
+	if (!meta) {
+		if (value_address)
+			*value_address = NULL;
+		return FALSE;
+	}
+
+	if (type)
+		*type = meta->option_type;
+	if (value_address)
+		*value_address = meta->addr;
+	return TRUE;
 }

--- a/src/mono/mono/utils/options.h
+++ b/src/mono/mono/utils/options.h
@@ -22,6 +22,13 @@ MONO_BEGIN_DECLS
 #include "options-def.h"
 MONO_END_DECLS
 
+typedef enum {
+	MONO_OPTION_BOOL,
+	MONO_OPTION_BOOL_READONLY,
+	MONO_OPTION_INT,
+	MONO_OPTION_STRING
+} MonoOptionType;
+
 extern int mono_options_version;
 
 void mono_options_print_usage (void);
@@ -30,5 +37,8 @@ void mono_options_parse_options (const char **args, int argc, int *out_argc, GPt
 
 /* returns a json blob representing the current values of all options */
 char * mono_options_get_as_json (void);
+
+gboolean
+mono_options_get (const char *name, MonoOptionType *type, void **value_address);
 
 #endif


### PR DESCRIPTION
The encode-decode-parse flow for the options JSON wastes some time during startup, this approach is a bit faster. The use of a string key still adds some overhead but it's much smaller than the previous overhead, and it's dwarfed by the cost of cwrap/ccall.