### PR TITLE
Fix Lock spin-waiting on single-proc machines

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -17,7 +17,7 @@ namespace System.Threading
         private static int s_staticsInitializationStage;
         private static bool s_isSingleProcessor;
         private static short s_maxSpinCount;
-        private static short s_minSpinCount;
+        private static short s_minSpinCountForAdaptiveSpin;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Lock"/> class.
@@ -191,7 +191,7 @@ namespace System.Threading
                     // If the stage is PartiallyComplete, these will have already been initialized
                     s_isSingleProcessor = Environment.IsSingleProcessor;
                     s_maxSpinCount = DetermineMaxSpinCount();
-                    s_minSpinCount = DetermineMinSpinCount();
+                    s_minSpinCountForAdaptiveSpin = DetermineMinSpinCountForAdaptiveSpin();
                 }
 
                 // Also initialize some types that are used later to prevent potential class construction cycles. If

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.NonNativeAot.cs
@@ -9,7 +9,7 @@ namespace System.Threading
     public sealed partial class Lock
     {
         private static readonly short s_maxSpinCount = DetermineMaxSpinCount();
-        private static readonly short s_minSpinCount = DetermineMinSpinCount();
+        private static readonly short s_minSpinCountForAdaptiveSpin = DetermineMinSpinCountForAdaptiveSpin();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Lock"/> class.


### PR DESCRIPTION
Small fix to check for a single proc during initialization. Also renamed things referring to "minSpinCount" to clarify it a bit.