### PR TITLE
Add the auto-created .mono/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ node_modules/
 *.metaproj
 *.metaproj.tmp
 bin.localpkg/
+.mono/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
I noticed we don't have a `.mono/` folder commited at the root of the repo, but it gets created sometimes when working with native code. I'm adding the entry to .gitignore ensures we don't accidentally get it included in a PR in the future.