### PR TITLE
Collect all `MethodDesc` fields in one place

### DIFF
--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -278,9 +278,6 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__LazyMachState__m_CaptureRip
 ASMCONSTANTS_C_ASSERT(OFFSETOF__LazyMachState__m_CaptureRsp
                     == offsetof(LazyMachState, m_CaptureRsp));
 
-#define               OFFSETOF__MethodDesc__m_wFlags        DBG_FRE(0x2E, 0x06)
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MethodDesc__m_wFlags == offsetof(MethodDesc, m_wFlags));
-
 #define               OFFSETOF__VASigCookie__pNDirectILStub     0x8
 ASMCONSTANTS_C_ASSERT(OFFSETOF__VASigCookie__pNDirectILStub
                     == offsetof(VASigCookie, pNDirectILStub));

--- a/src/coreclr/vm/arm/asmconstants.h
+++ b/src/coreclr/vm/arm/asmconstants.h
@@ -114,13 +114,6 @@ ASMCONSTANTS_C_ASSERT(SIZEOF__FloatArgumentRegisters == sizeof(FloatArgumentRegi
 #define ASM_ENREGISTERED_RETURNTYPE_MAXSIZE 0x20
 ASMCONSTANTS_C_ASSERT(ASM_ENREGISTERED_RETURNTYPE_MAXSIZE == ENREGISTERED_RETURNTYPE_MAXSIZE)
 
-
-#define MethodDesc__m_wFlags DBG_FRE(0x1A, 0x06)
-ASMCONSTANTS_C_ASSERT(MethodDesc__m_wFlags == offsetof(MethodDesc, m_wFlags))
-
-#define MethodDesc__mdcClassification 0x7
-ASMCONSTANTS_C_ASSERT(MethodDesc__mdcClassification == mdcClassification)
-
 #ifdef FEATURE_COMINTEROP
 
 #define Stub__m_pCode DBG_FRE(0x10, 0x0c)

--- a/src/coreclr/vm/classcompat.cpp
+++ b/src/coreclr/vm/classcompat.cpp
@@ -869,7 +869,7 @@ VOID MethodTableBuilder::BuildInteropVTable_PlaceMembers(
         bmtMethod->ppMethodDescList[i] = pNewMD;
 
         // Make sure that fcalls have a 0 rva.  This is assumed by the prejit fixup logic
-        _ASSERTE(((Classification & ~mdcMethodImpl) != mcFCall) || dwDescrOffset == 0);
+        _ASSERTE(((Classification & ~mdfMethodImpl) != mcFCall) || dwDescrOffset == 0);
 
         // Non-virtual method
         if (IsMdStatic(dwMemberAttrs) ||
@@ -938,7 +938,7 @@ VOID MethodTableBuilder::BuildInteropVTable_PlaceMembers(
             }
         }
 
-        if (Classification & mdcMethodImpl)
+        if (Classification & mdfMethodImpl)
         {   // If this method serves as the BODY of a MethodImpl specification, then
         // we should iterate all the MethodImpl's for this class and see just how many
         // of them this method participates in as the BODY.
@@ -2797,7 +2797,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         }
 
         // Generic methods should always be mcInstantiated
-        if (!((numGenericMethodArgs == 0) || ((Classification & mdcClassification) == mcInstantiated)))
+        if (!((numGenericMethodArgs == 0) || ((Classification & mdfClassification) == mcInstantiated)))
         {
             BuildMethodTableThrowException(BFA_GENERIC_METHODS_INST);
         }
@@ -2806,7 +2806,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         // from the overrides.
         for(DWORD impls = 0; impls < bmtMethodImpl->dwNumberMethodImpls; impls++) {
             if ((bmtMethodImpl->rgMethodImplTokens[impls].methodBody == tok) && !IsMdStatic(dwMemberAttrs)) {
-                Classification |= mdcMethodImpl;
+                Classification |= mdfMethodImpl;
                 break;
             }
         }
@@ -2830,7 +2830,7 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
 
         // Set the index into the storage locations
         BYTE impl;
-        if (Classification & mdcMethodImpl)
+        if (Classification & mdfMethodImpl)
         {
             impl = METHOD_IMPL;
         }
@@ -2840,25 +2840,25 @@ VOID    MethodTableBuilder::EnumerateClassMethods()
         }
 
         BYTE type;
-        if ((Classification & mdcClassification)  == mcNDirect)
+        if ((Classification & mdfClassification)  == mcNDirect)
         {
             type = METHOD_TYPE_NDIRECT;
         }
-        else if ((Classification & mdcClassification) == mcFCall)
+        else if ((Classification & mdfClassification) == mcFCall)
         {
             type = METHOD_TYPE_FCALL;
         }
-        else if ((Classification & mdcClassification) == mcEEImpl)
+        else if ((Classification & mdfClassification) == mcEEImpl)
         {
             type = METHOD_TYPE_EEIMPL;
         }
 #ifdef FEATURE_COMINTEROP
-        else if ((Classification & mdcClassification) == mcComInterop)
+        else if ((Classification & mdfClassification) == mcComInterop)
         {
             type = METHOD_TYPE_INTEROP;
         }
 #endif // FEATURE_COMINTEROP
-        else if ((Classification & mdcClassification) == mcInstantiated)
+        else if ((Classification & mdfClassification) == mcInstantiated)
         {
             type = METHOD_TYPE_INSTANTIATED;
         }

--- a/src/coreclr/vm/i386/asmconstants.h
+++ b/src/coreclr/vm/i386/asmconstants.h
@@ -233,13 +233,6 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__FrameHandlerExRecord__m_pEntryFrame == offsetof(
 
 #endif
 
-
-#define MethodDesc_m_wFlags                   DBG_FRE(0x1a, 0x06)
-ASMCONSTANTS_C_ASSERT(MethodDesc_m_wFlags == offsetof(MethodDesc, m_wFlags))
-
-#define MethodDesc_mdcClassification          7
-ASMCONSTANTS_C_ASSERT(MethodDesc_mdcClassification == mdcClassification)
-
 #define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x1C, 0x8)
 ASMCONSTANTS_C_ASSERT(ComPlusCallMethodDesc__m_pComPlusCallInfo == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo))
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -119,11 +119,11 @@ SIZE_T MethodDesc::SizeOf()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    SIZE_T size = s_ClassificationSizeTable[m_wClassification &
-        (mdcClassification
-        | mdcHasNonVtableSlot
-        | mdcMethodImpl
-        | mdcHasNativeCodeSlot)];
+    SIZE_T size = s_ClassificationSizeTable[m_wFlags &
+        (mdfClassification
+        | mdfHasNonVtableSlot
+        | mdfMethodImpl
+        | mdfHasNativeCodeSlot)];
 
     return size;
 }
@@ -799,14 +799,14 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
     }
     CONTRACTL_END;
 
-    WORD    wOldState = m_wClassification;
+    WORD    wOldState = m_wFlags;
     DWORD   dwMask = wMask;
 
     // We need to make this operation atomic (multiple threads can play with the flags field at the same time). But the flags field
     // is a word and we only have interlock operations over dwords. So we round down the flags field address to the nearest aligned
     // dword (along with the intended bitfield mask). Note that we make the assumption that the flags word is aligned itself, so we
     // only have two possibilities: the field already lies on a dword boundary or it's precisely one word out.
-    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wClassification - (offsetof(MethodDesc, m_wClassification) & 0x3));
+    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wFlags - (offsetof(MethodDesc, m_wFlags) & 0x3));
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -814,11 +814,11 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
 #endif // _PREFAST_
 
 #if BIGENDIAN
-    if ((offsetof(MethodDesc, m_wClassification) & 0x3) == 0) {
+    if ((offsetof(MethodDesc, m_wFlags) & 0x3) == 0) {
 #else // !BIGENDIAN
-    if ((offsetof(MethodDesc, m_wClassification) & 0x3) != 0) {
+    if ((offsetof(MethodDesc, m_wFlags) & 0x3) != 0) {
 #endif // !BIGENDIAN
-        static_assert_no_msg(sizeof(m_wClassification) == 2);
+        static_assert_no_msg(sizeof(m_wFlags) == 2);
         dwMask <<= 16;
     }
 #ifdef _PREFAST_
@@ -946,7 +946,7 @@ PTR_PCODE MethodDesc::GetAddrOfNativeCodeSlot()
 
     _ASSERTE(HasNativeCodeSlot());
 
-    SIZE_T size = s_ClassificationSizeTable[m_wClassification & (mdcClassification | mdcHasNonVtableSlot |  mdcMethodImpl)];
+    SIZE_T size = s_ClassificationSizeTable[m_wFlags & (mdfClassification | mdfHasNonVtableSlot |  mdfMethodImpl)];
 
     return (PTR_PCODE)(dac_cast<TADDR>(this) + size);
 }
@@ -2252,7 +2252,7 @@ MethodImpl *MethodDesc::GetMethodImpl()
     }
     CONTRACTL_END
 
-    SIZE_T size = s_ClassificationSizeTable[m_wClassification & (mdcClassification | mdcHasNonVtableSlot)];
+    SIZE_T size = s_ClassificationSizeTable[m_wFlags & (mdfClassification | mdfHasNonVtableSlot)];
 
     return PTR_MethodImpl(dac_cast<TADDR>(this) + size);
 }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -119,7 +119,7 @@ SIZE_T MethodDesc::SizeOf()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    SIZE_T size = s_ClassificationSizeTable[m_wFlags &
+    SIZE_T size = s_ClassificationSizeTable[m_wClassification &
         (mdcClassification
         | mdcHasNonVtableSlot
         | mdcMethodImpl
@@ -799,14 +799,14 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
     }
     CONTRACTL_END;
 
-    WORD    wOldState = m_wFlags;
+    WORD    wOldState = m_wClassification;
     DWORD   dwMask = wMask;
 
     // We need to make this operation atomic (multiple threads can play with the flags field at the same time). But the flags field
     // is a word and we only have interlock operations over dwords. So we round down the flags field address to the nearest aligned
     // dword (along with the intended bitfield mask). Note that we make the assumption that the flags word is aligned itself, so we
     // only have two possibilities: the field already lies on a dword boundary or it's precisely one word out.
-    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wFlags - (offsetof(MethodDesc, m_wFlags) & 0x3));
+    LONG* pdwFlags = (LONG*)((ULONG_PTR)&m_wClassification - (offsetof(MethodDesc, m_wClassification) & 0x3));
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -814,11 +814,11 @@ WORD MethodDesc::InterlockedUpdateFlags(WORD wMask, BOOL fSet)
 #endif // _PREFAST_
 
 #if BIGENDIAN
-    if ((offsetof(MethodDesc, m_wFlags) & 0x3) == 0) {
+    if ((offsetof(MethodDesc, m_wClassification) & 0x3) == 0) {
 #else // !BIGENDIAN
-    if ((offsetof(MethodDesc, m_wFlags) & 0x3) != 0) {
+    if ((offsetof(MethodDesc, m_wClassification) & 0x3) != 0) {
 #endif // !BIGENDIAN
-        static_assert_no_msg(sizeof(m_wFlags) == 2);
+        static_assert_no_msg(sizeof(m_wClassification) == 2);
         dwMask <<= 16;
     }
 #ifdef _PREFAST_
@@ -946,7 +946,7 @@ PTR_PCODE MethodDesc::GetAddrOfNativeCodeSlot()
 
     _ASSERTE(HasNativeCodeSlot());
 
-    SIZE_T size = s_ClassificationSizeTable[m_wFlags & (mdcClassification | mdcHasNonVtableSlot |  mdcMethodImpl)];
+    SIZE_T size = s_ClassificationSizeTable[m_wClassification & (mdcClassification | mdcHasNonVtableSlot |  mdcMethodImpl)];
 
     return (PTR_PCODE)(dac_cast<TADDR>(this) + size);
 }
@@ -2252,7 +2252,7 @@ MethodImpl *MethodDesc::GetMethodImpl()
     }
     CONTRACTL_END
 
-    SIZE_T size = s_ClassificationSizeTable[m_wFlags & (mdcClassification | mdcHasNonVtableSlot)];
+    SIZE_T size = s_ClassificationSizeTable[m_wClassification & (mdcClassification | mdcHasNonVtableSlot)];
 
     return PTR_MethodImpl(dac_cast<TADDR>(this) + size);
 }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -159,9 +159,6 @@ enum MethodDescFlags
     mdfIsIntrinsic                      = 0x8000  // Jit may expand method as an intrinsic
 };
 
-#define METHOD_MAX_RVA                          0x7FFFFFFF
-
-
 // The size of this structure needs to be a multiple of MethodDesc::ALIGNMENT
 //
 // @GENERICS:


### PR DESCRIPTION
Clarify the purpose of a field by renaming.