### PR TITLE
[RISC-V] Fix context restoration as #101709 describes

### DIFF
--- a/src/coreclr/pal/src/arch/riscv64/context2.S
+++ b/src/coreclr/pal/src/arch/riscv64/context2.S
@@ -110,8 +110,10 @@ LOCAL_LABEL(No_Restore_CONTEXT_INTEGER):
     sd  t1, -8(fp)
     ld  fp, (CONTEXT_Fp)(t4)
     ld  t1, (CONTEXT_Pc)(t4) // Since we cannot control $pc directly, we're going to corrupt t1
-    ld  sp, (CONTEXT_Sp)(t4)
-    ld  t4, -8(sp)
+    ld  t4, (CONTEXT_Sp)(t4)
+    addi sp, t4, -8
+    ld  t4, (sp)
+    addi sp, sp, 8
     jr  t1
 
 LOCAL_LABEL(No_Restore_CONTEXT_CONTROL):

--- a/src/coreclr/pal/src/arch/riscv64/context2.S
+++ b/src/coreclr/pal/src/arch/riscv64/context2.S
@@ -105,10 +105,13 @@ LOCAL_LABEL(No_Restore_CONTEXT_INTEGER):
     beqz t1, LOCAL_LABEL(No_Restore_CONTEXT_CONTROL)
 
     ld  ra, (CONTEXT_Ra)(t4)
+    ld  t1, (CONTEXT_T4)(t4)
+    ld  fp, (CONTEXT_Sp)(t4)
+    sd  t1, -8(fp)
     ld  fp, (CONTEXT_Fp)(t4)
-    ld  sp, (CONTEXT_Sp)(t4)
     ld  t1, (CONTEXT_Pc)(t4) // Since we cannot control $pc directly, we're going to corrupt t1
-    ld  t4, (CONTEXT_T4)(t4)
+    ld  sp, (CONTEXT_Sp)(t4)
+    ld  t4, -8(sp)
     jr  t1
 
 LOCAL_LABEL(No_Restore_CONTEXT_CONTROL):


### PR DESCRIPTION
@janvorli Is it proper fix? Seems for race condition case it would trash 2 temporary registers - t1 and t4, so it may be better completely remove t4 restoration `ld  t4, (CONTEXT_T4)(t4)`.

cc @jakobbotsch cc @dotnet/samsung 