### PR TITLE
Remove unnecessary indirect use of managed wcslen from AppContext setup

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -151,6 +151,16 @@ namespace System
                 s_dataStore.Add(new string(pNames[i]), new string(pValues[i]));
             }
         }
+
+        internal static unsafe void Setup(char** pNames, uint** pNameLengths, char** pValues, uint** pValueLengths, int count)
+        {
+            Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
+            s_dataStore = new Dictionary<string, object?>(count, StringComparer.Ordinal);
+            for (int i = 0; i < count; i++)
+            {
+                s_dataStore.Add(new string(pNames[i], 0, (int)pNameLengths[i]), new string(pValues[i], 0, (int)pValueLengths[i]));
+            }
+        }
 #endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -152,7 +152,7 @@ namespace System
             }
         }
 
-        internal static unsafe void Setup(char** pNames, uint** pNameLengths, char** pValues, uint** pValueLengths, int count)
+        internal static unsafe void Setup(char** pNames, uint* pNameLengths, char** pValues, uint* pValueLengths, int count)
         {
             Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
             s_dataStore = new Dictionary<string, object?>(count);

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -152,26 +152,10 @@ namespace System
             }
         }
 
-        private sealed class AppContextKeyComparer : IEqualityComparer<string?>
-        {
-            public bool Equals(string? x, string? y) => string.Equals(x, y);
-
-            public int GetHashCode(string? obj)
-            {
-                Debug.Assert(obj != null, "This implementation is only called from first-party collection types that guarantee non-null parameters.");
-                return obj.GetNonRandomizedHashCode();
-            }
-        }
-
         internal static unsafe void Setup(char** pNames, uint** pNameLengths, char** pValues, uint** pValueLengths, int count)
         {
             Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
-            // HACK: Use a special comparer that does not pull in all the dependencies that
-            //  the default BCL string comparers pull in
-            IEqualityComparer<string?> comparer = new AppContextKeyComparer();
-            // HACK: Use a special version of the Dictionary constructor that does not pull in a
-            //  large amount of extra code in order to instantiate this dictionary
-            s_dataStore = new Dictionary<string, object?>(count, comparer, true);
+            s_dataStore = new Dictionary<string, object?>(count);
             for (int i = 0; i < count; i++)
             {
                 s_dataStore.Add(new string(pNames[i], 0, (int)pNameLengths[i]), new string(pValues[i], 0, (int)pValueLengths[i]));

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -141,17 +141,7 @@ namespace System
             }
         }
 
-#if !NATIVEAOT
-        internal static unsafe void Setup(char** pNames, char** pValues, int count)
-        {
-            Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
-            s_dataStore = new Dictionary<string, object?>(count);
-            for (int i = 0; i < count; i++)
-            {
-                s_dataStore.Add(new string(pNames[i]), new string(pValues[i]));
-            }
-        }
-
+#if MONO
         internal static unsafe void Setup(char** pNames, uint* pNameLengths, char** pValues, uint* pValueLengths, int count)
         {
             Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
@@ -159,6 +149,16 @@ namespace System
             for (int i = 0; i < count; i++)
             {
                 s_dataStore.Add(new string(pNames[i], 0, (int)pNameLengths[i]), new string(pValues[i], 0, (int)pValueLengths[i]));
+            }
+        }
+#elif !NATIVEAOT
+        internal static unsafe void Setup(char** pNames, char** pValues, int count)
+        {
+            Debug.Assert(s_dataStore == null, "s_dataStore is not expected to be inited before Setup is called");
+            s_dataStore = new Dictionary<string, object?>(count);
+            for (int i = 0; i < count; i++)
+            {
+                s_dataStore.Add(new string(pNames[i]), new string(pValues[i]));
             }
         }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -68,7 +68,8 @@ namespace System.Collections.Generic
             {
                 _comparer = comparer ?? EqualityComparer<TKey>.Default;
 
-                if (!useProvidedComparer) {
+                if (!useProvidedComparer)
+                {
                     // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
                     // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
                     // hash buckets become unbalanced.

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -43,7 +43,9 @@ namespace System.Collections.Generic
 
         public Dictionary(IEqualityComparer<TKey>? comparer) : this(0, comparer) { }
 
-        public Dictionary(int capacity, IEqualityComparer<TKey>? comparer)
+        public Dictionary(int capacity, IEqualityComparer<TKey>? comparer) : this(0, comparer, false) { }
+
+        internal Dictionary(int capacity, IEqualityComparer<TKey>? comparer, bool useProvidedComparer)
         {
             if (capacity < 0)
             {
@@ -66,13 +68,15 @@ namespace System.Collections.Generic
             {
                 _comparer = comparer ?? EqualityComparer<TKey>.Default;
 
-                // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
-                // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
-                // hash buckets become unbalanced.
-                if (typeof(TKey) == typeof(string) &&
-                    NonRandomizedStringEqualityComparer.GetStringComparer(_comparer!) is IEqualityComparer<string> stringComparer)
-                {
-                    _comparer = (IEqualityComparer<TKey>)stringComparer;
+                if (!useProvidedComparer) {
+                    // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
+                    // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
+                    // hash buckets become unbalanced.
+                    if (typeof(TKey) == typeof(string) &&
+                        NonRandomizedStringEqualityComparer.GetStringComparer(_comparer!) is IEqualityComparer<string> stringComparer)
+                    {
+                        _comparer = (IEqualityComparer<TKey>)stringComparer;
+                    }
                 }
             }
             else if (comparer is not null && // first check for null to avoid forcing default comparer instantiation unnecessarily

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -880,9 +880,10 @@ mono_runtime_install_appctx_properties (void)
 	for (int i = 0; i < n_appctx_props; ++i) {
 		glong num_chars;
 		combined_keys [i] = g_utf8_to_utf16 (appctx_keys [i], -1, NULL, &num_chars, NULL);
-		combined_key_lengths [i] = GLONG_TO_UINT32 (num_chars);
+		// HACK: items_written from g_utf8_to_utf16 includes the null terminator unless you pass an explicit length.
+		combined_key_lengths [i] = GLONG_TO_UINT32 (num_chars ? num_chars - 1 : 0);
 		combined_values [i] = g_utf8_to_utf16 (appctx_values [i], -1, NULL, &num_chars, NULL);
-		combined_value_lengths [i] = GLONG_TO_UINT32 (num_chars);
+		combined_value_lengths [i] = GLONG_TO_UINT32 (num_chars ? num_chars - 1 : 0);
 	}
 
 	runtimeconfig_json_read_props (

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -891,7 +891,7 @@ mono_runtime_install_appctx_properties (void)
 		combined_values + n_appctx_props, combined_value_lengths + n_appctx_props
 	);
 
-	/* internal static unsafe void Setup_Mono(char** pNames, uint** pNameLengths, char** pValues, uint** pValueLengths, int count) */
+	/* internal static unsafe void Setup(char** pNames, uint* pNameLengths, char** pValues, uint* pValueLengths, int count) */
 	args [0] = combined_keys;
 	args [1] = combined_key_lengths;
 	args [2] = combined_values;

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -880,9 +880,9 @@ mono_runtime_install_appctx_properties (void)
 	for (int i = 0; i < n_appctx_props; ++i) {
 		glong num_chars;
 		combined_keys [i] = g_utf8_to_utf16 (appctx_keys [i], -1, NULL, &num_chars, NULL);
-		combined_key_lengths[i] = GLONG_TO_UINT32(num_chars);
+		combined_key_lengths [i] = GLONG_TO_UINT32 (num_chars);
 		combined_values [i] = g_utf8_to_utf16 (appctx_values [i], -1, NULL, &num_chars, NULL);
-		combined_value_lengths[i] = GLONG_TO_UINT32(num_chars);
+		combined_value_lengths [i] = GLONG_TO_UINT32 (num_chars);
 	}
 
 	runtimeconfig_json_read_props (

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -99,7 +99,11 @@ static const char *
 runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **file_map, gpointer *buf_handle);
 
 static void
-runtimeconfig_json_read_props (const char *ptr, const char **endp, int nprops, gunichar2 **dest_keys, gunichar2 **dest_values);
+runtimeconfig_json_read_props (
+	const char *ptr, const char **endp, int nprops,
+	gunichar2 **dest_keys, guint32 *dest_key_lengths,
+	gunichar2 **dest_values, guint32 *dest_value_lengths
+);
 
 static MonoLoadFunc load_function = NULL;
 
@@ -846,17 +850,19 @@ void
 mono_runtime_install_appctx_properties (void)
 {
 	ERROR_DECL (error);
-	gpointer args [3];
+	gpointer args [5];
 	int n_runtimeconfig_json_props = 0;
 	int n_combined_props;
 	gunichar2 **combined_keys;
 	gunichar2 **combined_values;
+	guint32 *combined_key_lengths;
+	guint32 *combined_value_lengths;
 	MonoFileMap *runtimeconfig_json_map = NULL;
 	gpointer runtimeconfig_json_map_handle = NULL;
 	const char *buffer_start = runtimeconfig_json_get_buffer (runtime_config_arg, &runtimeconfig_json_map, &runtimeconfig_json_map_handle);
 	const char *buffer = buffer_start;
 
-	MonoMethod *setup = mono_class_get_method_from_name_checked (mono_class_get_appctx_class (), "Setup", 3, 0, error);
+	MonoMethod *setup = mono_class_get_method_from_name_checked (mono_class_get_appctx_class (), "Setup", 5, 0, error);
 	g_assert (setup);
 
 	// FIXME: TRUSTED_PLATFORM_ASSEMBLIES is very large
@@ -867,19 +873,30 @@ mono_runtime_install_appctx_properties (void)
 
 	n_combined_props = n_appctx_props + n_runtimeconfig_json_props;
 	combined_keys = g_new0 (gunichar2 *, n_combined_props);
+	combined_key_lengths = g_new0 (guint32, n_combined_props);
 	combined_values = g_new0 (gunichar2 *, n_combined_props);
+	combined_value_lengths = g_new0 (guint32, n_combined_props);
 
 	for (int i = 0; i < n_appctx_props; ++i) {
-		combined_keys [i] = g_utf8_to_utf16 (appctx_keys [i], -1, NULL, NULL, NULL);
-		combined_values [i] = g_utf8_to_utf16 (appctx_values [i], -1, NULL, NULL, NULL);
+		glong num_chars;
+		combined_keys [i] = g_utf8_to_utf16 (appctx_keys [i], -1, NULL, &num_chars, NULL);
+		combined_key_lengths[i] = GLONG_TO_UINT32(num_chars);
+		combined_values [i] = g_utf8_to_utf16 (appctx_values [i], -1, NULL, &num_chars, NULL);
+		combined_value_lengths[i] = GLONG_TO_UINT32(num_chars);
 	}
 
-	runtimeconfig_json_read_props (buffer, &buffer, n_runtimeconfig_json_props, combined_keys + n_appctx_props, combined_values + n_appctx_props);
+	runtimeconfig_json_read_props (
+		buffer, &buffer, n_runtimeconfig_json_props,
+		combined_keys + n_appctx_props, combined_key_lengths + n_appctx_props,
+		combined_values + n_appctx_props, combined_value_lengths + n_appctx_props
+	);
 
-	/* internal static unsafe void Setup(char** pNames, char** pValues, int count) */
+	/* internal static unsafe void Setup_Mono(char** pNames, uint** pNameLengths, char** pValues, uint** pValueLengths, int count) */
 	args [0] = combined_keys;
-	args [1] = combined_values;
-	args [2] = &n_combined_props;
+	args [1] = combined_key_lengths;
+	args [2] = combined_values;
+	args [3] = combined_value_lengths;
+	args [4] = &n_combined_props;
 
 	mono_runtime_invoke_checked (setup, NULL, args, error);
 	mono_error_assert_ok (error);
@@ -900,6 +917,8 @@ mono_runtime_install_appctx_properties (void)
 	}
 	g_free (combined_keys);
 	g_free (combined_values);
+	g_free (combined_key_lengths);
+	g_free (combined_value_lengths);
 	for (int i = 0; i < n_appctx_props; ++i) {
 		g_free (appctx_keys [i]);
 		g_free (appctx_values [i]);
@@ -949,17 +968,24 @@ runtimeconfig_json_get_buffer (MonovmRuntimeConfigArguments *arg, MonoFileMap **
 }
 
 static void
-runtimeconfig_json_read_props (const char *ptr, const char **endp, int nprops, gunichar2 **dest_keys, gunichar2 **dest_values)
+runtimeconfig_json_read_props (
+	const char *ptr, const char **endp, int nprops,
+	gunichar2 **dest_keys, guint32 *dest_key_lengths,
+	gunichar2 **dest_values, guint32 *dest_value_lengths
+)
 {
 	for (int i = 0; i < nprops; ++i) {
 		int str_len;
+		glong chars_written;
 
 		str_len = mono_metadata_decode_value (ptr, &ptr);
-		dest_keys [i] = g_utf8_to_utf16 (ptr, str_len, NULL, NULL, NULL);
+		dest_keys [i] = g_utf8_to_utf16 (ptr, str_len, NULL, &chars_written, NULL);
+		dest_key_lengths [i] = GLONG_TO_UINT32 (chars_written);
 		ptr += str_len;
 
 		str_len = mono_metadata_decode_value (ptr, &ptr);
-		dest_values [i] = g_utf8_to_utf16 (ptr, str_len, NULL, NULL, NULL);
+		dest_values [i] = g_utf8_to_utf16 (ptr, str_len, NULL, &chars_written, NULL);
+		dest_value_lengths [i] = GLONG_TO_UINT32 (chars_written);
 		ptr += str_len;
 	}
 


### PR DESCRIPTION
At least on mono, during AppContext setup we use the `string::.ctor(char*)` constructor, which calls a managed, vectorized implementation of `wcslen` - this pulls in a bunch of vector code to optimize a codepath that is cold:
```
Generating (wrapper managed-to-managed) string:.ctor (char*) (7 byte(s)) dotnet.native.js:1345:16
Generating string:Ctor (char*) (57 byte(s)) dotnet.native.js:1345:16
Generating string:wcslen (char*) (7 byte(s)) dotnet.native.js:1345:16
Generating System.SpanHelpers:IndexOfNullCharacter (char*) (339 byte(s)) dotnet.native.js:1345:16
Generating System.SpanHelpers:UnalignedCountVector128 (char*) (16 byte(s)) dotnet.native.js:1345:16
Generating System.SpanHelpers:GetCharVector128SpanLength (intptr,intptr) (14 byte(s)) dotnet.native.js:1345:16
Generating System.Runtime.Intrinsics.Vector128:AsByte<uint16> (System.Runtime.Intrinsics.Vector128`1<uint16>) (7 byte(s)) dotnet.native.js:1345:16
Generating System.Runtime.Intrinsics.Vector128:As<uint16, byte> (System.Runtime.Intrinsics.Vector128`1<uint16>) (23 byte(s)) dotnet.native.js:1345:16
Generating System.ThrowHelper:ThrowForUnsupportedIntrinsicsVector128BaseType<uint16> () (15 byte(s)) dotnet.native.js:1345:16
Generating System.Runtime.Intrinsics.Vector128`1<uint16>:get_IsSupported () (346 byte(s)) dotnet.native.js:1345:16
Generating System.ThrowHelper:ThrowForUnsupportedIntrinsicsVector128BaseType<byte> () (15 byte(s)) dotnet.native.js:1345:16
Generating System.Runtime.Intrinsics.Vector128`1<byte>:get_IsSupported () (346 byte(s)) dotnet.native.js:1345:16
Generating System.Buffer:Memmove<char> (char&,char&,uintptr) (81 byte(s)) dotnet.native.js:1345:16
```

~We also use the default comparer when creating an instance of `Dictionary<string, object>`, which pulls in `GenericEqualityComparer` and `NonRandomizedStringEqualityComparer` stuff we don't need when we could just use an `OrdinalComparer` directly:~
```
Generating System.Collections.Generic.EqualityComparer`1<string>:get_Default () (38 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.EqualityComparer`1<string>:CreateComparer () (191 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.GenericEqualityComparer`1<string>:.ctor () (7 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.EqualityComparer`1<string>:.ctor () (7 byte(s)) dotnet.native.js:1345:16
Generating System.Threading.Interlocked:CompareExchange<System.Collections.Generic.EqualityComparer`1<string>> (System.Collections.Generic.EqualityComparer`1<string>&,System.Collections.Generic.EqualityComparer`1<string>,System.Collections.Generic.EqualityComparer`1<string>) (56 byte(s)) dotnet.native.js:1345:16
Generating System.Runtime.CompilerServices.Unsafe:IsNullRef<System.Collections.Generic.EqualityComparer`1<string>> (System.Collections.Generic.EqualityComparer`1<string>&) (16 byte(s)) dotnet.native.js:1345:16
Generating (wrapper managed-to-native) System.Threading.Interlocked:CompareExchange (object&,object&,object&,object&) (16 byte(s)) dotnet.native.js:1345:16
Generating (wrapper runtime-invoke) object:runtime_invoke_direct_void (object,intptr,intptr,intptr) (112 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.NonRandomizedStringEqualityComparer:.cctor () (46 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.NonRandomizedStringEqualityComparer/OrdinalComparer:.ctor (System.Collections.Generic.IEqualityComparer`1<string>) (8 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.NonRandomizedStringEqualityComparer:.ctor (System.Collections.Generic.IEqualityComparer`1<string>) (14 byte(s)) dotnet.native.js:1345:16
Generating System.StringComparer:get_Ordinal () (6 byte(s)) dotnet.native.js:1345:16
Generating (wrapper runtime-invoke) object:runtime_invoke_direct_void (object,intptr,intptr,intptr) (112 byte(s)) dotnet.native.js:1345:16
Generating System.OrdinalCaseSensitiveComparer:.cctor () (11 byte(s)) dotnet.native.js:1345:16
Generating System.OrdinalCaseSensitiveComparer:.ctor () (8 byte(s)) dotnet.native.js:1345:16
Generating System.OrdinalComparer:.ctor (bool) (14 byte(s)) dotnet.native.js:1345:16
Generating System.StringComparer:.ctor () (7 byte(s)) dotnet.native.js:1345:16
Generating System.StringComparer:get_OrdinalIgnoreCase () (6 byte(s)) dotnet.native.js:1345:16
Generating (wrapper runtime-invoke) object:runtime_invoke_direct_void (object,intptr,intptr,intptr) (112 byte(s)) dotnet.native.js:1345:16
Generating System.OrdinalIgnoreCaseComparer:.cctor () (11 byte(s)) dotnet.native.js:1345:16
Generating System.OrdinalIgnoreCaseComparer:.ctor () (8 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.NonRandomizedStringEqualityComparer/OrdinalIgnoreCaseComparer:.ctor (System.Collections.Generic.IEqualityComparer`1<string>) (8 byte(s)) dotnet.native.js:1345:16
Generating System.Collections.Generic.NonRandomizedStringEqualityComparer:GetStringComparer (object) (44 byte(s)) dotnet.native.js:1345:16
```

We already compute the length of the appcontext arguments when converting them to UTF-16, at least in mono, so this PR switches to a 5-argument variant of Setup that accepts an array of lengths, so it can use a simpler/faster string constructor overload. 

A lot of this code may get pulled in later by user code or library code in i.e. Blazor, but this ideally lets us get much further into app startup before that happens, at which point important network requests or background operations may have started instead of being blocked on the creation of AppContext.