### PR TITLE
JIT: Remove HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1256,27 +1256,6 @@ public:
         this->scaleBBWeight(BB_ZERO_WEIGHT);
     }
 
-    // makeBlockHot()
-    //     This is used to override any profiling data
-    //     and force a block to be in the hot region.
-    //     We only call this method for handler entry point
-    //     and only when HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION is 1.
-    //     Doing this helps fgReorderBlocks() by telling
-    //     it to try to move these blocks into the hot region.
-    //     Note that we do this strictly as an optimization,
-    //     not for correctness. fgDetermineFirstColdBlock()
-    //     will find all handler entry points and ensure that
-    //     for now we don't place them in the cold section.
-    //
-    void makeBlockHot()
-    {
-        if (this->bbWeight == BB_ZERO_WEIGHT)
-        {
-            this->RemoveFlags(BBF_RUN_RARELY | BBF_PROF_WEIGHT);
-            this->bbWeight = 1;
-        }
-    }
-
     bool isMaxBBWeight() const
     {
         return (bbWeight >= BB_MAX_WEIGHT);

--- a/src/coreclr/jit/fgehopt.cpp
+++ b/src/coreclr/jit/fgehopt.cpp
@@ -1229,16 +1229,6 @@ PhaseStatus Compiler::fgCloneFinally()
                     block->setBBProfileWeight(blockWeight * originalScale);
                     JITDUMP("Set weight of " FMT_BB " to " FMT_WT "\n", block->bbNum, block->bbWeight);
 
-#if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-                    // Handle a special case -- some handler entries can't have zero profile count.
-                    //
-                    if (bbIsHandlerBeg(block) && block->isRunRarely())
-                    {
-                        JITDUMP("Suppressing zero count for " FMT_BB " as it is a handler entry\n", block->bbNum);
-                        block->makeBlockHot();
-                    }
-#endif
-
                     BasicBlock* const clonedBlock = blockMap[block];
                     clonedBlock->setBBProfileWeight(blockWeight * clonedScale);
                     JITDUMP("Set weight of " FMT_BB " to " FMT_WT "\n", clonedBlock->bbNum, clonedBlock->bbWeight);

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -3018,21 +3018,10 @@ PhaseStatus Compiler::fgIncorporateProfileData()
 //
 // Notes:
 //   Does inlinee scaling.
-//   Handles handler entry special case.
 //
 void Compiler::fgSetProfileWeight(BasicBlock* block, weight_t profileWeight)
 {
     block->setBBProfileWeight(profileWeight);
-
-#if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-    // Handle a special case -- some handler entries can't have zero profile count.
-    //
-    if (this->bbIsHandlerBeg(block) && block->isRunRarely())
-    {
-        JITDUMP("Suppressing zero count for " FMT_BB " as it is a handler entry\n", block->bbNum);
-        block->makeBlockHot();
-    }
-#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3083,17 +3083,12 @@ bool Compiler::fgFuncletsAreCold()
 //
 // Notes:
 //    Walk the basic blocks list to determine the first block to place in the
-//    cold section.  This would be the first of a series of rarely executed blocks
+//    cold section. This would be the first of a series of rarely executed blocks
 //    such that no succeeding blocks are in a try region or an exception handler
 //    or are rarely executed.
 //
 PhaseStatus Compiler::fgDetermineFirstColdBlock()
 {
-    // Since we may need to create a new transition block
-    // we assert that it is OK to create new blocks.
-    //
-    assert(fgPredsComputed);
-    assert(fgSafeBasicBlockCreation);
     assert(fgFirstColdBlock == nullptr);
 
     if (!opts.compProcedureSplitting)

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3134,15 +3134,6 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
 
         for (lblk = nullptr, block = fgFirstBB; block != nullptr; lblk = block, block = block->Next())
         {
-            bool blockMustBeInHotSection = false;
-
-#if HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-            if (bbIsHandlerBeg(block))
-            {
-                blockMustBeInHotSection = true;
-            }
-#endif // HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION
-
             // Make note of if we're in the funclet section,
             // so we can stop the search early.
             if (block == fgFirstFuncletBB)
@@ -3156,7 +3147,7 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                 // We have a candidate for first cold block
 
                 // Is this a hot block?
-                if (blockMustBeInHotSection || (block->isRunRarely() == false))
+                if (!block->isRunRarely())
                 {
                     // We have to restart the search for the first cold block
                     firstColdBlock       = nullptr;
@@ -3195,7 +3186,7 @@ PhaseStatus Compiler::fgDetermineFirstColdBlock()
                 }
 
                 // Is this a cold block?
-                if (!blockMustBeInHotSection && block->isRunRarely())
+                if (block->isRunRarely())
                 {
                     //
                     // If the last block that was hot was a BBJ_COND

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -470,9 +470,8 @@ public:
 
 /*****************************************************************************/
 
-#define CSE_INTO_HANDLERS                    0
-#define DUMP_FLOWGRAPHS                      DEBUG // Support for creating Xml Flowgraph reports in *.fgx files
-#define HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION 0     // if 1 we must have all handler entry points in the Hot code section
+#define CSE_INTO_HANDLERS 0
+#define DUMP_FLOWGRAPHS   DEBUG // Support for creating Xml Flowgraph reports in *.fgx files
 
 /*****************************************************************************/
 


### PR DESCRIPTION
Late follow-up to #71273. I noticed `fgRelocateEHRegions` currently never tries to move handler regions (even if we aren't doing hot/cold splitting) because `fgDetermineFirstColdBlock` must keep handler entries hot, which is no longer true. I plan to enable that functionality in the next PR; for now, this cleans up all the dead code around HANDLER_ENTRY_MUST_BE_IN_HOT_SECTION. This should be a no-diff change.

cc @dotnet/jit-contrib, @AndyAyersMS PTAL. Thanks!