### PR TITLE
Fix handling of case-sensitive set loops in RegexPrefixAnalyzer.FindPrefixes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -59,9 +59,11 @@ namespace System.Text.RegularExpressions
                 // If we're too deep to analyze further, we can't trust what we've already computed, so stop iterating.
                 // Also bail if any of our results is already hitting the threshold, or if this node is RTL, which is
                 // not worth the complexity of handling.
+                // Or if we've already discovered more than the allowed number of prefixes.
                 if (!StackHelper.TryEnsureSufficientExecutionStack() ||
                     !results.TrueForAll(sb => sb.Length < MaxPrefixLength) ||
-                    (node.Options & RegexOptions.RightToLeft) != 0)
+                    (node.Options & RegexOptions.RightToLeft) != 0 ||
+                    results.Count > MaxPrefixes)
                 {
                     return false;
                 }
@@ -165,6 +167,10 @@ namespace System.Text.RegularExpressions
                                     for (int rep = 0; rep < reps; rep++)
                                     {
                                         int existingCount = results.Count;
+                                        if (existingCount * charCount > MaxPrefixes)
+                                        {
+                                            return false;
+                                        }
 
                                         // Duplicate all of the existing strings for all of the new suffixes, other than the first.
                                         foreach (char suffix in setChars.Slice(1, charCount - 1))
@@ -250,6 +256,12 @@ namespace System.Text.RegularExpressions
                                 for (int i = 0; i < childCount; i++)
                                 {
                                     _ = FindPrefixesCore(node.Child(i), alternateBranchResults, ignoreCase);
+
+                                    // If we now have too many results, bail.
+                                    if ((allBranchResults?.Count ?? 0) + alternateBranchResults.Count > MaxPrefixes)
+                                    {
+                                        return false;
+                                    }
 
                                     Debug.Assert(alternateBranchResults.Count > 0);
                                     foreach (StringBuilder sb in alternateBranchResults)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -162,23 +162,26 @@ namespace System.Text.RegularExpressions
                                 int reps = node.Kind is RegexNodeKind.Set ? 1 : Math.Min(node.M, MaxPrefixLength);
                                 if (!ignoreCase)
                                 {
-                                    int existingCount = results.Count;
-
-                                    // Duplicate all of the existing strings for all of the new suffixes, other than the first.
-                                    foreach (char suffix in setChars.Slice(1, charCount - 1))
+                                    for (int rep = 0; rep < reps; rep++)
                                     {
+                                        int existingCount = results.Count;
+
+                                        // Duplicate all of the existing strings for all of the new suffixes, other than the first.
+                                        foreach (char suffix in setChars.Slice(1, charCount - 1))
+                                        {
+                                            for (int existing = 0; existing < existingCount; existing++)
+                                            {
+                                                StringBuilder newSb = new StringBuilder().Append(results[existing]);
+                                                newSb.Append(suffix);
+                                                results.Add(newSb);
+                                            }
+                                        }
+
+                                        // Then append the first suffix to all of the existing strings.
                                         for (int existing = 0; existing < existingCount; existing++)
                                         {
-                                            StringBuilder newSb = new StringBuilder().Append(results[existing]);
-                                            newSb.Append(suffix, reps);
-                                            results.Add(newSb);
+                                            results[existing].Append(setChars[0]);
                                         }
-                                    }
-
-                                    // Then append the first suffix to all of the existing strings.
-                                    for (int existing = 0; existing < existingCount; existing++)
-                                    {
-                                        results[existing].Append(setChars[0], reps);
                                     }
                                 }
                                 else

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1172,6 +1172,7 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> Match_DeepNesting_MemberData()
         {
+            foreach (RegexOptions options in new[] { RegexOptions.None, RegexOptions.IgnoreCase })
             foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
             {
                 if (RegexHelpers.IsNonBacktracking(engine))
@@ -1180,15 +1181,15 @@ namespace System.Text.RegularExpressions.Tests
                     continue;
                 }
 
-                yield return new object[] { engine, 1 };
-                yield return new object[] { engine, 10 };
-                yield return new object[] { engine, 100 };
+                yield return new object[] { engine, options, 1 };
+                yield return new object[] { engine, options, 10 };
+                yield return new object[] { engine, options, 100 };
             }
         }
 
         [Theory]
         [MemberData(nameof(Match_DeepNesting_MemberData))]
-        public async Task Match_DeepNesting(RegexEngine engine, int count)
+        public async Task Match_DeepNesting(RegexEngine engine, RegexOptions options, int count)
         {
             const string Start = @"((?>abc|(?:def[ghi]", End = @")))";
             const string Match = "defg";
@@ -1196,7 +1197,7 @@ namespace System.Text.RegularExpressions.Tests
             string pattern = string.Concat(Enumerable.Repeat(Start, count)) + string.Concat(Enumerable.Repeat(End, count));
             string input = string.Concat(Enumerable.Repeat(Match, count));
 
-            Regex r = await RegexHelpers.GetRegexAsync(engine, pattern);
+            Regex r = await RegexHelpers.GetRegexAsync(engine, pattern, options);
             Match m = r.Match(input);
 
             Assert.True(m.Success);


### PR DESCRIPTION
For an expression like `[Aa]{2}`, we were generating the strings "AA" and "aa" but not "Aa" or "aA".

This code isn't exercised yet, as we're currently only using FindPrefixes for case-insensitive, but I'm trying to enable it for case-sensitive as well, and hit this. I'm not adding new tests here as plenty of existing tests catch it once it's enabled.