### PR TITLE
Download contents into a subfolder to preserve previous paths

### DIFF
--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -33,7 +33,7 @@ jobs:
         fetchDepth: 20
       - input: pipelineArtifact
         artifactName: IntermediateArtifacts
-        targetPath: $(Build.SourcesDirectory)\artifacts\PackageDownload
+        targetPath: $(Build.SourcesDirectory)\artifacts\PackageDownload\IntermediateArtifacts
       outputs:
       - output: pipelineArtifact
         displayName: 'Publish BuildLogs'


### PR DESCRIPTION
This will fix the official build

Official build run: https://dnceng.visualstudio.com/internal/_build/results?buildId=2435937&view=results