### PR TITLE
Disable UnrollEqualsStartsWith for gcstress. The test takes very long time.

### DIFF
--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-    <!-- Needed for CLRTestEnvironmentVariable and GCStressIncompatible -->
+    <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
+    <!-- Needed for CLRTestEnvironmentVariable and GCStressIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnrollEqualsStartsWith.cs" />

--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
@@ -3,6 +3,7 @@
     <Optimize>True</Optimize>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- This test takes very long time under gcstress and causes timeouts -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The test actually passes under gcstress, but takes very long time. (2 hours on osx-arm64)

The test just does a lot of calls. There are ~1000 of various SequenceEqual/StartsWith and similar calls applied to a dataset with a lot of strings and combinations. 

Fixes: https://github.com/dotnet/runtime/issues/101453

