### PR TITLE
Fix dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
-registries:
-  public-nuget:
-    type: nuget-feed
-    url: https://api.nuget.org/v3/index.json
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot rejects entries in `registries:` that don't have a matching entry in `updates:`

How this happened: the version I added in https://github.com/dotnet/runtime/pull/101406 was through error not the one I had tested in my fork. I've confirmed this one works and [creates PR's](https://github.com/danmoseley/runtime/pulls)