### PR TITLE
Fix condition for disabling extra checks in verify_class_overrides

### DIFF
--- a/src/mono/mono/metadata/class-setup-vtable.c
+++ b/src/mono/mono/metadata/class-setup-vtable.c
@@ -773,9 +773,7 @@ mono_method_get_method_definition (MonoMethod *method)
 static gboolean
 verify_class_overrides (MonoClass *klass, MonoMethod **overrides, int onum)
 {
-	// on windows and arm, we define NDEBUG for release builds
-	// on browser and wasi, we define DEBUG for debug builds
-#ifdef ENABLE_CHECKED_BUILD
+#ifndef ENABLE_CHECKED_BUILD
 	if (klass->image == mono_defaults.corlib)
 		return TRUE;
 #endif


### PR DESCRIPTION
`ENABLE_CHECKED_BUILD` is defined to mean "Enable additional checks" and is enabled in checked and debug builds. Therefore this performance optimization should be enabled when `ENABLE_CHECKED_BUILD` is *not* defined. This was introduced in #101312.

This PR also removes some comments that were introduced in an earlier revision of #101312 that are no longer relevant.

CC @kg 
