### PR TITLE
With system brotli, do not use versioned symbols

### DIFF
--- a/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/native/libs/System.IO.Compression.Native/CMakeLists.txt
@@ -66,7 +66,7 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
             ${NATIVE_LIBS_EXTRA}
         )
 
-        if (NOT CLR_CMAKE_TARGET_MACCATALYST AND NOT CLR_CMAKE_TARGET_IOS AND NOT CLR_CMAKE_TARGET_TVOS AND NOT CLR_CMAKE_TARGET_ANDROID)
+        if (NOT CLR_CMAKE_TARGET_MACCATALYST AND NOT CLR_CMAKE_TARGET_IOS AND NOT CLR_CMAKE_TARGET_TVOS AND NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE_USE_SYSTEM_BROTLI)
             set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/System.IO.Compression.Native_unixexports.src)
             set(EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/System.IO.Compression.Native.exports)
             generate_exports_file(${DEF_SOURCES} ${EXPORTS_FILE})
@@ -78,16 +78,14 @@ if (CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_BROWSER OR CLR_CMAKE_TARGET_WASI)
             set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_FLAGS ${EXPORTS_LINKER_OPTION})
             set_property(TARGET System.IO.Compression.Native APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
 
-            if (NOT CLR_CMAKE_USE_SYSTEM_BROTLI)
-                add_custom_command(TARGET System.IO.Compression.Native POST_BUILD
-                    COMMENT "Verifying System.IO.Compression.Native entry points against entrypoints.c "
-                    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-entrypoints.sh
-                        $<TARGET_FILE:System.IO.Compression.Native>
-                        ${CMAKE_CURRENT_SOURCE_DIR}/entrypoints.c
-                        ${CMAKE_NM}
-                    VERBATIM
-                )
-            endif ()
+            add_custom_command(TARGET System.IO.Compression.Native POST_BUILD
+                COMMENT "Verifying System.IO.Compression.Native entry points against entrypoints.c "
+                COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/../verify-entrypoints.sh
+                    $<TARGET_FILE:System.IO.Compression.Native>
+                    ${CMAKE_CURRENT_SOURCE_DIR}/entrypoints.c
+                    ${CMAKE_NM}
+                VERBATIM
+            )
         endif ()
 
         install_with_stripped_symbols (System.IO.Compression.Native PROGRAMS .)


### PR DESCRIPTION
The system version of libbrotli has symbols without the `V1.0` version. Support linking against that by removing the steps to use the versioned exports file.

Without this fix, the build only works with bfd linker (I am not sure how). When lld is used, the build errors out:

	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliDecoderCreateInstance' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliDecoderDecompress' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliDecoderDecompressStream' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliDecoderDestroyInstance' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliDecoderIsFinished' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderCompress' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderCompressStream' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderCreateInstance' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderDestroyInstance' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderHasMoreOutput' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	ld.lld : error : version script assignment of 'V1.0' to symbol 'BrotliEncoderSetParameter' failed: symbol not defined [runtime/src/native/libs/build-native.proj]
	clang-18 : error : linker command failed with exit code 1 (use -v to see invocation) [runtime/src/native/libs/build-native.proj]

I was able to reproduce this issue with clang and lld 18 installed and by running:

    ./build.sh --cmakeargs -DCLR_CMAKE_USE_SYSTEM_BROTLI=true