### PR TITLE
Use REG_INDIRECT_CALL_TARGET_REG for indirect calls on arm64

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3672,11 +3672,11 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             {
 #ifdef TARGET_ARM
                 // For arm32 we've allocated an internal register to load the target into.
-                // Loading into lr takes 4 bytes (instead of potentially 2 with another register).
+                // Loading into IP takes 4 bytes (instead of potentially 2 with another register).
                 targetAddrReg = internalRegisters.GetSingle(call);
 #else
-                // For arm64 we just use lr and skip the internal register.
-                targetAddrReg = REG_LR;
+                // For arm64 we just use IP0 and skip the internal register.
+                targetAddrReg = REG_INDIRECT_CALL_TARGET_REG;
 #endif
 
                 GetEmitter()->emitIns_R_R(ins_Load(TYP_I_IMPL), emitActualTypeSize(TYP_I_IMPL), targetAddrReg,

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -788,6 +788,9 @@ LinearScan::LinearScan(Compiler* theCompiler)
     regSelector = new (theCompiler, CMK_LSRA) RegisterSelection(this);
 
 #ifdef TARGET_ARM64
+    // Note: one known reason why we exclude LR is because NativeAOT has dependency on not
+    //       using LR as a GPR. See: https://github.com/dotnet/runtime/issues/101932
+    //       Once that is addressed, we may consider allowing LR in availableIntRegs.
     availableIntRegs = (RBM_ALLINT & ~(RBM_PR | RBM_FP | RBM_LR) & ~compiler->codeGen->regSet.rsMaskResvd);
 #elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     availableIntRegs = (RBM_ALLINT & ~(RBM_FP | RBM_RA) & ~compiler->codeGen->regSet.rsMaskResvd);

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -191,9 +191,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
         }
         else
         {
-            // For arm64 we can use lr for non-tailcalls so we skip the
-            // internal register as a TP optimization. We could do the same for
-            // arm32, but loading into lr cannot be encoded in 2 bytes, so
+            // For arm64 we can use REG_INDIRECT_CALL_TARGET_REG (IP0) for non-tailcalls
+            // so we skip the internal register as a TP optimization. We could do the same for
+            // arm32, but loading into IP cannot be encoded in 2 bytes, so
             // another register is usually better.
 #ifdef TARGET_ARM
             buildInternalIntRegisterDefForNode(call);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/101896

With https://github.com/dotnet/runtime/pull/101647 we started using LR as a general purpose register when doing indirect calls and that broke our logic on NativeAOT that detects whether a thread is in an epilog on linux-arm64

Using LR as a GPR is not illegal, just something that we did not do before, so once we see LR (or FP) loaded with some value, the epilog detection logic assumes that we are in an epilog.

Long-term (and assuming that some platforms will never learn how to unwind in epilogs), I think we should encode the epilog ranges. In GC info, I suppose. It will not be trivial as there could be more than one epilog in a method, so encoding them all and then searching through them to answer `IsUnwindable` question could be a bit tricky. However, it will be a more portable approach.

For now we can have a simpler fix - we do not have to use LR for indirect call targets, so let's not use it. 
It seems like `REG_INDIRECT_CALL_TARGET_REG` is a better fit for this.
