### PR TITLE
Explicitly link against the dotnet/llvm-project libc++

### DIFF
--- a/src/mono/CMakeLists.txt
+++ b/src/mono/CMakeLists.txt
@@ -635,9 +635,9 @@ if(LLVM_PREFIX)
   endif()
 
   if(HOST_LINUX AND NOT HOST_WASM AND NOT HOST_WASI AND ${llvm_api_version} GREATER_EQUAL 1600)
-    set(MONO_stdlib "-stdlib=libc++")
-    set(MONO_cxx_lib "-L${LLVM_PREFIX}/lib -lc++")
-    set(MONO_cxx_include "-I${LLVM_PREFIX}/include/c++/v1")
+    set(MONO_stdlib "-nostdinc++ -nostdlib++")
+    set(MONO_cxx_lib "-L${LLVM_PREFIX}/lib -lc++ -lc++abi")
+    set(MONO_cxx_include "-isystem ${LLVM_PREFIX}/include/c++/v1")
   endif()
 
   if(${llvm_api_version} GREATER_EQUAL 1600)

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -285,7 +285,7 @@
     <ItemGroup Condition="'$(HostOS)' == 'Linux' and '$(MonoEnableLLVM)' == 'true' and '$(TargetArchitecture)' != 'wasm' and '$(MonoUseLibCxx)' == 'true'">
       <_MonoCXXFLAGS Include="-I$(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\include\c++\v1" />
       <_MonoCXXFLAGS Include="-L$(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\lib" />
-      <_MonoCXXFLAGS Include="-stdlib=libc++" />
+      <_MonoCXXFLAGS Include="-lc++;-lc++abi" />
       <_MonoCMakeArgs Include="-DMONO_SET_RPATH_ORIGIN=true" />
     </ItemGroup>
 

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -283,7 +283,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(HostOS)' == 'Linux' and '$(MonoEnableLLVM)' == 'true' and '$(TargetArchitecture)' != 'wasm' and '$(MonoUseLibCxx)' == 'true'">
-      <_MonoCXXFLAGS Include="-I$(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\include\c++\v1" />
+      <_MonoCXXFLAGS Include="-isystem $(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\include\c++\v1" />
       <_MonoCXXFLAGS Include="-L$(MonoLLVMDir)\$(_MonoLLVMTargetArchitecture)\lib" />
       <_MonoCXXFLAGS Include="-lc++;-lc++abi" />
       <_MonoCMakeArgs Include="-DMONO_SET_RPATH_ORIGIN=true" />


### PR DESCRIPTION
Use -nostdlib++ and manual linker args instead of -stdlib=libc++ to ensure we're always building against our the local libc++, not a system one

Fixes the failures when building against a rootfs with a custom libc++ build.