### PR TITLE
[cdac] Update cdac-build-tool to omit type when it is empty

### DIFF
--- a/src/coreclr/tools/cdac-build-tool/DataDescriptorModel.cs
+++ b/src/coreclr/tools/cdac-build-tool/DataDescriptorModel.cs
@@ -185,10 +185,6 @@ public class DataDescriptorModel
             var globals = new Dictionary<string, GlobalModel>();
             foreach (var (globalName, globalBuilder) in _globals)
             {
-                if (globalBuilder.Type == string.Empty)
-                {
-                    throw new InvalidOperationException($"Type must be set for global {globalName}");
-                }
                 GlobalValue? v = globalBuilder.Value;
                 if (v == null)
                 {

--- a/src/coreclr/tools/cdac-build-tool/JsonConverter/FieldModelJsonConverter.cs
+++ b/src/coreclr/tools/cdac-build-tool/JsonConverter/FieldModelJsonConverter.cs
@@ -20,7 +20,7 @@ public class FieldModelJsonConverter : JsonConverter<DataDescriptorModel.FieldMo
 
     public override void Write(Utf8JsonWriter writer, DataDescriptorModel.FieldModel value, JsonSerializerOptions options)
     {
-        if (value.Type is null)
+        if (string.IsNullOrEmpty(value.Type))
         {
             writer.WriteNumberValue(value.Offset);
         }

--- a/src/coreclr/tools/cdac-build-tool/JsonConverter/GlobalModelJsonConverter.cs
+++ b/src/coreclr/tools/cdac-build-tool/JsonConverter/GlobalModelJsonConverter.cs
@@ -15,7 +15,7 @@ public class GlobalModelJsonConverter : JsonConverter<DataDescriptorModel.Global
 
     public override void Write(Utf8JsonWriter writer, DataDescriptorModel.GlobalModel value, JsonSerializerOptions options)
     {
-        if (value.Type is null)
+        if (string.IsNullOrEmpty(value.Type))
         {
             // no type: just write 'value' or '[value]'
             JsonSerializer.Serialize(writer, value.Value, options);


### PR DESCRIPTION
This makes it so that if we have `datadescriptor.h` with something like:
```c++
CDAC_TYPE_FIELD(TypeName, /*omit field type*/, FieldName, 8)
```
The descriptor will be `"FieldName":8` instead of `"FieldName":[8,""]`