### PR TITLE
[RISC-V] Add quirks for riscv to R2RDump

### DIFF
--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -1230,7 +1230,7 @@ namespace R2RDump
                     auipc
                     addi
                     ld
-                    jarl
+                    jalr
                 , where addi and ld may be repeated many times.
                 Instructions that have no effect on the jump 
                 address calculation are skipped.

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -1260,7 +1260,7 @@ namespace R2RDump
                     }
                     else
                     {
-                        // frist non-ld instruction
+                        // first non-ld instruction
                         isFound = StaticAnalyzeRiscV64Assembly(
                             rtf.StartAddress + currentInstrOffset, 
                             currentInstrOffset, 


### PR DESCRIPTION
 This PR adds a functionality `ProbeRiscV64Quirks(...)` to R2RDump in order to provide target function labels in the form of comments at the end of any `jalr` instructions. it mimics a similar solution for x64 and arm.
 
 Part of #84834, cc @dotnet/samsung