### PR TITLE
Code Versioning - move native code versioning state

### DIFF
--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -98,14 +98,6 @@ ASMCONSTANTS_C_ASSERT(SIZEOF__ComPrestubMethodFrame
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame
                     == sizeof(ComMethodFrame));
 
-#define               OFFSETOF__ComPlusCallMethodDesc__m_pComPlusCallInfo        DBG_FRE(0x30, 0x08)
-ASMCONSTANTS_C_ASSERT(OFFSETOF__ComPlusCallMethodDesc__m_pComPlusCallInfo
-                    == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo));
-
-#define               OFFSETOF__ComPlusCallInfo__m_pILStub                       0x0
-ASMCONSTANTS_C_ASSERT(OFFSETOF__ComPlusCallInfo__m_pILStub
-                      == offsetof(ComPlusCallInfo, m_pILStub));
-
 #endif // FEATURE_COMINTEROP
 
 #define               OFFSETOF__Thread__m_fPreemptiveGCDisabled     0x04

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1354,6 +1354,7 @@ HRESULT CodeVersionManager::GetOrCreateMethodDescVersioningState(MethodDesc* pMe
     CONTRACTL
     {
         NOTHROW;
+        GC_NOTRIGGER;
         PRECONDITION(pMethod != NULL);
         PRECONDITION(ppMethodVersioningState != NULL);
     }

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -475,36 +475,6 @@ private:
     PTR_NativeCodeVersionNode m_pFirstVersionNode;
 };
 
-class MethodDescVersioningStateHashTraits : public NoRemoveSHashTraits<DefaultSHashTraits<PTR_MethodDescVersioningState>>
-{
-public:
-    typedef typename DefaultSHashTraits<PTR_MethodDescVersioningState>::element_t element_t;
-    typedef typename DefaultSHashTraits<PTR_MethodDescVersioningState>::count_t count_t;
-
-    typedef const PTR_MethodDesc key_t;
-
-    static key_t GetKey(element_t e)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return e->GetMethodDesc();
-    }
-    static BOOL Equals(key_t k1, key_t k2)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return k1 == k2;
-    }
-    static count_t Hash(key_t k)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (count_t)dac_cast<TADDR>(k);
-    }
-
-    static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }
-    static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
-};
-
-typedef SHash<MethodDescVersioningStateHashTraits> MethodDescVersioningStateHash;
-
 class ILCodeVersioningState
 {
 public:
@@ -572,7 +542,7 @@ class CodeVersionManager
     friend class ILCodeVersion;
 
 public:
-    CodeVersionManager();
+    CodeVersionManager() = default;
 
     DWORD GetNonDefaultILVersionCount();
     ILCodeVersionCollection GetILCodeVersions(PTR_MethodDesc pMethod);
@@ -647,9 +617,6 @@ private:
 
     //Module,MethodDef -> ILCodeVersioningState
     ILCodeVersioningStateHash m_ilCodeVersioningStateMap;
-
-    //closed MethodDesc -> MethodDescVersioningState
-    MethodDescVersioningStateHash m_methodDescVersioningStateMap;
 
 private:
     static CrstStatic s_lock;

--- a/src/coreclr/vm/i386/asmconstants.h
+++ b/src/coreclr/vm/i386/asmconstants.h
@@ -233,7 +233,7 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__FrameHandlerExRecord__m_pEntryFrame == offsetof(
 
 #endif
 
-#define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x1C, 0x8)
+#define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x20, 0xC)
 ASMCONSTANTS_C_ASSERT(ComPlusCallMethodDesc__m_pComPlusCallInfo == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo))
 
 #define ComPlusCallInfo__m_pRetThunk 0x10

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -209,16 +209,20 @@ LoaderAllocator * MethodDesc::GetDomainSpecificLoaderAllocator()
 
 }
 
-void MethodDesc::AllocateCodeData()
+void MethodDesc::AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker)
 {
     CONTRACTL
     {
         THROWS;
+        PRECONDITION(pHeap != NULL);
+        PRECONDITION(pamTracker != NULL);
         PRECONDITION(m_codeData == NULL);
+        POSTCONDITION(m_codeData != NULL);
     }
     CONTRACTL_END;
 
-    m_codeData = (MethodDescCodeData*)(void*)GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(MethodDescCodeData)));
+    m_codeData = (MethodDescCodeData*)pamTracker->Track(
+        pHeap->AllocMem(S_SIZE_T(sizeof(MethodDescCodeData))));
 }
 
 bool MethodDesc::SetMethodDescVersionState(PTR_MethodDescVersioningState state)
@@ -1744,7 +1748,7 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
         {
             pMD->SetChunkIndex(pChunk);
             pMD->SetMethodDescIndex(i);
-            pMD->AllocateCodeData();
+            pMD->AllocateCodeData(pHeap, pamTracker);
 
             pMD->SetClassification(classification);
             if (fNonVtableSlot)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -217,7 +217,6 @@ void MethodDesc::AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker
         PRECONDITION(pHeap != NULL);
         PRECONDITION(pamTracker != NULL);
         PRECONDITION(m_codeData == NULL);
-        POSTCONDITION(m_codeData != NULL);
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -214,6 +214,7 @@ void MethodDesc::AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker
     CONTRACTL
     {
         THROWS;
+        GC_NOTRIGGER;
         PRECONDITION(pHeap != NULL);
         PRECONDITION(pamTracker != NULL);
     }

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -216,7 +216,6 @@ void MethodDesc::AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker
         THROWS;
         PRECONDITION(pHeap != NULL);
         PRECONDITION(pamTracker != NULL);
-        PRECONDITION(m_codeData == NULL);
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1638,7 +1638,7 @@ public:
     }
 
 #ifndef DACCESS_COMPILE
-    void AllocateCodeData();
+    void AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker);
 
     bool SetMethodDescVersionState(PTR_MethodDescVersioningState state);
 #endif //!DACCESS_COMPILE

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -35,7 +35,6 @@ class Dictionary;
 class GCCoverageInfo;
 class DynamicMethodDesc;
 class ReJitManager;
-class CodeVersionManager;
 class PrepareCodeConfig;
 
 typedef DPTR(FCallMethodDesc)        PTR_FCallMethodDesc;
@@ -159,6 +158,12 @@ enum MethodDescFlags
     mdfIsIntrinsic                      = 0x8000  // Jit may expand method as an intrinsic
 };
 
+struct MethodDescCodeData
+{
+    PTR_MethodDescVersioningState MDState;
+};
+using PTR_MethodDescCodeData = DPTR(MethodDescCodeData);
+
 // The size of this structure needs to be a multiple of MethodDesc::ALIGNMENT
 //
 // @GENERICS:
@@ -177,18 +182,6 @@ enum MethodDescFlags
 // It also knows how to get at its IL code (code:IMAGE_COR_ILMETHOD)
 class MethodDesc
 {
-    friend class EEClass;
-    friend class MethodTableBuilder;
-    friend class ArrayClass;
-    friend class NDirect;
-    friend class MethodDescChunk;
-    friend class InstantiatedMethodDesc;
-    friend class MethodImpl;
-    friend class CheckAsmOffsets;
-    friend class ClrDataAccess;
-
-    friend class MethodDescCallSite;
-
 public:
 
 #ifdef TARGET_64BIT
@@ -1624,6 +1617,7 @@ protected:
 
     WORD m_wSlotNumber; // The slot number of this MethodDesc in the vtable array.
     WORD m_wFlags; // See MethodDescFlags
+    PTR_MethodDescCodeData m_codeData;
 
 public:
 #ifdef DACCESS_COMPILE
@@ -1632,14 +1626,24 @@ public:
 
     BYTE GetMethodDescIndex()
     {
+        LIMITED_METHOD_CONTRACT;
         return m_methodIndex;
     }
 
     void SetMethodDescIndex(COUNT_T index)
     {
+        LIMITED_METHOD_CONTRACT;
         _ASSERTE(index <= 255);
         m_methodIndex = (BYTE)index;
     }
+
+#ifndef DACCESS_COMPILE
+    void AllocateCodeData();
+
+    bool SetMethodDescVersionState(PTR_MethodDescVersioningState state);
+#endif //!DACCESS_COMPILE
+
+    PTR_MethodDescVersioningState GetMethodDescVersionState();
 
 public:
     inline DWORD GetClassification() const
@@ -2108,7 +2112,6 @@ public:
 class MethodDescChunk
 {
     friend class MethodDesc;
-    friend class CheckAsmOffsets;
 
     enum {
         enum_flag_TokenRangeMask                           = 0x0FFF, // This must equal METHOD_TOKEN_RANGE_MASK calculated higher in this file
@@ -2411,9 +2414,7 @@ typedef DPTR(DynamicResolver)         PTR_DynamicResolver;
 class DynamicMethodDesc : public StoredSigMethodDesc
 {
     friend class ILStubCache;
-    friend class ILStubState;
     friend class DynamicMethodTable;
-    friend class MethodDesc;
 
 protected:
     PTR_CUTF8           m_pszMethodName;

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7065,6 +7065,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
 
         pMD->SetChunkIndex(pChunk);
         pMD->SetMethodDescIndex(methodDescCount);
+        pMD->AllocateCodeData();
 
         InitNewMethodDesc(pMDMethod, pMD);
 
@@ -7109,6 +7110,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // Reset the chunk index
             pUnboxedMD->SetChunkIndex(pChunk);
             pUnboxedMD->SetMethodDescIndex(methodDescCount);
+            pUnboxedMD->AllocateCodeData();
 
             if (bmtGenerics->GetNumGenericArgs() == 0) {
                 pUnboxedMD->SetHasNonVtableSlot();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7039,8 +7039,9 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
         PRECONDITION(sizeOfMethodDescs <= MethodDescChunk::MaxSizeOfMethodDescs);
     } CONTRACTL_END;
 
+    PTR_LoaderHeap pHeap = GetLoaderAllocator()->GetHighFrequencyHeap();
     void * pMem = GetMemTracker()->Track(
-        GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(TADDR) + sizeof(MethodDescChunk) + sizeOfMethodDescs)));
+        pHeap->AllocMem(S_SIZE_T(sizeof(TADDR) + sizeof(MethodDescChunk) + sizeOfMethodDescs)));
 
     // Skip pointer to temporary entrypoints
     MethodDescChunk * pChunk = (MethodDescChunk *)((BYTE*)pMem + sizeof(TADDR));
@@ -7065,7 +7066,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
 
         pMD->SetChunkIndex(pChunk);
         pMD->SetMethodDescIndex(methodDescCount);
-        pMD->AllocateCodeData();
+        pMD->AllocateCodeData(pHeap, GetMemTracker());
 
         InitNewMethodDesc(pMDMethod, pMD);
 
@@ -7110,7 +7111,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // Reset the chunk index
             pUnboxedMD->SetChunkIndex(pChunk);
             pUnboxedMD->SetMethodDescIndex(methodDescCount);
-            pUnboxedMD->AllocateCodeData();
+            pUnboxedMD->AllocateCodeData(pHeap, GetMemTracker());
 
             if (bmtGenerics->GetNumGenericArgs() == 0) {
                 pUnboxedMD->SetHasNonVtableSlot();


### PR DESCRIPTION
Remove the dictionary from the `CodeVersionManager`
and instead store the data directly on the `MethodDesc`.