### PR TITLE
Backport #89953, #91658 and #91643 to release/8.0-staging

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -265,8 +265,8 @@ jobs:
         PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
         PublishLocation: Container
         ${{ if notin(parameters.osGroup, 'browser', 'wasi') }}:
-          ArtifactName: Logs_Build_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
+          ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
         ${{ if in(parameters.osGroup, 'browser', 'wasi') }}:
-          ArtifactName: Logs_Build_${{ parameters.osGroup }}_${{ parameters.archType }}_${{ parameters.hostedOs }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
+          ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.archType }}_${{ parameters.hostedOs }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
       continueOnError: true
       condition: always()

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -149,6 +149,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_AnyOS_AnyCPU_$(buildConfig)_${{ parameters.testGroup }}'
+        artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_Attempt$(System.JobAttempt)_AnyOS_AnyCPU_$(buildConfig)_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -603,7 +603,7 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '${{ parameters.runtimeFlavor }}_${{ parameters.runtimeVariant }}_$(LogNamePrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
+        artifactName: '${{ parameters.runtimeFlavor }}_${{ parameters.runtimeVariant }}_$(LogNamePrefix)_Attempt$(System.JobAttempt)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()
 

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -341,11 +341,7 @@ jobs:
 
         timeoutPerTestInMinutes: $(timeoutPerTestInMinutes)
         timeoutPerTestCollectionInMinutes: $(timeoutPerTestCollectionInMinutes)
-
         runCrossGen2: ${{ eq(parameters.readyToRun, true) }}
-        ${{ if and(ne(parameters.testGroup, 'innerloop'), eq(parameters.runtimeFlavor, 'coreclr')) }}:
-          runPALTestsDir: '$(coreClrProductRootFolderPath)/paltests'
-
         compositeBuildMode: ${{ parameters.compositeBuildMode }}
         runInUnloadableContext: ${{ parameters.runInUnloadableContext }}
         tieringTest: ${{ parameters.tieringTest }}

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -17,7 +17,6 @@ parameters:
   timeoutPerTestCollectionInMinutes: ''
   timeoutPerTestInMinutes: ''
   runCrossGen2: ''
-  runPALTestsDir: ''
   compositeBuildMode: false
   helixProjectArguments: ''
   runInUnloadableContext: ''
@@ -58,7 +57,6 @@ steps:
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}
       _Scenarios: ${{ join(',', parameters.scenarios) }}
-      _PALTestsDir: ${{ parameters.runPALTestsDir }}
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       RuntimeFlavor: ${{ parameters.runtimeFlavor }}

--- a/eng/pipelines/coreclr/ci.yml
+++ b/eng/pipelines/coreclr/ci.yml
@@ -155,3 +155,23 @@ extends:
             readyToRun: true
             displayNameArgs: R2R_CG2
             liveLibrariesBuildConfig: Release
+
+      #
+      # PAL Tests
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: Debug
+          platforms:
+          - linux_x64
+          - linux_musl_x64
+          - linux_arm64
+          - linux_musl_arm64
+          - osx_x64
+          - osx_arm64
+          jobParameters:
+            buildArgs: -s clr.paltests+clr.paltestlist
+            nameSuffix: PALTests
+            extraStepsTemplate: /eng/pipelines/coreclr/templates/run-paltests-step.yml

--- a/eng/pipelines/coreclr/templates/build-jit-job.yml
+++ b/eng/pipelines/coreclr/templates/build-jit-job.yml
@@ -132,6 +132,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '$(publishLogsArtifactPrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        artifactName: '$(publishLogsArtifactPrefix)_Attempt$(System.JobAttempt)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -292,6 +292,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '$(publishLogsArtifactPrefix)${{ parameters.pgoType }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        artifactName: '$(publishLogsArtifactPrefix)_Attempt$(System.JobAttempt)_${{ parameters.pgoType }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -94,7 +94,7 @@ jobs:
       value: ''
     - ${{ if ne(parameters.testGroup, 'innerloop') }}:
       - name: clrRuntimeComponentsBuildArg
-        value: '-component runtime -component alljits -component paltests -component nativeaot -component spmi '
+        value: '-component runtime -component alljits -component nativeaot -component spmi '
 
     - name: pgoInstrumentArg
       value: ''
@@ -192,7 +192,7 @@ jobs:
         displayName: Disk Usage after Build
 
     # Build CoreCLR Managed Components
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages+clr.paltestlist $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
       displayName: Build managed product components and packages
 
     # Build native test components

--- a/eng/pipelines/coreclr/templates/crossdac-pack.yml
+++ b/eng/pipelines/coreclr/templates/crossdac-pack.yml
@@ -70,6 +70,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'CrossDacPackagingLogs'
+        artifactName: 'CrossDacPackagingLogs_Attempt$(System.JobAttempt)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/run-paltests-step.yml
+++ b/eng/pipelines/coreclr/templates/run-paltests-step.yml
@@ -1,0 +1,23 @@
+parameters:
+  continueOnError: 'false'        # optional -- determines whether to continue the build if the step errors
+  helixQueues: ''                 # required -- Helix queues
+  buildConfig: ''                 # required -- build configuration
+  archType: ''                    # required -- targeting CPU architecture
+  osGroup: ''                     # required -- operating system for the job
+  osSubgroup: ''                  # optional -- operating system subgroup
+  dependOnEvaluatePaths: false
+
+steps:
+  - template: /eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+    parameters:
+      displayName: 'Send job to Helix'
+      helixBuild: $(Build.BuildNumber)
+      helixSource: $(_HelixSource)
+      helixType: 'build/tests/'
+      helixQueues: ${{ parameters.helixQueues }}
+      creator: dotnet-bot
+      helixProjectArguments: '$(Build.SourcesDirectory)/src/coreclr/scripts/paltests.proj'
+      BuildConfig: ${{ parameters.buildConfig }}
+      osGroup: ${{ parameters.osGroup }}
+      archType: ${{ parameters.archType }}
+      shouldContinueOnError: ${{ parameters.continueOnError }}

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -86,18 +86,26 @@ jobs:
     - name: OfficialBuildArg
       value: ''
 
+    # Explicitly enable tests for linux even though it is a cross build using mariner
+    # They still work in this configuration and until they run on Helix, it is our only
+    # linux test coverage in the installer pipeline
     - name: SkipTests
       value: ${{ or(
         not(in(parameters.archType, 'x64', 'x86')),
         eq(parameters.runtimeFlavor, 'mono'),
         eq(parameters.isOfficialBuild, true),
-        eq(parameters.crossBuild, true),
+        and(
+          eq(parameters.crossBuild, true),
+          not(and(
+            eq(parameters.osGroup, 'linux'),
+            eq(parameters.osSubgroup, ''))
+          )),
         eq(parameters.pgoType, 'PGO')) }}
 
     - name: BuildAction
       value: -test
 
-    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), eq(parameters.crossBuild, true), eq(parameters.pgoType, 'PGO')), true) }}:
+    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), and(eq(parameters.crossBuild, true), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '')))), eq(parameters.pgoType, 'PGO')), true) }}:
       - name: BuildAction
         value: ''
 
@@ -405,6 +413,7 @@ jobs:
           runtimeVariant: ${{ parameters.runtimeVariant }}
           isOfficialBuild: ${{ eq(parameters.isOfficialBuild, true) }}
           pgoType: ${{ parameters.pgoType }}
+          skipTests: ${{ eq(variables.SkipTests, true) }}
 
       - ${{ if ne(parameters.osGroup, 'windows') }}:
         - script: set -x && df -h

--- a/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
@@ -71,6 +71,6 @@ steps:
   displayName: Publish BuildLogs
   inputs:
     targetPath: '$(Build.StagingDirectory)/BuildLogs'
-    artifactName: Installer-Logs-${{parameters.pgoType }}${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
+    artifactName: Installer-Logs_Attempt$(System.JobAttempt)-${{parameters.pgoType }}${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: always()

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -180,6 +180,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'BuildLogs_Mono_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        artifactName: 'BuildLogs_Attempt$(System.JobAttempt)_Mono_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/mono/templates/generate-offsets.yml
+++ b/eng/pipelines/mono/templates/generate-offsets.yml
@@ -87,6 +87,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'BuildLogs_Mono_Offsets_$(osGroup)$(osSubGroup)'
+        artifactName: 'BuildLogs_Attempt$(System.JobAttempt)_Mono_Offsets_$(osGroup)$(osSubGroup)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -96,7 +96,7 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'WorkloadLogs'
+        artifactName: 'WorkloadLogs_Attempt$(System.JobAttempt)'
       continueOnError: true
       condition: always()
 

--- a/src/coreclr/scripts/paltests.proj
+++ b/src/coreclr/scripts/paltests.proj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.DotNet.Helix.Sdk" DefaultTargets="Test">
+  <PropertyGroup>
+    <EnableXUnitReporter>true</EnableXUnitReporter>
+    <Creator>$(_Creator)</Creator>
+    <HelixAccessToken>$(_HelixAccessToken)</HelixAccessToken>
+    <HelixBuild>$(_HelixBuild)</HelixBuild>
+    <HelixSource>$(_HelixSource)</HelixSource>
+    <HelixTargetQueues>$(_HelixTargetQueues)</HelixTargetQueues>
+    <HelixType>$(_HelixType)</HelixType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PalTest Include="$(CoreClrArtifactsPath)/paltests/**/*" />
+    <PalTestArchive Include="$(OutputPath)paltests.tar.gz" />
+  </ItemGroup>
+
+  <Target
+    Name="PrepareArchive"
+    Inputs="@(PalTest)"
+    Outputs="@(PalTestArchive)">
+    <MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')"/>
+    <!--
+      We need to preserve the permission bits on the PAL tests.
+      Helix's default archive of Zip files does not preserve these bits,
+      so we'll manually make a tarball and upload that instead.
+     -->
+    <Exec
+          WorkingDirectory="$(CoreCLRArtifactsPath)/paltests"
+          Command="tar -czvf $(OutputPath)paltests.tar.gz `ls -A`"/>
+  </Target>
+
+  <Target
+    Name="AddWorkItem"
+    BeforeTargets="CoreTest"
+    DependsOnTargets="PrepareArchive">
+    <ItemGroup>
+      <HelixWorkItem Include="PALTests">
+        <PayloadArchive>@(PalTestArchive)</PayloadArchive>
+        <Command>./runpaltestshelix.sh</Command>
+        <Timeout>0:10</Timeout>
+      </HelixWorkItem>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -46,7 +46,6 @@
     <_RuntimeVariant></_RuntimeVariant>
     <BundledNETCoreAppPackageVersion>BundledNETCoreAppPackageVersion</BundledNETCoreAppPackageVersion>
     <HelixRuntimeRid></HelixRuntimeRid>
-    <_PALTestsDir></_PALTestsDir>
     <_SuperPmiCollect>false</_SuperPmiCollect>
   </PropertyGroup>
   <Target Name="printItems">
@@ -105,7 +104,6 @@
         RuntimeVariant=$(_RuntimeVariant);
         BundledNETCoreAppPackageVersion=$(BundledNETCoreAppPackageVersion);
         HelixRuntimeRid=$(HelixRuntimeRid);
-        PALTestsDir=$(_PALTestsDir);
         SuperPmiCollect=$(_SuperPmiCollect)
       </_PropertiesToPass>
 
@@ -132,7 +130,6 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PrepareCorrelationPayloadDirectory" Properties="$(_PropertiesToPass)" />
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePayloadDirectories" Properties="$(_PropertiesToPass)" StopOnFirstFailure="true" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="PreparePALTestArchive" Properties="$(_PropertiesToPass)" StopOnFirstFailure="true" />
 
     <ItemGroup>
       <_Scenarios Include="$(_Scenarios.Split(','))" />
@@ -322,12 +319,6 @@
     </ItemGroup>
 
     <MSBuild Projects="@(_ProjectsToBuild)" Targets="CreateTestEnvFile" StopOnFirstFailure="true" />
-  </Target>
-
-  <Target Name="PreparePALTestArchive">
-    <Exec Condition="'$(PALTestsDir)' != '' and '$(TestWrapperTargetsWindows)' != 'true'"
-          WorkingDirectory="$(PALTestsDir)"
-          Command="tar -czvf $(LegacyPayloadsRootDirectory)paltests.tar.gz `ls -A`"/>
   </Target>
 
   <Target Name="PreparePayloadDirectories" DependsOnTargets="PrepareMergedTestPayloadDirectories;PrepareLegacyPayloadDirectories" />
@@ -929,12 +920,6 @@
       <TestTarget>$(AppleTestTarget)</TestTarget>
       <TestTimeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</TestTimeout>
     </XHarnessAppBundleToTest>
-
-    <HelixWorkItem Condition="'$(PALTestsDir)' != '' and '$(TestWrapperTargetsWindows)' != 'true'" Include="PALTests">
-      <PayloadArchive>$(LegacyPayloadsRootDirectory)paltests.tar.gz</PayloadArchive>
-      <Command>$(_WorkaroundForNuGetMigrationsForPrepending) ./runpaltestshelix.sh</Command>
-      <Timeout Condition=" '$(TimeoutPerTestCollectionInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestCollectionInMinutes)))</Timeout>
-    </HelixWorkItem>
   </ItemGroup>
 
   <Import Sdk="Microsoft.DotNet.Helix.Sdk" Project="Sdk.targets" Condition=" '$(UsesHelixSdk)' == 'true' " />


### PR DESCRIPTION
This is part of the work to transition to the 1ES templates.

These PRs are relatively small and could be cherry-picked without any conflict, they will allow to almost cleanly backport https://github.com/dotnet/runtime/pull/92296.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2438904&view=results

cc @agocke @jkoritzinsky @amanasifkhalid 