### PR TITLE
[NativeAOT] `clang -fuse-ld=lld` output is low priority

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -50,7 +50,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     </PropertyGroup>
 
     <!-- alpine's gcc toolchain needs alpine-linux, see https://github.com/llvm/llvm-project/issues/89146 -->
-    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(CrossCompileArch)' != '' and '$(SysRoot)' != ''">
+    <Exec Command="grep -q ID=alpine &quot;$(SysRoot)/etc/os-release&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(CrossCompileArch)' != '' and '$(SysRoot)' != ''">
       <Output TaskParameter="ExitCode" PropertyName="_IsAlpineExitCode" />
     </Exec>
 
@@ -108,13 +108,13 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_WhereXcrun>0</_WhereXcrun>
     </PropertyGroup>
 
-    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true'">
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(_IsiOSLikePlatform)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
     </Exec>
     <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
       Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
 
-    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
+    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
     <Error Condition="!Exists('$(SysRoot)') and '$(_IsiOSLikePlatform)' == 'true'"
@@ -240,7 +240,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,--eh-frame-hdr" Condition="'$(_IsApplePlatform)' != 'true'" />
     </ItemGroup>
 
-    <Exec Command="clang --version" Condition="'$(_IsApplePlatform)' == 'true'" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+    <Exec Command="clang --version" Condition="'$(_IsApplePlatform)' == 'true'" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ExitCode" PropertyName="_XcodeVersionStringExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
     </Exec>
@@ -258,11 +258,11 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_CommandProbe Condition="$([MSBuild]::IsOSPlatform('Windows'))">where /Q</_CommandProbe>
     </PropertyGroup>
 
-    <Exec Command="$(_CommandProbe) &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low">
+    <Exec Command="$(_CommandProbe) &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinker" />
     </Exec>
 
-    <Exec Command="$(_CommandProbe) &quot;$(CppCompilerAndLinkerAlternative)&quot;" Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0'" IgnoreExitCode="true" StandardOutputImportance="Low">
+    <Exec Command="$(_CommandProbe) &quot;$(CppCompilerAndLinkerAlternative)&quot;" Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0'" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinkerAlt" />
     </Exec>
 
@@ -285,7 +285,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Error Condition="'$(_WhereLinker)' != '0' and '$(CppCompilerAndLinkerAlternative)' == '' and '$(_IsApplePlatform)' != 'true'"
       Text="Requested linker ('$(CppLinker)') not found in PATH." />
 
-    <Exec Command="&quot;$(CppLinker)&quot; -fuse-ld=lld -Wl,--version" Condition="'$(LinkerFlavor)' == 'lld'" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(CppLinker)&quot; -fuse-ld=lld -Wl,--version" Condition="'$(LinkerFlavor)' == 'lld'" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ExitCode" PropertyName="_LinkerVersionStringExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="_LinkerVersionString" />
     </Exec>
@@ -294,11 +294,11 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_LinkerVersion>$([System.Text.RegularExpressions.Regex]::Match($(_LinkerVersionString), '[1-9]\d*'))</_LinkerVersion>
     </PropertyGroup>
 
-    <Exec Command="$(_CommandProbe) &quot;$(ObjCopyName)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsApplePlatform)' != 'true' and '$(StripSymbols)' == 'true'">
+    <Exec Command="$(_CommandProbe) &quot;$(ObjCopyName)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(_IsApplePlatform)' != 'true' and '$(StripSymbols)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereSymbolStripper" />
     </Exec>
 
-    <Exec Command="$(_CommandProbe) &quot;$(ObjCopyNameAlternative)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsApplePlatform)' != 'true' and '$(ObjCopyNameAlternative)' != '' and '$(StripSymbols)' == 'true'">
+    <Exec Command="$(_CommandProbe) &quot;$(ObjCopyNameAlternative)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(_IsApplePlatform)' != 'true' and '$(ObjCopyNameAlternative)' != '' and '$(StripSymbols)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereSymbolStripperAlt" />
     </Exec>
 
@@ -312,13 +312,13 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Error Condition="'$(_WhereSymbolStripper)' != '0' and '$(StripSymbols)' == 'true' and '$(_IsApplePlatform)' != 'true'"
       Text="Symbol stripping tool ('$(ObjCopyName)') not found in PATH. Make sure '$(ObjCopyName)' is available in PATH or set the StripSymbols property to false to disable symbol stripping." />
 
-    <Exec Command="command -v dsymutil &amp;&amp; command -v strip" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsApplePlatform)' == 'true' and '$(StripSymbols)' == 'true'">
+    <Exec Command="command -v dsymutil &amp;&amp; command -v strip" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(_IsApplePlatform)' == 'true' and '$(StripSymbols)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereSymbolStripper" />
     </Exec>
     <Error Condition="'$(_WhereSymbolStripper)' != '0' and '$(StripSymbols)' == 'true' and '$(_IsApplePlatform)' != 'true'"
       Text="Symbol stripping tools ('dsymutil' and 'strip') not found in PATH. Make sure 'dsymutil' and 'strip' are available in PATH or set the StripSymbols property to false to disable symbol stripping." />
 
-    <Exec Command="dsymutil --help" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsApplePlatform)' == 'true' and '$(StripSymbols)' == 'true'">
+    <Exec Command="dsymutil --help" IgnoreExitCode="true" StandardOutputImportance="Low" StandardErrorImportance="Low" IgnoreStandardErrorWarningFormat="true" Condition="'$(_IsApplePlatform)' == 'true' and '$(StripSymbols)' == 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_DsymUtilOutput" />
     </Exec>
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/101727

Context: 410aa0a7cb47d66d82634c62633ba26e8a1a002d
Context: https://github.com/dotnet/msbuild/blob/1c3b240ce7417223672c62862a6ff7e884e6997a/src/Tasks/Exec.cs#L385
Context: https://github.com/dotnet/msbuild/blob/1c3b240ce7417223672c62862a6ff7e884e6997a/src/Shared/TaskLoggingHelper.cs#L1380

Imagine you want to build a NativeAot library for linux-bionic-arm64:

	% dotnet new classlib -n HelloBionicSharedLib
	% cd HelloBionicSharedLib
	% dotnet publish -c Release -r linux-bionic-arm64 -p:PublishAotUsingRuntimePack=true -p:PublishAot=true

…*but your environment is wrong*.  Because your environment is wrong, it will error out.  (It *should* error out!)

Are the generated errors *useful*?

	% dotnet publish -c Release -r linux-bionic-arm64 -p:PublishAotUsingRuntimePack=true -p:PublishAot=true
	…
	clang : error : invalid linker name in argument '-fuse-ld=lld'
	$HOME/.nuget/packages/microsoft.dotnet.ilcompiler/8.0.4/build/Microsoft.NETCore.Native.Unix.targets(236,5): error :
	Symbol stripping tool ('llvm-objcopy' or 'objcopy') not found in PATH. Try installing appropriate package for llvm-objcopy or objcopy to resolve the problem or set the StripSymbols property to false to disable symbol stripping.

There are two errors here: one from `clang`, and one from the `microsoft.dotnet.ilcompiler` NuGet package.  The first one from `clang` is useless ("what does it mean?! how do I fix it?!"), and the latter message is the *useful* error message.

Additionally, the first error *shouldn't even be emitted*!  It comes from commit 410aa0a7, which attempts to get the `lld` version:

	clang -fuse-ld=lld -Wl,--version

This check is supposed to be *optional*; if it fails, that's "fine."" The wrapping `<Exec/>` captures stdout and the error code, and wants the output to be Low priority so that it isn't be shown by default.

The problem is that it wasn't *really* fine; if there is no `lld`, then the above command will fail:

	% clang -fuse-ld=lld -Wl,--version
	[stderr] clang: error: invalid linker name in argument '-fuse-ld=lld'
	[exit code is 1]

and the [default "warning error format"][0] checks for the strings `error` and `warning`.  Meaning *because*
`clang -fuse-ld=lld -Wl,--version` writes a string containing `error` to stderr, that is converted into an MSBuild error.

Because this invocation is supposed to be optional, update the `<Exec/>` to set [`Exec.IgnoreStandardErrorWarningFormat`][1]=true and [`Exec.StandardErrorImportance`][2]=Low:

	<Exec Command="&quot;$(CppLinker)&quot; -fuse-ld=lld -Wl,--version"
	    …
	    IgnoreStandardErrorWarningFormat="true"
	    StandardErrorImportance="Low"
	/>

This ensures that the error messages from `clang` are *not* reported as errors, removing the unnecessary error message from the build.

Review the other `<Exec/>` invocations and set
`IgnoreStandardErrorWarningFormat="true"` and
`StandardErrorImportance="Low"` when `Exec.IgnoreExitCode`=true or `Exec.StandardOutputImportance`=Low.

[0]: https://github.com/dotnet/msbuild/blob/1c3b240ce7417223672c62862a6ff7e884e6997a/src/Shared/CanonicalError.cs#L77
[1]: https://learn.microsoft.com/dotnet/api/microsoft.build.tasks.exec.ignorestandarderrorwarningformat?view=msbuild-17-netcore
[2]: https://learn.microsoft.com/dotnet/api/microsoft.build.utilities.tooltask.standarderrorimportance?view=msbuild-17-netcore