### PR TITLE
Add tests for dataflow with invalid annotations

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -253,7 +253,7 @@ namespace ILLink.Shared.TrimAnalysis
 
         public static bool IsTypeInterestingForDataflow(TypeDesc type)
         {
-            // NOTE: this method is not particulary fast. It's assumed that the caller limits
+            // NOTE: this method is not particularly fast. It's assumed that the caller limits
             // calls to this method as much as possible.
 
             if (type.IsWellKnownType(WellKnownType.String))

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.Interfaces.OnReferenceTypeTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/Inheritance.Interfaces.OnReferenceTypeTests.g.cs
@@ -148,6 +148,12 @@ namespace ILLink.RoslynAnalyzer.Tests.Inheritance.Interfaces
 		}
 
 		[Fact]
+		public Task UnusedComInterfaceIsRemoved ()
+		{
+			return RunTest (allowMissingWarnings: true);
+		}
+
+		[Fact]
 		public Task UnusedExplicitInterfaceHasMethodPreservedViaXml ()
 		{
 			return RunTest (allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -35,7 +35,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			instance.UnknownValueToUnAnnotatedParameterOnInterestingMethod ();
 			instance.WriteToParameterOnInstanceMethod (null);
 			instance.LongWriteToParameterOnInstanceMethod (0, 0, 0, 0, null);
-			instance.UnsupportedParameterType (null);
 
 			ParametersPassedToInstanceCtor (typeof (TestType), typeof (TestType));
 
@@ -44,7 +43,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 #if !NATIVEAOT
 			TestVarargsMethod (typeof (TestType), __arglist (0, 1, 2));
 #endif
-
+			AnnotationOnUnsupportedParameter.Test ();
 			WriteCapturedParameter.Test ();
 		}
 
@@ -199,11 +198,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			RequirePublicParameterlessConstructorAndNothing (typeof (TestType), this.GetType ());
 		}
 
-		[ExpectedWarning ("IL2098", "p1", nameof (UnsupportedParameterType))]
-		private void UnsupportedParameterType ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)] object p1)
-		{
-		}
-
 		private class InstanceCtor
 		{
 			[ExpectedWarning ("IL2067", nameof (DataFlowTypeExtensions.RequiresPublicConstructors))]
@@ -241,6 +235,37 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 		static void TestVarargsMethod ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] Type type, __arglist)
 		{
+		}
+
+		class AnnotationOnUnsupportedParameter
+		{
+			class UnsupportedType ()
+			{
+			}
+
+			static UnsupportedType GetUnsupportedTypeInstance () => null;
+
+			[ExpectedWarning ("IL2098", nameof (UnsupportedType))]
+			[ExpectedWarning ("IL2067", ProducedBy = Tool.Analyzer)] // https://github.com/dotnet/runtime/issues/101211
+			static void RequirePublicMethods (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				UnsupportedType unsupportedTypeInstance)
+			{
+				RequirePublicFields (unsupportedTypeInstance);
+			}
+
+			[ExpectedWarning ("IL2098", nameof (UnsupportedType))]
+			static void RequirePublicFields (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+				UnsupportedType unsupportedTypeInstance)
+			{
+			}
+
+			[ExpectedWarning ("IL2072", ProducedBy = Tool.Analyzer)] // https://github.com/dotnet/runtime/issues/101211
+			public static void Test () {
+				var t = GetUnsupportedTypeInstance ();
+				RequirePublicMethods (t);
+			}
 		}
 
 		class WriteCapturedParameter

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -35,8 +35,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
 			instance.ReturnWithRequirementsAlwaysThrows ();
 
-			UnsupportedReturnType ();
 			UnsupportedReturnTypeAndParameter (null);
+			AnnotationOnUnsupportedReturnType.Test ();
 		}
 
 		static Type NoRequirements ()
@@ -181,14 +181,56 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			throw new NotImplementedException ();
 		}
 
-		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnType))]
-		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-		static object UnsupportedReturnType () => null;
-
 		[ExpectedWarning ("IL2106", nameof (UnsupportedReturnTypeAndParameter))]
 		[ExpectedWarning ("IL2098", nameof (UnsupportedReturnTypeAndParameter))]
 		[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 		static object UnsupportedReturnTypeAndParameter ([DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)] object param) => null;
+
+		class AnnotationOnUnsupportedReturnType
+		{
+			class UnsupportedType
+			{
+				[ExpectedWarning ("IL2082", ProducedBy = Tool.Analyzer)] // https://github.com/dotnet/runtime/issues/101211
+				public UnsupportedType () {
+					RequirePublicFields (this);
+				}
+			}
+
+			static UnsupportedType GetUnsupportedTypeInstance () => null;
+
+			[ExpectedWarning ("IL2106")]
+			// Linker and NativeAot should not produce IL2073
+			// They produce dataflow warnings despite the invalid annotations.
+			// https://github.com/dotnet/runtime/issues/101211
+			[ExpectedWarning ("IL2073", ProducedBy = Tool.Trimmer | Tool.NativeAot)]
+			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+			static UnsupportedType GetWithPublicMethods () {
+				return GetUnsupportedTypeInstance ();
+			}
+
+			[ExpectedWarning ("IL2098")]
+			static void RequirePublicFields (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicFields)]
+				UnsupportedType unsupportedTypeInstance)
+			{
+			}
+
+			[ExpectedWarning ("IL2072", ProducedBy = Tool.Analyzer)] // https://github.com/dotnet/runtime/issues/101211
+			static void TestMethodReturnValue () {
+				var t = GetWithPublicMethods ();
+				RequirePublicFields (t);
+			}
+
+			static void TestCtorReturnValue () {
+				var t = new UnsupportedType ();
+				RequirePublicFields (t);
+			}
+
+			public static void Test () {
+				TestMethodReturnValue ();
+				TestCtorReturnValue ();
+			}
+		}
 
 		class TestType
 		{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -23,7 +23,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			PropagateToThisWithSetters ();
 			AssignToThis ();
 
-			TestAnnotationOnNonTypeMethod ();
+			AnnotationOnUnsupportedThisParameter.Test ();
 			TestUnknownThis ();
 			TestFromParameterToThis (null);
 			TestFromFieldToThis ();
@@ -88,11 +88,56 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			s.AssignToThisCaptured ();
 		}
 
-		static void TestAnnotationOnNonTypeMethod ()
+		class AnnotationOnUnsupportedThisParameter
 		{
-			var t = new NonTypeType ();
-			t.GetMethod ("foo");
-			NonTypeType.StaticMethod ();
+			class UnsupportedType
+			{
+				// The AttributeTargets don't support constructors.
+				// [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				// public UnsupportedType () {
+				// 	RequirePublicFields (this);
+				// }
+
+				[ExpectedWarning ("IL2041")]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				public MethodInfo GetMethod (string name)
+				{
+					RequirePublicFields (this);
+					return null;
+				}
+
+				[ExpectedWarning ("IL2041")]
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				public static void StaticMethod ()
+				{
+				}
+			}
+
+			// Note: this returns a new instance, so that the GetMethod body is considered reachable.
+			// If nothing created an instance, ILLink would remove the GetMethod body and RequirePublicFields.
+			static UnsupportedType GetUnsupportedTypeInstance () => new ();
+
+			[ExpectedWarning ("IL2098")]
+			static void RequirePublicFields (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
+				UnsupportedType unsupportedTypeInstance) { }
+
+			[ExpectedWarning ("IL2075", nameof (UnsupportedType), nameof (UnsupportedType.GetMethod), ProducedBy = Tool.Analyzer)] // BUG
+			static void TestMethodThisParameter () {
+				var t = GetUnsupportedTypeInstance ();
+				t.GetMethod ("foo");
+			}
+
+			// static void TestConstructorThisParameter () {
+			// 	new UnsupportedType ();
+			// }
+
+			public static void Test ()
+			{
+				TestMethodThisParameter ();
+				// TestConstructorThisParameter ();
+				UnsupportedType.StaticMethod ();
+			}
 		}
 
 		[ExpectedWarning ("IL2065", nameof (MethodThisDataFlowTypeTest) + "." + nameof (MethodThisDataFlowTypeTest.RequireThisNonPublicMethods), "'this'")]
@@ -136,22 +181,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			GetWithPublicMethods ().PropagateToReturn ();
 			GetWithPublicMethods ().PropagateToField ();
 			GetWithPublicMethods ().PropagateToThis ();
-		}
-
-		class NonTypeType
-		{
-			[ExpectedWarning ("IL2041")]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-			public MethodInfo GetMethod (string name)
-			{
-				return null;
-			}
-
-			[ExpectedWarning ("IL2041")]
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
-			public static void StaticMethod ()
-			{
-			}
 		}
 
 		struct StructType


### PR DESCRIPTION
Adds some test coverage for https://github.com/dotnet/runtime/issues/101211, including a case where ILLink/NativeAot have a similar issue.