### PR TITLE
When initializing Lock in NativeAOT, get the processor count directly instead of using Environment

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Lock.NativeAot.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Runtime;
 using System.Runtime.CompilerServices;
 
 namespace System.Threading
@@ -188,8 +189,12 @@ namespace System.Threading
             {
                 if (oldStage == StaticsInitializationStage.NotStarted)
                 {
-                    // If the stage is PartiallyComplete, these will have already been initialized
-                    s_isSingleProcessor = Environment.IsSingleProcessor;
+                    // If the stage is PartiallyComplete, these will have already been initialized.
+                    //
+                    // Not using Environment.ProcessorCount here as it involves class construction, and if that property is
+                    // already being constructed earlier in the stack on the same thread, it would return the default value
+                    // here. Initialize s_isSingleProcessor first, as it may be used by other initialization afterwards.
+                    s_isSingleProcessor = RuntimeImports.RhGetProcessCpuCount() == 1;
                     s_maxSpinCount = DetermineMaxSpinCount();
                     s_minSpinCount = DetermineMinSpinCount();
                 }


### PR DESCRIPTION
It's a bit safer to get the proc count directly since the relevant Environment properties involve class construction. We used to get the proc count directly before, and there's still a reason to do so to get the correct value with the current initialization pattern due to a potential for in-thread reentrancy of the same class construction.