### PR TITLE
Use the standard nothrow tag instead of our own type

### DIFF
--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -3613,7 +3613,7 @@ inline void * __cdecl operator new[](size_t n, const InteropSafe&)
     return result;
 }
 
-inline void * __cdecl operator new(size_t n, const InteropSafe&, std::nothrow_t) noexcept
+inline void * __cdecl operator new(size_t n, const InteropSafe&, const std::nothrow_t&) noexcept
 {
     CONTRACTL
     {
@@ -3632,7 +3632,7 @@ inline void * __cdecl operator new(size_t n, const InteropSafe&, std::nothrow_t)
     return result;
 }
 
-inline void * __cdecl operator new[](size_t n, const InteropSafe&, std::nothrow_t) noexcept
+inline void * __cdecl operator new[](size_t n, const InteropSafe&, const std::nothrow_t&) noexcept
 {
     CONTRACTL
     {

--- a/src/coreclr/debug/ee/debugger.h
+++ b/src/coreclr/debug/ee/debugger.h
@@ -3613,7 +3613,7 @@ inline void * __cdecl operator new[](size_t n, const InteropSafe&)
     return result;
 }
 
-inline void * __cdecl operator new(size_t n, const InteropSafe&, const NoThrow&) throw()
+inline void * __cdecl operator new(size_t n, const InteropSafe&, std::nothrow_t) noexcept
 {
     CONTRACTL
     {
@@ -3632,7 +3632,7 @@ inline void * __cdecl operator new(size_t n, const InteropSafe&, const NoThrow&)
     return result;
 }
 
-inline void * __cdecl operator new[](size_t n, const InteropSafe&, const NoThrow&) throw()
+inline void * __cdecl operator new[](size_t n, const InteropSafe&, std::nothrow_t) noexcept
 {
     CONTRACTL
     {

--- a/src/coreclr/inc/new.hpp
+++ b/src/coreclr/inc/new.hpp
@@ -7,17 +7,9 @@
 #ifndef __new__hpp
 #define __new__hpp
 
-#if defined(_MSC_VER) && _MSC_VER < 1900
-#define NOEXCEPT
-#else
-#define NOEXCEPT noexcept
-#endif
+#include <new>
 
-struct NoThrow { int x; };
-extern const NoThrow nothrow;
-
-void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT;
-void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT;
+using std::nothrow;
 
 #ifdef _DEBUG
 void DisableThrowCheck();

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -807,7 +807,7 @@ public:
 #endif //!STRESS_LOG_READONLY && !STRESS_LOG_ANALYZER
 
 #if defined(MEMORY_MAPPED_STRESSLOG) && !defined(STRESS_LOG_ANALYZER)
-    void* __cdecl operator new(size_t n, std::nothrow_t) noexcept;
+    void* __cdecl operator new(size_t n, const std::nothrow_t&) noexcept;
     void __cdecl operator delete (void * chunk);
 #endif
 

--- a/src/coreclr/inc/stresslog.h
+++ b/src/coreclr/inc/stresslog.h
@@ -807,7 +807,7 @@ public:
 #endif //!STRESS_LOG_READONLY && !STRESS_LOG_ANALYZER
 
 #if defined(MEMORY_MAPPED_STRESSLOG) && !defined(STRESS_LOG_ANALYZER)
-    void* __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT;
+    void* __cdecl operator new(size_t n, std::nothrow_t) noexcept;
     void __cdecl operator delete (void * chunk);
 #endif
 

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3728,8 +3728,8 @@ extern const CExecutable executable;
 
 void * __cdecl operator new(size_t n, const CExecutable&);
 void * __cdecl operator new[](size_t n, const CExecutable&);
-void * __cdecl operator new(size_t n, const CExecutable&, std::nothrow_t);
-void * __cdecl operator new[](size_t n, const CExecutable&, std::nothrow_t);
+void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&);
+void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&);
 
 
 //

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -3728,8 +3728,8 @@ extern const CExecutable executable;
 
 void * __cdecl operator new(size_t n, const CExecutable&);
 void * __cdecl operator new[](size_t n, const CExecutable&);
-void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&);
-void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&);
+void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&) noexcept;
+void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&) noexcept;
 
 
 //

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -316,10 +316,10 @@ _Ret_bytecap_(n) void * __cdecl
 operator new[](size_t n);
 
 void __cdecl
-operator delete(void *p) NOEXCEPT;
+operator delete(void *p) noexcept;
 
 void __cdecl
-operator delete[](void *p) NOEXCEPT;
+operator delete[](void *p) noexcept;
 
 #ifdef _DEBUG_IMPL
 HRESULT _OutOfMemory(LPCSTR szFile, int iLine);
@@ -3728,8 +3728,8 @@ extern const CExecutable executable;
 
 void * __cdecl operator new(size_t n, const CExecutable&);
 void * __cdecl operator new[](size_t n, const CExecutable&);
-void * __cdecl operator new(size_t n, const CExecutable&, const NoThrow&);
-void * __cdecl operator new[](size_t n, const CExecutable&, const NoThrow&);
+void * __cdecl operator new(size_t n, const CExecutable&, std::nothrow_t);
+void * __cdecl operator new[](size_t n, const CExecutable&, std::nothrow_t);
 
 
 //

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -202,8 +202,6 @@ ClrDebugState *CLRInitDebugState()
 
 #endif //defined(_DEBUG_IMPL) && defined(ENABLE_CONTRACTS_IMPL)
 
-const NoThrow nothrow = { 0 };
-
 #if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
 // use standard heap functions for address sanitizer
 #else
@@ -341,7 +339,7 @@ operator new[](size_t n)
 
 #endif // HAS_ADDRESS_SANITIZER || DACCESS_COMPILE
 
-void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT
+void * __cdecl operator new(size_t n, std::nothrow_t) noexcept
 {
 #if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
     // use standard heap functions for address sanitizer (which doesn't provide for NoThrow)
@@ -360,7 +358,7 @@ void * __cdecl operator new(size_t n, const NoThrow&) NOEXCEPT
     return result;
 }
 
-void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT
+void * __cdecl operator new[](size_t n, std::nothrow_t) noexcept
 {
 #if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
     // use standard heap functions for address sanitizer (which doesn't provide for NoThrow)
@@ -383,7 +381,7 @@ void * __cdecl operator new[](size_t n, const NoThrow&) NOEXCEPT
 // use standard heap functions for address sanitizer
 #else
 void __cdecl
-operator delete(void *p) NOEXCEPT
+operator delete(void *p) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -395,7 +393,7 @@ operator delete(void *p) NOEXCEPT
 }
 
 void __cdecl
-operator delete[](void *p) NOEXCEPT
+operator delete[](void *p) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -494,7 +492,7 @@ void * __cdecl operator new[](size_t n, const CExecutable&)
     return result;
 }
 
-void * __cdecl operator new(size_t n, const CExecutable&, const NoThrow&)
+void * __cdecl operator new(size_t n, const CExecutable&, std::nothrow_t)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -511,7 +509,7 @@ void * __cdecl operator new(size_t n, const CExecutable&, const NoThrow&)
     return result;
 }
 
-void * __cdecl operator new[](size_t n, const CExecutable&, const NoThrow&)
+void * __cdecl operator new[](size_t n, const CExecutable&, std::nothrow_t)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -476,7 +476,7 @@ void * __cdecl operator new[](size_t n, const CExecutable&)
     return result;
 }
 
-void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&)
+void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -493,7 +493,7 @@ void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&)
     return result;
 }
 
-void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&)
+void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -336,7 +336,7 @@ operator new[](size_t n)
 };
 
 
-void * __cdecl operator new(size_t n, std::nothrow_t) noexcept
+void * __cdecl operator new(size_t n, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -350,7 +350,7 @@ void * __cdecl operator new(size_t n, std::nothrow_t) noexcept
     return result;
 }
 
-void * __cdecl operator new[](size_t n, std::nothrow_t) noexcept
+void * __cdecl operator new[](size_t n, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -476,7 +476,7 @@ void * __cdecl operator new[](size_t n, const CExecutable&)
     return result;
 }
 
-void * __cdecl operator new(size_t n, const CExecutable&, std::nothrow_t)
+void * __cdecl operator new(size_t n, const CExecutable&, const std::nothrow_t&)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -493,7 +493,7 @@ void * __cdecl operator new(size_t n, const CExecutable&, std::nothrow_t)
     return result;
 }
 
-void * __cdecl operator new[](size_t n, const CExecutable&, std::nothrow_t)
+void * __cdecl operator new[](size_t n, const CExecutable&, const std::nothrow_t&)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -387,7 +387,7 @@ operator delete[](void *p) noexcept
     TRASH_LASTERROR;
 }
 
-#endif // HAS_ADDRESS_SANITIZER || DACCESS_COMPILE
+#endif // !HAS_ADDRESS_SANITIZER && !DACCESS_COMPILE
 
 /* ------------------------------------------------------------------------ *
  * New operator overloading for the executable heap

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -202,10 +202,8 @@ ClrDebugState *CLRInitDebugState()
 
 #endif //defined(_DEBUG_IMPL) && defined(ENABLE_CONTRACTS_IMPL)
 
-#if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
-// use standard heap functions for address sanitizer
-#else
-
+// use standard heap functions for AddressSanitizer and for the DAC build.
+#if !defined(HAS_ADDRESS_SANITIZER) && !defined(DACCESS_COMPILE)
 #ifdef _DEBUG
 #ifdef TARGET_X86
 #define OS_HEAP_ALIGN 8
@@ -219,7 +217,7 @@ ClrDebugState *CLRInitDebugState()
 static HANDLE g_hProcessHeap;
 #endif
 
-FORCEINLINE void* ClrMalloc(size_t size)
+static FORCEINLINE void* ClrMalloc(size_t size)
 {
     STATIC_CONTRACT_NOTHROW;
 
@@ -337,14 +335,9 @@ operator new[](size_t n)
     return result;
 };
 
-#endif // HAS_ADDRESS_SANITIZER || DACCESS_COMPILE
 
 void * __cdecl operator new(size_t n, std::nothrow_t) noexcept
 {
-#if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
-    // use standard heap functions for address sanitizer (which doesn't provide for NoThrow)
-	void * result = operator new(n);
-#else
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_FAULT;
@@ -353,17 +346,12 @@ void * __cdecl operator new(size_t n, std::nothrow_t) noexcept
     INCONTRACT(_ASSERTE(!ARE_FAULTS_FORBIDDEN()));
 
     void* result = ClrMalloc(n);
-#endif // HAS_ADDRESS_SANITIZER || DACCESS_COMPILE
 	TRASH_LASTERROR;
     return result;
 }
 
 void * __cdecl operator new[](size_t n, std::nothrow_t) noexcept
 {
-#if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
-    // use standard heap functions for address sanitizer (which doesn't provide for NoThrow)
-	void * result = operator new[](n);
-#else
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_FAULT;
@@ -372,14 +360,10 @@ void * __cdecl operator new[](size_t n, std::nothrow_t) noexcept
     INCONTRACT(_ASSERTE(!ARE_FAULTS_FORBIDDEN()));
 
     void* result = ClrMalloc(n);
-#endif // HAS_ADDRESS_SANITIZER || DACCESS_COMPILE
 	TRASH_LASTERROR;
     return result;
 }
 
-#if defined(HAS_ADDRESS_SANITIZER) || defined(DACCESS_COMPILE)
-// use standard heap functions for address sanitizer
-#else
 void __cdecl
 operator delete(void *p) noexcept
 {

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -963,7 +963,7 @@ void* StressLog::AllocMemoryMapped(size_t n)
     return nullptr;
 }
 
-void* __cdecl ThreadStressLog::operator new(size_t n, std::nothrow_t) noexcept
+void* __cdecl ThreadStressLog::operator new(size_t n, const std::nothrow_t&) noexcept
 {
     if (StressLogChunk::s_memoryMapped)
         return StressLog::AllocMemoryMapped(n);

--- a/src/coreclr/utilcode/stresslog.cpp
+++ b/src/coreclr/utilcode/stresslog.cpp
@@ -963,7 +963,7 @@ void* StressLog::AllocMemoryMapped(size_t n)
     return nullptr;
 }
 
-void* __cdecl ThreadStressLog::operator new(size_t n, const NoThrow&) NOEXCEPT
+void* __cdecl ThreadStressLog::operator new(size_t n, std::nothrow_t) noexcept
 {
     if (StressLogChunk::s_memoryMapped)
         return StressLog::AllocMemoryMapped(n);

--- a/src/coreclr/vm/stackingallocator.cpp
+++ b/src/coreclr/vm/stackingallocator.cpp
@@ -399,7 +399,7 @@ void * __cdecl operator new[](size_t n, StackingAllocator * alloc)
     return retval;
 }
 
-void * __cdecl operator new(size_t n, StackingAllocator * alloc, const NoThrow&) throw()
+void * __cdecl operator new(size_t n, StackingAllocator * alloc, std::nothrow_t) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;
@@ -412,7 +412,7 @@ void * __cdecl operator new(size_t n, StackingAllocator * alloc, const NoThrow&)
     return alloc->UnsafeAllocNoThrow((unsigned)n);
 }
 
-void * __cdecl operator new[](size_t n, StackingAllocator * alloc, const NoThrow&) throw()
+void * __cdecl operator new[](size_t n, StackingAllocator * alloc, std::nothrow_t) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;

--- a/src/coreclr/vm/stackingallocator.cpp
+++ b/src/coreclr/vm/stackingallocator.cpp
@@ -399,7 +399,7 @@ void * __cdecl operator new[](size_t n, StackingAllocator * alloc)
     return retval;
 }
 
-void * __cdecl operator new(size_t n, StackingAllocator * alloc, std::nothrow_t) noexcept
+void * __cdecl operator new(size_t n, StackingAllocator * alloc, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;
@@ -412,7 +412,7 @@ void * __cdecl operator new(size_t n, StackingAllocator * alloc, std::nothrow_t)
     return alloc->UnsafeAllocNoThrow((unsigned)n);
 }
 
-void * __cdecl operator new[](size_t n, StackingAllocator * alloc, std::nothrow_t) noexcept
+void * __cdecl operator new[](size_t n, StackingAllocator * alloc, const std::nothrow_t&) noexcept
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;

--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -271,8 +271,8 @@ class StackingAllocatorHolder
 
 void * __cdecl operator new(size_t n, StackingAllocator *alloc);
 void * __cdecl operator new[](size_t n, StackingAllocator *alloc);
-void * __cdecl operator new(size_t n, StackingAllocator *alloc, std::nothrow_t) noexcept;
-void * __cdecl operator new[](size_t n, StackingAllocator *alloc, std::nothrow_t) noexcept;
+void * __cdecl operator new(size_t n, StackingAllocator *alloc, const std::nothrow_t&) noexcept;
+void * __cdecl operator new[](size_t n, StackingAllocator *alloc, const std::nothrow_t&) noexcept;
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -271,8 +271,8 @@ class StackingAllocatorHolder
 
 void * __cdecl operator new(size_t n, StackingAllocator *alloc);
 void * __cdecl operator new[](size_t n, StackingAllocator *alloc);
-void * __cdecl operator new(size_t n, StackingAllocator *alloc, const NoThrow&) throw();
-void * __cdecl operator new[](size_t n, StackingAllocator *alloc, const NoThrow&) throw();
+void * __cdecl operator new(size_t n, StackingAllocator *alloc, std::nothrow_t) noexcept;
+void * __cdecl operator new[](size_t n, StackingAllocator *alloc, std::nothrow_t) noexcept;
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
This ensures that we actually override the global `operator new(size_t, const std::nothrow_t&)` allocator, helping avoid mixed-allocator problems.