### PR TITLE
Missing `AddRef()` in test for `IDispatch`

### DIFF
--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -220,7 +220,7 @@ namespace NetClient
             var dispatchCoerceTesting = (DispatchCoerceTesting)new DispatchCoerceTestingClass();
 
             Console.WriteLine($"Calling {nameof(DispatchCoerceTesting.ReturnToManaged)} ...");
-            
+
             // Supported types
             // See returned values in DispatchCoerceTesting.h
             (VarEnum type, int expectedValue)[] supportedTypes =

--- a/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchCoerceTesting.h
@@ -168,7 +168,7 @@ private:
             }
             case VT_UNKNOWN:
             {
-                V_UNKNOWN(pVarResult) = static_cast<IUnknown *>(this);
+                (void)QueryInterface(IID_IUnknown, (void**)&V_UNKNOWN(pVarResult));
                 break;
             }
             default:


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/101898
Fixes https://github.com/dotnet/runtime/issues/101959