### PR TITLE
Provide MSBuild properties to use the new libc++ configuration we plan on using in our builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -323,7 +323,7 @@
     <!-- Runtime doesn't support Arcade-driven target framework filtering. -->
     <NoTargetFrameworkFiltering>true</NoTargetFrameworkFiltering>
 
-    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs</NativeBuildPartitionPropertiesToRemove>
+    <NativeBuildPartitionPropertiesToRemove>ClrFullNativeBuild;ClrRuntimeSubset;ClrJitSubset;ClrPalTestsSubset;ClrAllJitsSubset;ClrILToolsSubset;ClrNativeAotSubset;ClrSpmiSubset;ClrCrossComponentsSubset;ClrDebugSubset;HostArchitecture;PgoInstrument;NativeOptimizationDataSupported;CMakeArgs;CxxStandardLibrary;CxxStandardLibraryStatic;CxxAbiLibrary</NativeBuildPartitionPropertiesToRemove>
   </PropertyGroup>
 
   <!-- RepositoryEngineeringDir isn't set when Installer tests import this file. -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -131,7 +131,7 @@
   <PropertyGroup>
     <TargetCxxLibraryProperties Condition="'$(TargetCxxStandardLibrary)' != ''">CxxStandardLibrary=$(TargetCxxStandardLibrary)</TargetCxxLibraryProperties>
     <TargetCxxLibraryProperties Condition="'$(TargetCxxStandardLibraryStatic)' != ''">$(TargetCxxLibraryProperties);CxxStandardLibraryStatic=$(TargetCxxStandardLibraryStatic)</TargetCxxLibraryProperties>
-    <TargetCxxLibraryProperties Condition="'$(TargetCxxAbiLibrary)' != ''">$(TargetCxxLibraryProperties);CxxAbiLibrary=$(CxxAbiLibrary)</TargetCxxLibraryProperties>
+    <TargetCxxLibraryProperties Condition="'$(TargetCxxAbiLibrary)' != ''">$(TargetCxxLibraryProperties);CxxAbiLibrary=$(TargetCxxAbiLibrary)</TargetCxxLibraryProperties>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -127,6 +127,15 @@
     <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(UseContainerLibcxx)' == 'true'">
+    <UseContainerLibcxxProperties>CxxStandardLibrary=libc++;CxxStandardLibraryStatic=true</UseContainerLibcxxProperties>
+    <!-- 
+      When we are building a sanitized build using the libc++ in our containers, we'll use an instrumented libc++abi for better coverage.
+      When we're building the product for shipping, we'll use the system-provided libstdc++ for the ABI for size savings.
+    -->
+    <UseContainerLibcxxProperties Condition="'$(EnableNativeSanitizers)' == ''">$(UseContainerLibcxxProperties);CxxAbiLibrary=libstdc++</UseContainerLibcxxProperties>
+  </PropertyGroup>
+
   <ItemGroup>
     <!-- CoreClr -->
     <SubsetName Include="Clr" Description="The full CoreCLR runtime. Equivalent to: $(DefaultCoreClrSubsets)" />
@@ -265,7 +274,7 @@
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
-      AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets)"
+      AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets);$(UseContainerLibcxxProperties)"
       Category="clr" />
   </ItemGroup>
 
@@ -455,7 +464,7 @@
   <!-- Host sets -->
   <ItemGroup Condition="$(_subset.Contains('+host.native+'))">
     <CorehostProjectToBuild Include="$(SharedNativeRoot)corehost\corehost.proj" SignPhase="Binaries" />
-    <ProjectToBuild Include="@(CorehostProjectToBuild)" Pack="true" Category="host" />
+    <ProjectToBuild Include="@(CorehostProjectToBuild)" AdditionalProperties="$(UseContainerLibcxxProperties)" Pack="true" Category="host" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+host.tools+'))">

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -127,13 +127,11 @@
     <UseNativeAotCoreLib Condition="'$(TestNativeAot)' == 'true' or ($(_subset.Contains('+clr.nativeaotlibs+')) and !$(_subset.Contains('+clr.native+')) and !$(_subset.Contains('+clr.runtime+')) and !$(_subset.Contains('+clr.corelib+')))">true</UseNativeAotCoreLib>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseContainerLibcxx)' == 'true'">
-    <UseContainerLibcxxProperties>CxxStandardLibrary=libc++;CxxStandardLibraryStatic=true</UseContainerLibcxxProperties>
-    <!-- 
-      When we are building a sanitized build using the libc++ in our containers, we'll use an instrumented libc++abi for better coverage.
-      When we're building the product for shipping, we'll use the system-provided libstdc++ for the ABI for size savings.
-    -->
-    <UseContainerLibcxxProperties Condition="'$(EnableNativeSanitizers)' == ''">$(UseContainerLibcxxProperties);CxxAbiLibrary=libstdc++</UseContainerLibcxxProperties>
+  <!-- Configure build properties for C++ runtime library references. -->
+  <PropertyGroup>
+    <TargetCxxLibraryProperties Condition="'$(TargetCxxStandardLibrary)' != ''">CxxStandardLibrary=$(TargetCxxStandardLibrary)</TargetCxxLibraryProperties>
+    <TargetCxxLibraryProperties Condition="'$(TargetCxxStandardLibraryStatic)' != ''">$(TargetCxxLibraryProperties);CxxStandardLibraryStatic=$(TargetCxxStandardLibraryStatic)</TargetCxxLibraryProperties>
+    <TargetCxxLibraryProperties Condition="'$(TargetCxxAbiLibrary)' != ''">$(TargetCxxLibraryProperties);CxxAbiLibrary=$(CxxAbiLibrary)</TargetCxxLibraryProperties>
   </PropertyGroup>
 
   <ItemGroup>
@@ -274,7 +272,7 @@
   <ItemGroup Condition="'$(ClrRuntimeBuildSubsets)' != ''">
     <ProjectToBuild
       Include="$(CoreClrProjectRoot)runtime.proj"
-      AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets);$(UseContainerLibcxxProperties)"
+      AdditionalProperties="%(AdditionalProperties);$(ClrRuntimeBuildSubsets);$(TargetCxxLibraryProperties)"
       Category="clr" />
   </ItemGroup>
 
@@ -464,7 +462,7 @@
   <!-- Host sets -->
   <ItemGroup Condition="$(_subset.Contains('+host.native+'))">
     <CorehostProjectToBuild Include="$(SharedNativeRoot)corehost\corehost.proj" SignPhase="Binaries" />
-    <ProjectToBuild Include="@(CorehostProjectToBuild)" AdditionalProperties="$(UseContainerLibcxxProperties)" Pack="true" Category="host" />
+    <ProjectToBuild Include="@(CorehostProjectToBuild)" AdditionalProperties="$(TargetCxxLibraryProperties)" Pack="true" Category="host" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+host.tools+'))">

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -99,10 +99,11 @@ jobs:
         - name: crossArg
           value: '-cross'
 
-      - ${{ if ne(parameters.jobParameters.crossrootfsDir, '') }}:
-        # This is only required for cross builds.
-        - name: ROOTFS_DIR
-          value: ${{ parameters.jobParameters.crossrootfsDir }}
+      - name: UseContainerLibcxxArg
+        value: ''
+      - ${{ if eq(parameters.useContainerLibcxx, true) }}:
+        - name: UseContainerLibcxxArg
+          value: /p:UseContainerLibcxx=true
 
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -99,11 +99,26 @@ jobs:
         - name: crossArg
           value: '-cross'
 
-      - name: UseContainerLibcxxArg
+      - name: CxxStandardLibraryArg
         value: ''
-      - ${{ if eq(parameters.useContainerLibcxx, true) }}:
-        - name: UseContainerLibcxxArg
-          value: /p:UseContainerLibcxx=true
+      - ${{ if ne(parameters.cxxStandardLibrary, '') }}:
+        - name: CxxStandardLibraryArg
+          value: /p:TargetCxxStandardLibrary=${{ parameters.cxxStandardLibrary }}
+
+      - name: CxxStandardLibraryStaticArg
+        value: ''
+      - ${{ if ne(parameters.cxxStandardLibraryStatic, '') }}:
+        - name: CxxStandardLibraryStaticArg
+          value: /p:TargetCxxStandardLibraryStatic=${{ parameters.cxxStandardLibraryStatic }}
+
+      - name: CxxAbiLibraryArg
+        value: ''
+      - ${{ if ne(parameters.cxxAbiLibrary, '') }}:
+        - name: CxxAbiLibraryArg
+          value: /p:TargetCxxAbiLibraryArg=${{ parameters.cxxAbiLibrary }}
+      
+      - name: TargetCxxLibraryConfigurationArgs
+        value: $(CxxStandardLibraryArg) $(CxxStandardLibraryStaticArg) $(CxxAbiLibraryArg)
 
       - name: _officialBuildParameter
         ${{ if eq(parameters.isOfficialBuild, true) }}:

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -115,7 +115,7 @@ jobs:
         value: ''
       - ${{ if ne(parameters.cxxAbiLibrary, '') }}:
         - name: CxxAbiLibraryArg
-          value: /p:TargetCxxAbiLibraryArg=${{ parameters.cxxAbiLibrary }}
+          value: /p:TargetCxxAbiLibrary=${{ parameters.cxxAbiLibrary }}
       
       - name: TargetCxxLibraryConfigurationArgs
         value: $(CxxStandardLibraryArg) $(CxxStandardLibraryStaticArg) $(CxxAbiLibraryArg)

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -43,6 +43,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
@@ -112,6 +113,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm
@@ -134,6 +136,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
@@ -156,6 +159,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux Bionic arm
@@ -251,6 +255,8 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        ${{ if eq(parameters.container, '') }}:
+          useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x86
@@ -272,6 +278,7 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        useContainerLibcxx: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Runtime-dev-innerloop build

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -253,7 +253,7 @@ jobs:
         crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if containsValue(parameters.platforms, 'linux_x64_asan') }}:
+- ${{ if containsValue(parameters.platforms, 'linux_x64_sanitizer') }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}
@@ -264,7 +264,7 @@ jobs:
       targetRid: linux-x64
       platform: linux_x64
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_x64_asan
+      container: linux_x64_sanitizer
       jobParameters:
         runtimeFlavor: ${{ parameters.runtimeFlavor }}
         buildConfig: ${{ parameters.buildConfig }}
@@ -272,6 +272,7 @@ jobs:
         crossBuild: true
         cxxStandardLibrary: libc++
         cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x86

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -269,6 +269,27 @@ jobs:
           cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
+- ${{ if or(containsValue(parameters.platforms, 'linux_x64_asan'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+  - template: xplat-setup.yml
+    parameters:
+      jobTemplate: ${{ parameters.jobTemplate }}
+      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
+      variables: ${{ parameters.variables }}
+      osGroup: linux
+      archType: x64
+      targetRid: linux-x64
+      platform: linux_x64
+      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
+      container: linux_x64_asan
+      jobParameters:
+        runtimeFlavor: ${{ parameters.runtimeFlavor }}
+        buildConfig: ${{ parameters.buildConfig }}
+        helixQueueGroup: ${{ parameters.helixQueueGroup }}
+        crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        ${{ insert }}: ${{ parameters.jobParameters }}
+
 # Linux x86
 
 - ${{ if containsValue(parameters.platforms, 'linux_x86') }}:

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -269,7 +269,7 @@ jobs:
           cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-- ${{ if or(containsValue(parameters.platforms, 'linux_x64_asan'), containsValue(parameters.platforms, 'CoreClrTestBuildHost'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
+- ${{ if containsValue(parameters.platforms, 'linux_x64_asan') }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -43,7 +43,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        useContainerLibcxx: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
@@ -113,7 +115,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        useContainerLibcxx: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm
@@ -136,7 +140,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        useContainerLibcxx: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
@@ -159,7 +165,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        useContainerLibcxx: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux Bionic arm
@@ -256,7 +264,9 @@ jobs:
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
         ${{ if eq(parameters.container, '') }}:
-          useContainerLibcxx: true
+          cxxStandardLibrary: libc++
+          cxxStandardLibraryStatic: true
+          cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux x86
@@ -278,7 +288,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        useContainerLibcxx: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Runtime-dev-innerloop build

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -294,9 +294,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        cxxStandardLibrary: libc++
-        cxxStandardLibraryStatic: true
-        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Runtime-dev-innerloop build

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -43,9 +43,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        cxxStandardLibrary: libc++
-        cxxStandardLibraryStatic: true
-        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
@@ -115,9 +112,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        cxxStandardLibrary: libc++
-        cxxStandardLibraryStatic: true
-        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm
@@ -140,9 +134,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        cxxStandardLibrary: libc++
-        cxxStandardLibraryStatic: true
-        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
@@ -165,9 +156,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        cxxStandardLibrary: libc++
-        cxxStandardLibraryStatic: true
-        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux Bionic arm
@@ -263,10 +251,6 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
-        ${{ if eq(parameters.container, '') }}:
-          cxxStandardLibrary: libc++
-          cxxStandardLibraryStatic: true
-          cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if containsValue(parameters.platforms, 'linux_x64_asan') }}:

--- a/eng/pipelines/common/templates/global-build-step.yml
+++ b/eng/pipelines/common/templates/global-build-step.yml
@@ -4,12 +4,13 @@ parameters:
   shouldContinueOnError: false
   archParameter: $(_archParameter)
   crossArg: $(crossArg)
+  useContainerLibcxxArg: $(useContainerLibcxxArg)
   displayName: Build product
   container: ''
   condition: succeeded()
 
 steps:
-  - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci ${{ parameters.archParameter }} $(_osParameter) ${{ parameters.crossArg }} ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
+  - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci ${{ parameters.archParameter }} $(_osParameter) ${{ parameters.crossArg }} ${{ parameters.buildArgs }} ${{ parameters.useContainerLibcxxArg }} $(_officialBuildParameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
     displayName: ${{ parameters.displayName }}
     ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
       continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/global-build-step.yml
+++ b/eng/pipelines/common/templates/global-build-step.yml
@@ -4,13 +4,13 @@ parameters:
   shouldContinueOnError: false
   archParameter: $(_archParameter)
   crossArg: $(crossArg)
-  useContainerLibcxxArg: $(useContainerLibcxxArg)
+  targetCxxLibraryConfigurationArgs: $(TargetCxxLibraryConfigurationArgs)
   displayName: Build product
   container: ''
   condition: succeeded()
 
 steps:
-  - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci ${{ parameters.archParameter }} $(_osParameter) ${{ parameters.crossArg }} ${{ parameters.buildArgs }} ${{ parameters.useContainerLibcxxArg }} $(_officialBuildParameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
+  - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci ${{ parameters.archParameter }} $(_osParameter) ${{ parameters.crossArg }} ${{ parameters.buildArgs }} ${{ parameters.targetCxxLibraryConfigurationArgs }} $(_officialBuildParameter) $(_buildDarwinFrameworksParameter) $(_overrideTestScriptWindowsCmdParameter)
     displayName: ${{ parameters.displayName }}
     ${{ if eq(parameters.useContinueOnErrorDuringBuild, true) }}:
       continueOnError: ${{ parameters.shouldContinueOnError }}

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -71,6 +71,11 @@ extends:
       linux_musl_x64_dev_innerloop:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
 
+      linux_x64_asan:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net9.0-asan
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
+
       # We use a CentOS Stream 8 image here to test building from source on CentOS Stream 8.
       SourceBuild_centos_x64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream8

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -71,8 +71,8 @@ extends:
       linux_musl_x64_dev_innerloop:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.19-WithNode
 
-      linux_x64_asan:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net9.0-asan
+      linux_x64_sanitizer:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-amd64-net9.0-sanitizer
         env:
           ROOTFS_DIR: /crossrootfs/x64
 

--- a/eng/pipelines/runtime-sanitized.yml
+++ b/eng/pipelines/runtime-sanitized.yml
@@ -28,7 +28,7 @@ extends:
           buildConfig: Checked
           runtimeFlavor: coreclr
           platforms:
-            - linux_x64_asan
+            - linux_x64_sanitizer
             - osx_x64
             - windows_x64
           variables:
@@ -63,7 +63,7 @@ extends:
           buildConfig: Debug
           runtimeFlavor: coreclr
           platforms:
-            - linux_x64_asan
+            - linux_x64_sanitizer
             - osx_x64
           variables:
             - name: _nativeSanitizersArg
@@ -123,7 +123,7 @@ extends:
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           buildConfig: release
           platforms:
-            - linux_x64_asan
+            - linux_x64_sanitizer
             - osx_x64
             - windows_x64
           variables:

--- a/eng/pipelines/runtime-sanitized.yml
+++ b/eng/pipelines/runtime-sanitized.yml
@@ -28,7 +28,7 @@ extends:
           buildConfig: Checked
           runtimeFlavor: coreclr
           platforms:
-            - linux_x64
+            - linux_x64_asan
             - osx_x64
             - windows_x64
           variables:
@@ -63,7 +63,7 @@ extends:
           buildConfig: Debug
           runtimeFlavor: coreclr
           platforms:
-            - linux_x64
+            - linux_x64_asan
             - osx_x64
           variables:
             - name: _nativeSanitizersArg
@@ -123,7 +123,7 @@ extends:
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
           buildConfig: release
           platforms:
-            - linux_x64
+            - linux_x64_asan
             - osx_x64
             - windows_x64
           variables:

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -55,7 +55,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(CxxStandardLibrary)' != ''">
-      <_CoreClrBuildArg Include="-cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=libc++" />
+      <_CoreClrBuildArg Include="-cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=$(CxxStandardLibrary)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(CxxStandardLibraryStatic)' == 'true'">

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -54,6 +54,18 @@
       <_CoreClrBuildArg Include="-cmakeargs &quot;-DCDAC_BUILD_TOOL_BINARY_PATH=$(RuntimeBinDir)cdac-build-tool\cdac-build-tool.dll&quot;" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(CxxStandardLibrary)' != ''">
+      <_CoreClrBuildArg Include="-cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=libc++" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(CxxStandardLibraryStatic)' == 'true'">
+      <_CoreClrBuildArg Include="-cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY_STATIC=ON" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(CxxAbiLibrary)' != ''">
+      <_CoreClrBuildArg Include="-cmakeargs -DCLR_CMAKE_CXX_ABI_LIBRARY=$(CxxAbiLibrary)" />
+    </ItemGroup>
+
     <ItemGroup Condition="'$(ClrFullNativeBuild)' != 'true'">
       <_CoreClrBuildArg Condition="'$(ClrHostsSubset)' == 'true'" Include="-component hosts" />
       <_CoreClrBuildArg Condition="'$(ClrRuntimeSubset)' == 'true'" Include="-component runtime" />

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -78,6 +78,20 @@
       <_CoreHostUnixTargetOS Condition="'$(TargetsLinuxBionic)' == 'true'">linux-bionic</_CoreHostUnixTargetOS>
       <BuildArgs>$(Configuration) $(TargetArchitecture) -commithash "$([MSBuild]::ValueOrDefault('$(SourceRevisionId)', 'N/A'))" -os $(_CoreHostUnixTargetOS)</BuildArgs>
       <BuildArgs>$(BuildArgs) -cmakeargs "-DVERSION_FILE_PATH=$(NativeVersionFile)"</BuildArgs>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(CxxStandardLibrary)' != ''">
+      <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=libc++</BuildArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(CxxStandardLibraryStatic)' != ''">
+      <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY_STATIC=ON</BuildArgs>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(CxxAbiLibrary)' != ''">
+      <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_ABI_LIBRARY=$(CxxAbiLibrary)</BuildArgs>
+    </PropertyGroup>
+
+    <PropertyGroup>
       <BuildArgs Condition="'$(ConfigureOnly)' == 'true'">$(BuildArgs) -configureonly</BuildArgs>
       <BuildArgs Condition="'$(PortableBuild)' != 'true'">$(BuildArgs) -portablebuild=false</BuildArgs>
       <BuildArgs Condition="'$(KeepNativeSymbols)' != 'false'">$(BuildArgs) -keepnativesymbols</BuildArgs>

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -80,10 +80,10 @@
       <BuildArgs>$(BuildArgs) -cmakeargs "-DVERSION_FILE_PATH=$(NativeVersionFile)"</BuildArgs>
     </PropertyGroup>
     <PropertyGroup Condition="'$(CxxStandardLibrary)' != ''">
-      <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=libc++</BuildArgs>
+      <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY=$(CxxStandardLibrary)</BuildArgs>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(CxxStandardLibraryStatic)' != ''">
+    <PropertyGroup Condition="'$(CxxStandardLibraryStatic)' == 'true'">
       <BuildArgs>$(BuildArgs) -cmakeargs -DCLR_CMAKE_CXX_STANDARD_LIBRARY_STATIC=ON</BuildArgs>
     </PropertyGroup>
 


### PR DESCRIPTION
We're going to switch our Microsoft shipping builds to statically link to a live-built libc++ with a dynamically-linked libstdc++ as the C++ ABI. We're doing this change to address the concerns in https://github.com/dotnet/runtime/pull/101088#discussion_r1566580872. This change will allow us to use servicable/supported C++ headers in our product with the smallest possible size increase (+~53kB size on disk for libcoreclr.so on our linux-x64 images).

For our AddressSanitizer test legs, we're introducing a new image that instruments libc++ and uses (and instruments) libc++abi for the ABI layer (all statically linked).

Depends on https://github.com/dotnet/dotnet-buildtools-prereqs-docker/pull/1025, but I want to get this UX approved before I merge that PR.

No changes were made in the libraries build as that build is all in C as far as I know.