### PR TITLE
Add `alpine` to target triplet for crossbuild

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -48,8 +48,14 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-bionic-arm'">androideabi21</CrossCompileAbi>
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-musl-arm'">musleabihf</CrossCompileAbi>
 
+      <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
+      <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != ''">
+        <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
+      </Exec>
+
       <TargetTriple />
-      <TargetTriple Condition="'$(CrossCompileArch)' != ''">$(CrossCompileArch)-linux-$(CrossCompileAbi)</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and '$(_IsAlpineExitCode)' != '0'">$(CrossCompileArch)-linux-$(CrossCompileAbi)</TargetTriple>
+      <TargetTriple Condition="'$(CrossCompileArch)' != '' and '$(_IsAlpineExitCode)' == '0'">$(CrossCompileArch)-alpine-linux-$(CrossCompileAbi)</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and ($(CrossCompileRid.StartsWith('freebsd')))">$(CrossCompileArch)-unknown-freebsd12</TargetTriple>
 
       <IlcRPath Condition="'$(IlcRPath)' == '' and '$(_IsApplePlatform)' != 'true'">$ORIGIN</IlcRPath>

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -50,7 +50,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
     <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
-    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != ''">
+    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != '' and '$(SysRoot)' != ''">
       <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
     </Exec>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -47,12 +47,14 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-arm'">gnueabihf</CrossCompileAbi>
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-bionic-arm'">androideabi21</CrossCompileAbi>
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-musl-arm'">musleabihf</CrossCompileAbi>
+    </PropertyGroup>
 
-      <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
-      <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != ''">
-        <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
-      </Exec>
+    <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
+    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != ''">
+      <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
+    </Exec>
 
+    <PropertyGroup>
       <TargetTriple />
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and '$(_IsAlpineExitCode)' != '0'">$(CrossCompileArch)-linux-$(CrossCompileAbi)</TargetTriple>
       <TargetTriple Condition="'$(CrossCompileArch)' != '' and '$(_IsAlpineExitCode)' == '0'">$(CrossCompileArch)-alpine-linux-$(CrossCompileAbi)</TargetTriple>


### PR DESCRIPTION
Upstream issue: https://github.com/llvm/llvm-project/issues/89146.
Noticed in https://github.com/dotnet/runtime/pull/80154 after toggling NativeAotSupported for arm arch.

Note this check is only needed for `musleabihf` cross build (and also arm64->x86_64 cross build; which is currently not super important), but I have added it for all alpine cross build cases.

cc @jkoritzinsky, @filipnavara, @ayakael