### PR TITLE
[LoongArch64] clear float type when passed by integer reg.

### DIFF
--- a/src/coreclr/jit/targetloongarch64.cpp
+++ b/src/coreclr/jit/targetloongarch64.cpp
@@ -161,6 +161,7 @@ ABIPassingInformation LoongArch64Classifier::Classify(Compiler*    comp,
             canPassArgInRegisters = m_floatRegs.Count() > 0;
             if (!canPassArgInRegisters)
             {
+                type = TYP_I_IMPL;
                 m_floatRegs.Clear();
                 canPassArgInRegisters = m_intRegs.Count() > 0;
             }


### PR DESCRIPTION
clear the float type when passed by integer reg.