### PR TITLE
[mono] Add check for generic types as target types

### DIFF
--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -437,7 +437,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/89439", TestRuntimes.Mono)]
     public static void Verify_Generic_InvalidUseUnsafeAccessor()
     {
         Console.WriteLine($"Running {nameof(Verify_Generic_InvalidUseUnsafeAccessor)}");


### PR DESCRIPTION
Generic types are invalid unsafe accessor attribute target types.