### PR TITLE
[wasm] Disable interp pgo recording by default since it adds startup overhead

### DIFF
--- a/src/mono/browser/runtime/loader/run.ts
+++ b/src/mono/browser/runtime/loader/run.ts
@@ -158,6 +158,10 @@ export class HostBuilder implements DotnetHostBuilder {
                 interpreterPgo: value,
                 interpreterPgoSaveDelay: autoSaveDelay
             });
+            if (monoConfig.runtimeOptions)
+                monoConfig.runtimeOptions.push("--interp-pgo-recording");
+            else
+                monoConfig.runtimeOptions = ["--interp-pgo-recording"];
             return this;
         } catch (err) {
             mono_exit(1, err);
@@ -268,9 +272,10 @@ export class HostBuilder implements DotnetHostBuilder {
     withRuntimeOptions (runtimeOptions: string[]): DotnetHostBuilder {
         try {
             mono_assert(runtimeOptions && Array.isArray(runtimeOptions), "must be array of strings");
-            deep_merge_config(monoConfig, {
-                runtimeOptions
-            });
+            if (monoConfig.runtimeOptions)
+                monoConfig.runtimeOptions.push(...runtimeOptions);
+            else
+                monoConfig.runtimeOptions = runtimeOptions;
             return this;
         } catch (err) {
             mono_exit(1, err);

--- a/src/mono/mono/utils/options-def.h
+++ b/src/mono/mono/utils/options-def.h
@@ -61,7 +61,7 @@ DEFINE_BOOL(wasm_exceptions, "wasm-exceptions", FALSE, "Enable codegen for WASM 
 DEFINE_BOOL(aot_lazy_assembly_load, "aot-lazy-assembly-load", FALSE, "Load assemblies referenced by AOT images lazily")
 
 #if HOST_BROWSER
-DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", TRUE, "Record interpreter tiering information for automatic PGO")
+DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", FALSE, "Record interpreter tiering information for automatic PGO")
 #else
 DEFINE_BOOL(interp_pgo_recording, "interp-pgo-recording", FALSE, "Record interpreter tiering information for automatic PGO")
 DEFINE_BOOL(wasm_gc_safepoints, "wasm-gc-safepoints", FALSE, "Use GC safepoints on WASM")

--- a/src/mono/sample/wasm/browser-bench/main.js
+++ b/src/mono/sample/wasm/browser-bench/main.js
@@ -225,11 +225,6 @@ try {
         //  console to see statistics on how much code it generated and whether any new opcodes
         //  are causing traces to fail to compile
         .withRuntimeOptions(["--jiterpreter-stats-enabled"])
-        // We enable interpreter PGO so that you can exercise it in local tests, i.e.
-        //  run browser-bench one, then refresh the tab to measure the performance improvement
-        //  on the second run of browser-bench. The overall speed of the benchmarks won't
-        //  improve much, but the time spent generating code during the run will go down
-        .withInterpreterPgo(true, 30)
         .withElementOnExit()
         .withExitCodeLogging()
         .create();

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -37,7 +37,7 @@ switch (testCase) {
             let alreadyFailed = [];
             dotnet.withDiagnosticTracing(true).withResourceLoader((type, name, defaultUri, integrity, behavior) => {
                 if (type === "dotnetjs") {
-                    // loadBootResource could return string with unqualified name of resource. 
+                    // loadBootResource could return string with unqualified name of resource.
                     // It assumes that we resolve it with document.baseURI
                     // we test it here
                     return `_framework/${name}`;
@@ -81,7 +81,7 @@ switch (testCase) {
     case "InterpPgoTest":
         dotnet
             .withConsoleForwarding()
-            .withRuntimeOptions(['--interp-pgo-logging'])
+            .withRuntimeOptions(['--interp-pgo-logging', '--interp-pgo-recording'])
             .withInterpreterPgo(true);
         break;
 }
@@ -131,8 +131,8 @@ try {
                 }
             });
             const iterationCount = params.get("iterationCount") ?? 70;
-            for (let i = 0; i < iterationCount; i++) { 
-                exports.InterpPgoTest.Greeting(); 
+            for (let i = 0; i < iterationCount; i++) {
+                exports.InterpPgoTest.Greeting();
             };
             await INTERNAL.interp_pgo_save_data();
             exit(0);

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -81,7 +81,7 @@ switch (testCase) {
     case "InterpPgoTest":
         dotnet
             .withConsoleForwarding()
-            .withRuntimeOptions(['--interp-pgo-logging', '--interp-pgo-recording'])
+            .withRuntimeOptions(['--interp-pgo-logging'])
             .withInterpreterPgo(true);
         break;
 }


### PR DESCRIPTION
During startup for interpreted blazor we seem to spend a small but notable amount of time in here even if interp PGO isn't actually enabled. It's possible to set runtime options at startup, so anyone who wants to use interp PGO can just change this option in their app config, I think.

Open as draft for now because I think this will make a WBT fail.