### PR TITLE
[cdac] Read contract descriptor from target

### DIFF
--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -28,8 +28,12 @@ namespace
 
     int ReadFromTargetCallback(uint64_t addr, uint8_t* dest, uint32_t count, void* context)
     {
-        CDAC* cdac = reinterpret_cast<CDAC*>(context);
-        return cdac->ReadFromTarget(addr, dest, count);
+        ICorDebugDataTarget* target = reinterpret_cast<ICorDebugDataTarget*>(context);
+        HRESULT hr = ReadFromDataTarget(target, addr, dest, count);
+        if (FAILED(hr))
+            return hr;
+
+        return S_OK;
     }
 }
 
@@ -52,11 +56,12 @@ CDAC::CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target)
         return;
     }
 
+    m_target->AddRef();
     decltype(&cdac_reader_init) init = reinterpret_cast<decltype(&cdac_reader_init)>(::GetProcAddress(m_module, "cdac_reader_init"));
     decltype(&cdac_reader_get_sos_interface) getSosInterface = reinterpret_cast<decltype(&cdac_reader_get_sos_interface)>(::GetProcAddress(m_module, "cdac_reader_get_sos_interface"));
     _ASSERTE(init != nullptr && getSosInterface != nullptr);
 
-    init(descriptorAddr, &ReadFromTargetCallback, this, &m_cdac_handle);
+    init(descriptorAddr, &ReadFromTargetCallback, m_target, &m_cdac_handle);
     getSosInterface(m_cdac_handle, &m_sos);
 }
 
@@ -76,13 +81,4 @@ CDAC::~CDAC()
 IUnknown* CDAC::SosInterface()
 {
     return m_sos;
-}
-
-int CDAC::ReadFromTarget(uint64_t addr, uint8_t* dest, uint32_t count)
-{
-    HRESULT hr = ReadFromDataTarget(m_target, addr, dest, count);
-    if (FAILED(hr))
-        return hr;
-
-    return S_OK;
 }

--- a/src/coreclr/debug/daccess/cdac.h
+++ b/src/coreclr/debug/daccess/cdac.h
@@ -21,7 +21,7 @@ public:
     CDAC(CDAC&& other)
         : m_module{ other.m_module }
         , m_cdac_handle{ other.m_cdac_handle }
-        , m_target{ other.m_target }
+        , m_target{ other.m_target.Extract() }
         , m_sos{ other.m_sos.Extract() }
     {
         other.m_module = NULL;
@@ -34,7 +34,7 @@ public:
     {
         m_module = other.m_module;
         m_cdac_handle = other.m_cdac_handle;
-        m_target = other.m_target;
+        m_target = other.m_target.Extract();
         m_sos = other.m_sos.Extract();
 
         other.m_module = NULL;
@@ -54,7 +54,6 @@ public:
 
     // This does not AddRef the returned interface
     IUnknown* SosInterface();
-    int ReadFromTarget(uint64_t addr, uint8_t* dest, uint32_t count);
 
 private:
     CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target);
@@ -62,7 +61,7 @@ private:
 private:
     HMODULE m_module;
     intptr_t m_cdac_handle;
-    ICorDebugDataTarget* m_target;
+    NonVMComHolder<ICorDebugDataTarget> m_target;
     NonVMComHolder<IUnknown> m_sos;
 };
 

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5499,9 +5499,8 @@ ClrDataAccess::Initialize(void)
         DWORD val;
         if (enable.TryAsInteger(10, val) && val == 1)
         {
-            // TODO: [cdac] Get contract descriptor from exported symbol
             uint64_t contractDescriptorAddr = 0;
-            //if (TryGetSymbol(m_pTarget, m_globalBase, "DotNetRuntimeContractDescriptor", &contractDescriptorAddr))
+            if (TryGetSymbol(m_pTarget, m_globalBase, "DotNetRuntimeContractDescriptor", &contractDescriptorAddr))
             {
                 m_cdac = CDAC::Create(contractDescriptorAddr, m_pTarget);
                 if (m_cdac.IsValid())

--- a/src/native/managed/cdacreader/src/CdacRoots.xml
+++ b/src/native/managed/cdacreader/src/CdacRoots.xml
@@ -1,6 +1,0 @@
-<linker>
-  <assembly fullname="libcdacreader">
-    <!-- https://github.com/dotnet/runtime/issues/101205 -->
-    <type fullname="Microsoft.Diagnostics.DataContractReader.Root" preserve="all" />
-  </assembly>
-</linker>

--- a/src/native/managed/cdacreader/src/CdacRoots.xml
+++ b/src/native/managed/cdacreader/src/CdacRoots.xml
@@ -1,0 +1,6 @@
+<linker>
+  <assembly fullname="libcdacreader">
+    <!-- https://github.com/dotnet/runtime/issues/101205 -->
+    <type fullname="Microsoft.Diagnostics.DataContractReader.Root" preserve="all" />
+  </assembly>
+</linker>

--- a/src/native/managed/cdacreader/src/ContractDescriptorParser.cs
+++ b/src/native/managed/cdacreader/src/ContractDescriptorParser.cs
@@ -29,7 +29,7 @@ public partial class ContractDescriptorParser
     }
 
     [JsonSerializable(typeof(ContractDescriptor))]
-    [JsonSerializable(typeof(int))]
+    [JsonSerializable(typeof(int?))]
     [JsonSerializable(typeof(string))]
     [JsonSerializable(typeof(Dictionary<string, int>))]
     [JsonSerializable(typeof(Dictionary<string, TypeDescriptor>))]
@@ -38,11 +38,17 @@ public partial class ContractDescriptorParser
     [JsonSerializable(typeof(TypeDescriptor))]
     [JsonSerializable(typeof(FieldDescriptor))]
     [JsonSerializable(typeof(GlobalDescriptor))]
+    [JsonSerializable(typeof(Dictionary<string, JsonElement>))]
     [JsonSourceGenerationOptions(AllowTrailingCommas = true,
                                 DictionaryKeyPolicy = JsonKnownNamingPolicy.Unspecified, // contracts, types and globals are case sensitive
                                 PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
                                 NumberHandling = JsonNumberHandling.AllowReadingFromString,
-                                ReadCommentHandling = JsonCommentHandling.Skip)]
+                                ReadCommentHandling = JsonCommentHandling.Skip,
+                                UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+                                UnknownTypeHandling = JsonUnknownTypeHandling.JsonElement,
+                                Converters = [typeof(TypeDescriptorConverter),
+                                            typeof(FieldDescriptorConverter),
+                                            typeof(GlobalDescriptorConverter)])]
     internal sealed partial class ContractDescriptorContext : JsonSerializerContext
     {
     }
@@ -58,7 +64,13 @@ public partial class ContractDescriptorParser
         public Dictionary<string, GlobalDescriptor>? Globals { get; set; }
 
         [JsonExtensionData]
-        public Dictionary<string, object?>? Extras { get; set; }
+        public Dictionary<string, JsonElement>? Extras { get; set; }
+
+        public override string ToString()
+        {
+            return $"Version: {Version}, Baseline: {Baseline}, Contracts: {Contracts?.Count}, Types: {Types?.Count}, Globals: {Globals?.Count}";
+        }
+
     }
 
     [JsonConverter(typeof(TypeDescriptorConverter))]

--- a/src/native/managed/cdacreader/src/ContractDescriptorParser.cs
+++ b/src/native/managed/cdacreader/src/ContractDescriptorParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -23,6 +24,8 @@ public partial class ContractDescriptorParser
     /// <summary>
     ///  Parses the "compact" representation of a contract descriptor.
     /// </summary>
+    // Workaround for https://github.com/dotnet/runtime/issues/101205
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Root))]
     public static ContractDescriptor? ParseCompact(ReadOnlySpan<byte> json)
     {
         return JsonSerializer.Deserialize(json, ContractDescriptorContext.Default.ContractDescriptor);

--- a/src/native/managed/cdacreader/src/Entrypoints.cs
+++ b/src/native/managed/cdacreader/src/Entrypoints.cs
@@ -14,7 +14,10 @@ internal static class Entrypoints
     [UnmanagedCallersOnly(EntryPoint = $"{CDAC}init")]
     private static unsafe int Init(ulong descriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, IntPtr* handle)
     {
-        Target target = new(descriptor, readFromTarget, readContext);
+        // TODO: [cdac] Better error code/details
+        if (!Target.TryCreate(descriptor, readFromTarget, readContext, out Target? target))
+            return -1;
+
         GCHandle gcHandle = GCHandle.Alloc(target);
         *handle = GCHandle.ToIntPtr(gcHandle);
         return 0;

--- a/src/native/managed/cdacreader/src/Root.cs
+++ b/src/native/managed/cdacreader/src/Root.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+internal static class Root
+{
+    // https://github.com/dotnet/runtime/issues/101205
+    public static JsonDerivedTypeAttribute[] R1 = new JsonDerivedTypeAttribute[] { null! };
+}

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -17,8 +17,6 @@ public struct TargetPointer
 internal sealed unsafe class Target
 {
     private const int StackAllocByteThreshold = 1024;
-    private static readonly ReadOnlyMemory<byte> MagicLE = new byte[] { 0x44, 0x4e, 0x43, 0x43, 0x44, 0x41, 0x43, 0x00 }; // "DNCCDAC\0"
-    private static readonly ReadOnlyMemory<byte> MagicBE = new byte[] { 0x00, 0x43, 0x41, 0x44, 0x43, 0x43, 0x4e, 0x44 };
 
     private readonly delegate* unmanaged<ulong, byte*, uint, void*, int> _readFromTarget;
     private readonly void* _readContext;
@@ -45,8 +43,10 @@ internal sealed unsafe class Target
             throw new InvalidOperationException("Failed to read magic.");
 
         address += sizeof(ulong);
-        _isLittleEndian = buffer.SequenceEqual(MagicLE.Span);
-        if (!_isLittleEndian && !buffer.SequenceEqual(MagicBE.Span))
+        ReadOnlySpan<byte> magicLE = "DNCCDAC\0"u8;
+        ReadOnlySpan<byte> magicBE = "\0CADCCND"u8;
+        _isLittleEndian = buffer.SequenceEqual(magicLE);
+        if (!_isLittleEndian && !buffer.SequenceEqual(magicBE))
             throw new InvalidOperationException("Invalid magic.");
 
         // Flags - uint32_t

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -16,47 +16,140 @@ public struct TargetPointer
 
 internal sealed unsafe class Target
 {
+    private static readonly ReadOnlyMemory<byte> MagicLE = new byte[] { 0x44, 0x4e, 0x43, 0x43, 0x44, 0x41, 0x43, 0x00 }; // "DNCCDAC\0"
+    private static readonly ReadOnlyMemory<byte> MagicBE = new byte[] { 0x00, 0x43, 0x41, 0x44, 0x43, 0x43, 0x4e, 0x44 };
+
     private readonly delegate* unmanaged<ulong, byte*, uint, void*, int> _readFromTarget;
     private readonly void* _readContext;
 
     private bool _isLittleEndian;
     private int _pointerSize;
 
-    public Target(ulong _, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext)
+    private TargetPointer[] _pointerData = [];
+
+    public Target(ulong contractDescriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext)
     {
         _readFromTarget = readFromTarget;
         _readContext = readContext;
 
-        // TODO: [cdac] Populate from descriptor
-        _isLittleEndian = BitConverter.IsLittleEndian;
-        _pointerSize = IntPtr.Size;
+        ReadContractDescriptor(contractDescriptor);
+    }
+
+    // See docs/design/datacontracts/contract-descriptor.md
+    private void ReadContractDescriptor(ulong address)
+    {
+        // Magic - uint64_t
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        if (ReadFromTarget(address, buffer) < 0)
+            throw new InvalidOperationException("Failed to read magic.");
+
+        address += sizeof(ulong);
+        _isLittleEndian = buffer.SequenceEqual(MagicLE.Span);
+        if (!_isLittleEndian && !buffer.SequenceEqual(MagicBE.Span))
+            throw new InvalidOperationException("Invalid magic.");
+
+        // Flags - uint32_t
+        uint flags = ReadUInt32(address);
+        address += sizeof(uint);
+
+        // Bit 1 represents the pointer size. 0 = 64-bit, 1 = 32-bit.
+        _pointerSize = (int)(flags & 0x2) == 0 ? sizeof(ulong) : sizeof(uint);
+
+        // Descriptor size - uint32_t
+        uint descriptorSize = ReadUInt32(address);
+        address += sizeof(uint);
+
+        // Descriptor - char*
+        TargetPointer descriptor = ReadPointer(address);
+        address += (uint)_pointerSize;
+
+        // Pointer data count - uint32_t
+        uint pointerDataCount = ReadUInt32(address);
+        address += sizeof(uint);
+
+        // Padding
+        address += sizeof(uint);
+
+        // Pointer data - uintptr_t*
+        TargetPointer pointerData = ReadPointer(address);
+
+        // Read descriptor
+        // TODO: [cdac] Pass to JSON parser
+        Span<byte> descriptorBuffer = stackalloc byte[(int)descriptorSize];
+        if (ReadFromTarget(descriptor.Value, descriptorBuffer) < 0)
+            throw new InvalidOperationException("Failed to read descriptor.");
+
+        // Read pointer data
+        _pointerData = new TargetPointer[pointerDataCount];
+        for (int i = 0; i < pointerDataCount; i++)
+        {
+            _pointerData[i] = ReadPointer(pointerData.Value + (uint)(i * _pointerSize));
+        }
+    }
+
+    public uint ReadUInt32(ulong address)
+    {
+        if (!TryReadUInt32(address, out uint value))
+            throw new InvalidOperationException($"Failed to read uint32 at 0x{address:x8}.");
+
+        return value;
+    }
+
+    public bool TryReadUInt32(ulong address, out uint value)
+    {
+        value = 0;
+
+        Span<byte> buffer = stackalloc byte[sizeof(uint)];
+        if (ReadFromTarget(address, buffer) < 0)
+            return false;
+
+        value = _isLittleEndian
+            ? BinaryPrimitives.ReadUInt32LittleEndian(buffer)
+            : BinaryPrimitives.ReadUInt32BigEndian(buffer);
+
+        return true;
+    }
+
+    public TargetPointer ReadPointer(ulong address)
+    {
+        if (!TryReadPointer(address, out TargetPointer pointer))
+            throw new InvalidOperationException($"Failed to read pointer at 0x{address:x8}.");
+
+        return pointer;
     }
 
     public bool TryReadPointer(ulong address, out TargetPointer pointer)
     {
         pointer = TargetPointer.Null;
 
-        byte* buffer = stackalloc byte[_pointerSize];
-        ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(buffer, _pointerSize);
-        if (ReadFromTarget(address, buffer, (uint)_pointerSize) < 0)
+        Span<byte> buffer = stackalloc byte[_pointerSize];
+        if (ReadFromTarget(address, buffer) < 0)
             return false;
 
         if (_pointerSize == sizeof(uint))
         {
             pointer = new TargetPointer(
                 _isLittleEndian
-                    ? BinaryPrimitives.ReadUInt32LittleEndian(span)
-                    : BinaryPrimitives.ReadUInt32BigEndian(span));
+                    ? BinaryPrimitives.ReadUInt32LittleEndian(buffer)
+                    : BinaryPrimitives.ReadUInt32BigEndian(buffer));
         }
         else if (_pointerSize == sizeof(ulong))
         {
             pointer = new TargetPointer(
                 _isLittleEndian
-                    ? BinaryPrimitives.ReadUInt64LittleEndian(span)
-                    : BinaryPrimitives.ReadUInt64BigEndian(span));
+                    ? BinaryPrimitives.ReadUInt64LittleEndian(buffer)
+                    : BinaryPrimitives.ReadUInt64BigEndian(buffer));
         }
 
         return true;
+    }
+
+    private int ReadFromTarget(ulong address, Span<byte> buffer)
+    {
+        fixed (byte* bufferPtr = buffer)
+        {
+            return _readFromTarget(address, bufferPtr, (uint)buffer.Length, _readContext);
+        }
     }
 
     private int ReadFromTarget(ulong address, byte* buffer, uint bytesToRead)

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -16,6 +16,7 @@ public struct TargetPointer
 
 internal sealed unsafe class Target
 {
+    private const int StackAllocByteThreshold = 1024;
     private static readonly ReadOnlyMemory<byte> MagicLE = new byte[] { 0x44, 0x4e, 0x43, 0x43, 0x44, 0x41, 0x43, 0x00 }; // "DNCCDAC\0"
     private static readonly ReadOnlyMemory<byte> MagicBE = new byte[] { 0x00, 0x43, 0x41, 0x44, 0x43, 0x43, 0x4e, 0x44 };
 
@@ -75,7 +76,9 @@ internal sealed unsafe class Target
 
         // Read descriptor
         // TODO: [cdac] Pass to JSON parser
-        Span<byte> descriptorBuffer = stackalloc byte[(int)descriptorSize];
+        Span<byte> descriptorBuffer = descriptorSize <= StackAllocByteThreshold
+            ? stackalloc byte[(int)descriptorSize]
+            : new byte[(int)descriptorSize];
         if (ReadFromTarget(descriptor.Value, descriptorBuffer) < 0)
             throw new InvalidOperationException("Failed to read descriptor.");
 

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TrimmerRootDescriptor Include="CdacRoots.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="$(LibrariesProjectRoot)Common\src\System\HResults.cs" Link="Common\System\HResults.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/native/managed/cdacreader/src/cdacreader.csproj
+++ b/src/native/managed/cdacreader/src/cdacreader.csproj
@@ -9,7 +9,12 @@
     <!-- Do not produce a public package. This ships as part of the runtime -->
     <IsShippingPackage>false</IsShippingPackage>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
+
+  <ItemGroup>
+    <TrimmerRootDescriptor Include="CdacRoots.xml" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="$(LibrariesProjectRoot)Common\src\System\HResults.cs" Link="Common\System\HResults.cs" />

--- a/src/native/managed/cdacreader/tests/ContractDescriptorParserTests.cs
+++ b/src/native/managed/cdacreader/tests/ContractDescriptorParserTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Text.Json;
 using System.Text.Unicode;
 using Xunit;
 
@@ -12,6 +13,7 @@ public class ContractDescriptorParserTests
     [Fact]
     public void ParsesEmptyContract()
     {
+        Assert.False(JsonSerializer.IsReflectionEnabledByDefault);
         ReadOnlySpan<byte> json = "{}"u8;
         ContractDescriptorParser.ContractDescriptor descriptor = ContractDescriptorParser.ParseCompact(json);
         Assert.Null(descriptor.Version);

--- a/src/native/managed/cdacreader/tests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
+++ b/src/native/managed/cdacreader/tests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
 


### PR DESCRIPTION
- Get `DotNetRuntimeContractDescriptor` address from the target
- Read contract descriptor to determine endianness and pointer size
- Parse JSON descriptor and store contracts

Depends on https://github.com/dotnet/runtime/pull/100650 to actually work.

Contributes to https://github.com/dotnet/runtime/issues/99298