### PR TITLE
Updated coding-style.md to point to the new dotnet format repo

### DIFF
--- a/docs/coding-guidelines/coding-style.md
+++ b/docs/coding-guidelines/coding-style.md
@@ -36,7 +36,7 @@ The general rule we follow is "use Visual Studio defaults".
 
 An [EditorConfig](https://editorconfig.org "EditorConfig homepage") file (`.editorconfig`) has been provided at the root of the runtime repository, enabling C# auto-formatting conforming to the above guidelines.
 
-We also use the [.NET Codeformatter Tool](https://github.com/dotnet/codeformatter) to ensure the code base maintains a consistent style over time, the tool automatically fixes the code base to conform to the guidelines outlined above.
+We also use the [dotnet-format Tool](https://github.com/dotnet/format) to ensure the code base maintains a consistent style over time, the tool automatically fixes the code base to conform to the guidelines outlined above.
 
 ### Example File:
 


### PR DESCRIPTION
I updated the coding-style.md file to point to the new repo for the dotnet format command/tool. I'm not sure if you still use the old codeformatter tool, but I found it a bit odd when I was looking at the coding-style.md file that it linked to a archived/deprecated project so I chose to update the link since I couldn't find any pr's rejected on this subject.