### PR TITLE
JIT: SVE Cleanup - Merging some similar SVE formats into `SVE_AT_3A`

### DIFF
--- a/src/coreclr/jit/codegenarm64test.cpp
+++ b/src/coreclr/jit/codegenarm64test.cpp
@@ -5404,6 +5404,92 @@ void CodeGen::genArm64EmitterUnitTestsSve()
                               INS_SCALABLE_OPTS_UNPREDICATED); // UQADD   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
     theEmitter->emitIns_R_R_R(INS_sve_uqsub, EA_SCALABLE, REG_V31, REG_V31, REG_V31, INS_OPTS_SCALABLE_H,
                               INS_SCALABLE_OPTS_UNPREDICATED); // UQSUB   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_mul, EA_SCALABLE, REG_V5, REG_V0, REG_V31, INS_OPTS_SCALABLE_B,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // MUL     <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_smulh, EA_SCALABLE, REG_V0, REG_V31, REG_V5, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // SMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_umulh, EA_SCALABLE, REG_V31, REG_V5, REG_V0, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // UMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_sqdmulh, EA_SCALABLE, REG_V7, REG_V28, REG_V0,
+                              INS_OPTS_SCALABLE_B); // SQDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_sqrdmulh, EA_SCALABLE, REG_V23, REG_V3, REG_V31,
+                              INS_OPTS_SCALABLE_H); // SQRDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_ftssel, EA_SCALABLE, REG_V17, REG_V16, REG_V15,
+                              INS_OPTS_SCALABLE_D); // FTSSEL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_trn1, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_B,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_trn1, EA_SCALABLE, REG_V3, REG_V4, REG_V5, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_trn2, EA_SCALABLE, REG_V6, REG_V7, REG_V8, INS_OPTS_SCALABLE_S,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_trn2, EA_SCALABLE, REG_V9, REG_V10, REG_V11, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_SCALABLE, REG_V12, REG_V13, REG_V14, INS_OPTS_SCALABLE_B,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_SCALABLE, REG_V15, REG_V16, REG_V17, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uzp2, EA_SCALABLE, REG_V18, REG_V19, REG_V20, INS_OPTS_SCALABLE_S,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uzp2, EA_SCALABLE, REG_V21, REG_V22, REG_V23, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_zip1, EA_SCALABLE, REG_V24, REG_V25, REG_V26, INS_OPTS_SCALABLE_B,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_zip1, EA_SCALABLE, REG_V27, REG_V28, REG_V29, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_zip2, EA_SCALABLE, REG_V30, REG_V31, REG_V0, INS_OPTS_SCALABLE_S,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_zip2, EA_SCALABLE, REG_V1, REG_V2, REG_V3, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
+                              INS_OPTS_SCALABLE_B); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
+                              INS_OPTS_SCALABLE_H); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
+                              INS_OPTS_SCALABLE_S); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
+                              INS_OPTS_SCALABLE_D); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_sclamp, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
+                              INS_OPTS_SCALABLE_B); // SCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_sclamp, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
+                              INS_OPTS_SCALABLE_H); // SCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uclamp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
+                              INS_OPTS_SCALABLE_S); // UCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_uclamp, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
+                              INS_OPTS_SCALABLE_D); // UCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
+                              INS_OPTS_SCALABLE_H); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
+                              INS_OPTS_SCALABLE_S); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
+                              INS_OPTS_SCALABLE_D); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_eorbt, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
+                              INS_OPTS_SCALABLE_B); // EORBT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_eorbt, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
+                              INS_OPTS_SCALABLE_H); // EORBT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_eortb, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
+                              INS_OPTS_SCALABLE_S); // EORTB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_eortb, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
+                              INS_OPTS_SCALABLE_D); // EORTB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_bdep, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
+                              INS_OPTS_SCALABLE_B); // BDEP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_bext, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
+                              INS_OPTS_SCALABLE_H); // BEXT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_bgrp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
+                              INS_OPTS_SCALABLE_S); // BGRP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_bgrp, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
+                              INS_OPTS_SCALABLE_D); // BGRP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fadd, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FADD <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fmul, EA_SCALABLE, REG_V3, REG_V4, REG_V5, INS_OPTS_SCALABLE_S,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FMUL <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_frecps, EA_SCALABLE, REG_V6, REG_V7, REG_V8, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FRECPS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_frsqrts, EA_SCALABLE, REG_V9, REG_V10, REG_V11, INS_OPTS_SCALABLE_H,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FRSQRTS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_fsub, EA_SCALABLE, REG_V12, REG_V13, REG_V14, INS_OPTS_SCALABLE_S,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FSUB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
+    theEmitter->emitIns_R_R_R(INS_sve_ftsmul, EA_SCALABLE, REG_V15, REG_V16, REG_V17, INS_OPTS_SCALABLE_D,
+                              INS_SCALABLE_OPTS_UNPREDICATED); // FTSMUL <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
 
     // IF_SVE_BA_3A
     theEmitter->emitIns_R_R_R(INS_sve_index, EA_4BYTE, REG_V24, REG_ZR, REG_R9,
@@ -5411,23 +5497,9 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R(INS_sve_index, EA_8BYTE, REG_V12, REG_R15, REG_R0,
                               INS_OPTS_SCALABLE_D); // INDEX   <Zd>.<T>, <R><n>, <R><m>
 
-    // IF_SVE_BD_3A
-    theEmitter->emitIns_R_R_R(INS_sve_mul, EA_SCALABLE, REG_V5, REG_V0, REG_V31, INS_OPTS_SCALABLE_B,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // MUL     <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_smulh, EA_SCALABLE, REG_V0, REG_V31, REG_V5, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // SMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_umulh, EA_SCALABLE, REG_V31, REG_V5, REG_V0, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // UMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
     // IF_SVE_BD_3B
     theEmitter->emitIns_R_R_R(INS_sve_pmul, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
                               INS_OPTS_SCALABLE_B); // PMUL <Zd>.B, <Zn>.B, <Zm>.B
-
-    // IF_SVE_BE_3A
-    theEmitter->emitIns_R_R_R(INS_sve_sqdmulh, EA_SCALABLE, REG_V7, REG_V28, REG_V0,
-                              INS_OPTS_SCALABLE_B); // SQDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_sqrdmulh, EA_SCALABLE, REG_V23, REG_V3, REG_V31,
-                              INS_OPTS_SCALABLE_H); // SQRDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
 
     // IF_SVE_BG_3A
     theEmitter->emitIns_R_R_R(INS_sve_asr, EA_SCALABLE, REG_V9, REG_V31, REG_V2, INS_OPTS_SCALABLE_B,
@@ -5454,36 +5526,6 @@ void CodeGen::genArm64EmitterUnitTestsSve()
                                    INS_OPTS_SCALABLE_D_UXTW); // ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW{<amount>}]
     theEmitter->emitInsSve_R_R_R_I(INS_sve_adr, EA_SCALABLE, REG_V3, REG_V15, REG_V11, 3,
                                    INS_OPTS_SCALABLE_D_UXTW); // ADR     <Zd>.D, [<Zn>.D, <Zm>.D, UXTW{<amount>}]
-
-    // IF_SVE_BK_3A
-    theEmitter->emitIns_R_R_R(INS_sve_ftssel, EA_SCALABLE, REG_V17, REG_V16, REG_V15,
-                              INS_OPTS_SCALABLE_D); // FTSSEL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
-    // IF_SVE_BR_3A
-    theEmitter->emitIns_R_R_R(INS_sve_trn1, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_B,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_trn1, EA_SCALABLE, REG_V3, REG_V4, REG_V5, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_trn2, EA_SCALABLE, REG_V6, REG_V7, REG_V8, INS_OPTS_SCALABLE_S,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_trn2, EA_SCALABLE, REG_V9, REG_V10, REG_V11, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // TRN2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_SCALABLE, REG_V12, REG_V13, REG_V14, INS_OPTS_SCALABLE_B,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uzp1, EA_SCALABLE, REG_V15, REG_V16, REG_V17, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uzp2, EA_SCALABLE, REG_V18, REG_V19, REG_V20, INS_OPTS_SCALABLE_S,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uzp2, EA_SCALABLE, REG_V21, REG_V22, REG_V23, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // UZP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_zip1, EA_SCALABLE, REG_V24, REG_V25, REG_V26, INS_OPTS_SCALABLE_B,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_zip1, EA_SCALABLE, REG_V27, REG_V28, REG_V29, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP1 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_zip2, EA_SCALABLE, REG_V30, REG_V31, REG_V0, INS_OPTS_SCALABLE_S,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_zip2, EA_SCALABLE, REG_V1, REG_V2, REG_V3, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // ZIP2 <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
 
     // IF_SVE_BR_3B
     theEmitter->emitIns_R_R_R(INS_sve_trn1, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_Q,
@@ -5648,16 +5690,6 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R(INS_sve_tbl, EA_SCALABLE, REG_V9, REG_V10, REG_V11, INS_OPTS_SCALABLE_D,
                               INS_SCALABLE_OPTS_WITH_VECTOR_PAIR); // TBL <Zd>.<T>, {<Zn1>.<T>, <Zn2>.<T>}, <Zm>.<T>
 
-    // IF_SVE_CA_3A
-    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
-                              INS_OPTS_SCALABLE_B); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
-                              INS_OPTS_SCALABLE_H); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
-                              INS_OPTS_SCALABLE_S); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_tbxq, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
-                              INS_OPTS_SCALABLE_D); // TBXQ <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
     // IF_SVE_EH_3A
     theEmitter->emitIns_R_R_R(INS_sve_sdot, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
                               INS_OPTS_SCALABLE_S); // SDOT <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb>
@@ -5713,16 +5745,6 @@ void CodeGen::genArm64EmitterUnitTestsSve()
                               INS_OPTS_SCALABLE_D); // SQDMLSLB <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb>
     theEmitter->emitIns_R_R_R(INS_sve_sqdmlslt, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
                               INS_OPTS_SCALABLE_H); // SQDMLSLT <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb>
-
-    // IF_SVE_EV_3A
-    theEmitter->emitIns_R_R_R(INS_sve_sclamp, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
-                              INS_OPTS_SCALABLE_B); // SCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_sclamp, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
-                              INS_OPTS_SCALABLE_H); // SCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uclamp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
-                              INS_OPTS_SCALABLE_S); // UCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_uclamp, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
-                              INS_OPTS_SCALABLE_D); // UCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
 
     // IF_SVE_EX_3A
     theEmitter->emitIns_R_R_R(INS_sve_tblq, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
@@ -5812,26 +5834,6 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R(INS_sve_usmmla, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
                               INS_OPTS_SCALABLE_S); // USMMLA <Zda>.S, <Zn>.B, <Zm>.B
 
-    // IF_SVE_FP_3A
-    theEmitter->emitIns_R_R_R(INS_sve_eorbt, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
-                              INS_OPTS_SCALABLE_B); // EORBT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_eorbt, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
-                              INS_OPTS_SCALABLE_H); // EORBT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_eortb, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
-                              INS_OPTS_SCALABLE_S); // EORTB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_eortb, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
-                              INS_OPTS_SCALABLE_D); // EORTB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
-    // IF_SVE_FQ_3A
-    theEmitter->emitIns_R_R_R(INS_sve_bdep, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
-                              INS_OPTS_SCALABLE_B); // BDEP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_bext, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
-                              INS_OPTS_SCALABLE_H); // BEXT <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_bgrp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
-                              INS_OPTS_SCALABLE_S); // BGRP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_bgrp, EA_SCALABLE, REG_V9, REG_V10, REG_V11,
-                              INS_OPTS_SCALABLE_D); // BGRP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
     // IF_SVE_FS_3A
     theEmitter->emitIns_R_R_R(INS_sve_saddlbt, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
                               INS_OPTS_SCALABLE_H); // SADDLBT <Zd>.<T>, <Zn>.<Tb>, <Zm>.<Tb>
@@ -5884,31 +5886,9 @@ void CodeGen::genArm64EmitterUnitTestsSve()
     theEmitter->emitIns_R_R_R(INS_sve_histseg, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
                               INS_OPTS_SCALABLE_B); // HISTSEG <Zd>.B, <Zn>.B, <Zm>.B
 
-    // IF_SVE_GW_3A
-    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
-                              INS_OPTS_SCALABLE_H); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V3, REG_V4, REG_V5,
-                              INS_OPTS_SCALABLE_S); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_fclamp, EA_SCALABLE, REG_V6, REG_V7, REG_V8,
-                              INS_OPTS_SCALABLE_D); // FCLAMP <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-
     // IF_SVE_GW_3B
     theEmitter->emitIns_R_R_R(INS_sve_bfclamp, EA_SCALABLE, REG_V0, REG_V1, REG_V2,
                               INS_OPTS_SCALABLE_H); // BFCLAMP <Zd>.H, <Zn>.H, <Zm>.H
-
-    // IF_SVE_HK_3A
-    theEmitter->emitIns_R_R_R(INS_sve_fadd, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FADD <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_fmul, EA_SCALABLE, REG_V3, REG_V4, REG_V5, INS_OPTS_SCALABLE_S,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FMUL <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_frecps, EA_SCALABLE, REG_V6, REG_V7, REG_V8, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FRECPS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_frsqrts, EA_SCALABLE, REG_V9, REG_V10, REG_V11, INS_OPTS_SCALABLE_H,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FRSQRTS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_fsub, EA_SCALABLE, REG_V12, REG_V13, REG_V14, INS_OPTS_SCALABLE_S,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FSUB <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-    theEmitter->emitIns_R_R_R(INS_sve_ftsmul, EA_SCALABLE, REG_V15, REG_V16, REG_V17, INS_OPTS_SCALABLE_D,
-                              INS_SCALABLE_OPTS_UNPREDICATED); // FTSMUL <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
 
     // IF_SVE_HK_3B
     theEmitter->emitIns_R_R_R(INS_sve_bfadd, EA_SCALABLE, REG_V0, REG_V1, REG_V2, INS_OPTS_SCALABLE_H,

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -16583,7 +16583,7 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
             result.insLatency    = PERFSCORE_LATENCY_1C;    // need to fix
             break;
 
-        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd
+        case IF_SVE_AT_3A: // ........xx.mmmmm ......nnnnnddddd
             switch (ins)
             {
                 case INS_sve_tbxq:

--- a/src/coreclr/jit/emitarm64sve.cpp
+++ b/src/coreclr/jit/emitarm64sve.cpp
@@ -316,7 +316,7 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
                                                   IF_SVE_HW_4B, IF_SVE_HW_4B_D, IF_SVE_HX_3A_E, IF_SVE_IG_4A_G};
     const static insFormat formatEncode7A[7]   = {IF_SVE_IJ_3A, IF_SVE_IK_4A,   IF_SVE_IU_4A, IF_SVE_IU_4A_A,
                                                   IF_SVE_IU_4B, IF_SVE_IU_4B_B, IF_SVE_IV_3A};
-    const static insFormat formatEncode6A[6]   = {IF_SVE_AA_3A, IF_SVE_BD_3A, IF_SVE_EE_1A,
+    const static insFormat formatEncode6A[6]   = {IF_SVE_AA_3A, IF_SVE_AT_3A, IF_SVE_EE_1A,
                                                   IF_SVE_FD_3A, IF_SVE_FD_3B, IF_SVE_FD_3C};
     const static insFormat formatEncode6B[6]   = {IF_SVE_GY_3A, IF_SVE_GY_3B,   IF_SVE_GY_3B_D,
                                                   IF_SVE_HA_3A, IF_SVE_HA_3A_E, IF_SVE_HA_3A_F};
@@ -331,7 +331,7 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     const static insFormat formatEncode6G[6]   = {IF_SVE_JD_4A,   IF_SVE_JI_3A_A, IF_SVE_JK_4A,
                                                   IF_SVE_JK_4A_B, IF_SVE_JK_4B,   IF_SVE_JN_3A};
     const static insFormat formatEncode5A[5]   = {IF_SVE_AM_2A, IF_SVE_AA_3A, IF_SVE_AO_3A, IF_SVE_BF_2A, IF_SVE_BG_3A};
-    const static insFormat formatEncode5B[5]   = {IF_SVE_GX_3A, IF_SVE_GX_3B, IF_SVE_HK_3A, IF_SVE_HL_3A, IF_SVE_HM_2A};
+    const static insFormat formatEncode5B[5]   = {IF_SVE_GX_3A, IF_SVE_GX_3B, IF_SVE_AT_3A, IF_SVE_HL_3A, IF_SVE_HM_2A};
     const static insFormat formatEncode5C[5]   = {IF_SVE_EF_3A, IF_SVE_EG_3A, IF_SVE_EH_3A, IF_SVE_EY_3A, IF_SVE_EY_3B};
     const static insFormat formatEncode5D[5]   = {IF_SVE_HW_4A, IF_SVE_HW_4A_A, IF_SVE_HW_4B, IF_SVE_HX_3A_B,
                                                   IF_SVE_IG_4A_D};
@@ -339,7 +339,7 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
                                                   IF_SVE_IG_4A_E};
     const static insFormat formatEncode4A[4]   = {IF_SVE_AA_3A, IF_SVE_AU_3A, IF_SVE_BS_1A, IF_SVE_CZ_4A};
     const static insFormat formatEncode4B[4]   = {IF_SVE_BU_2A, IF_SVE_BV_2B, IF_SVE_EA_1A, IF_SVE_EB_1B};
-    const static insFormat formatEncode4E[4]   = {IF_SVE_BE_3A, IF_SVE_FI_3A, IF_SVE_FI_3B, IF_SVE_FI_3C};
+    const static insFormat formatEncode4E[4]   = {IF_SVE_AT_3A, IF_SVE_FI_3A, IF_SVE_FI_3B, IF_SVE_FI_3C};
     const static insFormat formatEncode4F[4]   = {IF_SVE_EM_3A, IF_SVE_FK_3A, IF_SVE_FK_3B, IF_SVE_FK_3C};
     const static insFormat formatEncode4G[4]   = {IF_SVE_AR_4A, IF_SVE_FF_3A, IF_SVE_FF_3B, IF_SVE_FF_3C};
     const static insFormat formatEncode4H[4]   = {IF_SVE_GM_3A, IF_SVE_GN_3A, IF_SVE_GZ_3A, IF_SVE_HB_3A};
@@ -350,11 +350,11 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     const static insFormat formatEncode3A[3]   = {IF_SVE_AA_3A, IF_SVE_AT_3A, IF_SVE_EC_1A};
     const static insFormat formatEncode3B[3]   = {IF_SVE_BH_3A, IF_SVE_BH_3B, IF_SVE_BH_3B_A};
     const static insFormat formatEncode3C[3]   = {IF_SVE_BW_2A, IF_SVE_CB_2A, IF_SVE_EB_1A};
-    const static insFormat formatEncode3D[3]   = {IF_SVE_BR_3A, IF_SVE_BR_3B, IF_SVE_CI_3A};
+    const static insFormat formatEncode3D[3]   = {IF_SVE_AT_3A, IF_SVE_BR_3B, IF_SVE_CI_3A};
     const static insFormat formatEncode3E[3]   = {IF_SVE_AT_3A, IF_SVE_EC_1A, IF_SVE_AA_3A};
     const static insFormat formatEncode3F[3]   = {IF_SVE_GU_3A, IF_SVE_GU_3B, IF_SVE_HU_4A};
     const static insFormat formatEncode3G[3]   = {IF_SVE_GH_3A, IF_SVE_GH_3B, IF_SVE_GH_3B_B};
-    const static insFormat formatEncode3H[3]   = {IF_SVE_HK_3A, IF_SVE_HL_3A, IF_SVE_HM_2A};
+    const static insFormat formatEncode3H[3]   = {IF_SVE_AT_3A, IF_SVE_HL_3A, IF_SVE_HM_2A};
     const static insFormat formatEncode3I[3]   = {IF_SVE_CM_3A, IF_SVE_CN_3A, IF_SVE_CO_3A};
     const static insFormat formatEncode3J[3]   = {IF_SVE_CX_4A, IF_SVE_CX_4A_A, IF_SVE_CY_3A};
     const static insFormat formatEncode3K[3]   = {IF_SVE_CX_4A, IF_SVE_CX_4A_A, IF_SVE_CY_3B};
@@ -374,7 +374,7 @@ emitter::code_t emitter::emitInsCodeSve(instruction ins, insFormat fmt)
     const static insFormat formatEncode2AC[2]  = {IF_SVE_AA_3A, IF_SVE_ED_1A};
     const static insFormat formatEncode2AD[2]  = {IF_SVE_AB_3B, IF_SVE_AT_3B};
     const static insFormat formatEncode2AE[2]  = {IF_SVE_CG_2A, IF_SVE_CJ_2A};
-    const static insFormat formatEncode2AF[2]  = {IF_SVE_AA_3A, IF_SVE_BD_3A};
+    const static insFormat formatEncode2AF[2]  = {IF_SVE_AA_3A, IF_SVE_AT_3A};
     const static insFormat formatEncode2AG[2]  = {IF_SVE_BS_1A, IF_SVE_CZ_4A};
     const static insFormat formatEncode2AH[2]  = {IF_SVE_BQ_2A, IF_SVE_BQ_2B};
     const static insFormat formatEncode2AI[2]  = {IF_SVE_AM_2A, IF_SVE_AA_3A};
@@ -3009,7 +3009,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             if (sopt == INS_SCALABLE_OPTS_UNPREDICATED)
             {
                 assert(isVectorRegister(reg2));
-                fmt = IF_SVE_BD_3A;
+                fmt = IF_SVE_AT_3A;
             }
             else
             {
@@ -3173,7 +3173,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
                 else
                 {
                     assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-                    fmt = IF_SVE_BR_3A;
+                    fmt = IF_SVE_AT_3A;
                 }
             }
             else
@@ -3219,7 +3219,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_CA_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_sdot:
@@ -3303,7 +3303,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_EV_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_zipq1:
@@ -3520,7 +3520,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_FP_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_bext:
@@ -3531,7 +3531,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_FQ_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_saddlbt:
@@ -3599,7 +3599,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_GW_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_clz:
@@ -3695,7 +3695,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg3));
             assert(insOptsScalableStandard(opt));
             assert(insScalableOptsNone(sopt));
-            fmt = IF_SVE_BE_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_ftssel:
@@ -3705,7 +3705,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg3));
             assert(insOptsScalableFloat(opt));
             assert(insScalableOptsNone(sopt));
-            fmt = IF_SVE_BK_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_compact:
@@ -4093,7 +4093,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             assert(isVectorRegister(reg2));                        // nnnnn
             assert(isVectorRegister(reg3));                        // mmmmm
             assert(isValidVectorElemsize(optGetSveElemsize(opt))); // xx
-            fmt = IF_SVE_HK_3A;
+            fmt = IF_SVE_AT_3A;
             break;
 
         case INS_sve_fadd:
@@ -4107,7 +4107,7 @@ void emitter::emitInsSve_R_R_R(instruction     ins,
             if (sopt == INS_SCALABLE_OPTS_UNPREDICATED)
             {
                 assert(isVectorRegister(reg2)); // nnnnn
-                fmt = IF_SVE_HK_3A;
+                fmt = IF_SVE_AT_3A;
             }
             else
             {
@@ -9996,35 +9996,24 @@ BYTE* emitter::emitOutput_InstrSve(BYTE* dst, instrDesc* id)
             break;
 
         // Scalable, 3 regs, no predicates
-        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated)
-        case IF_SVE_BD_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply vectors (unpredicated)
-        case IF_SVE_BE_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 signed saturating doubling multiply high
-                             // (unpredicated)
+        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd
         case IF_SVE_BG_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE bitwise shift by wide elements (unpredicated)
-        case IF_SVE_BK_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point trig select coefficient
-        case IF_SVE_BR_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
         case IF_SVE_BZ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
         case IF_SVE_BZ_3A_A: // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
-        case IF_SVE_CA_3A:   // ........xx.mmmmm ......nnnnnddddd -- sve_int_perm_tbxquads
         case IF_SVE_EH_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer dot product (unpredicated)
         case IF_SVE_EL_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply-add long
         case IF_SVE_EM_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add high
         case IF_SVE_EN_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add interleaved long
         case IF_SVE_EO_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add long
-        case IF_SVE_EV_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer clamp
         case IF_SVE_EX_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector elements (quadwords)
         case IF_SVE_FL_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract long
         case IF_SVE_FM_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract wide
         case IF_SVE_FN_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply long
-        case IF_SVE_FP_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise exclusive-or interleaved
-        case IF_SVE_FQ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise permute
         case IF_SVE_FS_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract interleaved long
         case IF_SVE_FW_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer absolute difference and accumulate
         case IF_SVE_FX_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer absolute difference and accumulate long
         case IF_SVE_GC_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract narrow high part
         case IF_SVE_GF_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 histogram generation (segment)
-        case IF_SVE_GW_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE FP clamp
-        case IF_SVE_HK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point arithmetic (unpredicated)
             code = emitInsCodeSve(ins, fmt);
             code |= insEncodeReg_V<4, 0>(id->idReg1());                      // ddddd
             code |= insEncodeReg_V<9, 5>(id->idReg2());                      // nnnnn
@@ -12639,35 +12628,24 @@ void emitter::emitInsSveSanityCheck(instrDesc* id)
             break;
 
         // Scalable, unpredicated
-        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated)
-        case IF_SVE_BD_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply vectors (unpredicated)
-        case IF_SVE_BE_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 signed saturating doubling multiply high
-                             // (unpredicated)
+        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd
         case IF_SVE_BG_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE bitwise shift by wide elements (unpredicated)
-        case IF_SVE_BK_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point trig select coefficient
-        case IF_SVE_BR_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
         case IF_SVE_BZ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
         case IF_SVE_BZ_3A_A: // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
-        case IF_SVE_CA_3A:   // ........xx.mmmmm ......nnnnnddddd -- sve_int_perm_tbxquads
         case IF_SVE_EH_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer dot product (unpredicated)
         case IF_SVE_EL_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply-add long
         case IF_SVE_EM_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add high
         case IF_SVE_EN_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add interleaved long
         case IF_SVE_EO_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add long
-        case IF_SVE_EV_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer clamp
         case IF_SVE_EX_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector elements (quadwords)
         case IF_SVE_FL_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract long
         case IF_SVE_FM_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract wide
         case IF_SVE_FN_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply long
-        case IF_SVE_FP_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise exclusive-or interleaved
-        case IF_SVE_FQ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise permute
         case IF_SVE_FS_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract interleaved long
         case IF_SVE_FW_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer absolute difference and accumulate
         case IF_SVE_FX_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer absolute difference and accumulate long
         case IF_SVE_GC_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract narrow high part
         case IF_SVE_GF_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 histogram generation (segment)
-        case IF_SVE_GW_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE FP clamp
-        case IF_SVE_HK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point arithmetic (unpredicated)
             assert(insOptsScalableStandard(id->idInsOpt())); // xx
             assert(isVectorRegister(id->idReg1()));          // ddddd
             assert(isVectorRegister(id->idReg2()));          // nnnnn
@@ -14523,18 +14501,7 @@ void emitter::emitDispInsSveHelp(instrDesc* id)
             break;
 
         // <Zd>.<T>, <Zn>.<T>, <Zm>.<T>
-        case IF_SVE_AT_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated)
-        case IF_SVE_BD_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply vectors (unpredicated)
-        case IF_SVE_BE_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 signed saturating doubling multiply high
-                           // (unpredicated)
-        case IF_SVE_FP_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise exclusive-or interleaved
-        case IF_SVE_FQ_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise permute
-        case IF_SVE_BK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point trig select coefficient
-        case IF_SVE_BR_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
-        case IF_SVE_CA_3A: // ........xx.mmmmm ......nnnnnddddd -- sve_int_perm_tbxquads
-        case IF_SVE_EV_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE integer clamp
-        case IF_SVE_GW_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE FP clamp
-        case IF_SVE_HK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point arithmetic (unpredicated)
+        case IF_SVE_AT_3A: // ........xx.mmmmm ......nnnnnddddd
         // <Zda>.<T>, <Zn>.<T>, <Zm>.<T>
         case IF_SVE_EM_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 saturating multiply-add high
         case IF_SVE_FW_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer absolute difference and accumulate
@@ -16486,9 +16453,6 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
                            // (predicated)
         case IF_SVE_AS_4A: // ........xx.mmmmm ...gggaaaaaddddd -- SVE integer multiply-add writing multiplicand
                            // (predicated)
-        case IF_SVE_BD_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply vectors (unpredicated)
-        case IF_SVE_BE_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 signed saturating doubling multiply high
-                           // (unpredicated)
         case IF_SVE_FD_3A: // .........i.iimmm ......nnnnnddddd -- SVE2 integer multiply (indexed)
         case IF_SVE_FD_3B: // ...........iimmm ......nnnnnddddd -- SVE2 integer multiply (indexed)
         case IF_SVE_FD_3C: // ...........immmm ......nnnnnddddd -- SVE2 integer multiply (indexed)
@@ -16605,10 +16569,7 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
         case IF_SVE_GX_3C:   // .........i.iimmm ......nnnnnddddd -- SVE floating-point multiply (indexed)
         case IF_SVE_EW_3A:   // ...........mmmmm ......nnnnnddddd -- SVE2 multiply-add (checked pointer)
         case IF_SVE_EW_3B:   // ...........mmmmm ......aaaaaddddd -- SVE2 multiply-add (checked pointer)
-        case IF_SVE_CA_3A:   // ........xx.mmmmm ......nnnnnddddd -- sve_int_perm_tbxquads
-        case IF_SVE_EV_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer clamp
         case IF_SVE_EX_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector elements (quadwords)
-        case IF_SVE_GW_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE FP clamp
         case IF_SVE_AT_3B:   // ...........mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated)
         case IF_SVE_AB_3B:   // ................ ...gggmmmmmddddd -- SVE integer add/subtract vectors (predicated)
         case IF_SVE_HL_3B:   // ................ ...gggmmmmmddddd -- SVE floating-point arithmetic (predicated)
@@ -16622,14 +16583,58 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
             result.insLatency    = PERFSCORE_LATENCY_1C;    // need to fix
             break;
 
-        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated)
-        case IF_SVE_BR_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
+        case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd
+            switch (ins)
+            {
+                case INS_sve_tbxq:
+                case INS_sve_sclamp:
+                case INS_sve_uclamp:
+                case INS_sve_fclamp:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_1C; // need to fix
+                    result.insLatency    = PERFSCORE_LATENCY_1C;    // need to fix
+                    break;
+
+                case INS_sve_bext:
+                case INS_sve_bdep:
+                case INS_sve_bgrp:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_6C;
+                    break;
+
+                case INS_sve_ftssel:
+                case INS_sve_fmul:
+                case INS_sve_ftsmul:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    result.insLatency    = PERFSCORE_LATENCY_3C;
+                    break;
+
+                case INS_sve_frecps:
+                case INS_sve_frsqrts:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    result.insLatency    = PERFSCORE_LATENCY_4C;
+                    break;
+
+                case INS_sve_mul:
+                case INS_sve_smulh:
+                case INS_sve_umulh:
+                case INS_sve_sqdmulh:
+                case INS_sve_sqrdmulh:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2X;
+                    result.insLatency    = PERFSCORE_LATENCY_5C;
+                    break;
+
+                default:
+                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
+                    result.insLatency    = PERFSCORE_LATENCY_2C;
+                    break;
+            }
+            break;
+
         case IF_SVE_BR_3B:   // ...........mmmmm ......nnnnnddddd -- SVE permute vector segments
         case IF_SVE_BZ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
         case IF_SVE_BZ_3A_A: // ........xx.mmmmm ......nnnnnddddd -- SVE table lookup (three sources)
         case IF_SVE_FL_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract long
         case IF_SVE_FM_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract wide
-        case IF_SVE_FP_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise exclusive-or interleaved
         case IF_SVE_FS_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract interleaved long
         case IF_SVE_GC_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer add/subtract narrow high part
         case IF_SVE_GF_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 histogram generation (segment)
@@ -16639,11 +16644,6 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
         case IF_SVE_BC_1A:   // ................ .....iiiiiiddddd -- SVE stack frame size
             result.insThroughput = PERFSCORE_THROUGHPUT_2C;
             result.insLatency    = PERFSCORE_LATENCY_2C;
-            break;
-
-        case IF_SVE_FQ_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise permute
-            result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-            result.insLatency    = PERFSCORE_LATENCY_6C;
             break;
 
         case IF_SVE_FN_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply long
@@ -16703,7 +16703,6 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
             result.insLatency    = PERFSCORE_LATENCY_2C;
             break;
 
-        case IF_SVE_BK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point trig select coefficient
         case IF_SVE_FO_3A: // ...........mmmmm ......nnnnnddddd -- SVE integer matrix multiply accumulate
             result.insThroughput = PERFSCORE_THROUGHPUT_2C;
             result.insLatency    = PERFSCORE_LATENCY_3C;
@@ -17101,34 +17100,6 @@ void emitter::getInsSveExecutionCharacteristics(instrDesc* id, insExecutionChara
         case IF_SVE_HJ_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point serial reduction (predicated)
             result.insLatency    = PERFSCORE_LATENCY_4C;
             result.insThroughput = PERFSCORE_THROUGHPUT_2X;
-            break;
-
-        case IF_SVE_HK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point arithmetic (unpredicated)
-            switch (ins)
-            {
-                case INS_sve_frecps:
-                case INS_sve_frsqrts:
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
-                    result.insLatency    = PERFSCORE_LATENCY_4C;
-                    break;
-
-                case INS_sve_fmul:
-                case INS_sve_ftsmul:
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
-                    result.insLatency    = PERFSCORE_LATENCY_3C;
-                    break;
-
-                case INS_sve_fadd:
-                case INS_sve_fsub:
-                    result.insThroughput = PERFSCORE_THROUGHPUT_2C;
-                    result.insLatency    = PERFSCORE_LATENCY_2C;
-                    break;
-
-                default:
-                    // all other instructions
-                    perfScoreUnhandledInstruction(id, &result);
-                    break;
-            }
             break;
 
         case IF_SVE_HL_3A: // ........xx...... ...gggmmmmmddddd -- SVE floating-point arithmetic (predicated)

--- a/src/coreclr/jit/emitfmtsarm64sve.h
+++ b/src/coreclr/jit/emitfmtsarm64sve.h
@@ -153,7 +153,7 @@ IF_DEF(SVE_AP_3A,   IS_NONE, NONE) // SVE_AP_3A  ........xx...... ...gggnnnnnddd
 IF_DEF(SVE_AQ_3A,   IS_NONE, NONE) // SVE_AQ_3A  ........xx...... ...gggnnnnnddddd  -- SVE integer unary operations (predicated)
 IF_DEF(SVE_AR_4A,   IS_NONE, NONE) // SVE_AR_4A  ........xx.mmmmm ...gggnnnnnddddd  -- SVE integer multiply-accumulate writing addend (predicated)
 IF_DEF(SVE_AS_4A,   IS_NONE, NONE) // SVE_AS_4A  ........xx.mmmmm ...gggaaaaaddddd  -- SVE integer multiply-add writing multiplicand (predicated)
-IF_DEF(SVE_AT_3A,   IS_NONE, NONE) // SVE_AT_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE integer add/subtract vectors (unpredicated)
+IF_DEF(SVE_AT_3A,   IS_NONE, NONE) // SVE_AT_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE integer add/subtract vectors (unpredicated) + SVE2 integer multiply vectors (unpredicated) + SVE2 signed saturating doubling multiply high (unpredicated) + SVE floating-point trig select coefficient + SVE permute vector segments + sve_int_perm_tbxquads + SVE integer clamp + SVE2 bitwise exclusive-or interleaved + SVE2 bitwise permute + SVE FP clamp + SVE floating-point arithmetic (unpredicated)
 IF_DEF(SVE_AT_3B,   IS_NONE, NONE) // SVE_AT_3B  ...........mmmmm ......nnnnnddddd  -- SVE integer add/subtract vectors (unpredicated)
 IF_DEF(SVE_AU_3A,   IS_NONE, NONE) // SVE_AU_3A  ...........mmmmm ......nnnnnddddd  -- SVE bitwise logical operations (unpredicated)
 IF_DEF(SVE_AV_3A,   IS_NONE, NONE) // SVE_AV_3A  ...........mmmmm ......kkkkkddddd  -- SVE2 bitwise ternary operations
@@ -164,9 +164,7 @@ IF_DEF(SVE_AZ_2A,   IS_NONE, NONE) // SVE_AZ_2A  ........xx.iiiii ......nnnnnddd
 IF_DEF(SVE_BA_3A,   IS_NONE, NONE) // SVE_BA_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE index generation (register start, register increment)
 IF_DEF(SVE_BB_2A,   IS_NONE, NONE) // SVE_BB_2A  ...........nnnnn .....iiiiiiddddd  -- SVE stack frame adjustment
 IF_DEF(SVE_BC_1A,   IS_NONE, NONE) // SVE_BC_1A  ................ .....iiiiiiddddd  -- SVE stack frame size
-IF_DEF(SVE_BD_3A,   IS_NONE, NONE) // SVE_BD_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 integer multiply vectors (unpredicated)
 IF_DEF(SVE_BD_3B,   IS_NONE, NONE) // SVE_BD_3B  ...........mmmmm ......nnnnnddddd  -- SVE2 integer multiply vectors (unpredicated)
-IF_DEF(SVE_BE_3A,   IS_NONE, NONE) // SVE_BE_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 signed saturating doubling multiply high (unpredicated)
 IF_DEF(SVE_BF_2A,   IS_NONE, NONE) // SVE_BF_2A  ........xx.xxiii ......nnnnnddddd  -- SVE bitwise shift by immediate (unpredicated)
 IF_DEF(SVE_BG_3A,   IS_NONE, NONE) // SVE_BG_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE bitwise shift by wide elements (unpredicated)
 IF_DEF(SVE_BH_3A,   IS_NONE, NONE) // SVE_BH_3A  .........x.mmmmm ....hhnnnnnddddd  -- SVE address generation
@@ -174,7 +172,6 @@ IF_DEF(SVE_BH_3B,   IS_NONE, NONE) // SVE_BH_3B  ...........mmmmm ....hhnnnnnddd
 IF_DEF(SVE_BH_3B_A, IS_NONE, NONE) // SVE_BH_3B_A  ...........mmmmm ....hhnnnnnddddd  -- 
 IF_DEF(SVE_BI_2A,   IS_NONE, NONE) // SVE_BI_2A  ................ ......nnnnnddddd  -- SVE constructive prefix (unpredicated)
 IF_DEF(SVE_BJ_2A,   IS_NONE, NONE) // SVE_BJ_2A  ........xx...... ......nnnnnddddd  -- SVE floating-point exponential accelerator
-IF_DEF(SVE_BK_3A,   IS_NONE, NONE) // SVE_BK_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE floating-point trig select coefficient
 IF_DEF(SVE_BL_1A,   IS_NONE, NONE) // SVE_BL_1A  ............iiii ......pppppddddd  -- SVE element count
 IF_DEF(SVE_BM_1A,   IS_NONE, NONE) // SVE_BM_1A  ............iiii ......pppppddddd  -- SVE inc/dec register by element count
 IF_DEF(SVE_BN_1A,   IS_NONE, NONE) // SVE_BN_1A  ............iiii ......pppppddddd  -- SVE inc/dec vector by element count
@@ -183,7 +180,6 @@ IF_DEF(SVE_BO_1A_A, IS_NONE, NONE) // SVE_BO_1A_A  ...........Xiiii ......pppppd
 IF_DEF(SVE_BP_1A,   IS_NONE, NONE) // SVE_BP_1A  ............iiii ......pppppddddd  -- SVE saturating inc/dec vector by element count
 IF_DEF(SVE_BQ_2A,   IS_NONE, NONE) // SVE_BQ_2A  ...........iiiii ...iiinnnnnddddd  -- SVE extract vector (immediate offset, destructive)
 IF_DEF(SVE_BQ_2B,   IS_NONE, NONE) // SVE_BQ_2B  ...........iiiii ...iiimmmmmddddd  -- SVE extract vector (immediate offset, destructive)
-IF_DEF(SVE_BR_3A,   IS_NONE, NONE) // SVE_BR_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE permute vector segments
 IF_DEF(SVE_BR_3B,   IS_NONE, NONE) // SVE_BR_3B  ...........mmmmm ......nnnnnddddd  -- SVE permute vector segments
 IF_DEF(SVE_BS_1A,   IS_NONE, NONE) // SVE_BS_1A  ..............ii iiiiiiiiiiiddddd  -- SVE bitwise logical with immediate (unpredicated)
 IF_DEF(SVE_BT_1A,   IS_NONE, NONE) // SVE_BT_1A  ..............ii iiiiiiiiiiiddddd  -- SVE broadcast bitmask immediate
@@ -197,7 +193,6 @@ IF_DEF(SVE_BX_2A,   IS_NONE, NONE) // SVE_BX_2A  ...........ixxxx ......nnnnnddd
 IF_DEF(SVE_BY_2A,   IS_NONE, NONE) // SVE_BY_2A  ............iiii ......mmmmmddddd  -- sve_int_perm_extq
 IF_DEF(SVE_BZ_3A,   IS_NONE, NONE) // SVE_BZ_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE table lookup (three sources)
 IF_DEF(SVE_BZ_3A_A, IS_NONE, NONE) // SVE_BZ_3A_A  ........xx.mmmmm ......nnnnnddddd  -- 
-IF_DEF(SVE_CA_3A,   IS_NONE, NONE) // SVE_CA_3A  ........xx.mmmmm ......nnnnnddddd  -- sve_int_perm_tbxquads
 IF_DEF(SVE_CB_2A,   IS_NONE, NONE) // SVE_CB_2A  ........xx...... ......nnnnnddddd  -- SVE broadcast general register
 IF_DEF(SVE_CC_2A,   IS_NONE, NONE) // SVE_CC_2A  ........xx...... ......mmmmmddddd  -- SVE insert SIMD&FP scalar register
 IF_DEF(SVE_CD_2A,   IS_NONE, NONE) // SVE_CD_2A  ........xx...... ......mmmmmddddd  -- SVE insert general register
@@ -282,7 +277,6 @@ IF_DEF(SVE_EN_3A,   IS_NONE, NONE) // SVE_EN_3A  ........xx.mmmmm ......nnnnnddd
 IF_DEF(SVE_EO_3A,   IS_NONE, NONE) // SVE_EO_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 saturating multiply-add long
 IF_DEF(SVE_EQ_3A,   IS_NONE, NONE) // SVE_EQ_3A  ........xx...... ...gggnnnnnddddd  -- SVE2 integer pairwise add and accumulate long
 IF_DEF(SVE_ES_3A,   IS_NONE, NONE) // SVE_ES_3A  ........xx...... ...gggnnnnnddddd  -- SVE2 integer unary operations (predicated)
-IF_DEF(SVE_EV_3A,   IS_NONE, NONE) // SVE_EV_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE integer clamp
 IF_DEF(SVE_EW_3A,   IS_NONE, NONE) // SVE_EW_3A  ...........mmmmm ......nnnnnddddd  -- SVE2 multiply-add (checked pointer)
 IF_DEF(SVE_EW_3B,   IS_NONE, NONE) // SVE_EW_3B  ...........mmmmm ......aaaaaddddd  -- SVE2 multiply-add (checked pointer)
 IF_DEF(SVE_EX_3A,   IS_NONE, NONE) // SVE_EX_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE permute vector elements (quadwords)
@@ -320,8 +314,6 @@ IF_DEF(SVE_FM_3A,   IS_NONE, NONE) // SVE_FM_3A  ........xx.mmmmm ......nnnnnddd
 IF_DEF(SVE_FN_3A,   IS_NONE, NONE) // SVE_FN_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 integer multiply long
 IF_DEF(SVE_FN_3B,   IS_NONE, NONE) // SVE_FN_3B  ...........mmmmm ......nnnnnddddd  -- SVE2 integer multiply long
 IF_DEF(SVE_FO_3A,   IS_NONE, NONE) // SVE_FO_3A  ...........mmmmm ......nnnnnddddd  -- SVE integer matrix multiply accumulate
-IF_DEF(SVE_FP_3A,   IS_NONE, NONE) // SVE_FP_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 bitwise exclusive-or interleaved
-IF_DEF(SVE_FQ_3A,   IS_NONE, NONE) // SVE_FQ_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 bitwise permute
 IF_DEF(SVE_FR_2A,   IS_NONE, NONE) // SVE_FR_2A  .........x.xxiii ......nnnnnddddd  -- SVE2 bitwise shift left long
 IF_DEF(SVE_FS_3A,   IS_NONE, NONE) // SVE_FS_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE2 integer add/subtract interleaved long
 IF_DEF(SVE_FT_2A,   IS_NONE, NONE) // SVE_FT_2A  ........xx.xxiii ......nnnnnddddd  -- SVE2 bitwise shift and insert
@@ -358,7 +350,6 @@ IF_DEF(SVE_GU_3A,   IS_NONE, NONE) // SVE_GU_3A  ...........iimmm ......nnnnnddd
 IF_DEF(SVE_GU_3B,   IS_NONE, NONE) // SVE_GU_3B  ...........immmm ......nnnnnddddd  -- SVE floating-point multiply-add (indexed)
 IF_DEF(SVE_GU_3C,   IS_NONE, NONE) // SVE_GU_3C  .........i.iimmm ......nnnnnddddd  -- SVE floating-point multiply-add (indexed)
 IF_DEF(SVE_GV_3A,   IS_NONE, NONE) // SVE_GV_3A  ...........immmm ....rrnnnnnddddd  -- SVE floating-point complex multiply-add (indexed)
-IF_DEF(SVE_GW_3A,   IS_NONE, NONE) // SVE_GW_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE FP clamp
 IF_DEF(SVE_GW_3B,   IS_NONE, NONE) // SVE_GW_3B  ...........mmmmm ......nnnnnddddd  -- SVE FP clamp
 IF_DEF(SVE_GX_3A,   IS_NONE, NONE) // SVE_GX_3A  ...........iimmm ......nnnnnddddd  -- SVE floating-point multiply (indexed)
 IF_DEF(SVE_GX_3B,   IS_NONE, NONE) // SVE_GX_3B  ...........immmm ......nnnnnddddd  -- SVE floating-point multiply (indexed)
@@ -380,7 +371,6 @@ IF_DEF(SVE_HG_2A,   IS_NONE, NONE) // SVE_HG_2A  ................ ......nnnn.ddd
 IF_DEF(SVE_HH_2A,   IS_NONE, NONE) // SVE_HH_2A  ................ ......nnnnnddddd  -- SVE2 FP8 upconverts
 IF_DEF(SVE_HI_3A,   IS_NONE, NONE) // SVE_HI_3A  ........xx...... ...gggnnnnn.DDDD  -- SVE floating-point compare with zero
 IF_DEF(SVE_HJ_3A,   IS_NONE, NONE) // SVE_HJ_3A  ........xx...... ...gggmmmmmddddd  -- SVE floating-point serial reduction (predicated)
-IF_DEF(SVE_HK_3A,   IS_NONE, NONE) // SVE_HK_3A  ........xx.mmmmm ......nnnnnddddd  -- SVE floating-point arithmetic (unpredicated)
 IF_DEF(SVE_HK_3B,   IS_NONE, NONE) // SVE_HK_3B  ...........mmmmm ......nnnnnddddd  -- SVE floating-point arithmetic (unpredicated)
 IF_DEF(SVE_HL_3A,   IS_NONE, NONE) // SVE_HL_3A  ........xx...... ...gggmmmmmddddd  -- SVE floating-point arithmetic (predicated)
 IF_DEF(SVE_HL_3B,   IS_NONE, NONE) // SVE_HL_3B  ................ ...gggmmmmmddddd  -- SVE floating-point arithmetic (predicated)

--- a/src/coreclr/jit/instrsarm64sve.h
+++ b/src/coreclr/jit/instrsarm64sve.h
@@ -239,10 +239,10 @@ INST7(ld1sw,             "ld1sw",                 0,                       IF_SV
     // LD1SW   {<Zt>.D }, <Pg>/Z, [<Xn|SP>, <Zm>.D]                                      SVE_IU_4B_B         11000101010mmmmm 100gggnnnnnttttt     C540 8000   
     // LD1SW   {<Zt>.D }, <Pg>/Z, [<Zn>.D{, #<imm>}]                                     SVE_IV_3A           11000101001iiiii 100gggnnnnnttttt     C520 8000   
 
-//    enum               name                     info                                              SVE_AA_3A        SVE_BD_3A        SVE_EE_1A        SVE_FD_3A        SVE_FD_3B        SVE_FD_3C        
+//    enum               name                     info                                              SVE_AA_3A        SVE_AT_3A        SVE_EE_1A        SVE_FD_3A        SVE_FD_3B        SVE_FD_3C        
 INST6(mul,               "mul",                   0,                       IF_SVE_6A,               0x04100000,      0x04206000,      0x2530C000,      0x4420F800,      0x44A0F800,      0x44E0F800       )
     // MUL     <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_AA_3A           00000100xx010000 000gggmmmmmddddd     0410 0000   
-    // MUL     <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BD_3A           00000100xx1mmmmm 011000nnnnnddddd     0420 6000   
+    // MUL     <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000100xx1mmmmm 011000nnnnnddddd     0420 6000   
     // MUL     <Zdn>.<T>, <Zdn>.<T>, #<imm>                                              SVE_EE_1A           00100101xx110000 110iiiiiiiiddddd     2530 C000   
     // MUL     <Zd>.H, <Zn>.H, <Zm>.H[<imm>]                                             SVE_FD_3A           010001000i1iimmm 111110nnnnnddddd     4420 F800   
     // MUL     <Zd>.S, <Zn>.S, <Zm>.S[<imm>]                                             SVE_FD_3B           01000100101iimmm 111110nnnnnddddd     44A0 F800   
@@ -364,11 +364,11 @@ INST5(lsr,               "lsr",                   RSH,                     IF_SV
     // LSR     <Zd>.<T>, <Zn>.<T>, <Zm>.D                                                SVE_BG_3A           00000100xx1mmmmm 100001nnnnnddddd     0420 8400   
 
 
-//    enum               name                     info                                              SVE_GX_3A        SVE_GX_3B        SVE_HK_3A        SVE_HL_3A        SVE_HM_2A        
+//    enum               name                     info                                              SVE_GX_3A        SVE_GX_3B        SVE_AT_3A        SVE_HL_3A        SVE_HM_2A        
 INST5(fmul,              "fmul",                  0,                       IF_SVE_5B,               0x64A02000,      0x64E02000,      0x65000800,      0x65028000,      0x651A8000       )
     // FMUL    <Zd>.S, <Zn>.S, <Zm>.S[<imm>]                                             SVE_GX_3A           01100100101iimmm 001000nnnnnddddd     64A0 2000   
     // FMUL    <Zd>.D, <Zn>.D, <Zm>.D[<imm>]                                             SVE_GX_3B           01100100111immmm 001000nnnnnddddd     64E0 2000   
-    // FMUL    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000010nnnnnddddd     6500 0800   
+    // FMUL    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000010nnnnnddddd     6500 0800   
     // FMUL    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_HL_3A           01100101xx000010 100gggmmmmmddddd     6502 8000   
     // FMUL    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <const>                                     SVE_HM_2A           01100101xx011010 100ggg0000iddddd     651A 8000   
 
@@ -443,15 +443,15 @@ INST4(fmov,              "fmov",                  0,                       IF_SV
 
 
 
-//    enum               name                     info                                              SVE_BE_3A        SVE_FI_3A        SVE_FI_3B        SVE_FI_3C        
+//    enum               name                     info                                              SVE_AT_3A        SVE_FI_3A        SVE_FI_3B        SVE_FI_3C        
 INST4(sqdmulh,           "sqdmulh",               0,                       IF_SVE_4E,               0x04207000,      0x4420F000,      0x44A0F000,      0x44E0F000       )
-    // SQDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BE_3A           00000100xx1mmmmm 011100nnnnnddddd     0420 7000   
+    // SQDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000100xx1mmmmm 011100nnnnnddddd     0420 7000   
     // SQDMULH <Zd>.H, <Zn>.H, <Zm>.H[<imm>]                                             SVE_FI_3A           010001000i1iimmm 111100nnnnnddddd     4420 F000   
     // SQDMULH <Zd>.S, <Zn>.S, <Zm>.S[<imm>]                                             SVE_FI_3B           01000100101iimmm 111100nnnnnddddd     44A0 F000   
     // SQDMULH <Zd>.D, <Zn>.D, <Zm>.D[<imm>]                                             SVE_FI_3C           01000100111immmm 111100nnnnnddddd     44E0 F000   
 
 INST4(sqrdmulh,          "sqrdmulh",              0,                       IF_SVE_4E,               0x04207400,      0x4420F400,      0x44A0F400,      0x44E0F400       )
-    // SQRDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                             SVE_BE_3A           00000100xx1mmmmm 011101nnnnnddddd     0420 7400   
+    // SQRDMULH <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                             SVE_AT_3A           00000100xx1mmmmm 011101nnnnnddddd     0420 7400   
     // SQRDMULH <Zd>.H, <Zn>.H, <Zm>.H[<imm>]                                            SVE_FI_3A           010001000i1iimmm 111101nnnnnddddd     4420 F400   
     // SQRDMULH <Zd>.S, <Zn>.S, <Zm>.S[<imm>]                                            SVE_FI_3B           01000100101iimmm 111101nnnnnddddd     44A0 F400   
     // SQRDMULH <Zd>.D, <Zn>.D, <Zm>.D[<imm>]                                            SVE_FI_3C           01000100111immmm 111101nnnnnddddd     44E0 F400   
@@ -581,34 +581,34 @@ INST3(dup,               "dup",                   0,                       IF_SV
     // DUP     <Zd>.<T>, #<imm>{, <shift>}                                               SVE_EB_1A           00100101xx111000 11hiiiiiiiiddddd     2538 C000   
 
 
-//    enum               name                     info                                              SVE_BR_3A        SVE_BR_3B        SVE_CI_3A        
+//    enum               name                     info                                              SVE_AT_3A        SVE_BR_3B        SVE_CI_3A        
 INST3(trn1,              "trn1",                  0,                       IF_SVE_3D,               0x05207000,      0x05A01800,      0x05205000       )
-    // TRN1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011100nnnnnddddd     0520 7000   
+    // TRN1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011100nnnnnddddd     0520 7000   
     // TRN1    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000110nnnnnddddd     05A0 1800   
     // TRN1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0101000NNNN0DDDD     0520 5000   
 
 INST3(trn2,              "trn2",                  0,                       IF_SVE_3D,               0x05207400,      0x05A01C00,      0x05205400       )
-    // TRN2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011101nnnnnddddd     0520 7400   
+    // TRN2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011101nnnnnddddd     0520 7400   
     // TRN2    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000111nnnnnddddd     05A0 1C00   
     // TRN2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0101010NNNN0DDDD     0520 5400   
 
 INST3(uzp1,              "uzp1",                  0,                       IF_SVE_3D,               0x05206800,      0x05A00800,      0x05204800       )
-    // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011010nnnnnddddd     0520 6800   
+    // UZP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011010nnnnnddddd     0520 6800   
     // UZP1    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000010nnnnnddddd     05A0 0800   
     // UZP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0100100NNNN0DDDD     0520 4800   
 
 INST3(uzp2,              "uzp2",                  0,                       IF_SVE_3D,               0x05206C00,      0x05A00C00,      0x05204C00       )
-    // UZP2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011011nnnnnddddd     0520 6C00   
+    // UZP2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011011nnnnnddddd     0520 6C00   
     // UZP2    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000011nnnnnddddd     05A0 0C00   
     // UZP2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0100110NNNN0DDDD     0520 4C00   
 
 INST3(zip1,              "zip1",                  0,                       IF_SVE_3D,               0x05206000,      0x05A00000,      0x05204000       )
-    // ZIP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011000nnnnnddddd     0520 6000   
+    // ZIP1    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011000nnnnnddddd     0520 6000   
     // ZIP1    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000000nnnnnddddd     05A0 0000   
     // ZIP1    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0100000NNNN0DDDD     0520 4000   
 
 INST3(zip2,              "zip2",                  0,                       IF_SVE_3D,               0x05206400,      0x05A00400,      0x05204400       )
-    // ZIP2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BR_3A           00000101xx1mmmmm 011001nnnnnddddd     0520 6400   
+    // ZIP2    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 011001nnnnnddddd     0520 6400   
     // ZIP2    <Zd>.Q, <Zn>.Q, <Zm>.Q                                                    SVE_BR_3B           00000101101mmmmm 000001nnnnnddddd     05A0 0400   
     // ZIP2    <Pd>.<T>, <Pn>.<T>, <Pm>.<T>                                              SVE_CI_3A           00000101xx10MMMM 0100010NNNN0DDDD     0520 4400   
 
@@ -654,14 +654,14 @@ INST3(luti4,             "luti4",                 0,                       IF_SV
     // LUTI4   <Zd>.H, {<Zn>.H }, <Zm>[<index>]                                          SVE_GH_3B_B         01000101ii1mmmmm 101111nnnnnddddd     4520 BC00   
 
 
-//    enum               name                     info                                              SVE_HK_3A        SVE_HL_3A        SVE_HM_2A        
+//    enum               name                     info                                              SVE_AT_3A        SVE_HL_3A        SVE_HM_2A        
 INST3(fadd,              "fadd",                  0,                       IF_SVE_3H,               0x65000000,      0x65008000,      0x65188000       )
-    // FADD    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000000nnnnnddddd     6500 0000   
+    // FADD    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000000nnnnnddddd     6500 0000   
     // FADD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_HL_3A           01100101xx000000 100gggmmmmmddddd     6500 8000   
     // FADD    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <const>                                     SVE_HM_2A           01100101xx011000 100ggg0000iddddd     6518 8000   
 
 INST3(fsub,              "fsub",                  0,                       IF_SVE_3H,               0x65000400,      0x65018000,      0x65198000       )
-    // FSUB    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000001nnnnnddddd     6500 0400   
+    // FSUB    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000001nnnnnddddd     6500 0400   
     // FSUB    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_HL_3A           01100101xx000001 100gggmmmmmddddd     6501 8000   
     // FSUB    <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <const>                                     SVE_HM_2A           01100101xx011001 100ggg0000iddddd     6519 8000   
 
@@ -960,14 +960,14 @@ INST2(rev,               "rev",                   0,                       IF_SV
     // REV     <Pd>.<T>, <Pn>.<T>                                                        SVE_CJ_2A           00000101xx110100 0100000NNNN0DDDD     0534 4000   
 
 
-//    enum               name                     info                                              SVE_AA_3A        SVE_BD_3A                   
+//    enum               name                     info                                              SVE_AA_3A        SVE_AT_3A                   
 INST2(smulh,             "smulh",                 0,                       IF_SVE_2AF,              0x04120000,      0x04206800                  )
     // SMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_AA_3A           00000100xx010010 000gggmmmmmddddd     0412 0000   
-    // SMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BD_3A           00000100xx1mmmmm 011010nnnnnddddd     0420 6800   
+    // SMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000100xx1mmmmm 011010nnnnnddddd     0420 6800   
 
 INST2(umulh,             "umulh",                 0,                       IF_SVE_2AF,              0x04130000,      0x04206C00                  )
     // UMULH   <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_AA_3A           00000100xx010011 000gggmmmmmddddd     0413 0000   
-    // UMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BD_3A           00000100xx1mmmmm 011011nnnnnddddd     0420 6C00   
+    // UMULH   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000100xx1mmmmm 011011nnnnnddddd     0420 6C00   
 
 
 //    enum               name                     info                                              SVE_BS_1A        SVE_CZ_4A                   
@@ -1780,15 +1780,15 @@ INST1(fscale,            "fscale",                0,                       IF_SV
     // FSCALE  <Zdn>.<T>, <Pg>/M, <Zdn>.<T>, <Zm>.<T>                                    SVE_HL_3A           01100101xx001001 100gggmmmmmddddd     6509 8000   
 
 
-//    enum               name                     info                                              SVE_HK_3A                                    
-INST1(frecps,            "frecps",                0,                       IF_SVE_HK_3A,            0x65001800                                   )
-    // FRECPS  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000110nnnnnddddd     6500 1800   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(frecps,            "frecps",                0,                       IF_SVE_AT_3A,            0x65001800                                   )
+    // FRECPS  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000110nnnnnddddd     6500 1800   
 
-INST1(frsqrts,           "frsqrts",               0,                       IF_SVE_HK_3A,            0x65001C00                                   )
-    // FRSQRTS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000111nnnnnddddd     6500 1C00   
+INST1(frsqrts,           "frsqrts",               0,                       IF_SVE_AT_3A,            0x65001C00                                   )
+    // FRSQRTS <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000111nnnnnddddd     6500 1C00   
 
-INST1(ftsmul,            "ftsmul",                0,                       IF_SVE_HK_3A,            0x65000C00                                   )
-    // FTSMUL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_HK_3A           01100101xx0mmmmm 000011nnnnnddddd     6500 0C00   
+INST1(ftsmul,            "ftsmul",                0,                       IF_SVE_AT_3A,            0x65000C00                                   )
+    // FTSMUL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100101xx0mmmmm 000011nnnnnddddd     6500 0C00   
 
 //    enum               name                     info                                              SVE_HT_4A                                    
 INST1(facge,             "facge",                 0,                       IF_SVE_HT_4A,            0x6500C010                                   )
@@ -2109,9 +2109,9 @@ INST1(fexpa,             "fexpa",                 0,                       IF_SV
     // FEXPA   <Zd>.<T>, <Zn>.<T>                                                        SVE_BJ_2A           00000100xx100000 101110nnnnnddddd     0420 B800   
 
 
-//    enum               name                     info                                              SVE_BK_3A                                    
-INST1(ftssel,            "ftssel",                0,                       IF_SVE_BK_3A,            0x0420B000                                   )
-    // FTSSEL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_BK_3A           00000100xx1mmmmm 101100nnnnnddddd     0420 B000   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(ftssel,            "ftssel",                0,                       IF_SVE_AT_3A,            0x0420B000                                   )
+    // FTSSEL  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000100xx1mmmmm 101100nnnnnddddd     0420 B000   
 
 
 //    enum               name                     info                                              SVE_BL_1A                                    
@@ -2170,9 +2170,9 @@ INST1(extq,              "extq",                  0,                       IF_SV
     // EXTQ    <Zdn>.B, <Zdn>.B, <Zm>.B, #<imm>                                          SVE_BY_2A           000001010110iiii 001001mmmmmddddd     0560 2400   
 
 
-//    enum               name                     info                                              SVE_CA_3A                                    
-INST1(tbxq,              "tbxq",                  0,                       IF_SVE_CA_3A,            0x05203400                                   )
-    // TBXQ    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_CA_3A           00000101xx1mmmmm 001101nnnnnddddd     0520 3400   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(tbxq,              "tbxq",                  0,                       IF_SVE_AT_3A,            0x05203400                                   )
+    // TBXQ    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           00000101xx1mmmmm 001101nnnnnddddd     0520 3400   
 
 
 //    enum               name                     info                                              SVE_CH_2A                                    
@@ -2319,12 +2319,12 @@ INST1(sqdmlslbt,         "sqdmlslbt",             0,                       IF_SV
     // SQDMLSLBT <Zda>.<T>, <Zn>.<Tb>, <Zm>.<Tb>                                         SVE_EN_3A           01000100xx0mmmmm 000011nnnnnddddd     4400 0C00   
 
 
-//    enum               name                     info                                              SVE_EV_3A                                    
-INST1(sclamp,            "sclamp",                0,                       IF_SVE_EV_3A,            0x4400C000                                   )
-    // SCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_EV_3A           01000100xx0mmmmm 110000nnnnnddddd     4400 C000   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(sclamp,            "sclamp",                0,                       IF_SVE_AT_3A,            0x4400C000                                   )
+    // SCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000100xx0mmmmm 110000nnnnnddddd     4400 C000   
 
-INST1(uclamp,            "uclamp",                0,                       IF_SVE_EV_3A,            0x4400C400                                   )
-    // UCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_EV_3A           01000100xx0mmmmm 110001nnnnnddddd     4400 C400   
+INST1(uclamp,            "uclamp",                0,                       IF_SVE_AT_3A,            0x4400C400                                   )
+    // UCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000100xx0mmmmm 110001nnnnnddddd     4400 C400   
 
 
 //    enum               name                     info                                              SVE_EW_3A                                    
@@ -2418,23 +2418,23 @@ INST1(usubwt,            "usubwt",                0,                       IF_SV
     // USUBWT  <Zd>.<T>, <Zn>.<T>, <Zm>.<Tb>                                             SVE_FM_3A           01000101xx0mmmmm 010111nnnnnddddd     4500 5C00   
 
 
-//    enum               name                     info                                              SVE_FP_3A                                    
-INST1(eorbt,             "eorbt",                 0,                       IF_SVE_FP_3A,            0x45009000                                   )
-    // EORBT   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_FP_3A           01000101xx0mmmmm 100100nnnnnddddd     4500 9000   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(eorbt,             "eorbt",                 0,                       IF_SVE_AT_3A,            0x45009000                                   )
+    // EORBT   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000101xx0mmmmm 100100nnnnnddddd     4500 9000   
 
-INST1(eortb,             "eortb",                 0,                       IF_SVE_FP_3A,            0x45009400                                   )
-    // EORTB   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_FP_3A           01000101xx0mmmmm 100101nnnnnddddd     4500 9400   
+INST1(eortb,             "eortb",                 0,                       IF_SVE_AT_3A,            0x45009400                                   )
+    // EORTB   <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000101xx0mmmmm 100101nnnnnddddd     4500 9400   
 
 
-//    enum               name                     info                                              SVE_FQ_3A                                    
-INST1(bdep,              "bdep",                  0,                       IF_SVE_FQ_3A,            0x4500B400                                   )
-    // BDEP    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_FQ_3A           01000101xx0mmmmm 101101nnnnnddddd     4500 B400   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(bdep,              "bdep",                  0,                       IF_SVE_AT_3A,            0x4500B400                                   )
+    // BDEP    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000101xx0mmmmm 101101nnnnnddddd     4500 B400   
 
-INST1(bext,              "bext",                  0,                       IF_SVE_FQ_3A,            0x4500B000                                   )
-    // BEXT    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_FQ_3A           01000101xx0mmmmm 101100nnnnnddddd     4500 B000   
+INST1(bext,              "bext",                  0,                       IF_SVE_AT_3A,            0x4500B000                                   )
+    // BEXT    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000101xx0mmmmm 101100nnnnnddddd     4500 B000   
 
-INST1(bgrp,              "bgrp",                  0,                       IF_SVE_FQ_3A,            0x4500B800                                   )
-    // BGRP    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_FQ_3A           01000101xx0mmmmm 101110nnnnnddddd     4500 B800   
+INST1(bgrp,              "bgrp",                  0,                       IF_SVE_AT_3A,            0x4500B800                                   )
+    // BGRP    <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01000101xx0mmmmm 101110nnnnnddddd     4500 B800   
 
 
 //    enum               name                     info                                              SVE_FR_2A                                    
@@ -2651,9 +2651,9 @@ INST1(fminqv,            "fminqv",                0,                       IF_SV
     // FMINQV  <Vd>.<T>, <Pg>, <Zn>.<Tb>                                                 SVE_GS_3A           01100100xx010111 101gggnnnnnddddd     6417 A000   
 
 
-//    enum               name                     info                                              SVE_GW_3A                                    
-INST1(fclamp,            "fclamp",                0,                       IF_SVE_GW_3A,            0x64202400                                   )
-    // FCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_GW_3A           01100100xx1mmmmm 001001nnnnnddddd     6420 2400   
+//    enum               name                     info                                              SVE_AT_3A                                    
+INST1(fclamp,            "fclamp",                0,                       IF_SVE_AT_3A,            0x64202400                                   )
+    // FCLAMP  <Zd>.<T>, <Zn>.<T>, <Zm>.<T>                                              SVE_AT_3A           01100100xx1mmmmm 001001nnnnnddddd     6420 2400   
 
 
 //    enum               name                     info                                              SVE_GW_3B                                    


### PR DESCRIPTION
Merging these formats together into `SVE_AT_3A`.
```
case IF_SVE_AT_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer add/subtract vectors (unpredicated) + SVE2 integer multiply vectors (unpredicated) + SVE2 signed saturating doubling multiply high (unpredicated) + SVE floating-point trig select coefficient + SVE permute vector segments + sve_int_perm_tbxquads + SVE integer clamp + SVE2 bitwise exclusive-or interleaved + SVE2 bitwise permute + SVE FP clamp + SVE floating-point arithmetic (unpredicated)
        case IF_SVE_BD_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 integer multiply vectors (unpredicated)
        case IF_SVE_BE_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 signed saturating doubling multiply high
                             // (unpredicated)
        case IF_SVE_BK_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point trig select coefficient
        case IF_SVE_BR_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE permute vector segments
        case IF_SVE_CA_3A:   // ........xx.mmmmm ......nnnnnddddd -- sve_int_perm_tbxquads
        case IF_SVE_EV_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE integer clamp
        case IF_SVE_FP_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise exclusive-or interleaved
        case IF_SVE_FQ_3A:   // ........xx.mmmmm ......nnnnnddddd -- SVE2 bitwise permute
        case IF_SVE_GW_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE FP clamp
        case IF_SVE_HK_3A: // ........xx.mmmmm ......nnnnnddddd -- SVE floating-point arithmetic (unpredicated)
```