### PR TITLE
[WASM] Fix third parameter marshaling on callbacks

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -1338,6 +1338,23 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWasmThreadingSupported))]
+        public void JsImportCallback_ActionIntLongDouble()
+        {
+            int calledA = -1;
+            long calledB = -1;
+            double calledC = -1;
+            JavaScriptTestHelper.back4_ActionIntLongDouble((a, b, c) =>
+            {
+                calledA = a;
+                calledB = b;
+                calledC = c;
+            }, 42, 43, 44.5);
+            Assert.Equal(42, calledA);
+            Assert.Equal(43, calledB);
+            Assert.Equal(44.5, calledC);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWasmThreadingSupported))]
         public void JsImportCallback_ActionIntThrow()
         {
             int called = -1;

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -493,6 +493,8 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [return: JSMarshalAs<JSType.Number>]
         internal static partial int back3_FunctionIntInt([JSMarshalAs<JSType.Function<JSType.Number, JSType.Number>>] Func<int, int>? fun, [JSMarshalAs<JSType.Number>] int a);
 
+        [JSImport("back4", "JavaScriptTestHelper")]
+        internal static partial void back4_ActionIntLongDouble([JSMarshalAs<JSType.Function<JSType.Number, JSType.Number, JSType.Number>>] Action<int, long, double>? action, [JSMarshalAs<JSType.Number>] int a, [JSMarshalAs<JSType.Number>] long b, [JSMarshalAs<JSType.Number>] double c);
 
         [JSImport("invoke1", "JavaScriptTestHelper")]
         [return: JSMarshalAs<JSType.Function<JSType.Number, JSType.Number>>]

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -383,6 +383,21 @@ export function back3(arg1, arg2, arg3) {
     }
 }
 
+export function back4(arg1, arg2, arg3, arg4) {
+    if (globalThis.gc) {
+        // console.log('globalThis.gc');
+        globalThis.gc();
+    }
+    try {
+        if (!(arg1 instanceof Function)) throw new Error('expecting Function!')
+
+        return arg1(arg2, arg3, arg4);
+    }
+    catch (ex) {
+        throw ex;
+    }
+}
+
 export function backback(arg1, arg2, arg3) {
     if (globalThis.gc) {
         // console.log('globalThis.gc');

--- a/src/mono/browser/runtime/marshal.ts
+++ b/src/mono/browser/runtime/marshal.ts
@@ -143,7 +143,7 @@ export function get_signature_arg2_type (sig: JSMarshalerType): MarshalerType {
 
 export function get_signature_arg3_type (sig: JSMarshalerType): MarshalerType {
     mono_assert(sig, "Null sig");
-    return <any>getU8(<any>sig + JSBindingTypeOffsets.Arg2MarshalerType);
+    return <any>getU8(<any>sig + JSBindingTypeOffsets.Arg3MarshalerType);
 }
 
 export function get_signature_argument_count (signature: JSFunctionSignature): number {


### PR DESCRIPTION
This reason of the issue seems to be a simple typo. On top of that adding a unit tests.

Note, I didn't figure out how to build wasm unit tests locally yet, so hopping for CI to help here.
Let me know, if I am missing anything. 

Fix #101637