### PR TITLE
Vector128<T> wrong throw helper call

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -1041,7 +1041,7 @@ namespace System.Runtime.Intrinsics
             }
             else
             {
-                ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
+                ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
                 Unsafe.SkipInit(out Vector128<T> result);
 
                 result.SetLowerUnsafe(lower);


### PR DESCRIPTION
`Create<T>(Vector64<T>, Vector64<T>)` should use
`ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>()` instead of the Vector256 one.