### PR TITLE
[wasm] Where possible, use ReadableStream.pipeTo to load files into the heap

### DIFF
--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -478,7 +478,7 @@ async function start_asset_download_with_throttle (asset: AssetEntryInternal): P
             ("body" in response) && response.body && // in some cases response.body can be missing or null
             asset.knownLength
         ) {
-            asset.stream = [response.body!, asset.knownLength];
+            asset.stream = response.body!;
         } else {
             if ((asset.behavior !== "vfs") && ENVIRONMENT_IS_WEB)
                 mono_log_warn(`Could not stream resource ${asset.resolvedUrl} with length ${asset.knownLength} and behavior ${asset.behavior}.`);

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -482,7 +482,7 @@ async function start_asset_download_with_throttle (asset: AssetEntryInternal): P
         ) {
             asset.stream = [response.body!, asset.knownLength];
         } else {
-            if (asset.behavior !== "vfs")
+            if ((asset.behavior !== "vfs") && ENVIRONMENT_IS_WEB)
                 mono_log_warn(`Could not stream resource ${asset.resolvedUrl} with length ${asset.knownLength} and behavior ${asset.behavior}.`);
             asset.buffer = await response.arrayBuffer();
         }

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -284,6 +284,14 @@ export interface AssetEntry {
     buffer?: ArrayBuffer | Promise<ArrayBuffer>,
 
     /**
+     * If provided, fetch was configured to provide a stream instead of a byte array
+     *  to optimize out overhead from asking the browser to create a buffer we will
+     *  then have to copy into the heap. We will read from this stream directly into
+     *  WebAssembly memory.
+     */
+    stream?: [ReadableStream, number] | Promise<[ReadableStream, number]>,
+
+    /**
      * If provided, runtime doesn't have to import it's JavaScript modules.
      * This will not work for multi-threaded runtime.
      */

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -217,6 +217,8 @@ export interface ResourceGroups {
 
     extensions?: ResourceExtensions
     vfs?: { [virtualPath: string]: ResourceList };
+
+    knownLengths?: { [name: string]: number };
 }
 
 /**
@@ -276,7 +278,11 @@ export interface AssetEntry {
     /**
      * If true, the runtime startup would not fail if the asset download was not successful.
      */
-    isOptional?: boolean
+    isOptional?: boolean,
+    /**
+     * If set, enables the runtime to stream the asset into memory as it downloads.
+     */
+    knownLength?: number,
     /**
      * If provided, runtime doesn't have to fetch the data.
      * Runtime would set the buffer to null after instantiation to free the memory.

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -293,9 +293,9 @@ export interface AssetEntry {
      * If provided, fetch was configured to provide a stream instead of a byte array
      *  to optimize out overhead from asking the browser to create a buffer we will
      *  then have to copy into the heap. We will read from this stream directly into
-     *  WebAssembly memory.
+     *  WebAssembly memory. knownLength must be set.
      */
-    stream?: [ReadableStream, number] | Promise<[ReadableStream, number]>,
+    stream?: ReadableStream | Promise<ReadableStream>,
 
     /**
      * If provided, runtime doesn't have to import it's JavaScript modules.

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -231,7 +231,7 @@ export type RuntimeHelpers = {
 
     //core
     stringify_as_error_with_stack?: (error: any) => string,
-    instantiate_asset: (asset: AssetEntry, url: string, bytesOrStream: Uint8Array | [ReadableStream, number]) => Promise<void>,
+    instantiate_asset: (asset: AssetEntry, url: string, bytesOrStream: Uint8Array | ReadableStream) => Promise<void>,
     instantiate_symbols_asset: (pendingAsset: AssetEntryInternal) => Promise<void>,
     instantiate_segmentation_rules_asset: (pendingAsset: AssetEntryInternal) => Promise<void>,
     jiterpreter_dump_stats?: (concise?: boolean) => void,

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -231,7 +231,7 @@ export type RuntimeHelpers = {
 
     //core
     stringify_as_error_with_stack?: (error: any) => string,
-    instantiate_asset: (asset: AssetEntry, url: string, bytes: Uint8Array) => void,
+    instantiate_asset: (asset: AssetEntry, url: string, bytesOrStream: Uint8Array | [ReadableStream, number]) => Promise<void>,
     instantiate_symbols_asset: (pendingAsset: AssetEntryInternal) => Promise<void>,
     instantiate_segmentation_rules_asset: (pendingAsset: AssetEntryInternal) => Promise<void>,
     jiterpreter_dump_stats?: (concise?: boolean) => void,

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -206,6 +206,9 @@ public class ResourcesData
 
     [DataMember(EmitDefaultValue = false)]
     public List<string> remoteSources { get; set; }
+
+    [DataMember(EmitDefaultValue = false)]
+    public Dictionary<string, long> knownLengths { get; set; }
 }
 
 public enum GlobalizationMode : int
@@ -247,4 +250,7 @@ public class AdditionalAsset
 
     [DataMember(Name = "behavior")]
     public string behavior { get; set; }
+
+    [DataMember(Name = "knownLength")]
+    public long knownLength { get; set; }
 }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/GenerateWasmBootJson.cs
@@ -391,6 +391,9 @@ public class GenerateWasmBootJson : Task
             {
                 Log.LogMessage(MessageImportance.Low, "Added resource '{0}' to the manifest.", resource.ItemSpec);
                 resourceList.Add(resourceKey, $"sha256-{resource.GetMetadata("FileHash")}");
+                long knownLength = new FileInfo(resource.GetMetadata("FullPath")).Length;
+                result.resources.knownLengths ??= new Dictionary<string, long>();
+                result.resources.knownLengths[resourceKey] = knownLength;
             }
         }
     }
@@ -433,7 +436,10 @@ public class GenerateWasmBootJson : Task
             additionalResources.Add(resourceName, new AdditionalAsset
             {
                 hash = $"sha256-{resource.GetMetadata("FileHash")}",
-                behavior = behavior
+                behavior = behavior,
+                knownLength = File.Exists(resource.ItemSpec)
+                    ? (new FileInfo(resource.ItemSpec)).Length
+                    : 0
             });
         }
     }

--- a/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/src/tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -93,6 +93,13 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
         return GlobalizationMode.Sharded;
     }
 
+    private static void RecordLength (BootJsonData bootConfig, string name, string fullPath)
+    {
+        var fi = new FileInfo(fullPath);
+        bootConfig.resources.knownLengths ??= new Dictionary<string, long>();
+        bootConfig.resources.knownLengths[name] = fi.Length;
+    }
+
     protected override bool ExecuteInternal()
     {
         var helper = new BootJsonBuilderHelper(Log);
@@ -179,6 +186,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
             Dictionary<string, string>? resourceList = helper.GetNativeResourceTargetInBootConfig(bootConfig, name);
             if (resourceList != null)
                 resourceList[name] = itemHash;
+            RecordLength(bootConfig, name, dest);
         }
 
         string packageJsonPath = Path.Combine(AppDir, "package.json");
@@ -207,6 +215,7 @@ public class WasmAppBuilder : WasmAppBuilderBaseTask
                 }
 
                 bootConfig.resources.assembly[Path.GetFileName(assemblyPath)] = Utils.ComputeIntegrity(bytes);
+                RecordLength(bootConfig, Path.GetFileName(assemblyPath), assemblyPath);
                 if (DebugLevel != 0)
                 {
                     var pdb = Path.ChangeExtension(assembly, ".pdb");


### PR DESCRIPTION
In profiles, we spend a sizable amount of CPU time during startup inside of the implementation of `Response.arrayBuffer()`. This PR switches to semi-asynchronously loading chunks of the response into our heap. Sadly zero-copy transfers aren't possible due to the design of the Streams API, but based on profiling of local browser-bench tests, this stream-based approach is faster. I can't be certain without someone else running measurements though, measurements are unstable on my hardware and browser-bench spends a lot of time at random points in GC.