### PR TITLE
Compile AOT compilers with InvariantGlobalization

### DIFF
--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -5,6 +5,7 @@
     <EventSourceSupport>true</EventSourceSupport>
     <OptimizationPreference>Speed</OptimizationPreference>
     <ControlFlowGuard>Guard</ControlFlowGuard>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With https://github.com/dotnet/runtime/pull/102036 this should just work and speed up compilation of the compiler/make compiler NuGet smaller.