### PR TITLE
Improve tests/profiler/multiple/multiple.cs

### DIFF
--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -135,9 +135,9 @@ namespace Profiler.Tests
 
             if (!verifier.HasPassingOutput)
             {
-                FailFastWithMessage("Profiler tests are expected to contain the text \'" + verifier.SuccessPhrase + "\' in the console output " +
-                    "of the profilee app to indicate a passing test. Usually it is printed from the Shutdown() method of the profiler implementation. This " +
-                    "text was not found in the output above.");
+                FailFastWithMessage($"Profiler tests are expected to contain the text '{verifier.SuccessPhrase}' in the console output " +
+                    $"of the profilee app to indicate a passing test. Usually it is printed from the Shutdown() method of the profiler implementation. This " +
+                    $"text was not found in the output above. Profilee returned exit code {process.ExitCode}.");
             }
 
             if (process.ExitCode != 100)
@@ -195,14 +195,16 @@ namespace Profiler.Tests
         /// </summary>
         class ProfileeOutputVerifier
         {
+            private volatile bool _hasPassingOutput;
+
             public string SuccessPhrase = "PROFILER TEST PASSES";
-            public bool HasPassingOutput { get; private set; }
+            public bool HasPassingOutput => _hasPassingOutput;
 
             public void WriteLine(string message)
             {
                 if (message != null && message.Contains(SuccessPhrase))
                 {
-                    HasPassingOutput = true;
+                    _hasPassingOutput = true;
                 }
             }
 
@@ -210,7 +212,7 @@ namespace Profiler.Tests
             {
                 if (string.Format(format,args).Contains(SuccessPhrase))
                 {
-                    HasPassingOutput = true;
+                    _hasPassingOutput = true;
                 }
             }
         }

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -35,7 +35,7 @@ namespace Profiler.Tests
             }
 
             Console.WriteLine("Waiting for profilers to all detach");
-            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(10)))
+            if (!_profilerDone.WaitOne(TimeSpan.FromMinutes(5)))
             {
                 throw new Exception("Test timed out waiting for the profilers to set the callback, test will fail.");
             }
@@ -45,11 +45,6 @@ namespace Profiler.Tests
 
         public static int Main(string[] args)
         {
-            // failing on MacOs 12 https://github.com/dotnet/runtime/issues/64765
-            if (OperatingSystem.IsMacOS())
-            {
-                return 100;
-            }
             if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
                 return RunTest(args);


### PR DESCRIPTION
- Add volatile for a field accessed by multiple threads without synchronization
- Improve logging
- Delete test supression against closed issue
- Revert timeout increase that tried to work around a hang that was fixed since then