### PR TITLE
Disable TensorPrimitives vectorization of Log, Cbrt, Pow, and RootN

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cbrt.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Cbrt.cs
@@ -26,7 +26,7 @@ namespace System.Numerics.Tensors
         private readonly struct CbrtOperator<T> : IUnaryOperator<T, T>
             where T : IRootFunctions<T>
         {
-            public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);
+            public static bool Vectorizable => false; // typeof(T) == typeof(float) || typeof(T) == typeof(double); // TODO: https://github.com/dotnet/runtime/issues/100535
 
             public static T Invoke(T x) => T.Cbrt(x);
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Log.cs
@@ -161,7 +161,7 @@ namespace System.Numerics.Tensors
         private readonly struct LogBaseOperator<T> : IBinaryOperator<T>
             where T : ILogarithmicFunctions<T>
         {
-            public static bool Vectorizable => LogOperator<T>.Vectorizable;
+            public static bool Vectorizable => false; //LogOperator<T>.Vectorizable; // TODO: https://github.com/dotnet/runtime/issues/100535
             public static T Invoke(T x, T y) => T.Log(x, y);
             public static Vector128<T> Invoke(Vector128<T> x, Vector128<T> y) => LogOperator<T>.Invoke(x) / LogOperator<T>.Invoke(y);
             public static Vector256<T> Invoke(Vector256<T> x, Vector256<T> y) => LogOperator<T>.Invoke(x) / LogOperator<T>.Invoke(y);

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Pow.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Pow.cs
@@ -59,7 +59,7 @@ namespace System.Numerics.Tensors
         private readonly struct PowOperator<T> : IBinaryOperator<T>
             where T : IPowerFunctions<T>
         {
-            public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);
+            public static bool Vectorizable => false; // typeof(T) == typeof(float) || typeof(T) == typeof(double); // TODO: https://github.com/dotnet/runtime/issues/100535
 
             public static T Invoke(T x, T y) => T.Pow(x, y);
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.RootN.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.RootN.cs
@@ -28,7 +28,7 @@ namespace System.Numerics.Tensors
         {
             private readonly int _n = n;
 
-            public static bool Vectorizable => typeof(T) == typeof(float) || typeof(T) == typeof(double);
+            public static bool Vectorizable => false; // typeof(T) == typeof(float) || typeof(T) == typeof(double); // TODO: https://github.com/dotnet/runtime/issues/100535
 
             public T Invoke(T x) => T.RootN(x, _n);
 

--- a/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/Helpers.cs
@@ -28,6 +28,11 @@ namespace System.Numerics.Tensors.Tests
 
         public static bool IsEqualWithTolerance<T>(T expected, T actual, T? tolerance = null) where T : unmanaged, INumber<T>
         {
+            if (T.IsNaN(expected) != T.IsNaN(actual))
+            {
+                return false;
+            }
+
             tolerance = tolerance ?? DefaultTolerance<T>.Value;
             T diff = T.Abs(expected - actual);
             return !(diff > tolerance && diff > T.Max(T.Abs(expected), T.Abs(actual)) * tolerance);
@@ -35,6 +40,11 @@ namespace System.Numerics.Tensors.Tests
 #else
         public static bool IsEqualWithTolerance(float expected, float actual, float? tolerance = null)
         {
+            if (float.IsNaN(expected) != float.IsNaN(actual))
+            {
+                return false;
+            }
+
             tolerance ??= DefaultFloatTolerance;
             float diff = MathF.Abs(expected - actual);
             return !(diff > tolerance && diff > MathF.Max(MathF.Abs(expected), MathF.Abs(actual)) * tolerance);


### PR DESCRIPTION
We had a test bug that was hiding cases where one of the expected / actual was NaN and the other wasn't.

https://github.com/dotnet/runtime/issues/100535