### PR TITLE
Trim instructionset name in helper

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -122,7 +122,7 @@ namespace System.CommandLine
                 string[] instructionSetParamsInput = instructionSet.Split(',');
                 for (int i = 0; i < instructionSetParamsInput.Length; i++)
                 {
-                    instructionSet = instructionSetParamsInput[i];
+                    instructionSet = instructionSetParamsInput[i].Trim();
 
                     if (string.IsNullOrEmpty(instructionSet))
                         throw new CommandLineException(string.Format(mustNotBeMessage, ""));


### PR DESCRIPTION
The comma-separated list shown in --help menu has leading spaces, while the argument parser was not allowing it.