### PR TITLE
Merge #91646 and #91708 into release/8.0-staging

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -32,7 +32,7 @@ usage()
   echo "                                  [Default: Debug]"
   echo "  --os                            Target operating system: windows, linux, freebsd, osx, maccatalyst, tvos,"
   echo "                                  tvossimulator, ios, iossimulator, android, browser, wasi, netbsd, illumos, solaris"
-  echo "                                  linux-musl, linux-bionic or haiku."
+  echo "                                  linux-musl, linux-bionic, tizen, or haiku."
   echo "                                  [Default: Your machine's OS.]"
   echo "  --outputrid <rid>               Optional argument that overrides the target rid name."
   echo "  --projects <value>              Project or solution file(s) to build."

--- a/eng/collect_vsinfo.ps1
+++ b/eng/collect_vsinfo.ps1
@@ -1,0 +1,65 @@
+<#
+.PARAMETER ArchiveRunName
+Name of the run for vs logs
+
+.NOTES
+Returns 0 if succeeds, 1 otherwise
+#>
+[CmdletBinding(PositionalBinding=$false)]
+Param (
+  [Parameter(Mandatory=$True)]
+  [string] $ArchiveRunName
+)
+
+. $PSScriptRoot/common/tools.ps1
+
+$ProgressPreference = "SilentlyContinue"
+$LogDir = Join-Path $LogDir $ArchiveRunName
+mkdir $LogDir
+
+$vscollect_uri="http://aka.ms/vscollect.exe"
+$vscollect="$env:TEMP\vscollect.exe"
+
+if (-not (Test-Path $vscollect)) {
+    Retry({
+        Write-Host "GET $vscollect_uri"
+        Invoke-WebRequest $vscollect_uri -OutFile $vscollect -UseBasicParsing
+    })
+
+    if (-not (Test-Path $vscollect)) {
+        Write-PipelineTelemetryError -Category 'InitializeToolset' -Message "Unable to download vscollect."
+        exit 1
+    }
+}
+
+&"$vscollect"
+Move-Item $env:TEMP\vslogs.zip "$LogDir"
+
+$vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path -Path "$vswhere" -PathType Leaf))
+{
+    Write-Error "Couldn't locate vswhere at $vswhere"
+    exit 1
+}
+
+&"$vswhere" -all -prerelease -products * |  Tee-Object -FilePath "$LogDir\vs_where.log"
+
+$vsdir = &"$vswhere" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+
+if (-not (Test-Path $vsdir))
+{
+    $procDumpDir = Join-Path $ToolsDir "procdump"
+    $procDumpToolPath = Join-Path $procDumpDir "procdump.exe"
+    $procdump_uri = "https://download.sysinternals.com/files/Procdump.zip"
+
+    if (-not (Test-Path $procDumpToolPath)) {
+        Retry({
+            Write-Host "GET $procdump_uri"
+            Invoke-WebRequest $procdump_uri -OutFile "$TempDir\Procdump.zip" -UseBasicParsing
+        })
+
+        Expand-Archive -Path "$TempDir\Procdump.zip" $procDumpDir
+    }
+
+    &"$procDumpToolPath" -ma -accepteula VSIXAutoUpdate.exe "$LogDir"
+}

--- a/eng/disable_vsupdate.ps1
+++ b/eng/disable_vsupdate.ps1
@@ -1,0 +1,23 @@
+schtasks /change /tn "\Microsoft\VisualStudio\VSIX Auto Update" /disable
+
+$vswhere = "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path -Path "$vswhere" -PathType Leaf))
+{
+    Write-Error "Couldn't locate vswhere at $vswhere"
+    exit 1
+}
+
+$vsdir = &"$vswhere" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+$vsregedit = "$vsdir\Common7\IDE\VsRegEdit.exe"
+
+if (-not (Test-Path -Path "$vsregedit" ))
+{
+    Write-Error "VSWhere returned path: $vsdir, but regedit $vsregedit doesn't exist."
+    exit 1
+}
+
+Write-Output "VSWhere returned path: $vsdir, using regedit $vsregedit"
+Write-Output "Disabling updates through VS Registry:"
+
+&"$vsdir\Common7\IDE\VsRegEdit.exe" set local HKCU ExtensionManager AutomaticallyCheckForUpdates2Override dword 0
+&"$vsdir\Common7\IDE\VsRegEdit.exe" read local HKCU ExtensionManager AutomaticallyCheckForUpdates2Override dword

--- a/eng/native/init-vs-env.cmd
+++ b/eng/native/init-vs-env.cmd
@@ -26,6 +26,8 @@ if defined VisualStudioVersion goto :VSDetected
 set "__VSWhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 set "__VSCOMNTOOLS="
 
+if not exist "%__VSWhere%" goto :VSWhereMissing
+
 if exist "%__VSWhere%" (
     for /f "tokens=*" %%p in (
         '"%__VSWhere%" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath'
@@ -54,6 +56,10 @@ if "%VisualStudioVersion%"=="17.0" (
 :VSMissing
 echo %__MsgPrefix%Error: Visual Studio 2022 with C++ tools required. ^
 Please see https://github.com/dotnet/runtime/blob/main/docs/workflow/requirements/windows-requirements.md for build requirements.
+exit /b 1
+
+:VSWhereMissing
+echo %__MsgPrefix%Error: vswhere couldn not be found in Visual Studio Installer directory at "%__VSWhere%"
 exit /b 1
 
 :SetVCEnvironment

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -254,6 +254,11 @@ jobs:
           shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
           ${{ insert }}: ${{ parameters.extraStepsParameters }}
 
+      - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.osGroup, 'windows')) }}:
+        - powershell: ./eng/collect_vsinfo.ps1 -ArchiveRunName postbuild_log
+          displayName: Collect vslogs on exit
+          condition: always()
+
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -883,7 +883,7 @@ jobs:
       jobTemplate: ${{ parameters.jobTemplate }}
       helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
       variables: ${{ parameters.variables }}
-      osGroup: tizen
+      osGroup: linux # Our build scripts don't support Tizen and have always used Linux as the OS parameter.
       archType: armel
       targetRid: tizen-armel
       platform: tizen_armel

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -119,7 +119,6 @@ jobs:
     - ${{ parameters.variables }}
 
     steps:
-
     # Install native dependencies
     # Linux builds use docker images with dependencies preinstalled,
     # and FreeBSD builds use a build agent with dependencies
@@ -281,6 +280,12 @@ jobs:
       - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         parameters:
           name: ${{ parameters.platform }}
+
+    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.osGroup, 'windows')) }}:
+      - powershell: ./eng/collect_vsinfo.ps1 -ArchiveRunName postbuild_log
+        displayName: Collect vslogs on exit
+        condition: always()
+
 
     # Publish Logs
     - task: PublishPipelineArtifact@1

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -95,9 +95,6 @@ jobs:
     - ${{ if ne(parameters.testGroup, 'innerloop') }}:
       - name: clrRuntimeComponentsBuildArg
         value: '-component runtime -component alljits -component paltests -component nativeaot -component spmi '
-    - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x86')) }}:
-      - name: clrRuntimeComponentsBuildArg
-        value: '-component runtime -component jit -component iltools -component spmi '
 
     - name: pgoInstrumentArg
       value: ''
@@ -107,12 +104,6 @@ jobs:
 
     - name: SignType
       value: $[ coalesce(variables.OfficialSignType, 'real') ]
-
-    - name: clrRuntimePortableBuildArg
-      value: ''
-    - ${{ if eq(parameters.osGroup, 'tizen') }}:
-      - name: clrRuntimePortableBuildArg
-        value: '-portablebuild=false'
 
     # Set a default empty argument for the pgo path.
     # This will be set during the 'native prerequisites' step if PGO optimization is enabled.
@@ -185,14 +176,14 @@ jobs:
 
     # Build CoreCLR Runtime
     - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(clrRuntimePortableBuildArg) $(CoreClrPgoDataArg) $(nativeSymbols)
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg) $(nativeSymbols)
         displayName: Build CoreCLR Runtime
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
 
     - ${{ if or(eq(parameters.crossBuild, 'true'), ne(parameters.archType, 'x64')) }}:
-      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 $(osArg) -ci $(compilerArg) -component crosscomponents -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" $(officialBuildIdArg) $(clrRuntimePortableBuildArg)
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -hostarch x64 $(osArg) -ci $(compilerArg) -component crosscomponents -cmakeargs "-DCLR_CROSS_COMPONENTS_BUILD=1" $(officialBuildIdArg)
         displayName: Build CoreCLR Cross-Arch Tools (Tools that run on x64 targeting x86)
 
     - ${{ if in(parameters.osGroup, 'osx', 'ios', 'tvos') }}:
@@ -202,12 +193,8 @@ jobs:
         displayName: Disk Usage after Build
 
     # Build CoreCLR Managed Components
-    - ${{ if or(ne(parameters.osGroup, 'linux'), ne(parameters.archType, 'x86')) }}:
-      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages+clr.paltestlist $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
-        displayName: Build managed product components and packages
-    - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x86')) }}:
-      - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib $(crossArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
-        displayName: Build managed product components and packages
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages+clr.paltestlist $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
+      displayName: Build managed product components and packages
 
     # Build native test components
     - ${{ if and(ne(parameters.isOfficialBuild, true), ne(parameters.disableClrTest, true)) }}:

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -370,6 +370,12 @@ jobs:
           displayName: Build and Package
           continueOnError: ${{ and(eq(variables.SkipTests, false), eq(parameters.shouldContinueOnError, true)) }}
 
+      - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.osGroup, 'windows')) }}:
+        - powershell: ./eng/collect_vsinfo.ps1 -ArchiveRunName postbuild_log
+          displayName: Collect vslogs on exit
+          condition: always()
+
+
       - ${{ if in(parameters.osGroup, 'osx', 'ios', 'tvos') }}:
         - script: |
             du -sh $(Build.SourcesDirectory)/*

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -171,6 +171,10 @@ jobs:
       - script: build$(scriptExt) -subset mono+clr.hosts -c $(buildConfig) -arch $(archType) $(osOverride) -ci $(officialBuildIdArg) $(aotCrossParameter) $(llvmParameter) -pack $(OutputRidArg)
         displayName: Build nupkg
 
+    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.osGroup, 'windows')) }}:
+      - powershell: ./eng/collect_vsinfo.ps1 -ArchiveRunName postbuild_log
+        displayName: Collect vslogs on exit
+        condition: always()
     # Publish Logs
     - task: PublishPipelineArtifact@1
       displayName: Publish Logs

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -70,7 +70,6 @@ extends:
           jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
           buildConfig: checked
           platforms:
-          - linux_x86
           - linux_x64
           - linux_arm
           - linux_arm64
@@ -79,7 +78,6 @@ extends:
           - linux_musl_arm64
           - linux_musl_x64
           - osx_arm64
-          - tizen_armel
           - windows_x86
           - windows_x64
           - windows_arm64
@@ -187,6 +185,48 @@ extends:
                 or(
                   eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
                   eq(variables['isRollingBuild'], true)))
+
+      #
+      # Build CoreCLR with no R2R
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: checked
+          runtimeFlavor: coreclr
+          platforms:
+          - linux_x86
+          jobParameters:
+            testScope: innerloop
+            nameSuffix: CoreCLR_NoR2R
+            buildArgs: -s clr.runtime+clr.jit+clr.iltools+clr.spmi+clr.corelib -c $(_BuildConfig)
+            timeoutInMinutes: 120
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build CoreCLR as a non-portable build
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: checked
+          runtimeFlavor: coreclr
+          platforms:
+          - tizen_armel
+          jobParameters:
+            testScope: innerloop
+            nameSuffix: CoreCLR_NonPortable
+            buildArgs: -s clr.native+clr.tools+clr.corelib+clr.nativecorelib+clr.aot+clr.packages -c $(_BuildConfig) /p:PortableBuild=false
+            timeoutInMinutes: 120
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
 
       #
       # CoreCLR NativeAOT debug build and smoke tests


### PR DESCRIPTION
This work is a continuation of https://github.com/dotnet/runtime/pull/100994, the whole task being making the release/8.0-staging branch transition to the official 1ES templates.

Both PRs (https://github.com/dotnet/runtime/pull/91646 and https://github.com/dotnet/runtime/pull/91708) consist of fairly simple changes (additions mostly) so should be a low risk PR.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2436370&view=results

CC @amanasifkhalid 