### PR TITLE
Extend the copy propagation type check to local field cases

### DIFF
--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -230,18 +230,16 @@ bool Compiler::optCopyProp(
             continue;
         }
 
-        if (tree->OperIs(GT_LCL_VAR))
+        var_types newLclType = newLclVarDsc->TypeGet();
+        if (!newLclVarDsc->lvNormalizeOnLoad())
         {
-            var_types newLclType = newLclVarDsc->TypeGet();
-            if (!newLclVarDsc->lvNormalizeOnLoad())
-            {
-                newLclType = genActualType(newLclType);
-            }
+            newLclType = genActualType(newLclType);
+        }
 
-            if (newLclType != tree->TypeGet())
-            {
-                continue;
-            }
+        var_types oldLclType = tree->OperIs(GT_LCL_VAR) ? tree->TypeGet() : varDsc->TypeGet();
+        if (newLclType != oldLclType)
+        {
+            continue;
         }
 
 #ifdef DEBUG

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -141,6 +141,7 @@
     <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <UseAppHost>false</UseAppHost>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <!-- Set arch specific properties -->

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101034/Runtime_101034.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101034/Runtime_101034.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public static unsafe class Runtime_101034
+{
+    [Fact]
+    public static void Test()
+    {
+        StructWithTwoShorts x = new() { ShortOne = -1, ShortTwo = -1 };
+        StructWithThreeBytes y = default;
+        Problem(&x, &y);
+        Assert.True(y.ByteThree == 0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static StructWithTwoShorts Problem(StructWithTwoShorts* s, StructWithThreeBytes* p)
+    {
+        StructWithTwoShorts y = *s;
+
+        int z = 255;
+        ForceILLocal(&z);
+        if (z == 255)
+        {
+            y.ShortOne = 255;
+        }
+        else
+        {
+            y.ShortOne = 1;
+        }
+
+        if (p != null)
+        {
+            int x = 255;
+            *p = Unsafe.As<int, StructWithThreeBytes>(ref x);
+        }
+
+        return y;
+    }
+
+    private static void ForceILLocal(void* x) { }
+
+    struct StructWithTwoShorts
+    {
+        public short ShortOne;
+        public short ShortTwo;
+    }
+
+    struct StructWithThreeBytes
+    {
+        public byte ByteOne;
+        public byte ByteTwo;
+        public byte ByteThree;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_101034/Runtime_101034.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_101034/Runtime_101034.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
NOL locals are not modeled faithfully by VN, which makes this type check universally necessary.

No significant diffs expected.

Fixes #101034.