### PR TITLE
Try to reduce cost of Async

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs
@@ -102,6 +102,12 @@ namespace System.Runtime.CompilerServices
             return sb.ToString();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static void LogTraceOperationBegin(Task t, Type stateMachineType)
+        {
+            TplEventSource.Log.TraceOperationBegin(t.Id, "Async: " + stateMachineType.Name, 0);
+        }
+
         internal static Action CreateContinuationWrapper(Action continuation, Action<Action, Task> invokeAction, Task innerTask) =>
             new ContinuationWrapper(continuation, invokeAction, innerTask).Invoke;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -157,6 +157,8 @@ namespace System.Runtime.CompilerServices
         {
             ExecutionContext? currentContext = ExecutionContext.Capture();
 
+            IAsyncStateMachineBox result;
+
             // Check first for the most common case: not the first yield in an async method.
             // In this case, the first yield will have already "boxed" the state machine in
             // a strongly-typed manner into an AsyncStateMachineBox.  It will already contain
@@ -168,9 +170,8 @@ namespace System.Runtime.CompilerServices
                 {
                     stronglyTypedBox.Context = currentContext;
                 }
-                return stronglyTypedBox;
+                result = stronglyTypedBox;
             }
-
             // The least common case: we have a weakly-typed boxed.  This results if the debugger
             // or some other use of reflection accesses a property like ObjectIdForDebugger or a
             // method like SetNotificationForWaitCompletion prior to the first await happening.  In
@@ -180,64 +181,67 @@ namespace System.Runtime.CompilerServices
             // result in a boxing allocation when storing the TStateMachine if it's a struct, but
             // this only happens in active debugging scenarios where such performance impact doesn't
             // matter.
-            if (taskField is AsyncStateMachineBox<IAsyncStateMachine> weaklyTypedBox)
+            else if (taskField is AsyncStateMachineBox<IAsyncStateMachine> weaklyTypedBox)
             {
                 // If this is the first await, we won't yet have a state machine, so store it.
                 if (weaklyTypedBox.StateMachine == null)
                 {
                     Debugger.NotifyOfCrossThreadDependency(); // same explanation as with usage below
-                    weaklyTypedBox.StateMachine = stateMachine;
+                    weaklyTypedBox.StateMachine = Unsafe.As<IAsyncStateMachine>(RuntimeHelpers.Box(ref Unsafe.As<TStateMachine, byte>(ref stateMachine), typeof(TStateMachine).TypeHandle));
                 }
 
                 // Update the context.  This only happens with a debugger, so no need to spend
                 // extra IL checking for equality before doing the assignment.
                 weaklyTypedBox.Context = currentContext;
-                return weaklyTypedBox;
+                result = weaklyTypedBox;
             }
+            else
+            {
+                // Alert a listening debugger that we can't make forward progress unless it slips threads.
+                // If we don't do this, and a method that uses "await foo;" is invoked through funceval,
+                // we could end up hooking up a callback to push forward the async method's state machine,
+                // the debugger would then abort the funceval after it takes too long, and then continuing
+                // execution could result in another callback being hooked up.  At that point we have
+                // multiple callbacks registered to push the state machine, which could result in bad behavior.
+                Debugger.NotifyOfCrossThreadDependency();
 
-            // Alert a listening debugger that we can't make forward progress unless it slips threads.
-            // If we don't do this, and a method that uses "await foo;" is invoked through funceval,
-            // we could end up hooking up a callback to push forward the async method's state machine,
-            // the debugger would then abort the funceval after it takes too long, and then continuing
-            // execution could result in another callback being hooked up.  At that point we have
-            // multiple callbacks registered to push the state machine, which could result in bad behavior.
-            Debugger.NotifyOfCrossThreadDependency();
-
-            // At this point, taskField should really be null, in which case we want to create the box.
-            // However, in a variety of debugger-related (erroneous) situations, it might be non-null,
-            // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-initialized
-            // as a Task<TResult> rather than as an AsyncStateMachineBox.  The worst that happens in such
-            // cases is we lose the ability to properly step in the debugger, as the debugger uses that
-            // object's identity to track this specific builder/state machine.  As such, we proceed to
-            // overwrite whatever's there anyway, even if it's non-null.
+                // At this point, taskField should really be null, in which case we want to create the box.
+                // However, in a variety of debugger-related (erroneous) situations, it might be non-null,
+                // e.g. if the Task property is examined in a Watch window, forcing it to be lazily-initialized
+                // as a Task<TResult> rather than as an AsyncStateMachineBox.  The worst that happens in such
+                // cases is we lose the ability to properly step in the debugger, as the debugger uses that
+                // object's identity to track this specific builder/state machine.  As such, we proceed to
+                // overwrite whatever's there anyway, even if it's non-null.
 #if NATIVEAOT
-            // DebugFinalizableAsyncStateMachineBox looks like a small type, but it actually is not because
-            // it will have a copy of all the slots from its parent. It will add another hundred(s) bytes
-            // per each async method in NativeAOT binaries without adding much value. Avoid
-            // generating this extra code until a better solution is implemented.
-            var box = new AsyncStateMachineBox<TStateMachine>();
+                // DebugFinalizableAsyncStateMachineBox looks like a small type, but it actually is not because
+                // it will have a copy of all the slots from its parent. It will add another hundred(s) bytes
+                // per each async method in NativeAOT binaries without adding much value. Avoid
+                // generating this extra code until a better solution is implemented.
+                var box = new AsyncStateMachineBox<TStateMachine>();
 #else
-            AsyncStateMachineBox<TStateMachine> box = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
-                CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>() :
-                new AsyncStateMachineBox<TStateMachine>();
+                AsyncStateMachineBox<TStateMachine> box = AsyncMethodBuilderCore.TrackAsyncMethodCompletion ?
+                    CreateDebugFinalizableAsyncStateMachineBox<TStateMachine>() :
+                    new AsyncStateMachineBox<TStateMachine>();
 #endif
-            taskField = box; // important: this must be done before storing stateMachine into box.StateMachine!
-            box.StateMachine = stateMachine;
-            box.Context = currentContext;
+                taskField = box; // important: this must be done before storing stateMachine into box.StateMachine!
+                box.StateMachine = stateMachine;
+                box.Context = currentContext;
 
-            // Log the creation of the state machine box object / task for this async method.
-            if (TplEventSource.Log.IsEnabled())
-            {
-                TplEventSource.Log.TraceOperationBegin(box.Id, "Async: " + stateMachine.GetType().Name, 0);
+                // Log the creation of the state machine box object / task for this async method.
+                if (TplEventSource.Log.IsEnabled())
+                {
+                    AsyncMethodBuilderCore.LogTraceOperationBegin(box, stateMachine.GetType());
+                }
+
+                // And if async debugging is enabled, track the task.
+                if (Threading.Tasks.Task.s_asyncDebuggingEnabled)
+                {
+                    Threading.Tasks.Task.AddToActiveTasks(box);
+                }
+                result = box;
             }
 
-            // And if async debugging is enabled, track the task.
-            if (Threading.Tasks.Task.s_asyncDebuggingEnabled)
-            {
-                Threading.Tasks.Task.AddToActiveTasks(box);
-            }
-
-            return box;
+            return result;
         }
 
 #if !NATIVEAOT

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -187,7 +187,7 @@ namespace System.Runtime.CompilerServices
                 if (weaklyTypedBox.StateMachine == null)
                 {
                     Debugger.NotifyOfCrossThreadDependency(); // same explanation as with usage below
-                    weaklyTypedBox.StateMachine = Unsafe.As<IAsyncStateMachine>(RuntimeHelpers.Box(ref Unsafe.As<TStateMachine, byte>(ref stateMachine), typeof(TStateMachine).TypeHandle));
+                    weaklyTypedBox.StateMachine = stateMachine;
                 }
 
                 // Update the context.  This only happens with a debugger, so no need to spend


### PR DESCRIPTION
Contributes to #79204.

I don't know if this will be considered mergeable, but I wanted to at least try something. For apps that use async a lot (like the Stage2 app we use for Goldilocks), the async infrastructure can cost 10% of the entire executable.

Shuffling a couple things in `GetStateMachineBox` I was able to get 0.23% saving. It's miniscule. In general async is death by a thousand papercuts so I don't see a silver bullet.

<details>

<summary>Click to expand existing assembly</summary>

```asm
    TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>:
00000001`40983370 4156               push    r14
00000001`40983372 57                 push    rdi
00000001`40983373 56                 push    rsi
00000001`40983374 55                 push    rbp
00000001`40983375 53                 push    rbx
00000001`40983376 4883ec20           sub     rsp, 20h
00000001`4098337a 488bf1             mov     rsi, stateMachine (rcx)
00000001`4098337d 488bda             mov     rbx, taskField (rdx)
00000001`40983380 e8eb68aaff         call    TodosApi!System.Threading.ExecutionContext__Capture (140429c70)
00000001`40983385 488be8             mov     rbp, rax
00000001`40983388 488b3b             mov     rdi, qword ptr [taskField (rbx)]
00000001`4098338b 4885ff             test    rdi, rdi
00000001`4098338e 742c               je      TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x4c (1409833bc)
00000001`40983390 488d0df93f3e00     lea     rcx, [TodosApi!??_7System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1_AsyncStateMachineBox`1<System.Threading.Tasks.VoidTaskResult__S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>@@6B@ (140d67390)]
00000001`40983397 48390f             cmp     qword ptr [rdi], rcx
00000001`4098339a 7520               jne     TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x4c (1409833bc)
00000001`4098339c 48396f10           cmp     qword ptr [stronglyTypedBox (rdi)+10h], currentContext (rbp)
00000001`409833a0 740c               je      TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x3e (1409833ae)
00000001`409833a2 488d4f10           lea     rcx, [stronglyTypedBox (rdi)+10h]
00000001`409833a6 488bd5             mov     rdx, rbp
00000001`409833a9 e8921a69ff         call    TodosApi!RhpAssignRefAVLocation (140014e40)
00000001`409833ae 488bc7             mov     rax, rdi
00000001`409833b1 4883c420           add     rsp, 20h
00000001`409833b5 5b                 pop     rbx
00000001`409833b6 5d                 pop     rbp
00000001`409833b7 5e                 pop     rsi
00000001`409833b8 5f                 pop     rdi
00000001`409833b9 415e               pop     r14
00000001`409833bb c3                 ret     
00000001`409833bc 4c8b33             mov     r14, qword ptr [taskField (rbx)]
00000001`409833bf 4d85f6             test    r14, r14
00000001`409833c2 7461               je      TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0xb5 (140983425)
00000001`409833c4 488d0d7d193e00     lea     rcx, [TodosApi!??_7System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1_AsyncStateMachineBox`1<System.Threading.Tasks.VoidTaskResult__System.Runtime.CompilerServices.IAsyncStateMachine>@@6B@ (140d64d48)]
00000001`409833cb 49390e             cmp     qword ptr [r14], rcx
00000001`409833ce 7555               jne     TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0xb5 (140983425)
00000001`409833d0 49837e4000         cmp     qword ptr [weaklyTypedBox (r14)+40h], 0
00000001`409833d5 7534               jne     TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x9b (14098340b)
00000001`409833d7 488d0d1a622a00     lea     rcx, [TodosApi!Boxed_S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100::`vftable' (140c295f8)]
00000001`409833de e84d1869ff         call    TodosApi!RhpNewFast (140014c30)
00000001`409833e3 488bd0             mov     rdx, rax
00000001`409833e3 488bd0             mov     rdx, rax
00000001`409833e6 488d7a08           lea     rdi, [rdx+8]
00000001`409833ea e8411c69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`409833ef e83c1c69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`409833f4 48a5               movs    qword ptr [rdi], qword ptr [rsi]
00000001`409833f6 e8351c69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`409833fb e8301c69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`40983400 48a5               movs    qword ptr [rdi], qword ptr [rsi]
00000001`40983402 498d4e40           lea     rcx, [weaklyTypedBox (r14)+40h]
00000001`40983406 e8351a69ff         call    TodosApi!RhpAssignRefAVLocation (140014e40)
00000001`4098340b 498d4e10           lea     rcx, [weaklyTypedBox (r14)+10h]
00000001`4098340f 488bd5             mov     rdx, rbp
00000001`40983412 e8291a69ff         call    TodosApi!RhpAssignRefAVLocation (140014e40)
00000001`40983417 498bc6             mov     rax, r14
00000001`4098341a 4883c420           add     rsp, 20h
00000001`4098341e 5b                 pop     rbx
00000001`4098341f 5d                 pop     rbp
00000001`40983420 5e                 pop     rsi
00000001`40983421 5f                 pop     rdi
00000001`40983422 415e               pop     r14
00000001`40983424 c3                 ret     
00000001`40983425 488d0d643f3e00     lea     rcx, [TodosApi!??_7System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1_AsyncStateMachineBox`1<System.Threading.Tasks.VoidTaskResult__S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>@@6B@ (140d67390)]
00000001`4098342c e8ff1769ff         call    TodosApi!RhpNewFast (140014c30)
00000001`40983431 4c8bf0             mov     r14, rax
00000001`40983434 41c7463400040002   mov     dword ptr [r14+34h], 2000400h
00000001`4098343c 41814e3400080000   or      dword ptr [r14+34h], 800h
00000001`40983444 488bcb             mov     rcx, rbx
00000001`40983447 498bd6             mov     rdx, r14
00000001`4098344a e8611a69ff         call    TodosApi!RhpCheckedAssignRefAVLocation (140014eb0)
00000001`4098344f 498d7e40           lea     rdi, [r14+40h]
00000001`40983453 e8d81b69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`40983458 e8d31b69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`4098345d 48a5               movs    qword ptr [rdi], qword ptr [rsi]
00000001`4098345f e8cc1b69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`40983464 e8c71b69ff         call    TodosApi!RhpByRefAssignRefAVLocation1 (140015030)
00000001`40983469 48a5               movs    qword ptr [rdi], qword ptr [rsi]
00000001`4098346b 498d4e10           lea     rcx, [r14+10h]
00000001`4098346f 488bd5             mov     rdx, rbp
00000001`40983472 e8c91969ff         call    TodosApi!RhpAssignRefAVLocation (140014e40)
00000001`40983477 488d0dea6f1f00     lea     rcx, [TodosApi!?__NONGCSTATICS@System.Threading.Tasks.TplEventSource@@ (140b7a468)]
00000001`4098347e 488379f800         cmp     qword ptr [rcx-8], 0
00000001`40983483 7559               jne     TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x16e (1409834de)
00000001`40983485 488b0d94b0c400     mov     rcx, qword ptr [TodosApi!?__GCSTATICS@System.Threading.Tasks.TplEventSource@@ (1415ce520)]
00000001`4098348c 488b5908           mov     rbx, qword ptr [rcx+8]
00000001`40983490 80bb9d00000000     cmp     byte ptr [rbx+9Dh], 0
00000001`40983497 7437               je      TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x160 (1409834d0)
00000001`40983499 498bce             mov     rcx, r14
00000001`4098349c e83f27abff         call    TodosApi!System.Threading.Tasks.Task__get_Id (140435be0)
00000001`409834a1 8bf0               mov     esi, eax
00000001`409834a3 488d0de68c1a00     lea     rcx, [TodosApi!__RuntimeType_S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100 (140b2c190)]
00000001`409834aa e85161a4ff         call    TodosApi!System.RuntimeType__get_Name (1403c9600)
00000001`409834af 488bd0             mov     rdx, rax
00000001`409834b2 488d0dff5c0e00     lea     rcx, [TodosApi!__Str_Async___4E51D638FE527E2B0672DE04B6E5F6B84BA81E64E12AA0136B0691A50E6F80FE (140a691b8)]
00000001`409834b9 e89285a4ff         call    TodosApi!String__Concat_6 (1403cba50)
00000001`409834be 4c8bc0             mov     r8, rax
00000001`409834c1 488bcb             mov     rcx, rbx
00000001`409834c4 8bd6               mov     edx, esi
00000001`409834c6 4533c9             xor     r9d, r9d
00000001`409834c9 3909               cmp     dword ptr [rcx], ecx
00000001`409834cb e8608cabff         call    TodosApi!System.Threading.Tasks.TplEventSource__TraceOperationBegin (14043c130)
00000001`409834d0 498bc6             mov     rax, r14
00000001`409834d3 4883c420           add     rsp, 20h
00000001`409834d7 5b                 pop     rbx
00000001`409834d8 5d                 pop     rbp
00000001`409834d9 5e                 pop     rsi
00000001`409834da 5f                 pop     rdi
00000001`409834db 415e               pop     r14
00000001`409834dd c3                 ret     
00000001`409834de e86a0f68ff         call    TodosApi!__GetGCStaticBase_System.Threading.Tasks.TplEventSource (14000444d)
00000001`409834e3 eba0               jmp     TodosApi!System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1<System.Threading.Tasks.VoidTaskResult>__GetStateMachineBox<S_P_Xml_System_Xml_XmlUtf8RawTextWriter__WriteEntityRefAsync_d__100>+0x115 (140983485)
```

</details>

Addresses following problems:

* Multiple expensive epilogs
* Copying the state machine is costly because they tend to be huge and are a mix of reference fields (need write barriers) and value fields. We need to copy twice - one is an assignment, the other is a box. See clusters of `RhpByRefAssignRefAVLocation1` - that's the write barrier. I'm making the box take a less efficient path based on comments.
* Logging is constructing a string that doesn't really need to be in generic code.

This is just a couple dozen bytes in savings per method, but ends up saving 50 kB for the whole app because that's how many specializations of the method we have.

Cc @stephentoub @jkotas for thoughts.