### PR TITLE
Fix TypeBuilder.DefineMethodOverride validation error

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -183,34 +183,8 @@ namespace System.Reflection.Emit
         [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
         public override Type GetInterface(string name, bool ignoreCase) { throw new NotSupportedException(); }
 
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2080:DynamicallyAccessedMemberTypes",
-            Justification = "Interfaces used in Reflection.Emit either dynamic or accessible")]
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)]
-        public override Type[] GetInterfaces()
-        {
-            Type[] ifaces = _genericType.GetInterfaces();
-
-            if (ifaces.Length == 0)
-            {
-                return ifaces;
-            }
-
-            Type[] ifacesCopy = new Type[ifaces.Length];
-
-            for(int i = 0; i < ifaces.Length; i++)
-            {
-                if (ifaces[i] is TypeBuilderInstantiation typeBldrIface)
-                {
-                    typeBldrIface.Substitute(GetGenericArguments());
-                }
-                else
-                {
-                    ifacesCopy[i] = ifaces[i];
-                }
-            }
-
-            return ifacesCopy;
-        }
+        public override Type[] GetInterfaces() { throw new NotSupportedException(); }
 
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
         public override EventInfo GetEvent(string name, BindingFlags bindingAttr) { throw new NotSupportedException(); }
@@ -279,72 +253,7 @@ namespace System.Reflection.Emit
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
         public override Type MakeGenericType(params Type[] inst) { throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this)); }
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2075:DynamicallyAccessedMemberTypes",
-            Justification = "Interfaces used in Reflection.Emit either dynamic or accessible")]
-        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c)
-        {
-            if (c == null)
-            {
-                return false;
-            }
-
-            if (this == c || IsAssignableFrom(c.BaseType))
-            {
-                return true;
-            }
-
-            if (!c.IsConstructedGenericType)
-            {
-                return false;
-            }
-
-            Type typeDefinition = c.GetGenericTypeDefinition();
-
-            if (typeDefinition.IsAssignableFrom(_genericType) &&
-                CheckArguments(c.GenericTypeArguments))
-            {
-                return true;
-            }
-
-            foreach (Type iface in typeDefinition.GetInterfaces())
-            {
-                if (iface.IsConstructedGenericType &&
-                    iface.GetGenericTypeDefinition().IsAssignableFrom(_genericType) &&
-                    CheckArguments(c.GenericTypeArguments))
-                {
-                    return true;
-                }
-            }
-
-            if (c.BaseType != null &&
-                c.BaseType.IsConstructedGenericType &&
-                c.BaseType.GetGenericTypeDefinition().IsAssignableFrom(_genericType) &&
-                CheckArguments(c.GenericTypeArguments))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool CheckArguments(Type[] genericTypeArguments)
-        {
-            if (_typeArguments.Length != genericTypeArguments.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < _typeArguments.Length; i++)
-            {
-                if (_typeArguments[i] != genericTypeArguments[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c) { throw new NotSupportedException(); }
 
         public override bool IsSubclassOf(Type c)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilderInstantiation.cs
@@ -253,7 +253,8 @@ namespace System.Reflection.Emit
 
         [RequiresUnreferencedCode("If some of the generic arguments are annotated (either with DynamicallyAccessedMembersAttribute, or generic constraints), trimming can't validate that the requirements of those annotations are met.")]
         public override Type MakeGenericType(params Type[] inst) { throw new InvalidOperationException(SR.Format(SR.Arg_NotGenericTypeDefinition, this)); }
-        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c) { throw new NotSupportedException(); }
+
+        public override bool IsAssignableFrom([NotNullWhen(true)] Type? c) => this == c;
 
         public override bool IsSubclassOf(Type c)
         {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -418,7 +418,7 @@ namespace System.Reflection.Emit
                             declType = declType.GetElementType();
                         }
 
-                        if (bodyType == null || !bodyType.Equals(declType))
+                        if (declType == null || !declType.IsAssignableFrom(bodyType))
                         {
                             throw ArgumentExceptionInvalidMethodOverride(methodInfoDeclaration.Name);
                         }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs
@@ -321,8 +321,6 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(SR.ArgumentException_BadMethodImplBody);
             }
             Type baseType = methodInfoDeclaration.DeclaringType!;
-            ValidateBaseType(baseType, methodInfoDeclaration.Name);
-            ValidateImplementedMethod(methodInfoBody, methodInfoDeclaration);
             _methodOverrides ??= new();
 
             if (_methodOverrides.TryGetValue(baseType, out List<(MethodInfo ifaceMethod, MethodInfo targetMethod)>? im))
@@ -339,24 +337,6 @@ namespace System.Reflection.Emit
                 im = new List<(MethodInfo ifaceMethod, MethodInfo targetMethod)>();
                 im.Add((methodInfoDeclaration, methodInfoBody));
                 _methodOverrides.Add(baseType, im);
-            }
-        }
-
-        private void ValidateBaseType(Type baseType, string methodName)
-        {
-            if (baseType.IsInterface)
-            {
-                if (!IsInterfaceImplemented(baseType))
-                {
-                    throw ArgumentExceptionInvalidMethodOverride(methodName);
-                }
-
-                return;
-            }
-
-            if (!baseType.IsAssignableFrom(_typeParent))
-            {
-                throw ArgumentExceptionInvalidMethodOverride(methodName);
             }
         }
 
@@ -389,47 +369,6 @@ namespace System.Reflection.Emit
 
         private ArgumentException ArgumentExceptionInvalidMethodOverride(string methodName) =>
             new ArgumentException(SR.Format(SR.Argument_InvalidMethodOverride, FullName, methodName), "methodInfoBody");
-
-        private void ValidateImplementedMethod(MethodInfo methodInfoBody, MethodInfo methodInfoDeclaration)
-        {
-            if ((methodInfoBody.IsVirtual || methodInfoBody.IsStatic) &&
-                (methodInfoDeclaration.IsAbstract || methodInfoDeclaration.IsVirtual) &&
-                methodInfoDeclaration.ReturnType.IsAssignableFrom(methodInfoBody.ReturnType))
-            {
-                ParameterInfo[] bodyParameters = methodInfoBody.GetParameters();
-                ParameterInfo[] declarationParameters = methodInfoDeclaration.GetParameters();
-                if (bodyParameters.Length == declarationParameters.Length)
-                {
-                    for (int i = 0; i < bodyParameters.Length; i++)
-                    {
-                        Type? bodyType = bodyParameters[i].ParameterType;
-                        Type? declType = declarationParameters[i].ParameterType;
-
-                        if (bodyType.IsArray != declType.IsArray ||
-                            bodyType.IsByRef != declType.IsByRef ||
-                            bodyType.IsPointer != declType.IsPointer)
-                        {
-                            throw ArgumentExceptionInvalidMethodOverride(methodInfoDeclaration.Name);
-                        }
-
-                        if (bodyType.HasElementType || declType.HasElementType)
-                        {
-                            bodyType = bodyType.GetElementType();
-                            declType = declType.GetElementType();
-                        }
-
-                        if (declType == null || !declType.IsAssignableFrom(bodyType))
-                        {
-                            throw ArgumentExceptionInvalidMethodOverride(methodInfoDeclaration.Name);
-                        }
-                    }
-
-                    return;
-                }
-            }
-
-            throw ArgumentExceptionInvalidMethodOverride(methodInfoDeclaration.Name);
-        }
 
         protected override TypeBuilder DefineNestedTypeCore(string name, TypeAttributes attr,
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? parent, Type[]? interfaces, PackingSize packSize, int typeSize)

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -167,6 +167,27 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
+        public void DefineMethodOverride_ImplementGenericInterfaceMethodGenericTypeMismatchThrows()
+        {
+            PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
+            TypeBuilder anotherType = ab.GetDynamicModule("MyModule").DefineType("AnotherType");
+            Type intfType = typeof(IConstructableDerived<>).MakeGenericType(typeBuilder);
+            typeBuilder.AddInterfaceImplementation(intfType);
+
+            MethodBuilder impl = typeBuilder.DefineMethod("Create", MethodAttributes.Public | MethodAttributes.Static, typeBuilder, [typeof(int)]);
+            impl.GetILGenerator().Emit(OpCodes.Ret);
+
+            MethodInfo intfMethod = TypeBuilder.GetMethod(typeof(IConstructable<>).MakeGenericType(anotherType), typeof(IConstructable<>).GetMethod("Create")!)!;
+            Assert.Throws<ArgumentException>("methodInfoBody", () => typeBuilder.DefineMethodOverride(impl, intfMethod));
+
+            MethodBuilder impl2 = typeBuilder.DefineMethod("Create2", MethodAttributes.Public | MethodAttributes.Static, typeBuilder, [typeof(int)]);
+            impl2.GetILGenerator().Emit(OpCodes.Ret);
+
+            MethodInfo intf2Method = TypeBuilder.GetMethod(typeof(IConstructableDerived<>).MakeGenericType(anotherType), typeof(IConstructableDerived<>).GetMethod("Create2")!)!;
+            Assert.Throws<ArgumentException>("methodInfoBody", () => typeBuilder.DefineMethodOverride(impl2, intf2Method));
+        }
+
+        [Fact]
         public void DefineMethodOverride_CalledAgainWithSameDeclaration_ThrowsArgumentException()
         {
             AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder type);
@@ -214,6 +235,15 @@ namespace System.Reflection.Emit.Tests
         public interface InterfaceWithMethod
         {
             int Method(string s, int i);
+        }
+
+        public abstract class Base<T> : GenericInterface<T>
+        {
+            public abstract T Method();
+        }
+
+        public abstract class Derived<T> : Base<T>
+        {
         }
 
         [Fact]
@@ -281,11 +311,16 @@ namespace System.Reflection.Emit.Tests
             static abstract T Create(int value);
         }
 
+        public interface IConstructableDerived<T> : IConstructable<T>
+        {
+            static abstract T Create2(int value);
+        }
+
         [Fact]
-        public void DefineMethodOverride_ImplementStaticAbstractMethodOfGenericInterface()
+        public void DefineMethodOverride_ImplementMethodsOfGenericInterfaceAndItsParentInterface()
         {
             PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
-            Type intfType = typeof(IConstructable<>).MakeGenericType(typeBuilder);
+            Type intfType = typeof(IConstructableDerived<>).MakeGenericType(typeBuilder);
             typeBuilder.AddInterfaceImplementation(intfType);
             ConstructorBuilder ctor = typeBuilder.DefineConstructor(MethodAttributes.Public, CallingConventions.Standard, [typeof(int)]);
             var il = ctor.GetILGenerator();
@@ -297,9 +332,86 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Call, ctor);
             il.Emit(OpCodes.Ret);
 
-            MethodInfo intfMethod = TypeBuilder.GetMethod(intfType, typeof(IConstructable<>).GetMethod("Create")!)!;
+            MethodInfo intfMethod = TypeBuilder.GetMethod(typeof(IConstructable<>).MakeGenericType(typeBuilder), typeof(IConstructable<>).GetMethod("Create")!)!;
             typeBuilder.DefineMethodOverride(impl, intfMethod);
+
+            MethodBuilder impl2 = typeBuilder.DefineMethod("Create2", MethodAttributes.Public | MethodAttributes.Static, typeBuilder, [typeof(int)]);
+            il = impl2.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, ctor);
+            il.Emit(OpCodes.Ret);
+
+            MethodInfo intf2Method = TypeBuilder.GetMethod(intfType, typeof(IConstructableDerived<>).GetMethod("Create2")!)!;
+            typeBuilder.DefineMethodOverride(impl2, intf2Method);
+
             typeBuilder.CreateType(); // should succeed
+        }
+
+        [Fact]
+        public void DefineMethodOverride_OverrideMethodOfGenericTypeBuilderWithTypeBuilderGenericParameter()
+        {
+            PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
+            TypeBuilder baseType = ab.GetDynamicModule("MyModule").DefineType("BaseType");
+            GenericTypeParameterBuilder[] parameters = baseType.DefineGenericParameters(["T"]);
+            MethodBuilder baseMethod = baseType.DefineMethod("Create", MethodAttributes.Abstract | MethodAttributes.Public, parameters[0], [parameters[0]]); 
+
+            Type constructedType = baseType.MakeGenericType(typeBuilder);
+            typeBuilder.SetParent(constructedType);
+
+            MethodBuilder impl = typeBuilder.DefineMethod("Create", MethodAttributes.Public | MethodAttributes.Virtual, typeBuilder, [typeBuilder]);
+            impl.GetILGenerator().Emit(OpCodes.Ret);
+
+            typeBuilder.DefineMethodOverride(impl, TypeBuilder.GetMethod(constructedType, baseMethod));
+        }
+
+        [Fact]
+        public void DefineMethodOverride_OverrideMethodOfParentOfGenericParentWithTypeBuilderParameter()
+        {
+            PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
+            
+            Type constructedType = typeof(Derived<>).MakeGenericType(typeBuilder);
+            typeBuilder.SetParent(constructedType);
+            MethodInfo baseMethod = TypeBuilder.GetMethod(typeof(Base<>).MakeGenericType(typeBuilder), typeof(Base<>).GetMethod("Method"));
+
+            MethodBuilder impl = typeBuilder.DefineMethod("Method", MethodAttributes.Public | MethodAttributes.Virtual, typeBuilder, Type.EmptyTypes);
+            impl.GetILGenerator().Emit(OpCodes.Ret);
+
+            typeBuilder.DefineMethodOverride(impl, baseMethod);
+        }
+
+        [Fact]
+        public void ConstructedGenericTypeBuilder_IsAssignableFromTests()
+        {
+            PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
+            Type baseTypeOfTypeBuilder = typeof(Base<>).MakeGenericType(typeBuilder);
+            Type derivedTypeOfTypeBuilder = typeof(Derived<>).MakeGenericType(typeBuilder);
+            Type derivedTypeOfInt = typeof(Derived<>).MakeGenericType(typeof(int));
+            Type grandParentIfaceOfTypeBuilder = typeof(GenericInterface<>).MakeGenericType(typeBuilder);
+            typeBuilder.SetParent(derivedTypeOfTypeBuilder);
+
+            Assert.True(derivedTypeOfTypeBuilder.IsAssignableFrom(derivedTypeOfTypeBuilder));
+            Assert.False(derivedTypeOfTypeBuilder.IsAssignableFrom(baseTypeOfTypeBuilder));
+            Assert.True(baseTypeOfTypeBuilder.IsAssignableFrom(derivedTypeOfTypeBuilder));
+            Assert.False(derivedTypeOfInt.IsAssignableFrom(baseTypeOfTypeBuilder));
+            Assert.False(baseTypeOfTypeBuilder.IsAssignableFrom(derivedTypeOfInt));
+            Assert.False(typeBuilder.IsAssignableFrom(baseTypeOfTypeBuilder));
+            Assert.True(derivedTypeOfTypeBuilder.IsAssignableFrom(typeBuilder));
+            Assert.True(baseTypeOfTypeBuilder.IsAssignableFrom(typeBuilder));
+            Assert.True(grandParentIfaceOfTypeBuilder.IsAssignableFrom(typeBuilder));
+
+            ModuleBuilder module = ab.GetDynamicModule("MyModule");
+            TypeBuilder genericType = module.DefineType("GenericType", TypeAttributes.Public);
+            GenericTypeParameterBuilder[] gParams = genericType.DefineGenericParameters("T");
+            Type constructedDerivedType2 = typeof(Derived<>).MakeGenericType(gParams[0]);
+            genericType.SetParent(constructedDerivedType2);
+            Type genericTypeOfTypeBuilder = genericType.MakeGenericType(typeBuilder);
+
+            Assert.True(derivedTypeOfTypeBuilder.IsAssignableFrom(genericTypeOfTypeBuilder));
+            Assert.True(baseTypeOfTypeBuilder.IsAssignableFrom(genericTypeOfTypeBuilder));
+            Assert.True(grandParentIfaceOfTypeBuilder.IsAssignableFrom(genericTypeOfTypeBuilder));
+            Assert.False(derivedTypeOfInt.IsAssignableFrom(genericTypeOfTypeBuilder));
+            Assert.False(typeof(Derived<>).IsAssignableFrom(genericType));
+            Assert.False(genericType.MakeGenericType(typeof(int)).IsAssignableFrom(genericTypeOfTypeBuilder));
         }
 
         [Fact]


### PR DESCRIPTION
On `TypeBuilder.DefineMethodOverride(MethodInfo methodInfoBody, MethodInfo methodInfoDeclaration)` `TypeBuilderImpl` validates if the `methodInfoBody` could override the `methodInfoDeclaration` https://github.com/dotnet/runtime/blob/3725bfc33df7e65a6c86c9341d078a1db6ff5ab1/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs#L323-L325

`ValidateBaseType` checks if the `TypeBuilderImpl` implements the declaring type of the `methodInfoDeclaration`  

https://github.com/dotnet/runtime/blob/3725bfc33df7e65a6c86c9341d078a1db6ff5ab1/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/TypeBuilderImpl.cs#L345-L351

In case the base type is constructed generic type that involves TypeBuilder (i.e. instance of `TypeBuilderInstantiation`) it throws as `IsAssignableFrom` is not implemented. 

Static `TypeBuilder.GetMethod(...)` only allow getting declared methods, so just comparing the instance with the type should be enough for `TypeBuilderInstantiation`

Fixes https://github.com/dotnet/runtime/issues/100537