### PR TITLE
Expose DOTNET_JitNoInline in Release

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -8575,13 +8575,11 @@ void Compiler::impCheckCanInline(GenTreeCall*           call,
         CORINFO_METHOD_HANDLE ftn          = pParam->fncHandle;
         InlineResult* const   inlineResult = pParam->result;
 
-#ifdef DEBUG
         if (JitConfig.JitNoInline())
         {
             inlineResult->NoteFatal(InlineObservation::CALLEE_IS_JIT_NOINLINE);
             return;
         }
-#endif
 
         JITDUMP("\nCheckCanInline: fetching method info for inline candidate %s -- context %p\n",
                 compiler->eeGetMethodName(ftn), compiler->dspPtr(pParam->exactContextHnd));

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -138,7 +138,6 @@ CONFIG_INTEGER(JitNoForceFallback, W("JitNoForceFallback"), 0) // Set to non-zer
                                                                // flags.
 CONFIG_INTEGER(JitNoForwardSub, W("JitNoForwardSub"), 0)       // Disables forward sub
 CONFIG_INTEGER(JitNoHoist, W("JitNoHoist"), 0)
-CONFIG_INTEGER(JitNoInline, W("JitNoInline"), 0)                   // Disables inlining of all methods
 CONFIG_INTEGER(JitNoMemoryBarriers, W("JitNoMemoryBarriers"), 0)   // If 1, don't generate memory barriers
 CONFIG_INTEGER(JitNoStructPromotion, W("JitNoStructPromotion"), 0) // Disables struct promotion 1 - for all, 2 - for
                                                                    // params.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -358,6 +358,9 @@ RELEASE_CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 1)
 // Enable the enregistration of locals that are defined or used in a multireg context.
 RELEASE_CONFIG_INTEGER(EnableMultiRegLocals, W("EnableMultiRegLocals"), 1)
 
+// Disables inlining of all methods
+RELEASE_CONFIG_INTEGER(JitNoInline, W("JitNoInline"), 0)
+
 // Enable EVEX encoding for SIMD instructions when AVX-512VL is available.
 CONFIG_INTEGER(JitStressEvexEncoding, W("JitStressEvexEncoding"), 0)
 


### PR DESCRIPTION
It can be used to improve quality of profiles (in case if it doesn't hide a problem one investigates) e.g. to profile lock contention and where exactly it's coming from since none of our profiling tools are able to properly show virtual inlinees.