### PR TITLE
JIT: Expand optRelopImpliesRelop for constants as op1

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7501,6 +7501,9 @@ public:
     BitVecTraits* optReachableBitVecTraits;
     BitVec        optReachableBitVec;
     void          optRelopImpliesRelop(RelopImplicationInfo* rii);
+    bool          optRelopTryInferWithOneEqualOperand(const VNFuncApp&      domApp,
+                                                      const VNFuncApp&      treeApp,
+                                                      RelopImplicationInfo* rii);
 
     /**************************************************************************
      *               Value/Assertion propagation


### PR DESCRIPTION
VN does not guarantee that constants in relops are first, so swap them if this isn't the case.

Need this to be able to utilize `optRelopImpliesRelop` to answer overflow related questions for strength reduction.