### PR TITLE
Use BitOperations.RoundUpToPowerOf2 in more places

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/CacheDict.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/CacheDict.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Threading;
 
 namespace System.Dynamic.Utils
@@ -40,25 +41,9 @@ namespace System.Dynamic.Utils
         /// <param name="size">The maximum number of elements to store will be this number aligned to next ^2.</param>
         internal CacheDict(int size)
         {
-            int alignedSize = AlignSize(size);
+            int alignedSize = (int)BitOperations.RoundUpToPowerOf2((uint)size);
             _mask = alignedSize - 1;
             _entries = new Entry[alignedSize];
-        }
-
-        private static int AlignSize(int size)
-        {
-            Debug.Assert(size > 0);
-
-            size--;
-            size |= size >> 1;
-            size |= size >> 2;
-            size |= size >> 4;
-            size |= size >> 8;
-            size |= size >> 16;
-            size++;
-
-            Debug.Assert((size & (~size + 1)) == size, "aligned size should be a power of 2");
-            return size;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadLocal.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 
 // A class that provides a simple, lightweight implementation of thread-local lazy-initialization, where a value is initialized once per accessing
 // thread; this provides an alternative to using a ThreadStatic static variable and having
@@ -552,40 +553,15 @@ namespace System.Threading
             }
             Debug.Assert(minSize > 0);
 
-            //
-            // Round up the size to the next power of 2
-            //
-            // The algorithm takes three steps:
-            // input -> subtract one -> propagate 1-bits to the right -> add one
-            //
-            // Let's take a look at the 3 steps in both interesting cases: where the input
-            // is (Example 1) and isn't (Example 2) a power of 2.
-            //
-            // Example 1: 100000 -> 011111 -> 011111 -> 100000
-            // Example 2: 011010 -> 011001 -> 011111 -> 100000
-            //
-            int newSize = minSize;
-
-            // Step 1: Decrement
-            newSize--;
-
-            // Step 2: Propagate 1-bits to the right.
-            newSize |= newSize >> 1;
-            newSize |= newSize >> 2;
-            newSize |= newSize >> 4;
-            newSize |= newSize >> 8;
-            newSize |= newSize >> 16;
-
-            // Step 3: Increment
-            newSize++;
+            uint newSize = BitOperations.RoundUpToPowerOf2((uint)minSize);
 
             // Don't set newSize to more than Array.MaxArrayLength
-            if ((uint)newSize > Array.MaxLength)
+            if (newSize > Array.MaxLength)
             {
-                newSize = Array.MaxLength;
+                newSize = (uint)Array.MaxLength;
             }
 
-            return newSize;
+            return (int)newSize;
         }
 
         /// <summary>


### PR DESCRIPTION
While reading `ThreadLocal`'s source, I noticed some code that has intensified implementation in `BitOperations`.