### PR TITLE
fix Alpine build break

### DIFF
--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -48,7 +48,7 @@ CDAC::CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target)
 {
     if (m_module == NULL)
     {
-        m_cdac_handle = NULL;
+        m_cdac_handle = 0;
         return;
     }
 
@@ -62,7 +62,7 @@ CDAC::CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target)
 
 CDAC::~CDAC()
 {
-    if (m_cdac_handle != NULL)
+    if (m_cdac_handle)
     {
         decltype(&cdac_reader_free) free = reinterpret_cast<decltype(&cdac_reader_free)>(::GetProcAddress(m_module, "cdac_reader_free"));
         _ASSERTE(free != nullptr);


### PR DESCRIPTION
Apline defines NULL as std::nullptr which is not comparable/assignable with intptr_t

Fixes https://github.com/dotnet/source-build/issues/4345