### PR TITLE
Enable control flow guard for AOT compilers

### DIFF
--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -4,6 +4,7 @@
     <TieredCompilation>false</TieredCompilation>
     <EventSourceSupport>true</EventSourceSupport>
     <OptimizationPreference>Speed</OptimizationPreference>
+    <ControlFlowGuard>Guard</ControlFlowGuard>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Binskim warnings.

Cc @dotnet/ilc-contrib 