### PR TITLE
Remove `IlcKeepManagedDebuggerSupport`

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -289,7 +289,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcDisableReflection) == 'true'" Include="--feature:System.Reflection.IsReflectionExecutionAvailable=false" />
 
       <!-- The managed debugging support in libraries is unused - trim it -->
-      <IlcArg Condition="'$(IlcKeepManagedDebuggerSupport)' != 'true'" Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
+      <IlcArg Condition="'$(DebuggerSupport)' != 'true'" Include="--feature:System.Diagnostics.Debugger.IsSupported=false" />
       <IlcArg Condition="'$(UseWindowsThreadPool)' != '' and '$(_targetOS)' == 'win'" Include="--feature:System.Threading.ThreadPool.UseWindowsThreadPool=$(UseWindowsThreadPool)" />
     </ItemGroup>
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System.Runtime.Tests.csproj
@@ -12,9 +12,7 @@
      <!-- some tests require full ICU data, force it -->
     <WasmIncludeFullIcuData>true</WasmIncludeFullIcuData>
 
-    <!-- The test is looking for debugger attributes we would have stripped with NativeAOT -->
-    <IlcKeepManagedDebuggerSupport>true</IlcKeepManagedDebuggerSupport>
-    <!-- Same for ILLink -->
+    <!-- The test is looking for debugger attributes we would have stripped -->
     <DebuggerSupport>true</DebuggerSupport>
     <!-- Active issue: https://github.com/dotnet/runtime/issues/97809 -->
     <ShouldILStrip>false</ShouldILStrip>


### PR DESCRIPTION
This was introduced in #82696, but on a second thought, we should be able to use the documented `DebuggerSupport` for this. We still don't want to full on default this to `false` for reasons described in the PR, but the explicit value of `true` can be the escape hatch. The property is empty by default.

Cc @dotnet/ilc-contrib @eerhardt @vitek-karas @jkotas