### PR TITLE
Set generic ctx type to void* for non-x86 path

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
@@ -313,7 +313,7 @@ namespace ILCompiler
                         }
                         else
                         {
-                            parameters[0] = Context.GetWellKnownType(WellKnownType.IntPtr);
+                            parameters[0] = Context.GetWellKnownType(WellKnownType.Void).MakePointerType();
                             for (int i = 0; i < _methodRepresented.Signature.Length; i++)
                                 parameters[i + 1] = _methodRepresented.Signature[i];
                         }


### PR DESCRIPTION
This PR changes the type of the first parameter for the interface thunks to generics, the generic context, to a `void *`.
This is inline with the x86 path and fixes  a LLVM/Wasm…type mismatch downstream in runtimelab/NativeAOT-LLVM.

cc @SingleAccretion 