### PR TITLE
Switch from arm64 biarch image to Azure Linux image

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -27,9 +27,8 @@ extends:
           ROOTFS_DIR: /crossrootfs/armv6
 
       linux_arm64:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-biarch-amd64-arm64
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm64-net9.0
         env:
-          ROOTFS_HOST_DIR: /crossrootfs/x64
           ROOTFS_DIR: /crossrootfs/arm64
 
       linux_musl_x64:


### PR DESCRIPTION
I couldn't find a ci leg where the biarch image is still needed, so trying to remove it.

Use of the biarch image was added in https://github.com/dotnet/runtime/pull/91019 but the job that used it was disabled for arm64 in https://github.com/dotnet/runtime/pull/92057. https://github.com/dotnet/runtime/issues/90427 tracks adding back the arm64 jobs.

From what I could gather, the arm64 fullaot job was added in https://github.com/dotnet/runtime/pull/55362 which explains:
> We don't ship any products using FullAOT on Linux x64/arm64, but this
compilation mode is used for iOS, FullAOT-related issues that affect iOS are
likely to be caught by FullAOT on Linux x64/arm64, and it is a lot easier to
build, develop, and debug on desktop OSes.

If the arm64 job is enabled again in the future, it should probably be made to use a new entry in `pipeline-with-resources.yml`, instead of modifying the image used for all other linux_arm64 jobs.

Fixes https://github.com/dotnet/runtime/issues/101707