### PR TITLE
[browser][MT] faster memory view refresh +  cleanup

### DIFF
--- a/src/mono/browser/runtime/cancelable-promise.ts
+++ b/src/mono/browser/runtime/cancelable-promise.ts
@@ -166,9 +166,7 @@ export class PromiseHolder extends ManagedObject {
         try {
             mono_assert(!this.isPosted, "Promise is already posted to managed.");
             this.isPosted = true;
-            if (WasmEnableThreads) {
-                forceThreadMemoryViewRefresh();
-            }
+            forceThreadMemoryViewRefresh();
 
             // we can unregister the GC handle just on JS side
             teardown_managed_proxy(this, this.gc_handle, /*skipManaged: */ true);

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -65,9 +65,7 @@ const enum JSBindingHeaderOffsets {
 }
 
 export function alloc_stack_frame (size: number): JSMarshalerArguments {
-    if (WasmEnableThreads) {
-        forceThreadMemoryViewRefresh();
-    }
+    forceThreadMemoryViewRefresh();
     const bytes = JavaScriptMarshalerArgSize * size;
     const args = Module.stackAlloc(bytes) as any;
     _zero_region(args, bytes);

--- a/src/mono/browser/runtime/memory.ts
+++ b/src/mono/browser/runtime/memory.ts
@@ -447,8 +447,8 @@ export function copyBytes (srcPtr: VoidPtr, dstPtr: VoidPtr, bytes: number): voi
 // on non-MT build, this will be a no-op trimmed by rollup
 export function receiveWorkerHeapViews () {
     if (!WasmEnableThreads) return;
-    const memory = runtimeHelpers.getMemory();
-    if (memory.buffer !== Module.HEAPU8.buffer) {
+    const wasmMemory = runtimeHelpers.getMemory();
+    if (wasmMemory.buffer !== Module.HEAPU8.buffer) {
         runtimeHelpers.updateMemoryViews();
     }
 }
@@ -484,5 +484,7 @@ export function forceThreadMemoryViewRefresh () {
     This only works because their implementation does not skip doing work even when you ask to grow by 0 pages.
     */
     wasmMemory.grow(0);
-    runtimeHelpers.updateMemoryViews();
+    if (wasmMemory.buffer !== Module.HEAPU8.buffer) {
+        runtimeHelpers.updateMemoryViews();
+    }
 }

--- a/src/mono/browser/runtime/scheduling.ts
+++ b/src/mono/browser/runtime/scheduling.ts
@@ -79,9 +79,7 @@ export function mono_wasm_schedule_timer (shortestDueTimeMs: number): void {
 function mono_wasm_schedule_timer_tick () {
     if (WasmEnableThreads) return;
     Module.maybeExit();
-    if (WasmEnableThreads) {
-        forceThreadMemoryViewRefresh();
-    }
+    forceThreadMemoryViewRefresh();
     if (!loaderHelpers.is_runtime_running()) {
         return;
     }

--- a/src/mono/browser/runtime/web-socket.ts
+++ b/src/mono/browser/runtime/web-socket.ts
@@ -78,9 +78,7 @@ export function ws_wasm_create (uri: string, sub_protocols: string[] | null, rec
         try {
             if (ws[wasm_ws_is_aborted]) return;
             if (!loaderHelpers.is_runtime_running()) return;
-            if (WasmEnableThreads) {
-                forceThreadMemoryViewRefresh();
-            }
+            forceThreadMemoryViewRefresh();
             open_promise_control.resolve(ws);
             prevent_timer_throttling();
         } catch (error: any) {
@@ -91,9 +89,7 @@ export function ws_wasm_create (uri: string, sub_protocols: string[] | null, rec
         try {
             if (ws[wasm_ws_is_aborted]) return;
             if (!loaderHelpers.is_runtime_running()) return;
-            if (WasmEnableThreads) {
-                forceThreadMemoryViewRefresh();
-            }
+            forceThreadMemoryViewRefresh();
             web_socket_on_message(ws, ev);
             prevent_timer_throttling();
         } catch (error: any) {
@@ -105,9 +101,7 @@ export function ws_wasm_create (uri: string, sub_protocols: string[] | null, rec
             ws.removeEventListener("message", local_on_message);
             if (ws[wasm_ws_is_aborted]) return;
             if (!loaderHelpers.is_runtime_running()) return;
-            if (WasmEnableThreads) {
-                forceThreadMemoryViewRefresh();
-            }
+            forceThreadMemoryViewRefresh();
 
             ws[wasm_ws_close_received] = true;
             ws["close_status"] = ev.code;
@@ -137,9 +131,7 @@ export function ws_wasm_create (uri: string, sub_protocols: string[] | null, rec
         try {
             if (ws[wasm_ws_is_aborted]) return;
             if (!loaderHelpers.is_runtime_running()) return;
-            if (WasmEnableThreads) {
-                forceThreadMemoryViewRefresh();
-            }
+            forceThreadMemoryViewRefresh();
             ws.removeEventListener("message", local_on_message);
             const message = ev.message
                 ? "WebSocket error: " + ev.message


### PR DESCRIPTION
- the only real change is adding `if (wasmMemory.buffer !== Module.HEAPU8.buffer)` to `forceThreadMemoryViewRefresh`
- removed duplicate `if (WasmEnableThreads)`

There is sibling PR for testing what would happen if we remove it all https://github.com/dotnet/runtime/pull/101248