### PR TITLE
[Release/8.0] Fix handling exceptions on shutdown

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -6696,14 +6696,6 @@ VEH_ACTION WINAPI CLRVectoredExceptionHandlerPhase3(PEXCEPTION_POINTERS pExcepti
 
 VEH_ACTION WINAPI CLRVectoredExceptionHandler(PEXCEPTION_POINTERS pExceptionInfo)
 {
-    // It is not safe to execute code inside VM after we shutdown EE.  One example is DisablePreemptiveGC
-    // will block forever.
-    if (g_fForbidEnterEE)
-    {
-        return VEH_CONTINUE_SEARCH;
-    }
-
-
     //
     // DO NOT USE CONTRACTS HERE AS THIS ROUTINE MAY NEVER RETURN.  You can use
     // static contracts, but currently this is all WRAPPER_NO_CONTRACT.
@@ -7384,12 +7376,6 @@ LONG WINAPI CLRVectoredExceptionHandlerShim(PEXCEPTION_POINTERS pExceptionInfo)
     //
     // WARNING WARNING WARNING WARNING WARNING WARNING WARNING
     //
-
-    // If runtime have been disabled, then simply return.
-    if (g_fForbidEnterEE)
-    {
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
 
     // WARNING
     //


### PR DESCRIPTION

Another partial backport of #100293 to release/8.0

## Customer Impact
A recent partial backport of a change to enable propagating exceptions on shutdown was missing two places in the code that were under a different condition than the global exception handling disabling that was removed. I must have made a mistake when testing that change (not setting watson registry settings properly or using a stale build). This change makes it work correctly.
During the runtime shutdown, we stop handling exceptions at all and we also prevent entering EE at few places. A customer has hit an issue with Watson dump being generated from a .NET app on every machine reboot due to that. That app was a networking app that was listening on a socket. Shutdown of the app resulted in a SocketException being thrown, but the exception handling was prevented and so the exception was reported as an unhandled exception which caused the dump to be taken.

## Testing
CI testing, local testing of a case equivalent to what the customer had - a grpc running as a service. Without the fix the issue reported by the customer can be reproduced, with the fix it is gone.

## Risk
Low - the change just enables exceptions handling during shutdown. So where previously the app would crash with an unhandled exception, it will now get proper handling of that exception upto the point the process is torn down by the OS.