### PR TITLE
[release/8.0-staging]: Add cryptographic operation counts to prevent process crashes

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -273,6 +273,9 @@
   <data name="Cryptography_CipherModeNotSupported" xml:space="preserve">
     <value>The specified CipherMode '{0}' is not supported.</value>
   </data>
+  <data name="Cryptography_ConcurrentUseNotSupported" xml:space="preserve">
+    <value>Concurrent operations from multiple threads on this type are not supported.</value>
+  </data>
   <data name="Cryptography_CngKeyWrongAlgorithm" xml:space="preserve">
     <value>This key is for algorithm '{0}'. Expected '{1}'.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -817,6 +817,7 @@
     <Compile Include="System\Security\Cryptography\CapiHelper.Unix.cs" />
     <Compile Include="System\Security\Cryptography\ChaCha20Poly1305.OpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\Cng.NotSupported.cs" />
+    <Compile Include="System\Security\Cryptography\ConcurrencyBlock.cs" />
     <Compile Include="System\Security\Cryptography\CspKeyContainerInfo.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\DESCryptoServiceProvider.Unix.cs" />
     <Compile Include="System\Security\Cryptography\DesImplementation.OpenSsl.cs" />
@@ -977,6 +978,7 @@
     <Compile Include="System\Security\Cryptography\CapiHelper.Shared.cs" />
     <Compile Include="System\Security\Cryptography\CapiHelper.Unix.cs" />
     <Compile Include="System\Security\Cryptography\Cng.NotSupported.cs" />
+    <Compile Include="System\Security\Cryptography\ConcurrencyBlock.NoOp.cs" />
     <Compile Include="System\Security\Cryptography\CspKeyContainerInfo.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\ChaCha20Poly1305.Android.cs" />
     <Compile Include="System\Security\Cryptography\DESCryptoServiceProvider.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ConcurrencyBlock.NoOp.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ConcurrencyBlock.NoOp.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+
+namespace System.Security.Cryptography
+{
+    internal struct ConcurrencyBlock
+    {
+        internal static Scope Enter(ref ConcurrencyBlock block)
+        {
+            _ = block;
+            return default;
+        }
+
+        internal ref struct Scope
+        {
+#pragma warning disable CA1822 // Member can be marked static
+            internal void Dispose()
+            {
+            }
+#pragma warning restore CA1822
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ConcurrencyBlock.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/ConcurrencyBlock.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+
+namespace System.Security.Cryptography
+{
+    internal struct ConcurrencyBlock
+    {
+        private int _count;
+
+        internal static Scope Enter(ref ConcurrencyBlock block)
+        {
+            int count = Interlocked.Increment(ref block._count);
+
+            if (count != 1)
+            {
+                Interlocked.Decrement(ref block._count);
+                throw new CryptographicException(SR.Cryptography_ConcurrentUseNotSupported);
+            }
+
+            return new Scope(ref block._count);
+        }
+
+        internal ref struct Scope
+        {
+            private ref int _parentCount;
+
+            internal Scope(ref int parentCount)
+            {
+                _parentCount = ref parentCount;
+            }
+
+            internal void Dispose()
+            {
+                Interlocked.Decrement(ref _parentCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Partial backport of #100371. Only the changes for Unix were back-ported as that is where all customer feedback has come from.

## Customer Impact

- [X] Customer reported
- [ ] Found internally

There have been a number of reports from the community where upon upgrading to .NET 8 docker images they report process crashes (#101722, #93205). This is due to two things happening.

1. The first is that the `dotnet` docker images for 8.0 move to Debian Bookworm, which changes OpenSSL to version 3.0, from 1.1 in previous Debian images.
2. Developers improperly using instances of `IncrementalHash` or `HashAlgorithm` and its derived types in a way that results in concurrent use (multithreaded).

Instances of HashAlgorithm never were thread-safe, however misuse acted in such a way that did not result in process crashes. We have observed that this concurrent use, when combined with OpenSSL 3.0, results in more frequent process crashes. These crashes are difficult for customers to diagnose because they occur in native code.

This change detects the misuse of concurrent operations and throws a managed `CryptographicException` with a message informing of the incorrect concurrent use.

## Regression

- [ ] Yes
- [ ] No
- [X] Sort of

Developers perceive this as a regression in .NET 8 because the docker image for the .NET 8 SDK and runtime change the behavior of a dependency.

## Testing

There are unit tests for this in the `main` branch of the runtime. The tests were not back ported because they were written with the assumption of all platforms.

## Risk

Medium-Low.

Non-concurrent use is verified with the plethora of tests already present for the types.  The new concurrency guard has an advantage, and a disadvantage.  The advantage is that when the race condition would have lined up for a process termination it now results in an exception (so something with a call stack to give a hint as to what went wrong).  The disadvantage is that our concurrency guard is wider than the native race, so what would have been "near misses" will also now throw (however, it would be quite difficult for a near miss to be reliable, as it is dependent upon the thread scheduler).