### PR TITLE
Fold nullchecks in Interlocked.*

### DIFF
--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -511,18 +511,9 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
 {
     assert(tree->OperIsIndirOrArrMetaData());
 
-    GenTree* addr = tree->GetIndirOrArrMetaDataAddr();
+    GenTree* addr = tree->GetIndirOrArrMetaDataAddr()->gtEffectiveVal();
 
     ssize_t offsetValue = 0;
-
-    // if we have COMMA(NULLCHECK(addr), addr) -> we can fold the nullcheck if addresses are the same
-    GenTreeLclVar* nullcheckAddr = nullptr;
-    if (addr->OperIs(GT_COMMA) && addr->gtGetOp1()->OperIs(GT_NULLCHECK) &&
-        addr->gtGetOp1()->AsIndir()->Addr()->OperIs(GT_LCL_VAR))
-    {
-        nullcheckAddr = addr->gtGetOp1()->AsIndir()->Addr()->AsLclVar();
-        addr          = addr->gtGetOp2();
-    }
 
     if ((addr->OperGet() == GT_ADD) && addr->gtGetOp2()->IsCnsIntOrI())
     {
@@ -530,12 +521,7 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
         addr = addr->gtGetOp1();
     }
 
-    if (!addr->OperIs(GT_LCL_VAR))
-    {
-        return nullptr;
-    }
-
-    if ((nullcheckAddr != nullptr) && !GenTree::Compare(nullcheckAddr, addr))
+    if (addr->OperGet() != GT_LCL_VAR)
     {
         return nullptr;
     }

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -523,10 +523,6 @@ GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckT
         nullcheckAddr = addr->gtGetOp1()->AsIndir()->Addr()->AsLclVar();
         addr          = addr->gtGetOp2();
     }
-    else
-    {
-        return nullptr;
-    }
 
     if ((addr->OperGet() == GT_ADD) && addr->gtGetOp2()->IsCnsIntOrI())
     {

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -175,7 +175,7 @@ GenTree* Compiler::optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheck
     optPropKind propKind     = optPropKind::OPK_INVALID;
     bool        folded       = false;
 
-    if (tree->OperIsIndirOrArrMetaData() || tree->OperIsAtomicOp())
+    if (tree->OperIsIndirOrArrMetaData())
     {
         // optFoldNullCheck takes care of updating statement info if a null check is removed.
         folded = optFoldNullCheck(tree, nullCheckMap);
@@ -503,22 +503,15 @@ bool Compiler::optFoldNullCheck(GenTree* tree, LocalNumberToNullCheckTreeMap* nu
 //       or
 //       indir(add(x, const2))
 //
-//       (indir is any node for which OperIsIndirOrArrMetaData() or OperIsAtomicOp() is true.)
+//       (indir is any node for which OperIsIndirOrArrMetaData() is true.)
 //
 //     2.  const1 + const2 if sufficiently small.
 
 GenTree* Compiler::optFindNullCheckToFold(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap)
 {
-    GenTree* addr;
-    if (tree->OperIsAtomicOp())
-    {
-        addr = tree->AsIndir()->Addr();
-    }
-    else
-    {
-        assert(tree->OperIsIndirOrArrMetaData());
-        addr = tree->GetIndirOrArrMetaDataAddr();
-    }
+    assert(tree->OperIsIndirOrArrMetaData());
+
+    GenTree* addr = tree->GetIndirOrArrMetaDataAddr();
 
     ssize_t offsetValue = 0;
 


### PR DESCRIPTION
This PR removes redundant nullchecks emitted with Interlocked.* apis since Interlocked load/store itself is an implicit nullcheck (like any other indir). Also, Interlocked implies a potentially contended memory so we should avoid probing it when it's not needed.
Example:

```cs
int fld;

void Test() => Interlocked.Increment(ref fld);
```
diff:
```diff
; Method Program:Test():this (FullOpts)
-      cmp      byte  ptr [rcx], cl
       add      rcx, 8
       lock     
       inc      dword ptr [rcx]
       ret      
-; Total bytes of code: 10
+; Total bytes of code: 8
```
