### PR TITLE
Fix data race leading to a deadlock when opening QuicStream

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1098,7 +1098,10 @@ namespace System.Net.Http.Functional.Tests
                     }
                     catch (Exception ex) // Ignore exception and continue until a viable connection is established.
                     {
+                        System.Console.WriteLine(ex.ToString());
                         _output.WriteLine(ex.ToString());
+                        var qe = Assert.IsType<QuicException>(ex);
+                        Assert.Equal(QuicError.ConnectionAborted, qe.QuicError);
                     }
                 }
                 await connection.HandleRequestAsync();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1098,10 +1098,7 @@ namespace System.Net.Http.Functional.Tests
                     }
                     catch (Exception ex) // Ignore exception and continue until a viable connection is established.
                     {
-                        System.Console.WriteLine(ex.ToString());
                         _output.WriteLine(ex.ToString());
-                        var qe = Assert.IsType<QuicException>(ex);
-                        Assert.Equal(QuicError.ConnectionAborted, qe.QuicError);
                     }
                 }
                 await connection.HandleRequestAsync();

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
@@ -64,6 +64,9 @@ internal static class ThrowHelper
         return false;
     }
 
+    // see TryGetStreamExceptionForMsQuicStatus for explanation
+    internal static bool IsConnectionAbortedWhenStartingStreamException(Exception ex) => ex is QuicException qe && qe.QuicError == QuicError.ConnectionAborted && qe.ApplicationErrorCode is null;
+
     internal static Exception GetExceptionForMsQuicStatus(int status, long? errorCode = default, string? message = null)
     {
         Exception ex = GetExceptionInternal(status, errorCode, message);

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
@@ -27,13 +27,27 @@ internal static class ThrowHelper
         return new QuicException(QuicError.OperationAborted, null, message ?? SR.net_quic_operationaborted);
     }
 
-    internal static bool TryGetStreamExceptionForMsQuicStatus(int status, [NotNullWhen(true)] out Exception? exception)
+    internal static bool TryGetStreamExceptionForMsQuicStatus(int status, [NotNullWhen(true)] out Exception? exception, bool streamWasSuccessfullyStarted = true, string? message = null)
     {
         if (status == QUIC_STATUS_ABORTED)
         {
-            // If status == QUIC_STATUS_ABORTED, we will receive an event later, which will complete the task source.
-            exception = null;
-            return false;
+            // Connection has been closed by the peer (either at transport or application level),
+            if (streamWasSuccessfullyStarted)
+            {
+                // we will receive an event later, which will complete the stream with concrete
+                // information why the connection was aborted.
+                exception = null;
+                return false;
+            }
+            else
+            {
+                // we won't be receiving any event callback for shutdown on this stream, so we don't
+                // necessarily know which error to report. So we throw an exception which we can distinguish
+                // at the caller (ConnectionAborted normally has App error code) and throw the correct
+                // exception from there.
+                exception = new QuicException(QuicError.ConnectionAborted, null, "");
+                return true;
+            }
         }
         else if (status == QUIC_STATUS_INVALID_STATE)
         {
@@ -43,7 +57,7 @@ internal static class ThrowHelper
         }
         else if (StatusFailed(status))
         {
-            exception = GetExceptionForMsQuicStatus(status);
+            exception = GetExceptionForMsQuicStatus(status, message: message);
             return true;
         }
         exception = null;

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -680,6 +680,8 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 task.GetAwaiter().GetResult();
             }
         }
+
+        Debug.Assert(_acceptQueue.Reader.Completion.IsCompleted);
     }
 
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -162,13 +162,24 @@ public sealed partial class QuicStream
         try
         {
             QUIC_HANDLE* handle;
-            ThrowHelper.ThrowIfMsQuicError(MsQuicApi.Api.StreamOpen(
+            int status = MsQuicApi.Api.StreamOpen(
                 connectionHandle,
                 type == QuicStreamType.Unidirectional ? QUIC_STREAM_OPEN_FLAGS.UNIDIRECTIONAL : QUIC_STREAM_OPEN_FLAGS.NONE,
                 &NativeCallback,
                 (void*)GCHandle.ToIntPtr(context),
-                &handle),
-                "StreamOpen failed");
+                &handle);
+
+            if (status == QUIC_STATUS_ABORTED)
+            {
+                // Connection has been closed by the peer (either at transport or application level),
+                // we won't be receiving any event callback for shutdown on this stream, so we don't
+                // necessarily know which error to report. So we throw an exception which we can distinguish
+                // at the caller (ConnectionAborted normally has App error code) and throw the correct
+                // exception from there.
+                throw new QuicException(QuicError.ConnectionAborted, null, "");
+            }
+
+            ThrowHelper.ThrowIfMsQuicError(status, "StreamOpen failed");
             _handle = new MsQuicContextSafeHandle(handle, context, SafeHandleType.Stream, connectionHandle);
             _handle.Disposable = _sendBuffers;
         }
@@ -245,6 +256,20 @@ public sealed partial class QuicStream
                 int status = MsQuicApi.Api.StreamStart(
                     _handle,
                     QUIC_STREAM_START_FLAGS.SHUTDOWN_ON_FAIL | QUIC_STREAM_START_FLAGS.INDICATE_PEER_ACCEPT);
+
+                if (status == QUIC_STATUS_ABORTED)
+                {
+                    // Connection has been closed by the peer (either at transport or application level),
+                    // we won't be receiving any event callback for shutdown on this stream, so we don't
+                    // necessarily know which error to report. So we throw an exception which we can distinguish
+                    // at the caller (ConnectionAborted normally has App error code) and throw the correct
+                    // exception from there.
+                    //
+                    // Also, avoid setting _startedTcs so that we don't try to wait for SHUTDOWN_COMPLETE
+                    // in DisposeAsync().
+                    throw new QuicException(QuicError.ConnectionAborted, null, "");
+                }
+
                 if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception))
                 {
                     _startedTcs.TrySetException(exception);


### PR DESCRIPTION
Fixes #101233.
Fixes #100971.
Contributes to #101463

See original issue for the description of the deadlock scenario.