### PR TITLE
[HTTP/3] Support for HTTP/3 multiple connections

### DIFF
--- a/src/libraries/System.Net.Http/ref/System.Net.Http.cs
+++ b/src/libraries/System.Net.Http/ref/System.Net.Http.cs
@@ -424,6 +424,7 @@ namespace System.Net.Http
         public System.Net.ICredentials? Credentials { get { throw null; } set { } }
         public System.Net.ICredentials? DefaultProxyCredentials { get { throw null; } set { } }
         public bool EnableMultipleHttp2Connections { get { throw null; } set { } }
+        public bool EnableMultipleHttp3Connections { get { throw null; } set { } }
         public System.TimeSpan Expect100ContinueTimeout { get { throw null; } set { } }
         public int InitialHttp2StreamWindowSize { get { throw null; } set { } }
         [System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute("browser")]

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -471,6 +471,9 @@
   <data name="net_http_invalid_header_name" xml:space="preserve">
     <value>Received an invalid header name: '{0}'.</value>
   </data>
+  <data name="net_http_http3_connection_not_established" xml:space="preserve">
+    <value>An HTTP/3 connection could not be established because the server did not complete the HTTP/3 handshake.</value>
+  </data>
   <data name="net_http_http3_connection_error" xml:space="preserve">
     <value>The HTTP/3 server sent invalid data on the connection. HTTP/3 error code '{0}' (0x{1}).</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/BrowserHttpHandler/SocketsHttpHandler.cs
@@ -196,6 +196,12 @@ namespace System.Net.Http
             set => throw new PlatformNotSupportedException();
         }
 
+        public bool EnableMultipleHttp3Connections
+        {
+            get => throw new PlatformNotSupportedException();
+            set => throw new PlatformNotSupportedException();
+        }
+
         public Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? ConnectCallback
         {
             get => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, DnsEndPoint endPoint, TimeSpan idleTimeout, SslClientAuthenticationOptions clientAuthenticationOptions, QuicConnectionStreamsAvailableCallback streamsAvailableCallback, CancellationToken cancellationToken)
+        public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, DnsEndPoint endPoint, TimeSpan idleTimeout, SslClientAuthenticationOptions clientAuthenticationOptions, Action<QuicConnection, QuicStreamCapacityChangedArgs> streamCapacityCallback, CancellationToken cancellationToken)
         {
             clientAuthenticationOptions = SetUpRemoteCertificateValidationCallback(clientAuthenticationOptions, request);
 
@@ -127,7 +127,7 @@ namespace System.Net.Http
                     DefaultCloseErrorCode = (long)Http3ErrorCode.NoError,
                     RemoteEndPoint = endPoint,
                     ClientAuthenticationOptions = clientAuthenticationOptions,
-                    StreamsAvailableCallback = streamsAvailableCallback,
+                    StreamCapacityCallback = streamCapacityCallback,
                 }, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -109,9 +109,9 @@ namespace System.Net.Http
             return sslStream;
         }
 
-        [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
         public static async ValueTask<QuicConnection> ConnectQuicAsync(HttpRequestMessage request, DnsEndPoint endPoint, TimeSpan idleTimeout, SslClientAuthenticationOptions clientAuthenticationOptions, Action<QuicConnection, QuicStreamCapacityChangedArgs> streamCapacityCallback, CancellationToken cancellationToken)
         {
             clientAuthenticationOptions = SetUpRemoteCertificateValidationCallback(clientAuthenticationOptions, request);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -118,7 +118,7 @@ namespace System.Net.Http
 
             try
             {
-                return await QuicConnection.ConnectAsync(new QuicClientConnectionOptions()
+                QuicConnection quicConnection = await QuicConnection.ConnectAsync(new QuicClientConnectionOptions()
                 {
                     MaxInboundBidirectionalStreams = 0, // Client doesn't support inbound streams: https://www.rfc-editor.org/rfc/rfc9114.html#name-bidirectional-streams. An extension might change this.
                     MaxInboundUnidirectionalStreams = 5, // Minimum is 3: https://www.rfc-editor.org/rfc/rfc9114.html#unidirectional-streams (1x control stream + 2x QPACK). Set to 100 if/when support for PUSH streams is added.
@@ -128,6 +128,14 @@ namespace System.Net.Http
                     RemoteEndPoint = endPoint,
                     ClientAuthenticationOptions = clientAuthenticationOptions
                 }, cancellationToken).ConfigureAwait(false);
+
+                if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
+                {
+                    await quicConnection.DisposeAsync().ConfigureAwait(false);
+                    throw new HttpRequestException(HttpRequestError.ConnectionError, "QUIC connected but no HTTP/3 indicated via ALPN.", null, RequestRetryType.RetryOnConnectionFailure);
+                }
+
+                return quicConnection;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
 
         [SupportedOSPlatformGuard("linux")]
         [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatformGuard("windows")]
         internal static bool IsHttp3Supported() => (OperatingSystem.IsLinux() && !OperatingSystem.IsAndroid()) || OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
 
         /// <summary>List of available HTTP/3 connections stored in the pool.</summary>
@@ -62,9 +62,9 @@ namespace System.Net.Http
         private bool EnableMultipleHttp3Connections => _poolManager.Settings.EnableMultipleHttp3Connections;
 
         // Returns null if HTTP3 cannot be used.
-        [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
+        [SupportedOSPlatform("windows")]
         private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Debug.Assert(IsHttp3Supported());
@@ -114,9 +114,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private bool TryGetPooledHttp3Connection(HttpRequestMessage request, [NotNullWhen(true)] out Http3Connection? connection, [NotNullWhen(false)] out HttpConnectionWaiter<Http3Connection?>? waiter)
         {
             Debug.Assert(IsHttp3Supported());
@@ -186,9 +186,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private void CheckForHttp3ConnectionInjection()
         {
             Debug.Assert(IsHttp3Supported());
@@ -225,9 +225,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private async Task InjectNewHttp3ConnectionAsync(RequestQueue<Http3Connection?>.QueueItem queueItem)
         {
             Debug.Assert(IsHttp3Supported());
@@ -302,9 +302,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private void HandleHttp3ConnectionFailure(HttpConnectionWaiter<Http3Connection?> requestWaiter, Exception? e)
         {
             Debug.Assert(IsHttp3Supported());
@@ -333,9 +333,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private void ReturnHttp3Connection(Http3Connection connection, bool isNewConnection, HttpConnectionWaiter<Http3Connection?>? initialRequestWaiter = null)
         {
             Debug.Assert(IsHttp3Supported());
@@ -457,9 +457,9 @@ namespace System.Net.Http
         /// Disable usage of the specified connection because it cannot handle any more streams at the moment.
         /// We will register to be notified when it can handle more streams (or becomes permanently unusable).
         /// </summary>
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private void DisableHttp3Connection(Http3Connection connection)
         {
             Debug.Assert(IsHttp3Supported());
@@ -500,9 +500,9 @@ namespace System.Net.Http
         /// <summary>
         /// Called when an Http3Connection from this pool is no longer usable.
         /// </summary>
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         public void InvalidateHttp3Connection(Http3Connection connection)
         {
             Debug.Assert(IsHttp3Supported());
@@ -536,9 +536,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatformGuard("linux")]
-        [SupportedOSPlatformGuard("macOS")]
-        [SupportedOSPlatformGuard("Windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macOS")]
+        [SupportedOSPlatform("windows")]
         private static int ScavengeHttp3ConnectionList(List<Http3Connection> list, ref List<HttpConnectionBase>? toDispose, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
         {
             Debug.Assert(IsHttp3Supported());

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -62,9 +62,9 @@ namespace System.Net.Http
         private bool EnableMultipleHttp3Connections => _poolManager.Settings.EnableMultipleHttp3Connections;
 
         // Returns null if HTTP3 cannot be used.
+        [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("macos")]
-        [SupportedOSPlatform("windows")]
         private async ValueTask<HttpResponseMessage?> TrySendUsingHttp3Async(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             Debug.Assert(IsHttp3Supported());
@@ -114,9 +114,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private bool TryGetPooledHttp3Connection(HttpRequestMessage request, [NotNullWhen(true)] out Http3Connection? connection, [NotNullWhen(false)] out HttpConnectionWaiter<Http3Connection?>? waiter)
         {
             Debug.Assert(IsHttp3Supported());
@@ -186,9 +186,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private void CheckForHttp3ConnectionInjection()
         {
             Debug.Assert(IsHttp3Supported());
@@ -225,9 +225,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private async Task InjectNewHttp3ConnectionAsync(RequestQueue<Http3Connection?>.QueueItem queueItem)
         {
             Debug.Assert(IsHttp3Supported());
@@ -302,9 +302,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private void HandleHttp3ConnectionFailure(HttpConnectionWaiter<Http3Connection?> requestWaiter, Exception? e)
         {
             Debug.Assert(IsHttp3Supported());
@@ -333,9 +333,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private void ReturnHttp3Connection(Http3Connection connection, bool isNewConnection, HttpConnectionWaiter<Http3Connection?>? initialRequestWaiter = null)
         {
             Debug.Assert(IsHttp3Supported());
@@ -457,9 +457,9 @@ namespace System.Net.Http
         /// Disable usage of the specified connection because it cannot handle any more streams at the moment.
         /// We will register to be notified when it can handle more streams (or becomes permanently unusable).
         /// </summary>
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private void DisableHttp3Connection(Http3Connection connection)
         {
             Debug.Assert(IsHttp3Supported());
@@ -500,9 +500,9 @@ namespace System.Net.Http
         /// <summary>
         /// Called when an Http3Connection from this pool is no longer usable.
         /// </summary>
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         public void InvalidateHttp3Connection(Http3Connection connection)
         {
             Debug.Assert(IsHttp3Supported());
@@ -536,9 +536,9 @@ namespace System.Net.Http
             }
         }
 
-        [SupportedOSPlatform("linux")]
-        [SupportedOSPlatform("macOS")]
         [SupportedOSPlatform("windows")]
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
         private static int ScavengeHttp3ConnectionList(List<Http3Connection> list, ref List<HttpConnectionBase>? toDispose, long nowTicks, TimeSpan pooledConnectionLifetime, TimeSpan pooledConnectionIdleTimeout)
         {
             Debug.Assert(IsHttp3Supported());

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.Http3.cs
@@ -252,7 +252,7 @@ namespace System.Net.Http
                     // If the authority was sent as an option through alt-svc then include alt-used header.
                     connection = new Http3Connection(this, authority, includeAltUsedHeader: _http3Authority == authority);
 
-                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamsAvailableCallback, cts.Token).ConfigureAwait(false);
+                    QuicConnection quicConnection = await ConnectHelper.ConnectQuicAsync(queueItem.Request, new DnsEndPoint(authority.IdnHost, authority.Port), _poolManager.Settings._pooledConnectionIdleTimeout, _sslOptionsHttp3!, connection.StreamCapacityCallback, cts.Token).ConfigureAwait(false);
                     if (quicConnection.NegotiatedApplicationProtocol != SslApplicationProtocol.Http3)
                     {
                         await quicConnection.DisposeAsync().ConfigureAwait(false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -247,7 +247,7 @@ namespace System.Net.Http
             }
             if (IsHttp3Supported() && _http3Enabled)
             {
-                _http3RequestQueue = new RequestQueue<Http3Connection>();
+                _http3RequestQueue = new RequestQueue<Http3Connection?>();
             }
 
             if (_proxyUri != null && HttpUtilities.IsSupportedSecureScheme(_proxyUri.Scheme))
@@ -887,7 +887,8 @@ namespace System.Net.Http
 
                 if (IsHttp3Supported() && _availableHttp3Connections is not null)
                 {
-                    toDispose = [.. _availableHttp3Connections];
+                    toDispose ??= new();
+                    toDispose.AddRange(_availableHttp3Connections);
                     _associatedHttp3ConnectionCount -= _availableHttp3Connections.Count;
                     _availableHttp3Connections.Clear();
                 }
@@ -960,7 +961,7 @@ namespace System.Net.Http
                     // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
                     // Http2 connections will not, hence the difference in handing _associatedHttp2ConnectionCount.
                 }
-                if (_availableHttp3Connections is not null)
+                if (IsHttp3Supported() && _availableHttp3Connections is not null)
                 {
                     int removed = ScavengeHttp3ConnectionList(_availableHttp3Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
                     _associatedHttp3ConnectionCount -= removed;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -245,6 +245,10 @@ namespace System.Net.Http
             {
                 _http2RequestQueue = new RequestQueue<Http2Connection?>();
             }
+            if (IsHttp3Supported() && _http3Enabled)
+            {
+                _http3RequestQueue = new RequestQueue<Http3Connection>();
+            }
 
             if (_proxyUri != null && HttpUtilities.IsSupportedSecureScheme(_proxyUri.Scheme))
             {
@@ -881,11 +885,11 @@ namespace System.Net.Http
                     _availableHttp2Connections.Clear();
                 }
 
-                if (_http3Connection is not null)
+                if (IsHttp3Supported() && _availableHttp3Connections is not null)
                 {
-                    toDispose ??= new();
-                    toDispose.Add(_http3Connection);
-                    _http3Connection = null;
+                    toDispose = [.. _availableHttp3Connections];
+                    _associatedHttp3ConnectionCount -= _availableHttp3Connections.Count;
+                    _availableHttp3Connections.Clear();
                 }
 
                 if (_authorityExpireTimer != null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -960,6 +960,14 @@ namespace System.Net.Http
                     // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
                     // Http2 connections will not, hence the difference in handing _associatedHttp2ConnectionCount.
                 }
+                if (_availableHttp3Connections is not null)
+                {
+                    int removed = ScavengeHttp3ConnectionList(_availableHttp3Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
+                    _associatedHttp3ConnectionCount -= removed;
+
+                    // Note: Http11 connections will decrement the _associatedHttp11ConnectionCount when disposed.
+                    // Http3 connections will not, hence the difference in handing _associatedHttp3ConnectionCount.
+                }
             }
 
             // Dispose the stale connections outside the pool lock, to avoid holding the lock too long.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal sealed class HttpConnectionWaiter<T> : TaskCompletionSourceWithCancellation<T>
+    internal class HttpConnectionWaiter<T> : TaskCompletionSourceWithCancellation<T>
         where T : HttpConnectionBase?
     {
         // When a connection attempt is pending, reference the connection's CTS, so we can tear it down if the initiating request is cancelled

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionWaiter.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    internal class HttpConnectionWaiter<T> : TaskCompletionSourceWithCancellation<T>
+    internal sealed class HttpConnectionWaiter<T> : TaskCompletionSourceWithCancellation<T>
         where T : HttpConnectionBase?
     {
         // When a connection attempt is pending, reference the connection's CTS, so we can tear it down if the initiating request is cancelled

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -14,9 +14,9 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("windows")]
     internal sealed class Http3Connection : HttpConnectionBase
     {
         private readonly HttpAuthority _authority;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -258,6 +258,7 @@ namespace System.Net.Http
                 catch (QuicException e) when (e.QuicError != QuicError.OperationAborted) { }
                 finally
                 {
+                    ReleaseStream();
                     if (queueStartingTimestamp != 0)
                     {
                         TimeSpan duration = Stopwatch.GetElapsedTime(queueStartingTimestamp);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -235,6 +235,7 @@ namespace System.Net.Http
                     return Task.FromResult(true);
                 }
 
+                Debug.Assert(_availableStreamsWaiter is null);
                 _availableStreamsWaiter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 return _availableStreamsWaiter.Task;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -202,6 +202,9 @@ namespace System.Net.Http
 
                 if (NetEventSource.Log.IsEnabled()) Trace($"ReleaseStream: _availableRequestStreamsCount = {_availableRequestStreamsCount}");
                 ++_availableRequestStreamsCount;
+
+                _availableStreamsWaiter?.SetResult(!ShuttingDown);
+                _availableStreamsWaiter = null;
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -284,7 +284,6 @@ namespace System.Net.Http
 
                 if (quicStream == null)
                 {
-                    ReleaseStream();
                     throw new HttpRequestException(HttpRequestError.Unknown, SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure);
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -185,10 +185,6 @@ namespace System.Net.Http
                     return false;
                 }
 
-                if (_activeRequests.Count == 0)
-                {
-                    MarkConnectionAsNotIdle();
-                }
                 --_availableRequestStreamsCount;
                 return true;
             }
@@ -262,6 +258,10 @@ namespace System.Net.Http
                         requestStream = new Http3RequestStream(request, this, quicStream);
                         lock (SyncObj)
                         {
+                            if (_activeRequests.Count == 0)
+                            {
+                                MarkConnectionAsNotIdle();
+                            }
                             _activeRequests.Add(quicStream, requestStream);
                         }
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -429,7 +429,7 @@ namespace System.Net.Http
         public override long GetIdleTicks(long nowTicks)
         {
             // The pool is holding the lock as part of its scavenging logic.
-            // We must not lock on Http2Connection.SyncObj here as that could lead to lock ordering problems.
+            // We must not lock on Http3Connection.SyncObj here as that could lead to lock ordering problems.
             Debug.Assert(_pool.HasSyncObjLock);
 
             // There is a race condition here where the connection pool may see this connection as idle right before

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -208,7 +208,7 @@ namespace System.Net.Http
             }
         }
 
-        public void StreamsAvailableCallback(QuicConnection connection, int bidirectionalStreamsCountIncrement, int _)
+        public void StreamCapacityCallback(QuicConnection connection, QuicStreamCapacityChangedArgs args)
         {
             Debug.Assert(_connection is null || connection == _connection);
 
@@ -216,9 +216,9 @@ namespace System.Net.Http
             {
                 Debug.Assert(_availableRequestStreamsCount >= 0);
 
-                if (NetEventSource.Log.IsEnabled()) Trace($"StreamsAvailableCallback: _availableRequestStreamsCount = {_availableRequestStreamsCount} + bidirectionalStreamsCountIncrement = {bidirectionalStreamsCountIncrement}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"StreamCapacityCallback: _availableRequestStreamsCount = {_availableRequestStreamsCount} + bidirectionalStreamsCountIncrement = {args.BidirectionalIncrement}");
 
-                _availableRequestStreamsCount += bidirectionalStreamsCountIncrement;
+                _availableRequestStreamsCount += args.BidirectionalIncrement;
                 _availableStreamsWaiter?.SetResult(!ShuttingDown);
                 _availableStreamsWaiter = null;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -178,7 +178,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(_availableRequestStreamsCount >= 0);
 
-                if (NetEventSource.Log.IsEnabled()) Trace($"TryReserveStream: _availableRequestStreamsCount = {_availableRequestStreamsCount}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"_availableRequestStreamsCount = {_availableRequestStreamsCount}");
 
                 if (_availableRequestStreamsCount == 0)
                 {
@@ -200,7 +200,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(_availableRequestStreamsCount >= 0);
 
-                if (NetEventSource.Log.IsEnabled()) Trace($"ReleaseStream: _availableRequestStreamsCount = {_availableRequestStreamsCount}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"_availableRequestStreamsCount = {_availableRequestStreamsCount}");
                 ++_availableRequestStreamsCount;
 
                 _availableStreamsWaiter?.SetResult(!ShuttingDown);
@@ -216,7 +216,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(_availableRequestStreamsCount >= 0);
 
-                if (NetEventSource.Log.IsEnabled()) Trace($"StreamCapacityCallback: _availableRequestStreamsCount = {_availableRequestStreamsCount} + bidirectionalStreamsCountIncrement = {args.BidirectionalIncrement}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"_availableRequestStreamsCount = {_availableRequestStreamsCount} + bidirectionalStreamsCountIncrement = {args.BidirectionalIncrement}");
 
                 _availableRequestStreamsCount += args.BidirectionalIncrement;
                 _availableStreamsWaiter?.SetResult(!ShuttingDown);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -264,7 +264,6 @@ namespace System.Net.Http
                 catch (QuicException e) when (e.QuicError != QuicError.OperationAborted) { }
                 finally
                 {
-                    ReleaseStream();
                     if (queueStartingTimestamp != 0)
                     {
                         TimeSpan duration = Stopwatch.GetElapsedTime(queueStartingTimestamp);
@@ -280,6 +279,7 @@ namespace System.Net.Http
 
                 if (quicStream == null)
                 {
+                    ReleaseStream();
                     throw new HttpRequestException(HttpRequestError.Unknown, SR.net_http_request_aborted, null, RequestRetryType.RetryOnConnectionFailure);
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -17,9 +17,9 @@ using System.Threading.Tasks;
 
 namespace System.Net.Http
 {
-    [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
+    [SupportedOSPlatform("windows")]
     internal sealed class Http3RequestStream : IHttpStreamHeadersHandler, IAsyncDisposable, IDisposable
     {
         private readonly HttpRequestMessage _request;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -42,7 +42,6 @@ namespace System.Net.Http
         private static readonly ulong s_http10Bytes = BitConverter.ToUInt64("HTTP/1.0"u8);
         private static readonly ulong s_http11Bytes = BitConverter.ToUInt64("HTTP/1.1"u8);
 
-        private readonly HttpConnectionPool _pool;
         internal readonly Stream _stream;
         private readonly TransportContext? _transportContext;
 
@@ -77,10 +76,8 @@ namespace System.Net.Http
             IPEndPoint? remoteEndPoint)
             : base(pool, remoteEndPoint)
         {
-            Debug.Assert(pool != null);
             Debug.Assert(stream != null);
 
-            _pool = pool;
             _stream = stream;
 
             _transportContext = transportContext;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -16,17 +16,19 @@ namespace System.Net.Http
 {
     internal abstract class HttpConnectionBase : IDisposable, IHttpTrace
     {
+        protected readonly HttpConnectionPool _pool;
+
         private static long s_connectionCounter = -1;
 
         // May be null if none of the counters were enabled when the connection was established.
-        private readonly ConnectionMetrics? _connectionMetrics;
+        private ConnectionMetrics? _connectionMetrics;
 
         // Indicates whether we've counted this connection as established, so that we can
         // avoid decrementing the counter once it's closed in case telemetry was enabled in between.
-        private readonly bool _httpTelemetryMarkedConnectionAsOpened;
+        private bool _httpTelemetryMarkedConnectionAsOpened;
 
         private readonly long _creationTickCount = Environment.TickCount64;
-        private long _idleSinceTickCount;
+        private long? _idleSinceTickCount;
 
         /// <summary>Cached string for the last Date header received on this connection.</summary>
         private string? _lastDateHeaderValue;
@@ -35,13 +37,23 @@ namespace System.Net.Http
 
         public long Id { get; } = Interlocked.Increment(ref s_connectionCounter);
 
-        public HttpConnectionBase(HttpConnectionPool pool, IPEndPoint? remoteEndPoint)
+        public HttpConnectionBase(HttpConnectionPool pool)
         {
             Debug.Assert(this is HttpConnection or Http2Connection or Http3Connection);
-            Debug.Assert(pool.Settings._metrics is not null);
+            Debug.Assert(pool != null);
+            _pool = pool;
+        }
+        public HttpConnectionBase(HttpConnectionPool pool, IPEndPoint? remoteEndPoint)
+            : this(pool)
+        {
+            MarkConnectionAsEstablished(remoteEndPoint);
+        }
 
-            SocketsHttpHandlerMetrics metrics = pool.Settings._metrics;
+        protected void MarkConnectionAsEstablished(IPEndPoint? remoteEndPoint)
+        {
+            Debug.Assert(_pool.Settings._metrics is not null);
 
+            SocketsHttpHandlerMetrics metrics = _pool.Settings._metrics;
             if (metrics.OpenConnections.Enabled || metrics.ConnectionDuration.Enabled)
             {
                 // While requests may report HTTP/1.0 as the protocol, we treat all HTTP/1.X connections as HTTP/1.1.
@@ -53,9 +65,9 @@ namespace System.Net.Http
                 _connectionMetrics = new ConnectionMetrics(
                     metrics,
                     protocol,
-                    pool.IsSecure ? "https" : "http",
-                    pool.OriginAuthority.HostValue,
-                    pool.IsDefaultPort ? null : pool.OriginAuthority.Port,
+                    _pool.IsSecure ? "https" : "http",
+                    _pool.OriginAuthority.HostValue,
+                    _pool.IsDefaultPort ? null : _pool.OriginAuthority.Port,
                     remoteEndPoint?.Address?.ToString());
 
                 _connectionMetrics.ConnectionEstablished();
@@ -67,9 +79,9 @@ namespace System.Net.Http
             {
                 _httpTelemetryMarkedConnectionAsOpened = true;
 
-                string scheme = pool.IsSecure ? "https" : "http";
-                string host = pool.OriginAuthority.HostValue;
-                int port = pool.OriginAuthority.Port;
+                string scheme = _pool.IsSecure ? "https" : "http";
+                string host = _pool.OriginAuthority.HostValue;
+                int port = _pool.OriginAuthority.Port;
 
                 if (this is HttpConnection) HttpTelemetry.Log.Http11ConnectionEstablished(Id, scheme, host, port, remoteEndPoint);
                 else if (this is Http2Connection) HttpTelemetry.Log.Http20ConnectionEstablished(Id, scheme, host, port, remoteEndPoint);
@@ -101,6 +113,7 @@ namespace System.Net.Http
 
         public void MarkConnectionAsNotIdle()
         {
+            _idleSinceTickCount = null;
             _connectionMetrics?.IdleStateChanged(idle: false);
         }
 
@@ -146,7 +159,7 @@ namespace System.Net.Http
 
         public long GetLifetimeTicks(long nowTicks) => nowTicks - _creationTickCount;
 
-        public virtual long GetIdleTicks(long nowTicks) => nowTicks - _idleSinceTickCount;
+        public long GetIdleTicks(long nowTicks) => _idleSinceTickCount is long idleSinceTickCount ? nowTicks - idleSinceTickCount : 0;
 
         /// <summary>Check whether a connection is still usable, or should be scavenged.</summary>
         /// <returns>True if connection can be used.</returns>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -61,6 +61,8 @@ namespace System.Net.Http
 
         internal bool _enableMultipleHttp2Connections;
 
+        internal bool _enableMultipleHttp3Connections;
+
         internal Func<SocketsHttpConnectionContext, CancellationToken, ValueTask<Stream>>? _connectCallback;
         internal Func<SocketsHttpPlaintextStreamFilterContext, CancellationToken, ValueTask<Stream>>? _plaintextStreamFilter;
 
@@ -123,6 +125,7 @@ namespace System.Net.Http
                 _requestHeaderEncodingSelector = _requestHeaderEncodingSelector,
                 _responseHeaderEncodingSelector = _responseHeaderEncodingSelector,
                 _enableMultipleHttp2Connections = _enableMultipleHttp2Connections,
+                _enableMultipleHttp3Connections = _enableMultipleHttp3Connections,
                 _connectCallback = _connectCallback,
                 _plaintextStreamFilter = _plaintextStreamFilter,
                 _initialHttp2StreamWindowSize = _initialHttp2StreamWindowSize,
@@ -139,6 +142,8 @@ namespace System.Net.Http
         public int MaxResponseHeadersByteLength => (int)Math.Min(int.MaxValue, _maxResponseHeadersLength * 1024L);
 
         public bool EnableMultipleHttp2Connections => _enableMultipleHttp2Connections;
+
+        public bool EnableMultipleHttp3Connections => _enableMultipleHttp3Connections;
 
         private byte[]? _http3SettingsFrame;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -372,6 +372,21 @@ namespace System.Net.Http
             }
         }
 
+        /// <summary>
+        /// Gets or sets a value that indicates whether additional HTTP/3 connections can be established to the same server
+        /// when the maximum of concurrent streams is reached on all existing connections.
+        /// </summary>
+        public bool EnableMultipleHttp3Connections
+        {
+            get => _settings._enableMultipleHttp3Connections;
+            set
+            {
+                CheckDisposedOrStarted();
+
+                _settings._enableMultipleHttp3Connections = value;
+            }
+        }
+
         internal const bool SupportsAutomaticDecompression = true;
         internal const bool SupportsProxy = true;
         internal const bool SupportsRedirectConfiguration = true;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -358,9 +358,11 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Gets or sets a value that indicates whether additional HTTP/2 connections can be established to the same server
-        /// when the maximum of concurrent streams is reached on all existing connections.
+        /// Gets or sets a value that indicates whether additional HTTP/2 connections can be established to the same server.
         /// </summary>
+        /// <remarks>
+        /// Enabling multiple connections to the same server explicitly goes against <see href="https://www.rfc-editor.org/rfc/rfc9113.html#section-9.1-2">RFC 9113 - HTTP/2</see>.
+        /// </remarks>
         public bool EnableMultipleHttp2Connections
         {
             get => _settings._enableMultipleHttp2Connections;
@@ -373,9 +375,11 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Gets or sets a value that indicates whether additional HTTP/3 connections can be established to the same server
-        /// when the maximum of concurrent streams is reached on all existing connections.
+        /// Gets or sets a value that indicates whether additional HTTP/3 connections can be established to the same server.
         /// </summary>
+        /// <remarks>
+        /// Enabling multiple connections to the same server explicitly goes against <see href="https://www.rfc-editor.org/rfc/rfc9114.html#section-3.3-4">RFC 9114 - HTTP/3</see>.
+        /// </remarks>
         public bool EnableMultipleHttp3Connections
         {
             get => _settings._enableMultipleHttp3Connections;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2841,6 +2841,7 @@ namespace System.Net.Http.Functional.Tests
         private static SocketsHttpHandler CreateHandler() => new SocketsHttpHandler
         {
             EnableMultipleHttp2Connections = true,
+            EnableMultipleHttp3Connections = true,
             PooledConnectionIdleTimeout = TimeSpan.FromHours(1),
             PooledConnectionLifetime = TimeSpan.FromHours(1),
             SslOptions = { RemoteCertificateValidationCallback = delegate { return true; } }

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/StressClient.cs
@@ -57,6 +57,8 @@ namespace HttpStress
                     return new SocketsHttpHandler()
                     {
                         PooledConnectionLifetime = _config.ConnectionLifetime.GetValueOrDefault(Timeout.InfiniteTimeSpan),
+                        EnableMultipleHttp2Connections = true,
+                        EnableMultipleHttp3Connections = true,
                         SslOptions = new SslClientAuthenticationOptions
                         {
                             RemoteCertificateValidationCallback = delegate { return true; }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -49,7 +49,7 @@ namespace System.Net.Quic
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
         public System.Net.Quic.QuicConnectionStreamsAvailableCallback? StreamsAvailableCallback { get { throw null; } set { } }
     }
-    public delegate void QuicConnectionStreamsAvailableCallback(System.Net.Quic.QuicConnection sender, int bidirectionalStreamsCountIncrement, int unidirectionalStreamsCountIncrement);
+    public delegate void QuicConnectionStreamsAvailableCallback(System.Net.Quic.QuicConnection connection, int bidirectionalStreamsCountIncrement, int unidirectionalStreamsCountIncrement);
     public enum QuicError
     {
         Success = 0,

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -23,15 +23,12 @@ namespace System.Net.Quic
     public sealed partial class QuicConnection : System.IAsyncDisposable
     {
         internal QuicConnection() { }
-        public int AvailableBidirectionalStreamsCount { get { throw null; } }
-        public int AvailableUnidirectionalStreamsCount { get { throw null; } }
         public static bool IsSupported { get { throw null; } }
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public string TargetHostName { get { throw null; } }
-        public event System.Net.Quic.QuicConnectionStreamsAvailableEventHandler? StreamsAvailable { add { } remove { } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptInboundStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<System.Net.Quic.QuicConnection> ConnectAsync(System.Net.Quic.QuicClientConnectionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -50,14 +47,9 @@ namespace System.Net.Quic
         public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
         public int MaxInboundBidirectionalStreams { get { throw null; } set { } }
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
+        public System.Net.Quic.QuicConnectionStreamsAvailableCallback? StreamsAvailableCallback { get { throw null; } set { } }
     }
-    public partial class QuicConnectionStreamsAvailableEventArgs : System.EventArgs
-    {
-        internal QuicConnectionStreamsAvailableEventArgs() { }
-        public int BidirectionalStreamsCountIncrement { get { throw null; } }
-        public int UnidirectionalStreamsCountIncrement { get { throw null; } }
-    }
-    public delegate void QuicConnectionStreamsAvailableEventHandler(object? sender, System.Net.Quic.QuicConnectionStreamsAvailableEventArgs e);
+    public delegate void QuicConnectionStreamsAvailableCallback(System.Net.Quic.QuicConnection sender, int bidirectionalStreamsCountIncrement, int unidirectionalStreamsCountIncrement);
     public enum QuicError
     {
         Success = 0,

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -144,6 +144,8 @@ namespace System.Net.Quic
     }
     public readonly partial struct QuicStreamCapacityChangedArgs
     {
+        private readonly object _dummy;
+        private readonly int _dummyPrimitive;
         public int BidirectionalIncrement { get { throw null; } init { } }
         public int UnidirectionalIncrement { get { throw null; } init { } }
     }

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -47,9 +47,8 @@ namespace System.Net.Quic
         public System.TimeSpan KeepAliveInterval { get { throw null; } set { } }
         public int MaxInboundBidirectionalStreams { get { throw null; } set { } }
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
-        public System.Net.Quic.QuicConnectionStreamsAvailableCallback? StreamsAvailableCallback { get { throw null; } set { } }
+        public System.Action<System.Net.Quic.QuicConnection, System.Net.Quic.QuicStreamCapacityChangedArgs>? StreamCapacityCallback { get { throw null; } set { } }
     }
-    public delegate void QuicConnectionStreamsAvailableCallback(System.Net.Quic.QuicConnection connection, int bidirectionalStreamsCountIncrement, int unidirectionalStreamsCountIncrement);
     public enum QuicError
     {
         Success = 0,
@@ -142,6 +141,11 @@ namespace System.Net.Quic
         public System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, bool completeWrites, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override System.Threading.Tasks.ValueTask WriteAsync(System.ReadOnlyMemory<byte> buffer, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public override void WriteByte(byte value) { }
+    }
+    public readonly partial struct QuicStreamCapacityChangedArgs
+    {
+        public int BidirectionalIncrement { get { throw null; } init { } }
+        public int UnidirectionalIncrement { get { throw null; } init { } }
     }
     public enum QuicStreamType
     {

--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -23,12 +23,15 @@ namespace System.Net.Quic
     public sealed partial class QuicConnection : System.IAsyncDisposable
     {
         internal QuicConnection() { }
+        public int AvailableBidirectionalStreamsCount { get { throw null; } }
+        public int AvailableUnidirectionalStreamsCount { get { throw null; } }
         public static bool IsSupported { get { throw null; } }
         public System.Net.IPEndPoint LocalEndPoint { get { throw null; } }
         public System.Net.Security.SslApplicationProtocol NegotiatedApplicationProtocol { get { throw null; } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? RemoteCertificate { get { throw null; } }
         public System.Net.IPEndPoint RemoteEndPoint { get { throw null; } }
         public string TargetHostName { get { throw null; } }
+        public event System.Net.Quic.QuicConnectionStreamsAvailableEventHandler? StreamsAvailable { add { } remove { } }
         public System.Threading.Tasks.ValueTask<System.Net.Quic.QuicStream> AcceptInboundStreamAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public System.Threading.Tasks.ValueTask CloseAsync(long errorCode, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static System.Threading.Tasks.ValueTask<System.Net.Quic.QuicConnection> ConnectAsync(System.Net.Quic.QuicClientConnectionOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
@@ -48,6 +51,13 @@ namespace System.Net.Quic
         public int MaxInboundBidirectionalStreams { get { throw null; } set { } }
         public int MaxInboundUnidirectionalStreams { get { throw null; } set { } }
     }
+    public partial class QuicConnectionStreamsAvailableEventArgs : System.EventArgs
+    {
+        internal QuicConnectionStreamsAvailableEventArgs() { }
+        public int BidirectionalStreamsCountIncrement { get { throw null; } }
+        public int UnidirectionalStreamsCountIncrement { get { throw null; } }
+    }
+    public delegate void QuicConnectionStreamsAvailableEventHandler(object? sender, System.Net.Quic.QuicConnectionStreamsAvailableEventArgs e);
     public enum QuicError
     {
         Success = 0,

--- a/src/libraries/System.Net.Quic/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Quic/src/Resources/Strings.resx
@@ -202,7 +202,10 @@
     <value>The server refused the connection.</value>
   </data>
   <data name="net_quic_protocol_error" xml:space="preserve">
-    <value>A QUIC protocol error was encountered</value>
+    <value>A QUIC protocol error was encountered.</value>
+  </data>
+  <data name="net_quic_alpn_in_use" xml:space="preserve">
+    <value>A specified application protocol is already in use.</value>
   </data>
   <data name="net_quic_ver_neg_error" xml:space="preserve">
     <value>A version negotiation error was encountered.</value>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
@@ -54,6 +54,8 @@ internal unsafe partial struct QUIC_CONNECTION_EVENT
                 => $"{{ {nameof(DATAGRAM_RECEIVED.Flags)} = {DATAGRAM_RECEIVED.Flags} }}",
             QUIC_CONNECTION_EVENT_TYPE.DATAGRAM_SEND_STATE_CHANGED
                 => $"{{ {nameof(DATAGRAM_SEND_STATE_CHANGED.ClientContext)} = 0x{(IntPtr)DATAGRAM_SEND_STATE_CHANGED.ClientContext:X11}, {nameof(DATAGRAM_SEND_STATE_CHANGED.State)} = {DATAGRAM_SEND_STATE_CHANGED.State} }}",
+            QUIC_CONNECTION_EVENT_TYPE.RESUMED
+                => $"{{ {nameof(RESUMED.ResumptionStateLength)} = {RESUMED.ResumptionStateLength} }}",
             QUIC_CONNECTION_EVENT_TYPE.RESUMPTION_TICKET_RECEIVED
                 => $"{{ {nameof(RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength)} = {RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength} }}",
             QUIC_CONNECTION_EVENT_TYPE.PEER_CERTIFICATE_RECEIVED

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/MsQuicExtensions.cs
@@ -54,8 +54,6 @@ internal unsafe partial struct QUIC_CONNECTION_EVENT
                 => $"{{ {nameof(DATAGRAM_RECEIVED.Flags)} = {DATAGRAM_RECEIVED.Flags} }}",
             QUIC_CONNECTION_EVENT_TYPE.DATAGRAM_SEND_STATE_CHANGED
                 => $"{{ {nameof(DATAGRAM_SEND_STATE_CHANGED.ClientContext)} = 0x{(IntPtr)DATAGRAM_SEND_STATE_CHANGED.ClientContext:X11}, {nameof(DATAGRAM_SEND_STATE_CHANGED.State)} = {DATAGRAM_SEND_STATE_CHANGED.State} }}",
-            QUIC_CONNECTION_EVENT_TYPE.RESUMED
-                => $"{{ {nameof(RESUMED.ResumptionStateLength)} = {RESUMED.ResumptionStateLength} }}",
             QUIC_CONNECTION_EVENT_TYPE.RESUMPTION_TICKET_RECEIVED
                 => $"{{ {nameof(RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength)} = {RESUMPTION_TICKET_RECEIVED.ResumptionTicketLength} }}",
             QUIC_CONNECTION_EVENT_TYPE.PEER_CERTIFICATE_RECEIVED

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/Internal/ThrowHelper.cs
@@ -89,7 +89,7 @@ internal static class ThrowHelper
             if (status == QUIC_STATUS_VER_NEG_ERROR) return new QuicException(QuicError.VersionNegotiationError, null, errorCode, SR.net_quic_ver_neg_error);
             if (status == QUIC_STATUS_CONNECTION_IDLE) return new QuicException(QuicError.ConnectionIdle, null, errorCode, SR.net_quic_connection_idle);
             if (status == QUIC_STATUS_PROTOCOL_ERROR) return new QuicException(QuicError.TransportError, null, errorCode, SR.net_quic_protocol_error);
-            if (status == QUIC_STATUS_ALPN_IN_USE) return new QuicException(QuicError.AlpnInUse, null, errorCode, SR.net_quic_protocol_error);
+            if (status == QUIC_STATUS_ALPN_IN_USE) return new QuicException(QuicError.AlpnInUse, null, errorCode, SR.net_quic_alpn_in_use);
 
             //
             // Transport errors will throw SocketException

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -232,6 +232,11 @@ public sealed partial class QuicConnection : IAsyncDisposable
         {
             return;
         }
+        // No increment, nothing to report.
+        if (bidirectionalIncrement == 0 && unidirectionalIncrement == 0)
+        {
+            return;
+        }
 
         // Do not invoke user-defined event handler code on MsQuic thread.
         await Task.CompletedTask.ConfigureAwait(ConfigureAwaitOptions.ForceYielding);
@@ -465,7 +470,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// <param name="streamType">Type of the stream to decrement appropriate field.</param>
     private void DecrementStreamCapacity(QuicStreamType streamType)
     {
-        if (streamType == QuicStreamType.Unidirectional)
+        if (streamType == QuicStreamType.Unidirectional && _unidirectionalStreamCapacity > 0)
         {
             --_unidirectionalStreamCapacity;
             if (NetEventSource.Log.IsEnabled())
@@ -473,7 +478,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 NetEventSource.Info(this, $"{this} decremented stream count for {streamType} to {_unidirectionalStreamCapacity}.");
             }
         }
-        else
+        if (streamType == QuicStreamType.Bidirectional && _bidirectionalStreamCapacity > 0)
         {
             --_bidirectionalStreamCapacity;
             if (NetEventSource.Log.IsEnabled())

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -180,7 +180,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// </summary>
     private IPEndPoint _localEndPoint = null!;
     /// <summary>
-    /// Occurres when an additional stream capacity has been released by the peer. Corresponds to receiving MAX_STREAMS frame.
+    /// Occurres when an additional stream capacity has been released by the peer. Corresponds to receiving a MAX_STREAMS frame.
     /// </summary>
     private Action<QuicConnection, QuicStreamCapacityChangedArgs>? _streamCapacityCallback;
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -505,7 +505,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
                 NetEventSource.Info(this, $"{this} New outbound {type} stream {stream}.");
             }
 
-            await stream.StartAsync(DecrementStreamCapacity, cancellationToken).ConfigureAwait(false);
+            await stream.StartAsync(_decrementStreamCapacity, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -233,6 +233,10 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         try
         {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(this, $"{this} Signaling StreamsAvailable with {bidirectionalStreamsCountIncrement} bidirectional increment (absolute value {_availableBidirectionalStreamsCount}) and {unidirectionalStreamsCountIncrement} unidirectional increment (absolute value {_availableUnidirectionalStreamsCount}).");
+            }
             _streamsAvailableCallback(this, bidirectionalStreamsCountIncrement, unidirectionalStreamsCountIncrement);
         }
         catch (Exception ex)
@@ -457,10 +461,18 @@ public sealed partial class QuicConnection : IAsyncDisposable
         if (streamType == QuicStreamType.Unidirectional)
         {
             --_availableUnidirectionalStreamsCount;
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(this, $"{this} decremented stream count for {streamType} to {_availableUnidirectionalStreamsCount}.");
+            }
         }
         else
         {
             --_availableBidirectionalStreamsCount;
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Info(this, $"{this} decremented stream count for {streamType} to {_availableBidirectionalStreamsCount}.");
+            }
         }
     }
 

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -56,11 +56,11 @@ public sealed class QuicReceiveWindowSizes
 public readonly struct QuicStreamCapacityChangedArgs
 {
     /// <summary>
-    /// The increment saying how many additional bidirectional streams can be opened on the connection, increased via the latest STREAMS_AVAILABLE frame.
+    /// The increment saying how many additional bidirectional streams can be opened on the connection, increased via the latest MAX_STREAMS frame.
     /// </summary>
     public int BidirectionalIncrement { get; init; }
     /// <summary>
-    /// The increment saying how many additional unidirectional streams can be opened on the connection, increased via the latest STREAMS_AVAILABLE frame.
+    /// The increment saying how many additional unidirectional streams can be opened on the connection, increased via the latest MAX_STREAMS frame.
     /// </summary>
     public int UnidirectionalIncrement { get; init; }
 }
@@ -140,7 +140,7 @@ public abstract class QuicConnectionOptions
     public TimeSpan HandshakeTimeout { get; set; } = QuicDefaults.HandshakeTimeout;
 
     /// <summary>
-    /// Optional callback that is invoked when new stream limit is released by the peer. Corresponds to receiving MAX_STREAMS frame.
+    /// Optional callback that is invoked when new stream limit is released by the peer. Corresponds to receiving a MAX_STREAMS frame.
     /// The callback values represent increments of stream limits, e.g.: current limit is 10 bidirectional streams, callback arguments notify 5 more additional bidirectional streams => 15 bidirectional streams can be opened in total at the moment.
     /// The initial capacity is reported with the first invocation of the callback that might happen before the <see cref="QuicConnection"/> instance is handed out via either
     /// <see cref="QuicConnection.ConnectAsync(QuicClientConnectionOptions, CancellationToken)"/> or <see cref="QuicListener.AcceptConnectionAsync(CancellationToken)"/>.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -51,6 +51,21 @@ public sealed class QuicReceiveWindowSizes
 }
 
 /// <summary>
+/// Arguments for <see cref="QuicConnectionOptions.StreamCapacityCallback"/>.
+/// </summary>
+public readonly struct QuicStreamCapacityChangedArgs
+{
+    /// <summary>
+    /// The increment saying how many additional bidirectional streams can be opened on the connection, increased via the latest STREAMS_AVAILABLE frame.
+    /// </summary>
+    public int BidirectionalIncrement { get; init; }
+    /// <summary>
+    /// The increment saying how many additional unidirectional streams can be opened on the connection, increased via the latest STREAMS_AVAILABLE frame.
+    /// </summary>
+    public int UnidirectionalIncrement { get; init; }
+}
+
+/// <summary>
 /// Shared options for both client (outbound) and server (inbound) <see cref="QuicConnection" />.
 /// </summary>
 public abstract class QuicConnectionOptions
@@ -130,7 +145,7 @@ public abstract class QuicConnectionOptions
     /// The initial capacity is reported with the first invocation of the callback that might happen before the <see cref="QuicConnection"/> instance is handed out via either
     /// <see cref="QuicConnection.ConnectAsync(QuicClientConnectionOptions, CancellationToken)"/> or <see cref="QuicListener.AcceptConnectionAsync(CancellationToken)"/>.
     /// </summary>
-    public QuicConnectionStreamsAvailableCallback? StreamsAvailableCallback { get; set; }
+    public Action<QuicConnection, QuicStreamCapacityChangedArgs>? StreamCapacityCallback { get; set; }
 
     /// <summary>
     /// Validates the options and potentially sets platform specific defaults.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnectionOptions.cs
@@ -125,6 +125,14 @@ public abstract class QuicConnectionOptions
     public TimeSpan HandshakeTimeout { get; set; } = QuicDefaults.HandshakeTimeout;
 
     /// <summary>
+    /// Optional callback that is invoked when new stream limit is released by the peer. Corresponds to receiving MAX_STREAMS frame.
+    /// The callback values represent increments of stream limits, e.g.: current limit is 10 bidirectional streams, callback arguments notify 5 more additional bidirectional streams => 15 bidirectional streams can be opened in total at the moment.
+    /// The initial capacity is reported with the first invocation of the callback that might happen before the <see cref="QuicConnection"/> instance is handed out via either
+    /// <see cref="QuicConnection.ConnectAsync(QuicClientConnectionOptions, CancellationToken)"/> or <see cref="QuicListener.AcceptConnectionAsync(CancellationToken)"/>.
+    /// </summary>
+    public QuicConnectionStreamsAvailableCallback? StreamsAvailableCallback { get; set; }
+
+    /// <summary>
     /// Validates the options and potentially sets platform specific defaults.
     /// </summary>
     /// <param name="argumentName">Name of the from the caller.</param>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -263,6 +263,7 @@ public sealed partial class QuicStream
 
             if (ThrowHelper.TryGetStreamExceptionForMsQuicStatus(status, out Exception? exception, streamWasSuccessfullyStarted: false))
             {
+                _decrementStreamCapacity = null;
                 _startedTcs.TrySetException(exception);
             }
         }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -252,6 +252,7 @@ public sealed partial class QuicStream
     {
         _startedTcs.TryInitialize(out ValueTask valueTask, this, cancellationToken);
         {
+            _decrementAvailableStreamCount = decrementAvailableStreamCount;
             unsafe
             {
                 int status = MsQuicApi.Api.StreamStart(
@@ -265,7 +266,6 @@ public sealed partial class QuicStream
             }
         }
 
-        _decrementAvailableStreamCount = decrementAvailableStreamCount;
         return valueTask;
     }
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -189,6 +189,49 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
+        public async Task GetAvailableStreamsCount_OpenCloseStream_CountsCorrectly()
+        {
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection();
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, clientConnection.AvailableBidirectionalStreamsCount);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, clientConnection.AvailableUnidirectionalStreamsCount);
+            Assert.Equal(QuicDefaults.DefaultClientMaxInboundBidirectionalStreams, serverConnection.AvailableBidirectionalStreamsCount);
+            Assert.Equal(QuicDefaults.DefaultClientMaxInboundUnidirectionalStreams, serverConnection.AvailableUnidirectionalStreamsCount);
+
+            SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
+            int bidiIncrement = -1, unidiIncrement = -1;
+            clientConnection.StreamsAvailable += (sender, eventArgs) =>
+            {
+                bidiIncrement = eventArgs.BidirectionalStreamsCountIncrement;
+                unidiIncrement = eventArgs.UnidirectionalStreamsCountIncrement;
+                streamsAvailableFired.Release();
+            };
+
+            var clientStreamBidi = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams - 1, clientConnection.AvailableBidirectionalStreamsCount);
+            await clientStreamBidi.DisposeAsync();
+            var serverStreamBidi = await serverConnection.AcceptInboundStreamAsync();
+            await serverStreamBidi.DisposeAsync();
+
+            // STREAMS_AVAILABLE event comes asynchronously, give it a chance to propagate
+            await streamsAvailableFired.WaitAsync();
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, clientConnection.AvailableBidirectionalStreamsCount);
+            Assert.Equal(1, bidiIncrement);
+            Assert.Equal(0, unidiIncrement);
+
+            var clientStreamUnidi = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Unidirectional);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams - 1, clientConnection.AvailableUnidirectionalStreamsCount);
+            await clientStreamUnidi.DisposeAsync();
+            var serverStreamUnidi = await serverConnection.AcceptInboundStreamAsync();
+            await serverStreamUnidi.DisposeAsync();
+
+            // STREAMS_AVAILABLE event comes asynchronously, give it a chance to propagate
+            await streamsAvailableFired.WaitAsync();
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, clientConnection.AvailableUnidirectionalStreamsCount);
+            Assert.Equal(0, bidiIncrement);
+            Assert.Equal(1, unidiIncrement);
+        }
+
+        [Fact]
         public async Task ConnectionClosedByPeer_WithPendingAcceptAndConnect_PendingAndSubsequentThrowConnectionAbortedException()
         {
             using var sync = new SemaphoreSlim(0);

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -195,10 +195,10 @@ namespace System.Net.Quic.Tests
             int bidiIncrement = -1, unidiIncrement = -1;
 
             var clientOptions = CreateQuicClientOptions(new IPEndPoint(0, 0));
-            clientOptions.StreamsAvailableCallback = (sender, bidirectionalStreamsCountIncrement, unidirectionalStreamsCountIncrement) =>
+            clientOptions.StreamCapacityCallback = (connection, args) =>
             {
-                bidiIncrement = bidirectionalStreamsCountIncrement;
-                unidiIncrement = unidirectionalStreamsCountIncrement;
+                bidiIncrement = args.BidirectionalIncrement;
+                unidiIncrement = args.UnidirectionalIncrement;
                 streamsAvailableFired.Release();
             };
 

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -235,8 +235,6 @@ namespace System.Net.Quic.Tests
         [InlineData(false)]
         public async Task GetStreamCapacity_OpenCloseStreamIntoNegative_CountsCorrectly(bool unidirectional)
         {
-            using var _ = new TestEventListener(Console.Out, TestEventListener.NetworkingEvents);
-
             SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
             int bidiIncrement = -1, unidiIncrement = -1;
             int bidiTotal = 0;
@@ -307,8 +305,6 @@ namespace System.Net.Quic.Tests
         [InlineData(false)]
         public async Task GetStreamCapacity_OpenCloseStreamCanceledIntoNegative_CountsCorrectly(bool unidirectional)
         {
-            using var _ = new TestEventListener(Console.Out, TestEventListener.NetworkingEvents);
-
             SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
             int bidiIncrement = -1, unidiIncrement = -1;
             int bidiTotal = 0;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -189,7 +189,7 @@ namespace System.Net.Quic.Tests
         }
 
         [Fact]
-        public async Task GetAvailableStreamsCount_OpenCloseStream_CountsCorrectly()
+        public async Task GetStreamCapacity_OpenCloseStream_CountsCorrectly()
         {
             SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
             int bidiIncrement = -1, unidiIncrement = -1;

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicConnectionTests.cs
@@ -230,18 +230,25 @@ namespace System.Net.Quic.Tests
             Assert.Equal(1, unidiIncrement);
         }
 
-        [Fact]
-        public async Task GetStreamCapacity_OpenCloseStreamIntoNegative_CountsCorrectly()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GetStreamCapacity_OpenCloseStreamIntoNegative_CountsCorrectly(bool unidirectional)
         {
-            //using var _ = new TestEventListener(_output, TestEventListener.NetworkingEvents);
+            using var _ = new TestEventListener(Console.Out, TestEventListener.NetworkingEvents);
+
             SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
             int bidiIncrement = -1, unidiIncrement = -1;
+            int bidiTotal = 0;
+            int unidiTotal = 0;
 
             var clientOptions = CreateQuicClientOptions(new IPEndPoint(0, 0));
             clientOptions.StreamCapacityCallback = (connection, args) =>
             {
-                bidiIncrement = args.BidirectionalIncrement;
-                unidiIncrement = args.UnidirectionalIncrement;
+                Interlocked.Exchange(ref bidiIncrement, args.BidirectionalIncrement);
+                Interlocked.Exchange(ref unidiIncrement, args.UnidirectionalIncrement);
+                Interlocked.Add(ref bidiTotal, args.BidirectionalIncrement);
+                Interlocked.Add(ref unidiTotal, args.UnidirectionalIncrement);
                 streamsAvailableFired.Release();
             };
 
@@ -249,12 +256,17 @@ namespace System.Net.Quic.Tests
             await streamsAvailableFired.WaitAsync();
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiIncrement);
             Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiIncrement);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiTotal);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
 
-            List<QuicStream> clientStreams = (await Task.WhenAll(Enumerable.Range(0, QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
-                                                                           .Select(i => clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional).AsTask())))
+            // Open # of streams up to the capacity.
+            List<QuicStream> clientStreams = (await Task.WhenAll(Enumerable.Range(0, unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
+                                                                           .Select(i => clientConnection.OpenOutboundStreamAsync(unidirectional ? QuicStreamType.Unidirectional : QuicStreamType.Bidirectional).AsTask())))
                                                                            .ToList();
-            List<Task<QuicStream>> pendingClientStreams = Enumerable.Range(0, QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
-                                                                    .Select(i => clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional).AsTask())
+            // Open another # of streams up to 2x capacity all together.
+            CancellationTokenSource cts = new CancellationTokenSource();
+            List<Task<QuicStream>> pendingClientStreams = Enumerable.Range(0, unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
+                                                                    .Select(i => clientConnection.OpenOutboundStreamAsync(unidirectional ? QuicStreamType.Unidirectional : QuicStreamType.Bidirectional, cts.Token).AsTask())
                                                                     .ToList();
             foreach (var task in pendingClientStreams)
             {
@@ -262,27 +274,170 @@ namespace System.Net.Quic.Tests
             }
             Assert.False(streamsAvailableFired.CurrentCount > 0);
 
-            // Dispose streams to release capacity.
+            // Dispose streams to release capacity up to 0 (nothing gets reported yet).
             foreach (var clientStream in clientStreams)
             {
                 await clientStream.DisposeAsync();
                 await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
             }
             clientStreams.Clear();
-
-            // Pending streams should get opened.
             Assert.False(streamsAvailableFired.CurrentCount > 0);
+
+            // All the pending streams should get accepted now.
             clientStreams.AddRange(await Task.WhenAll(pendingClientStreams));
 
-            // Disposing the streams now should lead to stream capacity increments.
+            // Disposing the pending streams now should lead to stream capacity increments.
+            bool first = true; // The stream capacity is cumulatively reported only after the STREAMS_AVAILABLE reached over 0.
             foreach (var clientStream in clientStreams)
             {
                 await clientStream.DisposeAsync();
                 await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
                 await streamsAvailableFired.WaitAsync();
-                Assert.Equal(1, bidiIncrement);
-                Assert.Equal(0, unidiIncrement);
+                Assert.Equal(unidirectional ? 0 : (first ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams + 1 : 1), bidiIncrement);
+                Assert.Equal(unidirectional ? (first ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams + 1 : 1) : 0, unidiIncrement);
+                first = false;
             }
+            Assert.False(streamsAvailableFired.CurrentCount > 0);
+            Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams * 3, bidiTotal);
+            Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams * 3 : QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GetStreamCapacity_OpenCloseStreamCanceledIntoNegative_CountsCorrectly(bool unidirectional)
+        {
+            using var _ = new TestEventListener(Console.Out, TestEventListener.NetworkingEvents);
+
+            SemaphoreSlim streamsAvailableFired = new SemaphoreSlim(0);
+            int bidiIncrement = -1, unidiIncrement = -1;
+            int bidiTotal = 0;
+            int unidiTotal = 0;
+
+            var clientOptions = CreateQuicClientOptions(new IPEndPoint(0, 0));
+            clientOptions.StreamCapacityCallback = (connection, args) =>
+            {
+                Interlocked.Exchange(ref bidiIncrement, args.BidirectionalIncrement);
+                Interlocked.Exchange(ref unidiIncrement, args.UnidirectionalIncrement);
+                Interlocked.Add(ref bidiTotal, args.BidirectionalIncrement);
+                Interlocked.Add(ref unidiTotal, args.UnidirectionalIncrement);
+                streamsAvailableFired.Release();
+            };
+
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions);
+            await streamsAvailableFired.WaitAsync();
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiIncrement);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiIncrement);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundBidirectionalStreams, bidiTotal);
+            Assert.Equal(QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
+
+            // Open # of streams up to the capacity.
+            List<QuicStream> clientStreams = (await Task.WhenAll(Enumerable.Range(0, unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
+                                                                           .Select(i => clientConnection.OpenOutboundStreamAsync(unidirectional ? QuicStreamType.Unidirectional : QuicStreamType.Bidirectional).AsTask())))
+                                                                           .ToList();
+            // Open another # of streams up to 2x capacity all together.
+            CancellationTokenSource cts = new CancellationTokenSource();
+            List<Task<QuicStream>> pendingClientStreams = Enumerable.Range(0, unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams)
+                                                                    .Select(i => clientConnection.OpenOutboundStreamAsync(unidirectional ? QuicStreamType.Unidirectional : QuicStreamType.Bidirectional, cts.Token).AsTask())
+                                                                    .ToList();
+            foreach (var task in pendingClientStreams)
+            {
+                Assert.False(task.IsCompleted);
+            }
+            Assert.False(streamsAvailableFired.CurrentCount > 0);
+
+            // Cancel pending streams if requested.
+            cts.Cancel();
+
+            // Dispose streams to release capacity up to 0 (nothing gets reported yet).
+            foreach (var clientStream in clientStreams)
+            {
+                await clientStream.DisposeAsync();
+                await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
+            }
+            clientStreams.Clear();
+            Assert.False(streamsAvailableFired.CurrentCount > 0);
+
+            // Pending streams should get cancelled and disposing the streams now should lead to stream capacity increments.
+            bool first = true; // The stream capacity is cumulatively reported only after the STREAMS_AVAILABLE reached over 0.
+            foreach (var cancelledStream in pendingClientStreams)
+            {
+                Assert.True(cancelledStream.IsCanceled);
+                await (await serverConnection.AcceptInboundStreamAsync()).DisposeAsync();
+                await streamsAvailableFired.WaitAsync();
+                Assert.Equal(unidirectional ? 0 : (first ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams + 1 : 1), bidiIncrement);
+                Assert.Equal(unidirectional ? (first ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams + 1 : 1) : 0, unidiIncrement);
+                first = false;
+            }
+            Assert.False(streamsAvailableFired.CurrentCount > 0);
+            Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundBidirectionalStreams : QuicDefaults.DefaultServerMaxInboundBidirectionalStreams * 3, bidiTotal);
+            Assert.Equal(unidirectional ? QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams * 3 : QuicDefaults.DefaultServerMaxInboundUnidirectionalStreams, unidiTotal);
+        }
+
+        [Fact]
+        public async Task GetStreamCapacity_SumInvariant()
+        {
+            int maxStreamIndex = 0;
+            const int Limit = 5;
+
+            var clientOptions = CreateQuicClientOptions(new IPEndPoint(0, 0));
+            clientOptions.StreamCapacityCallback = (connection, args) =>
+            {
+                Interlocked.Add(ref maxStreamIndex, args.BidirectionalIncrement);
+            };
+
+            var listenerOptions = CreateQuicListenerOptions();
+            listenerOptions.ConnectionOptionsCallback = (_, _, _) =>
+            {
+                var options = CreateQuicServerOptions();
+                options.MaxInboundBidirectionalStreams = Limit;
+                return ValueTask.FromResult(options);
+            };
+
+            (QuicConnection clientConnection, QuicConnection serverConnection) = await CreateConnectedQuicConnection(clientOptions, listenerOptions);
+
+            Assert.Equal(Limit, maxStreamIndex);
+
+            Queue<(QuicStream client, QuicStream server)> streams = new();
+
+            for (int i = 0; i < Limit; i++)
+            {
+                QuicStream clientStream = await clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                await clientStream.WriteAsync(new byte[1]);
+                QuicStream serverStream = await serverConnection.AcceptInboundStreamAsync();
+                streams.Enqueue((clientStream, serverStream));
+            }
+
+            Queue<Task<QuicStream>> tasks = new();
+            // enqueue more stream creations
+            for (int i = 0; i < Limit; i++)
+            {
+                var newClientStreamTask = clientConnection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                Assert.False(newClientStreamTask.IsCompleted, "Stream creation should not be completed synchronously");
+                tasks.Enqueue(newClientStreamTask.AsTask());
+            }
+
+            // dispose streams
+            while (streams.Count > 0)
+            {
+                var (clientStream, serverStream) = streams.Dequeue();
+                await clientStream.DisposeAsync();
+                await serverStream.DisposeAsync();
+
+                if (tasks.TryDequeue(out var task))
+                {
+                    clientStream = await task;
+                    await clientStream.WriteAsync(new byte[1]);
+                    serverStream = await serverConnection.AcceptInboundStreamAsync();
+                    streams.Enqueue((clientStream, serverStream));
+                }
+            }
+
+            // give time to update the count
+            await Task.Delay(1000);
+
+            // by now, we opened and closed 2 * Limit, and expect a budget of 'Limit' more
+            Assert.Equal(3 * Limit, maxStreamIndex);
         }
 
         [Fact]


### PR DESCRIPTION
__Feel free to review and discuss the API changes. This is NO MERGE until we have the APIs approved and all the TODOs resolved__

The implementation takes H/2 connection pooling and slightly adjusts it for H/3 specific behaviors (see a diff between HttpConnectionPool.Http2.cs and HttpConnectionPool.Http3.cs).

The PR depends on 2 API reviews:
- #101535: for `EnableMultipleHttp3Connections`
- #101534: for `QuicConnection` changes

__TODO: Add numbers from benchmarks when it runs__
__TODO: Stress run depends on https://github.com/dotnet/aspnetcore/pull/55282__

Fixes #51775
Fixes #54968
Fixes #68380
Resolves #101535
Resolves #101534