### PR TITLE
Partially revert "Disable msvc vectorization in GC get_promoted_bytes (#100309)"

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -24247,9 +24247,6 @@ size_t gc_heap::get_promoted_bytes()
 
     dprintf (3, ("h%d getting surv", heap_number));
     size_t promoted = 0;
-#ifdef _MSC_VER
-#pragma loop(no_vector)
-#endif
     for (size_t i = 0; i < region_count; i++)
     {
         if (survived_per_region[i] > 0)


### PR DESCRIPTION
(commit 765ca4e9f2dddca2005ffdb45863b7980247a886)

Revert workaround but leave test in place.  Toolchain was moved away from previews in #100598.