### PR TITLE
LSRA: Remove assert that enforces all multi-reg RefPositions to be either copy or reload but not mixed

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7391,7 +7391,6 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
     // child needs to be copied or reloaded to that reg.
     if (parent->IsCopyOrReload())
     {
-        noway_assert(parent->OperGet() == oper);
         noway_assert(tree->IsMultiRegNode());
         GenTreeCopyOrReload* copyOrReload = parent->AsCopyOrReload();
         noway_assert(copyOrReload->GetRegNumByIdx(multiRegIdx) == REG_NA);


### PR DESCRIPTION
The consumer for a multi-reg node can be a `GT_COPY`, individual registers of multi-reg node can either get copied (they are assigned a different register at the use than the one they were assigned at def) or reloaded (they are spilled and got assigned to a different register than they were originally assigned at the def). Our code paths already handle the situation where `RefPosition` can be mixed of copy/reload and as such there is no need of an assert that enforce that all RefPositions should either be copy or all should be reload.

In https://github.com/dotnet/runtime/issues/99810, the call in the test produced 4 registers, and one of which (because of constraint enforced by `JitStressRegs=8`) get spilled and hence marked for reload. But that should be ok to have and the current assert was prohibiting us from such scenario to exist.

Other details: https://github.com/dotnet/runtime/issues/99810#issuecomment-2091810219

Fixes: #99810