### PR TITLE
[wasi][windows] Disable the wasi-aot-library tests on windows

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -888,7 +888,6 @@ extends:
             - browser_wasm
             - browser_wasm_win
             - wasi_wasm
-            - wasi_wasm_win
           nameSuffix: _Smoke_AOT
           runAOT: true
           shouldRunSmokeOnly: true


### PR DESCRIPTION
The clang in the wasi-sdk is a 32bit exe and it is failing to do aot compilation correctly so disable the lane until that is fixed

https://github.com/dotnet/runtime/issues/101533