### PR TITLE
[browser] Don't run AOT smoke tests on Firefox

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -35,6 +35,5 @@ jobs:
           - WasmTestOnV8
         - ${{ if eq(platform, 'browser_wasm_win') }}:
           - WasmTestOnChrome
-          - WasmTestOnFirefox
         - ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
           - WasmTestOnWasmtime


### PR DESCRIPTION
Should remove failures in https://github.com/dotnet/runtime/issues/101617