### PR TITLE
Prototype fix for `Environement.GetCommandLineArgs()[0]` (#101837)

### DIFF
--- a/src/coreclr/dlls/mscoree/exports.cpp
+++ b/src/coreclr/dlls/mscoree/exports.cpp
@@ -487,7 +487,18 @@ int coreclr_execute_assembly(
     ICLRRuntimeHost4* host = reinterpret_cast<ICLRRuntimeHost4*>(hostHandle);
 
     ConstWStringArrayHolder argvW;
-    argvW.Set(StringArrayToUnicode(argc, argv), argc);
+    // If argc is negative, it means that argv[0] is the real argv[0]
+    // so we want to pass this information to ExecuteAssembly while transforming all arguments
+    if (argc < 0)
+    {
+        argc = -argc;
+        argvW.Set(StringArrayToUnicode(argc, argv), argc);
+        argc = -argc;
+    }
+    else
+    {
+        argvW.Set(StringArrayToUnicode(argc, argv), argc);
+    }
 
     ConstWStringHolder managedAssemblyPathW = StringToUnicode(managedAssemblyPath);
 

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -429,7 +429,7 @@ static int run(const configuration& config)
         result = coreclr_execute_func(
             CurrentClrInstance,
             CurrentAppDomainId,
-            config.entry_assembly_argc,
+            -config.entry_assembly_argc, // We pass a negative argc to indicate that the first argument in argv is the original argv[0]
             argv_utf8.get(),
             entry_assembly_utf8.c_str(),
             (uint32_t*)&exit_code);
@@ -509,12 +509,13 @@ static bool parse_args(
             config.entry_assembly_fullpath = pal::get_absolute_path(argv[i]);
             i++; // Move to next argument.
 
-            config.entry_assembly_argc = argc - i;
+            config.entry_assembly_argc = argc - i + 1;
             config.entry_assembly_argv = (const char_t**)::malloc(config.entry_assembly_argc * sizeof(const char_t*));
             assert(config.entry_assembly_argv != nullptr);
-            for (int c = 0; c < config.entry_assembly_argc; ++c)
+            config.entry_assembly_argv[0] = pal::strdup(argv[0]);
+            for (int c = 1; c < config.entry_assembly_argc; ++c)
             {
-                config.entry_assembly_argv[c] = pal::strdup(argv[i + c]);
+                config.entry_assembly_argv[c] = pal::strdup(argv[i + c - 1]);
             }
 
             // Successfully parsed arguments.

--- a/src/coreclr/vm/corhost.cpp
+++ b/src/coreclr/vm/corhost.cpp
@@ -239,10 +239,22 @@ static PTRARRAYREF SetCommandLineArgs(PCWSTR pwzAssemblyPath, int argc, PCWSTR* 
     }
     CONTRACTL_END;
 
+    // If argc is negative if argv includes the original argv[0]
+    PCWSTR exePath;
+    if (argc < 0)
+    {
+        argc = -argc;
+        exePath = argv[0];
+        argv++; // We skip the exePath
+        argc--;
+    }
+    else
+    {
+        exePath = Bundle::AppIsBundle() ? static_cast<PCWSTR>(Bundle::AppBundle->Path()) : pwzAssemblyPath;
+    }
+
     // Record the command line.
     SaveManagedCommandLine(pwzAssemblyPath, argc, argv);
-
-    PCWSTR exePath = Bundle::AppIsBundle() ? static_cast<PCWSTR>(Bundle::AppBundle->Path()) : pwzAssemblyPath;
 
     PTRARRAYREF result;
     PREPARE_NONVIRTUAL_CALLSITE(METHOD__ENVIRONMENT__INITIALIZE_COMMAND_LINE_ARGS);
@@ -281,12 +293,7 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
     if(!pwzAssemblyPath)
         return E_POINTER;
 
-    if(argc < 0)
-    {
-        return E_INVALIDARG;
-    }
-
-    if(argc > 0 && argv == NULL)
+    if(argc != 0 && argv == NULL)
     {
         return E_INVALIDARG;
     }


### PR DESCRIPTION
Fixes #101837

I'm putting this PR in a draft state, as the code in this PR is hacking around with the restriction of the existing API. As I believe that the API `CorHost2::ExecuteAssembly` cannot be changed, so it makes the correction trickier. I would appreciate guidance on how to solve this properly.

Another aspect that I'm unfamiliar with is how `dotnet.exe foo.dll` relates to the changes made here. It could definitely be broken by these changes.