### PR TITLE
Ignore line endings when comparing AsnXml generated content

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -1,15 +1,58 @@
 <Project>
   <PropertyGroup>
     <AsnXml />
-    <_AsnXmlDiffCmd>%24%28command -v diff%29 -q -a</_AsnXmlDiffCmd>
-    <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('windows')) == 'true'">$(SystemRoot)\System32\fc.exe /a</_AsnXmlDiffCmd>
-    <_AsnXmlDiffCmd Condition="$([MSBuild]::IsOsPlatform('osx')) == 'true'">diff</_AsnXmlDiffCmd>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)asn.xsd">
       <Link>Common\System\Security\Cryptography\Asn1\asn.xsd</Link>
     </None>
   </ItemGroup>
+
+  <UsingTask
+    TaskName="CompareFilesIgnoreLineEndings"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <GeneratedFile ParameterType="Microsoft.Build.Framework.ITaskItem" Required="true" />
+      <ExistingFile ParameterType="Microsoft.Build.Framework.ITaskItem" Required="true" />
+      <ContentsDiffer ParameterType="System.Boolean" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          if (!File.Exists(ExistingFile.ItemSpec))
+          {
+              ContentsDiffer = true;
+              return true;
+          }
+
+          using (IEnumerator<string> existingLines = File.ReadLines(ExistingFile.ItemSpec).GetEnumerator())
+          using (IEnumerator<string> generatedLines = File.ReadLines(GeneratedFile.ItemSpec).GetEnumerator())
+          {
+              while (generatedLines.MoveNext())
+              {
+                  if (!existingLines.MoveNext())
+                  {
+                      ContentsDiffer = true;
+                      return true;
+                  }
+
+                  if (generatedLines.Current != existingLines.Current)
+                  {
+                      ContentsDiffer = true;
+                      return true;
+                  }
+              }
+
+              ContentsDiffer = existingLines.MoveNext();
+          }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
   <Target Name="CompileAsn" BeforeTargets="CoreCompile"
     Condition=" '@(AsnXml)' != '' "
@@ -27,18 +70,17 @@
       XmlInputPaths="@(AsnXml)"
       OutputPaths="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')" />
 
-    <Exec
-      IgnoreExitCode="true"
-      StandardOutputImportance="Low"
-      Command="$(_AsnXmlDiffCmd) @(AsnXml -> '&quot;$(_AsnIntermediatePath)%(filename).cs&quot;') @(AsnXml -> '&quot;%(Identity).cs&quot;')">
-      <Output TaskParameter="ExitCode" ItemName="_AsnXmlDiffCode" />
-    </Exec>
+    <CompareFilesIgnoreLineEndings
+      GeneratedFile="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
+      ExistingFile="@(AsnXml -> '%(Identity).cs')">
+      <Output TaskParameter="ContentsDiffer" ItemName="_FilesDiffer" />
+    </CompareFilesIgnoreLineEndings>
 
     <Copy
-      Condition="'@(_AsnXmlDiffCode)' != '0'"
+      Condition="'@(_FilesDiffer)' == 'True'"
       SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
-    <Warning Condition="'@(_AsnXmlDiffCode)' != '0'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
+    <Warning Condition="'@(_FilesDiffer)' == 'True'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
   </Target>
 </Project>

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AsnXml.targets
@@ -18,37 +18,12 @@
       <ContentsDiffer ParameterType="System.Boolean" Output="true" />
     </ParameterGroup>
     <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.Collections.Generic" />
       <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
       <Code Type="Fragment" Language="cs">
         <![CDATA[
-          if (!File.Exists(ExistingFile.ItemSpec))
-          {
-              ContentsDiffer = true;
-              return true;
-          }
-
-          using (IEnumerator<string> existingLines = File.ReadLines(ExistingFile.ItemSpec).GetEnumerator())
-          using (IEnumerator<string> generatedLines = File.ReadLines(GeneratedFile.ItemSpec).GetEnumerator())
-          {
-              while (generatedLines.MoveNext())
-              {
-                  if (!existingLines.MoveNext())
-                  {
-                      ContentsDiffer = true;
-                      return true;
-                  }
-
-                  if (generatedLines.Current != existingLines.Current)
-                  {
-                      ContentsDiffer = true;
-                      return true;
-                  }
-              }
-
-              ContentsDiffer = existingLines.MoveNext();
-          }
+        ContentsDiffer = !File.Exists(ExistingFile.ItemSpec) ||
+          !File.ReadLines(ExistingFile.ItemSpec).SequenceEqual(File.ReadLines(GeneratedFile.ItemSpec));
         ]]>
       </Code>
     </Task>
@@ -77,10 +52,10 @@
     </CompareFilesIgnoreLineEndings>
 
     <Copy
-      Condition="'@(_FilesDiffer)' == 'True'"
+      Condition="'@(_FilesDiffer)' == 'true'"
       SourceFiles="@(AsnXml -> '$(_AsnIntermediatePath)%(filename).cs')"
       DestinationFiles="@(AsnXml -> '%(Identity).cs')" />
 
-    <Warning Condition="'@(_FilesDiffer)' == 'True'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
+    <Warning Condition="'@(_FilesDiffer)' == 'true'" Text="AsnXml regenerated files, be sure to check them in: @(AsnXml -> '%(Identity).cs')" />
   </Target>
 </Project>


### PR DESCRIPTION
Some developers configure their git to check out files as LF instead of CRLF on Windows. That causes the diff detection for the AsnXml target to think the generator produced a meaningful change, when it really didn't. There unfortunately is not a good way to fix this in `.gitattributes` if the developer _really_ insists that the line endings are LF on Windows, e.g:

```
git config --global core.autocrlf input
git config --global core.eol lf
```

We can't tell .gitattributes "No really, you definitely want to check these files out as CRLF on Windows and LF everywhere else".

Instead, we can just ignore the line endings for comparison sake. I could not figure out a way to do this in MSBuild, so I added a small C# task. I feel like this should be doable with `<ReadLinesFromFile />` and comparing the `Lines` output, but I couldn't quite get that to work.

Fixes #101651