### PR TITLE
WIP: Allow supplying a Regex object to a RegularExpressionAttribute

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -28,12 +28,12 @@ namespace System.ComponentModel.DataAnnotations
         /// <summary>
         ///     Constructor that accepts the regular expression pattern
         /// </summary>
-        /// <param name="pattern">The regular expression to use.  It cannot be null.</param>
-        public RegularExpressionAttribute(Regex pattern)
+        /// <param name="regex">The regular expression to use.  It cannot be null.</param>
+        public RegularExpressionAttribute(Regex regex)
             : base(() => SR.RegexAttribute_ValidationError)
         {
-            Regex = pattern;
-            Pattern = pattern.ToString();
+            Regex = regex;
+            Pattern = regex.ToString();
             MatchTimeoutInMilliseconds = 2000;
         }
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -26,6 +26,18 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         /// <summary>
+        ///     Constructor that accepts the regular expression pattern
+        /// </summary>
+        /// <param name="pattern">The regular expression to use.  It cannot be null.</param>
+        public RegularExpressionAttribute(Regex pattern)
+            : base(() => SR.RegexAttribute_ValidationError)
+        {
+            Regex = pattern;
+            Pattern = pattern.ToString();
+            MatchTimeoutInMilliseconds = 2000;
+        }
+
+        /// <summary>
         ///     Gets or sets the timeout to use when matching the regular expression pattern (in milliseconds)
         ///     (-1 means never timeout).
         /// </summary>

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
@@ -9,6 +9,36 @@ namespace System.ComponentModel.DataAnnotations.Tests
 {
     public sealed partial class RegularExpressionAttributeTests : ValidationAttributeTestBase
     {
+        [GeneratedRegex("SomePattern")]
+        private static partial Regex SomePatternRegex();
+
+        [GeneratedRegex("defghi")]
+        private static partial Regex DefghiRegex();
+
+        [GeneratedRegex("[^a]+\\.[^z]+")]
+        private static partial Regex SlowRegex();
+
+        [GeneratedRegex("abc")]
+        private static partial Regex AbcRegex();
+
+        [GeneratedRegex("1")]
+        private static partial Regex OneRegex();
+
+        [GeneratedRegex("def")]
+        private static partial Regex DefRegex();
+
+        [GeneratedRegex("2")]
+        private static partial Regex TwoRegex();
+
+        [GeneratedRegex("foo(?<1bar)")]
+        private static partial Regex FooBarRegex();
+
+        [GeneratedRegex("")]
+        private static partial Regex EmptyRegex();
+
+        [GeneratedRegex("(a[ab]+)+$")]
+        private static partial Regex EvenSlowerRegex();
+
         protected override IEnumerable<TestCase> ValidValues()
         {
             yield return new TestCase(new RegularExpressionAttribute("SomePattern"), null);
@@ -19,6 +49,15 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new RegularExpressionAttribute("abc"), new ClassWithValidToString());
             yield return new TestCase(new RegularExpressionAttribute("1"), 1);
             yield return new TestCase(new RegularExpressionAttribute("abc"), new IFormattableImplementor());
+
+            yield return new TestCase(new RegularExpressionAttribute(SomePatternRegex()), null);
+            yield return new TestCase(new RegularExpressionAttribute(SomePatternRegex()) { MatchTimeoutInMilliseconds = -1 }, string.Empty);
+            yield return new TestCase(new RegularExpressionAttribute(DefghiRegex()) { MatchTimeoutInMilliseconds = 5000 }, "defghi");
+            yield return new TestCase(new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = 10000 }, "bcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxy");
+
+            yield return new TestCase(new RegularExpressionAttribute(AbcRegex()), new ClassWithValidToString());
+            yield return new TestCase(new RegularExpressionAttribute(OneRegex()), 1);
+            yield return new TestCase(new RegularExpressionAttribute(AbcRegex()), new IFormattableImplementor());
         }
 
         protected override IEnumerable<TestCase> InvalidValues()
@@ -35,6 +74,19 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new RegularExpressionAttribute("def"), new ClassWithValidToString());
             yield return new TestCase(new RegularExpressionAttribute("2"), 1);
             yield return new TestCase(new RegularExpressionAttribute("def"), new IFormattableImplementor());
+
+            yield return new TestCase(new RegularExpressionAttribute(DefghiRegex()), "zyxwvu");
+            yield return new TestCase(new RegularExpressionAttribute(DefghiRegex()), "defghijkl");
+            yield return new TestCase(new RegularExpressionAttribute(DefghiRegex()), "abcdefghi");
+            yield return new TestCase(new RegularExpressionAttribute(DefghiRegex()), "abcdefghijkl");
+            yield return new TestCase(new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = 10000 }, "aaaaa");
+            yield return new TestCase(new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = 10000 }, "zzzzz");
+            yield return new TestCase(new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = 10000 }, "b.z");
+            yield return new TestCase(new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = 10000 }, "a.y");
+
+            yield return new TestCase(new RegularExpressionAttribute(DefRegex()), new ClassWithValidToString());
+            yield return new TestCase(new RegularExpressionAttribute(TwoRegex()), 1);
+            yield return new TestCase(new RegularExpressionAttribute(DefRegex()), new IFormattableImplementor());
         }
 
         [Theory]
@@ -44,6 +96,15 @@ namespace System.ComponentModel.DataAnnotations.Tests
         {
             var attribute = new RegularExpressionAttribute(pattern);
             Assert.Equal(pattern, attribute.Pattern);
+        }
+
+        [Theory]
+        [InlineData(SomePatternRegex())]
+        [InlineData(FooBarRegex())]
+        public static void Ctor_Regex(Regex pattern)
+        {
+            var attribute = new RegularExpressionAttribute(pattern);
+            Assert.Equal(pattern.toString(), attribute.Pattern);
         }
 
         [Theory]
@@ -59,7 +120,16 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public static void Validate_InvalidPattern_ThrowsInvalidOperationException(string pattern)
+        public static void Validate_InvalidPattern_ThrowsInvalidOperationException_String(string pattern)
+        {
+            var attribute = new RegularExpressionAttribute(pattern);
+            Assert.Throws<InvalidOperationException>(() => attribute.Validate("Any", new ValidationContext(new object())));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(EmptyRegex())]
+        public static void Validate_InvalidPattern_ThrowsInvalidOperationException_Regex(Regex pattern)
         {
             var attribute = new RegularExpressionAttribute(pattern);
             Assert.Throws<InvalidOperationException>(() => attribute.Validate("Any", new ValidationContext(new object())));
@@ -68,23 +138,47 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Theory]
         [InlineData(0)]
         [InlineData(-2)]
-        public static void Validate_InvalidMatchTimeoutInMilliseconds_ThrowsArgumentOutOfRangeException(int timeout)
+        public static void Validate_InvalidMatchTimeoutInMilliseconds_ThrowsArgumentOutOfRangeException_String(int timeout)
         {
             RegularExpressionAttribute attribute = new RegularExpressionAttribute("[^a]+\\.[^z]+") { MatchTimeoutInMilliseconds = timeout };
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => attribute.Validate("a", new ValidationContext(new object())));
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-2)]
+        public static void Validate_InvalidMatchTimeoutInMilliseconds_ThrowsArgumentOutOfRangeException_Regex(int timeout)
+        {
+            RegularExpressionAttribute attribute = new RegularExpressionAttribute(SlowRegex()) { MatchTimeoutInMilliseconds = timeout };
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => attribute.Validate("a", new ValidationContext(new object())));
+        }
+
+
         [Fact]
-        public static void Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException()
+        public static void Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException_String()
         {
             RegularExpressionAttribute attribute = new RegularExpressionAttribute("(a[ab]+)+$") { MatchTimeoutInMilliseconds = 1 };
             Assert.Throws<RegexMatchTimeoutException>(() => attribute.Validate("aaaaaaaaaaaaaaaaaaaaaaaaaaaa>", new ValidationContext(new object())));
         }
 
         [Fact]
-        public static void Validate_InvalidPattern_ThrowsArgumentException()
+        public static void Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException_Regex()
+        {
+            RegularExpressionAttribute attribute = new RegularExpressionAttribute(EvenSlowerRegex()) { MatchTimeoutInMilliseconds = 1 };
+            Assert.Throws<RegexMatchTimeoutException>(() => attribute.Validate("aaaaaaaaaaaaaaaaaaaaaaaaaaaa>", new ValidationContext(new object())));
+        }
+
+        [Fact]
+        public static void Validate_InvalidPattern_ThrowsArgumentException_String()
         {
             RegularExpressionAttribute attribute = new RegularExpressionAttribute("foo(?<1bar)");
+            Assert.ThrowsAny<ArgumentException>(() => attribute.Validate("Any", new ValidationContext(new object())));
+        }
+
+        [Fact]
+        public static void Validate_InvalidPattern_ThrowsArgumentException_Regex()
+        {
+            RegularExpressionAttribute attribute = new RegularExpressionAttribute(FooBarRegex());
             Assert.ThrowsAny<ArgumentException>(() => attribute.Validate("Any", new ValidationContext(new object())));
         }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/101965

TODO:
* [ ] Apply MatchTimeoutInMilliseconds to the Regex object?