### PR TITLE
enable dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: daily
     open-pull-requests-limit: 5
     labels:
-      - area-infrastructure
+      - area-codeflow

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+registries:
+  public-nuget:
+    type: nuget-feed
+    url: https://api.nuget.org/v3/index.json
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    labels:
+      - area-infrastructure


### PR DESCRIPTION
This will make a few PR's like

https://github.com/danmoseley/runtime/pull/12
https://github.com/danmoseley/runtime/pull/13

and we can decide whether to take them. I think in general we would (eg., some old versions are getting deprecated)

@jeffhandley we discussed whether actions need to have hashes to securely identify their implementation. That is unrelated to this change (well, except they might need updating as well), but I can't find your answer. Would you mind answering that again?