### PR TITLE
[mono] Use simdhash for aot method lookup ptr->methodinfo cache

### DIFF
--- a/src/mono/mono/metadata/CMakeLists.txt
+++ b/src/mono/mono/metadata/CMakeLists.txt
@@ -42,12 +42,6 @@ else()
 set(metadata_platform_sources ${metadata_unix_sources})
 endif()
 
-set(imported_native_sources
-    ../../../native/containers/dn-simdhash.c
-    ../../../native/containers/dn-simdhash-string-ptr.c
-    ../../../native/containers/dn-simdhash-u32-ptr.c
-    ../../../native/containers/dn-simdhash-ptrpair-ptr.c)
-
 set(metadata_common_sources
     appdomain.c
     domain.c
@@ -201,7 +195,7 @@ elseif(MONO_GC STREQUAL "boehm")
     set(metadata_compile_definitions "HAVE_BOEHM_GC")
 endif()
 
-set(metadata_sources "${metadata_platform_sources};${metadata_common_sources};${metadata_gc_dependent_sources};${metadata_gc_sources};${ilgen_sources};${imported_native_sources}")
+set(metadata_sources "${metadata_platform_sources};${metadata_common_sources};${metadata_gc_dependent_sources};${metadata_gc_sources};${ilgen_sources}")
 
 if(HOST_WIN32 AND NOT DISABLE_SHARED_LIBS)
     add_library(metadata_objects_shared OBJECT ${metadata_sources})

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -84,6 +84,9 @@ set(mini_common_sources
     aot-compiler.h
     aot-compiler.c
     aot-runtime.c
+    # metadata_amodule->method_ref_to_method
+    ../../../native/containers/dn-simdhash.c
+    ../../../native/containers/dn-simdhash-ptr-ptr.c
     aot-runtime-wasm.c
     graph.c
     mini-codegen.c

--- a/src/mono/mono/mini/CMakeLists.txt
+++ b/src/mono/mono/mini/CMakeLists.txt
@@ -49,6 +49,13 @@ endif()
 # MINI
 #
 
+set(imported_native_sources
+    ../../../native/containers/dn-simdhash.c
+    ../../../native/containers/dn-simdhash-ptr-ptr.c
+    ../../../native/containers/dn-simdhash-string-ptr.c
+    ../../../native/containers/dn-simdhash-u32-ptr.c
+    ../../../native/containers/dn-simdhash-ptrpair-ptr.c)
+
 set(mini_common_sources
     mini.c
     mini-runtime.c
@@ -84,9 +91,6 @@ set(mini_common_sources
     aot-compiler.h
     aot-compiler.c
     aot-runtime.c
-    # metadata_amodule->method_ref_to_method
-    ../../../native/containers/dn-simdhash.c
-    ../../../native/containers/dn-simdhash-ptr-ptr.c
     aot-runtime-wasm.c
     graph.c
     mini-codegen.c
@@ -305,7 +309,7 @@ else()
 set(profiler_sources "")
 endif()
 
-set(mini_sources "main-core.c;${mini_common_sources};${arch_sources};${os_sources};${mini_interp_sources};${llvm_sources};${debugger_sources};${profiler_sources};${llvm_runtime_sources}")
+set(mini_sources "main-core.c;${imported_native_sources};${mini_common_sources};${arch_sources};${os_sources};${mini_interp_sources};${llvm_sources};${debugger_sources};${profiler_sources};${llvm_runtime_sources}")
 
 if(LLVM_INCLUDEDIR)
   include_directories(BEFORE SYSTEM "${LLVM_INCLUDEDIR}")

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -108,7 +108,7 @@ struct MonoAotModule {
 	/* Maps methods to their code */
 	GHashTable *method_to_code;
 	/* Maps pointers into the method info to the methods themselves */
-	GHashTable *method_ref_to_method;
+	dn_simdhash_ptr_ptr_t *method_ref_to_method;
 	MonoAssemblyName *image_names;
 	char **image_guids;
 	MonoAssembly *assembly;
@@ -4513,7 +4513,7 @@ find_aot_method_in_amodule (MonoAotModule *code_amodule, MonoMethod *method, gui
 
 	index = 0xffffff;
 	while (TRUE) {
-		MonoMethod *m;
+		MonoMethod *m = NULL;
 		guint8 *p, *orig_p;
 
 		key = decode_uint_with_len (key_len, entry);
@@ -4528,8 +4528,9 @@ find_aot_method_in_amodule (MonoAotModule *code_amodule, MonoMethod *method, gui
 
 		amodule_lock (metadata_amodule);
 		if (!metadata_amodule->method_ref_to_method)
-			metadata_amodule->method_ref_to_method = g_hash_table_new (NULL, NULL);
-		m = (MonoMethod *)g_hash_table_lookup (metadata_amodule->method_ref_to_method, p);
+			// FIXME: Select a better initial capacity.
+			metadata_amodule->method_ref_to_method = dn_simdhash_ptr_ptr_new (4096, NULL);
+		dn_simdhash_ptr_ptr_try_get_value (metadata_amodule->method_ref_to_method, p, (void **)&m);
 		amodule_unlock (metadata_amodule);
 		if (!m) {
 			m = decode_resolve_method_ref_with_target (code_amodule, method, p, &p, error);
@@ -4540,7 +4541,7 @@ find_aot_method_in_amodule (MonoAotModule *code_amodule, MonoMethod *method, gui
 			 */
 			if (m && m->wrapper_type != MONO_WRAPPER_RUNTIME_INVOKE) {
 				amodule_lock (metadata_amodule);
-				g_hash_table_insert (metadata_amodule->method_ref_to_method, orig_p, m);
+				dn_simdhash_ptr_ptr_try_add (metadata_amodule->method_ref_to_method, orig_p, m);
 				amodule_unlock (metadata_amodule);
 			}
 		}


### PR DESCRIPTION
Based on profiling, AOT'd applications can spend a lot of time in these ghashtable lookups, and simdhash appears to perform much better for this scenario.