### PR TITLE
Enable RuntimeType.GenericCache to hold multiple types of cache entries

### DIFF
--- a/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -237,7 +237,8 @@
     <Compile Include="$(CommonPath)System\Collections\Generic\ArrayBuilder.cs">
       <Link>Common\System\Collections\Generic\ArrayBuilder.cs</Link>
     </Compile>
-    <Compile Include="src\System\RuntimeType.CreateUninitializedCache.CoreCLR.cs" />    
+    <Compile Include="src\System\RuntimeType.CreateUninitializedCache.CoreCLR.cs" />
+    <Compile Include="src\System\RuntimeType.GenericCache.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(FeatureComWrappers)' == 'true'">
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\ComWrappers.cs" />

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -662,7 +662,7 @@ namespace System
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_GetElementConstructorEntrypoint")]
             private static partial delegate*<ref byte, void> GetElementConstructorEntrypoint(QCallTypeHandle arrayType);
 
-            public static RuntimeType.IGenericCacheEntry.GenericCacheKind Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.ArrayInitialize;
+            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.ArrayInitialize;
 
             private ArrayInitializeCache(delegate*<ref byte, void> constructorEntrypoint)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -662,7 +662,7 @@ namespace System
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_GetElementConstructorEntrypoint")]
             private static partial delegate*<ref byte, void> GetElementConstructorEntrypoint(QCallTypeHandle arrayType);
 
-            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.ArrayInitialize;
+            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry<ArrayInitializeCache>.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.ArrayInitialize;
 
             private ArrayInitializeCache(delegate*<ref byte, void> constructorEntrypoint)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -662,17 +662,14 @@ namespace System
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_GetElementConstructorEntrypoint")]
             private static partial delegate*<ref byte, void> GetElementConstructorEntrypoint(QCallTypeHandle arrayType);
 
-            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry<ArrayInitializeCache>.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.ArrayInitialize;
-
             private ArrayInitializeCache(delegate*<ref byte, void> constructorEntrypoint)
             {
                 ConstructorEntrypoint = constructorEntrypoint;
             }
 
-            public static ArrayInitializeCache Create(RuntimeType arrayType)
-            {
-                return new(GetElementConstructorEntrypoint(new QCallTypeHandle(ref arrayType)));
-            }
+            public static ArrayInitializeCache Create(RuntimeType arrayType) => new(GetElementConstructorEntrypoint(new QCallTypeHandle(ref arrayType)));
+            public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._arrayInitializeCache = this;
+            public static ref ArrayInitializeCache? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry) => ref compositeEntry._arrayInitializeCache;
         }
     }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -105,7 +105,7 @@ namespace System
 
         internal sealed partial class EnumInfo<TStorage> : RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>
         {
-            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.EnumInfo;
+            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.EnumInfo;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             public static EnumInfo<TStorage> CreateWithNames(RuntimeType type)

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -105,7 +105,7 @@ namespace System
 
         internal sealed partial class EnumInfo<TStorage> : RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>
         {
-            public static RuntimeType.IGenericCacheEntry.GenericCacheKind Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.EnumInfo;
+            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.EnumInfo;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             public static EnumInfo<TStorage> CreateWithNames(RuntimeType type)

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -98,14 +98,14 @@ namespace System
                 // force that copy into the cache even if we already have a cache entry without names
                 // so we don't have to recompute the names if asked again.
                 return getNames
-                    ? enumType.ReplaceCacheEntry(EnumInfo<TStorage>.CreateWithNames(enumType))
+                    ? enumType.ReplaceCacheEntry(EnumInfo<TStorage>.Create(enumType, getNames: true))
                     : enumType.GetOrCreateCacheEntry<EnumInfo<TStorage>>();
             }
         }
 
         internal sealed partial class EnumInfo<TStorage> : RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>
         {
-            public static EnumInfo<TStorage> CreateWithNames(RuntimeType type)
+            public static EnumInfo<TStorage> Create(RuntimeType type. bool getNames)
             {
                 TStorage[]? values = null;
                 string[]? names = null;
@@ -114,7 +114,7 @@ namespace System
                     new QCallTypeHandle(ref type),
                     ObjectHandleOnStack.Create(ref values),
                     ObjectHandleOnStack.Create(ref names),
-                    Interop.BOOL.TRUE);
+                    getNames ? Interop.BOOL.TRUE : Interop.BOOL.FALSE);
 
                 Debug.Assert(values!.GetType() == typeof(TStorage[]));
 
@@ -123,7 +123,7 @@ namespace System
                 return new EnumInfo<TStorage>(hasFlagsAttribute, values, names!);
             }
 
-            public static EnumInfo<TStorage> Create(RuntimeType type)
+            public static EnumInfo<TStorage> Create(RuntimeType type) => Create(type, getNames: false);
             {
                 TStorage[]? values = null;
                 string[]? names = null;

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -87,6 +87,8 @@ namespace System
                 typeof(TStorage) == typeof(nuint) || typeof(TStorage) == typeof(float) || typeof(TStorage) == typeof(double) || typeof(TStorage) == typeof(char),
                 $"Unexpected {nameof(TStorage)} == {typeof(TStorage)}");
 
+            return EnumInfo<TStorage>.CreateWithNames(enumType);
+#if false // TODO!!!!!
             return enumType.FindCacheEntry<EnumInfo<TStorage>>() is {} info && (!getNames || info.Names is not null) ?
                 info :
                 InitializeEnumInfo(enumType, getNames);
@@ -101,13 +103,11 @@ namespace System
                     ? enumType.OverwriteCacheEntry(EnumInfo<TStorage>.CreateWithNames(enumType))
                     : enumType.GetOrCreateCacheEntry<EnumInfo<TStorage>>();
             }
+#endif
         }
 
         internal sealed partial class EnumInfo<TStorage> : RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>
         {
-            static RuntimeType.IGenericCacheEntry.GenericCacheKind RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>.Kind => RuntimeType.IGenericCacheEntry.GenericCacheKind.EnumInfo;
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
             public static EnumInfo<TStorage> CreateWithNames(RuntimeType type)
             {
                 TStorage[]? values = null;
@@ -126,7 +126,6 @@ namespace System
                 return new EnumInfo<TStorage>(hasFlagsAttribute, values, names!);
             }
 
-            [MethodImpl(MethodImplOptions.NoInlining)]
             public static EnumInfo<TStorage> Create(RuntimeType type)
             {
                 TStorage[]? values = null;
@@ -144,6 +143,9 @@ namespace System
 
                 return new EnumInfo<TStorage>(hasFlagsAttribute, values, null!);
             }
+
+            public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._enumInfo = this;
+            public static ref EnumInfo<TStorage>? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry) => throw new Exception(); // TODO!!!
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -105,7 +105,7 @@ namespace System
 
         internal sealed partial class EnumInfo<TStorage> : RuntimeType.IGenericCacheEntry<EnumInfo<TStorage>>
         {
-            public static EnumInfo<TStorage> Create(RuntimeType type. bool getNames)
+            public static EnumInfo<TStorage> Create(RuntimeType type, bool getNames)
             {
                 TStorage[]? values = null;
                 string[]? names = null;

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -124,22 +124,6 @@ namespace System
             }
 
             public static EnumInfo<TStorage> Create(RuntimeType type) => Create(type, getNames: false);
-            {
-                TStorage[]? values = null;
-                string[]? names = null;
-
-                GetEnumValuesAndNames(
-                    new QCallTypeHandle(ref type),
-                    ObjectHandleOnStack.Create(ref values),
-                    ObjectHandleOnStack.Create(ref names),
-                    Interop.BOOL.FALSE);
-
-                Debug.Assert(values!.GetType() == typeof(TStorage[]));
-
-                bool hasFlagsAttribute = type.IsDefined(typeof(FlagsAttribute), inherit: false);
-
-                return new EnumInfo<TStorage>(hasFlagsAttribute, values, null!);
-            }
 
             public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._enumInfo = this;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
@@ -13,7 +13,7 @@ namespace System
         /// A cache which allows optimizing <see cref="Activator.CreateInstance"/>,
         /// <see cref="CreateInstanceDefaultCtor"/>, and related APIs.
         /// </summary>
-        private sealed unsafe class ActivatorCache
+        private sealed unsafe class ActivatorCache : IGenericCacheEntry<ActivatorCache>
         {
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).
             // In the case of the COM allocator, first arg is ComClassFactory*, not MethodTable*.
@@ -24,13 +24,15 @@ namespace System
             private readonly delegate*<object?, void> _pfnCtor;
             private readonly bool _ctorIsPublic;
 
-            private CreateUninitializedCache? _createUninitializedCache;
-
 #if DEBUG
             private readonly RuntimeType _originalRuntimeType;
 #endif
 
-            internal ActivatorCache(RuntimeType rt)
+            public static IGenericCacheEntry.GenericCacheKind Kind => IGenericCacheEntry.GenericCacheKind.Activator;
+
+            public static ActivatorCache Create(RuntimeType type) => new ActivatorCache(type);
+
+            private ActivatorCache(RuntimeType rt)
             {
                 Debug.Assert(rt != null);
 
@@ -121,15 +123,6 @@ namespace System
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal void CallConstructor(object? uninitializedObject) => _pfnCtor(uninitializedObject);
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal CreateUninitializedCache GetCreateUninitializedCache(RuntimeType rt)
-            {
-#if DEBUG
-                CheckOriginalRuntimeType(rt);
-#endif
-                return _createUninitializedCache ??= new CreateUninitializedCache(rt);
-            }
 
 #if DEBUG
             private void CheckOriginalRuntimeType(RuntimeType rt)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
@@ -28,7 +28,7 @@ namespace System
             private readonly RuntimeType _originalRuntimeType;
 #endif
 
-            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.Activator;
+            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<ActivatorCache>.Kind => IGenericCacheEntry.GenericCacheKind.Activator;
 
             public static ActivatorCache Create(RuntimeType type) => new ActivatorCache(type);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
@@ -28,7 +28,7 @@ namespace System
             private readonly RuntimeType _originalRuntimeType;
 #endif
 
-            public static IGenericCacheEntry.GenericCacheKind Kind => IGenericCacheEntry.GenericCacheKind.Activator;
+            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.Activator;
 
             public static ActivatorCache Create(RuntimeType type) => new ActivatorCache(type);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.ActivatorCache.cs
@@ -13,7 +13,7 @@ namespace System
         /// A cache which allows optimizing <see cref="Activator.CreateInstance"/>,
         /// <see cref="CreateInstanceDefaultCtor"/>, and related APIs.
         /// </summary>
-        private sealed unsafe class ActivatorCache : IGenericCacheEntry<ActivatorCache>
+        internal sealed unsafe class ActivatorCache : IGenericCacheEntry<ActivatorCache>
         {
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).
             // In the case of the COM allocator, first arg is ComClassFactory*, not MethodTable*.
@@ -28,9 +28,9 @@ namespace System
             private readonly RuntimeType _originalRuntimeType;
 #endif
 
-            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<ActivatorCache>.Kind => IGenericCacheEntry.GenericCacheKind.Activator;
-
-            public static ActivatorCache Create(RuntimeType type) => new ActivatorCache(type);
+            public static ActivatorCache Create(RuntimeType type) => new(type);
+            public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._activatorCache = this;
+            public static ref ActivatorCache? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry) => ref compositeEntry._activatorCache;
 
             private ActivatorCache(RuntimeType rt)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1499,11 +1499,7 @@ namespace System
 
             #region Internal Members
 
-            internal object? GenericCache
-            {
-                get => m_genericCache;
-                set => m_genericCache = value;
-            }
+            internal ref object? GenericCache => ref m_genericCache;
 
             private sealed class FunctionPointerCache : IGenericCacheEntry<FunctionPointerCache>
             {
@@ -1931,15 +1927,6 @@ namespace System
 
             GC.KeepAlive(methodInstantiation);
             return retval;
-        }
-
-        /// <summary>
-        /// Generic cache for rare scenario specific data. See <see cref="IGenericCacheEntry" /> for more information on what data can be cached here.
-        /// </summary>
-        internal object? GenericCache
-        {
-            get => CacheIfExists?.GenericCache;
-            set => Cache.GenericCache = value;
         }
 
         internal T GetOrCreateCacheEntry<T>()

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1454,10 +1454,8 @@ namespace System
             private static CerHashtable<RuntimeMethodInfo, RuntimeMethodInfo> s_methodInstantiations;
             private static object? s_methodInstantiationsLock;
             private string? m_defaultMemberName;
-            // Generic cache for rare scenario specific data. Used for:
-            // - Enum names and values (EnumInfo)
-            // - Activator.CreateInstance (ActivatorCache)
-            // - Array.Initialize (ArrayInitializeCache)
+            // Generic cache for rare scenario specific data.
+            // See IGenericCacheEntry for more information.
             private object? m_genericCache;
             private object[]? _emptyArray; // Object array cache for Attribute.GetCustomAttributes() pathological no-result case.
             private RuntimeType? _genericTypeDefinition;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -3947,7 +3947,8 @@ namespace System
                 throw new MissingMethodException(SR.Format(SR.Arg_NoDefCTor, this));
             }
 
-            object? obj = GetOrCreateCacheEntry<CreateUninitializedCache>().CreateUninitializedObject(this);
+            // We reuse ActivatorCache here to ensure that we aren't always creating two entries in the cache.
+            object? obj = GetOrCreateCacheEntry<ActivatorCache>().CreateUninitializedObject(this);
             try
             {
                 cache.CallConstructor(obj);

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1455,8 +1455,7 @@ namespace System
             private static object? s_methodInstantiationsLock;
             private string? m_defaultMemberName;
             // Generic cache for rare scenario specific data.
-            // See IGenericCacheEntry for more information.
-            private object? m_genericCache;
+            private IGenericCacheEntry? m_genericCache;
             private object[]? _emptyArray; // Object array cache for Attribute.GetCustomAttributes() pathological no-result case.
             private RuntimeType? _genericTypeDefinition;
             #endregion
@@ -1499,11 +1498,11 @@ namespace System
 
             #region Internal Members
 
-            internal ref object? GenericCache => ref m_genericCache;
+            internal ref IGenericCacheEntry? GenericCache => ref m_genericCache;
 
             private sealed class FunctionPointerCache : IGenericCacheEntry<FunctionPointerCache>
             {
-                static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.FunctionPointer;
+                static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<FunctionPointerCache>.Kind => IGenericCacheEntry.GenericCacheKind.FunctionPointer;
 
                 public Type[] FunctionPointerReturnAndParameterTypes { get; }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1509,7 +1509,7 @@ namespace System
 
             private sealed class FunctionPointerCache : IGenericCacheEntry<FunctionPointerCache>
             {
-                public static IGenericCacheEntry.GenericCacheKind Kind => IGenericCacheEntry.GenericCacheKind.FunctionPointer;
+                static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.FunctionPointer;
 
                 public Type[] FunctionPointerReturnAndParameterTypes { get; }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1934,20 +1934,18 @@ namespace System
             return IGenericCacheEntry<T>.GetOrCreate(this);
         }
 
-#if false
         internal T? FindCacheEntry<T>()
             where T : class, IGenericCacheEntry<T>
         {
             return IGenericCacheEntry<T>.Find(this);
         }
 
-        internal T OverwriteCacheEntry<T>(T entry)
+        internal T ReplaceCacheEntry<T>(T entry)
             where T : class, IGenericCacheEntry<T>
         {
-            IGenericCacheEntry<T>.Overwrite(this, entry);
+            IGenericCacheEntry<T>.Replace(this, entry);
             return entry;
         }
-#endif
 
         internal static FieldInfo GetFieldInfo(IRuntimeFieldInfo fieldHandle)
         {

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2060,7 +2060,7 @@ namespace System
                 name = fullname;
             }
         }
-#endregion
+        #endregion
 
         #region Filters
         internal static BindingFlags FilterPreCalculate(bool isPublic, bool isInherited, bool isStatic)

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -1500,10 +1500,8 @@ namespace System
 
             internal ref IGenericCacheEntry? GenericCache => ref m_genericCache;
 
-            private sealed class FunctionPointerCache : IGenericCacheEntry<FunctionPointerCache>
+            internal sealed class FunctionPointerCache : IGenericCacheEntry<FunctionPointerCache>
             {
-                static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<FunctionPointerCache>.Kind => IGenericCacheEntry.GenericCacheKind.FunctionPointer;
-
                 public Type[] FunctionPointerReturnAndParameterTypes { get; }
 
                 private FunctionPointerCache(Type[] functionPointerReturnAndParameterTypes)
@@ -1516,6 +1514,8 @@ namespace System
                     Debug.Assert(type.IsFunctionPointer);
                     return new(RuntimeTypeHandle.GetArgumentTypesFromFunctionPointer(type));
                 }
+                public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._functionPointerCache = this;
+                public static ref FunctionPointerCache? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry) => ref compositeEntry._functionPointerCache;
             }
 
             internal Type[] FunctionPointerReturnAndParameterTypes
@@ -1934,6 +1934,7 @@ namespace System
             return IGenericCacheEntry<T>.GetOrCreate(this);
         }
 
+#if false
         internal T? FindCacheEntry<T>()
             where T : class, IGenericCacheEntry<T>
         {
@@ -1946,6 +1947,7 @@ namespace System
             IGenericCacheEntry<T>.Overwrite(this, entry);
             return entry;
         }
+#endif
 
         internal static FieldInfo GetFieldInfo(IRuntimeFieldInfo fieldHandle)
         {
@@ -2060,7 +2062,7 @@ namespace System
                 name = fullname;
             }
         }
-        #endregion
+#endregion
 
         #region Filters
         internal static BindingFlags FilterPreCalculate(bool isPublic, bool isInherited, bool isStatic)
@@ -2387,7 +2389,7 @@ namespace System
 
         #endregion
 
-        #endregion
+#endregion
 
         #region Private Data Members
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
@@ -14,7 +14,7 @@ namespace System
         /// </summary>
         private sealed unsafe partial class CreateUninitializedCache : IGenericCacheEntry<CreateUninitializedCache>
         {
-            public static IGenericCacheEntry.GenericCacheKind Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
+            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
             public static CreateUninitializedCache Create(RuntimeType type) => new CreateUninitializedCache(type);
 
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
@@ -12,8 +12,11 @@ namespace System
         /// <summary>
         /// A cache which allows optimizing <see cref="RuntimeHelpers.GetUninitializedObject(Type)"/>.
         /// </summary>
-        private sealed unsafe partial class CreateUninitializedCache
+        private sealed unsafe partial class CreateUninitializedCache : IGenericCacheEntry<CreateUninitializedCache>
         {
+            public static IGenericCacheEntry.GenericCacheKind Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
+            public static CreateUninitializedCache Create(RuntimeType type) => new CreateUninitializedCache(type);
+
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).
             private readonly delegate*<void*, object> _pfnAllocator;
             private readonly void* _allocatorFirstArg;
@@ -22,7 +25,7 @@ namespace System
             private readonly RuntimeType _originalRuntimeType;
 #endif
 
-            internal CreateUninitializedCache(RuntimeType rt)
+            private CreateUninitializedCache(RuntimeType rt)
             {
                 Debug.Assert(rt != null);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
@@ -14,7 +14,7 @@ namespace System
         /// </summary>
         private sealed unsafe partial class CreateUninitializedCache : IGenericCacheEntry<CreateUninitializedCache>
         {
-            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry.Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
+            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<CreateUninitializedCache>.Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
             public static CreateUninitializedCache Create(RuntimeType type) => new CreateUninitializedCache(type);
 
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
@@ -12,10 +12,11 @@ namespace System
         /// <summary>
         /// A cache which allows optimizing <see cref="RuntimeHelpers.GetUninitializedObject(Type)"/>.
         /// </summary>
-        private sealed unsafe partial class CreateUninitializedCache : IGenericCacheEntry<CreateUninitializedCache>
+        internal sealed unsafe partial class CreateUninitializedCache : IGenericCacheEntry<CreateUninitializedCache>
         {
-            static IGenericCacheEntry.GenericCacheKind IGenericCacheEntry<CreateUninitializedCache>.Kind => IGenericCacheEntry.GenericCacheKind.CreateUninitialized;
-            public static CreateUninitializedCache Create(RuntimeType type) => new CreateUninitializedCache(type);
+            public static CreateUninitializedCache Create(RuntimeType type) => new(type);
+            public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry) => compositeEntry._createUninitializedCache = this;
+            public static ref CreateUninitializedCache? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry) => ref compositeEntry._createUninitializedCache;
 
             // The managed calli to the newobj allocator, plus its first argument (MethodTable*).
             private readonly delegate*<void*, object> _pfnAllocator;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -91,10 +91,12 @@ namespace System
                 // and trying to make the code resilient to this would be more expensive.
                 // Just make sure we read the cache field once and set it if we need to update it.
                 var maybeCompositeCache = type.GenericCache;
+
+                Debug.Assert(maybeCompositeCache is not null);
                 if (maybeCompositeCache is not CompositeCacheEntry composite)
                 {
                     // Convert the current cache into a composite cache.
-                    composite = CompositeCacheEntry.Create((IGenericCacheEntry)maybeCompositeCache);
+                    composite = CompositeCacheEntry.Create((IGenericCacheEntry)maybeCompositeCache!);
                     type.GenericCache = composite;
                 }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -104,7 +104,7 @@ namespace System
                 if (currentCache is null)
                 {
                     TCache newCache = TCache.Create(type);
-                    currentCache = newCache;
+                    genericCache = newCache;
                     return newCache;
                 }
                 else if (currentCache is TCache existing)
@@ -149,7 +149,8 @@ namespace System
             public static void Overwrite(RuntimeType type, TCache cache)
             {
                 ref object? genericCache = ref type.Cache.GenericCache;
-                if (genericCache is null)
+                object? currentCache = genericCache;
+                if (currentCache is null)
                 {
                     genericCache = cache;
                     return;
@@ -160,8 +161,8 @@ namespace System
                 // but we can't easily do a lock-free CompareExchange with the current design,
                 // and we can't assume that we won't have one thread adding another item to the cache
                 // while another is trying to overwrite the (currently) only entry in the cache.
-                CompositeCacheEntry composite = GetOrUpgradeToCompositeCache(ref genericCache);
-
+                CompositeCacheEntry composite = GetOrUpgradeToCompositeCache(ref currentCache);
+                genericCache = currentCache;
                 composite.OverwriteNestedCache(cache);
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -97,6 +97,7 @@ namespace System
                 return ref Unsafe.Unbox<CompositeCacheEntry>(currentCache);
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static TCache GetOrCreate(RuntimeType type)
             {
                 ref object? genericCache = ref type.Cache.GenericCache;
@@ -126,6 +127,7 @@ namespace System
                 return composite.OverwriteNestedCache(TCache.Create(type));
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static TCache? Find(RuntimeType type)
             {
                 object? genericCache = type.CacheIfExists?.GenericCache;
@@ -147,6 +149,7 @@ namespace System
                 }
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void Overwrite(RuntimeType type, TCache cache)
             {
                 ref object? genericCache = ref type.Cache.GenericCache;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal sealed partial class RuntimeType
+    {
+        /// <summary>
+        /// A base interface for all cache entries that can be stored in <see cref="RuntimeType.GenericCache"/>.
+        /// </summary>
+        internal interface IGenericCacheEntry
+        {
+            /// <summary>
+            /// The different kinds of entries that can be stored in <see cref="RuntimeType.GenericCache"/>.
+            /// </summary>
+            public enum GenericCacheKind
+            {
+                ArrayInitialize,
+                EnumInfo,
+                Activator,
+                CreateUninitialized,
+                FunctionPointer
+            }
+
+            public abstract GenericCacheKind CacheKind { get; }
+
+            public static abstract GenericCacheKind Kind { get; }
+
+            /// <summary>
+            /// A composite cache entry that can store multiple cache entries of different kinds.
+            /// </summary>
+            /// <remarks>
+            /// For better performance, each entry is stored as a separate field instead of something like a dictionary.
+            /// </remarks>
+            protected sealed class CompositeCacheEntry
+            {
+                private IGenericCacheEntry? _arrayInitializeCache;
+                private IGenericCacheEntry? _enumInfoCache;
+                private IGenericCacheEntry? _activatorCache;
+                private IGenericCacheEntry? _createUninitializedCache;
+                private IGenericCacheEntry? _functionPointerCache;
+
+                private ref IGenericCacheEntry? GetCacheFieldForKind(IGenericCacheEntry.GenericCacheKind kind)
+                {
+                    switch (kind)
+                    {
+                        case IGenericCacheEntry.GenericCacheKind.ArrayInitialize:
+                            return ref _arrayInitializeCache;
+                        case IGenericCacheEntry.GenericCacheKind.EnumInfo:
+                            return ref _enumInfoCache;
+                        case IGenericCacheEntry.GenericCacheKind.Activator:
+                            return ref _activatorCache;
+                        case IGenericCacheEntry.GenericCacheKind.CreateUninitialized:
+                            return ref _createUninitializedCache;
+                        case IGenericCacheEntry.GenericCacheKind.FunctionPointer:
+                            return ref _functionPointerCache;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(kind));
+                    }
+                }
+
+                public static CompositeCacheEntry Create(IGenericCacheEntry cache)
+                {
+                    var composite = new CompositeCacheEntry();
+                    composite.GetCacheFieldForKind(cache.CacheKind) = cache;
+                    return composite;
+                }
+
+                public IGenericCacheEntry GetNestedCache(IGenericCacheEntry.GenericCacheKind kind)
+                {
+                    return GetCacheFieldForKind(kind)!;
+                }
+
+                public IGenericCacheEntry OverwriteNestedCache<T>(T cache)
+                    where T : IGenericCacheEntry
+                {
+                    return GetCacheFieldForKind(T.Kind) = cache;
+                }
+            }
+        }
+
+        /// <summary>
+        /// A typed cache entry. This type provides a base type that handles contruction of entries and maintenance of
+        /// the <see cref="RuntimeType.GenericCache"/> storage.
+        /// </summary>
+        /// <typeparam name="TCache">The cache entry type.</typeparam>
+        internal interface IGenericCacheEntry<TCache> : IGenericCacheEntry
+            where TCache: class, IGenericCacheEntry<TCache>
+        {
+            GenericCacheKind IGenericCacheEntry.CacheKind => TCache.Kind;
+
+            public static abstract TCache Create(RuntimeType type);
+
+            public static TCache GetOrCreate(RuntimeType type)
+            {
+                if (type.GenericCache is null)
+                {
+                    TCache newCache = TCache.Create(type);
+                    type.GenericCache = newCache;
+                    return newCache;
+                }
+                else if (type.GenericCache is IGenericCacheEntry existing && existing.CacheKind == TCache.Kind)
+                {
+                    return (TCache)type.GenericCache;
+                }
+
+                if (type.GenericCache is not CompositeCacheEntry composite)
+                {
+                    // Convert the current cache into a composite cache.
+                    composite = CompositeCacheEntry.Create((IGenericCacheEntry)type.GenericCache);
+                    type.GenericCache = composite;
+                }
+
+                if (composite.GetNestedCache(TCache.Kind) is TCache cache)
+                {
+                    return cache;
+                }
+
+                return (TCache)composite.OverwriteNestedCache(TCache.Create(type));
+            }
+
+            public static TCache? Find(RuntimeType type)
+            {
+                if (type.GenericCache is null)
+                {
+                    return null;
+                }
+                else if (type.GenericCache is IGenericCacheEntry existing && existing.CacheKind == TCache.Kind)
+                {
+                    return (TCache)type.GenericCache;
+                }
+                else if (type.GenericCache is CompositeCacheEntry composite)
+                {
+                    return (TCache)composite.GetNestedCache(TCache.Kind);
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            public static void Overwrite(RuntimeType type, TCache cache)
+            {
+                if (type.GenericCache is null)
+                {
+                    type.GenericCache = cache;
+                    return;
+                }
+                else if (type.GenericCache is IGenericCacheEntry existing && existing.CacheKind == TCache.Kind)
+                {
+                    type.GenericCache = cache;
+                    return;
+                }
+
+                if (type.GenericCache is not CompositeCacheEntry composite)
+                {
+                    // Convert the current cache into a composite cache.
+                    composite = CompositeCacheEntry.Create((IGenericCacheEntry)type.GenericCache);
+                    type.GenericCache = composite;
+                }
+
+                composite.OverwriteNestedCache(cache);
+            }
+        }
+    }
+}

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -75,13 +75,16 @@ namespace System
                 ref IGenericCacheEntry? genericCache = ref type.Cache.GenericCache;
                 // Read the GenericCache once to avoid multiple reads of the same field.
                 IGenericCacheEntry? currentCache = genericCache;
-                if (currentCache is TCache existing)
+                if (currentCache is not null)
                 {
-                    return existing;
-                }
-                if (currentCache is CompositeCacheEntry composite)
-                {
-                    return TCache.GetStorageRef(composite);
+                   if (currentCache is TCache existing)
+                    {
+                        return existing;
+                    }
+                    if (currentCache is CompositeCacheEntry composite)
+                    {
+                        return TCache.GetStorageRef(composite);
+                    }
                 }
 
                 return null;

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.EnumInfo.cs
@@ -11,7 +11,7 @@ namespace System
 {
     public abstract partial class Enum
     {
-        internal sealed class EnumInfo<TStorage>
+        internal sealed partial class EnumInfo<TStorage>
             where TStorage : struct, INumber<TStorage>
         {
             public readonly bool HasFlagsAttribute;


### PR DESCRIPTION
Enable GenericCache to hold multiple types of cache entries in preparation for some boxing optimizations that can use the cache. Try to encapsulate the design so the users of the `GenericCache` don't need to think about multiple cache entries.