### PR TITLE
Support using the system rapidjson to build

### DIFF
--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -83,6 +83,10 @@ add_library(fxr_resolver INTERFACE)
 target_sources(fxr_resolver INTERFACE fxr_resolver.cpp)
 target_include_directories(fxr_resolver INTERFACE fxr)
 
+if ((NOT DEFINED CLR_CMAKE_USE_SYSTEM_RAPIDJSON) OR (NOT CLR_CMAKE_USE_SYSTEM_RAPIDJSON))
+    include_directories(${CLR_SRC_NATIVE_DIR}/external/)
+endif()
+
 add_subdirectory(hostcommon)
 add_subdirectory(hostmisc)
 add_subdirectory(fxr)

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -27,6 +27,10 @@ add_subdirectory(../../hostmisc hostmisc)
 configure_file(${CLR_SRC_NATIVE_DIR}/corehost/configure.h.in ${GENERATED_INCLUDE_DIR}/corehost/configure.h)
 target_include_directories(hostmisc PUBLIC ${GENERATED_INCLUDE_DIR}/corehost)
 
+if ((NOT DEFINED CLR_CMAKE_USE_SYSTEM_RAPIDJSON) OR (NOT CLR_CMAKE_USE_SYSTEM_RAPIDJSON))
+    include_directories(${CLR_SRC_NATIVE_DIR}/external/)
+endif()
+
 set(SOURCES
     ../bundle_marker.cpp
     ./hostfxr_resolver.cpp

--- a/src/native/corehost/json_parser.cpp
+++ b/src/native/corehost/json_parser.cpp
@@ -10,7 +10,7 @@
 #define RAPIDJSON_ERROR_STRING(x) _X(x)
 
 #include <json_parser.h>
-#include <external/rapidjson/error/en.h>
+#include <rapidjson/error/en.h>
 #include "utils.h"
 #include <cassert>
 #include <cstdint>

--- a/src/native/corehost/json_parser.h
+++ b/src/native/corehost/json_parser.h
@@ -17,8 +17,8 @@
 #endif
 
 #include "pal.h"
-#include <external/rapidjson/document.h>
-#include <external/rapidjson/fwd.h>
+#include <rapidjson/document.h>
+#include <rapidjson/fwd.h>
 #include <vector>
 #include "bundle/info.h"
 

--- a/src/native/corehost/runtime_config.cpp
+++ b/src/native/corehost/runtime_config.cpp
@@ -3,7 +3,7 @@
 
 #include "json_parser.h"
 #include "pal.h"
-#include <external/rapidjson/writer.h>
+#include <rapidjson/writer.h>
 #include "roll_fwd_on_no_candidate_fx_option.h"
 #include "runtime_config.h"
 #include "trace.h"


### PR DESCRIPTION
We have a bundled copy of rapidjson in runtime, but some Linux distributions also ship with another version of that library. Support using that too, optionally.

This does not change the default behaviour - the bundled copy of rapidjson is used. A cmake argument of
CLR_CMAKE_USE_SYSTEM_RAPIDJSON=true needs to be set to use the system version of rapidjson.