### PR TITLE
[mono] Optimize startup vtable setup

### DIFF
--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -45,7 +45,8 @@ endif()
 set(imported_native_sources
     ../../../native/containers/dn-simdhash.c
     ../../../native/containers/dn-simdhash-string-ptr.c
-    ../../../native/containers/dn-simdhash-u32-ptr.c)
+    ../../../native/containers/dn-simdhash-u32-ptr.c
+    ../../../native/containers/dn-simdhash-ptrpair-ptr.c)
 
 set(metadata_common_sources
     appdomain.c

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -773,6 +773,11 @@ mono_method_get_method_definition (MonoMethod *method)
 static gboolean
 verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 {
+#ifndef DEBUG
+	if (klass->image == mono_defaults.corlib)
+		return TRUE;
+#endif
+
 	int i;
 
 	for (i = 0; i < onum; ++i) {
@@ -1760,7 +1765,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 			MonoMethod *override = iface_overrides [i*2 + 1];
 			if (mono_class_is_gtd (override->klass)) {
 				override = mono_class_inflate_generic_method_full_checked (override, ic, mono_class_get_context (ic), error);
-			} 
+			}
 			// there used to be code here to inflate decl if decl->is_inflated, but in https://github.com/dotnet/runtime/pull/64102#discussion_r790019545 we
 			// think that this does not correspond to any real code.
 			if (!apply_override (klass, ic, vtable, decl, override, &override_map, &override_class_map, &conflict_map))

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -773,7 +773,9 @@ mono_method_get_method_definition (MonoMethod *method)
 static gboolean
 verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 {
-#ifndef DEBUG
+	// on windows and arm, we define NDEBUG for release builds
+	// on browser and wasi, we define DEBUG for debug builds
+#if defined(NDEBUG) || !defined(DEBUG)
 	if (klass->image == mono_defaults.corlib)
 		return TRUE;
 #endif

--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -775,7 +775,7 @@ verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 {
 	// on windows and arm, we define NDEBUG for release builds
 	// on browser and wasi, we define DEBUG for debug builds
-#if defined(NDEBUG) || !defined(DEBUG)
+#ifdef ENABLE_CHECKED_BUILD
 	if (klass->image == mono_defaults.corlib)
 		return TRUE;
 #endif

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -4485,11 +4485,11 @@ mono_class_implement_interface_slow (MonoClass *target, MonoClass *candidate)
 
 	result = mono_class_implement_interface_slow_cached (target, candidate, cache);
 
+	// Under most circumstances we won't have multiple threads competing to run implement_interface_slow,
+	//  so it's not worth making this thread-local and potentially keeping a cache instance around per-thread.
 	cas_result = mono_atomic_cas_ptr ((volatile gpointer *)&implement_interface_scratch_cache, cache, NULL);
-	if (cas_result != NULL) {
-		g_printf ("freeing extra implement_interface cache\n");
+	if (cas_result != NULL)
 		dn_simdhash_free (cache);
-	}
 
 	return result;
 }

--- a/src/native/containers/containers.cmake
+++ b/src/native/containers/containers.cmake
@@ -13,6 +13,8 @@ list(APPEND SHARED_CONTAINER_SOURCES
     # dn-simdhash-string-ptr.c
     # dn-simdhash-u32-ptr.c
     # dn-simdhash-ptr-ptr.c
+    # dn-simdhash-ght-compatible.c
+    # dn-simdhash-ptrpair-ptr.c
 )
 
 list(APPEND SHARED_CONTAINER_HEADERS

--- a/src/native/containers/dn-simdhash-ptrpair-ptr.c
+++ b/src/native/containers/dn-simdhash-ptrpair-ptr.c
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <config.h>
+#include "dn-simdhash.h"
+
+#include "dn-simdhash-utils.h"
+
+typedef struct dn_ptrpair_t {
+	void *first;
+	void *second;
+} dn_ptrpair_t;
+
+static inline uint32_t
+dn_ptrpair_t_hash (dn_ptrpair_t key)
+{
+	return (MurmurHash3_32_ptr(key.first, 0) ^ MurmurHash3_32_ptr(key.second, 1));
+}
+
+static inline uint8_t
+dn_ptrpair_t_equals (dn_ptrpair_t lhs, dn_ptrpair_t rhs)
+{
+	return (lhs.first == rhs.first) && (lhs.second == rhs.second);
+}
+
+#define DN_SIMDHASH_T dn_simdhash_ptrpair_ptr
+#define DN_SIMDHASH_KEY_T dn_ptrpair_t
+#define DN_SIMDHASH_VALUE_T void *
+#define DN_SIMDHASH_KEY_HASHER(hash, key) dn_ptrpair_t_hash(key)
+#define DN_SIMDHASH_KEY_EQUALS(hash, lhs, rhs) dn_ptrpair_t_equals(lhs, rhs)
+#if SIZEOF_VOID_P == 8
+// 192 bytes holds 12 16-byte blocks, so 11 keys and one suffix table
+#define DN_SIMDHASH_BUCKET_CAPACITY 11
+#else
+// 128 bytes holds 16 8-byte blocks, so 14 keys and one suffix table
+#define DN_SIMDHASH_BUCKET_CAPACITY 14
+#endif
+
+#include "dn-simdhash-specialization.h"

--- a/src/native/containers/dn-simdhash-specializations.h
+++ b/src/native/containers/dn-simdhash-specializations.h
@@ -59,4 +59,19 @@ typedef struct dn_simdhash_str_key dn_simdhash_str_key;
 
 #include "dn-simdhash-ght-compatible.h"
 
+
+typedef struct dn_ptrpair_t {
+    void *first, *second;
+} dn_ptrpair_t;
+
+#define DN_SIMDHASH_T dn_simdhash_ptrpair_ptr
+#define DN_SIMDHASH_KEY_T dn_ptrpair_t
+#define DN_SIMDHASH_VALUE_T void *
+
+#include "dn-simdhash-specialization-declarations.h"
+
+#undef DN_SIMDHASH_T
+#undef DN_SIMDHASH_KEY_T
+#undef DN_SIMDHASH_VALUE_T
+
 #endif

--- a/src/native/containers/dn-simdhash.c
+++ b/src/native/containers/dn-simdhash.c
@@ -140,6 +140,19 @@ dn_simdhash_count (dn_simdhash_t *hash)
 	return hash->count;
 }
 
+uint32_t
+dn_simdhash_overflow_count (dn_simdhash_t *hash)
+{
+	assert(hash);
+	uint32_t result = 0;
+	for (uint32_t bucket_index = 0; bucket_index < hash->buffers.buckets_length; bucket_index++) {
+		uint8_t *suffixes = ((uint8_t *)hash->buffers.buckets) + (bucket_index * hash->meta->bucket_size_bytes);
+		uint8_t cascade_count = suffixes[DN_SIMDHASH_CASCADED_SLOT];
+		result += cascade_count;
+	}
+	return result;
+}
+
 void
 dn_simdhash_ensure_capacity (dn_simdhash_t *hash, uint32_t capacity)
 {

--- a/src/native/containers/dn-simdhash.c
+++ b/src/native/containers/dn-simdhash.c
@@ -119,8 +119,7 @@ dn_simdhash_clear (dn_simdhash_t *hash)
 	if (hash->vtable.destroy_all)
 		hash->vtable.destroy_all(hash);
 	hash->count = 0;
-	// TODO: Scan through buckets sequentially and only erase ones with data in them
-	// Maybe skip erasing the key slots too?
+	// TODO: Implement a fast clear algorithm that scans buckets and only clears ones w/nonzero count
 	memset(hash->buffers.buckets, 0, hash->buffers.buckets_length * hash->meta->bucket_size_bytes);
 	// Skip this for performance; memset is especially slow in wasm
 	// memset(hash->buffers.values, 0, hash->buffers.values_length * hash->meta->value_size);

--- a/src/native/containers/dn-simdhash.h
+++ b/src/native/containers/dn-simdhash.h
@@ -144,6 +144,11 @@ dn_simdhash_capacity (dn_simdhash_t *hash);
 uint32_t
 dn_simdhash_count (dn_simdhash_t *hash);
 
+// Returns the estimated number of items that have overflowed out of a bucket.
+// WARNING: This is expensive to calculate.
+uint32_t
+dn_simdhash_overflow_count (dn_simdhash_t *hash);
+
 // Automatically resizes the table if it is too small to hold the requested number
 //  of items. Will not shrink the table if it is already bigger.
 void


### PR DESCRIPTION
During startup (mostly in interpreted builds, but also a little bit in AOT) we spend a good chunk of time setting up vtables, and a lot of that time is spent in `mono_class_implement_interface_slow`. Once a check enters that slow path, all checks underneath it also stay on the slow path, which can result in a (small) exponential explosion of recursive checks that scan moderately large arrays, comparing A against B. The interface inheritance chains on BCL types are quite deep now in some cases thanks to things like generic arithmetic.

This PR adds a simple simdhash-based cache for mono_class_implement_interface_slow. In my testing it has a cache hit rate of ~60% during runs of System.Runtime.Tests and System.Text.Json.Tests, along with a cache hit rate of 40-50% on simpler applications. The number of expensive checks optimized out this way is fairly significant - tens of thousands on those test suites. Improvements from this should be more dramatic for more complex codebases.

The cache implementation is somewhat suboptimal - it will involve temporary allocations if multiple threads are racing to initialize vtables, and when the cache gets too big we have to clear it instead of pruning the oldest entries, which reduces the effective hit rate - but the memory usage is deterministic and based on my profiles the performance characteristics are good.

This PR also disables `verify_class_overrides` for types inside corlib unless you're building for debug - @lambdageek pointed out that we don't really need to verify corlib types since csc should never generate invalid types for code under our control. This verification is a source of some of these redundant checks, though there are still plenty even with it disabled.