### PR TITLE
Ensure the scalar Reciprocal*Estimate APIs use AVX512 where possible

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1594,7 +1594,7 @@ enum class ProfileChecks : unsigned int
 {
     CHECK_NONE          = 0,
     CHECK_HASLIKELIHOOD = 1 << 0, // check all FlowEdges for hasLikelihood
-    CHECK_LIKELIHOODSUM = 1 << 1, // check block succesor likelihoods sum to 1                              
+    CHECK_LIKELIHOODSUM = 1 << 1, // check block succesor likelihoods sum to 1
     CHECK_LIKELY        = 1 << 2, // fully check likelihood based weights
     RAISE_ASSERT        = 1 << 3, // assert on check failure
     CHECK_ALL_BLOCKS    = 1 << 4, // check blocks even if bbHasProfileWeight is false
@@ -4525,6 +4525,11 @@ protected:
                           CORINFO_THIS_TRANSFORM  constraintCallThisTransform,
                           NamedIntrinsic*         pIntrinsicName,
                           bool*                   isSpecialIntrinsic = nullptr);
+    GenTree* impEstimateIntrinsic(CORINFO_METHOD_HANDLE method,
+                                  CORINFO_SIG_INFO*     sig,
+                                  CorInfoType           callJitType,
+                                  NamedIntrinsic        intrinsicName,
+                                  bool                  tailCall);
     GenTree* impMathIntrinsic(CORINFO_METHOD_HANDLE method,
                               CORINFO_SIG_INFO*     sig,
                               var_types             callType,

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -8752,16 +8752,15 @@ void Compiler::impCheckCanInline(GenTreeCall*           call,
 }
 
 //------------------------------------------------------------------------
-// impMinMaxIntrinsic: Imports a min or max intrinsic
+// impEstimateIntrinsic: Imports one of the *Estimate intrinsics which are
+// explicitly allowed to differ in result based on the hardware they're running
+// against
 //
 // Arguments:
 //   method        - The handle of the method being imported
 //   callType      - The underlying type for the call
 //   intrinsicName - The intrinsic being imported
 //   tailCall      - true if the method is a tail call; otherwise false
-//   isMax         - true if the intrinsic computes the max; false for the min
-//   isMagnitude   - true if the intrinsic compares using the absolute value of the inputs
-//   isNumber      - true if the intrinsic propagates the number; false for NaN
 //
 GenTree* Compiler::impEstimateIntrinsic(CORINFO_METHOD_HANDLE method,
                                         CORINFO_SIG_INFO*     sig,

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -8865,7 +8865,6 @@ GenTree* Compiler::impEstimateIntrinsic(CORINFO_METHOD_HANDLE method,
     return nullptr;
 }
 
-
 GenTree* Compiler::impMathIntrinsic(CORINFO_METHOD_HANDLE method,
                                     CORINFO_SIG_INFO*     sig,
                                     var_types             callType,

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -51,6 +51,8 @@ enum NamedIntrinsic : unsigned short
     NI_System_Math_MinMagnitudeNumber,
     NI_System_Math_MinNumber,
     NI_System_Math_Pow,
+    NI_System_Math_ReciprocalEstimate,
+    NI_System_Math_ReciprocalSqrtEstimate,
     NI_System_Math_Round,
     NI_System_Math_Sin,
     NI_System_Math_Sinh,

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
@@ -95,11 +95,13 @@ namespace System.Numerics.Tensors
 
             public static Vector128<T> Invoke(Vector128<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.VL.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.VL.Reciprocal14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.VL.Reciprocal14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 if (Sse.IsSupported)
                 {
@@ -121,11 +123,13 @@ namespace System.Numerics.Tensors
 
             public static Vector256<T> Invoke(Vector256<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.VL.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.VL.Reciprocal14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.VL.Reciprocal14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 if (Avx.IsSupported)
                 {
@@ -137,11 +141,13 @@ namespace System.Numerics.Tensors
 
             public static Vector512<T> Invoke(Vector512<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.Reciprocal14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.Reciprocal14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 return Vector512<T>.One / x;
             }
@@ -155,11 +161,13 @@ namespace System.Numerics.Tensors
 
             public static Vector128<T> Invoke(Vector128<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.VL.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.VL.ReciprocalSqrt14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.VL.ReciprocalSqrt14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 if (Sse.IsSupported)
                 {
@@ -181,11 +189,13 @@ namespace System.Numerics.Tensors
 
             public static Vector256<T> Invoke(Vector256<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.VL.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.VL.ReciprocalSqrt14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.VL.ReciprocalSqrt14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 if (Avx.IsSupported)
                 {
@@ -197,11 +207,13 @@ namespace System.Numerics.Tensors
 
             public static Vector512<T> Invoke(Vector512<T> x)
             {
+#if NET9_0_OR_GREATER
                 if (Avx512F.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx512F.ReciprocalSqrt14(x.AsSingle()).As<float, T>();
                     if (typeof(T) == typeof(double)) return Avx512F.ReciprocalSqrt14(x.AsDouble()).As<double, T>();
                 }
+#endif
 
                 return Vector512<T>.One / Vector512.Sqrt(x);
             }

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Reciprocal.cs
@@ -95,6 +95,12 @@ namespace System.Numerics.Tensors
 
             public static Vector128<T> Invoke(Vector128<T> x)
             {
+                if (Avx512F.VL.IsSupported)
+                {
+                    if (typeof(T) == typeof(float)) return Avx512F.VL.Reciprocal14(x.AsSingle()).As<float, T>();
+                    if (typeof(T) == typeof(double)) return Avx512F.VL.Reciprocal14(x.AsDouble()).As<double, T>();
+                }
+
                 if (Sse.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Sse.Reciprocal(x.AsSingle()).As<float, T>();
@@ -115,6 +121,12 @@ namespace System.Numerics.Tensors
 
             public static Vector256<T> Invoke(Vector256<T> x)
             {
+                if (Avx512F.VL.IsSupported)
+                {
+                    if (typeof(T) == typeof(float)) return Avx512F.VL.Reciprocal14(x.AsSingle()).As<float, T>();
+                    if (typeof(T) == typeof(double)) return Avx512F.VL.Reciprocal14(x.AsDouble()).As<double, T>();
+                }
+
                 if (Avx.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx.Reciprocal(x.AsSingle()).As<float, T>();
@@ -143,6 +155,12 @@ namespace System.Numerics.Tensors
 
             public static Vector128<T> Invoke(Vector128<T> x)
             {
+                if (Avx512F.VL.IsSupported)
+                {
+                    if (typeof(T) == typeof(float)) return Avx512F.VL.ReciprocalSqrt14(x.AsSingle()).As<float, T>();
+                    if (typeof(T) == typeof(double)) return Avx512F.VL.ReciprocalSqrt14(x.AsDouble()).As<double, T>();
+                }
+
                 if (Sse.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Sse.ReciprocalSqrt(x.AsSingle()).As<float, T>();
@@ -163,6 +181,12 @@ namespace System.Numerics.Tensors
 
             public static Vector256<T> Invoke(Vector256<T> x)
             {
+                if (Avx512F.VL.IsSupported)
+                {
+                    if (typeof(T) == typeof(float)) return Avx512F.VL.ReciprocalSqrt14(x.AsSingle()).As<float, T>();
+                    if (typeof(T) == typeof(double)) return Avx512F.VL.ReciprocalSqrt14(x.AsDouble()).As<double, T>();
+                }
+
                 if (Avx.IsSupported)
                 {
                     if (typeof(T) == typeof(float)) return Avx.ReciprocalSqrt(x.AsSingle()).As<float, T>();

--- a/src/libraries/System.Numerics.Tensors/tests/Net8Tests/System.Numerics.Tensors.Net8.Tests.csproj
+++ b/src/libraries/System.Numerics.Tensors/tests/Net8Tests/System.Numerics.Tensors.Net8.Tests.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);SNT_NET8_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -386,7 +386,12 @@ namespace System.Numerics.Tensors.Tests
             yield return Create(TensorPrimitives.Reciprocal, f => T.One / f);
             yield return Create(TensorPrimitives.ReciprocalEstimate, T.ReciprocalEstimate, T.CreateTruncating(Helpers.DefaultToleranceForEstimates));
             yield return Create(TensorPrimitives.ReciprocalSqrt, f => T.One / T.Sqrt(f));
+
+#if !SNT_NET8_TESTS
+            // Avoid running with the net8 tests due to: https://github.com/dotnet/runtime/issues/101846
             yield return Create(TensorPrimitives.ReciprocalSqrtEstimate, T.ReciprocalSqrtEstimate, T.CreateTruncating(Helpers.DefaultToleranceForEstimates));
+#endif
+
             yield return Create(TensorPrimitives.Round, T.Round);
             yield return Create(TensorPrimitives.Sin, T.Sin, trigTolerance);
             yield return Create(TensorPrimitives.Sinh, T.Sinh, Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14));

--- a/src/libraries/System.Private.CoreLib/src/System/Double.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Double.cs
@@ -865,9 +865,11 @@ namespace System
         public static double Lerp(double value1, double value2, double amount) => (value1 * (1.0 - amount)) + (value2 * amount);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
+        [Intrinsic]
         public static double ReciprocalEstimate(double x) => Math.ReciprocalEstimate(x);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalSqrtEstimate(TSelf)" />
+        [Intrinsic]
         public static double ReciprocalSqrtEstimate(double x) => Math.ReciprocalSqrtEstimate(x);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ScaleB(TSelf, int)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1195,21 +1195,11 @@ namespace System
         ///    <para>On ARM64 hardware this may use the <c>FRECPE</c> instruction which performs a single Newton-Raphson iteration.</para>
         ///    <para>On hardware without specialized support, this may just return <c>1.0 / d</c>.</para>
         /// </remarks>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ReciprocalEstimate(double d)
         {
-            if (Avx512F.IsSupported)
-            {
-                return Avx512F.Reciprocal14Scalar(Vector128.CreateScalarUnsafe(d)).ToScalar();
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                return AdvSimd.Arm64.ReciprocalEstimateScalar(Vector64.CreateScalar(d)).ToScalar();
-            }
-            else
-            {
-                return 1.0 / d;
-            }
+            return 1.0 / d;
         }
 
         /// <summary>Returns an estimate of the reciprocal square root of a specified number.</summary>
@@ -1219,21 +1209,11 @@ namespace System
         ///    <para>On ARM64 hardware this may use the <c>FRSQRTE</c> instruction which performs a single Newton-Raphson iteration.</para>
         ///    <para>On hardware without specialized support, this may just return <c>1.0 / Sqrt(d)</c>.</para>
         /// </remarks>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ReciprocalSqrtEstimate(double d)
         {
-            if (Avx512F.IsSupported)
-            {
-                return Avx512F.ReciprocalSqrt14Scalar(Vector128.CreateScalarUnsafe(d)).ToScalar();
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                return AdvSimd.Arm64.ReciprocalSquareRootEstimateScalar(Vector64.CreateScalar(d)).ToScalar();
-            }
-            else
-            {
-                return 1.0 / Sqrt(d);
-            }
+            return 1.0 / Sqrt(d);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1198,9 +1198,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ReciprocalEstimate(double d)
         {
-            // x86 doesn't provide an estimate instruction for double-precision reciprocal
-
-            if (AdvSimd.Arm64.IsSupported)
+            if (Avx512F.IsSupported)
+            {
+                return Avx512F.Reciprocal14Scalar(Vector128.CreateScalarUnsafe(d)).ToScalar();
+            }
+            else if (AdvSimd.Arm64.IsSupported)
             {
                 return AdvSimd.Arm64.ReciprocalEstimateScalar(Vector64.CreateScalar(d)).ToScalar();
             }
@@ -1220,9 +1222,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double ReciprocalSqrtEstimate(double d)
         {
-            // x86 doesn't provide an estimate instruction for double-precision reciprocal square root
-
-            if (AdvSimd.Arm64.IsSupported)
+            if (Avx512F.IsSupported)
+            {
+                return Avx512F.ReciprocalSqrt14Scalar(Vector128.CreateScalarUnsafe(d)).ToScalar();
+            }
+            else if (AdvSimd.Arm64.IsSupported)
             {
                 return AdvSimd.Arm64.ReciprocalSquareRootEstimateScalar(Vector64.CreateScalar(d)).ToScalar();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -313,25 +313,11 @@ namespace System
         ///    <para>On ARM64 hardware this may use the <c>FRECPE</c> instruction which performs a single Newton-Raphson iteration.</para>
         ///    <para>On hardware without specialized support, this may just return <c>1.0 / x</c>.</para>
         /// </remarks>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ReciprocalEstimate(float x)
         {
-            if (Avx512F.IsSupported)
-            {
-                return Avx512F.Reciprocal14Scalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else if (Sse.IsSupported)
-            {
-                return Sse.ReciprocalScalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                return AdvSimd.Arm64.ReciprocalEstimateScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else
-            {
-                return 1.0f / x;
-            }
+            return 1.0f / x;
         }
 
         /// <summary>Returns an estimate of the reciprocal square root of a specified number.</summary>
@@ -342,25 +328,11 @@ namespace System
         ///    <para>On ARM64 hardware this may use the <c>FRSQRTE</c> instruction which performs a single Newton-Raphson iteration.</para>
         ///    <para>On hardware without specialized support, this may just return <c>1.0 / Sqrt(x)</c>.</para>
         /// </remarks>
+        [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ReciprocalSqrtEstimate(float x)
         {
-            if (Avx512F.IsSupported)
-            {
-                return Avx512F.ReciprocalSqrt14Scalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else if (Sse.IsSupported)
-            {
-                return Sse.ReciprocalSqrtScalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else if (AdvSimd.Arm64.IsSupported)
-            {
-                return AdvSimd.Arm64.ReciprocalSquareRootEstimateScalar(Vector64.CreateScalarUnsafe(x)).ToScalar();
-            }
-            else
-            {
-                return 1.0f / Sqrt(x);
-            }
+            return 1.0f / Sqrt(x);
         }
 
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -316,7 +316,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ReciprocalEstimate(float x)
         {
-            if (Sse.IsSupported)
+            if (Avx512F.IsSupported)
+            {
+                return Avx512F.Reciprocal14Scalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
+            }
+            else if (Sse.IsSupported)
             {
                 return Sse.ReciprocalScalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
             }
@@ -341,7 +345,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float ReciprocalSqrtEstimate(float x)
         {
-            if (Sse.IsSupported)
+            if (Avx512F.IsSupported)
+            {
+                return Avx512F.ReciprocalSqrt14Scalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
+            }
+            else if (Sse.IsSupported)
             {
                 return Sse.ReciprocalSqrtScalar(Vector128.CreateScalarUnsafe(x)).ToScalar();
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Single.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Single.cs
@@ -848,9 +848,11 @@ namespace System
         public static float Lerp(float value1, float value2, float amount) => (value1 * (1.0f - amount)) + (value2 * amount);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalEstimate(TSelf)" />
+        [Intrinsic]
         public static float ReciprocalEstimate(float x) => MathF.ReciprocalEstimate(x);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ReciprocalSqrtEstimate(TSelf)" />
+        [Intrinsic]
         public static float ReciprocalSqrtEstimate(float x) => MathF.ReciprocalSqrtEstimate(x);
 
         /// <inheritdoc cref="IFloatingPointIeee754{TSelf}.ScaleB(TSelf, int)" />


### PR DESCRIPTION
This resolves #98732, resolves #101721, and resolves #101731

The general issue was that the `TensorPrimitives` APIs used AVX512 or SSE, depending on availability while the scalar APIs only used SSE. -- This was not reproducing everywhere as it only reproduces on AVX512 capable hardware, which not all CI machines are.

There is a subtle difference between the handling of denormalized values between the AVX512 and SSE instructions where AVX512 treats them negatives while SSE treats them as flushed to zero, which in turn causes a difference in result. This difference is fine and expected since this is explicitly an `Estimate` API and doesn't impact calls within a single process.