### PR TITLE
Fix S.D.Tracing testapps with AOT

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourcePropertyValueTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourcePropertyValueTest.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 
 /// <summary>
@@ -34,6 +35,7 @@ internal class Program
         public TestEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) { }
 
         [Event(1)]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(TestSubData))]
         public void LogData(TestData data)
         {
             Write("LogData", data);

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -648,7 +648,6 @@
                       Condition="'$(TestPackages)' == 'true'" />
 
     <!-- We need to go over these disablements: https://github.com/dotnet/runtime/issues/101228 -->
-    <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Diagnostics.Tracing\tests\TrimmingTests\System.Diagnostics.Tracing.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Queryable\tests\TrimmingTests\System.Linq.Queryable.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Private.Xml.Linq\tests\TrimmingTests\System.Xml.Linq.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Net.Http\tests\TrimmingTests\System.Net.Http.TrimmingTests.proj" />


### PR DESCRIPTION
Contributes to #101228.

I believe what the test is doing is not trim safe and only succeeds due to lucky IL trimming implementation details.
