### PR TITLE
Run System.Net.Http trimming tests with AOT

### DIFF
--- a/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
@@ -5,6 +5,8 @@
     <TestConsoleAppSourceFiles Include="DecompressionHandlerTrimmedTest.cs" />
     <TestConsoleAppSourceFiles Include="HttpClientTest.cs">
       <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
+      <!-- https://github.com/dotnet/runtime/issues/73290 -->
+      <NativeAotIncompatible>true</NativeAotIncompatible>
     </TestConsoleAppSourceFiles>
   </ItemGroup>
 

--- a/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
+++ b/src/libraries/System.Net.Http/tests/TrimmingTests/System.Net.Http.TrimmingTests.proj
@@ -5,7 +5,7 @@
     <TestConsoleAppSourceFiles Include="DecompressionHandlerTrimmedTest.cs" />
     <TestConsoleAppSourceFiles Include="HttpClientTest.cs">
       <SkipOnTestRuntimes>browser-wasm</SkipOnTestRuntimes>
-      <!-- https://github.com/dotnet/runtime/issues/73290 -->
+      <!-- Checks for presence of managed assemblies on disk -->
       <NativeAotIncompatible>true</NativeAotIncompatible>
     </TestConsoleAppSourceFiles>
   </ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -650,7 +650,6 @@
     <!-- We need to go over these disablements: https://github.com/dotnet/runtime/issues/101228 -->
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Queryable\tests\TrimmingTests\System.Linq.Queryable.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Private.Xml.Linq\tests\TrimmingTests\System.Xml.Linq.TrimmingTests.proj" />
-    <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Net.Http\tests\TrimmingTests\System.Net.Http.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Expressions\tests\TrimmingTests\System.Linq.Expressions.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Private.Xml\tests\TrimmingTests\System.Private.Xml.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Runtime\tests\System.Runtime.Tests\TrimmingTests\System.Runtime.TrimmingTests.proj" />


### PR DESCRIPTION
One is not compatible due to a known bug.