### PR TITLE
Backport #92296 to release/8.0-staging

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -504,7 +504,7 @@
       </ItemGroup>
       <ItemGroup Condition="'$(BuildNativeAOTRuntimePack)' != 'true' and '$(PgoInstrument)' != 'true'">
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Host.sfxproj" />
-        <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' != 'Mono'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Crossgen2.sfxproj" />
+        <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' != 'Mono' and '$(PgoInstrument)' != 'true'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Crossgen2.sfxproj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-host.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-hostfxr.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-runtime-deps\*.proj" />

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -14,7 +14,6 @@ parameters:
   dependsOn: []
   pool: ''
   platform: ''
-  pgoType: ''
   condition: true
   useContinueOnErrorDuringBuild: false
   shouldContinueOnError: false
@@ -134,7 +133,6 @@ jobs:
             targetRid: ${{ parameters.targetRid }}
             nameSuffix: ${{ parameters.nameSuffix }}
             platform: ${{ parameters.platform }}
-            pgoType: ${{ parameters.pgoType }}
             shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
             ${{ if ne(variableTemplate.forwardedParameters, '') }}:
               ${{ each parameter in variableTemplate.forwardedParameters }}:
@@ -250,7 +248,6 @@ jobs:
           targetRid: ${{ parameters.targetRid }}
           nameSuffix: ${{ parameters.nameSuffix }}
           platform: ${{ parameters.platform }}
-          pgoType: ${{ parameters.pgoType }}
           shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
           ${{ insert }}: ${{ parameters.extraStepsParameters }}
 

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -14,7 +14,6 @@ parameters:
   dependsOn: []
   dependOnEvaluatePaths: false
   crossBuild: false
-  pgoType: ''
 
 ### Build managed test components (native components are getting built as part
 ### of the product build job).

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -17,7 +17,6 @@ parameters:
   testGroup: ''
   timeoutInMinutes: ''
   variables: {}
-  pgoType: ''
 
 ### Product build
 jobs:
@@ -36,21 +35,18 @@ jobs:
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
     disableComponentGovernance: ${{ parameters.disableComponentGovernance }}
     disableClrTest: ${{ parameters.disableClrTest }}
-    pgoType: ${{ parameters.pgoType }}
 
     # Compute job name from template parameters
-    name: ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}{5}',
+    name: ${{ format('coreclr_{0}_product_build_{1}{2}_{3}_{4}',
       parameters.runtimeVariant,
       parameters.osGroup,
       parameters.osSubgroup,
       parameters.archType,
-      parameters.buildConfig,
-      parameters.pgoType) }}
-    displayName: ${{ format('CoreCLR {0} Product Build {1}{2} {3} {4} {5}',
+      parameters.buildConfig) }}
+    displayName: ${{ format('CoreCLR {0} Product Build {1}{2} {3} {4}',
       parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup,
       parameters.archType,
-      parameters.buildConfig,
-      parameters.pgoType) }}
+      parameters.buildConfig) }}
 
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml
@@ -80,7 +76,7 @@ jobs:
     - name: enforcePgoArg
       value: ''
     # The EnforcePGO script is only supported on Windows and is not supported on arm64.
-    - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'windows'), ne(parameters.archType, 'arm64')), ne(parameters.pgoType, 'pgo')) }}:
+    - ${{ if and(eq(parameters.buildConfig, 'Release'), and(eq(parameters.osGroup, 'windows'), ne(parameters.archType, 'arm64'))) }}:
       - name: enforcePgoArg
         value: '-enforcepgo'
 
@@ -95,12 +91,6 @@ jobs:
     - ${{ if ne(parameters.testGroup, 'innerloop') }}:
       - name: clrRuntimeComponentsBuildArg
         value: '-component runtime -component alljits -component nativeaot -component spmi '
-
-    - name: pgoInstrumentArg
-      value: ''
-    - ${{ if eq(parameters.pgoType, 'PGO' )}}:
-      - name: pgoInstrumentArg
-        value: '-pgoinstrument '
 
     - name: SignType
       value: $[ coalesce(variables.OfficialSignType, 'real') ]
@@ -175,10 +165,10 @@ jobs:
 
     # Build CoreCLR Runtime
     - ${{ if ne(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg) $(nativeSymbols)
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) $(crossArg) $(osArg) -ci $(compilerArg) $(clrRuntimeComponentsBuildArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg) $(nativeSymbols)
         displayName: Build CoreCLR Runtime
     - ${{ if eq(parameters.osGroup, 'windows') }}:
-      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(pgoInstrumentArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
+      - script: $(Build.SourcesDirectory)/src/coreclr/build-runtime$(scriptExt) $(buildConfig) $(archType) -ci $(enforcePgoArg) $(officialBuildIdArg) $(clrInterpreterBuildArg) $(CoreClrPgoDataArg)
         displayName: Build CoreCLR Runtime
 
     - ${{ if or(eq(parameters.crossBuild, 'true'), ne(parameters.archType, 'x64')) }}:
@@ -192,7 +182,7 @@ jobs:
         displayName: Disk Usage after Build
 
     # Build CoreCLR Managed Components
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(pgoInstrumentArg) $(officialBuildIdArg) -ci
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -subset clr.corelib+clr.nativecorelib+clr.nativeaotlibs+clr.tools+clr.packages $(crossArg) $(compilerArg) -arch $(archType) $(osArg) -c $(buildConfig) $(officialBuildIdArg) -ci
       displayName: Build managed product components and packages
 
     # Build native test components
@@ -241,7 +231,7 @@ jobs:
           artifactName: $(buildProductArtifactName)
           displayName: 'product build'
 
-    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(in(parameters.osGroup, 'windows', 'linux'), ne(parameters.archType, 'x86')) }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: ${{ parameters.archType }}
@@ -253,7 +243,7 @@ jobs:
             ${{ else }}:
               hostArchType: x64
 
-    - ${{ if and(in(parameters.osGroup, 'windows'), eq(parameters.archType, 'x86'), eq(parameters.pgoType, '')) }}:
+    - ${{ if and(in(parameters.osGroup, 'windows'), eq(parameters.archType, 'x86')) }}:
         - template: /eng/pipelines/coreclr/templates/crossdac-build.yml
           parameters:
             archType: arm
@@ -264,7 +254,7 @@ jobs:
 
     - ${{ if and(ne(parameters.testGroup, ''), ne(parameters.disableClrTest, true)) }}:
       # Publish test native components for consumption by test execution.
-      - ${{ if and(ne(parameters.isOfficialBuild, true), eq(parameters.pgoType, '')) }}:
+      - ${{ if ne(parameters.isOfficialBuild, true) }}:
         - template: /eng/pipelines/common/upload-artifact-step.yml
           parameters:
             rootFolder: $(nativeTestArtifactRootFolderPath)
@@ -276,7 +266,7 @@ jobs:
             displayName: 'native test components'
 
     # Save packages using the prepare-signed-artifacts format.
-    - ${{ if and(eq(parameters.isOfficialBuild, true), eq(parameters.pgoType, '')) }}:
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
       - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
         parameters:
           name: ${{ parameters.platform }}
@@ -292,6 +282,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '$(publishLogsArtifactPrefix)_Attempt$(System.JobAttempt)_${{ parameters.pgoType }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        artifactName: '$(publishLogsArtifactPrefix)_Attempt$(System.JobAttempt)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/coreclr/templates/superpmi-asmdiffs-checked-release-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-asmdiffs-checked-release-job.yml
@@ -34,7 +34,7 @@ jobs:
     - name: releaseProductRootFolderPath
       value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).Release'
     - name: releaseProductArtifactName
-      value: 'CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_release'
+      value: 'CoreCLRProduct_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_release'
 
     steps:
 

--- a/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
+++ b/eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
@@ -49,7 +49,7 @@ jobs:
         - name: releaseProductRootFolderPath
           value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).Release'
       - name: releaseProductArtifactName
-        value: 'CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_release'
+        value: 'CoreCLRProduct_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_release'
 
     steps:
 

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -38,7 +38,6 @@ jobs:
     crossBuild: ${{ parameters.crossBuild }}
     strategy: ${{ parameters.strategy }}
     pool: ${{ parameters.pool }}
-    pgoType: ${{ parameters.pgoType }}
 
     # arcade-specific parameters
     condition: and(succeeded(), ${{ parameters.condition }})
@@ -65,7 +64,7 @@ jobs:
 
     # Build product defines what we are trying to build, either coreclr or mono
     - name: buildProductArtifactName
-      value: 'CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      value: 'CoreCLRProduct_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: buildProductRootFolderPath
       value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)'
@@ -78,13 +77,13 @@ jobs:
 
     # We need this because both mono and coreclr build currently depends on CoreClr
     - name: coreClrProductArtifactName
-      value: 'CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      value: 'CoreCLRProduct_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: coreClrProductRootFolderPath
       value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)'
 
     - name: corelibProductArtifactName
-      value: 'CoreLib_${{ parameters.pgoType }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      value: 'CoreLib_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: managedGenericTestArtifactName
       value: 'CoreCLRManagedTestArtifacts_AnyOS_AnyCPU_$(buildConfig)'

--- a/eng/pipelines/installer/jobs/build-job.yml
+++ b/eng/pipelines/installer/jobs/build-job.yml
@@ -19,7 +19,6 @@ parameters:
   displayName: ''
   runtimeVariant: ''
   pool: ''
-  pgoType: ''
   runOnlyIfDependenciesSucceeded: false
 
   # The target names here should match container names in the resources section in our pipelines, like runtime.yml
@@ -59,11 +58,10 @@ jobs:
 
     dependOnEvaluatePaths: ${{ parameters.dependOnEvaluatePaths }}
     disableClrTest: ${{ parameters.disableClrTest }}
-    pgoType: ${{ parameters.pgoType }}
 
     # Compute job name from template parameters
-    name: ${{ format('installer_{0}_{1}_{2}_{3}_{4}_', parameters.pgoType, parameters.runtimeFlavor, parameters.runtimeVariant, coalesce(parameters.name, parameters.platform), parameters.buildConfig) }}
-    displayName: ${{ format('{0} Installer Build and Test {1} {2} {3} {4}', parameters.pgoType, parameters.runtimeFlavor, parameters.runtimeVariant, coalesce(parameters.name, parameters.platform), parameters.buildConfig) }}
+    name: ${{ format('installer_{0}_{1}_{2}_{3}_', parameters.runtimeFlavor, parameters.runtimeVariant, coalesce(parameters.name, parameters.platform), parameters.buildConfig) }}
+    displayName: ${{ format('Installer Build and Test {0} {1} {2} {3}', parameters.runtimeFlavor, parameters.runtimeVariant, coalesce(parameters.name, parameters.platform), parameters.buildConfig) }}
 
     # Run all steps in the container.
     # Note that the containers are defined in platform-matrix.yml
@@ -99,24 +97,17 @@ jobs:
           not(and(
             eq(parameters.osGroup, 'linux'),
             eq(parameters.osSubgroup, ''))
-          )),
-        eq(parameters.pgoType, 'PGO')) }}
+          ))) }}
 
     - name: BuildAction
       value: -test
 
-    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), and(eq(parameters.crossBuild, true), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, '')))), eq(parameters.pgoType, 'PGO')), true) }}:
+    - ${{ if eq(or(not(in(parameters.archType, 'x64', 'x86')), eq(parameters.runtimeFlavor, 'mono'), eq(parameters.isOfficialBuild, true), and(eq(parameters.crossBuild, true), not(and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, ''))))), true) }}:
       - name: BuildAction
         value: ''
 
     - name: SignType
       value: test
-
-    - name: pgoInstrumentArg
-      value: ''
-    - ${{ if eq(parameters.pgoType, 'PGO' )}}:
-      - name: pgoInstrumentArg
-        value: '-pgoinstrument '
 
     # Set up non-PR build from internal project
     - ${{ if eq(parameters.isOfficialBuild, true) }}:
@@ -153,7 +144,6 @@ jobs:
           build.cmd -subset host+packs -ci
           $(BuildAction)
           -configuration $(_BuildConfig)
-          $(pgoInstrumentArg)
           $(LiveOverridePathArgs)
           $(CommonMSBuildArgs)
           $(MsbuildSigningArguments)
@@ -225,7 +215,6 @@ jobs:
           /p:CrossBuild=${{ parameters.crossBuild }}
           /p:PortableBuild=$(_PortableBuild)
           /p:SkipTests=$(SkipTests)
-          $(pgoInstrumentArg)
           $(LiveOverridePathArgs)
           $(CommonMSBuildArgs)
 
@@ -265,7 +254,7 @@ jobs:
           /p:RuntimeArtifactsPath=$(buildCommandSourcesDirectory)$(RuntimeDownloadPath)
           /p:RuntimeConfiguration=${{ parameters.liveRuntimeBuildConfig }}
       - name: RuntimeArtifactName
-        value: $(runtimeFlavorName)Product_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_$(liveRuntimeLegName)
+        value: $(runtimeFlavorName)Product_${{ parameters.runtimeVariant }}_$(liveRuntimeLegName)
 
     - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
       - name: liveLibrariesLegName
@@ -286,14 +275,13 @@ jobs:
       - evaluate_paths
     - ${{ parameters.dependsOn }}
     - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
-      - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}{6}',
+      - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}',
           parameters.runtimeFlavor,
           parameters.runtimeVariant,
           parameters.osGroup,
           parameters.osSubgroup,
           parameters.archType,
-          parameters.liveRuntimeBuildConfig,
-          parameters.pgoType) }}
+          parameters.liveRuntimeBuildConfig) }}
     - ${{ if ne(parameters.liveLibrariesBuildConfig, '') }}:
       - libraries_build_${{ format('{0}{1}_{2}_{3}',
           parameters.osGroup,
@@ -391,7 +379,7 @@ jobs:
           displayName: Disk Usage after Build
 
       # Only in glibc leg, we produce RPMs and Debs
-      - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), or(eq(parameters.platform, 'linux_x64'), eq(parameters.platform, 'linux_arm64')), eq(parameters.osSubgroup, ''), eq(parameters.pgoType, ''))}}:
+      - ${{ if and(eq(parameters.runtimeFlavor, 'coreclr'), or(eq(parameters.platform, 'linux_x64'), eq(parameters.platform, 'linux_arm64')), eq(parameters.osSubgroup, ''))}}:
         - ${{ each packageBuild in parameters.packageDistroList }}:
           # This leg's RID matches the build image. Build its distro-dependent packages, as well as
           # the distro-independent installers. (There's no particular reason to build the distro-
@@ -412,7 +400,6 @@ jobs:
           runtimeFlavor: ${{ parameters.runtimeFlavor }}
           runtimeVariant: ${{ parameters.runtimeVariant }}
           isOfficialBuild: ${{ eq(parameters.isOfficialBuild, true) }}
-          pgoType: ${{ parameters.pgoType }}
           skipTests: ${{ eq(variables.SkipTests, true) }}
 
       - ${{ if ne(parameters.osGroup, 'windows') }}:

--- a/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
+++ b/eng/pipelines/installer/jobs/steps/upload-job-artifacts.yml
@@ -3,7 +3,6 @@ parameters:
   runtimeFlavor: 'coreclr'
   runtimeVariant: ''
   isOfficialBuild: false
-  pgoType: ''
 
 steps:
 # Upload build artifacts (packages) to pipeline only if official, to save storage space.
@@ -51,7 +50,7 @@ steps:
     displayName: Publish binaries
     inputs:
       pathtoPublish: '$(Build.StagingDirectory)/corehost-bin-${{ parameters.name }}-$(_BuildConfig)$(archiveExtension)'
-      artifactName: Installer-Binaries-${{parameters.pgoType }}${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
+      artifactName: Installer-Binaries-${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
     continueOnError: true
     condition: failed()
 
@@ -71,6 +70,6 @@ steps:
   displayName: Publish BuildLogs
   inputs:
     targetPath: '$(Build.StagingDirectory)/BuildLogs'
-    artifactName: Installer-Logs_Attempt$(System.JobAttempt)-${{parameters.pgoType }}${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
+    artifactName: Installer-Logs_Attempt$(System.JobAttempt)-${{ parameters.runtimeFlavor }}-${{ parameters.runtimeVariant }}-${{ parameters.name }}-$(_BuildConfig)
   continueOnError: true
   condition: always()

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -23,7 +23,6 @@ parameters:
   testScope: ''
   pool: ''
   runTests: false
-  pgoType: ''
 
 jobs:
   - template: /eng/common/templates/job/job.yml
@@ -98,7 +97,7 @@ jobs:
           - _runtimeDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/${{ parameters.runtimeFlavor }}'
           - _runtimeConfigurationArg: -rc ${{ parameters.liveRuntimeBuildConfig }}
           - ${{ if eq(parameters.runTests, true) }}:
-            - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.pgoType }}_${{ parameters.runtimeVariant}}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
+            - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.runtimeVariant}}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
             - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
           - ${{ if eq(parameters.testDisplayName, '') }}:
             - _testRunNamePrefixSuffix: $(runtimeFlavorName)_${{ parameters.liveRuntimeBuildConfig }}

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -15,7 +15,6 @@ parameters:
   dependsOn: []
   monoCrossAOTTargetOS: []
   dependOnEvaluatePaths: false
-  pgoType: ''
 
 ### Product build
 jobs:

--- a/eng/pipelines/mono/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/mono/templates/xplat-pipeline-job.yml
@@ -52,22 +52,22 @@ jobs:
 
     variables:
     - name: coreClrProductArtifactName
-      value: 'CoreCLRProduct___$(osGroup)$(osSubgroup)_$(archType)_${{ parameters.liveRuntimeBuildConfig }}'
+      value: 'CoreCLRProduct__$(osGroup)$(osSubgroup)_$(archType)_${{ parameters.liveRuntimeBuildConfig }}'
 
     - name: coreClrProductRootFolderPath
       value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(liveRuntimeBuildConfigUpper)'
 
     - name: buildProductArtifactName
-      value: 'MonoProduct__${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+      value: 'MonoProduct_${{ parameters.runtimeVariant }}_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     # minijit and monointerpreter do not use separate product builds.
     - ${{ if or(eq(parameters.runtimeVariant, 'minijit'), eq(parameters.runtimeVariant, 'monointerpreter')) }}:
       - name : buildProductArtifactName
-        value : 'MonoProduct___$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        value : 'MonoProduct__$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - ${{ if eq(parameters.runtimeVariant, 'llvmfullaot') }}:
       - name : buildProductArtifactName
-        value : 'MonoProduct__llvmaot_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+        value : 'MonoProduct_llvmaot_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: binTestsPath
       value: '$(Build.SourcesDirectory)/artifacts/tests/coreclr'

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -425,42 +425,27 @@ extends:
           - windows_arm64
 
       #
-      # Build PGO CoreCLR release
+      # Build PGO Instrumented CoreCLR Release
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
-          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x64
-          - windows_x86
-          - linux_x64
-          - windows_arm64
-          - linux_arm64
-          jobParameters:
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            signBinaries: false
-            testGroup: innerloop
-            pgoType: 'PGO'
-
-      #
-      # PGO Build
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: Release
-          jobParameters:
-            isOfficialBuild: ${{ variables.isOfficialBuild }}
-            liveRuntimeBuildConfig: release
-            liveLibrariesBuildConfig: Release
-            pgoType: 'PGO'
+          helixQueueGroup: ci
           platforms:
           - windows_x64
           - windows_x86
           - linux_x64
           - windows_arm64
           - linux_arm64
+          jobParameters:
+            buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            nameSuffix: PGO
+            extraStepsTemplate: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
+            extraStepsParameters:
+              name: PGO
+            timeoutInMinutes: 95
 
       #
       # Build Workloads
@@ -490,9 +475,9 @@ extends:
             - Build_tvossimulator_arm64_release_AllSubsets_Mono
             - Build_tvossimulator_x64_release_AllSubsets_Mono
             - Build_windows_x64_release_CrossAOT_Mono
-            - installer__coreclr__windows_x64_Release_
-            - installer__coreclr__windows_x86_Release_
-            - installer__coreclr__windows_arm64_Release_
+            - installer_coreclr__windows_x64_Release_
+            - installer_coreclr__windows_x86_Release_
+            - installer_coreclr__windows_arm64_Release_
 
     - ${{ if eq(variables.isOfficialBuild, true) }}:
       - template: /eng/pipelines/official/stages/publish.yml

--- a/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
+++ b/eng/pipelines/runtimelab/runtimelab-post-build-steps.yml
@@ -5,7 +5,6 @@ parameters:
   osSubgroup: ''
   nameSuffix: ''
   platform: ''
-  pgoType: ''
   runtimeVariant: ''
   librariesBinArtifactName: ''
   isOfficialBuild: false
@@ -32,7 +31,7 @@ steps:
       tarCompression: $(tarCompression)
       includeRootFolder: false
       archiveExtension: $(archiveExtension)
-      artifactName: CoreCLRProduct_${{ parameters.pgoType }}_${{ parameters.runtimeVariant }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
+      artifactName: CoreCLRProduct_${{ parameters.runtimeVariant }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}
       displayName: 'CoreCLR product build'
 
   # Zip Test Build


### PR DESCRIPTION
This is part of the work to transition to the 1ES templates in servicing branches.

Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2440254&view=results

cc @jkoritzinsky @agocke @amanasifkhalid 