### PR TITLE
Track unknown value as result of unimplemented operations

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimAnalysisVisitor.cs
@@ -75,15 +75,21 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 		// - 'this' parameter (for annotated methods)
 		// - field reference
 
-		public override MultiValue Visit (IOperation? operation, StateValue argument)
+		public override MultiValue DefaultVisit (IOperation operation, StateValue argument)
 		{
-			var returnValue = base.Visit (operation, argument);
+			var returnValue = base.DefaultVisit (operation, argument);
 
 			// If the return value is empty (TopValue basically) and the Operation tree
 			// reports it as having a constant value, use that as it will automatically cover
 			// cases we don't need/want to handle.
-			if (operation != null && returnValue.IsEmpty () && TryGetConstantValue (operation, out var constValue))
+			if (!returnValue.IsEmpty ())
+				return returnValue;
+
+			if (TryGetConstantValue (operation, out var constValue))
 				return constValue;
+
+			if (operation.Type is not null)
+				return UnknownValue.Instance;
 
 			return returnValue;
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DataFlowTests.cs
@@ -186,7 +186,7 @@ namespace ILLink.RoslynAnalyzer.Tests
 		}
 
 		[Fact]
-		public Task InterpolatedStringHandlerDataFlow ()
+		public Task InterpolatedStringDataFlow ()
 		{
 			return RunTest ();
 		}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/DynamicallyAccessedMembersAnalyzerTests.cs
@@ -1309,7 +1309,9 @@ namespace System
 
 			return VerifyDynamicallyAccessedMembersAnalyzer (Source, consoleApplication: false,
 				// (12,34): error CS0103: The name 'type' does not exist in the current context
-				DiagnosticResult.CompilerError ("CS0103").WithSpan (12, 34, 12, 38).WithArguments ("type"));
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (12, 34, 12, 38).WithArguments ("type"),
+				// (12,34): warning IL2063: Value returned from method 'C.GetTypeWithAll()' can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.
+				VerifyCS.Diagnostic (DiagnosticId.MethodReturnValueCannotBeStaticallyDetermined).WithSpan(12, 34, 12, 38).WithArguments("C.GetTypeWithAll()"));
 		}
 
 		[Fact]
@@ -1333,7 +1335,9 @@ namespace System
 
 			return VerifyDynamicallyAccessedMembersAnalyzer (Source, consoleApplication: false,
 				// (8,22): error CS0103: The name 'type' does not exist in the current context
-				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 22, 8, 26).WithArguments ("type"));
+				DiagnosticResult.CompilerError ("CS0103").WithSpan (8, 22, 8, 26).WithArguments ("type"),
+				// (8,3): warning IL2064: Value assigned to C.fieldRequiresAll can not be statically determined and may not meet 'DynamicallyAccessedMembersAttribute' requirements.
+				VerifyCS.Diagnostic(DiagnosticId.FieldValueCannotBeStaticallyDetermined).WithSpan(8, 3, 8, 26).WithArguments("C.fieldRequiresAll"));
 		}
 
 		[Fact]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringDataFlow.cs
@@ -33,7 +33,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			Debug.Assert (b, $"Debug interpolated string handler {b}");
 		}
 
-		[ExpectedWarning ("IL2057", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/101733")]
+		[ExpectedWarning ("IL2057")]
 		static void TestUnknownInterpolatedString (string input = "test") {
 			Type.GetType ($"{input}");
 		}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/InterpolatedStringDataFlow.cs
@@ -15,14 +15,15 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 	[ExpectedNoWarnings]
 	[SkipKeptItemsValidation]
 	[Define ("DEBUG")]
-	public class InterpolatedStringHandlerDataFlow
+	public class InterpolatedStringDataFlow
 	{
 		public static void Main ()
 		{
-			Test ();
+			TestInterpolatedStringHandler ();
+			TestUnknownInterpolatedString ();
 		}
 
-		static void Test(bool b = true) {
+		static void TestInterpolatedStringHandler (bool b = true) {
 			// Creates a control-flow graph for the analyzer that has an
 			// IFlowCaptureReferenceOperation that represents a capture
 			// because it is used as an out param (so has IsInitialization = true).
@@ -30,6 +31,11 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			// This test ensures the analyzer has coverage for cases
 			// where IsInitialization = true.
 			Debug.Assert (b, $"Debug interpolated string handler {b}");
+		}
+
+		[ExpectedWarning ("IL2057", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/101733")]
+		static void TestUnknownInterpolatedString (string input = "test") {
+			Type.GetType ($"{input}");
 		}
 	}
 }


### PR DESCRIPTION
Up until now, the analyzer has been set up to return `TopValue` for operations which are not handled by their own `Visit` overrides, to avoid producing warnings that are not produced from ILLink or ILC. This changes the default handling to return `UnknownValue.Instance`, so that such operations produce warnings if the return value flows into a location with dataflow requirements.

Fixes https://github.com/dotnet/runtime/issues/101733, where the return value of a string interpolation operation (which doesn't have special handling in a `Visit` override) was not producing warnings when passed to `Type.GetType`.