### PR TITLE
[mono] Miscellaneous startup optimizations

### DIFF
--- a/src/mono/mono/eglib/gslist.c
+++ b/src/mono/mono/eglib/gslist.c
@@ -52,7 +52,8 @@ g_slist_append (GSList *list, gpointer data)
 GSList*
 g_slist_prepend (GSList *list, gpointer data)
 {
-	GSList *head = g_slist_alloc ();
+	// We don't need to zero the allocation using g_slist_alloc since we fully initialize the node
+	GSList *head = g_new (GSList, 1);
 	head->data = data;
 	head->next = list;
 

--- a/src/mono/mono/metadata/class-getters.h
+++ b/src/mono/mono/metadata/class-getters.h
@@ -48,6 +48,7 @@ MONO_CLASS_GETTER(m_class_is_interfaces_inited, gboolean, , MonoClass, interface
 MONO_CLASS_GETTER(m_class_is_simd_type, gboolean, , MonoClass, simd_type)
 MONO_CLASS_GETTER(m_class_is_has_finalize_inited, gboolean, , MonoClass, has_finalize_inited)
 MONO_CLASS_GETTER(m_class_is_fields_inited, gboolean, , MonoClass, fields_inited)
+MONO_CLASS_GETTER(m_class_is_exception_class, gboolean, , MonoClass, is_exception_class)
 MONO_CLASS_GETTER(m_class_has_failure, gboolean, , MonoClass, has_failure)
 MONO_CLASS_GETTER(m_class_has_deferred_failure, gboolean, , MonoClass, has_deferred_failure)
 MONO_CLASS_GETTER(m_class_has_weak_fields, gboolean, , MonoClass, has_weak_fields)

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -735,6 +735,17 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		}
 	}
 
+	// compute is_exception_class, used by interp to avoid inlining exception handling code
+	if (
+		klass->parent && !m_class_is_valuetype (klass) &&
+		!m_class_is_interface (klass)
+	) {
+		if (klass->parent->is_exception_class)
+			klass->is_exception_class = 1;
+		else if (!strcmp (klass->name, "Exception") && !strcmp(klass->name_space, "System"))
+			klass->is_exception_class = 1;
+	}
+
 	mono_loader_unlock ();
 
 	MONO_PROFILER_RAISE (class_loaded, (klass));

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -740,7 +740,7 @@ mono_class_create_from_typedef (MonoImage *image, guint32 type_token, MonoError 
 		klass->parent && !m_class_is_valuetype (klass) &&
 		!m_class_is_interface (klass)
 	) {
-		if (klass->parent->is_exception_class)
+		if (m_class_is_exception_class (klass->parent))
 			klass->is_exception_class = 1;
 		else if (!strcmp (klass->name, "Exception") && !strcmp(klass->name_space, "System"))
 			klass->is_exception_class = 1;

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -937,6 +937,7 @@ mono_class_create_generic_inst (MonoGenericClass *gclass)
 	klass->this_arg.byref__ = TRUE;
 	klass->is_inlinearray = gklass->is_inlinearray;
 	klass->inlinearray_value = gklass->inlinearray_value;
+	klass->is_exception_class = gklass->is_exception_class;
 	klass->enumtype = gklass->enumtype;
 	klass->valuetype = gklass->valuetype;
 

--- a/src/mono/mono/metadata/class-private-definition.h
+++ b/src/mono/mono/metadata/class-private-definition.h
@@ -68,9 +68,8 @@ struct _MonoClass {
 	guint no_special_static_fields : 1; /* has no thread/context static fields */
 
 	guint nested_classes_inited : 1; /* Whenever nested_class is initialized */
-
-	/* next byte*/
 	guint interfaces_inited : 1; /* interfaces is initialized */
+	/* next byte*/
 	guint simd_type : 1; /* class is a simd intrinsic type */
 	guint has_finalize_inited    : 1; /* has_finalize is initialized */
 	guint fields_inited : 1; /* setup_fields () has finished */
@@ -79,6 +78,8 @@ struct _MonoClass {
 	guint has_dim_conflicts : 1; /* Class has conflicting default interface methods */
 	guint any_field_has_auto_layout : 1; /* a field in this type's layout uses auto-layout */
 	guint has_deferred_failure : 1;
+	/* next byte*/
+	guint is_exception_class : 1; /* is System.Exception or derived from it */
 
 	MonoClass  *parent;
 	MonoClass  *nested_in;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2907,6 +2907,9 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 	if (g_list_find (td->dont_inline, method))
 		return FALSE;
 
+	if (method->klass->is_exception_class)
+		return FALSE;
+
 	return TRUE;
 }
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2907,7 +2907,7 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 	if (g_list_find (td->dont_inline, method))
 		return FALSE;
 
-	if (m_class_is_exception_class (method->klass))
+	if (m_class_is_exception_class (method->klass) && !strcmp (method->name, ".ctor"))
 		return FALSE;
 
 	return TRUE;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2907,7 +2907,7 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 	if (g_list_find (td->dont_inline, method))
 		return FALSE;
 
-	if (method->klass->is_exception_class)
+	if (m_class_is_exception_class (method->klass))
 		return FALSE;
 
 	return TRUE;


### PR DESCRIPTION
* g_slist_prepend does a zeroed allocation and then fully initializes the result, which wastes a small but measurable amount of time (memset is abnormally slow on wasm, and we use g_slist a lot, so this does show up in profiles)
* when the interpreter generates code for wrappers it always optimizes them, and as a result exception-handling methods and constructors tend to get inlined into every wrapper. this PR globally disables interp inlining of all methods on Exception and its derived types, since it is pretty safe to assume that they won't be called in hot paths. for my test application this reduces the number of `generate_code` invocations during startup from 862 to 802, a reduction of 60. It's possible this might be too aggressive.