### PR TITLE
Specify and test that `0x` is case-invariant in the Convert class

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2046,7 +2046,7 @@ namespace System
         //
         // Parses value in base base.  base can only
         // be 2, 8, 10, or 16.  If base is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         public static byte ToByte(string? value, int fromBase)
         {
@@ -2068,7 +2068,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
         public static sbyte ToSByte(string? value, int fromBase)
@@ -2094,7 +2094,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         public static short ToInt16(string? value, int fromBase)
         {
@@ -2119,7 +2119,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
         public static ushort ToUInt16(string? value, int fromBase)
@@ -2142,7 +2142,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         public static int ToInt32(string? value, int fromBase)
         {
@@ -2157,7 +2157,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
         public static uint ToUInt32(string? value, int fromBase)
@@ -2173,7 +2173,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         public static long ToInt64(string? value, int fromBase)
         {
@@ -2188,7 +2188,7 @@ namespace System
 
         // Parses value in base fromBase.  fromBase can only
         // be 2, 8, 10, or 16.  If fromBase is 16, the number may be preceded
-        // by 0x; any other leading or trailing characters cause an error.
+        // by 0x or 0X; any other leading or trailing characters cause an error.
         //
         [CLSCompliant(false)]
         public static ulong ToUInt64(string? value, int fromBase)

--- a/src/libraries/System.Private.CoreLib/src/System/Convert.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Convert.cs
@@ -2202,11 +2202,11 @@ namespace System
                 0;
         }
 
-        // Convert the byte value to a string in base fromBase
+        // Convert the byte value to a string in base toBase
         public static string ToString(byte value, int toBase) =>
             ToString((int)value, toBase);
 
-        // Convert the Int16 value to a string in base fromBase
+        // Convert the Int16 value to a string in base toBase
         public static string ToString(short value, int toBase)
         {
             string format = "d";

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToByte.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToByte.cs
@@ -131,9 +131,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "10", "100", "1011", "ff", "0xff", "77", "11", "11111111" };
-            int[] testBases = { 10, 2, 8, 16, 10, 10, 2, 16, 16, 8, 2, 2 };
-            byte[] expectedValues = { 0, 0, 0, 0, 10, 100, 11, 255, 255, 63, 3, 255 };
+            string[] testValues = { null, null, null, null, "10", "100", "1011", "ff", "0xff", "77", "11", "11111111", "0XFF" };
+            int[] testBases = { 10, 2, 8, 16, 10, 10, 2, 16, 16, 8, 2, 2, 16 };
+            byte[] expectedValues = { 0, 0, 0, 0, 10, 100, 11, 255, 255, 63, 3, 255, 255 };
             VerifyFromStringWithBase(Convert.ToByte, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "256", "111111111", "ffffe", "7777777", "-1" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt16.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt16.cs
@@ -130,9 +130,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "7fff", "32767", "77777", "111111111111111", "8000", "-32768", "100000", "1000000000000000" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-            short[] expectedValues = { 0, 0, 0, 0, short.MaxValue, short.MaxValue, short.MaxValue, short.MaxValue, short.MinValue, short.MinValue, short.MinValue, short.MinValue };
+            string[] testValues = { null, null, null, null, "7fff", "32767", "77777", "111111111111111", "8000", "-32768", "100000", "1000000000000000", "0x7fff", "0X7FFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 16, 16 };
+            short[] expectedValues = { 0, 0, 0, 0, short.MaxValue, short.MaxValue, short.MaxValue, short.MaxValue, short.MinValue, short.MinValue, short.MinValue, short.MinValue, short.MaxValue, short.MaxValue };
             VerifyFromStringWithBase(Convert.ToInt16, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "32768", "-32769", "11111111111111111", "1FFFF", "777777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt32.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt32.cs
@@ -127,9 +127,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "7FFFFFFF", "2147483647", "17777777777", "1111111111111111111111111111111", "80000000", "-2147483648", "20000000000", "10000000000000000000000000000000", };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, };
-            int[] expectedValues = { 0, 0, 0, 0, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, };
+            string[] testValues = { null, null, null, null, "7FFFFFFF", "2147483647", "17777777777", "1111111111111111111111111111111", "80000000", "-2147483648", "20000000000", "10000000000000000000000000000000", "0x7fffffff", "0X7FFFFFFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 16, 16 };
+            int[] expectedValues = { 0, 0, 0, 0, int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue, int.MinValue, int.MinValue, int.MinValue, int.MinValue, int.MaxValue, int.MaxValue };
             VerifyFromStringWithBase(Convert.ToInt32, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "2147483648", "-2147483649", "111111111111111111111111111111111", "1FFFFffff", "777777777777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt64.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToInt64.cs
@@ -124,9 +124,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "7FFFFFFFFFFFFFFF", "9223372036854775807", "777777777777777777777", "111111111111111111111111111111111111111111111111111111111111111", "8000000000000000", "-9223372036854775808", "1000000000000000000000", "1000000000000000000000000000000000000000000000000000000000000000" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-            long[] expectedValues = { 0, 0, 0, 0, long.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue };
+            string[] testValues = { null, null, null, null, "7FFFFFFFFFFFFFFF", "9223372036854775807", "777777777777777777777", "111111111111111111111111111111111111111111111111111111111111111", "8000000000000000", "-9223372036854775808", "1000000000000000000000", "1000000000000000000000000000000000000000000000000000000000000000", "0x7fffffffffffffff", "0X7FFFFFFFFFFFFFFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 16, 16 };
+            long[] expectedValues = { 0, 0, 0, 0, long.MaxValue, long.MaxValue, long.MaxValue, long.MaxValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue, long.MaxValue, long.MaxValue };
             VerifyFromStringWithBase(Convert.ToInt64, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "9223372036854775808", "-9223372036854775809", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToSByte.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToSByte.cs
@@ -141,9 +141,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "7f", "127", "177", "1111111", "80", "-128", "200", "10000000" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-            sbyte[] expectedValues = { 0, 0, 0, 0, sbyte.MaxValue, sbyte.MaxValue, sbyte.MaxValue, sbyte.MaxValue, sbyte.MinValue, sbyte.MinValue, sbyte.MinValue, sbyte.MinValue };
+            string[] testValues = { null, null, null, null, "7f", "127", "177", "1111111", "80", "-128", "200", "10000000", "0x7f", "0X7F" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 16, 16 };
+            sbyte[] expectedValues = { 0, 0, 0, 0, sbyte.MaxValue, sbyte.MaxValue, sbyte.MaxValue, sbyte.MaxValue, sbyte.MinValue, sbyte.MinValue, sbyte.MinValue, sbyte.MinValue, sbyte.MaxValue, sbyte.MaxValue };
             VerifyFromStringWithBase(Convert.ToSByte, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "128", "-129", "111111111", "1FF", "777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt16.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt16.cs
@@ -136,9 +136,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "ffff", "65535", "177777", "1111111111111111", "0", "0", "0", "0" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2 };
-            ushort[] expectedValues = { 0, 0, 0, 0, ushort.MaxValue, ushort.MaxValue, ushort.MaxValue, ushort.MaxValue, ushort.MinValue, ushort.MinValue, ushort.MinValue, ushort.MinValue };
+            string[] testValues = { null, null, null, null, "ffff", "65535", "177777", "1111111111111111", "0", "0", "0", "0", "0xffff", "0XFFFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 16, 16 };
+            ushort[] expectedValues = { 0, 0, 0, 0, ushort.MaxValue, ushort.MaxValue, ushort.MaxValue, ushort.MaxValue, ushort.MinValue, ushort.MinValue, ushort.MinValue, ushort.MinValue, ushort.MaxValue, ushort.MaxValue };
             VerifyFromStringWithBase(Convert.ToUInt16, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "65536", "-1", "11111111111111111", "1FFFF", "777777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt32.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt32.cs
@@ -136,9 +136,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "ffffffff", "4294967295", "37777777777", "11111111111111111111111111111111", "0", "0", "0", "0", "2147483647", "2147483648", "2147483649" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10 };
-            uint[] expectedValues = { 0, 0, 0, 0, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MinValue, uint.MinValue, uint.MinValue, uint.MinValue, (uint)int.MaxValue, (uint)int.MaxValue + 1, (uint)int.MaxValue + 2 };
+            string[] testValues = { null, null, null, null, "ffffffff", "4294967295", "37777777777", "11111111111111111111111111111111", "0", "0", "0", "0", "2147483647", "2147483648", "2147483649", "0xffffffff", "0XFFFFFFFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10, 16, 16 };
+            uint[] expectedValues = { 0, 0, 0, 0, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MaxValue, uint.MinValue, uint.MinValue, uint.MinValue, uint.MinValue, (uint)int.MaxValue, (uint)int.MaxValue + 1, (uint)int.MaxValue + 2, uint.MaxValue, uint.MaxValue};
             VerifyFromStringWithBase(Convert.ToUInt32, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt64.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.ToUInt64.cs
@@ -136,9 +136,9 @@ namespace System.Tests
         [Fact]
         public void FromStringWithBase()
         {
-            string[] testValues = { null, null, null, null, "ffffffffffffffff", "18446744073709551615", "1777777777777777777777", "1111111111111111111111111111111111111111111111111111111111111111", "0", "0", "0", "0", "9223372036854775807", "9223372036854775808" /*VSWhidbey #526568*/, "9223372036854775809", "9223372036854775810", "9223372036854775811" };
-            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10, 10, 10 };
-            ulong[] expectedValues = { 0, 0, 0, 0, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MinValue, ulong.MinValue, ulong.MinValue, ulong.MinValue, (ulong)long.MaxValue, (ulong)long.MaxValue + 1 /*VSWhidbey #526568*/, (ulong)long.MaxValue + 2, (ulong)long.MaxValue + 3, (ulong)long.MaxValue + 4 };
+            string[] testValues = { null, null, null, null, "ffffffffffffffff", "18446744073709551615", "1777777777777777777777", "1111111111111111111111111111111111111111111111111111111111111111", "0", "0", "0", "0", "9223372036854775807", "9223372036854775808" /*VSWhidbey #526568*/, "9223372036854775809", "9223372036854775810", "9223372036854775811", "0xffffffffffffffff", "0XFFFFFFFFFFFFFFFF" };
+            int[] testBases = { 10, 2, 8, 16, 16, 10, 8, 2, 16, 10, 8, 2, 10, 10, 10, 10, 10, 16, 16 };
+            ulong[] expectedValues = { 0, 0, 0, 0, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MaxValue, ulong.MinValue, ulong.MinValue, ulong.MinValue, ulong.MinValue, (ulong)long.MaxValue, (ulong)long.MaxValue + 1 /*VSWhidbey #526568*/, (ulong)long.MaxValue + 2, (ulong)long.MaxValue + 3, (ulong)long.MaxValue + 4, ulong.MaxValue, ulong.MaxValue };
             VerifyFromStringWithBase(Convert.ToUInt64, testValues, testBases, expectedValues);
 
             string[] overflowValues = { "18446744073709551616", "18446744073709551617", "18446744073709551618", "18446744073709551619", "18446744073709551620", "-4294967297", "11111111111111111111111111111111111111111111111111111111111111111", "1FFFFffffFFFFffff", "7777777777777777777777777" };


### PR DESCRIPTION
Hi!
I was confused by the comment, so decided to specify that method can accept `0x` and `0X` as a prefix for hex numbers