### PR TITLE
Notify the debugger of a cross-thread dependency in Lock

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -338,7 +338,7 @@ namespace System.Threading
             // At this point, a full lock attempt has been made, and it's time to retry or wait for the lock.
             //
 
-            // Notify the debugger that this thread is about to waiting for a lock that is likely owned by another thread. The
+            // Notify the debugger that this thread is about to wait for a lock that is likely held by another thread. The
             // debugger may choose to enable other threads to run to help resolve the dependency, or it may choose to abort the
             // FuncEval here. The lock state is consistent here for an abort, whereas letting a FuncEval continue to run could
             // lead to the FuncEval timing out and potentially aborting at an arbitrary place where the lock state may not be

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -334,6 +334,17 @@ namespace System.Threading
                 return new ThreadId(0);
             }
 
+            //
+            // At this point, a full lock attempt has been made, and it's time to retry or wait for the lock.
+            //
+
+            // Notify the debugger that this thread is about to waiting for a lock that is likely owned by another thread. The
+            // debugger may choose to enable other threads to run to help resolve the dependency, or it may choose to abort the
+            // FuncEval here. The lock state is consistent here for an abort, whereas letting a FuncEval continue to run could
+            // lead to the FuncEval timing out and potentially aborting at an arbitrary place where the lock state may not be
+            // consistent.
+            Debugger.NotifyOfCrossThreadDependency();
+
             if (LazyInitializeOrEnter() == TryLockResult.Locked)
             {
                 goto Locked;


### PR DESCRIPTION
When a FuncEval tries to acquire a Lock that is held by a different thread, notify the debugger of a cross-thread dependency.