### PR TITLE
[browser] make slow Utf8JsonWriterTests tests OuterLoop

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -3072,6 +3072,7 @@ namespace System.Text.Json.Tests
         [Theory]
         [MemberData(nameof(JsonOptions_TestData))]
         [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/45464", ~RuntimeConfiguration.Release)]
+        [OuterLoop("Too slow", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void Writing3MBBase64Bytes(JsonWriterOptions options)
         {
             byte[] value = new byte[3 * 1024 * 1024];
@@ -4421,6 +4422,7 @@ namespace System.Text.Json.Tests
 
         [Theory]
         [MemberData(nameof(JsonOptions_TestData))]
+        [OuterLoop("Too slow", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void EscapeCharacters(JsonWriterOptions options)
         {
             // Do not include surrogate pairs.
@@ -5303,6 +5305,7 @@ namespace System.Text.Json.Tests
         [Theory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [MemberData(nameof(WriteValue_TestData))]
+        [OuterLoop("Too slow", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser))]
         public void WriteNumbers(JsonWriterOptions options, string keyString)
         {
             var random = new Random(42);


### PR DESCRIPTION
![image](https://github.com/dotnet/runtime/assets/271576/0ba6afbb-5efd-4c4f-bde9-1e2666ccabeb)
