### PR TITLE
Add tests for OAVariantLib

### DIFF
--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -242,6 +242,14 @@ namespace NetClient
                 int result = dispatchCoerceTesting.ReturnToManaged((short)vt);
                 Assert.NotEqual(0, result);
             }
+
+            // DISP_E_PARAMNOTFOUND: Converts to Missing, rejected by VariantChangeTypeEx
+            var comException = Assert.Throws<COMException>(() => dispatchCoerceTesting.ReturnToManaged(unchecked((short)((short)VarEnum.VT_ERROR | 0x8000))));
+            Assert.Equal(unchecked((int)0x80020005), comException.HResult);
+
+            // Invalid: Rejected before reaching coerce
+            var variantException = Assert.Throws<InvalidOleVariantTypeException>(() => dispatchCoerceTesting.ReturnToManaged(0x7FFF));
+            Assert.Equal(unchecked((int)0x80131531), variantException.HResult);
         }
 
         [Fact]

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -268,6 +268,10 @@ namespace NetClient
             Assert.Throws<InvalidCastException>(() => dispatchCoerceTesting.ReturnToManaged((short)VarEnum.VT_UNKNOWN));
             Console.WriteLine("Converting VT_NULL to int should fail from VariantChangeTypeEx.");
             Assert.Throws<InvalidCastException>(() => dispatchCoerceTesting.ReturnToManaged((short)VarEnum.VT_NULL));
+
+            // LOCAL_BOOL
+            Console.WriteLine("VARIANT_BOOL should convert to non-numeric string.");
+            Assert.NotEqual("-1", dispatchCoerceTesting.BoolToString());
         }
 
         [Fact]

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -222,6 +222,7 @@ namespace NetClient
             Console.WriteLine($"Calling {nameof(DispatchCoerceTesting.ReturnToManaged)} ...");
             
             // Supported types
+            // See returned values in DispatchCoerceTesting.h
             (VarEnum type, int expectedValue)[] supportedTypes =
             {
                 (VarEnum.VT_EMPTY, 0),

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -222,25 +222,26 @@ namespace NetClient
             Console.WriteLine($"Calling {nameof(DispatchCoerceTesting.ReturnToManaged)} ...");
             
             // Supported types
-            VarEnum[] supportedTypes =
+            (VarEnum type, int expectedValue)[] supportedTypes =
             {
-                VarEnum.VT_I2,
-                VarEnum.VT_I4,
-                VarEnum.VT_R4,
-                VarEnum.VT_R8,
-                VarEnum.VT_CY,
-                VarEnum.VT_DATE,
-                VarEnum.VT_BSTR,
-                VarEnum.VT_ERROR,
-                VarEnum.VT_BOOL,
-                VarEnum.VT_DECIMAL,
+                (VarEnum.VT_EMPTY, 0),
+                (VarEnum.VT_I2, 123),
+                (VarEnum.VT_I4, 123),
+                (VarEnum.VT_R4, 1),
+                (VarEnum.VT_R8, 1),
+                (VarEnum.VT_CY, 123),
+                (VarEnum.VT_DATE, 1),
+                (VarEnum.VT_BSTR, 123),
+                (VarEnum.VT_ERROR, 123),
+                (VarEnum.VT_BOOL, -1),
+                (VarEnum.VT_DECIMAL, 123),
             };
 
-            foreach (VarEnum vt in supportedTypes)
+            foreach (var (vt, expected) in supportedTypes)
             {
                 Console.WriteLine($"Converting {vt} to int should be supported.");
                 int result = dispatchCoerceTesting.ReturnToManaged((short)vt);
-                Assert.NotEqual(0, result);
+                Assert.Equal(expected, result);
             }
 
             // Invalid: Rejected before reaching coerce
@@ -271,7 +272,7 @@ namespace NetClient
 
             // LOCAL_BOOL
             Console.WriteLine("VARIANT_BOOL should convert to non-numeric string.");
-            Assert.NotEqual("-1", dispatchCoerceTesting.BoolToString());
+            Assert.Equal("True", dispatchCoerceTesting.BoolToString());
         }
 
         [Fact]

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -215,6 +215,35 @@ namespace NetClient
             }
         }
 
+        static void Validate_ValueCoerce_ReturnToManaged()
+        {
+            var dispatchCoerceTesting = (DispatchCoerceTesting)new DispatchCoerceTestingClass();
+
+            Console.WriteLine($"Calling {nameof(DispatchCoerceTesting.ReturnToManaged)} ...");
+            
+            // Supported types
+            VarEnum[] supportedTypes =
+            {
+                VarEnum.VT_I2,
+                VarEnum.VT_I4,
+                VarEnum.VT_R4,
+                VarEnum.VT_R8,
+                VarEnum.VT_CY,
+                VarEnum.VT_DATE,
+                VarEnum.VT_BSTR,
+                VarEnum.VT_ERROR,
+                VarEnum.VT_BOOL,
+                VarEnum.VT_DECIMAL,
+            };
+
+            foreach (VarEnum vt in supportedTypes)
+            {
+                Console.WriteLine($"{vt} should be supported.");
+                int result = dispatchCoerceTesting.ReturnToManaged((short)vt);
+                Assert.NotEqual(0, result);
+            }
+        }
+
         [Fact]
         public static int TestEntryPoint()
         {
@@ -233,6 +262,7 @@ namespace NetClient
                 Validate_StructNotSupported();
                 Validate_LCID_Marshaled();
                 Validate_Enumerator();
+                Validate_ValueCoerce_ReturnToManaged();
             }
             catch (Exception e)
             {

--- a/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
@@ -14,7 +14,7 @@ public class DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
 {
     public int ReturnToManaged(short vt)
     {
-        return 42;
+        throw new NotImplementedException();
     }
 
     public int ManagedArgument(int arg)

--- a/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+using Server.Contract;
+
+[ComVisible(true)]
+[Guid(Server.Contract.Guids.DispatchCoerceTesting)]
+public class DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
+{
+    public int ReturnToManaged(short vt)
+    {
+        return 42;
+    }
+
+    public int ManagedArgument(int arg)
+    {
+        return arg;
+    }
+}

--- a/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
@@ -21,4 +21,14 @@ public class DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
     {
         return arg;
     }
+
+    public System.Reflection.Missing ReturnToManaged_Missing()
+    {
+        return Type.Missing;
+    }
+
+    public DBNull ReturnToManaged_DBNull()
+    {
+        return DBNull.Value;
+    }
 }

--- a/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
@@ -31,4 +31,9 @@ public class DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
     {
         return DBNull.Value;
     }
+
+    public string BoolToString()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchCoerceTesting.cs
@@ -24,7 +24,7 @@ public class DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
 
     public System.Reflection.Missing ReturnToManaged_Missing()
     {
-        return Type.Missing;
+        return System.Reflection.Missing.Value;
     }
 
     public DBNull ReturnToManaged_DBNull()

--- a/src/tests/Interop/COM/NativeClients/Dispatch/Client.cpp
+++ b/src/tests/Interop/COM/NativeClients/Dispatch/Client.cpp
@@ -462,6 +462,71 @@ void Validate_Enumerator()
     ValidateReturnedEnumerator(&result);
 }
 
+void Validate_ParamCoerce_Type(ComSmartPtr<IDispatchCoerceTesting>& dispatchCoerceTesting, VARENUM type, int lcid, DISPID methodId)
+{
+    HRESULT hr;
+
+    DISPPARAMS params;
+    VARIANTARG arg;
+    params.cArgs = 1;
+    params.rgvarg = &arg;
+    params.cNamedArgs = 0;
+    params.rgdispidNamedArgs = nullptr;
+
+    VARIANT result;
+
+    V_VT(&arg) = type;
+
+    switch (type)
+    {
+        case VT_BSTR:
+        {
+            BSTR str = ::SysAllocString(L"123");
+            V_BSTR(&arg) = str;
+            break;
+        }
+        case VT_R4:
+        {
+            V_R4(&arg) = 1.23f;
+            break;
+        }
+        case VT_DATE:
+        case VT_R8:
+        {
+            V_R8(&arg) = 1.23;
+            break;
+        }
+        case VT_CY:
+        {
+            VarCyFromI4(123, &V_CY(&arg));
+            break;
+        }
+        case VT_DECIMAL:
+        {
+            VarDecFromI4(123, &V_DECIMAL(&arg));
+            break;
+        }
+        default:
+        {
+            V_I1(&arg) = 123;
+            break;
+        }
+    }
+
+    THROW_IF_FAILED(dispatchCoerceTesting->Invoke(
+        methodId,
+        IID_NULL,
+        lcid,
+        DISPATCH_METHOD,
+        &params,
+        &result,
+        nullptr,
+        nullptr
+    ));
+
+    THROW_FAIL_IF_FALSE(V_I4(&result) != 0);
+}
+
 void Validate_ParamCoerce()
 {
     HRESULT hr;
@@ -483,30 +548,24 @@ void Validate_ParamCoerce()
         lcid,
         &methodId));
     
-    {
-        DISPPARAMS params;
-        params.cArgs = 1;
-        params.rgvarg = new VARIANTARG[params.cArgs];
-        params.cNamedArgs = 0;
-        params.rgdispidNamedArgs = nullptr;
-
-        VARIANT result;
-
-        V_VT(&params.rgvarg[0]) = VT_I8;
-        V_I8(&params.rgvarg[0]) = 42;
-
-
-        THROW_IF_FAILED(dispatchCoerceTesting->Invoke(
-            methodId,
-            IID_NULL,
-            lcid,
-            DISPATCH_METHOD,
-            &params,
-            &result,
-            nullptr,
-            nullptr
-        ));
-
-        THROW_FAIL_IF_FALSE(V_I4(&result) == 42);
-    }
+    ::wprintf(W("Validating VT_I2\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_I2, lcid, methodId);
+    ::wprintf(W("Validating VT_I4\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_I4, lcid, methodId);
+    ::wprintf(W("Validating VT_R4\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_R4, lcid, methodId);
+    ::wprintf(W("Validating VT_R8\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_R8, lcid, methodId);
+    ::wprintf(W("Validating VT_CY\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_CY, lcid, methodId);
+    ::wprintf(W("Validating VT_DATE\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_DATE, lcid, methodId);
+    ::wprintf(W("Validating VT_BSTR\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_BSTR, lcid, methodId);
+    ::wprintf(W("Validating VT_ERROR\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_ERROR, lcid, methodId);
+    ::wprintf(W("Validating VT_BOOL\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_BOOL, lcid, methodId);
+    ::wprintf(W("Validating VT_DECIMAL\n"));
+    Validate_ParamCoerce_Type(dispatchCoerceTesting, VT_DECIMAL, lcid, methodId);
 }

--- a/src/tests/Interop/COM/NativeClients/Dispatch/CoreShim.X.manifest
+++ b/src/tests/Interop/COM/NativeClients/Dispatch/CoreShim.X.manifest
@@ -11,6 +11,11 @@
   <comClass
     clsid="{0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726}"
     threadingModel="Both" />
+
+  <!-- DispatchCoerceTesting -->
+  <comClass
+    clsid="{661F9962-3477-416B-BE40-4CBA3190A562}"
+    threadingModel="Both" />
 </file>
 
 </assembly>

--- a/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
+++ b/src/tests/Interop/COM/NativeServer/COMNativeServer.X.manifest
@@ -42,6 +42,11 @@
     clsid="{4DBD9B61-E372-499F-84DE-EFC70AA8A009}"
     threadingModel="Both" />
 
+  <!-- DispatchCoerceTesting -->
+  <comClass
+    clsid="{661F9962-3477-416B-BE40-4CBA3190A562}"
+    threadingModel="Both" />
+
   <!-- AggregationTesting -->
   <comClass
     clsid="{4CEFE36D-F377-4B6E-8C34-819A8BB9CB04}"

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -5,17 +5,6 @@
 
 #include "Servers.h"
 
-/*template<typename T>
-HRESULT VerifyValues(_In_ const T expected, _In_ const T actual)
-{
-    return (expected == actual) ? S_OK : E_INVALIDARG;
-}
-
-VARIANTARG *NextArg(_In_ VARIANTARG *args, _Inout_ size_t &currIndex)
-{
-    return (args + (currIndex--));
-}*/
-
 class DispatchCoerceTesting : public UnknownImpl, public IDispatchCoerceTesting
 {
 private:

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -128,9 +128,9 @@ private:
         }
 
         VARENUM resultType = (VARENUM)*args[0];
-        V_VT(pVarResult) = resultType;
+        V_VT(pVarResult) = resultType & 0x7FFF;
 
-        switch (resultType)
+        switch ((uint16_t)resultType)
         {
             case VT_BSTR:
             {
@@ -157,6 +157,11 @@ private:
             case VT_DECIMAL:
             {
                 VarDecFromI4(123, &V_DECIMAL(pVarResult));
+                break;
+            }
+            case ((VT_ERROR | 0x8000)):
+            {
+                V_I4(pVarResult) = DISP_E_PARAMNOTFOUND;
                 break;
             }
             default:

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -129,6 +129,7 @@ private:
         }
 
         VARENUM resultType = (VARENUM)*args[0];
+        VariantInit(pVarResult);
         V_VT(pVarResult) = resultType & 0x7FFF;
 
         switch ((uint16_t)resultType)

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -94,6 +94,14 @@ public: // IDispatch
             {
                 return ManagedArgument_Dispatch(pDispParams, pVarResult);
             }
+            case 3:
+            {
+                return ReturnToManaged_Missing_Dispatch(pDispParams, pVarResult);
+            }
+            case 4:
+            {
+                return ReturnToManaged_DBNull_Dispatch(pDispParams, pVarResult);
+            }
             }
 
             return E_NOTIMPL;
@@ -164,6 +172,11 @@ private:
                 V_I4(pVarResult) = DISP_E_PARAMNOTFOUND;
                 break;
             }
+            case VT_UNKNOWN:
+            {
+                V_UNKNOWN(pVarResult) = static_cast<IUnknown *>(this);
+                break;
+            }
             default:
             {
                 V_I1(pVarResult) = 123;
@@ -202,6 +215,36 @@ private:
         return S_OK;
     }
 
+    HRESULT ReturnToManaged_Missing_Dispatch(_In_ DISPPARAMS *pDispParams, _Inout_ VARIANT *pVarResult)
+    {
+        HRESULT hr;
+
+        size_t expectedArgCount = 0;
+        RETURN_IF_FAILED(VerifyValues(uint32_t(expectedArgCount), pDispParams->cArgs));
+
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        V_VT(pVarResult) = VT_I4;
+        V_I4(pVarResult) = 1234;
+        return S_OK;
+    }
+
+    HRESULT ReturnToManaged_DBNull_Dispatch(_In_ DISPPARAMS *pDispParams, _Inout_ VARIANT *pVarResult)
+    {
+        HRESULT hr;
+
+        size_t expectedArgCount = 0;
+        RETURN_IF_FAILED(VerifyValues(uint32_t(expectedArgCount), pDispParams->cArgs));
+
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        V_VT(pVarResult) = VT_I4;
+        V_I4(pVarResult) = 1234;
+        return S_OK;
+    }
+
 public: // IUnknown
     STDMETHOD(QueryInterface)(
         /* [in] */ REFIID riid,
@@ -217,7 +260,9 @@ const WCHAR * const DispatchCoerceTesting::Names[] =
 {
     W("__RESERVED__"),
     W("ReturnToManaged"),
-    W("ManagedArgument")
+    W("ManagedArgument"),
+    W("ReturnToManaged_Missing"),
+    W("ReturnToManaged_DBNull")
 };
 
 const int DispatchCoerceTesting::NamesCount = ARRAY_SIZE(DispatchCoerceTesting::Names);

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -102,6 +102,10 @@ public: // IDispatch
             {
                 return ReturnToManaged_DBNull_Dispatch(pDispParams, pVarResult);
             }
+            case 5:
+            {
+                return BoolToString_Dispatch(pDispParams, pVarResult);
+            }
             }
 
             return E_NOTIMPL;
@@ -245,6 +249,21 @@ private:
         return S_OK;
     }
 
+    HRESULT BoolToString_Dispatch(_In_ DISPPARAMS *pDispParams, _Inout_ VARIANT *pVarResult)
+    {
+        HRESULT hr;
+
+        size_t expectedArgCount = 0;
+        RETURN_IF_FAILED(VerifyValues(uint32_t(expectedArgCount), pDispParams->cArgs));
+
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        V_VT(pVarResult) = VT_BOOL;
+        V_BOOL(pVarResult) = VARIANT_TRUE;
+        return S_OK;
+    }
+
 public: // IUnknown
     STDMETHOD(QueryInterface)(
         /* [in] */ REFIID riid,
@@ -262,7 +281,8 @@ const WCHAR * const DispatchCoerceTesting::Names[] =
     W("ReturnToManaged"),
     W("ManagedArgument"),
     W("ReturnToManaged_Missing"),
-    W("ReturnToManaged_DBNull")
+    W("ReturnToManaged_DBNull"),
+    W("BoolToString")
 };
 
 const int DispatchCoerceTesting::NamesCount = ARRAY_SIZE(DispatchCoerceTesting::Names);

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -1,0 +1,218 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "Servers.h"
+
+/*template<typename T>
+HRESULT VerifyValues(_In_ const T expected, _In_ const T actual)
+{
+    return (expected == actual) ? S_OK : E_INVALIDARG;
+}
+
+VARIANTARG *NextArg(_In_ VARIANTARG *args, _Inout_ size_t &currIndex)
+{
+    return (args + (currIndex--));
+}*/
+
+class DispatchCoerceTesting : public UnknownImpl, public IDispatchCoerceTesting
+{
+private:
+    static const WCHAR * const Names[];
+    static const int NamesCount;
+
+public: // IDispatch
+        virtual HRESULT STDMETHODCALLTYPE GetTypeInfoCount(
+            /* [out] */ __RPC__out uint32_t *pctinfo)
+        {
+            *pctinfo = 0;
+            return S_OK;
+        }
+
+        virtual HRESULT STDMETHODCALLTYPE GetTypeInfo(
+            /* [in] */ uint32_t iTInfo,
+            /* [in] */ LCID lcid,
+            /* [out] */ __RPC__deref_out_opt ITypeInfo **ppTInfo)
+        {
+            return E_NOTIMPL;
+        }
+
+        virtual HRESULT STDMETHODCALLTYPE GetIDsOfNames(
+            /* [in] */ __RPC__in REFIID,
+            /* [size_is][in] */ __RPC__in_ecount_full(cNames) LPOLESTR *rgszNames,
+            /* [range][in] */ __RPC__in_range(0,16384) uint32_t cNames,
+            /* [in] */ LCID,
+            /* [size_is][out] */ __RPC__out_ecount_full(cNames) DISPID *rgDispId)
+        {
+            bool containsUnknown = false;
+            DISPID *curr = rgDispId;
+            for (uint32_t i = 0; i < cNames; ++i)
+            {
+                *curr = DISPID_UNKNOWN;
+                LPOLESTR name = rgszNames[i];
+                for (int j = 1; j < NamesCount; ++j)
+                {
+                    const WCHAR *nameMaybe = Names[j];
+                    if (::TP_wcmp_s(name, nameMaybe) == 0)
+                    {
+                        *curr = DISPID{ j };
+                        break;
+                    }
+                }
+
+                containsUnknown &= (*curr == DISPID_UNKNOWN);
+                curr++;
+            }
+
+            return (containsUnknown) ? DISP_E_UNKNOWNNAME : S_OK;
+        }
+
+        virtual /* [local] */ HRESULT STDMETHODCALLTYPE Invoke(
+            /* [annotation][in] */ _In_  DISPID dispIdMember,
+            /* [annotation][in] */ _In_  REFIID riid,
+            /* [annotation][in] */ _In_  LCID lcid,
+            /* [annotation][in] */ _In_  uint16_t wFlags,
+            /* [annotation][out][in] */ _In_  DISPPARAMS *pDispParams,
+            /* [annotation][out] */ _Out_opt_  VARIANT *pVarResult,
+            /* [annotation][out] */ _Out_opt_  EXCEPINFO *pExcepInfo,
+            /* [annotation][out] */ _Out_opt_  uint32_t *puArgErr)
+        {
+            //
+            // Note that arguments are received in reverse order for IDispatch::Invoke()
+            //
+
+            // HRESULT hr;
+
+            switch (dispIdMember)
+            {
+            case 1:
+            {
+                return ReturnToManaged_Dispatch(pDispParams, pVarResult);
+            }
+            case 2:
+            {
+                return ManagedArgument_Dispatch(pDispParams, pVarResult);
+            }
+            }
+
+            return E_NOTIMPL;
+        }
+
+public: // IDispatchCoerceTesting
+    // Methods should only be invoked via IDispatch
+
+private:
+
+    HRESULT ReturnToManaged_Dispatch(_In_ DISPPARAMS *pDispParams, _Inout_ VARIANT *pVarResult)
+    {
+        HRESULT hr;
+
+        short *args[1];
+        size_t expectedArgCount = 1;
+        RETURN_IF_FAILED(VerifyValues(uint32_t(expectedArgCount), pDispParams->cArgs));
+
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        VARENUM currType;
+        VARIANTARG *currArg;
+        size_t argIdx = expectedArgCount - 1;
+
+        // Extract args
+        {
+            currType = VT_I2;
+            currArg = NextArg(pDispParams->rgvarg, argIdx);
+            RETURN_IF_FAILED(VerifyValues(VARENUM(currType), VARENUM(currArg->vt)));
+            args[0] = &currArg->iVal;
+        }
+
+        VARENUM resultType = (VARENUM)*args[0];
+        V_VT(pVarResult) = resultType;
+
+        switch (resultType)
+        {
+            case VT_BSTR:
+            {
+                BSTR str = ::SysAllocString(L"123");
+                V_BSTR(pVarResult) = str;
+                break;
+            }
+            case VT_R4:
+            {
+                V_R4(pVarResult) = 1.23f;
+                break;
+            }
+            case VT_DATE:
+            case VT_R8:
+            {
+                V_R8(pVarResult) = 1.23;
+                break;
+            }
+            case VT_CY:
+            {
+                VarCyFromI4(123, &V_CY(pVarResult));
+                break;
+            }
+            case VT_DECIMAL:
+            {
+                VarDecFromI4(123, &V_DECIMAL(pVarResult));
+                break;
+            }
+            default:
+            {
+                V_I1(pVarResult) = 123;
+                break;
+            }
+        }
+
+        return S_OK;
+    }
+
+    HRESULT ManagedArgument_Dispatch(_In_ DISPPARAMS *pDispParams, _Inout_ VARIANT *pVarResult)
+    {
+        HRESULT hr;
+
+        int *args[1];
+        size_t expectedArgCount = 1;
+        RETURN_IF_FAILED(VerifyValues(uint32_t(expectedArgCount), pDispParams->cArgs));
+
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        VARENUM currType;
+        VARIANTARG *currArg;
+        size_t argIdx = expectedArgCount - 1;
+
+        // Extract args
+        {
+            currType = VT_I4;
+            currArg = NextArg(pDispParams->rgvarg, argIdx);
+            RETURN_IF_FAILED(VerifyValues(VARENUM(currType), VARENUM(currArg->vt)));
+            args[0] = &currArg->intVal;
+        }
+
+        V_VT(pVarResult) = VT_I2;
+        V_I2(pVarResult) = *args[0];
+        return S_OK;
+    }
+
+public: // IUnknown
+    STDMETHOD(QueryInterface)(
+        /* [in] */ REFIID riid,
+        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
+    {
+        return DoQueryInterface(riid, ppvObject, static_cast<IDispatch *>(this), static_cast<IDispatchCoerceTesting *>(this));
+    }
+
+    DEFINE_REF_COUNTING();
+};
+
+const WCHAR * const DispatchCoerceTesting::Names[] =
+{
+    W("__RESERVED__"),
+    W("ReturnToManaged"),
+    W("ManagedArgument")
+};
+
+const int DispatchCoerceTesting::NamesCount = ARRAY_SIZE(DispatchCoerceTesting::Names);

--- a/src/tests/Interop/COM/NativeServer/Servers.cpp
+++ b/src/tests/Interop/COM/NativeServer/Servers.cpp
@@ -3,7 +3,6 @@
 
 #include "stdafx.h"
 #include "Servers.h"
-#include <stdio.h>
 
 namespace
 {

--- a/src/tests/Interop/COM/NativeServer/Servers.cpp
+++ b/src/tests/Interop/COM/NativeServer/Servers.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 #include "Servers.h"
+#include <stdio.h>
 
 namespace
 {
@@ -166,6 +167,7 @@ STDAPI DllRegisterServer(void)
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ErrorMarshalTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(DispatchTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(EventTesting), L"Both"));
+    RETURN_IF_FAILED(RegisterClsid(__uuidof(DispatchCoerceTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(AggregationTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(ColorTesting), L"Both"));
     RETURN_IF_FAILED(RegisterClsid(__uuidof(InspectableTesting), L"Both"));
@@ -185,6 +187,7 @@ STDAPI DllUnregisterServer(void)
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ErrorMarshalTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(DispatchTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(EventTesting)));
+    RETURN_IF_FAILED(RemoveClsid(__uuidof(DispatchCoerceTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(AggregationTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(ColorTesting)));
     RETURN_IF_FAILED(RemoveClsid(__uuidof(InspectableTesting)));
@@ -215,6 +218,9 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Out_ LPVOID FA
 
     if (rclsid == __uuidof(EventTesting))
         return ClassFactoryBasic<EventTesting>::Create(riid, ppv);
+
+    if (rclsid == __uuidof(DispatchCoerceTesting))
+        return ClassFactoryBasic<DispatchCoerceTesting>::Create(riid, ppv);
 
     if (rclsid == __uuidof(AggregationTesting))
         return ClassFactoryAggregate<AggregationTesting>::Create(riid, ppv);

--- a/src/tests/Interop/COM/NativeServer/Servers.h
+++ b/src/tests/Interop/COM/NativeServer/Servers.h
@@ -16,6 +16,7 @@ class DECLSPEC_UUID("CCFF894B-A27C-45E0-9B30-6C88D722E843") MiscTypesTesting;
 class DECLSPEC_UUID("71CF5C45-106C-4B32-B418-43A463C6041F") ErrorMarshalTesting;
 class DECLSPEC_UUID("0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726") DispatchTesting;
 class DECLSPEC_UUID("4DBD9B61-E372-499F-84DE-EFC70AA8A009") EventTesting;
+class DECLSPEC_UUID("661F9962-3477-416B-BE40-4CBA3190A562") DispatchCoerceTesting;
 class DECLSPEC_UUID("4CEFE36D-F377-4B6E-8C34-819A8BB9CB04") AggregationTesting;
 class DECLSPEC_UUID("C222F472-DA5A-4FC6-9321-92F4F7053A65") ColorTesting;
 class DECLSPEC_UUID("66DB7882-E2B0-471D-92C7-B2B52A0EA535") LicenseTesting;
@@ -30,6 +31,7 @@ class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesti
 #define CLSID_ErrorMarshalTesting __uuidof(ErrorMarshalTesting)
 #define CLSID_DispatchTesting __uuidof(DispatchTesting)
 #define CLSID_EventTesting __uuidof(EventTesting)
+#define CLSID_DispatchCoerceTesting __uuidof(DispatchCoerceTesting)
 #define CLSID_AggregationTesting __uuidof(AggregationTesting)
 #define CLSID_ColorTesting __uuidof(ColorTesting)
 #define CLSID_LicenseTesting __uuidof(LicenseTesting)
@@ -45,6 +47,7 @@ class DECLSPEC_UUID("4F54231D-9E11-4C0B-8E0B-2EBD8B0E5811") TrackMyLifetimeTesti
 #define IID_IDispatchTesting __uuidof(IDispatchTesting)
 #define IID_TestingEvents __uuidof(TestingEvents)
 #define IID_IEventTesting __uuidof(IEventTesting)
+#define IID_IDispatchCoerceTesting __uuidof(IDispatchCoerceTesting)
 #define IID_IAggregationTesting __uuidof(IAggregationTesting)
 #define IID_IColorTesting __uuidof(IColorTesting)
 #define IID_ILicenseTesting __uuidof(ILicenseTesting)
@@ -89,6 +92,7 @@ private:
     #include "ErrorMarshalTesting.h"
     #include "DispatchTesting.h"
     #include "EventTesting.h"
+    #include "DispatchCoerceTesting.h"
     #include "AggregationTesting.h"
     #include "ColorTesting.h"
     #include "LicenseTesting.h"

--- a/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.CoClasses.cs
@@ -127,6 +127,25 @@ namespace Server.Contract.Servers
     /// Managed definition of CoClass
     /// </summary>
     [ComImport]
+    [CoClass(typeof(DispatchCoerceTestingClass))]
+    [Guid("B630A508-4DA5-4C14-A7AB-618AD66B2EBF")]
+    internal interface DispatchCoerceTesting : Server.Contract.IDispatchCoerceTesting
+    {
+    }
+
+    /// <summary>
+    /// Managed activation for CoClass
+    /// </summary>
+    [ComImport]
+    [Guid(Server.Contract.Guids.DispatchCoerceTesting)]
+    internal class DispatchCoerceTestingClass
+    {
+    }
+
+    /// <summary>
+    /// Managed definition of CoClass
+    /// </summary>
+    [ComImport]
     [CoClass(typeof(AggregationTestingClass))]
     [Guid("98cc27f0-d521-4f79-8b63-e980e3a92974")]
     internal interface AggregationTesting : Server.Contract.IAggregationTesting

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -331,6 +331,8 @@ namespace Server.Contract
         System.Reflection.Missing ReturnToManaged_Missing();
 
         DBNull ReturnToManaged_DBNull();
+
+        string BoolToString();
     }
 
     [ComVisible(true)]

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -327,6 +327,10 @@ namespace Server.Contract
         int ReturnToManaged(short vt);
 
         int ManagedArgument(int arg);
+
+        System.Reflection.Missing ReturnToManaged_Missing();
+
+        DBNull ReturnToManaged_DBNull();
     }
 
     [ComVisible(true)]

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -320,6 +320,16 @@ namespace Server.Contract
     };
 
     [ComVisible(true)]
+    [Guid("B630A508-4DA5-4C14-A7AB-618AD66B2EBF")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
+    public interface IDispatchCoerceTesting
+    {
+        int ReturnToManaged(short vt);
+
+        int ManagedArgument(int arg);
+    }
+
+    [ComVisible(true)]
     [Guid("98cc27f0-d521-4f79-8b63-e980e3a92974")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IAggregationTesting

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -452,6 +452,12 @@ TestingEvents : IDispatch
     // void OnEvent(_In_z_ BSTR t);
 };
 
+struct __declspec(uuid("b630a508-4da5-4c14-a7ab-618ad66b2ebf"))
+IDispatchCoerceTesting : IDispatch
+{
+    // Methods should only be invoked via IDispatch
+};
+
 struct __declspec(uuid("98cc27f0-d521-4f79-8b63-e980e3a92974"))
 IAggregationTesting : IUnknown
 {

--- a/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
+++ b/src/tests/Interop/COM/ServerContracts/ServerGuids.cs
@@ -15,6 +15,7 @@ namespace Server.Contract
         public const string ErrorMarshalTesting = "71CF5C45-106C-4B32-B418-43A463C6041F";
         public const string DispatchTesting = "0F8ACD0C-ECE0-4F2A-BD1B-6BFCA93A0726";
         public const string EventTesting = "4DBD9B61-E372-499F-84DE-EFC70AA8A009";
+        public const string DispatchCoerceTesting = "661F9962-3477-416B-BE40-4CBA3190A562";
         public const string AggregationTesting = "4CEFE36D-F377-4B6E-8C34-819A8BB9CB04";
         public const string ColorTesting = "C222F472-DA5A-4FC6-9321-92F4F7053A65";
         public const string LicenseTesting = "66DB7882-E2B0-471D-92C7-B2B52A0EA535";


### PR DESCRIPTION
Test for #100176.

`OAVariantLib.ChangeType` will be called when a value is passed from native COM to managed via IDispatch (parameter in ComToClr call, or return value of ClrToCom call, or out value from byref parameter), and the type mismatches from managed signature. The calling order of current behavior is roughly:

- `OleVariant::MarshalObjectForOleVariant`, marshals a default managed representation of the VARIANT. Invalid/unsupported VARIANT type will be rejected here and throws InvalidOleVariantTypeException.
- `RuntimeType.ForwardCallToInvokeMember`, `OleAutBinder.ChangeType` in managed code, handles common cases like type already matches, *primitive->enum* and *ref non-primitive->underlying type*. It misses the case of *ref primitive->underlying type* and will always treat it as a type mismatch.
- `OAVariantLib.ChangeType` and `OAVariant_ChangeType`: Convert source value and target type back to VARIANT and VARENUM. Specially handles the case when target is `System.Color`. Uses a custom mapping logic that's slightly different. Types rejected here will throw `NotSupportedException`, caught by `OleAutBinder.ChangeType` and rethrown as `COMException(0x80020005)`.
- `VariantChangeTypeEx`. It does the conversion with its own order. Errors will be thrown as-is, typically `InvalidCastException`.

This PR adds test for:

- Supported conversions for different positions, including parameter in ComToClr call and return value of ClrToCom call.
- Different rejected behaviors at each path, only for the return value case.

The test is not exhaustive and try not to exercise of detailed behavior of `VariantChangeTypeEx`.

@AaronRobinsonMSFT @jkotas 