### PR TITLE
[LoongArch64] modify the offset's formate of the float's load/store as decimal.

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -4190,8 +4190,9 @@ void emitter::emitDisInsName(code_t code, const BYTE* addr, instrDesc* id)
             return;
         case DF_F_RG12I:
         {
-            tmp = ((code >> 10) & 0xfff);
-            printf("%s, %s, 0x%x\n", RegNames[regd + 32], RegNames[regj], tmp);
+            tmp = code << 10;
+            tmp >>= 20;
+            printf("%s, %s, %d\n", RegNames[regd + 32], RegNames[regj], tmp);
             return;
         }
         case DF_F_FG:


### PR DESCRIPTION
modify the offset's formate of the float's load/store as decimal.

```
G_M47983_IG01:        ; offs=0x000000, size=0x0058, bbWeight=1, gcrefRegs=0000 {}, byrefRegs=0000 {}, byref, nogc <-- Prolog IG
  02FD4063  addi.d          sp, sp, -176
  29C26076  st.d            fp, sp, 152
  29C28061  st.d            ra, sp, 160
  2BC2A078  fst.d           f24, sp, 168
  02C26076  addi.d          fp, sp, 152
  29BDD2C0  st.w            zero, fp, -140
  29BFF2C4  st.w            a0, fp, -4
  29FFA2C5  st.d            a1, fp, -24
  29FFC2C6  st.d            a2, fp, -16
  29FF62C7  st.d            a3, fp, -40
  29FF82C8  st.d            a4, fp, -32
  2BFF22C0  fst.d           f0, fp, -56
  2BFF42C1  fst.d           f1, fp, -48
  2BFEE2C2  fst.d           f2, fp, -72
  2BFF02C3  fst.d           f3, fp, -64
  2BFEA2C4  fst.d           f4, fp, -88
  2BFEC2C5  fst.d           f5, fp, -80
  29FE62C9  st.d            a5, fp, -104
  29FE82CA  st.d            a6, fp, -96
  29FE22CB  st.d            a7, fp, -120
  2BFDE2C6  fst.d           f6, fp, -136
  2BFE02C7  fst.d           f7, fp, -128
                        ;; size=88 bbWeight=1 PerfScore 0.00
```