### PR TITLE
[release/8.0-staging] Extend mono_gsharedvt_constrained_call for static virtual calls

### DIFF
--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1450,7 +1450,8 @@ mono_gsharedvt_constrained_call (gpointer mp, MonoMethod *cmethod, MonoClass *kl
 		break;
 	case MONO_GSHAREDVT_CONSTRAINT_CALL_TYPE_REF:
 		/* Calling a ref method with a ref receiver */
-		this_arg = *(gpointer*)mp;
+		/* Static calls don't have this arg */
+		this_arg = m_method_is_static (cmethod) ? NULL : *(gpointer*)mp;
 		m = info->method;
 		break;
 	default:

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -3884,13 +3884,8 @@ handle_constrained_gsharedvt_call (MonoCompile *cfg, MonoMethod *cmethod, MonoMe
 			int addr_reg;
 
 			if (mini_is_gsharedvt_type (fsig->params [i])) {
-				MonoInst *is_deref;
-				int deref_arg_reg;
 				ins = mini_emit_get_gsharedvt_info_klass (cfg, mono_class_from_mono_type_internal (fsig->params [i]), MONO_RGCTX_INFO_CLASS_BOX_TYPE);
-				deref_arg_reg = alloc_preg (cfg);
-				/* deref_arg = BOX_TYPE != MONO_GSHAREDVT_BOX_TYPE_VTYPE */
-				EMIT_NEW_BIALU_IMM (cfg, is_deref, OP_ISUB_IMM, deref_arg_reg, ins->dreg, 1);
-				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STOREI1_MEMBASE_REG, is_gsharedvt_ins->dreg, i, is_deref->dreg);
+				MONO_EMIT_NEW_STORE_MEMBASE (cfg, OP_STOREI1_MEMBASE_REG, is_gsharedvt_ins->dreg, i, ins->dreg);
 			} else if (has_gsharedvt) {
 				MONO_EMIT_NEW_STORE_MEMBASE_IMM (cfg, OP_STOREI1_MEMBASE_IMM, is_gsharedvt_ins->dreg, i, 0);
 			}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_94467/Runtime_94467.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_94467/Runtime_94467.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+public static class Runtime_94467
+{
+    public interface ITypeChecker
+    {
+        static abstract bool Test<T>(T value);
+    }
+
+    public interface IHandler
+    {
+        bool Test<T>(T value);
+    }
+
+    public struct TypeChecker : ITypeChecker
+    {
+        public static bool Test<T>(T value) => true;
+    }
+
+    public class Handler<TChecker> : IHandler where TChecker : ITypeChecker
+    {
+        public bool Test<T>(T value) => TChecker.Test(value);
+    }
+
+    public static IHandler GetHandler() => new Handler<TypeChecker>();
+
+    [Fact]
+    public static int Test()
+    {
+        try {
+            var handler = GetHandler();
+            if (handler.Test<bool>(true) && handler.Test<bool?>(true))
+                return 100;
+            else
+                return 101;
+        } catch (Exception) {
+            return -1;
+        }
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_94467/Runtime_94467.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_94467/Runtime_94467.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Description

Backport of #94787 to release/8.0-staging

Before this change, when an icall was made from the gsharedvt with a constrained static virtual method, the `this` argument wasn't handled properly, leading to a `SIGSEGV` error. Additionally, nullable boxed value types were not dereferenced correctly. This PR expands the functionality of `mono_gsharedvt_constrained_call` to manage static call arguments and avoid dereferencing sharedvt reference arguments if they are nullable value types.

## Customer Impact

The issue was reported on Apple mobile platforms in https://github.com/dotnet/runtime/issues/94467 and https://github.com/dotnet/runtime/issues/101427. It should fix https://github.com/dotnet/runtime/issues/101427 and resolve tests failures on Apple mobile platforms.

This issue also fixes a regression introduced in .NET 8.0.2 that prevents Blazor WebAssembly applications that use MudBlazor from being AOTed.  Fixes #100527 

## Testing

This PR introduces a runtime test, similar to the one implemented for .NET 9 (https://github.com/dotnet/runtime/pull/101489). This fix is verified manually and by the existing `System.Collections.Immutable.Tests` on Apple mobile platforms. 

## Risk

Low risk. This change extends functionality of the `mono_gsharedvt_constrained_call` icalls to handle static virtual methods.

This backport is for a servicing release 8.0.3.

- The PR target branch is `release/X.0-staging`, not `release/X.0`.

- If the change touches code that ships in a NuGet package, you have added the necessary [package authoring](https://github.com/dotnet/runtime/blob/main/docs/project/library-servicing.md) and gotten it explicitly reviewed.
