### PR TITLE
[RISC-V] fix rm field in riscvd instruction

### DIFF
--- a/src/coreclr/jit/instrsriscv64.h
+++ b/src/coreclr/jit/instrsriscv64.h
@@ -205,8 +205,8 @@ INST(fmin_d,        "fmin.d",         0,   0x2a000053)
 INST(fmax_d,        "fmax.d",         0,   0x2a001053)
 
 //// R_R
-INST(fcvt_s_d,      "fcvt.s.d",       0,   0x40101053)
-INST(fcvt_d_s,      "fcvt.d.s",       0,   0x42001053)
+INST(fcvt_s_d,      "fcvt.s.d",       0,   0x40100053)
+INST(fcvt_d_s,      "fcvt.d.s",       0,   0x42000053)
 
 //// R_R_R
 INST(feq_d,         "feq.d",          0,   0xa2002053)
@@ -215,10 +215,10 @@ INST(fle_d,         "fle.d",          0,   0xa2000053)
 
 //// R_R
 INST(fclass_d,      "fclass.d",       0,   0xe2001053)
-INST(fcvt_w_d,      "fcvt.w.d",       0,   0xc2001053)
-INST(fcvt_wu_d,     "fcvt.wu.d",      0,   0xc2101053)
-INST(fcvt_d_w,      "fcvt.d.w",       0,   0xd2001053)
-INST(fcvt_d_wu,     "fcvt.d.wu",      0,   0xd2101053)
+INST(fcvt_w_d,      "fcvt.w.d",       0,   0xc2000053)
+INST(fcvt_wu_d,     "fcvt.wu.d",      0,   0xc2100053)
+INST(fcvt_d_w,      "fcvt.d.w",       0,   0xd2000053)
+INST(fcvt_d_wu,     "fcvt.d.wu",      0,   0xd2100053)
 
 //// R_R_I
 INST(flw,           "flw",            LD,  0x00002007)


### PR DESCRIPTION
When i was working on #101683 I found that R2RDump prints `Decode Failure` for those instructions:
- fcvt.d.w
- fcvt.d.wu 
- fcvt.d.s
, when i ran R2RDump e.g. for `System.Private.CoreLib.dll`. I checked it is printed by `libcoredistools` because LLVM MC cannot decode instructions properly. The problem is with `rm` field. According to The RISC-V Instruction Set Manual
> software should set their rm field to RNE (000)

and when i changed this field to 0 it fixed the problem. Below instructions also set `rm` to 1
- fcvt.w.d
- fcvt.wu.d
- fcvt.s.d

I checked my changes running tests for coreclr with priority 1 and i didn't get any new error.

Part of #84834, cc @dotnet/samsung 
