### PR TITLE
[wasm] Don't use SyncTextWriter in single-threaded wasm builds

### DIFF
--- a/src/libraries/System.Console/src/System/Console.cs
+++ b/src/libraries/System.Console/src/System/Console.cs
@@ -235,23 +235,16 @@ namespace System
 
         private static TextWriter CreateOutputWriter(Stream outputStream)
         {
-            if (outputStream == Stream.Null)
-                return TextWriter.Null;
-
-            StreamWriter writer = new StreamWriter(
-                stream: outputStream,
-                encoding: OutputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
-                bufferSize: WriteBufferSize,
-                leaveOpen: true
-            ) {
-                AutoFlush = true
-            };
-
-#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
-            return writer;
-#else
-            return TextWriter.Synchronized(writer);
-#endif
+            return outputStream == Stream.Null ?
+                TextWriter.Null :
+                TextWriter.Synchronized(new StreamWriter(
+                    stream: outputStream,
+                    encoding: OutputEncoding.RemovePreamble(), // This ensures no prefix is written to the stream.
+                    bufferSize: WriteBufferSize,
+                    leaveOpen: true)
+                    {
+                        AutoFlush = true
+                    });
         }
 
         private static StrongBox<bool>? _isStdInRedirected;
@@ -709,10 +702,7 @@ namespace System
             // are nops.
             if (newOut != TextWriter.Null)
             {
-#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
-#else
                 newOut = TextWriter.Synchronized(newOut);
-#endif
             }
 
             lock (s_syncObject)
@@ -729,10 +719,7 @@ namespace System
             // Ensure all access to the writer is synchronized. See comment in SetOut.
             if (newError != TextWriter.Null)
             {
-#if TARGET_BROWSER && !FEATURE_WASM_MANAGED_THREADS
-#else
                 newError = TextWriter.Synchronized(newError);
-#endif
             }
 
             lock (s_syncObject)

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -158,7 +158,9 @@ public class ReadAndWrite
                 Console.SetOut(sw);
                 TextWriter writer = Console.Out;
                 Assert.NotNull(writer);
-                Assert.NotEqual(writer, sw); // the writer we provide gets wrapped
+                // Browser bypasses SyncTextWriter for faster startup
+                if (!OperatingSystem.IsBrowser())
+                    Assert.NotEqual(writer, sw); // the writer we provide gets wrapped
 
                 // We just want to ensure none of these throw exceptions, we don't actually validate
                 // what was written.

--- a/src/libraries/System.Console/tests/SyncTextWriter.cs
+++ b/src/libraries/System.Console/tests/SyncTextWriter.cs
@@ -13,6 +13,7 @@ using Xunit;
 public class SyncTextWriter
 {
     [Fact]
+    [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
     public void SyncTextWriterLockedOnThis()
     {
         TextWriter oldWriter = Console.Out;

--- a/src/libraries/System.Console/tests/SyncTextWriter.cs
+++ b/src/libraries/System.Console/tests/SyncTextWriter.cs
@@ -12,8 +12,8 @@ using Xunit;
 
 public class SyncTextWriter
 {
-    [Fact]
-    [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
+    // Browser bypasses SyncTextWriter for faster startup
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
     public void SyncTextWriterLockedOnThis()
     {
         TextWriter oldWriter = Console.Out;

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -22,6 +22,8 @@
     <IsBigEndian Condition="'$(Platform)' == 's390x'">true</IsBigEndian>
     <Is64Bit Condition="'$(Platform)' == 'arm64' or '$(Platform)' == 'x64' or '$(Platform)' == 's390x' or '$(Platform)' == 'loongarch64' or '$(Platform)' == 'ppc64le' or '$(Platform)' == 'riscv64'">true</Is64Bit>
     <UseMinimalGlobalizationData Condition="'$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true'">true</UseMinimalGlobalizationData>
+    <FeatureWasmManagedThreads Condition="'$(WasmEnableThreads)' == 'true'">true</FeatureWasmManagedThreads>
+    <DefineConstants Condition="'$(FeatureWasmManagedThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_MANAGED_THREADS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(IsBigEndian)' == 'true'">$(DefineConstants);BIGENDIAN</DefineConstants>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -759,7 +759,11 @@ namespace System.IO
         {
             ArgumentNullException.ThrowIfNull(writer);
 
+#if !TARGET_BROWSER || FEATURE_WASM_MANAGED_THREADS
             return writer is SyncTextWriter ? writer : new SyncTextWriter(writer);
+#else
+            return writer;
+#endif
         }
 
         internal sealed class SyncTextWriter : TextWriter, IDisposable

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
@@ -30,6 +30,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
         public void Synchronized_NewObject()
         {
             using (Stream str = GetLargeStream())

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamReader/StreamReader.cs
@@ -29,8 +29,8 @@ namespace System.IO.Tests
             Assert.Throws<ObjectDisposedException>(() => sr.ReadLine());
         }
 
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
+        // Browser bypasses SyncTextWriter for faster startup
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Synchronized_NewObject()
         {
             using (Stream str = GetLargeStream())

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
@@ -8,6 +8,7 @@ namespace System.IO.Tests
     public partial class WriteTests
     {
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
         public void Synchronized_NewObject()
         {
             using (Stream str = CreateStream())

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/StreamWriter/StreamWriter.cs
@@ -7,8 +7,8 @@ namespace System.IO.Tests
 {
     public partial class WriteTests
     {
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
+        // Browser bypasses SyncTextWriter for faster startup
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Synchronized_NewObject()
         {
             using (Stream str = CreateStream())

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
@@ -690,8 +690,8 @@ namespace System.IO.Tests
             Assert.Same(e, vt.AsTask().Exception.InnerException);
         }
 
-        [Fact]
-        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
+        // Browser bypasses SyncTextWriter for faster startup
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task FlushAsync_Precanceled()
         {
             Assert.Equal(TaskStatus.RanToCompletion, TextWriter.Null.FlushAsync(new CancellationToken(true)).Status);

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/TextWriter/TextWriterTests.cs
@@ -691,6 +691,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.Browser, "Browser bypasses SyncTextWriter for faster startup")]
         public async Task FlushAsync_Precanceled()
         {
             Assert.Equal(TaskStatus.RanToCompletion, TextWriter.Null.FlushAsync(new CancellationToken(true)).Status);


### PR DESCRIPTION
(New description, PR was revised)

We normally wrap custom console streams with SyncTextWriter, which forces the mono interpreter/jit/aot compiler to use synchronized wrappers for all calls through the class. Wrappers have optimization force-enabled, which means all the methods they call get inlined into the wrapper every time, increasing the size of the wrapper's code and the amount of time we spend in codegen for it.

The default wasm configuration right now is single-threaded, so we can skip using SyncTextWriter and as a result skip the synchronized wrapper. While this doesn't fully prevent monitors from becoming involved in startup, it removes a bunch of inlined monitor API calls, which should be an improvement to startup time for any wasm application that touches the console.