### PR TITLE
Store last OSR transition context in static memory in DEBUG builds

### DIFF
--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5316,10 +5316,9 @@ void JIT_Patchpoint(int* counter, int ilOffset)
             InitializeContext(pBuffer, contextFlags, &pFrameContext, &contextSize);
         _ASSERTE(success);
 #else // TARGET_WINDOWS && TARGET_AMD64
-
         CONTEXT frameContext;
-        pFrameContext = &frameContext;
         pFrameContext->ContextFlags = CONTEXT_FULL;
+        pFrameContext = &frameContext;
 
 #endif // TARGET_WINDOWS && TARGET_AMD64
 

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5317,15 +5317,8 @@ void JIT_Patchpoint(int* counter, int ilOffset)
         _ASSERTE(success);
 #else // TARGET_WINDOWS && TARGET_AMD64
 
-#ifdef _DEBUG
-        // Temporary change to avoid the frame context being overwritten after
-        // a crash after transition
-        pFrameContext = (CONTEXT*)_alloca(sizeof(CONTEXT) + 0x40000);
-#else
         CONTEXT frameContext;
         pFrameContext = &frameContext;
-#endif
-
         pFrameContext->ContextFlags = CONTEXT_FULL;
 
 #endif // TARGET_WINDOWS && TARGET_AMD64
@@ -5397,6 +5390,12 @@ void JIT_Patchpoint(int* counter, int ilOffset)
 
         // Install new entry point as IP
         SetIP(pFrameContext, osrMethodCode);
+
+#ifdef _DEBUG
+        // Keep this context around to aid in debugging OSR transitions problems
+        static CONTEXT s_lastOSRTransitionContext;
+        s_lastOSRTransitionContext = *pFrameContext;
+#endif
 
         // Restore last error (since call below does not return)
         // END_PRESERVE_LAST_ERROR;

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5319,7 +5319,6 @@ void JIT_Patchpoint(int* counter, int ilOffset)
         CONTEXT frameContext;
         frameContext.ContextFlags = CONTEXT_FULL;
         pFrameContext = &frameContext;
-
 #endif // TARGET_WINDOWS && TARGET_AMD64
 
         // Find context for the original method

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5144,7 +5144,7 @@ void JIT_Patchpoint(int* counter, int ilOffset)
     const int counterBump = g_pConfig->OSR_CounterBump();
     *counter = counterBump;
 
-#if _DEBUG
+#ifdef _DEBUG
     const int ppId = ppInfo->m_patchpointId;
 #endif
 
@@ -5316,9 +5316,18 @@ void JIT_Patchpoint(int* counter, int ilOffset)
             InitializeContext(pBuffer, contextFlags, &pFrameContext, &contextSize);
         _ASSERTE(success);
 #else // TARGET_WINDOWS && TARGET_AMD64
+
+#ifdef _DEBUG
+        // Temporary change to avoid the frame context being overwritten after
+        // a crash after transition
+        pFrameContext = (CONTEXT*)_alloca(sizeof(CONTEXT) + 0x40000);
+#else
         CONTEXT frameContext;
-        frameContext.ContextFlags = CONTEXT_FULL;
         pFrameContext = &frameContext;
+#endif
+
+        pFrameContext->ContextFlags = CONTEXT_FULL;
+
 #endif // TARGET_WINDOWS && TARGET_AMD64
 
         // Find context for the original method

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5431,7 +5431,7 @@ HCIMPL1(VOID, JIT_PartialCompilationPatchpoint, int ilOffset)
     // Patchpoint identity is the helper return address
     PCODE ip = (PCODE)_ReturnAddress();
 
-#if _DEBUG
+#ifdef _DEBUG
     // Friendly ID number
     int ppId = 0;
 #endif
@@ -5445,7 +5445,7 @@ HCIMPL1(VOID, JIT_PartialCompilationPatchpoint, int ilOffset)
     OnStackReplacementManager* manager = allocator->GetOnStackReplacementManager();
     ppInfo = manager->GetPerPatchpointInfo(ip);
 
-#if _DEBUG
+#ifdef _DEBUG
     ppId = ppInfo->m_patchpointId;
 #endif
 

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5317,7 +5317,7 @@ void JIT_Patchpoint(int* counter, int ilOffset)
         _ASSERTE(success);
 #else // TARGET_WINDOWS && TARGET_AMD64
         CONTEXT frameContext;
-        pFrameContext->ContextFlags = CONTEXT_FULL;
+        frameContext.ContextFlags = CONTEXT_FULL;
         pFrameContext = &frameContext;
 
 #endif // TARGET_WINDOWS && TARGET_AMD64

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -5390,7 +5390,7 @@ void JIT_Patchpoint(int* counter, int ilOffset)
         SetIP(pFrameContext, osrMethodCode);
 
 #ifdef _DEBUG
-        // Keep this context around to aid in debugging OSR transitions problems
+        // Keep this context around to aid in debugging OSR transition problems
         static CONTEXT s_lastOSRTransitionContext;
         s_lastOSRTransitionContext = *pFrameContext;
 #endif


### PR DESCRIPTION
Hopefully will help with diagnosing #101060 once we get a new dump.