### PR TITLE
Replace usage of out-of-support TFM compiler directives

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/Utilities/LockFreeReaderHashtable.cs
@@ -367,7 +367,7 @@ namespace Internal.TypeSystem
 
         private TValue AddOrGetExistingInner(TValue value, out bool addedValue)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(value);
 #else
             if (value == null)
@@ -596,7 +596,7 @@ namespace Internal.TypeSystem
         /// <returns>Value from the hashtable if found, otherwise null.</returns>
         public TValue GetValueIfExists(TValue value)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(value);
 #else
             if (value == null)

--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Security.Authentication;
@@ -31,7 +31,7 @@ namespace System.DirectoryServices.Protocols
         public int HighPart => _highPart;
     }
 
-#if NET7_0_OR_GREATER
+#if NET
     [NativeMarshalling(typeof(Marshaller))]
 #endif
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -49,7 +49,7 @@ namespace System.DirectoryServices.Protocols
         public string packageList;
         public int packageListLength;
 
-#if NET7_0_OR_GREATER
+#if NET
         [CustomMarshaller(typeof(SEC_WINNT_AUTH_IDENTITY_EX), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
         internal static class Marshaller
         {
@@ -176,7 +176,7 @@ namespace System.DirectoryServices.Protocols
         public int tv_usec;
     }
 
-#if NET7_0_OR_GREATER
+#if NET
     [NativeMarshalling(typeof(PinningMarshaller))]
 #endif
     [StructLayout(LayoutKind.Sequential)]
@@ -185,7 +185,7 @@ namespace System.DirectoryServices.Protocols
         public int bv_len;
         public IntPtr bv_val = IntPtr.Zero;
 
-#if NET7_0_OR_GREATER
+#if NET
         [CustomMarshaller(typeof(BerVal), MarshalMode.ManagedToUnmanagedIn, typeof(PinningMarshaller))]
         internal static unsafe class PinningMarshaller
         {
@@ -207,7 +207,7 @@ namespace System.DirectoryServices.Protocols
         public LdapControl() { }
     }
 
-#if NET7_0_OR_GREATER
+#if NET
     [NativeMarshalling(typeof(Marshaller))]
 #endif
     [StructLayout(LayoutKind.Sequential)]
@@ -217,7 +217,7 @@ namespace System.DirectoryServices.Protocols
         public QUERYFORCONNECTIONInternal query;
         public NOTIFYOFNEWCONNECTIONInternal notify;
         public DEREFERENCECONNECTIONInternal dereference;
-#if NET7_0_OR_GREATER
+#if NET
         public static readonly unsafe int Size = sizeof(Marshaller.MarshalValue.Native);
 
         [CustomMarshaller(typeof(LdapReferralCallback), MarshalMode.ManagedToUnmanagedIn, typeof(MarshalValue))]

--- a/src/libraries/Common/src/Interop/Interop.Odbc.cs
+++ b/src/libraries/Common/src/Interop/Interop.Odbc.cs
@@ -5,7 +5,7 @@ using System;
 using System.Data.Odbc;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Runtime.Versioning;
@@ -38,7 +38,7 @@ internal static partial class Interop
             /*SQLUSMALLINT*/ushort ColumnNumber,
             /*SQLSMALLINT*/ODBC32.SQL_C TargetType,
             /*SQLPOINTER*/
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef TargetValue,
@@ -64,13 +64,13 @@ internal static partial class Interop
             /*SQLULEN*/IntPtr cbColDef,
             /*SQLSMALLINT*/IntPtr ibScale,
             /*SQLPOINTER*/
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef rgbValue,
             /*SQLLEN*/IntPtr BufferLength,
             /*SQLLEN* */
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef StrLen_or_Ind);
@@ -326,7 +326,7 @@ internal static partial class Interop
             /*SQLSMALLINT*/short ColumnNumber,
             /*SQLSMALLINT*/ODBC32.SQL_DESC FieldIdentifier,
             /*SQLPOINTER*/
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef CharacterAttribute,

--- a/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
+++ b/src/libraries/Common/src/Interop/Windows/CryptUI/Interop.CryptUIDlgCertificate.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using Microsoft.Win32.SafeHandles;
@@ -13,7 +13,7 @@ internal static partial class Interop
 {
     internal static partial class CryptUI
     {
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -39,7 +39,7 @@ internal static partial class Interop
             internal IntPtr rgPropSheetPages;
             internal uint nStartPage;
 
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(CRYPTUI_VIEWCERTIFICATE_STRUCTW), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {
@@ -127,7 +127,7 @@ internal static partial class Interop
 #endif
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #else
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -151,7 +151,7 @@ internal static partial class Interop
             internal IntPtr rgPropSheetPages;
             internal IntPtr hSelectedCertStore;
 
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(CRYPTUI_SELECTCERTIFICATE_STRUCTW), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.AbortDoc.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.AbortDoc.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int AbortDoc(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleBitmap.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateCompatibleBitmap.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial IntPtr CreateCompatibleBitmap(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, int width, int height);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateDIBSection.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.CreateDIBSection.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial IntPtr CreateDIBSection(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hdc, ref BITMAPINFO_FLAT bmi, int iUsage, ref IntPtr ppvBits, IntPtr hSection, int dwOffset);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.EndDoc.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.EndDoc.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int EndDoc(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.EndPage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.EndPage.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int EndPage(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.ExtEscape.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.ExtEscape.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -16,14 +16,14 @@ internal static partial class Interop
 
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int ExtEscape(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, int nEscape, int cbInput, ref int inData, int cbOutput, out int outData);
 
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int ExtEscape(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, int nEscape, int cbInput, byte[] inData, int cbOutput, out int outData);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDIBits.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetDIBits.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,11 +13,11 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32)]
         internal static partial int GetDIBits(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hdc,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hbm, int arg1, int arg2, IntPtr arg3, ref BITMAPINFO_FLAT bmi, int arg5);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetObject.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,20 +13,20 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, EntryPoint = "GetObjectW", SetLastError = true)]
         internal static partial int GetObject(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hObject, int nSize, ref BITMAP bm);
 
         [LibraryImport(Libraries.Gdi32, EntryPoint = "GetObjectW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial int GetObject(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hObject, int nSize, ref Interop.User32.LOGFONT lf);
 
         internal static unsafe int GetObject(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hObject, ref Interop.User32.LOGFONT lp)

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetPaletteEntries.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.GetPaletteEntries.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32)]
         internal static partial uint GetPaletteEntries(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hpal, int iStartIndex, int nEntries, byte[] lppe);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.IntersectClipRect.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.IntersectClipRect.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int IntersectClipRect(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, int x1, int y1, int x2, int y2);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.ResetDC.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.ResetDC.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,11 +13,11 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, EntryPoint = "ResetDCW", SetLastError = true)]
         internal static partial IntPtr /*HDC*/ ResetDC(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef /*DEVMODE*/ lpDevMode);

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.StartDoc.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.StartDoc.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,12 +13,12 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, EntryPoint = "StartDocW", SetLastError = true)]
         internal static partial int StartDoc(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, in DOCINFO lpDocInfo);
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
@@ -32,7 +32,7 @@ internal static partial class Interop
 
             public DOCINFO() { }
 
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(DOCINFO), MarshalMode.ManagedToUnmanagedIn, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.StartPage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Gdi32/Interop.StartPage.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial int StartPage(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC);

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SelectObject.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SelectObject.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,11 +13,11 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Gdi32, SetLastError = true)]
         internal static partial IntPtr SelectObject(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hdc,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef obj);

--- a/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ExtractAssociatedIcon.cs
+++ b/src/libraries/Common/src/Interop/Windows/Shell32/Interop.ExtractAssociatedIcon.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Shell32, EntryPoint = "ExtractAssociatedIconW")]
         internal static unsafe partial IntPtr ExtractAssociatedIcon(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hInst, char* iconPath, ref int index);

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.CopyImage.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.CopyImage.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.User32, SetLastError = true)]
         internal static partial IntPtr CopyImage(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hImage, int uType, int cxDesired, int cyDesired, int fuFlags);

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.CreateIconFromResourceEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.CreateIconFromResourceEx.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.DestroyIcon.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.DestroyIcon.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -14,7 +14,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.User32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DestroyIcon(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hIcon);

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.DrawIconEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.DrawIconEx.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -14,15 +14,15 @@ internal static partial class Interop
         [LibraryImport(Libraries.User32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool DrawIconEx(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hDC, int x, int y,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hIcon, int width, int height, int iStepIfAniCursor,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hBrushFlickerFree, int diFlags);

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetIconInfo.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetIconInfo.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -14,7 +14,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.User32, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetIconInfo(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hIcon, ref ICONINFO info);

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetSystemMetrics.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetSystemMetrics.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.LoadIcon.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.LoadIcon.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,7 +13,7 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.User32, EntryPoint = "LoadIconW", SetLastError = true)]
         internal static partial IntPtr LoadIcon(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hInst, IntPtr iconId);

--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Text;
@@ -45,7 +45,7 @@ internal static partial class Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         public static partial bool WinHttpAddRequestHeaders(
             SafeWinHttpHandle requestHandle,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(SimpleStringBufferMarshaller))] StringBuilder headers,
 #else
 #pragma warning disable CA1838 // Uses pooled StringBuilder
@@ -55,7 +55,7 @@ internal static partial class Interop
             uint headersLength,
             uint modifiers);
 
-#if NET7_0_OR_GREATER
+#if NET
         [CustomMarshaller(typeof(StringBuilder), MarshalMode.ManagedToUnmanagedIn, typeof(SimpleStringBufferMarshaller))]
         private static unsafe class SimpleStringBufferMarshaller
         {

--- a/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinHttp/Interop.winhttp_types.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Text;
@@ -247,7 +247,7 @@ internal static partial class Interop
             IntPtr statusInformation,
             uint statusInformationLength);
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -261,7 +261,7 @@ internal static partial class Interop
             public uint Reserved2;
             [MarshalAs(UnmanagedType.Bool)]
             public bool AutoLoginIfChallenged;
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(WINHTTP_AUTOPROXY_OPTIONS), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/Common/src/Interop/Windows/WinMm/Interop.waveOutGetDevCaps.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinMm/Interop.waveOutGetDevCaps.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -12,7 +12,7 @@ internal static partial class Interop
     internal static partial class WinMM
     {
 #pragma warning disable CA1823 // unused fields
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         internal struct WAVEOUTCAPS
@@ -27,7 +27,7 @@ internal static partial class Interop
             private ushort wChannels;
             private ushort wReserved1;
             private ushort dwSupport;
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(WAVEOUTCAPS), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/Common/src/Interop/Windows/Winspool/Interop.DocumentProperties.cs
+++ b/src/libraries/Common/src/Interop/Windows/Winspool/Interop.DocumentProperties.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 
@@ -13,26 +13,26 @@ internal static partial class Interop
     {
         [LibraryImport(Libraries.Winspool, EntryPoint = "DocumentPropertiesW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial int DocumentProperties(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hwnd,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hPrinter, string pDeviceName, IntPtr /*DEVMODE*/ pDevModeOutput,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef /*DEVMODE*/ pDevModeInput, int fMode);
 
         [LibraryImport(Libraries.Winspool, EntryPoint = "DocumentPropertiesW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
         internal static partial int DocumentProperties(
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hwnd,
-#if NET7_0_OR_GREATER
+#if NET
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
             HandleRef hPrinter, string pDeviceName, IntPtr /*DEVMODE*/ pDevModeOutput, IntPtr /*DEVMODE*/ pDevModeInput, int fMode);

--- a/src/libraries/Common/src/Interop/Windows/Winspool/Interop.EnumPrinters.cs
+++ b/src/libraries/Common/src/Interop/Windows/Winspool/Interop.EnumPrinters.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 

--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReference.cs
@@ -42,7 +42,7 @@ namespace System.Runtime.Serialization
 
         public CodeTypeReference(Type type)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(type);
 #else
             if (type is null)
@@ -271,7 +271,7 @@ namespace System.Runtime.Serialization
             }
 
             // Now see if we have some arity.  baseType could be null if this is an array type.
-#if NET5_0_OR_GREATER
+#if NET
             if (_baseType != null && _baseType.Contains('`')) // string.Contains(char) is .NetCore2.1+ specific
 #else
             if (_baseType != null && _baseType.IndexOf('`') != -1) // string.Contains(char) is .NetCore2.1+ specific

--- a/src/libraries/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
+++ b/src/libraries/Common/src/System/CodeDom/CodeTypeReferenceCollection.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.Serialization
 
         public void AddRange(CodeTypeReference[] value)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(value);
 #else
             if (value is null)
@@ -58,7 +58,7 @@ namespace System.Runtime.Serialization
 
         public void AddRange(CodeTypeReferenceCollection value)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(value);
 #else
             if (value is null)

--- a/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
+++ b/src/libraries/Common/src/System/Data/Common/DbConnectionOptions.Common.cs
@@ -50,7 +50,7 @@ namespace System.Data.Common
         private static readonly Regex s_connectionStringRegex = CreateConnectionStringRegex();
         private static readonly Regex s_connectionStringRegexOdbc = CreateConnectionStringRegexOdbc();
 
-#if NET7_0_OR_GREATER
+#if NET
         [GeneratedRegex(ConnectionStringPattern, RegexOptions.ExplicitCapture)]
         private static partial Regex CreateConnectionStringRegex();
 
@@ -67,7 +67,7 @@ namespace System.Data.Common
         private static readonly Regex s_connectionStringQuoteValueRegex = CreateConnectionStringQuoteValueRegex(); // generally do not quote the value if it matches the pattern
         private static readonly Regex s_connectionStringQuoteOdbcValueRegex = CreateConnectionStringQuoteOdbcValueRegex(); // do not quote odbc value if it matches this pattern
 
-#if NET7_0_OR_GREATER
+#if NET
         [GeneratedRegex("^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$")]
         private static partial Regex CreateConnectionStringValidKeyRegex();
         [GeneratedRegex("^[^\"'=;\\s\\p{Cc}]*$")]

--- a/src/libraries/Common/src/System/IO/TempFileCollection.cs
+++ b/src/libraries/Common/src/System/IO/TempFileCollection.cs
@@ -153,7 +153,7 @@ namespace System.IO.Internal
             }
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         private string GetTempDirectory()
         {
             _createdTempDirectory = true;

--- a/src/libraries/Common/src/System/IO/Win32Marshal.cs
+++ b/src/libraries/Common/src/System/IO/Win32Marshal.cs
@@ -76,7 +76,7 @@ namespace System.IO
             {
                 // Call Kernel32.GetMessage directly in CoreLib. It eliminates one level of indirection and it is necessary to
                 // produce correct error messages for CoreCLR Win32 PAL.
-#if NET7_0_OR_GREATER && !SYSTEM_PRIVATE_CORELIB
+#if NET && !SYSTEM_PRIVATE_CORELIB
                 return Marshal.GetPInvokeErrorMessage(errorCode);
 #else
                 return Interop.Kernel32.GetMessage(errorCode);

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.manual.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.manual.cs
@@ -7,7 +7,7 @@ namespace System.Security.Cryptography.Asn1
     {
         public AttributeAsn(AsnEncodedData attribute)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(attribute);
 #else
             if (attribute is null)

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.manual.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.manual.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.Asn1
     {
         public X509ExtensionAsn(X509Extension extension)
         {
-#if NET5_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(extension);
 #else
             if (extension is null)

--- a/src/libraries/Common/src/System/Security/Cryptography/CryptoThrowHelper.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CryptoThrowHelper.Windows.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Security.Cryptography;
 
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
 using System.Diagnostics;
 using System.Runtime.Serialization;
 #endif
@@ -25,7 +25,7 @@ namespace Internal.Cryptography
                 hr = (hr & 0x0000FFFF) | unchecked((int)0x80070000);
             }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
             return new CryptographicException(message)
             {
                 HResult = hr
@@ -40,7 +40,7 @@ namespace Internal.Cryptography
 #endif
         }
 
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
         [Serializable]
         private sealed class WindowsCryptographicException : CryptographicException
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationManaged.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationManaged.cs
@@ -10,9 +10,6 @@ using System.Threading;
 
 namespace System.Security.Cryptography
 {
-#if !NET7_0_OR_GREATER && NET
-    [UnsupportedOSPlatform("browser")]
-#endif
     internal sealed partial class SP800108HmacCounterKdfImplementationManaged : SP800108HmacCounterKdfImplementationBase
     {
         private byte[] _key;

--- a/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
@@ -31,7 +31,7 @@ namespace System.Threading.Tasks
         /// </remarks>
         public static IAsyncResult Begin(Task task, AsyncCallback? callback, object? state)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(task);
 #else
             if (task is null)
@@ -68,7 +68,7 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentException"><paramref name="asyncResult"/> was not produced by a call to <see cref="Begin"/>.</exception>
         public static Task Unwrap(IAsyncResult asyncResult)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(asyncResult);
 #else
             if (asyncResult is null)
@@ -97,7 +97,7 @@ namespace System.Threading.Tasks
         /// </exception>
         public static Task<TResult> Unwrap<TResult>(IAsyncResult asyncResult)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(asyncResult);
 #else
             if (asyncResult is null)

--- a/src/libraries/Common/src/System/ThrowHelper.cs
+++ b/src/libraries/Common/src/System/ThrowHelper.cs
@@ -15,7 +15,7 @@ namespace System
         /// <param name="argument">The reference type argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
         internal static void ThrowIfNull(
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             [NotNull]
 #endif
             object? argument,
@@ -27,7 +27,7 @@ namespace System
             }
         }
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [DoesNotReturn]
 #endif
         private static void Throw(string? paramName) => throw new ArgumentNullException(paramName);
@@ -40,17 +40,17 @@ namespace System
         /// <param name="paramName">The name of the parameter being checked.</param>
         /// <returns>The original value of <paramref name="argument"/>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [return: NotNull]
 #endif
         public static string IfNullOrWhitespace(
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             [NotNull]
 #endif
             string? argument,
             [CallerArgumentExpression(nameof(argument))] string paramName = "")
         {
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
             if (argument == null)
             {
                 throw new ArgumentNullException(paramName);
@@ -74,7 +74,7 @@ namespace System
     }
 }
 
-#if !NETCOREAPP3_0_OR_GREATER
+#if !NET
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NET6_0_OR_GREATER
+#if NET
 using System.Runtime.Intrinsics;
 #endif
 using System.Threading;
@@ -710,7 +710,7 @@ namespace System
             return (*(ulong*)(&value)) == 0x0000000000000000;
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         static unsafe bool IsNegativeZero(Half value)
         {
             return (*(ushort*)(&value)) == 0x8000;
@@ -780,7 +780,7 @@ namespace System
             }
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         static string ToStringPadded(Half value)
         {
             if (Half.IsNaN(value))
@@ -1036,7 +1036,7 @@ namespace System
             }
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         /// <summary>Verifies that two <see cref="Half"/> values are equal, within the <paramref name="variance"/>.</summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The value to be compared against</param>
@@ -1196,7 +1196,7 @@ namespace System
             throw EqualException.ForMismatchedValues(ToStringPadded(expected), ToStringPadded(actual));
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         /// <summary>Verifies that two <see cref="Half"/> values's binary representations are identical.</summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The value to be compared against</param>

--- a/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/WindowsIdentityFixture.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Security.Cryptography;
@@ -127,7 +127,7 @@ namespace System
         [LibraryImport("netapi32.dll")]
         internal static partial uint NetUserDel([MarshalAs(UnmanagedType.LPWStr)] string servername, [MarshalAs(UnmanagedType.LPWStr)] string username);
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(USER_INFO_1.Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
@@ -142,7 +142,7 @@ namespace System
             public uint usri1_flags;
             public string usri1_script_path;
 
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(USER_INFO_1), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
+++ b/src/libraries/Common/tests/TestUtilities/TestEventListener.cs
@@ -99,7 +99,7 @@ public sealed class TestEventListener : EventListener
     protected override void OnEventWritten(EventWrittenEventArgs eventData)
     {
         StringBuilder sb = new StringBuilder().
-#if NETCOREAPP2_2_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
             Append($"{eventData.TimeStamp:HH:mm:ss.fffffff}[{eventData.EventName}] ");
 #else
             Append($"[{eventData.EventName}] ");

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/IMemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/IMemoryCache.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="key">An object identifying the entry.</param>
         void Remove(object key);
 
-#if NET6_0_OR_GREATER
+#if NET
         /// <summary>
         /// Gets a snapshot of the cache statistics if available.
         /// </summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheGetCurrentStatisticsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheGetCurrentStatisticsTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Caching.Memory
             }
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         [Fact]
         public void GetCurrentStatistics_DIMReturnsNull()
         {

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFilesWatcher.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Extensions.FileProviders.Physical
             }
 
             IChangeToken changeToken;
-#if NET5_0_OR_GREATER
+#if NET
             bool isWildCard = pattern.Contains('*');
 #else
             bool isWildCard = pattern.IndexOf('*') != -1;

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/src/WindowsServiceHelpers.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.Hosting.WindowsServices
             if (
 #if NETFRAMEWORK
                 Environment.OSVersion.Platform != PlatformID.Win32NT
-#elif NET5_0_OR_GREATER
+#elif NET
                 !OperatingSystem.IsWindows()
 #else
                 !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostBuilder.cs
@@ -190,11 +190,6 @@ namespace Microsoft.Extensions.Hosting
             return diagnosticListener;
         }
 
-// Remove when https://github.com/dotnet/runtime/pull/78532 is merged and consumed by the used SDK.
-#if NET7_0
-        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
-            Justification = "DiagnosticSource is used here to pass objects in-memory to code using HostFactoryResolver. This won't require creating new generic types.")]
-#endif
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
             Justification = "The values being passed into Write are being consumed by the application already.")]
         private static void Write<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] T>(

--- a/src/libraries/Microsoft.Extensions.Http/ref/Microsoft.Extensions.Http.cs
+++ b/src/libraries/Microsoft.Extensions.Http/ref/Microsoft.Extensions.Http.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder RedactLoggedHeaders(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Func<string, bool> shouldRedactHeaderValue) { throw null; }
         public static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder RemoveAllLoggers(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder) { throw null; }
         public static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder SetHandlerLifetime(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.TimeSpan handlerLifetime) { throw null; }
-#if NET5_0_OR_GREATER
+#if NET
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
         public static Microsoft.Extensions.DependencyInjection.IHttpClientBuilder UseSocketsHttpHandler(this Microsoft.Extensions.DependencyInjection.IHttpClientBuilder builder, System.Action<System.Net.Http.SocketsHttpHandler, System.IServiceProvider>? configureHandler = null) { throw null; }
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
@@ -64,14 +64,14 @@ namespace Microsoft.Extensions.DependencyInjection
         string Name { get; }
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
-#if NET5_0_OR_GREATER
+#if NET
     public partial interface ISocketsHttpHandlerBuilder
     {
         string Name { get; }
         Microsoft.Extensions.DependencyInjection.IServiceCollection Services { get; }
     }
 #endif
-#if NET5_0_OR_GREATER
+#if NET
     public static partial class SocketsHttpHandlerBuilderExtensions
     {
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/DefaultSocketsHttpHandlerBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/DefaultSocketsHttpHandlerBuilder.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET5_0_OR_GREATER
+#if NET
 namespace Microsoft.Extensions.DependencyInjection
 {
     internal sealed class DefaultSocketsHttpHandlerBuilder : ISocketsHttpHandlerBuilder

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/HttpClientBuilderExtensions.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         /// <summary>
         /// Adds or updates <see cref="SocketsHttpHandler"/> as a primary handler for a named <see cref="HttpClient"/>. If provided,
         /// also adds a delegate that will be used to configure the primary <see cref="SocketsHttpHandler"/>.

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/ISocketsHttpHandlerBuilder.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/ISocketsHttpHandlerBuilder.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET5_0_OR_GREATER
+#if NET
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>

--- a/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/SocketsHttpHandlerBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DependencyInjection/SocketsHttpHandlerBuilderExtensions.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET5_0_OR_GREATER
+#if NET
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/HttpClientLoggerHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/HttpClientLoggerHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Http.Logging
             }
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ThrowHelper.ThrowIfNull(request);

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.Http.Logging
                 var stopwatch = ValueStopwatch.StartNew();
                 HttpResponseMessage response = useAsync
                     ? await base.SendAsync(request, cancellationToken).ConfigureAwait(false)
-#if NET5_0_OR_GREATER
+#if NET
                     : base.Send(request, cancellationToken);
 #else
                     : throw new NotImplementedException("Unreachable code");
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.Http.Logging
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => SendCoreAsync(request, useAsync: true, cancellationToken);
 
-#if NET5_0_OR_GREATER
+#if NET
         /// <inheritdoc />
         /// <remarks>Logs the request to and response from the sent <see cref="HttpRequestMessage"/>.</remarks>
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.Http.Logging
                     Log.RequestPipelineStart(_logger, request, shouldRedactHeaderValue);
                     HttpResponseMessage response = useAsync
                         ? await base.SendAsync(request, cancellationToken).ConfigureAwait(false)
-#if NET5_0_OR_GREATER
+#if NET
                         : base.Send(request, cancellationToken);
 #else
                         : throw new NotImplementedException("Unreachable code");
@@ -80,7 +80,7 @@ namespace Microsoft.Extensions.Http.Logging
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => SendCoreAsync(request, useAsync: true, cancellationToken);
 
-#if NET5_0_OR_GREATER
+#if NET
         /// <inheritdoc />
         /// <remarks>Logs the request to and response from the sent <see cref="HttpRequestMessage"/>.</remarks>
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/HttpClientLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/HttpClientLoggerTest.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Extensions.Http.Logging
             }
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
         [InlineData(false, false)]
         [InlineData(false, true)]
@@ -588,7 +588,7 @@ namespace Microsoft.Extensions.Http.Logging
                         }
                         else
                         {
-#if NET5_0_OR_GREATER
+#if NET
                             return base.Send(request, cancellationToken);
 #else
                             throw new NotImplementedException("unreachable");
@@ -609,7 +609,7 @@ namespace Microsoft.Extensions.Http.Logging
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
                 => SendAsyncCore(request, async: true, cancellationToken);
 
-#if NET5_0_OR_GREATER
+#if NET
             protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
                 => SendAsyncCore(request, async: false, cancellationToken).GetAwaiter().GetResult();
 #endif

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/LoggingUriOutputTests.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/Logging/LoggingUriOutputTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Http.Tests.Logging
             Assert.Equal("HTTP GET http://api.example.com/search?term=Western%20Australia", message.Scope.ToString());
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
         public void LoggingHttpMessageHandler_LogsAbsoluteUri_Sync()
         {

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/SocketsHttpHandlerConfigurationTest.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NET5_0_OR_GREATER
+#if NET
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/TestMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/TestMessageHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.Http
             return Task.FromResult(response);
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken) => _responseFactory(request);
 #endif
     }

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/EmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/EmitterTests.cs
@@ -25,7 +25,7 @@ public class EmitterTests
         foreach (var file in Directory.GetFiles("TestClasses"))
         {
 #if NET
-            sources.Add("#define NETCOREAPP3_1_OR_GREATER\n" + File.ReadAllText(file));
+            sources.Add("#define NET\n" + File.ReadAllText(file));
 #else
             sources.Add(File.ReadAllText(file));
 #endif

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/EmitterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/EmitterTests.cs
@@ -24,7 +24,7 @@ public class EmitterTests
 #pragma warning disable RS1035 // To allow using the File IO APIs inside the analyzer test
         foreach (var file in Directory.GetFiles("TestClasses"))
         {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
             sources.Add("#define NETCOREAPP3_1_OR_GREATER\n" + File.ReadAllText(file));
 #else
             sources.Add(File.ReadAllText(file));
@@ -46,7 +46,7 @@ public class EmitterTests
         Assert.Empty(d);
         _ = Assert.Single(r);
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         string baseline = File.ReadAllText(@"Baselines/NetCoreApp/Validators.g.cs");
 #else
         string baseline = File.ReadAllText(@"Baselines/NetFX/Validators.g.cs");

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/OptionsValidationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/OptionsValidationTests.cs
@@ -186,7 +186,7 @@ public class OptionsValidationTests
     [Fact]
     public void RangeAttributeModelDateValid()
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         // Setting non-invariant culture to check that
         // attribute's "ParseLimitsInInvariantCulture" property
         // was set up correctly in the validator:

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/Utils.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/Generated/Utils.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
 using System.Linq;
 #endif
 using Microsoft.Extensions.Options;
@@ -15,7 +15,7 @@ internal static class Utils
     {
         Assert.NotNull(vr);
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         var failures = vr.Failures!.ToArray();
 #else
         var failures = vr.FailureMessage!.Split(';');

--- a/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/TestClasses/Models.cs
+++ b/src/libraries/Microsoft.Extensions.Options/tests/SourceGenerationTests/TestClasses/Models.cs
@@ -76,7 +76,7 @@ namespace TestClasses.OptionsValidation
 
     public class RangeAttributeModelDate
     {
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         [Range(typeof(DateTime), "1/2/2004", "3/4/2004", ParseLimitsInInvariantCulture = true)]
 #else
         [Range(typeof(DateTime), "1/2/2004", "3/4/2004")]

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Constants.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Constants.cs
@@ -61,19 +61,13 @@ namespace System.Collections.Frozen
             typeof(T) == typeof(DateTime) ||
             typeof(T) == typeof(DateTimeOffset) ||
             typeof(T) == typeof(Guid) ||
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             typeof(T) == typeof(Rune) ||
-#endif
-#if NET5_0_OR_GREATER
             typeof(T) == typeof(Half) ||
             typeof(T) == typeof(nint) ||
             typeof(T) == typeof(nuint) ||
-#endif
-#if NET6_0_OR_GREATER
             typeof(T) == typeof(DateOnly) ||
             typeof(T) == typeof(TimeOnly) ||
-#endif
-#if NET7_0_OR_GREATER
             typeof(T) == typeof(Int128) ||
             typeof(T) == typeof(UInt128) ||
 #endif

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -159,7 +159,7 @@ namespace System.Collections.Frozen
             if (!hashCodesAreUnique)
             {
                 codes =
-#if NETCOREAPP2_0_OR_GREATER
+#if NET
                     new HashSet<int>(hashCodes.Length);
 #else
                     new HashSet<int>();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenSet.cs
@@ -202,7 +202,7 @@ namespace System.Collections.Frozen
     [DebuggerTypeProxy(typeof(ImmutableEnumerableDebuggerProxy<>))]
     [DebuggerDisplay("Count = {Count}")]
     public abstract class FrozenSet<T> : ISet<T>,
-#if NET5_0_OR_GREATER
+#if NET
         IReadOnlySet<T>,
 #endif
         IReadOnlyCollection<T>, ICollection

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/KeyAnalyzer.cs
@@ -64,7 +64,7 @@ namespace System.Collections.Frozen
                 new JustifiedCaseInsensitiveSubstringComparer();
 
             HashSet<string> set = new HashSet<string>(
-#if NET6_0_OR_GREATER
+#if NET
                 uniqueStrings.Length,
 #endif
                 comparer);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBuckets.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBuckets.cs
@@ -28,7 +28,7 @@ namespace System.Collections.Frozen
             }
 
             int arraySize = spread * MaxPerLength;
-#if NET6_0_OR_GREATER
+#if NET
             if (arraySize > Array.MaxLength)
 #else
             if (arraySize > 0X7FFFFFC7)
@@ -87,7 +87,7 @@ namespace System.Collections.Frozen
                 return null;
             }
 
-#if NET6_0_OR_GREATER
+#if NET
             // We don't need an array with every value initialized to zero if we are just about to overwrite every value anyway.
             int[] copy = GC.AllocateUninitializedArray<int>(arraySize);
             Array.Copy(buckets, copy, arraySize);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -589,7 +589,7 @@ namespace System.Collections.Immutable
                 if (index + length < this._count)
                 {
 
-#if NET6_0_OR_GREATER
+#if NET
                     if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
                     {
                         Array.Clear(_elements, index, length); // Clear the elements so that the gc can reclaim the references.
@@ -919,7 +919,7 @@ namespace System.Collections.Immutable
             /// </summary>
             public void Reverse()
             {
-#if NETCOREAPP2_0_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
                 Array.Reverse<T>(_elements, 0, _count);
 #else
                 // The non-generic Array.Reverse is not used because it does not perform
@@ -963,7 +963,7 @@ namespace System.Collections.Immutable
 
                 if (Count > 1)
                 {
-#if NET6_0_OR_GREATER
+#if NET
                     // MemoryExtensions.Sort is not available in .NET Framework / Standard 2.0.
                     // But the overload with a Comparison argument doesn't allocate.
                     _elements.AsSpan(0, _count).Sort(comparison);

--- a/src/libraries/System.Collections.Immutable/src/System/Polyfills.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Polyfills.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Collections.Generic
 {
-#if !NETCOREAPP2_0_OR_GREATER
+#if !NET
     internal static class KeyValuePairExtensions
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -18,7 +18,7 @@ namespace System.Collections.Generic
     }
 #endif
 
-#if !NET5_0_OR_GREATER
+#if !NET
     internal interface IReadOnlySet<T> : IReadOnlyCollection<T>
     {
         bool Contains(T item);
@@ -34,7 +34,7 @@ namespace System.Collections.Generic
 
 namespace System.Numerics
 {
-#if !NETCOREAPP3_0_OR_GREATER
+#if !NET
     internal static class BitOperations
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -45,7 +45,7 @@ namespace System.Numerics
 
 namespace System.Runtime.CompilerServices
 {
-#if !NETCOREAPP3_0_OR_GREATER
+#if !NET
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
     internal sealed class CallerArgumentExpressionAttribute : Attribute
     {

--- a/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenSetTests.cs
+++ b/src/libraries/System.Collections.Immutable/tests/Frozen/FrozenSetTests.cs
@@ -297,7 +297,7 @@ namespace System.Collections.Frozen.Tests
 
         private sealed class EmptySet :
             ISet<T>
-#if NET5_0_OR_GREATER
+#if NET
             , IReadOnlySet<T>
 #endif
         {

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ImplicitMachineConfigHost.cs
@@ -81,7 +81,7 @@ namespace System.Configuration
         <section name='assemblyBinding' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='satelliteassemblies' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />
         <section name='startup' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />" +
-#if NET7_0_OR_GREATER
+#if NET
 @"        <section name='system.diagnostics' type='System.Diagnostics.SystemDiagnosticsSection, System.Configuration.ConfigurationManager' allowLocation='false' />" +
 #endif
 @"        <section name='system.runtime.remoting' type='System.Configuration.IgnoreSection, System.Configuration.ConfigurationManager' allowLocation='false' />

--- a/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
+++ b/src/libraries/System.Data.OleDb/src/DbConnectionOptions.cs
@@ -59,7 +59,7 @@ namespace System.Data.Common
         private static readonly Regex ConnectionStringRegex = CreateConnectionStringRegex();
         private static readonly Regex ConnectionStringRegexOdbc = CreateConnectionStringRegexOdbc();
 
-#if NET7_0_OR_GREATER
+#if NET
         [GeneratedRegex(ConnectionStringPattern, RegexOptions.ExplicitCapture)]
         private static partial Regex CreateConnectionStringRegex();
 
@@ -76,7 +76,7 @@ namespace System.Data.Common
         private static readonly Regex ConnectionStringQuoteValueRegex = CreateConnectionStringQuoteValueRegex(); // generally do not quote the value if it matches the pattern
         private static readonly Regex ConnectionStringQuoteOdbcValueRegex = CreateConnectionStringQuoteOdbcValueRegex(); // do not quote odbc value if it matches this pattern
 
-#if NET7_0_OR_GREATER
+#if NET
         [GeneratedRegex("^(?![;\\s])[^\\p{Cc}]+(?<!\\s)$")]
         private static partial Regex CreateConnectionStringValidKeyRegex();
         [GeneratedRegex("^[^\"'=;\\s\\p{Cc}]*$")]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -226,7 +226,7 @@ namespace System.Diagnostics
                     Span<char> flagsChars = stackalloc char[2];
                     HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _w3CIdFlags), flagsChars, 0, HexConverter.Casing.Lower);
                     string id =
-#if NET6_0_OR_GREATER
+#if NET
                         string.Create(null, stackalloc char[128], $"00-{_traceId}-{_spanId}-{flagsChars}");
 #else
                         "00-" + _traceId + "-" + _spanId + "-" + flagsChars.ToString();
@@ -258,7 +258,7 @@ namespace System.Diagnostics
                         Span<char> flagsChars = stackalloc char[2];
                         HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _parentTraceFlags), flagsChars, 0, HexConverter.Casing.Lower);
                         string parentId =
-#if NET6_0_OR_GREATER
+#if NET
                             string.Create(null, stackalloc char[128], $"00-{_traceId}-{_parentSpanId}-{flagsChars}");
 #else
                             "00-" + _traceId + "-" + _parentSpanId + "-" + flagsChars.ToString();

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterAggregator.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/CounterAggregator.cs
@@ -33,7 +33,7 @@ namespace System.Diagnostics.Metrics
             // Get the delta best associated with the current thread, preferring to use core ID rather than
             // thread ID to reduce contention.
             ref PaddedDouble delta = ref deltas[
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
                 Thread.GetCurrentProcessorId()
 #else
                 Environment.CurrentManagedThreadId

--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/UnsafeNativeMethods.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Diagnostics.Eventing.Reader;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.InteropServices.Marshalling;
 #endif
 using System.Security;
@@ -341,7 +341,7 @@ namespace Microsoft.Win32
             EvtRpcLogin = 1
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Sequential)]
@@ -355,7 +355,7 @@ namespace Microsoft.Win32
             public string Domain;
             public CoTaskMemUnicodeSafeHandle Password;
             public int Flags;
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(EvtRpcLogin), MarshalMode.ManagedToUnmanagedRef, typeof(ValueMarshaller))]
             public static class Marshaller
             {
@@ -695,7 +695,7 @@ namespace Microsoft.Win32
                             out int buffUsed,
                             out int propCount);
 
-#if NET7_0_OR_GREATER
+#if NET
         [NativeMarshalling(typeof(Marshaller))]
 #endif
         [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
@@ -708,7 +708,7 @@ namespace Microsoft.Win32
             [FieldOffset(12)]
             public uint Type;
 
-#if NET7_0_OR_GREATER
+#if NET
             [CustomMarshaller(typeof(EvtStringVariant), MarshalMode.Default, typeof(Marshaller))]
             public static class Marshaller
             {

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -104,7 +104,7 @@ namespace System.Formats.Asn1
         {
             ReadOnlySpan<byte> contents = ReadIntegerBytes(source, ruleSet, out int consumed, expectedTag);
 
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
             BigInteger value = new BigInteger(contents, isBigEndian: true);
 #else
             byte[] tmp = CryptoPool.Rent(contents.Length);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnWriter.Integer.cs
@@ -281,7 +281,7 @@ namespace System.Formats.Asn1
             Debug.Assert(!tag.IsConstructed);
             WriteTag(tag);
 
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
             WriteLength(value.GetByteCount());
             // WriteLength ensures the content-space
             value.TryWriteBytes(_buffer.AsSpan(_offset), out int bytesWritten, isBigEndian: true);

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/SetOfValueComparer.cs
@@ -17,7 +17,7 @@ namespace System.Formats.Asn1
             int min = Math.Min(x.Length, y.Length);
             int diff;
 
-#if NET7_0_OR_GREATER
+#if NET
             int diffIndex = x.CommonPrefixLength(y);
 
             if (diffIndex != min)

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc32.cs
@@ -169,7 +169,7 @@ namespace System.IO.Hashing
 
         private static uint Update(uint crc, ReadOnlySpan<byte> source)
         {
-#if NET7_0_OR_GREATER
+#if NET
             if (CanBeVectorized(source))
             {
                 return UpdateVectorized(crc, source);
@@ -181,7 +181,7 @@ namespace System.IO.Hashing
 
         private static uint UpdateScalar(uint crc, ReadOnlySpan<byte> source)
         {
-#if NET6_0_OR_GREATER
+#if NET
             // Use ARM intrinsics for CRC if available. This is used for the trailing bytes on the vectorized path
             // and is the primary method if the vectorized path is unavailable.
             if (System.Runtime.Intrinsics.Arm.Crc32.Arm64.IsSupported)

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/Crc64.cs
@@ -167,7 +167,7 @@ namespace System.IO.Hashing
 
         private static ulong Update(ulong crc, ReadOnlySpan<byte> source)
         {
-#if NET7_0_OR_GREATER
+#if NET
             if (CanBeVectorized(source))
             {
                 return UpdateVectorized(crc, source);

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash128.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash128.cs
@@ -17,7 +17,7 @@ namespace System.IO.Hashing
     /// For methods that persist the computed numerical hash value as bytes,
     /// the value is written in the Big Endian byte order.
     /// </remarks>
-#if NET5_0_OR_GREATER
+#if NET
     [SkipLocalsInit]
 #endif
     public sealed unsafe class XxHash128 : NonCryptographicHashAlgorithm
@@ -51,7 +51,7 @@ namespace System.IO.Hashing
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte[] Hash(byte[] source, long seed)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(source);
 #else
             if (source is null)
@@ -110,7 +110,7 @@ namespace System.IO.Hashing
             return false;
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         /// <summary>Computes the XXH128 hash of the provided data.</summary>
         /// <param name="source">The data to hash.</param>
         /// <param name="seed">The seed value for this hash computation. The default is zero.</param>
@@ -197,7 +197,7 @@ namespace System.IO.Hashing
             return current;
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         /// <summary>Gets the current computed hash value without modifying accumulated state.</summary>
         /// <returns>The hash value for the data already provided.</returns>
         [CLSCompliant(false)]

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHash3.cs
@@ -16,7 +16,7 @@ namespace System.IO.Hashing
     /// For methods that persist the computed numerical hash value as bytes,
     /// the value is written in the Big Endian byte order.
     /// </remarks>
-#if NET5_0_OR_GREATER
+#if NET
     [SkipLocalsInit]
 #endif
     public sealed unsafe class XxHash3 : NonCryptographicHashAlgorithm
@@ -50,7 +50,7 @@ namespace System.IO.Hashing
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
         public static byte[] Hash(byte[] source, long seed)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ArgumentNullException.ThrowIfNull(source);
 #else
             if (source is null)

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/XxHashShared.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if NET7_0_OR_GREATER
+#if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
@@ -15,7 +15,7 @@ using System.Runtime.Intrinsics.X86;
 namespace System.IO.Hashing
 {
     /// <summary>Shared implementation of the XXH3 hash algorithm for 64-bit in <see cref="XxHash3"/> and <see cref="XxHash128"/> version.</summary>
-#if NET5_0_OR_GREATER
+#if NET
     [SkipLocalsInit]
 #endif
     internal static unsafe class XxHashShared
@@ -333,7 +333,7 @@ namespace System.IO.Hashing
         {
             fixed (ulong* stateAccumulators = state.Accumulators)
             {
-#if NET7_0_OR_GREATER
+#if NET
                 if (Vector256.IsHardwareAccelerated)
                 {
                     Vector256.Store(Vector256.Load(stateAccumulators), accumulators);
@@ -390,7 +390,7 @@ namespace System.IO.Hashing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void InitializeAccumulators(ulong* accumulators)
         {
-#if NET7_0_OR_GREATER
+#if NET
             if (Vector256.IsHardwareAccelerated)
             {
                 Vector256.Store(Vector256.Create(Prime32_3, Prime64_1, Prime64_2, Prime64_3), accumulators);
@@ -452,7 +452,7 @@ namespace System.IO.Hashing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ulong Multiply64To128(ulong left, ulong right, out ulong lower)
         {
-#if NET5_0_OR_GREATER
+#if NET
             return Math.BigMul(left, right, out lower);
 #else
             ulong lowerLow = Multiply32To64((uint)left, (uint)right);
@@ -479,7 +479,7 @@ namespace System.IO.Hashing
         {
             fixed (byte* defaultSecret = &MemoryMarshal.GetReference(DefaultSecret))
             {
-#if NET7_0_OR_GREATER
+#if NET
                 if (Vector256.IsHardwareAccelerated && BitConverter.IsLittleEndian)
                 {
                     Vector256<ulong> seedVec = Vector256.Create(seed, 0u - seed, seed, 0u - seed);
@@ -515,7 +515,7 @@ namespace System.IO.Hashing
             byte* secretForAccumulate = secret;
             byte* secretForScramble = secret + (SecretLengthBytes - StripeLengthBytes);
 
-#if NET7_0_OR_GREATER
+#if NET
             if (Vector256.IsHardwareAccelerated && BitConverter.IsLittleEndian)
             {
                 Vector256<ulong> acc1 = Vector256.Load(accumulators);
@@ -620,7 +620,7 @@ namespace System.IO.Hashing
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Accumulate512Inlined(ulong* accumulators, byte* source, byte* secret)
         {
-#if NET7_0_OR_GREATER
+#if NET
             if (Vector256.IsHardwareAccelerated && BitConverter.IsLittleEndian)
             {
                 for (int i = 0; i < AccumulatorCount / Vector256<ulong>.Count; i++)
@@ -659,7 +659,7 @@ namespace System.IO.Hashing
             }
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector256<ulong> Accumulate256(Vector256<ulong> accVec, byte* source, Vector256<uint> secret)
         {
@@ -714,7 +714,7 @@ namespace System.IO.Hashing
 
         private static void ScrambleAccumulators(ulong* accumulators, byte* secret)
         {
-#if NET7_0_OR_GREATER
+#if NET
             if (Vector256.IsHardwareAccelerated && BitConverter.IsLittleEndian)
             {
                 for (int i = 0; i < AccumulatorCount / Vector256<ulong>.Count; i++)
@@ -752,7 +752,7 @@ namespace System.IO.Hashing
             }
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector256<ulong> ScrambleAccumulator256(Vector256<ulong> accVec, Vector256<ulong> secret)
         {

--- a/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
+++ b/src/libraries/System.IO.Hashing/tests/NonCryptoHashTestDriver.cs
@@ -420,7 +420,7 @@ namespace System.IO.Hashing.Tests
 
             public IEnumerable<ReadOnlyMemory<byte>> EnumerateDataChunks()
             {
-#if NET5_0_OR_GREATER
+#if NET
                 byte[] chunk = GC.AllocateUninitializedArray<byte>(1024 * 1024);
 #else
                 byte[] chunk = new byte[1024 * 1024];

--- a/src/libraries/System.IO.Hashing/tests/XxHash128Tests.cs
+++ b/src/libraries/System.IO.Hashing/tests/XxHash128Tests.cs
@@ -41,7 +41,7 @@ namespace System.IO.Hashing.Tests
                 Assert.Equal(expectedHash128, ReadHashBigEndian(XxHash128.Hash(input, test.Seed)));
                 Assert.Equal(expectedHash128, ReadHashBigEndian(XxHash128.Hash((ReadOnlySpan<byte>)input, test.Seed)));
 
-#if NET7_0_OR_GREATER
+#if NET
                 // Validate `XxHash128.HashToUInt128`
                 Assert.Equal(new UInt128(test.HashHigh, test.HashLow), XxHash128.HashToUInt128(input, test.Seed));
 #endif
@@ -110,7 +110,7 @@ namespace System.IO.Hashing.Tests
 
                             // Validate that the hash we get from doing a one-shot of all the data up to this point
                             // matches the incremental hash for the data appended until now.
-#if NET7_0_OR_GREATER
+#if NET
                             Assert.Equal(XxHash128.HashToUInt128(asciiBytes.AsSpan(0, processed), test.Seed), hash.GetCurrentHashAsUInt128());
 #endif
                             Assert.True(hash.TryGetCurrentHash(destination, out int bytesWritten));
@@ -120,7 +120,7 @@ namespace System.IO.Hashing.Tests
                         }
 
                         // Validate the final hash code.
-#if NET7_0_OR_GREATER
+#if NET
                         Assert.Equal(new UInt128(test.HashHigh, test.HashLow), hash.GetCurrentHashAsUInt128());
 #endif
                         Array.Clear(destination, 0, destination.Length);

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -320,7 +320,7 @@ namespace System.IO.Packaging
             {
                 try
                 {
-#if NET6_0_OR_GREATER
+#if NET
                     relationshipTargetMode = Enum.Parse<TargetMode>(targetModeAttributeValue, ignoreCase: false);
 #else
                     relationshipTargetMode = (TargetMode)(Enum.Parse(typeof(TargetMode), targetModeAttributeValue, ignoreCase: false));

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.PackUriScheme.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackUriHelper.PackUriScheme.cs
@@ -285,7 +285,7 @@ namespace System.IO.Packaging
             // This is currently enforced by the order of characters in the s_specialCharacterChars array
             foreach (char c in s_specialCharacterChars)
             {
-#if NET5_0_OR_GREATER
+#if NET
                 if (path.Contains(c))
 #else
                 if (path.IndexOf(c) != -1)

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -349,7 +349,7 @@ namespace System.IO.Pipelines.Tests
                 Check(count);
                 base.Write(buffer, offset, count);
             }
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             public override void Write(ReadOnlySpan<byte> buffer)
             {
                 Check(buffer.Length);

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialPort.cs
@@ -963,7 +963,7 @@ namespace System.IO.Ports
                 Buffer.BlockCopy(_inBuffer, _readPos, bytesReceived, 0, CachedBytesToRead);
             }
 
-#if NET7_0_OR_GREATER
+#if NET
             _internalSerialStream.ReadExactly(bytesReceived, CachedBytesToRead, bytesReceived.Length - CachedBytesToRead);    // get everything
 #else
             int readCount = bytesReceived.Length - CachedBytesToRead;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/StreamExtensions.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/StreamExtensions.cs
@@ -78,7 +78,7 @@ namespace System.Reflection.Internal
 
 #if NETCOREAPP
         internal static int TryReadAll(this Stream stream, Span<byte> buffer)
-#if NET7_0_OR_GREATER
+#if NET
             => stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false);
 #else
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/Helpers.cs
@@ -134,7 +134,7 @@ namespace System.Reflection.TypeLoading
 
         public static string UnescapeTypeNameIdentifier(this string identifier)
         {
-#if NET5_0_OR_GREATER
+#if NET
             if (identifier.Contains('\\'))
 #else
             if (identifier.IndexOf('\\') != -1)

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
@@ -331,7 +331,7 @@ namespace System.Reflection.TypeLoading
         private volatile RoType? _lazyUnderlyingEnumType;
         public sealed override Array GetEnumValues() => throw new InvalidOperationException(SR.Arg_InvalidOperation_Reflection);
 
-#if NET7_0_OR_GREATER
+#if NET
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2085:UnrecognizedReflectionPattern",
             Justification = "Enum Types are not trimmed.")]
         public override Array GetEnumValuesAsUnderlyingType()

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Type/TypeTests.cs
@@ -365,7 +365,7 @@ namespace System.Reflection.Tests
             }
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [Fact]
         public static void GetEnumValuesAsUnderlyingType()
         {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -364,7 +364,7 @@ namespace Internal.Cryptography
             return ToUpperHexString(serialBytes);
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         private static string ToUpperHexString(ReadOnlySpan<byte> ba)
         {
             return Convert.ToHexString(ba);

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -720,7 +720,7 @@ namespace System.Security.Cryptography.Xml
             return collection;
         }
 
-#if NET5_0_OR_GREATER
+#if NET
         internal static string EncodeHexString(byte[] sArray)
         {
             return Convert.ToHexString(sArray);

--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlResolverHelper.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/XmlResolverHelper.cs
@@ -11,14 +11,14 @@ namespace System.Security.Cryptography.Xml
     {
         internal static XmlResolver GetThrowingResolver()
         {
-#if NET7_0_OR_GREATER
+#if NET
             return XmlResolver.ThrowingResolver;
 #else
             return XmlThrowingResolver.s_singleton;
 #endif
         }
 
-#if !NET7_0_OR_GREATER
+#if !NET
         // An XmlResolver that forbids all external entity resolution.
         // (Copied from XmlResolver.ThrowingResolver.cs.)
         private sealed class XmlThrowingResolver : XmlResolver

--- a/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/XmlBuffer.cs
+++ b/src/libraries/System.ServiceModel.Syndication/src/System/ServiceModel/XmlBuffer.cs
@@ -87,7 +87,7 @@ namespace System.ServiceModel
             _buffer = new byte[_stream.Length];
             _stream.Position = 0;
 
-#if NET7_0_OR_GREATER
+#if NET
             _stream.ReadExactly(_buffer);
 #else
             int totalRead = 0;

--- a/src/libraries/System.Speech/src/Internal/Synthesis/AudioBase.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/AudioBase.cs
@@ -122,7 +122,7 @@ namespace System.Speech.Internal.Synthesis
                     {
                         byte[] data = new byte[(int)audio._stream.Length];
 
-#if NET7_0_OR_GREATER
+#if NET
                         audio._stream.ReadExactly(data);
 #else
                         int totalRead = 0;

--- a/src/libraries/System.Speech/src/Internal/Synthesis/EngineSite.cs
+++ b/src/libraries/System.Speech/src/Internal/Synthesis/EngineSite.cs
@@ -175,7 +175,7 @@ namespace System.Speech.Internal.Synthesis
                     MemoryStream memStream = new(cLen);
                     byte[] ab = new byte[cLen];
 
-#if NET7_0_OR_GREATER
+#if NET
                     stream.ReadExactly(ab);
 #else
                     int totalRead = 0;

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.cs
@@ -197,7 +197,7 @@ namespace System.Text
         internal static unsafe ref T GetNonNullPinnableReference<T>(T[] array) where T : struct
         {
             return ref
-#if NET5_0_OR_GREATER
+#if NET
                 MemoryMarshal.GetArrayDataReference(array);
 #else
                 array.Length != 0 ? ref array[0] : ref Unsafe.AsRef<T>((void*)1);

--- a/src/libraries/System.Text.Json/Common/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/Common/JsonHelpers.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json
         internal static void StableSortByKey<T, TKey>(this List<T> items, Func<T, TKey> keySelector)
             where TKey : unmanaged, IComparable<TKey>
         {
-#if NET6_0_OR_GREATER
+#if NET
             Span<T> span = CollectionsMarshal.AsSpan(items);
 
             // Tuples implement lexical ordering OOTB which can be used to encode stable sorting

--- a/src/libraries/System.Text.Json/ref/System.Text.Json.netcoreapp.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.netcoreapp.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static System.Text.Json.Serialization.JsonConverter<System.Half> HalfConverter { get { throw null; } }
         public static System.Text.Json.Serialization.JsonConverter<System.TimeOnly> TimeOnlyConverter { get { throw null; } }
 
-#if NET7_0_OR_GREATER
+#if NET
         public static System.Text.Json.Serialization.JsonConverter<System.Int128> Int128Converter { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public static System.Text.Json.Serialization.JsonConverter<System.UInt128> UInt128Converter { get { throw null; } }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.MetadataDb.cs
@@ -240,7 +240,7 @@ namespace System.Text.Json
                 // Note: Array.MaxLength exists only on .NET 6 or greater,
                 // so for the other versions value is hardcoded
                 const int MaxArrayLength = 0x7FFFFFC7;
-#if NET6_0_OR_GREATER
+#if NET
                 Debug.Assert(MaxArrayLength == Array.MaxLength);
 #endif
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json
 
         // When transcoding from UTF8 -> UTF16, the byte count threshold where we rent from the array pool before performing a normal alloc.
         public const long ArrayPoolMaxSizeBeforeUsingNormalAlloc =
-#if NET6_0_OR_GREATER
+#if NET
             1024 * 1024 * 1024; // ArrayPool limit increased in .NET 6
 #else
             1024 * 1024;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.MultiSegment.cs
@@ -633,7 +633,7 @@ namespace System.Text.Json
 
             int indexOfFirstMismatch;
 
-#if NET7_0_OR_GREATER
+#if NET
             indexOfFirstMismatch = span.CommonPrefixLength(literal);
 #else
             int minLength = Math.Min(span.Length, literal.Length);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/DefaultJsonTypeInfoResolver.Converters.cs
@@ -74,7 +74,7 @@ namespace System.Text.Json.Serialization.Metadata
             Add(JsonMetadataServices.UInt16Converter);
             Add(JsonMetadataServices.UInt32Converter);
             Add(JsonMetadataServices.UInt64Converter);
-#if NET7_0_OR_GREATER
+#if NET
             Add(JsonMetadataServices.Int128Converter);
             Add(JsonMetadataServices.UInt128Converter);
 #endif

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonMetadataServices.Converters.cs
@@ -108,7 +108,7 @@ namespace System.Text.Json.Serialization.Metadata
         public static JsonConverter<long> Int64Converter => s_int64Converter ??= new Int64Converter();
         private static JsonConverter<long>? s_int64Converter;
 
-#if NET7_0_OR_GREATER
+#if NET
         /// <summary>
         /// Returns a <see cref="JsonConverter{T}"/> instance that converts <see cref="Int128"/> values.
         /// </summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonPropertyInfo.cs
@@ -626,7 +626,7 @@ namespace System.Text.Json.Serialization.Metadata
 #if NETCOREAPP
                 potentialNumberType == typeof(Half) ||
 #endif
-#if NET7_0_OR_GREATER
+#if NET
                 potentialNumberType == typeof(Int128) ||
                 potentialNumberType == typeof(UInt128) ||
 #endif

--- a/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.NonStringKey.cs
+++ b/src/libraries/System.Text.Json/tests/Common/CollectionTests/CollectionTests.Dictionary.NonStringKey.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json.Serialization.Tests
             yield return WrapArgs(DateTime.MaxValue, 1, expectedJson: $@"{{""{DateTime.MaxValue:O}"":1}}");
             yield return WrapArgs(DateTimeOffset.MaxValue, 1, expectedJson: $@"{{""{DateTimeOffset.MaxValue:O}"":1}}");
             yield return WrapArgs(TimeSpan.MaxValue, 1, expectedJson: $@"{{""{TimeSpan.MaxValue}"":1}}");
-#if NET6_0_OR_GREATER
+#if NET
             yield return WrapArgs(DateOnly.MaxValue, 1, expectedJson: $@"{{""{DateOnly.MaxValue:O}"":1}}");
             yield return WrapArgs(TimeOnly.MaxValue, 1, expectedJson: $@"{{""{TimeOnly.MaxValue:O}"":1}}");
 #endif

--- a/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/Common/TestClasses/TestClasses.cs
@@ -1907,7 +1907,7 @@ namespace System.Text.Json.Serialization.Tests
 
     public static class ReflectionExtensions
     {
-#if NET6_0_OR_GREATER
+#if NET
         [return: System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]
         public static Type WithConstructors(
             [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembers(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors)]

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -563,7 +563,7 @@ namespace System.Text.RegularExpressions
             }
 
             return
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
                 string
 #else
                 StringExtensions
@@ -1304,7 +1304,7 @@ namespace System.Text.RegularExpressions
                 }
 
                 uint[]? cache = asciiLazyCache ?? Interlocked.CompareExchange(ref asciiLazyCache, new uint[CacheArrayLength], null) ?? asciiLazyCache;
-#if NET5_0_OR_GREATER
+#if NET
                 Interlocked
 #else
                 InterlockedExtensions
@@ -1594,7 +1594,7 @@ namespace System.Text.RegularExpressions
 #pragma warning disable CS8500 // takes address of managed type
             ReadOnlySpan<char> tmpChars = chars; // avoid address exposing the span and impacting the other code in the method that uses it
             return
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
                 string
 #else
                 StringExtensions

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexWriter.cs
@@ -177,7 +177,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         private int StringCode(string str)
         {
-#if NET6_0_OR_GREATER
+#if NET
             ref int i = ref CollectionsMarshal.GetValueRefOrAddDefault(_stringTable, str, out bool exists);
             if (!exists)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Threading/StackHelper.cs
@@ -12,7 +12,7 @@ namespace System.Threading
         /// <summary>Tries to ensure there is sufficient stack to execute the average .NET function.</summary>
         public static bool TryEnsureSufficientExecutionStack()
         {
-#if NETCOREAPP2_0_OR_GREATER
+#if NET
             return RuntimeHelpers.TryEnsureSufficientExecutionStack();
 #else
             try

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1326,7 +1326,7 @@ namespace System.Text.RegularExpressions.Tests
             }, ((int)engine).ToString(CultureInfo.InvariantCulture)).Dispose();
         }
 
-#if NET7_0_OR_GREATER
+#if NET
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void Match_InstanceMethods_DefaultTimeout_SourceGenerated_Throws()
         {
@@ -1884,7 +1884,7 @@ namespace System.Text.RegularExpressions.Tests
             Regex r = await RegexHelpers.GetRegexAsync(engine, pattern, options);
 
             Assert.Equal(expectedSuccessStartAt, r.IsMatch(input, startat));
-#if NET7_0_OR_GREATER
+#if NET
             Assert.Equal(expectedSuccessStartAt, r.IsMatch(input.AsSpan(), startat));
 #endif
 
@@ -2068,7 +2068,7 @@ namespace System.Text.RegularExpressions.Tests
             Regex r1 = await RegexHelpers.GetRegexAsync(engine, "[\u012F-\u0130]", RegexOptions.IgnoreCase);
             Regex r2 = await RegexHelpers.GetRegexAsync(engine, "[\u012F\u0130]", RegexOptions.IgnoreCase);
             Assert.Equal(r1.IsMatch("\u0130"), r2.IsMatch("\u0130"));
-#if NET7_0_OR_GREATER
+#if NET
             Assert.Equal(r1.IsMatch("\u0130".AsSpan()), r2.IsMatch("\u0130".AsSpan()));
 #endif
 
@@ -2490,14 +2490,14 @@ namespace System.Text.RegularExpressions.Tests
             if (r == null)
             {
                 Assert.Throws<T>(() => timeout == Regex.InfiniteMatchTimeout ? Regex.IsMatch(input, pattern, options) : Regex.IsMatch(input, pattern, options, timeout));
-#if NET7_0_OR_GREATER
+#if NET
                 Assert.Throws<T>(() => timeout == Regex.InfiniteMatchTimeout ? Regex.IsMatch(input.AsSpan(), pattern, options) : Regex.IsMatch(input.AsSpan(), pattern, options, timeout));
 #endif
             }
             else
             {
                 Assert.Throws<T>(() => r.IsMatch(input));
-#if NET7_0_OR_GREATER
+#if NET
                 Assert.Throws<T>(() => r.IsMatch(input.AsSpan()));
 #endif
             }
@@ -2512,7 +2512,7 @@ namespace System.Text.RegularExpressions.Tests
                 {
                     Assert.Equal(expected, Regex.IsMatch(input, pattern));
                 }
-#if NET7_0_OR_GREATER
+#if NET
                 Assert.Equal(expected, timeout == Regex.InfiniteMatchTimeout ? Regex.IsMatch(input.AsSpan(), pattern, options) : Regex.IsMatch(input.AsSpan(), pattern, options, timeout));
                 if (options == RegexOptions.None)
                 {
@@ -2523,7 +2523,7 @@ namespace System.Text.RegularExpressions.Tests
             else
             {
                 Assert.Equal(expected, r.IsMatch(input));
-#if NET7_0_OR_GREATER
+#if NET
                 Assert.Equal(expected, r.IsMatch(input.AsSpan()));
 #endif
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
@@ -187,7 +187,7 @@ namespace System.Text.RegularExpressions.Tests
         /// <summary>Set the AppContext variable REGEX_NONBACKTRACKING_MAX_AUTOMATA_SIZE to the given max value. Only used with Nonbacktracking engine.</summary>
         public static void SetSafeSizeThreshold(int maxSize)
         {
-#if NET7_0_OR_GREATER
+#if NET
             AppContext.SetData("REGEX_NONBACKTRACKING_MAX_AUTOMATA_SIZE", maxSize);
 #endif
         }
@@ -195,7 +195,7 @@ namespace System.Text.RegularExpressions.Tests
         /// <summary>Remove the AppContext variable REGEX_NONBACKTRACKING_MAX_AUTOMATA_SIZE value. Only used with Nonbacktracking engine.</summary>
         public static void RestoreSafeSizeThresholdToDefault()
         {
-#if NET7_0_OR_GREATER
+#if NET
             AppContext.SetData("REGEX_NONBACKTRACKING_MAX_AUTOMATA_SIZE", null);
 #endif
         }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexRunnerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexRunnerTests.cs
@@ -50,7 +50,7 @@ namespace System.Text.RegularExpressions.Tests
             MethodInfo getTextMethod = typeof(Match).GetMethod("get_Text", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.Null(getTextMethod.Invoke(runmatch, []));
             Assert.Equal(string.Empty, runmatch.Value);
-#if NET7_0_OR_GREATER
+#if NET
             Assert.True(runmatch.ValueSpan == ReadOnlySpan<char>.Empty);
 #endif
         }

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -1470,7 +1470,7 @@ namespace System.Threading.Tasks.Dataflow
                 {
                     // When cancellation is requested, unlink the target from the source and cancel the target.
                     target._ctr = cancellationToken.Register(
-#if NET6_0_OR_GREATER
+#if NET
                         OutputAvailableAsyncTarget<TOutput>.CancelAndUnlink,
 #else
                         static state => OutputAvailableAsyncTarget<TOutput>.CancelAndUnlink(state, default),

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Internal/Common.cs
@@ -190,7 +190,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
                 // data, and we also want to dispose of that registration when we complete so that we don't
                 // leak into a long-living cancellation token.
                 CancellationTokenRegistration reg = cancellationToken.Register(
-#if NET6_0_OR_GREATER
+#if NET
                     completeAction, completeState
 #else
                     state =>

--- a/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -314,7 +314,7 @@ namespace System.Media
                 int streamLen = (int)_stream.Length;
                 _currentPos = 0;
                 _streamData = new byte[streamLen];
-#if NET7_0_OR_GREATER
+#if NET
                 _stream.ReadExactly(_streamData);
 #else
                 int totalRead = 0;

--- a/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Security/Cryptography/X509Certificates/X509Certificate2UI.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 // Initialize view structure.
                 Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW ViewInfo = default;
-#if NET7_0_OR_GREATER
+#if NET
                 ViewInfo.dwSize = (uint)sizeof(Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW.Marshaller.Native);
 #else
                 ViewInfo.dwSize = (uint)Marshal.SizeOf<Interop.CryptUI.CRYPTUI_VIEWCERTIFICATE_STRUCTW>();
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography.X509Certificates
             Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW csc = default;
             // Older versions of CRYPTUI do not check the size correctly,
             // so always force it to the oldest version of the structure.
-#if NET7_0_OR_GREATER
+#if NET
             // Declare a local for Native to enable us to get the managed byte offset
             // without having a null check cause a failure.
             Interop.CryptUI.CRYPTUI_SELECTCERTIFICATE_STRUCTW.Marshaller.Native native;

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -213,7 +213,7 @@ public class WebcilConverter
         WriteStructure(s, sectionHeader);
     }
 
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
     private static void WriteStructure<T>(Stream s, T structure)
         where T : unmanaged
     {
@@ -256,7 +256,7 @@ public class WebcilConverter
         }
     }
 
-#if NETCOREAPP2_1_OR_GREATER
+#if NET
     private static void ReadExactly(FileStream s, Span<byte> buffer)
     {
         s.ReadExactly(buffer);

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilWasmWrapper.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilWasmWrapper.cs
@@ -63,7 +63,7 @@ public class WebcilWasmWrapper
     //
     // extracted by wasm-reader -s wrapper.wasm
     private static
-#if NET7_0_OR_GREATER
+#if NET
         ReadOnlyMemory<byte>
 #else
         byte[]
@@ -80,7 +80,7 @@ public class WebcilWasmWrapper
     //
     // extracted by wasm-reader -s wrapper.wasm
     private static
-#if NET7_0_OR_GREATER
+#if NET
         ReadOnlyMemory<byte>
 #else
         byte[]
@@ -91,7 +91,7 @@ public class WebcilWasmWrapper
 
     private static void WriteWasmHeader(Stream outputStream)
     {
-#if NET7_0_OR_GREATER
+#if NET
         outputStream.Write(s_wasmWrapperPrefix.Span);
 #else
         outputStream.Write(s_wasmWrapperPrefix, 0, s_wasmWrapperPrefix.Length);
@@ -100,7 +100,7 @@ public class WebcilWasmWrapper
 
     private static void WriteWasmSuffix(Stream outputStream)
     {
-#if NET7_0_OR_GREATER
+#if NET
         outputStream.Write(s_wasmWrapperSuffix.Span);
 #else
         outputStream.Write(s_wasmWrapperSuffix, 0, s_wasmWrapperSuffix.Length);

--- a/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
+++ b/src/tests/tracing/eventpipe/common/Microsoft.Diagnostics.NETCore.Client/DiagnosticsServerRouter/DiagnosticsServerRouterFactory.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Diagnostics.NETCore.Client
 
         protected bool IsCompletedSuccessfully(Task t)
         {
-#if NETCOREAPP2_0_OR_GREATER
+#if NET
             return t.IsCompletedSuccessfully;
 #else
             return t.IsCompleted && !t.IsCanceled && !t.IsFaulted;


### PR DESCRIPTION
... and directives for TFMs that we don't target anymore in main.

Replaces the following directives with `NET` or `!NET`:
- `#if NETCOREAPP2*`
- `#if !NETCOREAPP2*`
- `#if NETCOREAPP3*`
- `#if !NETCOREAPP3*`
- `#if NET5*`
- `#if !NET5*`
- `#if NET6*`
- `#if !NET6*`
- `#if NET7*`
- `#if !NET7*`