### PR TITLE
[mono][wasm] Refactor mono_fixup_symbol_name

### DIFF
--- a/src/mono/browser/runtime/runtime.c
+++ b/src/mono/browser/runtime/runtime.c
@@ -214,8 +214,9 @@ get_native_to_interp (MonoMethod *method, void *extra_arg)
 
 	assert (strlen (name) < 100);
 	snprintf (key, sizeof(key), "%s_%s_%s", name, class_name, method_name);
-	char* fixedName = mono_fixup_symbol_name("", key, "");
+	char *fixedName = mono_fixup_symbol_name ("", key, "");
 	addr = wasm_dl_get_native_to_interp (fixedName, extra_arg);
+	free (fixedName);
 	MONO_EXIT_GC_UNSAFE;
 	return addr;
 }

--- a/src/mono/browser/runtime/runtime.c
+++ b/src/mono/browser/runtime/runtime.c
@@ -65,7 +65,7 @@
 int mono_wasm_enable_gc = 1;
 
 /* Missing from public headers */
-char *mono_fixup_symbol_name (char *key);
+char *mono_fixup_symbol_name (const char *prefix, const char *key, const char *suffix);
 void mono_icall_table_init (void);
 void mono_wasm_enable_debugging (int);
 void mono_ee_interp_init (const char *opts);
@@ -214,7 +214,7 @@ get_native_to_interp (MonoMethod *method, void *extra_arg)
 
 	assert (strlen (name) < 100);
 	snprintf (key, sizeof(key), "%s_%s_%s", name, class_name, method_name);
-	char* fixedName = mono_fixup_symbol_name(key);
+	char* fixedName = mono_fixup_symbol_name("", key, "");
 	addr = wasm_dl_get_native_to_interp (fixedName, extra_arg);
 	MONO_EXIT_GC_UNSAFE;
 	return addr;

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1245,7 +1245,7 @@ is_symbol_char_underscore (unsigned char c)
 	}
 }
 
-static int mono_precompute_size (const char *key)
+static size_t mono_precompute_size (const char *key)
 {
 	size_t size = 1; // Null terminator
 	size_t len = (int)strlen (key);

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1223,11 +1223,32 @@ mono_loader_install_pinvoke_override (PInvokeOverrideFn override_fn)
 	pinvoke_override = override_fn;
 }
 
+static int mono_precompute_size (const char *key)
+{
+	int size = 1; // Null terminator
+	int len = (int)strlen (key);
+	for (int i = 0; i < len; ++i) {
+		unsigned char b = key[i];
+		if ((b >= '0' && b <= '9') ||
+		    (b >= 'a' && b <= 'z') ||
+			(b >= 'A' && b <= 'Z') ||
+			b == '_' || b == '.' || b == '-' || b ==  '+' || b == '<' || b == '>') {
+			size++;
+		}
+		else {
+			size += 4;
+		}
+	}
+	return size;
+}
+
 // Keep synced with FixupSymbolName from src/tasks/Common/Utils.cs
-char* mono_fixup_symbol_name (char *key) {
-	char* fixedName = malloc(256);
+char* mono_fixup_symbol_name (const char *prefix, const char *key, const char *suffix) {
+	int size = mono_precompute_size (key) + strlen (prefix) + strlen (suffix);
+	char fixedName[size];
 	int sb_index = 0;
 	int len = (int)strlen (key);
+	strcpy(fixedName, prefix);
 
 	for (int i = 0; i < len; ++i) {
 		unsigned char b = key[i];
@@ -1242,12 +1263,14 @@ char* mono_fixup_symbol_name (char *key) {
 		}
 		else {
 			// Append the hexadecimal representation of b between underscores
-			sprintf(&fixedName[sb_index], "_%X_", b);
+			snprintf(&fixedName[sb_index], sizeof(fixedName) - sb_index - 1, "_%X_", b);
 			sb_index += 4; // Move the index after the appended hexadecimal characters
 		}
 	}
 
+	strcpy(&fixedName[sb_index], suffix);
+
 	// Null-terminate the fixedName string
-	fixedName[sb_index] = '\0';
+	fixedName[size-1] = '\0';
 	return fixedName;
 }

--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1247,9 +1247,9 @@ is_symbol_char_underscore (unsigned char c)
 
 static int mono_precompute_size (const char *key)
 {
-	int size = 1; // Null terminator
-	int len = (int)strlen (key);
-	for (int i = 0; i < len; ++i) {
+	size_t size = 1; // Null terminator
+	size_t len = (int)strlen (key);
+	for (size_t i = 0; i < len; ++i) {
 		unsigned char b = key[i];
 		if (is_symbol_char_verbatim (b) || is_symbol_char_underscore (b)) {
 			size++;
@@ -1263,12 +1263,12 @@ static int mono_precompute_size (const char *key)
 
 // Keep synced with FixupSymbolName from src/tasks/Common/Utils.cs
 char* mono_fixup_symbol_name (const char *prefix, const char *key, const char *suffix) {
-	int size = mono_precompute_size (key) + strlen (prefix) + strlen (suffix);
+	size_t size = mono_precompute_size (key) + strlen (prefix) + strlen (suffix);
 	GString *str = g_string_sized_new (size);
-	int len = (int)strlen (key);
+	size_t len = (int)strlen (key);
 	g_string_append_printf (str, "%s", prefix);
 
-	for (int i = 0; i < len; ++i) {
+	for (size_t i = 0; i < len; ++i) {
 		unsigned char b = key[i];
 		if (is_symbol_char_verbatim (b)) {
 			g_string_append_c (str, b);

--- a/src/mono/mono/metadata/native-library.h
+++ b/src/mono/mono/metadata/native-library.h
@@ -36,6 +36,6 @@ void
 mono_loader_install_pinvoke_override (PInvokeOverrideFn override_fn);
 
 char *
-mono_fixup_symbol_name (char *key);
+mono_fixup_symbol_name (const char *prefix, const char *key, const char *suffix);
 
 #endif

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -15113,7 +15113,13 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_LLVM_ONLY);
 
 	acfg->assembly_name_sym = g_strdup (get_assembly_prefix (acfg->image));
-	acfg->global_prefix = mono_fixup_symbol_name ("mono_aot_", acfg->assembly_name_sym, "");
+	char *p;
+	/* Get rid of characters which cannot occur in symbols */
+	for (p = acfg->assembly_name_sym; *p; ++p) {
+		if (!(isalnum (*p) || *p == '_'))
+			*p = '_';
+	}
+	acfg->global_prefix = g_strdup_printf ("mono_aot_%s", acfg->assembly_name_sym);
 	acfg->plt_symbol = g_strdup_printf ("%s_plt", acfg->global_prefix);
 	acfg->got_symbol = g_strdup_printf ("%s_got", acfg->global_prefix);
  	if (acfg->llvm) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12407,24 +12407,21 @@ emit_file_info (MonoAotCompile *acfg)
 	init_aot_file_info (acfg, info);
 
 	if (acfg->aot_opts.static_link) {
-		char prefix [MAX_SYMBOL_SIZE];
+		char symbol [MAX_SYMBOL_SIZE];
 
 		/*
 		 * Emit a global symbol which can be passed by an embedding app to
 		 * mono_aot_register_module (). The symbol points to a pointer to the file info
 		 * structure.
 		 */
-		snprintf (prefix, MAX_SYMBOL_SIZE, "%smono_aot_module_", acfg->user_symbol_prefix);
-		acfg->static_linking_symbol = mono_fixup_symbol_name (prefix, acfg->image->assembly->aname.name, "_info");
+		snprintf (symbol, MAX_SYMBOL_SIZE, "%smono_aot_module_%s", acfg->user_symbol_prefix, acfg->image->assembly->aname.name);
+		acfg->static_linking_symbol = mono_fixup_symbol_name ("", symbol, "_info");
 	}
 
 	if (acfg->llvm)
 		mono_llvm_emit_aot_file_info (info, acfg->has_jitted_code);
 	else
 		emit_aot_file_info (acfg, info);
-
-	if (acfg->static_linking_symbol != NULL)
-		g_free (acfg->static_linking_symbol);
 }
 
 static void

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12414,8 +12414,8 @@ emit_file_info (MonoAotCompile *acfg)
 		 * mono_aot_register_module (). The symbol points to a pointer to the file info
 		 * structure.
 		 */
-		sprintf (prefix, "%smono_aot_module_", acfg->user_symbol_prefix);
-		acfg->static_linking_symbol = g_strdup (mono_fixup_symbol_name(prefix, acfg->image->assembly->aname.name, "_info"));
+		snprintf (prefix, MAX_SYMBOL_SIZE, "%smono_aot_module_", acfg->user_symbol_prefix);
+		acfg->static_linking_symbol = mono_fixup_symbol_name (prefix, acfg->image->assembly->aname.name, "_info");
 	}
 
 	if (acfg->llvm)
@@ -15112,7 +15112,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_LLVM_ONLY);
 
 	acfg->assembly_name_sym = g_strdup (get_assembly_prefix (acfg->image));
-	acfg->global_prefix = mono_fixup_symbol_name("mono_aot_", acfg->assembly_name_sym, "");
+	acfg->global_prefix = mono_fixup_symbol_name ("mono_aot_", acfg->assembly_name_sym, "");
 	acfg->plt_symbol = g_strdup_printf ("%s_plt", acfg->global_prefix);
 	acfg->got_symbol = g_strdup_printf ("%s_got", acfg->global_prefix);
  	if (acfg->llvm) {

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12422,6 +12422,9 @@ emit_file_info (MonoAotCompile *acfg)
 		mono_llvm_emit_aot_file_info (info, acfg->has_jitted_code);
 	else
 		emit_aot_file_info (acfg, info);
+
+	if (acfg->static_linking_symbol != NULL)
+		g_free (acfg->static_linking_symbol);
 }
 
 static void
@@ -14284,6 +14287,7 @@ acfg_free (MonoAotCompile *acfg)
 	g_free (acfg->static_linking_symbol);
 	g_free (acfg->got_symbol);
 	g_free (acfg->plt_symbol);
+	g_free (acfg->global_prefix);
 	g_ptr_array_free (acfg->methods, TRUE);
 	g_ptr_array_free (acfg->image_table, TRUE);
 	g_ptr_array_free (acfg->globals, TRUE);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14284,6 +14284,7 @@ acfg_free (MonoAotCompile *acfg)
 	g_free (acfg->static_linking_symbol);
 	g_free (acfg->got_symbol);
 	g_free (acfg->plt_symbol);
+	g_free (acfg->global_prefix);
 	g_free (acfg->assembly_name_sym);
 	g_ptr_array_free (acfg->methods, TRUE);
 	g_ptr_array_free (acfg->image_table, TRUE);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -14284,7 +14284,7 @@ acfg_free (MonoAotCompile *acfg)
 	g_free (acfg->static_linking_symbol);
 	g_free (acfg->got_symbol);
 	g_free (acfg->plt_symbol);
-	g_free (acfg->global_prefix);
+	g_free (acfg->assembly_name_sym);
 	g_ptr_array_free (acfg->methods, TRUE);
 	g_ptr_array_free (acfg->image_table, TRUE);
 	g_ptr_array_free (acfg->globals, TRUE);
@@ -15112,13 +15112,7 @@ aot_assembly (MonoAssembly *ass, guint32 jit_opts, MonoAotOptions *aot_options)
 	if (acfg->aot_opts.llvm_only)
 		acfg->flags = (MonoAotFileFlags)(acfg->flags | MONO_AOT_FILE_FLAG_LLVM_ONLY);
 
-	acfg->assembly_name_sym = g_strdup (get_assembly_prefix (acfg->image));
-	char *p;
-	/* Get rid of characters which cannot occur in symbols */
-	for (p = acfg->assembly_name_sym; *p; ++p) {
-		if (!(isalnum (*p) || *p == '_'))
-			*p = '_';
-	}
+	acfg->assembly_name_sym = mono_fixup_symbol_name ("", get_assembly_prefix (acfg->image), "");
 	acfg->global_prefix = g_strdup_printf ("mono_aot_%s", acfg->assembly_name_sym);
 	acfg->plt_symbol = g_strdup_printf ("%s_plt", acfg->global_prefix);
 	acfg->got_symbol = g_strdup_printf ("%s_got", acfg->global_prefix);

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -14542,22 +14542,9 @@ emit_aot_file_info (MonoLLVMModule *module)
 	LLVMSetInitializer (info_var, LLVMConstNamedStruct (module->info_var_type, fields, nfields));
 
 	if (module->static_link) {
-		char *s;
 		LLVMValueRef var;
 
-		s = g_strdup_printf ("mono_aot_module_%s_info", module->assembly->aname.name);
-#ifdef TARGET_WASM
-		var = LLVMAddGlobal (module->lmodule, pointer_type (LLVMInt8Type ()), g_strdup (mono_fixup_symbol_name(s)));
-#else
-		/* Get rid of characters which cannot occur in symbols */
-		char *p = s;
-		for (p = s; *p; ++p) {
-			if (!(isalnum (*p) || *p == '_'))
-			*p = '_';
-		}
-		var = LLVMAddGlobal (module->lmodule, pointer_type (LLVMInt8Type ()), s);
-#endif
-		g_free (s);
+		var = LLVMAddGlobal (module->lmodule, pointer_type (LLVMInt8Type ()), g_strdup (mono_fixup_symbol_name("mono_aot_module_", module->assembly->aname.name, "_info")));
 		LLVMSetInitializer (var, LLVMConstBitCast (LLVMGetNamedGlobal (module->lmodule, "mono_aot_file_info"), pointer_type (LLVMInt8Type ())));
 		LLVMSetLinkage (var, LLVMExternalLinkage);
 	}

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1960,7 +1960,7 @@ static char*
 get_aotconst_name (MonoJumpInfoType type, gconstpointer data, int got_offset)
 {
 	char *name;
-	size_t len;
+	//size_t len;
 
 	switch (type) {
 	case MONO_PATCH_INFO_JIT_ICALL_ID:

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1960,7 +1960,7 @@ static char*
 get_aotconst_name (MonoJumpInfoType type, gconstpointer data, int got_offset)
 {
 	char *name;
-	//size_t len;
+	size_t len;
 
 	switch (type) {
 	case MONO_PATCH_INFO_JIT_ICALL_ID:
@@ -1986,16 +1986,15 @@ get_aotconst_name (MonoJumpInfoType type, gconstpointer data, int got_offset)
 	case MONO_PATCH_INFO_METHOD_RGCTX: {
 		MonoMethod *method = (MonoMethod*)data;
 		char *typestr = ji_type_to_string_lower (type);
-		char *fixedName = mono_fixup_symbol_name (typestr, method->name, "");
-		// char *n = g_strdup (method->name);
-		// len = strlen (n);
-		// for (size_t i = 0; i < len; ++i) {
-		// 	if (!isalnum (n [i]))
-		// 		n [i] = '_';
-		// }
-		name = g_strdup_printf ("%s_%d", fixedName, got_offset);
+		char *n = g_strdup (method->name);
+		len = strlen (n);
+		for (size_t i = 0; i < len; ++i) {
+			if (!isalnum (n [i]))
+				n [i] = '_';
+		}
+		name = g_strdup_printf ("%s_%s_%d", typestr, n, got_offset);
 		g_free (typestr);
-		g_free (fixedName);
+		g_free (n);
 		break;
 	}
 	default: {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -1986,15 +1986,16 @@ get_aotconst_name (MonoJumpInfoType type, gconstpointer data, int got_offset)
 	case MONO_PATCH_INFO_METHOD_RGCTX: {
 		MonoMethod *method = (MonoMethod*)data;
 		char *typestr = ji_type_to_string_lower (type);
-		char *n = g_strdup (method->name);
-		len = strlen (n);
-		for (size_t i = 0; i < len; ++i) {
-			if (!isalnum (n [i]))
-				n [i] = '_';
-		}
-		name = g_strdup_printf ("%s_%s_%d", typestr, n, got_offset);
+		char *fixedName = mono_fixup_symbol_name (typestr, method->name, "");
+		// char *n = g_strdup (method->name);
+		// len = strlen (n);
+		// for (size_t i = 0; i < len; ++i) {
+		// 	if (!isalnum (n [i]))
+		// 		n [i] = '_';
+		// }
+		name = g_strdup_printf ("%s_%d", fixedName, got_offset);
 		g_free (typestr);
-		g_free (n);
+		g_free (fixedName);
 		break;
 	}
 	default: {

--- a/src/mono/mono/mini/mini-llvm.c
+++ b/src/mono/mono/mini/mini-llvm.c
@@ -14543,8 +14543,9 @@ emit_aot_file_info (MonoLLVMModule *module)
 
 	if (module->static_link) {
 		LLVMValueRef var;
-
-		var = LLVMAddGlobal (module->lmodule, pointer_type (LLVMInt8Type ()), g_strdup (mono_fixup_symbol_name("mono_aot_module_", module->assembly->aname.name, "_info")));
+		char *fixedName = mono_fixup_symbol_name ("mono_aot_module_", module->assembly->aname.name, "_info");
+		var = LLVMAddGlobal (module->lmodule, pointer_type (LLVMInt8Type ()), fixedName);
+		free (fixedName);
 		LLVMSetInitializer (var, LLVMConstBitCast (LLVMGetNamedGlobal (module->lmodule, "mono_aot_file_info"), pointer_type (LLVMInt8Type ())));
 		LLVMSetLinkage (var, LLVMExternalLinkage);
 	}

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -752,7 +752,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (CollectTrimmingEligibleMethods)
         {
-            string assemblyName = assemblyFilename.Replace(".", "_");
+            string assemblyName = FixupSymbolName(assemblyFilename);
             string outputFileName = assemblyName + "_compiled_methods.txt";
             string outputFilePath;
             if (string.IsNullOrEmpty(TrimmingEligibleMethodsOutputDirectory))

--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -752,7 +752,7 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
 
         if (CollectTrimmingEligibleMethods)
         {
-            string assemblyName = FixupSymbolName(assemblyFilename);
+            string assemblyName = assemblyFilename.Replace(".", "_");
             string outputFileName = assemblyName + "_compiled_methods.txt";
             string outputFilePath;
             if (string.IsNullOrEmpty(TrimmingEligibleMethodsOutputDirectory))


### PR DESCRIPTION
This PR is a follow up for https://github.com/dotnet/runtime/pull/101106

- [x] Refactor mono_fixup_symbol_name to handle properly leaking the memory
- [x] Apply same logic for all platforms