### PR TITLE
Fix some comment typos

### DIFF
--- a/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/TargetHostNameHelper.cs
@@ -32,7 +32,7 @@ namespace System.Net.Security
             }
             catch (ArgumentException) when (IsSafeDnsString(targetHost))
             {
-                // Seems like name that does not confrom to IDN but apers somewhat valid according to original DNS rfc.
+                // Seems like name that does not conform to IDN but appears somewhat valid according to original DNS rfc.
             }
 
             return targetHost;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -692,7 +692,7 @@ namespace System.IO.Compression
             if (_everOpenedForWrite)
                 throw new IOException(SR.CreateModeWriteOnceAndOneEntryAtATime);
 
-            // we assume that if another entry grabbed the archive stream, that it set this entry's _everOpenedForWrite property to true by calling WriteLocalFileHeaderIfNeeed
+            // we assume that if another entry grabbed the archive stream, that it set this entry's _everOpenedForWrite property to true by calling WriteLocalFileHeaderAndDataIfNeeded
             _archive.DebugAssertIsStillArchiveStreamOwner(this);
 
             _everOpenedForWrite = true;

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -245,7 +245,7 @@ namespace System
             // character is simply accepted. Fancier handling is not required
             // because the program name must be a legal NTFS/HPFS file name.
             // Note that the double-quote characters are not copied, nor do they
-            // contribyte to character_count.
+            // contribute to character_count.
 
             bool inQuotes = false;
             stringBuilder = new ValueStringBuilder(stringBuffer);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs
@@ -49,7 +49,7 @@ namespace System.IO
             if (PathInternal.IsEffectivelyEmpty(path.AsSpan()))
                 throw new ArgumentException(SR.Arg_PathEmpty, nameof(path));
 
-            // Embedded null characters are the only invalid character case we trully care about.
+            // Embedded null characters are the only invalid character case we truly care about.
             // This is because the nulls will signal the end of the string to Win32 and therefore have
             // unpredictable results.
             if (path.Contains('\0'))

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CLong.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Constructs an instance from a 32-bit integer.
         /// </summary>
-        /// <param name="value">The integer vaule.</param>
+        /// <param name="value">The integer value.</param>
         public CLong(int value)
         {
             _value = (NativeType)value;
@@ -38,7 +38,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Constructs an instance from a native sized integer.
         /// </summary>
-        /// <param name="value">The integer vaule.</param>
+        /// <param name="value">The integer value.</param>
         /// <exception cref="OverflowException"><paramref name="value"/> is outside the range of the underlying storage type.</exception>
         public CLong(nint value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CULong.cs
@@ -29,7 +29,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Constructs an instance from a 32-bit unsigned integer.
         /// </summary>
-        /// <param name="value">The integer vaule.</param>
+        /// <param name="value">The integer value.</param>
         public CULong(uint value)
         {
             _value = (NativeType)value;
@@ -38,7 +38,7 @@ namespace System.Runtime.InteropServices
         /// <summary>
         /// Constructs an instance from a native sized unsigned integer.
         /// </summary>
-        /// <param name="value">The integer vaule.</param>
+        /// <param name="value">The integer value.</param>
         /// <exception cref="OverflowException"><paramref name="value"/> is outside the range of the underlying storage type.</exception>
         public CULong(nuint value)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CriticalHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CriticalHandle.cs
@@ -36,10 +36,10 @@
 ** operations against a single handle at the same time or block their
 ** access to Close and Dispose unless you are very comfortable with the
 ** semantics of passing an invalid (or possibly invalidated and
-** reallocated) to the unamanged routines you marshal your handle to
+** reallocated) to the unmanaged routines you marshal your handle to
 ** (and the effects of closing such a handle while those calls are in
 ** progress). The runtime cannot protect you from undefined program
-** behvior that might result from such scenarios. You have been warned.
+** behavior that might result from such scenarios. You have been warned.
 **
 **
 ===========================================================*/

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomQueryInterfaceResult.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomQueryInterfaceResult.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 
 namespace System.Runtime.InteropServices
 {
-    // The enum of the return value of IQuerable.GetInterface
+    // The enum of the return value of ICustomQueryInterface.GetInterface
     [EditorBrowsable(EditorBrowsableState.Never)]
     public enum CustomQueryInterfaceResult
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/LibraryImportAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/LibraryImportAttribute.cs
@@ -18,7 +18,7 @@ namespace System.Runtime.InteropServices
     public
 #else
 #pragma warning disable CS0436 // Type conflicts with imported type
-                               // Some assemblies that target downlevel have InternalsVisibleTo to their test assembiles.
+                               // Some assemblies that target downlevel have InternalsVisibleTo to their test assemblies.
                                // As this is only used in this repo and isn't a problem in shipping code,
                                // just disable the duplicate type warning.
     internal

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -550,7 +550,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Creates a new instance of "structuretype" and marshals data from a
+        /// Creates a new instance of "structureType" and marshals data from a
         /// native memory block to it.
         /// </summary>
         [RequiresDynamicCode("Marshalling code for the object might not be available")]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -550,7 +550,7 @@ namespace System.Runtime.InteropServices
         }
 
         /// <summary>
-        /// Creates a new instance of "structureType" and marshals data from a
+        /// Creates a new instance of <paramref name="structureType"/> and marshals data from a
         /// native memory block to it.
         /// </summary>
         [RequiresDynamicCode("Marshalling code for the object might not be available")]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -225,7 +225,7 @@ namespace System.Runtime.InteropServices
         /// <param name="libraryName">The native library to load.</param>
         /// <param name="assembly">The assembly trying load the native library.</param>
         /// <param name="hasDllImportSearchPathFlags">If the pInvoke has DefaultDllImportSearchPathAttribute.</param>
-        /// <param name="dllImportSearchPathFlags">If hasdllImportSearchPathFlags is true, the flags in
+        /// <param name="dllImportSearchPathFlags">If hasDllImportSearchPathFlags is true, the flags in
         ///                                       DefaultDllImportSearchPathAttribute; meaningless otherwise </param>
         /// <returns>The handle for the loaded library on success. Null on failure.</returns>
         internal static IntPtr LoadLibraryCallbackStub(string libraryName, Assembly assembly,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.cs
@@ -225,7 +225,7 @@ namespace System.Runtime.InteropServices
         /// <param name="libraryName">The native library to load.</param>
         /// <param name="assembly">The assembly trying load the native library.</param>
         /// <param name="hasDllImportSearchPathFlags">If the pInvoke has DefaultDllImportSearchPathAttribute.</param>
-        /// <param name="dllImportSearchPathFlags">If hasDllImportSearchPathFlags is true, the flags in
+        /// <param name="dllImportSearchPathFlags">If <paramref name="hasDllImportSearchPathFlags"/> is true, the flags in
         ///                                       DefaultDllImportSearchPathAttribute; meaningless otherwise </param>
         /// <returns>The handle for the loaded library on success. Null on failure.</returns>
         internal static IntPtr LoadLibraryCallbackStub(string libraryName, Assembly assembly,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/StringMarshalling.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices
     enum StringMarshalling
     {
         /// <summary>
-        /// Indicates the user is suppling a specific marshaller in <see cref="LibraryImportAttribute.StringMarshallingCustomType"/>.
+        /// Indicates the user is supplying a specific marshaller in <see cref="LibraryImportAttribute.StringMarshallingCustomType"/>.
         /// </summary>
         Custom = 0,
         /// <summary>


### PR DESCRIPTION
The title says it all. No functional changes.

I've verified that `WriteLocalFileHeaderIfNeeed` really means `WriteLocalFileHeaderAndDataIfNeeded`,
and that the reference to `IQuerable.GetInterface` really should be `ICustomQueryInterface.GetInterface`.

All other typos are trivial.