### PR TITLE
[cdac] Read/store globals from contract descriptor

### DIFF
--- a/docs/design/datacontracts/contract-descriptor.md
+++ b/docs/design/datacontracts/contract-descriptor.md
@@ -45,7 +45,7 @@ reserved bits should be written as zero.  Diagnostic tooling may ignore non-zero
 
 The `descriptor` is a pointer to a UTF-8 JSON string described in [data descriptor physical layout](./data_descriptor.md#Physical_JSON_descriptor).  The total number of bytes is given by `descriptor_size`.
 
-The auxiliary data for the JSON descriptor is stored at the location `aux_data` in `aux_data_count` pointer-sized slots.
+The auxiliary data for the JSON descriptor is stored at the location `pointer_data` in `pointer_data_count` pointer-sized slots.
 
 ### Architecture properties
 
@@ -83,7 +83,7 @@ a JSON integer constant.
   "globals":
   {
     "FEATURE_COMINTEROP": 0,
-    "s_pThreadStore": [ 0 ] // indirect from aux data offset 0
+    "s_pThreadStore": [ 0 ] // indirect from pointer data offset 0
   },
   "contracts": {"Thread": 1, "GCHandle": 1, "ThreadStore": 1}
 }

--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -41,27 +41,31 @@ CDAC CDAC::Create(uint64_t descriptorAddr, ICorDebugDataTarget* target)
 {
     HMODULE cdacLib;
     if (!TryLoadCDACLibrary(&cdacLib))
-        return CDAC::Invalid();
+        return {};
 
-    return CDAC{cdacLib, descriptorAddr, target};
+    decltype(&cdac_reader_init) init = reinterpret_cast<decltype(&cdac_reader_init)>(::GetProcAddress(cdacLib, "cdac_reader_init"));
+    _ASSERTE(init != nullptr);
+
+    intptr_t handle;
+    if (init(descriptorAddr, &ReadFromTargetCallback, target, &handle) != 0)
+    {
+        ::FreeLibrary(cdacLib);
+        return {};
+    }
+
+    return CDAC{cdacLib, handle, target};
 }
 
-CDAC::CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target)
+CDAC::CDAC(HMODULE module, intptr_t handle, ICorDebugDataTarget* target)
     : m_module{module}
-    , m_cdac_handle{0}
+    , m_cdac_handle{handle}
     , m_target{target}
 {
-    if (m_module == NULL)
-        return;
+    _ASSERTE(m_module != NULL && m_cdac_handle != 0 && m_target != NULL);
 
     m_target->AddRef();
-    decltype(&cdac_reader_init) init = reinterpret_cast<decltype(&cdac_reader_init)>(::GetProcAddress(m_module, "cdac_reader_init"));
     decltype(&cdac_reader_get_sos_interface) getSosInterface = reinterpret_cast<decltype(&cdac_reader_get_sos_interface)>(::GetProcAddress(m_module, "cdac_reader_get_sos_interface"));
-    _ASSERTE(init != nullptr && getSosInterface != nullptr);
-
-    if (init(descriptorAddr, &ReadFromTargetCallback, m_target, &m_cdac_handle) != 0)
-        return;
-
+    _ASSERTE(getSosInterface != nullptr);
     getSosInterface(m_cdac_handle, &m_sos);
 }
 

--- a/src/coreclr/debug/daccess/cdac.cpp
+++ b/src/coreclr/debug/daccess/cdac.cpp
@@ -47,21 +47,21 @@ CDAC CDAC::Create(uint64_t descriptorAddr, ICorDebugDataTarget* target)
 }
 
 CDAC::CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target)
-    : m_module(module)
+    : m_module{module}
+    , m_cdac_handle{0}
     , m_target{target}
 {
     if (m_module == NULL)
-    {
-        m_cdac_handle = 0;
         return;
-    }
 
     m_target->AddRef();
     decltype(&cdac_reader_init) init = reinterpret_cast<decltype(&cdac_reader_init)>(::GetProcAddress(m_module, "cdac_reader_init"));
     decltype(&cdac_reader_get_sos_interface) getSosInterface = reinterpret_cast<decltype(&cdac_reader_get_sos_interface)>(::GetProcAddress(m_module, "cdac_reader_get_sos_interface"));
     _ASSERTE(init != nullptr && getSosInterface != nullptr);
 
-    init(descriptorAddr, &ReadFromTargetCallback, m_target, &m_cdac_handle);
+    if (init(descriptorAddr, &ReadFromTargetCallback, m_target, &m_cdac_handle) != 0)
+        return;
+
     getSosInterface(m_cdac_handle, &m_sos);
 }
 

--- a/src/coreclr/debug/daccess/cdac.h
+++ b/src/coreclr/debug/daccess/cdac.h
@@ -9,12 +9,13 @@ class CDAC final
 public: // static
     static CDAC Create(uint64_t descriptorAddr, ICorDebugDataTarget *pDataTarget);
 
-    static CDAC Invalid()
-    {
-        return CDAC{nullptr, 0, nullptr};
-    }
-
 public:
+    CDAC()
+        : m_module{NULL}
+        , m_cdac_handle{0}
+        , m_target{NULL}
+    { }
+
     CDAC(const CDAC&) = delete;
     CDAC& operator=(const CDAC&) = delete;
 
@@ -56,7 +57,7 @@ public:
     IUnknown* SosInterface();
 
 private:
-    CDAC(HMODULE module, uint64_t descriptorAddr, ICorDebugDataTarget* target);
+    CDAC(HMODULE module, intptr_t handle, ICorDebugDataTarget* target);
 
 private:
     HMODULE m_module;

--- a/src/coreclr/debug/daccess/cdac.h
+++ b/src/coreclr/debug/daccess/cdac.h
@@ -10,11 +10,7 @@ public: // static
     static CDAC Create(uint64_t descriptorAddr, ICorDebugDataTarget *pDataTarget);
 
 public:
-    CDAC()
-        : m_module{NULL}
-        , m_cdac_handle{0}
-        , m_target{NULL}
-    { }
+    CDAC() = default;
 
     CDAC(const CDAC&) = delete;
     CDAC& operator=(const CDAC&) = delete;

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -3038,6 +3038,7 @@ private:
 //----------------------------------------------------------------------------
 
 ClrDataAccess::ClrDataAccess(ICorDebugDataTarget * pTarget, ICLRDataTarget * pLegacyTarget/*=0*/)
+    : m_cdac{}
 {
     SUPPORTS_DAC_HOST_ONLY;     // ctor does no marshalling - don't check with DacCop
 

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -3038,7 +3038,6 @@ private:
 //----------------------------------------------------------------------------
 
 ClrDataAccess::ClrDataAccess(ICorDebugDataTarget * pTarget, ICLRDataTarget * pLegacyTarget/*=0*/)
-    : m_cdac{CDAC::Invalid()}
 {
     SUPPORTS_DAC_HOST_ONLY;     // ctor does no marshalling - don't check with DacCop
 

--- a/src/native/managed/cdacreader/src/Constants.cs
+++ b/src/native/managed/cdacreader/src/Constants.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+internal static class Constants
+{
+    internal static class Globals
+    {
+        // See src/coreclr/debug/runtimeinfo/datadescriptor.h
+        internal const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
+    }
+}

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -35,7 +35,7 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
 
     public int GetBreakingChangeVersion()
     {
-        return _target.ReadGlobalUInt8(Constants.Globals.SOSBreakingChangeVersion);
+        return _target.ReadGlobal<byte>(Constants.Globals.SOSBreakingChangeVersion);
     }
 
     public unsafe int GetCCWData(ulong ccw, void* data) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -35,8 +35,7 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
 
     public int GetBreakingChangeVersion()
     {
-        // TODO: Return non-hard-coded version
-        return 4;
+        return _target.ReadGlobalUInt8(Constants.Globals.SOSBreakingChangeVersion);
     }
 
     public unsafe int GetCCWData(ulong ccw, void* data) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -157,6 +157,29 @@ internal sealed unsafe class Target
         return true;
     }
 
+    public byte ReadUInt8(ulong address)
+    {
+        if (!TryReadUInt8(address, out byte value))
+            throw new InvalidOperationException($"Failed to read uint8 at 0x{address:x8}.");
+
+        return value;
+    }
+
+    public bool TryReadUInt8(ulong address, out byte value)
+        => TryReadUInt8(address, _reader, out value);
+
+    private static bool TryReadUInt8(ulong address, Reader reader, out byte value)
+    {
+        value = 0;
+        fixed (byte* ptr = &value)
+        {
+            if (reader.ReadFromTarget(address, ptr, 1) < 0)
+                return false;
+        }
+
+        return true;
+    }
+
     public uint ReadUInt32(ulong address)
     {
         if (!TryReadUInt32(address, out uint value))
@@ -217,6 +240,28 @@ internal sealed unsafe class Target
                     : BinaryPrimitives.ReadUInt64BigEndian(buffer));
         }
 
+        return true;
+    }
+
+    public byte ReadGlobalUInt8(string name)
+    {
+        if (!TryReadGlobalUInt8(name, out byte value))
+            throw new InvalidOperationException($"Failed to read global uint8 '{name}'.");
+
+        return value;
+    }
+
+    public bool TryReadGlobalUInt8(string name, out byte value)
+    {
+        value = 0;
+
+        if (!_globals.TryGetValue(name, out (ulong Value, string? Type) global))
+            return false;
+
+        if (global.Type is not null && global.Type != "uint8")
+            return false;
+
+        value = (byte)global.Value;
         return true;
     }
 

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -186,7 +186,7 @@ public sealed unsafe class Target
     public ulong ReadUInt64(ulong address)
     {
         if (!TryReadUInt64(address, out ulong value))
-            throw new InvalidOperationException($"Failed to read uint32 at 0x{address:x8}.");
+            throw new InvalidOperationException($"Failed to read uint64 at 0x{address:x8}.");
 
         return value;
     }

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -237,6 +237,7 @@ public sealed unsafe class Target
         if (!_globals.TryGetValue(name, out (ulong Value, string? Type) global))
             return false;
 
+        // TODO: [cdac] Move type validation out of the read such that it does not have to happen for every read
         if (global.Type is not null)
         {
             string? expectedType = Type.GetTypeCode(typeof(T)) switch
@@ -251,7 +252,7 @@ public sealed unsafe class Target
                 TypeCode.UInt64 => "uint64",
                 _ => null,
             };
-            if (expectedType is not null && global.Type != expectedType)
+            if (expectedType is null || global.Type != expectedType)
             {
                 return false;
             }

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -146,7 +146,12 @@ public unsafe class TargetTests
         }
     }
 
-    private static void ValidateGlobals(Target target, (string Name, ulong Value, string? Type)[] globals)
+    private static void ValidateGlobals(
+        Target target,
+        (string Name, ulong Value, string? Type)[] globals,
+        [CallerMemberName] string caller = "",
+        [CallerFilePath] string filePath = "",
+        [CallerLineNumber] int lineNumber = 0)
     {
         foreach (var (name, value, type) in globals)
         {
@@ -154,58 +159,63 @@ public unsafe class TargetTests
             // and that it matches the expected value if successfully read
             {
                 bool success = target.TryReadGlobal(name, out sbyte actual);
-                Assert.Equal(type is null || type == "int8", success);
+                AssertEqualsWithCallerInfo(type is null || type == "int8", success);
                 if (success)
-                    Assert.Equal((sbyte)value, actual);
+                    AssertEqualsWithCallerInfo((sbyte)value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out byte actual);
-                Assert.Equal(type is null || type == "uint8", success);
+                AssertEqualsWithCallerInfo(type is null || type == "uint8", success);
                 if (success)
-                    Assert.Equal(value, actual);
+                    AssertEqualsWithCallerInfo(value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out short actual);
-                Assert.Equal(type is null || type == "int16", success);
+                AssertEqualsWithCallerInfo(type is null || type == "int16", success);
                 if (success)
-                    Assert.Equal((short)value, actual);
+                    AssertEqualsWithCallerInfo((short)value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out ushort actual);
-                Assert.Equal(type is null || type == "uint16", success);
+                AssertEqualsWithCallerInfo(type is null || type == "uint16", success);
                 if (success)
-                    Assert.Equal(value, actual);
+                    AssertEqualsWithCallerInfo(value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out int actual);
-                Assert.Equal(type is null || type == "int32", success);
+                AssertEqualsWithCallerInfo(type is null || type == "int32", success);
                 if (success)
-                    Assert.Equal((int)value, actual);
+                    AssertEqualsWithCallerInfo((int)value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out uint actual);
-                Assert.Equal(type is null || type == "uint32", success);
+                AssertEqualsWithCallerInfo(type is null || type == "uint32", success);
                 if (success)
-                    Assert.Equal(value, actual);
+                    AssertEqualsWithCallerInfo(value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out long actual);
-                Assert.Equal(type is null || type == "int64", success);
+                AssertEqualsWithCallerInfo(type is null || type == "int64", success);
                 if (success)
-                    Assert.Equal((long)value, actual);
+                    AssertEqualsWithCallerInfo((long)value, actual);
             }
             {
                 bool success = target.TryReadGlobal(name, out ulong actual);
-                Assert.Equal(type is null || type == "uint64", success);
+                AssertEqualsWithCallerInfo(type is null || type == "uint64", success);
                 if (success)
-                    Assert.Equal(value, actual);
+                    AssertEqualsWithCallerInfo(value, actual);
             }
             {
                 bool success = target.TryReadGlobalPointer(name, out TargetPointer actual);
-                Assert.Equal(type is null || type == "pointer" || type == "nint" || type == "nuint", success);
+                AssertEqualsWithCallerInfo(type is null || type == "pointer" || type == "nint" || type == "nuint", success);
                 if (success)
-                    Assert.Equal(value, actual.Value);
+                    AssertEqualsWithCallerInfo(value, actual.Value);
             }
+        }
+
+        void AssertEqualsWithCallerInfo<T>(T expected, T actual) where T : unmanaged
+        {
+            Assert.True(expected.Equals(actual), $"Expected: {expected}. Actual: {actual}. [test case: {caller} in {filePath}:{lineNumber}]");
         }
     }
 

--- a/src/native/managed/cdacreader/tests/TargetTests.cs
+++ b/src/native/managed/cdacreader/tests/TargetTests.cs
@@ -1,0 +1,226 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers.Binary;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.UnitTests;
+
+public unsafe class TargetTests
+{
+    private struct ReadContext
+    {
+        public byte IsLittleEndian;
+        public int PointerSize;
+
+        public byte* ContractDescriptor;
+        public int ContractDescriptorLength;
+
+        public byte* JsonDescriptor;
+        public int JsonDescriptorLength;
+
+        public byte* PointerData;
+        public int PointerDataLength;
+    }
+
+    private const ulong ContractDescriptorAddr = 0xaaaaaaaa;
+    private const uint JsonDescriptorAddr = 0xdddddddd;
+    private const uint PointerDataAddr = 0xeeeeeeee;
+
+    private static class ContractDescriptor
+    {
+        public static int Size(bool is64Bit) => is64Bit ? sizeof(ContractDescriptor64) : sizeof(ContractDescriptor32);
+
+        public static void Fill(Span<byte> dest, bool isLittleEndian, bool is64Bit, int jsonDescriptorSize, int pointerDataCount)
+        {
+            if (is64Bit)
+            {
+                ContractDescriptor64.Fill(dest, isLittleEndian, jsonDescriptorSize, pointerDataCount);
+            }
+            else
+            {
+                ContractDescriptor32.Fill(dest, isLittleEndian, jsonDescriptorSize, pointerDataCount);
+            }
+        }
+
+        private struct ContractDescriptor32
+        {
+            public ulong Magic = BitConverter.ToUInt64("DNCCDAC\0"u8);
+            public uint Flags = 0x2 /*32-bit*/ | 0x1;
+            public uint DescriptorSize;
+            public uint Descriptor = JsonDescriptorAddr;
+            public uint PointerDataCount;
+            public uint Pad0 = 0;
+            public uint PointerData = PointerDataAddr;
+
+            public ContractDescriptor32() { }
+
+            public static void Fill(Span<byte> dest, bool isLittleEndian, int jsonDescriptorSize, int pointerDataCount)
+            {
+                ContractDescriptor32 descriptor = new()
+                {
+                    DescriptorSize = (uint)jsonDescriptorSize,
+                    PointerDataCount = (uint)pointerDataCount,
+                };
+                if (BitConverter.IsLittleEndian != isLittleEndian)
+                    descriptor.ReverseEndianness();
+
+                MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref descriptor, 1)).CopyTo(dest);
+            }
+
+            private void ReverseEndianness()
+            {
+                Magic = BinaryPrimitives.ReverseEndianness(Magic);
+                Flags = BinaryPrimitives.ReverseEndianness(Flags);
+                DescriptorSize = BinaryPrimitives.ReverseEndianness(DescriptorSize);
+                Descriptor = BinaryPrimitives.ReverseEndianness(Descriptor);
+                PointerDataCount = BinaryPrimitives.ReverseEndianness(PointerDataCount);
+                Pad0 = BinaryPrimitives.ReverseEndianness(Pad0);
+                PointerData = BinaryPrimitives.ReverseEndianness(PointerData);
+            }
+        }
+
+        private struct ContractDescriptor64
+        {
+            public ulong Magic = BitConverter.ToUInt64("DNCCDAC\0"u8);
+            public uint Flags = 0x1;
+            public uint DescriptorSize;
+            public ulong Descriptor = JsonDescriptorAddr;
+            public uint PointerDataCount;
+            public uint Pad0 = 0;
+            public ulong PointerData = PointerDataAddr;
+
+            public ContractDescriptor64() { }
+
+            public static void Fill(Span<byte> dest, bool isLittleEndian, int jsonDescriptorSize, int pointerDataCount)
+            {
+                ContractDescriptor64 descriptor = new()
+                {
+                    DescriptorSize = (uint)jsonDescriptorSize,
+                    PointerDataCount = (uint)pointerDataCount,
+                };
+                if (BitConverter.IsLittleEndian != isLittleEndian)
+                    descriptor.ReverseEndianness();
+
+                MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref descriptor, 1)).CopyTo(dest);
+            }
+
+            private void ReverseEndianness()
+            {
+                Magic = BinaryPrimitives.ReverseEndianness(Magic);
+                Flags = BinaryPrimitives.ReverseEndianness(Flags);
+                DescriptorSize = BinaryPrimitives.ReverseEndianness(DescriptorSize);
+                Descriptor = BinaryPrimitives.ReverseEndianness(Descriptor);
+                PointerDataCount = BinaryPrimitives.ReverseEndianness(PointerDataCount);
+                Pad0 = BinaryPrimitives.ReverseEndianness(Pad0);
+                PointerData = BinaryPrimitives.ReverseEndianness(PointerData);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void ReadGlobalValue(bool isLittleEndian, bool is64Bit)
+    {
+        (string Name, ulong Value, string? Type)[] globals =
+        [
+            ("value", 0xff, null),
+            ("int8Value", 0x12, "int8"),
+            ("uint8Value", 0x12, "uint8"),
+            ("int16Value", 0x1234, "int16"),
+            ("uint16Value", 0x1234, "uint16"),
+            ("int32Value", 0x12345678, "int32"),
+            ("uint32Value", 0x12345678, "uint32"),
+            ("int64Value", 0x123456789abcdef0, "int64"),
+            ("uint64Value", 0x123456789abcdef0, "uint64"),
+            ("nintValue", 0xabcdef0, "nint"),
+            ("nuintValue", 0xabcdef0, "nuint"),
+            ("pointerValue", 0xabcdef0, "pointer"),
+        ];
+        string globalsJson = string.Join(',', globals.Select(i => $"\"{i.Name}\": {(i.Type is null ? i.Value.ToString() : $"[{i.Value}, \"{i.Type}\"]")}"));
+        byte[] json = Encoding.UTF8.GetBytes($$"""
+        {
+            "version": 0,
+            "baseline": "empty",
+            "contracts": {},
+            "types": {},
+            "globals": { {{globalsJson}} }
+        }
+        """);
+        Span<byte> descriptor = stackalloc byte[ContractDescriptor.Size(is64Bit)];
+        ContractDescriptor.Fill(descriptor, isLittleEndian, is64Bit, json.Length, 0);
+        fixed (byte* jsonPtr = json)
+        {
+            ReadContext context = new ReadContext
+            {
+                IsLittleEndian = (byte)(isLittleEndian ? 1 : 0),
+                PointerSize = is64Bit ? sizeof(ulong) : sizeof(uint),
+                ContractDescriptor = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(descriptor)),
+                ContractDescriptorLength = descriptor.Length,
+                JsonDescriptor = jsonPtr,
+                JsonDescriptorLength = json.Length,
+            };
+
+            bool success = Target.TryCreate(ContractDescriptorAddr, &ReadFromTarget, &context, out Target? target);
+            Assert.True(success);
+
+            foreach (var (name, value, type) in globals)
+            {
+                {
+                    success = target.TryReadGlobalUInt8(name, out byte actual);
+                    Assert.Equal(type is null || type == "uint8", success);
+                    if (success)
+                        Assert.Equal(value, actual);
+                }
+                {
+                    success = target.TryReadGlobalPointer(name, out TargetPointer actual);
+                    Assert.Equal(type is null || type == "pointer" || type == "nint" || type == "nuint", success);
+                    if (success)
+                        Assert.Equal(value, actual.Value);
+                }
+            }
+        }
+    }
+
+    [UnmanagedCallersOnly]
+    private static int ReadFromTarget(ulong address, byte* buffer, uint length, void* context)
+    {
+        ReadContext* readContext = (ReadContext*)context;
+
+        bool isLittleEndian = readContext->IsLittleEndian != 0;
+        int pointerSize = readContext->PointerSize;
+
+        var span = new Span<byte>(buffer, (int)length);
+
+        if (address >= ContractDescriptorAddr
+            && address <= ContractDescriptorAddr + (ulong)readContext->ContractDescriptorLength - length)
+        {
+            ulong offset = address - ContractDescriptorAddr;
+            new ReadOnlySpan<byte>(readContext->ContractDescriptor + offset, (int)length).CopyTo(span);
+            return 0;
+        }
+
+        if (address == JsonDescriptorAddr)
+        {
+            new ReadOnlySpan<byte>(readContext->JsonDescriptor, readContext->JsonDescriptorLength).CopyTo(span);
+            return 0;
+        }
+
+        if (address >= PointerDataAddr && address <= PointerDataAddr + (ulong)readContext->PointerDataLength - length)
+        {
+            ulong offset = address - PointerDataAddr;
+            new ReadOnlySpan<byte>(readContext->PointerData + offset, (int)length).CopyTo(span);
+            return 0;
+        }
+
+        return -1;
+    }
+}


### PR DESCRIPTION
- Map indirect global values to corresponding values in `pointer_data` array from contract descriptor
- Add `[Try]Read<T>`, `[Try]ReadPointer`, `[Try]ReadGlobal<T>` and `[Try]ReadGlobalPointer` to `Target`
- Make cDAC implementation of `ISOSDacInterface9.GetBreakingChangeVersion` read value from globals
- Create test helpers for mocking out reading from the target and providing a contract descriptor for different bitness/endianness
- Add unit tests for reading global values (direct and indirect)

Contributes to https://github.com/dotnet/runtime/issues/99298