### PR TITLE
Avoid unnecessary lazy init in StructuralComparisons

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/StructuralComparisons.cs
+++ b/src/libraries/System.Collections/src/System/Collections/StructuralComparisons.cs
@@ -7,16 +7,15 @@ namespace System.Collections
 {
     public static class StructuralComparisons
     {
-        private static volatile IComparer? s_StructuralComparer;
-        private static volatile IEqualityComparer? s_StructuralEqualityComparer;
+        public static IComparer StructuralComparer => System.Collections.StructuralComparer.s_instance
 
-        public static IComparer StructuralComparer => s_StructuralComparer ??= new StructuralComparer();
-
-        public static IEqualityComparer StructuralEqualityComparer => s_StructuralEqualityComparer ??= new StructuralEqualityComparer();
+        public static IEqualityComparer StructuralEqualityComparer => System.Collections.StructuralEqualityComparer.s_instance;
     }
 
     internal sealed class StructuralEqualityComparer : IEqualityComparer
     {
+        internal static readonly StructuralEqualityComparer s_instance = new();
+
         public new bool Equals(object? x, object? y)
         {
             if (x != null)
@@ -58,6 +57,8 @@ namespace System.Collections
 
     internal sealed class StructuralComparer : IComparer
     {
+        internal static readonly StructuralComparer s_instance = new();
+
         public int Compare(object? x, object? y)
         {
             if (x == null) return y == null ? 0 : -1;

--- a/src/libraries/System.Collections/src/System/Collections/StructuralComparisons.cs
+++ b/src/libraries/System.Collections/src/System/Collections/StructuralComparisons.cs
@@ -7,7 +7,7 @@ namespace System.Collections
 {
     public static class StructuralComparisons
     {
-        public static IComparer StructuralComparer => System.Collections.StructuralComparer.s_instance
+        public static IComparer StructuralComparer => System.Collections.StructuralComparer.s_instance;
 
         public static IEqualityComparer StructuralEqualityComparer => System.Collections.StructuralEqualityComparer.s_instance;
     }


### PR DESCRIPTION
The only benefit of having these be lazy in this manner is avoiding one of the two objects being constructed. We can instead just combine them into a singleton that's initialized in a static readonly.

Best reviewed without whitespace diff: https://github.com/dotnet/runtime/pull/101344/files?w=1