### PR TITLE
[cdac] disable live ILLink in a different way

### DIFF
--- a/src/coreclr/tools/cdac-build-tool/Directory.Build.props
+++ b/src/coreclr/tools/cdac-build-tool/Directory.Build.props
@@ -1,7 +1,10 @@
 <Project>
-  <!-- we don't trim cdac-build-tool; we don't need the live trimmer -->
   <PropertyGroup>
-    <_RequiresLiveILLink>false</_RequiresLiveILLink>
+    <!-- we don't ship cdac-build-tool, and don't need to pack it into a single file. -->
+    <!-- turning this off also turns off _RequiresLiveILLink which caused file access issues during
+         windows CI builds because it seems like something tries to write over the live
+         ILLink.Tasks.dll while it is used during the build of cdac-build-tool. -->
+    <EnableSingleFileAnalyzer>false</EnableSingleFileAnalyzer>
   </PropertyGroup>
   <Import Project="..\Directory.Build.props" />
 </Project>


### PR DESCRIPTION
Instead of turning off `_RequiresLiveILLink` directly, turn off EnableSingleFileAnalyzer (we don't ship cdac-build-tool as a singlefile or otherwise).  We don't want live ILLink because it caused file access issues during windows CI builds. It seems like something tries to write over the live ILLink.Tasks.dll while it is used during the build of cdac-build-tool