### PR TITLE
Declare __cxa_demangle where it's used based on the Itanium ABI instead of including the ABI header.

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -927,6 +927,17 @@ CrashInfo::SearchMemoryRegions(const std::set<MemoryRegion>& regions, const Memo
     return nullptr;
 }
 
+// Declare the prototype for the Itanium C++ ABI demangler API.
+// We may not have the Itanium C++ ABI header available even when we're building against this ABI
+// so we'll declare the prototype ourselves.
+// See Itanium C++ ABI, March 14, 2017 Revision, Chapter 3, Section 3.4
+namespace abi {
+  extern "C" char* __cxa_demangle (const char* mangled_name,
+				   char* buf,
+				   size_t* n,
+				   int* status);
+}
+
 //
 // Lookup a symbol in a module. The caller needs to call "free()" on symbol returned.
 //

--- a/src/coreclr/debug/createdump/createdump.h
+++ b/src/coreclr/debug/createdump/createdump.h
@@ -72,7 +72,6 @@ typedef int T_CONTEXT;
 #include <dirent.h>
 #include <fcntl.h>
 #include <dlfcn.h>
-#include <cxxabi.h>
 #ifdef __APPLE__
 #include <ELF.h>
 #else


### PR DESCRIPTION
When we switch to the libc++ build, we won't have the cxxabi.h header for libstdc++ available. 

Inline the prototype of the Itanium C++ ABI function that the header was included for.