### PR TITLE
Fixing Typo in comment in Boolean.cs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Boolean.cs
@@ -108,7 +108,7 @@ namespace System
             {
                 if (destination.Length > 4)
                 {
-                    ulong fals_val = BitConverter.IsLittleEndian ? 0x73006C00610046ul : 0x460061006C0073ul; // "Fals"
+                    ulong fals_val = BitConverter.IsLittleEndian ? 0x73006C00610046ul : 0x460061006C0073ul; // "False"
                     MemoryMarshal.Write(MemoryMarshal.AsBytes(destination), in fals_val);
                     destination[4] = 'e';
                     charsWritten = 5;


### PR DESCRIPTION
There is a typo that exists on the "False" Comment in line 111 of Boolean.cs. This PR Fixes "Fals" to "False"