### PR TITLE
SuperPMI: Reset method context 'fileHandle' to the beginning

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -622,9 +622,13 @@ bool MethodContextReader::IsMethodExcluded(MethodContext* mc)
 
 void MethodContextReader::Reset(const int* newIndexes, int newIndexCount)
 {
-    Indexes = newIndexes;
-    IndexCount = newIndexCount;
+    __int64 pos    = 0;
+    BOOL    result = SetFilePointerEx(fileHandle, *(PLARGE_INTEGER)&pos, NULL, FILE_BEGIN);
+    assert(result);
+    
+    Indexes     = newIndexes;
+    IndexCount  = newIndexCount;
     curIndexPos = 0;
-    curMCIndex = 0;
+    curMCIndex  = 0;
     curTOCIndex = 0;
 }


### PR DESCRIPTION
When resetting the state for `MethodContextReader`, we were not resetting the `fileHandle` position to the beginning. This was resulting in incorrect method reads in SuperPMI streaming mode.