### PR TITLE
Fix SocketsHttpHandlerTest_HttpClientHandlerTest_Http3.ReadAsStreamAsync_Cancellation data race

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+#if !NETFRAMEWORK
 using System.Net.Quic;
+#endif
 using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography;
@@ -1397,10 +1399,12 @@ namespace System.Net.Http.Functional.Tests
                         await connection.SendResponseAsync(HttpStatusCode.OK, headers: new HttpHeaderData[] { new HttpHeaderData("Transfer-Encoding", "chunked") }, isFinal: false);
                         await connection.SendResponseBodyAsync("1\r\nh\r\n", false);
                     }
+#if !NETFRAMEWORK
                     catch (QuicException ex) when (ex.ApplicationErrorCode == 0x10c /*H3_REQUEST_CANCELLED*/)
                     {
                         // The request was cancelled before we sent the body, ignore
                     }
+#endif
                     catch (IOException ex)
                     {
                         // when testing in the browser, we are using the WebSocket for the loopback

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Net.Sockets;
+using System.Net.Quic;
 using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography;
@@ -1395,6 +1396,10 @@ namespace System.Net.Http.Functional.Tests
                     {
                         await connection.SendResponseAsync(HttpStatusCode.OK, headers: new HttpHeaderData[] { new HttpHeaderData("Transfer-Encoding", "chunked") }, isFinal: false);
                         await connection.SendResponseBodyAsync("1\r\nh\r\n", false);
+                    }
+                    catch (QuicException ex) when (ex.ApplicationErrorCode == 0x10c /*H3_REQUEST_CANCELLED*/)
+                    {
+                        // The request was cancelled before we sent the body, ignore
                     }
                     catch (IOException ex)
                     {


### PR DESCRIPTION
Encountered in local runs

```
    System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http3.ReadAsStreamAsync_Cancellation [FAIL]
      System.Net.Quic.QuicException : Stream aborted by peer (268).
      Stack Trace:
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs(177,0): at System.Net.Quic.ResettableValueTaskSource.TryComplete(Exception exception, Boolean final)
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs(237,0): at System.Net.Quic.ResettableValueTaskSource.TrySetException(Exception exception, Boolean final)
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs(591,0): at System.Net.Quic.QuicStream.HandleEventPeerReceiveAborted(_PEER_RECEIVE_ABORTED_e__Struct& data)
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs(642,0): at System.Net.Quic.QuicStream.HandleStreamEvent(QUIC_STREAM_EVENT& streamEvent)
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs(673,0): at System.Net.Quic.QuicStream.NativeCallback(QUIC_HANDLE* stream, Void* context, QUIC_STREAM_EVENT* streamEvent)
        --- End of stack trace from previous location ---
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ResettableValueTaskSource.cs(251,0): at System.Net.Quic.ResettableValueTaskSource.System.Threading.Tasks.Sources.IValueTaskSource.GetResult(Int16 token)
        /source/runtime/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs(376,0): at System.Net.Quic.QuicStream.WriteAsync(ReadOnlyMemory`1 buffer, Boolean completeWrites, CancellationToken cancellationToken)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs(165,0): at System.Net.Test.Common.Http3LoopbackStream.SendFrameAsync(Int64 frameType, ReadOnlyMemory`1 framePayload)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs(120,0): at System.Net.Test.Common.Http3LoopbackStream.SendHeadersFrameAsync(Nullable`1 statusCode, IEnumerable`1 headers, Boolean qpackEncodeStatus)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs(265,0): at System.Net.Test.Common.Http3LoopbackStream.SendResponseHeadersAsync(Nullable`1 statusCode, IEnumerable`1 headers)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackStream.cs(248,0): at System.Net.Test.Common.Http3LoopbackStream.SendResponseAsync(HttpStatusCode statusCode, IList`1 headers, String content, Boolean isFinal)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackConnection.cs(217,0): at System.Net.Test.Common.Http3LoopbackConnection.SendResponseAsync(HttpStatusCode statusCode, IList`1 headers, String content, Boolean isFinal)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs(1398,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest.<>c__DisplayClass31_0.<<ReadAsStreamAsync_Cancellation>b__3>d.MoveNext()
        /source/runtime/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs(1407,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest.<>c__DisplayClass31_0.<<ReadAsStreamAsync_Cancellation>b__3>d.MoveNext()
        --- End of stack trace from previous location ---
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs(91,0): at System.Net.Test.Common.Http3LoopbackServer.AcceptConnectionAsync(Func`2 funcAsync)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs(92,0): at System.Net.Test.Common.Http3LoopbackServer.AcceptConnectionAsync(Func`2 funcAsync)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs(1392,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest.<>c__DisplayClass31_0.<<ReadAsStreamAsync_Cancellation>b__1>d.MoveNext()
        --- End of stack trace from previous location ---
        /source/runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(120,0): at System.Threading.Tasks.TaskTimeoutExtensions.GetRealException(Task task)
        --- End of stack trace from previous location ---
        /source/runtime/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs(90,0): at System.Threading.Tasks.TaskTimeoutExtensions.WhenAllOrAnyFailed(Task[] tasks)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/GenericLoopbackServer.cs(44,0): at System.Net.Test.Common.LoopbackServerFactory.<>c__DisplayClass6_0.<<CreateClientAndServerAsync>b__0>d.MoveNext()
        --- End of stack trace from previous location ---
        /source/runtime/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs(116,0): at System.Net.Test.Common.Http3LoopbackServerFactory.CreateServerAsync(Func`3 funcAsync, Int32 millisecondsTimeout, GenericLoopbackOptions options)
        /source/runtime/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs(1378,0): at System.Net.Http.Functional.Tests.HttpClientHandlerTest.ReadAsStreamAsync_Cancellation()
        --- End of stack trace from previous location ---
```

The connection was closed before the test loopback server managed to write response body. We can ignore the exception.