### PR TITLE
JIT: Test RPO-based block layout in runtime-jit-experimental

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -537,6 +537,7 @@ jobs:
             - jitosr_stress
             - jitpartialcompilation_pgo
             - jitoptrepeat
+            - jitrpolayout
           ${{ else }}:
             scenarios:
             - jitosr_stress
@@ -549,6 +550,7 @@ jobs:
             - jitphysicalpromotion_full
             - jitrlcse
             - jitoptrepeat
+            - jitrpolayout
         ${{ if in(parameters.testGroup, 'jit-cfg') }}:
           scenarios:
           - jitcfg

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -84,6 +84,7 @@
       DOTNET_JitEnableOptRepeat;
       DOTNET_JitOptRepeat;
       DOTNET_JitOptRepeatCount;
+      DOTNET_JitDoReversePostOrderLayout;
     </DOTNETVariables>
   </PropertyGroup>
   <ItemGroup>
@@ -243,6 +244,7 @@
     <TestEnvironment Include="syntheticpgo_blend" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitSynthesizeCounts="3" JitCheckSynthesizedCounts="1" />
     <TestEnvironment Include="jitrlcse" JitRLCSEGreedy="1" />
     <TestEnvironment Include="jitoptrepeat" JitEnableOptRepeat="1" JitOptRepeat="*" JitOptRepeatCount="2"/>
+    <TestEnvironment Include="jitrpolayout" JitDoReversePostOrderLayout="1"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' == 'true'" GCName="clrgc.dll"/>
     <TestEnvironment Include="gcstandalone" Condition="'$(TargetsWindows)' != 'true'" GCName="libclrgc.so"/>
     <TestEnvironment Include="gcstandaloneserver" Condition="'$(TargetsWindows)' == 'true'" gcServer="1" GCName="clrgc.dll"/>


### PR DESCRIPTION
Follow-up to #101473. Since the new block layout is disabled by default, we ought to test it periodically.