### PR TITLE
fixed the split error for LoongArch64.

### DIFF
--- a/src/coreclr/jit/abi.cpp
+++ b/src/coreclr/jit/abi.cpp
@@ -258,16 +258,12 @@ bool ABIPassingInformation::HasExactlyOneStackSegment() const
 //
 bool ABIPassingInformation::IsSplitAcrossRegistersAndStack() const
 {
-    if (NumSegments < 2)
-        return false;
-
-    bool isFirstInReg = Segments[0].IsPassedInRegister();
-    for (unsigned i = 1; i < NumSegments; i++)
+    if (NumSegments != 2)
     {
-        if (isFirstInReg != Segments[i].IsPassedInRegister())
-            return true;
+        return false;
     }
-    return false;
+
+    return Segments[0].IsPassedInRegister() && Segments[1].IsPassedOnStack();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/abi.cpp
+++ b/src/coreclr/jit/abi.cpp
@@ -258,12 +258,20 @@ bool ABIPassingInformation::HasExactlyOneStackSegment() const
 //
 bool ABIPassingInformation::IsSplitAcrossRegistersAndStack() const
 {
-    if (NumSegments != 2)
+    if (NumSegments < 2)
     {
         return false;
     }
 
-    return Segments[0].IsPassedInRegister() && Segments[1].IsPassedOnStack();
+    bool isFirstInReg = Segments[0].IsPassedInRegister();
+    for (unsigned i = 1; i < NumSegments; i++)
+    {
+        if (isFirstInReg != Segments[i].IsPassedInRegister())
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4159,14 +4159,14 @@ void CodeGen::genHomeStackSegment(unsigned                 lclNum,
     }
     emitAttr size = emitTypeSize(loadType);
 
-    int loadOffset;
+    int loadOffset = (int)seg.GetStackOffset();
     if (isFramePointerUsed())
     {
-        loadOffset = -genCallerSPtoFPdelta();
+        loadOffset -= genCallerSPtoFPdelta();
     }
     else
     {
-        loadOffset = -(int)seg.GetStackOffset() - genCallerSPtoInitialSPdelta();
+        loadOffset -= genCallerSPtoInitialSPdelta();
     }
 
 #ifdef TARGET_XARCH

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4119,7 +4119,7 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
     }
 }
 
-#if defined(SWIFT_SUPPORT) || defined(TARGET_RISCV64)
+#if defined(SWIFT_SUPPORT) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
 //-----------------------------------------------------------------------------
 // genHomeSwiftStructParameters: Move the incoming segment to the local stack frame.
 //
@@ -4159,8 +4159,16 @@ void CodeGen::genHomeStackSegment(unsigned                 lclNum,
     }
     emitAttr size = emitTypeSize(loadType);
 
-    int loadOffset =
-        -(isFramePointerUsed() ? genCallerSPtoFPdelta() : genCallerSPtoInitialSPdelta()) + (int)seg.GetStackOffset();
+    int loadOffset;
+    if (isFramePointerUsed())
+    {
+        loadOffset = -genCallerSPtoFPdelta();
+    }
+    else
+    {
+        loadOffset = -(int)seg.GetStackOffset() - genCallerSPtoInitialSPdelta();
+    }
+
 #ifdef TARGET_XARCH
     GetEmitter()->emitIns_R_AR(ins_Load(loadType), size, initReg, genFramePointerReg(), loadOffset);
 #else
@@ -4171,7 +4179,7 @@ void CodeGen::genHomeStackSegment(unsigned                 lclNum,
     if (initRegStillZeroed)
         *initRegStillZeroed = false;
 }
-#endif // defined(SWIFT_SUPPORT) || defined(TARGET_RISCV64)
+#endif // defined(SWIFT_SUPPORT) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
 
 #ifdef SWIFT_SUPPORT
 
@@ -4248,7 +4256,7 @@ void CodeGen::genHomeSwiftStructParameters(bool handleStack)
 //
 void CodeGen::genHomeStackPartOfSplitParameter(regNumber initReg, bool* initRegStillZeroed)
 {
-#ifdef TARGET_RISCV64
+#if defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
     unsigned lclNum = 0;
     for (; lclNum < compiler->info.compArgsCount; lclNum++)
     {
@@ -4273,7 +4281,7 @@ void CodeGen::genHomeStackPartOfSplitParameter(regNumber initReg, bool* initRegS
         }
         break;
     }
-#endif
+#endif // TARGET_RISCV64 || TARGET_LOONGARCH64
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4282,9 +4282,9 @@ void CodeGen::genHomeStackPartOfSplitParameter(regNumber initReg, bool* initRegS
 #ifdef DEBUG
             for (lclNum += 1; lclNum < compiler->info.compArgsCount; lclNum++)
             {
-                abiInfo = compiler->lvaGetParameterABIInfo(lclNum);
+                const ABIPassingInformation& abiInfo2 = compiler->lvaGetParameterABIInfo(lclNum);
                 // There should be only one split parameter
-                assert(!abiInfo.IsSplitAcrossRegistersAndStack());
+                assert(!abiInfo2.IsSplitAcrossRegistersAndStack());
             }
 #endif
             break;


### PR DESCRIPTION
Fixed the split error for LoongArch64. https://github.com/dotnet/runtime/pull/101288#pullrequestreview-2025621422

