### PR TITLE
[mono] UnsafeAccessor: Enable tests for extern static methods without type parameters

### DIFF
--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2322,6 +2322,7 @@ method_sig_from_accessor_sig (MonoMethodBuilder *mb, gboolean hasthis, MonoMetho
 	ret->hasthis = hasthis;
 	for (int i = 1; i < ret->param_count; i++)
 		ret->params [i - 1] = ret->params [i];
+	memset (&ret->params[ret->param_count - 1], 0, sizeof (MonoType*)); // just in case
 	ret->param_count--;
 	return ret;
 }

--- a/src/mono/mono/metadata/marshal-lightweight.c
+++ b/src/mono/mono/metadata/marshal-lightweight.c
@@ -2322,7 +2322,6 @@ method_sig_from_accessor_sig (MonoMethodBuilder *mb, gboolean hasthis, MonoMetho
 	ret->hasthis = hasthis;
 	for (int i = 1; i < ret->param_count; i++)
 		ret->params [i - 1] = ret->params [i];
-	memset (&ret->params[ret->param_count - 1], 0, sizeof (MonoType)); // just in case
 	ret->param_count--;
 	return ret;
 }
@@ -2467,7 +2466,7 @@ emit_unsafe_accessor_method_wrapper (MonoMethodBuilder *mb, MonoMethod *accessor
 static void
 emit_unsafe_accessor_wrapper_ilgen (MonoMethodBuilder *mb, MonoMethod *accessor_method, MonoMethodSignature *sig, MonoGenericContext *ctx, MonoUnsafeAccessorKind kind, const char *member_name)
 {
-	if (accessor_method->is_inflated || accessor_method->is_generic || mono_class_is_ginst (accessor_method->klass) || ctx != NULL) {
+	if (accessor_method->is_generic || ctx != NULL) {
 		mono_mb_emit_exception_full (mb, "System", "BadImageFormatException", "UnsafeAccessor_Generics");
 		return;
 	}

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -63,31 +63,15 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    public static void Verify_Generic_AccessStaticFieldClass_NonGenericMethod()
+    public static void Verify_Generic_AccessStaticFieldClass()
     {
-        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass_NonGenericMethod)}");
+        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass)}");
 
         Assert.Equal(typeof(int).ToString(), GetPrivateStaticFieldInt((MyList<int>)null));
 
         Assert.Equal(typeof(string).ToString(), GetPrivateStaticFieldString((MyList<string>)null));
 
         Assert.Equal(typeof(Struct).ToString(), GetPrivateStaticFieldStruct((MyList<Struct>)null));
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldInt(MyList<int> d);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<string>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldString(MyList<string> d);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<Struct>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldStruct(MyList<Struct> d);
-    }
-
-    [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
-    public static void Verify_Generic_AccessStaticFieldClass_GenericMethod()
-    {
-        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass_GenericMethod)}");
 
         {
             int expected = 10;
@@ -99,6 +83,15 @@ public static unsafe class UnsafeAccessorsTestsGenerics
             MyList<string>.SetStaticGenericField(expected);
             Assert.Equal(expected, GetPrivateStaticField((MyList<string>)null));
         }
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldInt(MyList<int> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<string>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldString(MyList<string> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<Struct>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldStruct(MyList<Struct> d);
 
         [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticGenericFieldName)]
         extern static ref V GetPrivateStaticField<V>(MyList<V> d);

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -98,7 +98,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
     public static void Verify_Generic_AccessFieldClass()
     {
         Console.WriteLine($"Running {nameof(Verify_Generic_AccessFieldClass)}");

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -63,16 +63,31 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
-    public static void Verify_Generic_AccessStaticFieldClass()
+    public static void Verify_Generic_AccessStaticFieldClass_NonGenericMethod()
     {
-        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass)}");
+        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass_NonGenericMethod)}");
 
         Assert.Equal(typeof(int).ToString(), GetPrivateStaticFieldInt((MyList<int>)null));
 
         Assert.Equal(typeof(string).ToString(), GetPrivateStaticFieldString((MyList<string>)null));
 
         Assert.Equal(typeof(Struct).ToString(), GetPrivateStaticFieldStruct((MyList<Struct>)null));
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldInt(MyList<int> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<string>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldString(MyList<string> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<Struct>.StaticFieldName)]
+        extern static ref string GetPrivateStaticFieldStruct(MyList<Struct> d);
+    }
+
+    [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
+    public static void Verify_Generic_AccessStaticFieldClass_GenericMethod()
+    {
+        Console.WriteLine($"Running {nameof(Verify_Generic_AccessStaticFieldClass_GenericMethod)}");
 
         {
             int expected = 10;
@@ -84,15 +99,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
             MyList<string>.SetStaticGenericField(expected);
             Assert.Equal(expected, GetPrivateStaticField((MyList<string>)null));
         }
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldInt(MyList<int> d);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<string>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldString(MyList<string> d);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<Struct>.StaticFieldName)]
-        extern static ref string GetPrivateStaticFieldStruct(MyList<Struct> d);
 
         [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticGenericFieldName)]
         extern static ref V GetPrivateStaticField<V>(MyList<V> d);
@@ -284,7 +290,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
     public static void Verify_Generic_GenericTypeNonGenericInstanceMethod()
     {
         Console.WriteLine($"Running {nameof(Verify_Generic_GenericTypeNonGenericInstanceMethod)}");
@@ -358,7 +363,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
     public static void Verify_Generic_GenericTypeNonGenericStaticMethod()
     {
         Console.WriteLine($"Running {nameof(Verify_Generic_GenericTypeNonGenericStaticMethod)}");


### PR DESCRIPTION
Contributes to #99830