### PR TITLE
Pin arm image to unblock ci

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -17,7 +17,7 @@ extends:
 
     containers:
       linux_arm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm-net9.0
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm-net9.0-20240507035943-1390eea
         env:
           ROOTFS_DIR: /crossrootfs/arm
 


### PR DESCRIPTION
Temporary fix for https://github.com/dotnet/runtime/issues/102030. I'll work on getting us a debian 12 helix image for the arm runs so we can undo this ASAP.