### PR TITLE
Fix CodeQL issue cpp/enum-index in mono

### DIFF
--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -127,7 +127,7 @@ static const char * const single_xmmregs [] = {
 const char*
 mono_arch_fregname (int reg)
 {
-	if (reg < AMD64_XMM_NREG)
+	if (reg >= 0 && reg < AMD64_XMM_NREG)
 		return single_xmmregs [reg];
 	else
 		return "unknown";
@@ -136,7 +136,7 @@ mono_arch_fregname (int reg)
 const char *
 mono_arch_xregname (int reg)
 {
-	if (reg < AMD64_XMM_NREG)
+	if (reg >= 0 && reg < AMD64_XMM_NREG)
 		return packed_xmmregs [reg];
 	else
 		return "unknown";

--- a/src/mono/mono/mini/mini-s390x.c
+++ b/src/mono/mono/mini/mini-s390x.c
@@ -464,7 +464,7 @@ mono_arch_fregname (int reg)
 const char *
 mono_arch_xregname (int reg)
 {
-	if (reg < s390_VR_NREG)
+	if (reg >= 0 && reg < s390_VR_NREG)
 		return vrNames [reg];
 	else
 		return "unknown";


### PR DESCRIPTION
There's no data flow which would ever allow these values to go negative, so it's not an issue in practice. Still, may as well improve the functions' hygiene. This brings these methods in line with the other `mono_arch_fregname` and `mono_arch_xregname` implementations which perform proper bounds checking.