### PR TITLE
Properly disable S.L.Queryable trimming tests with AOT

### DIFF
--- a/src/libraries/System.Linq.Queryable/tests/TrimmingTests/System.Linq.Queryable.TrimmingTests.proj
+++ b/src/libraries/System.Linq.Queryable/tests/TrimmingTests/System.Linq.Queryable.TrimmingTests.proj
@@ -2,7 +2,10 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="QueryableTests.cs" />
+    <TestConsoleAppSourceFiles Include="QueryableTests.cs">
+      <!-- Queryable is not compatible with AOT -->
+      <NativeAotIncompatible>true</NativeAotIncompatible>
+    </TestConsoleAppSourceFiles>
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />

--- a/src/libraries/System.Linq.Queryable/tests/TrimmingTests/System.Linq.Queryable.TrimmingTests.proj
+++ b/src/libraries/System.Linq.Queryable/tests/TrimmingTests/System.Linq.Queryable.TrimmingTests.proj
@@ -3,7 +3,7 @@
 
   <ItemGroup>
     <TestConsoleAppSourceFiles Include="QueryableTests.cs">
-      <!-- Queryable is not compatible with AOT -->
+      <!-- https://github.com/dotnet/runtime/issues/101903 -->
       <NativeAotIncompatible>true</NativeAotIncompatible>
     </TestConsoleAppSourceFiles>
   </ItemGroup>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -648,7 +648,6 @@
                       Condition="'$(TestPackages)' == 'true'" />
 
     <!-- We need to go over these disablements: https://github.com/dotnet/runtime/issues/101228 -->
-    <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Queryable\tests\TrimmingTests\System.Linq.Queryable.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Private.Xml.Linq\tests\TrimmingTests\System.Xml.Linq.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Net.Http\tests\TrimmingTests\System.Net.Http.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Expressions\tests\TrimmingTests\System.Linq.Expressions.TrimmingTests.proj" />


### PR DESCRIPTION
The `ProjectExclusions` list should disappear.