### PR TITLE
[mono] Check if type is compatible right before emitting box

### DIFF
--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -9595,8 +9595,7 @@ calli_end:
 
 			if (klass == mono_defaults.void_class)
 				UNVERIFIED;
-			if (target_type_is_incompatible (cfg, m_class_get_byval_arg (klass), val))
-				UNVERIFIED;
+
 			/* frequent check in generic code: box (struct), brtrue */
 
 			/*
@@ -9955,6 +9954,8 @@ calli_end:
 				MONO_ADD_INS (cfg->cbb, ins);
 				*sp++ = ins;
 			} else {
+				if (target_type_is_incompatible (cfg, m_class_get_byval_arg (klass), val))
+					UNVERIFIED;
 				*sp++ = mini_emit_box (cfg, val, klass, context_used);
 			}
 			CHECK_CFG_EXCEPTION;


### PR DESCRIPTION
Currently, mono checks if type is compatible right after entering the world of handling `box`. However, there are many scenarios when the box could be optimized away. This PR moves the type compatible check to right before emitting `box`, when `box` is indeed needed.

This issue was uncovered by https://github.com/dotnet/runtime/pull/101458