### PR TITLE
Add the autocreated .mono/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,7 @@ node_modules/
 *.metaproj
 *.metaproj.tmp
 bin.localpkg/
+.mono/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
When working with VS Code on Linux, a .mono/ folder gets created at the root, but should be ignored by git.