### PR TITLE
[PERF] Temp forced dotnet version: Use a version that will consistently be found.

### DIFF
--- a/eng/pipelines/coreclr/templates/run-performance-job.yml
+++ b/eng/pipelines/coreclr/templates/run-performance-job.yml
@@ -179,7 +179,7 @@ jobs:
       displayName: Performance Setup (Unix)
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
-    - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments) ${{ parameters.additionalSetupParameters }} --dotnet-versions 9.0.100-preview.5.24230.4 # Temporarily add a specific dotnet-version as Windows runs are currently failing to install the dotnet version
+    - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments) ${{ parameters.additionalSetupParameters }} --dotnet-versions 9.0.100-preview.4.24215.2 # Temporarily add a specific dotnet-version as Windows runs are currently failing to install the dotnet version
       displayName: Run ci setup script
       # Run perf testing in helix
     - template: /eng/pipelines/coreclr/templates/perf-send-to-helix.yml

--- a/eng/pipelines/coreclr/templates/run-scenarios-job.yml
+++ b/eng/pipelines/coreclr/templates/run-scenarios-job.yml
@@ -135,7 +135,7 @@ jobs:
       condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
       continueOnError: ${{ parameters.continueOnError }}
     # run ci-setup
-    - script: $(Python) $(PerformanceDirectory)\scripts\ci_setup.py $(SetupArguments) $(ExtraSetupArguments) --dotnet-versions 9.0.100-preview.5.24230.4 --output-file $(WorkItemDirectory)\machine-setup.cmd # Temporarily add a specific dotnet-version as Windows runs are currently failing to install the dotnet version
+    - script: $(Python) $(PerformanceDirectory)\scripts\ci_setup.py $(SetupArguments) $(ExtraSetupArguments) --dotnet-versions 9.0.100-preview.4.24215.2 --output-file $(WorkItemDirectory)\machine-setup.cmd # Temporarily add a specific dotnet-version as Windows runs are currently failing to install the dotnet version
       displayName: Run ci setup script (Windows)
       condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'))
     - script: $(Python) $(PerformanceDirectory)/scripts/ci_setup.py $(SetupArguments) $(ExtraSetupArguments) --output-file $(WorkItemDirectory)/machine-setup.sh


### PR DESCRIPTION
The version I switched to was grabbed from the runtime eng/Version.props file and tested locally on windows and wsl. Update to https://github.com/dotnet/runtime/pull/101747