### PR TITLE
Add top-level controls for VMR to enable/disable system lbiraries

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -53,6 +53,13 @@
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)verbosity $(LogVerbosity)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)nodereuse $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
       <InnerBuildArgs>$(InnerBuildArgs) $(FlagParameterPrefix)warnAsError $(ArcadeFalseBoolBuildArg)</InnerBuildArgs>
+
+      <InnerBuildArgs Condition="'$(UseSystemBrotli)' != ''">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_BROTLI=$(UseSystemBrotli)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(UseSystemLibunwind)' != ''">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=$(UseSystemLibunwind)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(UseSystemLlvmLibunwind)' != ''">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LLVM_LIBUNWIND=$(UseSystemLlvmLibunwind)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(UseSystemRapidjson)' != ''">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_RAPIDJSON=$(UseSystemRapidjson)</InnerBuildArgs>
+      <InnerBuildArgs Condition="'$(UseSystemZlib)' != ''">$(InnerBuildArgs) --cmakeargs -DCLR_CMAKE_USE_SYSTEM_ZLIB=$(UseSystemZlib)</InnerBuildArgs>
+
       <InnerBuildArgs Condition="'$(SourceBuildUseMonoRuntime)' == 'true'">$(InnerBuildArgs) $(FlagParameterPrefix)usemonoruntime</InnerBuildArgs>
       <!-- TODO: This parameter is only available on the Unix script. Intentional? -->
       <InnerBuildArgs Condition="'$(OS)' != 'Windows_NT'">$(InnerBuildArgs) --outputrid $(TargetRid)</InnerBuildArgs>


### PR DESCRIPTION
Make it easier for the VMR to pass top-level options to let the runtime use bundled/vendored (`external`) vs system versions of libraries.