### PR TITLE
Small followup to Use QueueUserAPC2 for EE suspension on CoreCLR win-arm64

### DIFF
--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -6060,7 +6060,13 @@ void ThreadSuspend::Initialize()
         HMODULE hModNtdll = WszLoadLibrary(W("ntdll.dll"));
         if (hModNtdll != NULL)
         {
-            g_returnAddressHijackTarget = (void*)GetProcAddress(hModNtdll, "RtlGetReturnAddressHijackTarget");
+            typedef void* (*PFN_RtlGetReturnAddressHijackTarget)(void);
+
+            void* rtlGetReturnAddressHijackTarget = GetProcAddress(hModNtdll, "RtlGetReturnAddressHijackTarget");
+            if (rtlGetReturnAddressHijackTarget != NULL)
+            {
+                g_returnAddressHijackTarget = ((PFN_RtlGetReturnAddressHijackTarget)rtlGetReturnAddressHijackTarget)();
+            }
         }
         if (g_returnAddressHijackTarget == NULL)
         {


### PR DESCRIPTION
Re: https://github.com/dotnet/runtime/pull/101891

`RtlGetReturnAddressHijackTarget` needs to be invoked. It is not the hijack address, it is the provider of the address.