### PR TITLE
Handle more than 64 registers - Part 1

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3829,9 +3829,9 @@ void CodeGen::genZeroInitFltRegs(const regMaskTP& initFltRegs, const regMaskTP& 
 
     // Iterate through float/double registers and initialize them to 0 or
     // copy from already initialized register of the same type.
-    regMaskTP regMask = genRegMask(REG_FP_FIRST);
-    for (regNumber reg = REG_FP_FIRST; reg <= REG_FP_LAST; reg = REG_NEXT(reg), regMask <<= 1)
+    for (regNumber reg = REG_FP_FIRST; reg <= REG_FP_LAST; reg = REG_NEXT(reg))
     {
+        regMaskTP regMask = genRegMask(reg);
         if (regMask & initFltRegs)
         {
             // Do we have a float register already set to 0?
@@ -5732,10 +5732,9 @@ void CodeGen::genFnProlog()
 
     if (initRegs)
     {
-        regMaskTP regMask = 0x1;
-
-        for (regNumber reg = REG_INT_FIRST; reg <= REG_INT_LAST; reg = REG_NEXT(reg), regMask <<= 1)
+        for (regNumber reg = REG_INT_FIRST; reg <= REG_INT_LAST; reg = REG_NEXT(reg))
         {
+            regMaskTP regMask = genRegMask(reg);
             if (regMask & initRegs)
             {
                 // Check if we have already zeroed this register

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5076,11 +5076,11 @@ BasicBlockVisit FlowGraphNaturalLoop::VisitRegularExitBlocks(TFunc func)
     return BasicBlockVisit::Continue;
 }
 
-//regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
+// regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
 //{
-//    regMaskTP result(first.low ^ second.getLow());
-//    return result;
-//}
+//     regMaskTP result(first.low ^ second.getLow());
+//     return result;
+// }
 
 /*****************************************************************************/
 #endif //_COMPILER_HPP_

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -987,7 +987,7 @@ inline regNumber genFirstRegNumFromMaskAndToggle(regMaskTP& mask)
     regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
 #endif
 
-    mask ^= regNum;
+    mask ^= genRegMask(regNum);
 
     return regNum;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -99,6 +99,33 @@ inline bool genExactlyOneBit(T value)
     return ((value != 0) && genMaxOneBit(value));
 }
 
+#ifdef TARGET_ARM64
+inline regMaskTP genFindLowestBit(regMaskTP value)
+{
+    return regMaskTP(genFindLowestBit(value.getLow()));
+}
+
+/*****************************************************************************
+ *
+ *  Return true if the given value has exactly zero or one bits set.
+ */
+
+inline bool genMaxOneBit(regMaskTP value)
+{
+    return PopCount(value) <= 1;
+}
+
+/*****************************************************************************
+ *
+ *  Return true if the given value has exactly one bit set.
+ */
+
+inline bool genExactlyOneBit(regMaskTP value)
+{
+    return PopCount(value) == 1;
+}
+#endif
+
 /*****************************************************************************
  *
  *  Given a value that has exactly one bit set, return the position of that
@@ -146,6 +173,13 @@ inline unsigned genCountBits(uint64_t bits)
 {
     return BitOperations::PopCount(bits);
 }
+
+#ifdef TARGET_ARM64
+inline unsigned genCountBits(regMaskTP mask)
+{
+    return BitOperations::PopCount(mask.getLow());
+}
+#endif
 
 /*****************************************************************************
  *
@@ -914,11 +948,18 @@ inline regNumber genRegNumFromMask(regMaskTP mask)
 
     /* Convert the mask to a register number */
 
+#ifdef TARGET_ARM64
+    regNumber regNum = (regNumber)genLog2(mask.getLow());
+
+    /* Make sure we got it right */
+    assert(genRegMask(regNum) == mask.getLow());
+
+#else
     regNumber regNum = (regNumber)genLog2(mask);
 
     /* Make sure we got it right */
-
     assert(genRegMask(regNum) == mask);
+#endif
 
     return regNum;
 }
@@ -940,8 +981,8 @@ inline regNumber genFirstRegNumFromMaskAndToggle(regMaskTP& mask)
 
     /* Convert the mask to a register number */
 
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
-    mask ^= genRegMask(regNum);
+    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask.getLow());
+    mask ^= regNum;
 
     return regNum;
 }
@@ -962,7 +1003,7 @@ inline regNumber genFirstRegNumFromMask(regMaskTP mask)
 
     /* Convert the mask to a register number */
 
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
+    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask.getLow());
 
     return regNum;
 }
@@ -4463,7 +4504,11 @@ inline void* operator new[](size_t sz, Compiler* compiler, CompMemKind cmk)
 
 inline void printRegMask(regMaskTP mask)
 {
+#ifdef TARGET_ARM64
+    printf(REG_MASK_ALL_FMT, mask.getLow());
+#else
     printf(REG_MASK_ALL_FMT, mask);
+#endif
 }
 
 inline char* regMaskToString(regMaskTP mask, Compiler* context)
@@ -4471,14 +4516,22 @@ inline char* regMaskToString(regMaskTP mask, Compiler* context)
     const size_t cchRegMask = 24;
     char*        regmask    = new (context, CMK_Unknown) char[cchRegMask];
 
+#ifdef TARGET_ARM64
+    sprintf_s(regmask, cchRegMask, REG_MASK_ALL_FMT, mask.getLow());
+#else
     sprintf_s(regmask, cchRegMask, REG_MASK_ALL_FMT, mask);
+#endif
 
     return regmask;
 }
 
 inline void printRegMaskInt(regMaskTP mask)
 {
+#ifdef TARGET_ARM64
+    printf(REG_MASK_INT_FMT, (mask & RBM_ALLINT).getLow());
+#else
     printf(REG_MASK_INT_FMT, (mask & RBM_ALLINT));
+#endif
 }
 
 inline char* regMaskIntToString(regMaskTP mask, Compiler* context)
@@ -4486,7 +4539,11 @@ inline char* regMaskIntToString(regMaskTP mask, Compiler* context)
     const size_t cchRegMask = 24;
     char*        regmask    = new (context, CMK_Unknown) char[cchRegMask];
 
+#ifdef TARGET_ARM64
+    sprintf_s(regmask, cchRegMask, REG_MASK_INT_FMT, (mask & RBM_ALLINT).getLow());
+#else
     sprintf_s(regmask, cchRegMask, REG_MASK_INT_FMT, (mask & RBM_ALLINT));
+#endif
 
     return regmask;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5076,6 +5076,12 @@ BasicBlockVisit FlowGraphNaturalLoop::VisitRegularExitBlocks(TFunc func)
     return BasicBlockVisit::Continue;
 }
 
+//regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
+//{
+//    regMaskTP result(first.low ^ second.getLow());
+//    return result;
+//}
+
 /*****************************************************************************/
 #endif //_COMPILER_HPP_
 /*****************************************************************************/

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -981,7 +981,12 @@ inline regNumber genFirstRegNumFromMaskAndToggle(regMaskTP& mask)
 
     /* Convert the mask to a register number */
 
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask.getLow());
+#ifdef TARGET_ARM64
+    regNumber regNum = (regNumber)BitScanForward(mask);
+#else
+    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
+#endif
+
     mask ^= regNum;
 
     return regNum;
@@ -1003,7 +1008,11 @@ inline regNumber genFirstRegNumFromMask(regMaskTP mask)
 
     /* Convert the mask to a register number */
 
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask.getLow());
+#ifdef TARGET_ARM64
+    regNumber regNum = (regNumber)BitScanForward(mask);
+#else
+    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
+#endif
 
     return regNum;
 }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -112,7 +112,7 @@ inline regMaskTP genFindLowestBit(regMaskTP value)
 
 inline bool genMaxOneBit(regMaskTP value)
 {
-    return genMaxOneBit(value.low);
+    return genMaxOneBit(value.getLow());
 }
 
 /*****************************************************************************
@@ -122,7 +122,7 @@ inline bool genMaxOneBit(regMaskTP value)
 
 inline bool genExactlyOneBit(regMaskTP value)
 {
-    return genExactlyOneBit(value.low);
+    return genExactlyOneBit(value.getLow());
 }
 #endif
 
@@ -981,11 +981,7 @@ inline regNumber genFirstRegNumFromMaskAndToggle(regMaskTP& mask)
 
     /* Convert the mask to a register number */
 
-#ifdef TARGET_ARM64
     regNumber regNum = (regNumber)BitScanForward(mask);
-#else
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
-#endif
 
     mask ^= genRegMask(regNum);
 
@@ -1008,11 +1004,7 @@ inline regNumber genFirstRegNumFromMask(regMaskTP mask)
 
     /* Convert the mask to a register number */
 
-#ifdef TARGET_ARM64
     regNumber regNum = (regNumber)BitScanForward(mask);
-#else
-    regNumber regNum = (regNumber)BitOperations::BitScanForward(mask);
-#endif
 
     return regNum;
 }
@@ -5075,12 +5067,6 @@ BasicBlockVisit FlowGraphNaturalLoop::VisitRegularExitBlocks(TFunc func)
 
     return BasicBlockVisit::Continue;
 }
-
-// regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
-//{
-//     regMaskTP result(first.low ^ second.getLow());
-//     return result;
-// }
 
 /*****************************************************************************/
 #endif //_COMPILER_HPP_

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -112,7 +112,7 @@ inline regMaskTP genFindLowestBit(regMaskTP value)
 
 inline bool genMaxOneBit(regMaskTP value)
 {
-    return PopCount(value) <= 1;
+    return genMaxOneBit(value.low);
 }
 
 /*****************************************************************************
@@ -122,7 +122,7 @@ inline bool genMaxOneBit(regMaskTP value)
 
 inline bool genExactlyOneBit(regMaskTP value)
 {
-    return PopCount(value) == 1;
+    return genExactlyOneBit(value.low);
 }
 #endif
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3470,7 +3470,7 @@ void emitter::emitDispRegSet(regMaskTP regs)
             continue;
         }
 
-        regs -= curReg;
+        regs ^= curReg;
 
         if (sp)
         {
@@ -3828,8 +3828,8 @@ void emitter::emitDispGCRegDelta(const char* title, regMaskTP prevRegs, regMaskT
     {
         emitDispGCDeltaTitle(title);
         regMaskTP sameRegs    = prevRegs & curRegs;
-        regMaskTP removedRegs = prevRegs - sameRegs;
-        regMaskTP addedRegs   = curRegs - sameRegs;
+        regMaskTP removedRegs = prevRegs ^ sameRegs;
+        regMaskTP addedRegs   = curRegs ^ sameRegs;
         if (removedRegs != RBM_NONE)
         {
             printf(" -");
@@ -8920,7 +8920,7 @@ void emitter::emitUpdateLiveGCregs(GCtype gcType, regMaskTP regs, BYTE* addr)
                 emitGCregDeadUpd(reg, addr);
             }
 
-            chg -= bit;
+            chg ^= bit;
         } while (chg);
 
         assert(emitThisXXrefRegs == regs);

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4667,7 +4667,7 @@ void GCInfo::gcInfoRecordGCRegStateChange(GcInfoEncoder* gcInfoEncoder,
         }
 
         // Turn the bit we've just generated off and continue.
-        regMask -= tmpMask; // EAX,ECX,EDX,EBX,---,EBP,ESI,EDI
+        regMask ^= tmpMask; // EAX,ECX,EDX,EBX,---,EBP,ESI,EDI
     }
 }
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -13609,11 +13609,7 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*                current
                                                             &overallLimitCandidates);
                 assert(limitConsecutiveResult != RBM_NONE);
 
-#ifdef TARGET_ARM64
                 unsigned startRegister = BitScanForward(limitConsecutiveResult);
-#else
-                unsigned startRegister = BitOperations::BitScanForward(limitConsecutiveResult);
-#endif
 
                 regMaskTP registersNeededMask = (1ULL << refPosition->regCount) - 1;
                 candidates |= (registersNeededMask << startRegister);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -13609,7 +13609,11 @@ regMaskTP LinearScan::RegisterSelection::select(Interval*                current
                                                             &overallLimitCandidates);
                 assert(limitConsecutiveResult != RBM_NONE);
 
+#ifdef TARGET_ARM64
+                unsigned startRegister = BitScanForward(limitConsecutiveResult);
+#else
                 unsigned startRegister = BitOperations::BitScanForward(limitConsecutiveResult);
+#endif
 
                 regMaskTP registersNeededMask = (1ULL << refPosition->regCount) - 1;
                 candidates |= (registersNeededMask << startRegister);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -794,8 +794,8 @@ private:
     static const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R3 | RBM_R4 | RBM_R5);
     static const regMaskTP LsraLimitSmallFPSet  = (RBM_F0 | RBM_F1 | RBM_F2 | RBM_F16 | RBM_F17);
 #elif defined(TARGET_ARM64)
-    static const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R19 | RBM_R20);
-    static const regMaskTP LsraLimitSmallFPSet  = (RBM_V0 | RBM_V1 | RBM_V2 | RBM_V8 | RBM_V9);
+    const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R19 | RBM_R20);
+    const regMaskTP LsraLimitSmallFPSet  = (RBM_V0 | RBM_V1 | RBM_V2 | RBM_V8 | RBM_V9);
 #elif defined(TARGET_X86)
     static const regMaskTP LsraLimitSmallIntSet = (RBM_EAX | RBM_ECX | RBM_EDI);
     static const regMaskTP LsraLimitSmallFPSet  = (RBM_XMM0 | RBM_XMM1 | RBM_XMM2 | RBM_XMM6 | RBM_XMM7);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -794,8 +794,8 @@ private:
     static const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R3 | RBM_R4 | RBM_R5);
     static const regMaskTP LsraLimitSmallFPSet  = (RBM_F0 | RBM_F1 | RBM_F2 | RBM_F16 | RBM_F17);
 #elif defined(TARGET_ARM64)
-    const regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R19 | RBM_R20);
-    const regMaskTP LsraLimitSmallFPSet  = (RBM_V0 | RBM_V1 | RBM_V2 | RBM_V8 | RBM_V9);
+    static constexpr regMaskTP LsraLimitSmallIntSet = (RBM_R0 | RBM_R1 | RBM_R2 | RBM_R19 | RBM_R20);
+    static constexpr regMaskTP LsraLimitSmallFPSet  = (RBM_V0 | RBM_V1 | RBM_V2 | RBM_V8 | RBM_V9);
 #elif defined(TARGET_X86)
     static const regMaskTP LsraLimitSmallIntSet = (RBM_EAX | RBM_ECX | RBM_EDI);
     static const regMaskTP LsraLimitSmallFPSet  = (RBM_XMM0 | RBM_XMM1 | RBM_XMM2 | RBM_XMM6 | RBM_XMM7);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -180,7 +180,7 @@ regMaskTP LinearScan::filterConsecutiveCandidates(regMaskTP    candidates,
                                                   unsigned int registersNeeded,
                                                   regMaskTP*   allConsecutiveCandidates)
 {
-    if (BitOperations::PopCount(candidates) < registersNeeded)
+    if (PopCount(candidates) < registersNeeded)
     {
         // There is no way the register demanded can be satisfied for this RefPosition
         // based on the candidates from which it can allocate a register.
@@ -205,7 +205,7 @@ regMaskTP LinearScan::filterConsecutiveCandidates(regMaskTP    candidates,
     do
     {
         // From LSB, find the first available register (bit `1`)
-        regAvailableStartIndex = BitOperations::BitScanForward(static_cast<DWORD64>(currAvailableRegs));
+        regAvailableStartIndex = BitScanForward(currAvailableRegs);
         regMaskTP startMask    = (1ULL << regAvailableStartIndex) - 1;
 
         // Mask all the bits that are processed from LSB thru regAvailableStart until the last `1`.
@@ -223,7 +223,7 @@ regMaskTP LinearScan::filterConsecutiveCandidates(regMaskTP    candidates,
         }
         else
         {
-            regAvailableEndIndex = BitOperations::BitScanForward(static_cast<DWORD64>(maskProcessed));
+            regAvailableEndIndex = BitScanForward(maskProcessed);
         }
         regMaskTP endMask = (1ULL << regAvailableEndIndex) - 1;
 
@@ -335,7 +335,7 @@ regMaskTP LinearScan::filterConsecutiveCandidatesForSpill(regMaskTP consecutiveC
     do
     {
         // From LSB, find the first available register (bit `1`)
-        regAvailableStartIndex = BitOperations::BitScanForward(static_cast<DWORD64>(unprocessedRegs));
+        regAvailableStartIndex = BitScanForward(unprocessedRegs);
 
         // For the current range, find how many registers are free vs. busy
         regMaskTP maskForCurRange        = RBM_NONE;
@@ -370,7 +370,7 @@ regMaskTP LinearScan::filterConsecutiveCandidatesForSpill(regMaskTP consecutiveC
             // In the given range, there are some free registers available. Calculate how many registers
             // will need spilling if this range is picked.
 
-            int curSpillRegs = registersNeeded - BitOperations::PopCount(maskForCurRange);
+            int curSpillRegs = registersNeeded - PopCount(maskForCurRange);
             if (curSpillRegs < maxSpillRegs)
             {
                 consecutiveResultForBusy = 1ULL << regAvailableStartIndex;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2898,7 +2898,11 @@ void LinearScan::stressSetRandomParameterPreferences()
 
         // Select a random register from all possible parameter registers
         // (of the right type). Preference this parameter to that register.
+#ifdef TARGET_ARM64
+        unsigned numBits = PopCount(*regs);
+#else
         unsigned numBits = BitOperations::PopCount(*regs);
+#endif
         if (numBits == 0)
         {
             continue;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -2898,11 +2898,7 @@ void LinearScan::stressSetRandomParameterPreferences()
 
         // Select a random register from all possible parameter registers
         // (of the right type). Preference this parameter to that register.
-#ifdef TARGET_ARM64
         unsigned numBits = PopCount(*regs);
-#else
-        unsigned numBits = BitOperations::PopCount(*regs);
-#endif
         if (numBits == 0)
         {
             continue;

--- a/src/coreclr/jit/regset.cpp
+++ b/src/coreclr/jit/regset.cpp
@@ -960,7 +960,7 @@ regMaskSmall genRegMaskFromCalleeSavedMask(unsigned short calleeSaveMask)
     regMaskSmall res = 0;
     for (int i = 0; i < CNT_CALLEE_SAVED; i++)
     {
-        if ((calleeSaveMask & ((regMaskTP)1 << i)) != 0)
+        if ((calleeSaveMask & (1 << i)) != 0)
         {
             res |= raRbmCalleeSaveOrder[i];
         }

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -249,7 +249,7 @@ struct regMaskTP
     }
 };
 
-static uint32_t PopCount(const regMaskTP& value)
+static uint32_t PopCount(regMaskTP value)
 {
     return BitOperations::PopCount(value.getLow());
 }
@@ -259,31 +259,31 @@ static uint32_t BitScanForward(regMaskTP mask)
     return BitOperations::BitScanForward(mask.low);
 }
 
-static regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator^(regMaskTP first, regMaskTP second)
 {
     regMaskTP result(first.low ^ second.getLow());
     return result;
 }
 
-static regMaskTP operator&(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator&(regMaskTP first, regMaskTP second)
 {
     regMaskTP result(first.low & second.getLow());
     return result;
 }
 
-static regMaskTP operator|(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator|(regMaskTP first, regMaskTP second)
 {
     regMaskTP result(first.low | second.getLow());
     return result;
 }
 
-static regMaskTP operator<<(const regMaskTP& first, const int b)
+static regMaskTP operator<<(regMaskTP first, const int b)
 {
     regMaskTP result(first.low << b);
     return result;
 }
 
-static regMaskTP operator>>(const regMaskTP& first, const int b)
+static regMaskTP operator>>(regMaskTP first, const int b)
 {
     regMaskTP result(first.low >> b);
     return result;
@@ -295,64 +295,64 @@ static regMaskTP& operator>>=(regMaskTP& first, const int b)
     return first;
 }
 
-static regMaskTP& operator|=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator|=(regMaskTP& first, regMaskTP second)
 {
     first.low |= second.low;
     return first;
 }
 
-static regMaskTP& operator^=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator^=(regMaskTP& first, regMaskTP second)
 {
     first.low ^= second.low;
     return first;
 }
 
-static regMaskSmall operator^=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator^=(regMaskSmall& first, regMaskTP second)
 {
     first ^= second.low;
     return first;
 }
 
-static regMaskSmall operator&=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator&=(regMaskSmall& first, regMaskTP second)
 {
     first &= second.low;
     return first;
 }
 
-static regMaskSmall operator|=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator|=(regMaskSmall& first, regMaskTP second)
 {
     first |= second.low;
     return first;
 }
 
-static regMaskTP& operator<<=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator<<=(regMaskTP& first, regMaskTP second)
 {
     first.low <<= second.low;
     return first;
 }
 
-static regMaskTP& operator&=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator&=(regMaskTP& first, regMaskTP second)
 {
     first.low &= second.low;
     return first;
 }
 
-static constexpr bool operator==(const regMaskTP& first, const regMaskTP& second)
+static bool operator==(regMaskTP first, regMaskTP second)
 {
     return (first.low == second.low);
 }
 
-static constexpr bool operator!=(const regMaskTP& first, const regMaskTP& second)
+static bool operator!=(regMaskTP first, regMaskTP second)
 {
     return (first.low != second.low);
 }
 
-static constexpr bool operator>(const regMaskTP& first, const regMaskTP& second)
+static bool operator>(regMaskTP first, regMaskTP second)
 {
     return (first.low > second.low);
 }
 
-static regMaskTP operator~(const regMaskTP& first)
+static regMaskTP operator~(regMaskTP first)
 {
     regMaskTP result(~first.low);
     return result;

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -215,23 +215,17 @@ typedef unsigned char   regNumberSmall;
 typedef unsigned __int64 regMaskTP;
 #elif defined(TARGET_ARM64)
 typedef unsigned __int64 regMaskSmall;
-struct _regMaskAll
+struct regMaskTP
 {
     unsigned __int64 low;
 
-    _regMaskAll(unsigned __int64 regMask)
+    regMaskTP(unsigned __int64 regMask)
         : low(regMask)
     {
     }
 
-    _regMaskAll()
-        : low(RBM_NONE)
+    regMaskTP()
     {
-    }
-
-    FORCEINLINE operator _regMaskAll() const
-    {
-        return _regMaskAll{static_cast<uint64_t>(low)};
     }
 
     FORCEINLINE explicit operator bool() const
@@ -254,112 +248,111 @@ struct _regMaskAll
         return low;
     }
 };
-typedef _regMaskAll regMaskTP;
 
-FORCEINLINE static uint32_t PopCount(const _regMaskAll& value)
+static uint32_t PopCount(const regMaskTP& value)
 {
     return BitOperations::PopCount(value.getLow());
 }
 
-FORCEINLINE static uint32_t BitScanForward(regMaskTP mask)
+static uint32_t BitScanForward(regMaskTP mask)
 {
     return BitOperations::BitScanForward(mask.low);
 }
 
-FORCEINLINE regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator^(const regMaskTP& first, const regMaskTP& second)
 {
     regMaskTP result(first.low ^ second.getLow());
     return result;
 }
 
-FORCEINLINE regMaskTP operator&(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator&(const regMaskTP& first, const regMaskTP& second)
 {
     regMaskTP result(first.low & second.getLow());
     return result;
 }
 
-FORCEINLINE regMaskTP operator|(const regMaskTP& first, const regMaskTP& second)
+static regMaskTP operator|(const regMaskTP& first, const regMaskTP& second)
 {
     regMaskTP result(first.low | second.getLow());
     return result;
 }
 
-FORCEINLINE regMaskTP operator<<(const regMaskTP& first, const int b)
+static regMaskTP operator<<(const regMaskTP& first, const int b)
 {
     regMaskTP result(first.low << b);
     return result;
 }
 
-FORCEINLINE regMaskTP operator>>(const regMaskTP& first, const int b)
+static regMaskTP operator>>(const regMaskTP& first, const int b)
 {
     regMaskTP result(first.low >> b);
     return result;
 }
 
-FORCEINLINE regMaskTP& operator>>=(regMaskTP& first, const int b)
+static regMaskTP& operator>>=(regMaskTP& first, const int b)
 {
     first = first >> b;
     return first;
 }
 
-FORCEINLINE regMaskTP& operator|=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator|=(regMaskTP& first, const regMaskTP& second)
 {
     first.low |= second.low;
     return first;
 }
 
-FORCEINLINE regMaskTP& operator^=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator^=(regMaskTP& first, const regMaskTP& second)
 {
     first.low ^= second.low;
     return first;
 }
 
-FORCEINLINE regMaskSmall operator^=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator^=(regMaskSmall& first, const regMaskTP& second)
 {
     first ^= second.low;
     return first;
 }
 
-FORCEINLINE regMaskSmall operator&=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator&=(regMaskSmall& first, const regMaskTP& second)
 {
     first &= second.low;
     return first;
 }
 
-FORCEINLINE regMaskSmall operator|=(regMaskSmall& first, const regMaskTP& second)
+static regMaskSmall operator|=(regMaskSmall& first, const regMaskTP& second)
 {
     first |= second.low;
     return first;
 }
 
-FORCEINLINE regMaskTP& operator<<=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator<<=(regMaskTP& first, const regMaskTP& second)
 {
     first.low <<= second.low;
     return first;
 }
 
-FORCEINLINE regMaskTP& operator&=(regMaskTP& first, const regMaskTP& second)
+static regMaskTP& operator&=(regMaskTP& first, const regMaskTP& second)
 {
     first.low &= second.low;
     return first;
 }
 
-FORCEINLINE constexpr bool operator==(const regMaskTP& first, const regMaskTP& second)
+static constexpr bool operator==(const regMaskTP& first, const regMaskTP& second)
 {
     return (first.low == second.low);
 }
 
-FORCEINLINE constexpr bool operator!=(const regMaskTP& first, const regMaskTP& second)
+static constexpr bool operator!=(const regMaskTP& first, const regMaskTP& second)
 {
     return (first.low != second.low);
 }
 
-FORCEINLINE constexpr bool operator>(const regMaskTP& first, const regMaskTP& second)
+static constexpr bool operator>(const regMaskTP& first, const regMaskTP& second)
 {
     return (first.low > second.low);
 }
 
-FORCEINLINE regMaskTP operator~(const regMaskTP& first)
+static regMaskTP operator~(const regMaskTP& first)
 {
     regMaskTP result(~first.low);
     return result;

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -249,11 +249,6 @@ public:
     {
         return low;
     }
-
-    void setLow(uint64_t _low)
-    {
-        low = _low;
-    }
 };
 
 static regMaskTP operator^(regMaskTP first, regMaskTP second)
@@ -294,13 +289,13 @@ static regMaskTP& operator>>=(regMaskTP& first, const int b)
 
 static regMaskTP& operator|=(regMaskTP& first, regMaskTP second)
 {
-    first.setLow(first.getLow() | second.getLow());
+    first = first | second;
     return first;
 }
 
 static regMaskTP& operator^=(regMaskTP& first, regMaskTP second)
 {
-    first.setLow(first.getLow() ^ second.getLow());
+    first = first ^ second;
     return first;
 }
 
@@ -324,7 +319,7 @@ static regMaskSmall operator|=(regMaskSmall& first, regMaskTP second)
 
 static regMaskTP& operator&=(regMaskTP& first, regMaskTP second)
 {
-    first.setLow(first.getLow() & second.getLow());
+    first = first & second;
     return first;
 }
 

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -230,27 +230,27 @@ public:
     {
     }
 
-    FORCEINLINE explicit operator bool() const
+    explicit operator bool() const
     {
         return low != RBM_NONE;
     }
 
-    FORCEINLINE explicit operator regMaskSmall() const
+    explicit operator regMaskSmall() const
     {
         return (regMaskSmall)low;
     }
 
-    FORCEINLINE explicit operator unsigned int() const
+    explicit operator unsigned int() const
     {
         return (unsigned int)low;
     }
 
-    FORCEINLINE uint64_t getLow() const
+    uint64_t getLow() const
     {
         return low;
     }
 
-    FORCEINLINE void setLow(uint64_t _low)
+    void setLow(uint64_t _low)
     {
         low = _low;
     }

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -417,11 +417,6 @@ const char* dspRegRange(regMaskTP regMask, size_t& minSiz, const char* sep, regN
             sep        = " ";
         }
 
-        if (regBit > regMask)
-        {
-            break;
-        }
-
         regPrev = regNum;
     }
 


### PR DESCRIPTION
The general feedback for https://github.com/dotnet/runtime/pull/98258 was to come up with smaller PRs concentrated around LSRA. This is part 1 of that. 

For Arm64, this PR changes the `typedef unsigned __int64 regMaskTP` to `typedef 

```c++
typedef struct _regMaskTP
{
  unsigned __int64 low;
} regMaskTP;
```

A version of `PopCount` and `BitOperations` has been added next to `regMaskTP` struct definition.

Most of the method implementation is pulled from https://github.com/dotnet/runtime/pull/96196. 