### PR TITLE
Fix for profiler test arm64

### DIFF
--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -210,7 +210,7 @@ namespace Profiler.Tests
                         _hasPassingOutput = true;
                     }
 
-                    Console.WriteLine($"Profiler STDOUT: {line}");
+                    Console.WriteLine($"Profilee STDOUT: {line}");
                 }
             }
         }

--- a/src/tests/profiler/common/ProfilerTestRunner.cs
+++ b/src/tests/profiler/common/ProfilerTestRunner.cs
@@ -52,7 +52,7 @@ namespace Profiler.Tests
                 if (loadAsNotification)
                 {
                     StringBuilder builder = new StringBuilder();
-                    for(int i = 0; i < notificationCopies; ++i)
+                    for (int i = 0; i < notificationCopies; ++i)
                     {
                         builder.Append(profilerPath);
                         builder.Append("=");
@@ -94,12 +94,10 @@ namespace Profiler.Tests
 
             envVars.Add("Profiler_Test_Name", testName);
 
-            if(!File.Exists(profilerPath))
+            if (!File.Exists(profilerPath))
             {
                 FailFastWithMessage("Profiler library not found at expected path: " + profilerPath);
             }
-
-            ProfileeOutputVerifier verifier = new ProfileeOutputVerifier();
 
             Process process = new Process();
             process.StartInfo.FileName = program;
@@ -117,15 +115,10 @@ namespace Profiler.Tests
                 process.StartInfo.EnvironmentVariables[key] = envVars[key];
             }
 
-            process.OutputDataReceived += (sender, args) =>
-            {
-                Console.WriteLine(args.Data);
-                verifier.WriteLine(args.Data);
-            };
             process.Start();
+            ProfileeOutputVerifier verifier = new ProfileeOutputVerifier(process.StandardOutput);
 
-            process.BeginOutputReadLine();
-
+            verifier.VerifyOutput();
             process.WaitForExit();
 
             // There are two conditions for profiler tests to pass, the output of the profiled program
@@ -198,21 +191,26 @@ namespace Profiler.Tests
             private volatile bool _hasPassingOutput;
 
             public string SuccessPhrase = "PROFILER TEST PASSES";
-            public bool HasPassingOutput => _hasPassingOutput;
+            private StreamReader standardOutput;
 
-            public void WriteLine(string message)
+            public ProfileeOutputVerifier(StreamReader standardOutput)
             {
-                if (message != null && message.Contains(SuccessPhrase))
-                {
-                    _hasPassingOutput = true;
-                }
+                this.standardOutput = standardOutput;
             }
 
-            public void WriteLine(string format, params object[] args)
+            public bool HasPassingOutput => _hasPassingOutput;
+
+            internal void VerifyOutput()
             {
-                if (string.Format(format,args).Contains(SuccessPhrase))
+                string line;
+                while ((line = standardOutput.ReadLine()) != null)
                 {
-                    _hasPassingOutput = true;
+                    if (line.Contains(SuccessPhrase))
+                    {
+                        _hasPassingOutput = true;
+                    }
+
+                    Console.WriteLine($"Profiler STDOUT: {line}");
                 }
             }
         }

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -10,10 +10,10 @@ namespace Profiler.Tests
 {
     class MultiplyLoaded
     {
-        static readonly Guid MultipleProfilerGuid = new Guid("BFA8EF13-E144-49B9-B95C-FC1C150C7651");
-        static readonly string ProfilerPath = ProfilerTestRunner.GetProfilerPath();
+        private static readonly Guid MultipleProfilerGuid = new Guid("BFA8EF13-E144-49B9-B95C-FC1C150C7651");
+        private static readonly string ProfilerPath = ProfilerTestRunner.GetProfilerPath();
 
-        static ManualResetEvent _profilerDone = new ManualResetEvent(false);
+        private static ManualResetEvent _profilerDone = new ManualResetEvent(false);
 
         [DllImport("Profiler")]
         private static extern void PassCallbackToProfiler(ProfilerCallback callback);

--- a/src/tests/profiler/multiple/multiple.cs
+++ b/src/tests/profiler/multiple/multiple.cs
@@ -13,13 +13,19 @@ namespace Profiler.Tests
         static readonly Guid MultipleProfilerGuid = new Guid("BFA8EF13-E144-49B9-B95C-FC1C150C7651");
         static readonly string ProfilerPath = ProfilerTestRunner.GetProfilerPath();
 
+        static ManualResetEvent _profilerDone = new ManualResetEvent(false);
+
         [DllImport("Profiler")]
         private static extern void PassCallbackToProfiler(ProfilerCallback callback);
 
+        private static void ProfilerDone()
+        {
+            _profilerDone.Set();
+        }
+
         public static int RunTest(String[] args)
         {
-            ManualResetEvent _profilerDone = new ManualResetEvent(false);
-            PassCallbackToProfiler(() => _profilerDone.Set());
+            PassCallbackToProfiler(ProfilerDone);
 
             ProfilerControlHelpers.AttachProfilerToSelf(MultipleProfilerGuid, ProfilerPath);
 

--- a/src/tests/profiler/native/multiple/multiple.cpp
+++ b/src/tests/profiler/native/multiple/multiple.cpp
@@ -57,11 +57,14 @@ HRESULT MultiplyLoaded::ProfilerDetachSucceeded()
     ++_detachCount;
 
     printf("ProfilerDetachSucceeded _detachCount=%d\n", _detachCount.load());
-    if (_detachCount == MAX_PROFILERS
-        &&  _exceptionThrownSeenCount >= MAX_PROFILERS
-        &&  _failures == 0)
+    if (_detachCount == MAX_PROFILERS)
     {
-        printf("PROFILER TEST PASSES\n");
+        if (_exceptionThrownSeenCount >= MAX_PROFILERS &&  _failures == 0)
+        {
+            printf("PROFILER TEST PASSES\n");
+            fflush(stdout);
+        }
+
         NotifyManagedCodeViaCallback(pCorProfilerInfo);
     }
 


### PR DESCRIPTION
While trying to investigate #100114 I found an unrelated issue, the delegate that we pass to the profiler can be garbage collected and cause the process to crash. This fixes that issue, as well as adds code to read all of the profilee's stdout.