### PR TITLE
JIT: Enable cross-block local assertion prop for natural loops

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4856,9 +4856,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // Expose candidates for implicit byref last-use copy elision.
     DoPhase(this, PHASE_IMPBYREF_COPY_OMISSION, &Compiler::fgMarkImplicitByRefCopyOmissionCandidates);
 
-    // Locals tree list is no longer kept valid.
-    fgNodeThreading = NodeThreading::None;
-
     // Apply the type update to implicit byref parameters; also choose (based on address-exposed
     // analysis) which implicit byref promotions to keep (requires copy to initialize) or discard.
     //
@@ -4875,7 +4872,14 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         // Build post-order that morph will use, and remove dead blocks
         //
         DoPhase(this, PHASE_DFS_BLOCKS, &Compiler::fgDfsBlocksAndRemove);
+
+        // Find loops and annotations that morph will use for assertion prop
+        //
+        DoPhase(this, PHASE_FIND_LOOPS_BEFORE_MORPH, &Compiler::optFindLoopsBeforeMorph);
     }
+
+    // Locals tree list is no longer kept valid.
+    fgNodeThreading = NodeThreading::None;
 
     // Morph the trees in all the blocks of the method
     //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7536,7 +7536,6 @@ public:
 public:
     // Data structures for assertion prop
     BitVecTraits* apTraits;
-    ASSERT_TP     apFull;
     ASSERT_TP     apLocal;
     ASSERT_TP     apLocalIfTrue;
 
@@ -7889,6 +7888,8 @@ public:
                                       bool             helperCallArgs = false);
 
     AssertionIndex optFinalizeCreatingAssertion(AssertionDsc* assertion);
+
+    void optRemoveCopyAssertions(ASSERT_TP& assertions);
 
     bool optTryExtractSubrangeAssertion(GenTree* source, IntegralRange* pRange);
 

--- a/src/coreclr/jit/compphases.h
+++ b/src/coreclr/jit/compphases.h
@@ -31,6 +31,7 @@ CompPhaseNameMacro(PHASE_POST_IMPORT,                "Post-import",             
 CompPhaseNameMacro(PHASE_IBCPREP,                    "Profile instrumentation prep",   false, -1, false)
 CompPhaseNameMacro(PHASE_IBCINSTR,                   "Profile instrumentation",        false, -1, false)
 CompPhaseNameMacro(PHASE_INCPROFILE,                 "Profile incorporation",          false, -1, false)
+CompPhaseNameMacro(PHASE_FIND_LOOPS_BEFORE_MORPH,    "Find loops before morph",        false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_INIT,                 "Morph - Init",                   false, -1, false)
 CompPhaseNameMacro(PHASE_MORPH_INLINE,               "Morph - Inlining",               false, -1, true)
 CompPhaseNameMacro(PHASE_MORPH_ADD_INTERNAL,         "Morph - Add internal blocks",    false, -1, true)

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4760,6 +4760,7 @@ void Compiler::fgDebugCheckFlowGraphAnnotations()
     assert((m_loops == nullptr) || (m_loops->GetDfsTree() == m_dfsTree));
     assert((m_domTree == nullptr) || (m_domTree->GetDfsTree() == m_dfsTree));
     assert((m_reachabilitySets == nullptr) || (m_reachabilitySets->GetDfsTree() == m_dfsTree));
+    assert((m_loopDefinitions == nullptr) || (m_loopDefinitions->GetLoops() == m_loops));
 }
 
 /*****************************************************************************/

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4093,6 +4093,7 @@ void Compiler::fgInvalidateDfsTree()
 {
     m_dfsTree          = nullptr;
     m_loops            = nullptr;
+    m_loopDefinitions  = nullptr;
     m_domTree          = nullptr;
     m_reachabilitySets = nullptr;
     fgSsaValid         = false;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13853,6 +13853,11 @@ void Compiler::fgMorphBlock(BasicBlock* block)
                     m_loopDefinitions->VisitDefinedLocalNums(loop, [=](unsigned lclNum) {
                         BitVecOps::DiffD(apTraits, apLocal, GetAssertionDep(lclNum));
                     });
+
+                    // Kill all copy prop assertions. Copy propagation into
+                    // loops creates long-lived lifetimes that has very mixed
+                    // benefits.
+                    optRemoveCopyAssertions(apLocal);
                 }
             }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -4566,6 +4566,16 @@ LoopDefinitions* LoopDefinitions::Find(FlowGraphNaturalLoops* loops)
                     result->Add(loop, lcl->GetLclNum());
 
                     LclVarDsc* lclDsc = comp->lvaGetDesc(lcl);
+                    if (comp->lvaIsImplicitByRefLocal(lcl->GetLclNum()) && lclDsc->lvPromoted)
+                    {
+                        // fgRetypeImplicitByRefArgs created a new promoted
+                        // struct local to represent this arg. The stores will
+                        // be rewritten by morph.
+                        assert(lclDsc->lvFieldLclStart != 0);
+                        result->Add(loop, lclDsc->lvFieldLclStart);
+                        lclDsc = comp->lvaGetDesc(lclDsc->lvFieldLclStart);
+                    }
+
                     if (lclDsc->lvPromoted)
                     {
                         for (unsigned i = 0; i < lclDsc->lvFieldCnt; i++)


### PR DESCRIPTION
For natural loop headers we can allow propagating assertions from the entering predecessors without intersecting them with the assertions from the backedges, provided that we take care to kill all assertions about locals that may be defined within the loop. We can pay a bit of TP to compute this set before morph.

This is a similar to what VN does for natural loops, just less general.