### PR TITLE
[cdac] Read types from contract descriptor

### DIFF
--- a/src/coreclr/debug/runtimeinfo/contracts.jsonc
+++ b/src/coreclr/debug/runtimeinfo/contracts.jsonc
@@ -9,6 +9,7 @@
 // cdac-build-tool can take multiple "-c contract_file" arguments
 // so to conditionally include contracts, put additional contracts in a separate file
 {
+  "Thread": 1,
   "SOSBreakingChangeVersion": 1 // example contract: "runtime exports an SOS breaking change version global"
 }
 

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -103,11 +103,17 @@
 CDAC_BASELINE("empty")
 CDAC_TYPES_BEGIN()
 
-CDAC_TYPE_BEGIN(ManagedThread)
-CDAC_TYPE_INDETERMINATE(ManagedThread)
-CDAC_TYPE_FIELD(ManagedThread, GCHandle, GCHandle, cdac_offsets<Thread>::ExposedObject)
-CDAC_TYPE_FIELD(ManagedThread, pointer, LinkNext, cdac_offsets<Thread>::Link)
-CDAC_TYPE_END(ManagedThread)
+CDAC_TYPE_BEGIN(Thread)
+CDAC_TYPE_INDETERMINATE(Thread)
+CDAC_TYPE_FIELD(Thread, GCHandle, GCHandle, cdac_offsets<Thread>::ExposedObject)
+CDAC_TYPE_FIELD(Thread, pointer, LinkNext, cdac_offsets<Thread>::Link)
+CDAC_TYPE_END(Thread)
+
+CDAC_TYPE_BEGIN(ThreadStore)
+CDAC_TYPE_INDETERMINATE(ThreadStore)
+CDAC_TYPE_FIELD(ThreadStore, /*omit type*/, ThreadCount, cdac_offsets<ThreadStore>::ThreadCount)
+CDAC_TYPE_FIELD(ThreadStore, /*omit type*/, ThreadList, cdac_offsets<ThreadStore>::ThreadList)
+CDAC_TYPE_END(ThreadStore)
 
 CDAC_TYPE_BEGIN(GCHandle)
 CDAC_TYPE_SIZE(sizeof(OBJECTHANDLE))
@@ -116,7 +122,7 @@ CDAC_TYPE_END(GCHandle)
 CDAC_TYPES_END()
 
 CDAC_GLOBALS_BEGIN()
-CDAC_GLOBAL_POINTER(ManagedThreadStore, &ThreadStore::s_pThreadStore)
+CDAC_GLOBAL_POINTER(ThreadStore, &ThreadStore::s_pThreadStore)
 #if FEATURE_EH_FUNCLETS
 CDAC_GLOBAL(FeatureEHFunclets, uint8, 1)
 #else

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4335,6 +4335,15 @@ public:
     void OnMaxGenerationGCStarted();
     bool ShouldTriggerGCForDeadThreads();
     void TriggerGCForDeadThreadsIfNecessary();
+
+    template<typename T> friend struct ::cdac_offsets;
+};
+
+template<>
+struct cdac_offsets<ThreadStore>
+{
+    static constexpr size_t ThreadList = offsetof(ThreadStore, m_ThreadList);
+    static constexpr size_t ThreadCount = offsetof(ThreadStore, m_ThreadCount);
 };
 
 struct TSSuspendHelper {

--- a/src/native/managed/cdacreader/src/Constants.cs
+++ b/src/native/managed/cdacreader/src/Constants.cs
@@ -8,6 +8,7 @@ internal static class Constants
     internal static class Globals
     {
         // See src/coreclr/debug/runtimeinfo/datadescriptor.h
+        internal const string ThreadStore = nameof(ThreadStore);
         internal const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
     }
 }

--- a/src/native/managed/cdacreader/src/Contracts/IContract.cs
+++ b/src/native/managed/cdacreader/src/Contracts/IContract.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal interface IContract
+{
+    static virtual IContract Create(Target target) => throw new NotImplementedException();
+}

--- a/src/native/managed/cdacreader/src/Contracts/IContract.cs
+++ b/src/native/managed/cdacreader/src/Contracts/IContract.cs
@@ -7,5 +7,6 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 internal interface IContract
 {
-    static virtual IContract Create(Target target) => throw new NotImplementedException();
+    static virtual string Name => throw new NotImplementedException();
+    static virtual IContract Create(Target target, int version) => throw new NotImplementedException();
 }

--- a/src/native/managed/cdacreader/src/Contracts/Registry.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Registry.cs
@@ -20,13 +20,13 @@ internal sealed class Registry
 
     public Thread Thread => GetContract<Thread>();
 
-    private T GetContract<T>() where T : IContract, new()
+    private T GetContract<T>() where T : IContract
     {
         if (_contracts.TryGetValue(typeof(T), out IContract? contractMaybe))
             return (T)contractMaybe;
 
         if (!_target.TryGetContractVersion(T.Name, out int version))
-            return new T();
+            throw new NotImplementedException();
 
         // Create and register the contract
         IContract contract = T.Create(_target, version);

--- a/src/native/managed/cdacreader/src/Contracts/Registry.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Registry.cs
@@ -18,7 +18,7 @@ internal sealed class Registry
         _target = target;
     }
 
-    public Thread Thread => GetContract<Thread>();
+    public IThread Thread => GetContract<IThread>();
 
     private T GetContract<T>() where T : IContract
     {

--- a/src/native/managed/cdacreader/src/Contracts/Registry.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Registry.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal sealed class Registry
+{
+    public Dictionary<Type, IContract> _contracts = [];
+    public Target _target;
+
+    public Registry(Target target)
+    {
+        _target = target;
+    }
+
+    public Thread Thread => GetContract<Thread>();
+
+    private T GetContract<T>() where T : IContract
+    {
+        if (_contracts.TryGetValue(typeof(T), out IContract? contractMaybe))
+            return (T)contractMaybe;
+
+        IContract contract = T.Create(_target);
+
+        // Still okay if contract was already registered by someone else
+        _ = _contracts.TryAdd(typeof(T), contract);
+        return (T)contract;
+    }
+}

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -18,9 +18,7 @@ internal class Thread : IContract
 
     public static IContract Create(Target target, int version)
     {
-        if (!target.TryReadGlobalPointer(Constants.Globals.ThreadStore, out TargetPointer threadStore))
-            return NotImplemented;
-
+        TargetPointer threadStore = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
         return version switch
         {
             1 => new Thread_1(target, threadStore),

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -14,11 +14,10 @@ internal class Thread : IContract
 {
     public static Thread NotImplemented = new Thread();
 
-    public static IContract Create(Target target)
-    {
-        if (!target.TryGetContractVersion(nameof(Thread), out int version))
-            return NotImplemented;
+    public static string Name { get; } = nameof(Thread);
 
+    public static IContract Create(Target target, int version)
+    {
         if (!target.TryReadGlobalPointer(Constants.Globals.ThreadStore, out TargetPointer threadStore))
             return NotImplemented;
 

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -10,26 +10,28 @@ public record struct ThreadStoreData(
     int ThreadCount,
     TargetPointer FirstThread);
 
-internal class Thread : IContract
+internal interface IThread : IContract
 {
-    public static Thread NotImplemented = new Thread();
-
-    public static string Name { get; } = nameof(Thread);
-
-    public static IContract Create(Target target, int version)
+    static string IContract.Name { get; } = nameof(Thread);
+    static IContract IContract.Create(Target target, int version)
     {
         TargetPointer threadStore = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
         return version switch
         {
             1 => new Thread_1(target, threadStore),
-            _ => NotImplemented,
+            _ => default(Thread),
         };
     }
 
     public virtual ThreadStoreData GetThreadStoreData() => throw new NotImplementedException();
 }
 
-internal sealed class Thread_1 : Thread
+internal readonly struct Thread : IThread
+{
+    // Everything throws NotImplementedException
+}
+
+internal readonly struct Thread_1 : IThread
 {
     private readonly Target _target;
     private readonly TargetPointer _threadStoreAddr;
@@ -40,7 +42,7 @@ internal sealed class Thread_1 : Thread
         _threadStoreAddr = threadStore;
     }
 
-    public override ThreadStoreData GetThreadStoreData()
+    ThreadStoreData IThread.GetThreadStoreData()
     {
         Data.ThreadStore? threadStore;
         if (!_target.ProcessedData.TryGet(_threadStoreAddr.Value, out threadStore))

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+// TODO: [cdac] Add other counts / threads
+public record struct ThreadStoreData(
+    int ThreadCount,
+    TargetPointer FirstThread);
+
+internal sealed class Thread
+{
+    private readonly Target _target;
+    private readonly int _version;
+    private readonly TargetPointer _threadStoreAddr;
+
+    public static bool TryCreate(Target target, [NotNullWhen(true)] out Thread? thread)
+    {
+        thread = default;
+        if (!target.TryGetContractVersion(nameof(Thread), out int version))
+            return false;
+
+        if (!target.TryReadGlobalPointer(Constants.Globals.ThreadStore, out TargetPointer threadStore))
+            return false;
+
+        thread = new Thread(target, version, threadStore);
+        return true;
+    }
+
+    private Thread(Target target, int version, TargetPointer threadStore)
+    {
+        _target = target;
+        _version = version;
+        _threadStoreAddr = threadStore;
+    }
+
+    public ThreadStoreData GetThreadStoreData()
+    {
+        Data.ThreadStore threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
+        return new ThreadStoreData(threadStore.ThreadCount, threadStore.FirstThread);
+    }
+}

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -38,7 +38,15 @@ internal sealed class Thread
 
     public ThreadStoreData GetThreadStoreData()
     {
-        Data.ThreadStore threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
+        Data.ThreadStore? threadStore;
+        if (!_target.ProcessedData.TryGet(_threadStoreAddr.Value, out threadStore))
+        {
+            threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
+
+            // Still okay if processed data is already registered by someone else
+            _ = _target.ProcessedData.TryRegister(_threadStoreAddr.Value, threadStore);
+        }
+
         return new ThreadStoreData(threadStore.ThreadCount, threadStore.FirstThread);
     }
 }

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 // TODO: [cdac] Add other counts / threads
-public record struct ThreadStoreData(
+internal record struct ThreadStoreData(
     int ThreadCount,
     TargetPointer FirstThread);
 

--- a/src/native/managed/cdacreader/src/Data/ThreadStore.cs
+++ b/src/native/managed/cdacreader/src/Data/ThreadStore.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class ThreadStore
+{
+    public ThreadStore(Target target, TargetPointer pointer)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.ThreadStore);
+        TargetPointer addr = target.ReadPointer(pointer.Value);
+
+        ThreadCount = target.Read<int>(addr.Value + (ulong)type.Fields[nameof(ThreadCount)].Offset);
+        FirstThread = TargetPointer.Null;
+    }
+
+    public int ThreadCount { get; init; }
+
+    public TargetPointer FirstThread { get; init; }
+}

--- a/src/native/managed/cdacreader/src/DataType.cs
+++ b/src/native/managed/cdacreader/src/DataType.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+public enum DataType
+{
+    Unknown = 0,
+
+    int8,
+    uint8,
+    int16,
+    uint16,
+    int32,
+    uint32,
+    int64,
+    uint64,
+    nint,
+    nuint,
+    pointer,
+
+    GCHandle,
+    Thread,
+    ThreadStore,
+}

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -106,7 +106,20 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
     public unsafe int GetThreadFromThinlockID(uint thinLockId, ulong* pThread) => HResults.E_NOTIMPL;
     public unsafe int GetThreadLocalModuleData(ulong thread, uint index, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetThreadpoolData(void* data) => HResults.E_NOTIMPL;
-    public unsafe int GetThreadStoreData(DacpThreadStoreData* data) => HResults.E_NOTIMPL;
+
+    public unsafe int GetThreadStoreData(DacpThreadStoreData* data)
+    {
+        if (!Contracts.Thread.TryCreate(_target, out Contracts.Thread? thread))
+            return HResults.E_NOTIMPL;
+
+        Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();
+        data->threadCount = threadStoreData.ThreadCount;
+        data->firstThread = threadStoreData.FirstThread.Value;
+        data->fHostConfig = 0;
+
+        return HResults.E_NOTIMPL;
+    }
+
     public unsafe int GetTLSIndex(uint* pIndex) => HResults.E_NOTIMPL;
     public unsafe int GetUsefulGlobals(void* data) => HResults.E_NOTIMPL;
     public unsafe int GetWorkRequestData(ulong addrWorkRequest, void* data) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -109,14 +109,18 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
 
     public unsafe int GetThreadStoreData(DacpThreadStoreData* data)
     {
-        Contracts.Thread thread = _target.Contracts.Thread;
-        if (thread == Contracts.Thread.NotImplemented)
-            return HResults.E_NOTIMPL;
-
-        Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();
-        data->threadCount = threadStoreData.ThreadCount;
-        data->firstThread = threadStoreData.FirstThread.Value;
-        data->fHostConfig = 0;
+        try
+        {
+            Contracts.Thread thread = _target.Contracts.Thread;
+            Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();
+            data->threadCount = threadStoreData.ThreadCount;
+            data->firstThread = threadStoreData.FirstThread.Value;
+            data->fHostConfig = 0;
+        }
+        catch (Exception ex)
+        {
+            return ex.HResult;
+        }
 
         return HResults.E_NOTIMPL;
     }

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -111,7 +111,7 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
     {
         try
         {
-            Contracts.Thread thread = _target.Contracts.Thread;
+            Contracts.IThread thread = _target.Contracts.Thread;
             Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();
             data->threadCount = threadStoreData.ThreadCount;
             data->firstThread = threadStoreData.FirstThread.Value;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -109,7 +109,8 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
 
     public unsafe int GetThreadStoreData(DacpThreadStoreData* data)
     {
-        if (!Contracts.Thread.TryCreate(_target, out Contracts.Thread? thread))
+        Contracts.Thread thread = _target.Contracts.Thread;
+        if (thread == Contracts.Thread.NotImplemented)
             return HResults.E_NOTIMPL;
 
         Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -50,6 +50,7 @@ public sealed unsafe class Target
     private readonly Dictionary<DataType, TypeInfo> _knownTypes = [];
     private readonly Dictionary<string, TypeInfo> _types = [];
 
+    internal Contracts.Registry Contracts { get; }
     internal DataCache ProcessedData { get; } = new DataCache();
 
     public static bool TryCreate(ulong contractDescriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, out Target? target)
@@ -67,6 +68,7 @@ public sealed unsafe class Target
 
     private Target(Configuration config, ContractDescriptorParser.ContractDescriptor descriptor, TargetPointer[] pointerData, Reader reader)
     {
+        Contracts = new Contracts.Registry(this);
         _config = config;
         _reader = reader;
 

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -376,10 +376,12 @@ public sealed unsafe class Target
         => _contracts.TryGetValue(contractName, out version);
 
     /// <summary>
-    /// Store of addresses that have already been read into corresponding data models
+    /// Store of addresses that have already been read into corresponding data models.
+    /// This is simply used to avoid re-processing data on every request.
     /// </summary>
     internal sealed class DataCache
     {
+        // TODO: [cdac] We may want to allow different types for the same address
         private readonly Dictionary<ulong, object?> _readDataByAddress = [];
 
         public bool TryRegister(ulong address, object data)

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -44,7 +44,7 @@ public sealed unsafe class Target
     private readonly Configuration _config;
     private readonly Reader _reader;
 
-    private readonly IReadOnlyDictionary<string, int> _contracts = new Dictionary<string, int>();
+    private readonly Dictionary<string, int> _contracts = [];
     private readonly IReadOnlyDictionary<string, (ulong Value, string? Type)> _globals = new Dictionary<string, (ulong, string?)>();
     private readonly Dictionary<DataType, TypeInfo> _knownTypes = [];
     private readonly Dictionary<string, TypeInfo> _types = [];
@@ -366,6 +366,9 @@ public sealed unsafe class Target
 
         return TryGetTypeInfo(dataType, out typeInfo);
     }
+
+    internal bool TryGetContractVersion(string contractName, out int version)
+        => _contracts.TryGetValue(contractName, out version);
 
     private sealed class Reader
     {

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -364,20 +364,17 @@ public sealed unsafe class Target
     /// </summary>
     internal sealed class DataCache
     {
-        // TODO: [cdac] We may want to allow different types for the same address
-        private readonly Dictionary<ulong, object?> _readDataByAddress = [];
+        private readonly Dictionary<(ulong, Type), object?> _readDataByAddress = [];
 
-        public bool TryRegister(ulong address, object data)
+        public bool TryRegister<T>(ulong address, T data)
         {
-            bool success = _readDataByAddress.TryAdd(address, data);
-            System.Diagnostics.Debug.Assert(success || data.GetType() == _readDataByAddress[address]!.GetType());
-            return success;
+            return _readDataByAddress.TryAdd((address, typeof(T)), data);
         }
 
         public bool TryGet<T>(ulong address, [NotNullWhen(true)] out T? data)
         {
             data = default;
-            if (!_readDataByAddress.TryGetValue(address, out object? dataObj))
+            if (!_readDataByAddress.TryGetValue((address, typeof(T)), out object? dataObj))
                 return false;
 
             if (dataObj is T dataMaybe)


### PR DESCRIPTION
- Read/store types from contract descriptor into an internal representation of the type layout info
- Add functions to `Target` for getting type info and contract version
- Add placeholder for thread contract and getting thread store data
  - Add ThreadStore to data descriptor
  - `GetThreadStoreData` continues to return E_NOTIMPL, but will go through trying to use the contract
- Store processed data for the target by its address and data model type
- Add unit tests for getting type info

Contributes to https://github.com/dotnet/runtime/issues/99298