### PR TITLE
Disable most of S.T.Json trimming tests on AOT the right way

### DIFF
--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
@@ -1,7 +1,9 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
-  <ItemGroup>
+  <!-- These tests need to be rewritten to use source generator: https://github.com/dotnet/runtime/issues/53437,
+       so conditioning on RunNativeAotTestApps -->
+  <ItemGroup Condition="'$(RunNativeAotTestApps)' != 'true'"">
     <TestConsoleAppSourceFiles Include="Collections\Array.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
@@ -3,7 +3,7 @@
 
   <!-- These tests need to be rewritten to use source generator: https://github.com/dotnet/runtime/issues/53437,
        so conditioning on RunNativeAotTestApps -->
-  <ItemGroup Condition="'$(RunNativeAotTestApps)' != 'true'"">
+  <ItemGroup Condition="'$(RunNativeAotTestApps)' != 'true'">
     <TestConsoleAppSourceFiles Include="Collections\Array.cs">
       <AdditionalSourceFiles>Helper.cs</AdditionalSourceFiles>
     </TestConsoleAppSourceFiles>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -654,7 +654,6 @@
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Linq.Expressions\tests\TrimmingTests\System.Linq.Expressions.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Private.Xml\tests\TrimmingTests\System.Private.Xml.TrimmingTests.proj" />
     <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Runtime\tests\System.Runtime.Tests\TrimmingTests\System.Runtime.TrimmingTests.proj" />
-    <ProjectExclusions Condition="'$(RunNativeAotTestApps)' == 'true'" Include="$(MSBuildThisFileDirectory)\System.Text.Json\tests\System.Text.Json.Tests\TrimmingTests\System.Text.Json.TrimmingTests.proj" />
 
     <TrimmingTestProjects Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"
                       Exclude="@(ProjectExclusions)"


### PR DESCRIPTION
These don't seem to use the source generator, so they're not really "trimming tests" and obviously they don't work. The underlying issue to fix them up has been closed.