### PR TITLE
[NativeAOT] Remove `linux-arm` as a supported RID in .NET8

### DIFF
--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props
@@ -2,7 +2,6 @@
   <ItemGroup>
     <!-- The officially-supported subset of these RIDs should be included in ILCompilerSupportedRids in
          https://github.com/dotnet/installer/blob/main/src/redist/targets/GenerateBundledVersions.targets -->
-    <OfficialBuildRID Include="linux-arm" Platform="arm" />
     <OfficialBuildRID Include="linux-musl-arm64" Platform="arm64" />
     <OfficialBuildRID Include="linux-arm64" Platform="arm64" />
     <OfficialBuildRID Include="linux-musl-x64" Platform="x64" />


### PR DESCRIPTION
## Customer Impact

- [X] Customer reported
- [X] Found internally

In .NET8 `linux-arm` is incorrectly listed as the officially supported RID with NativeAOT:
https://github.com/dotnet/runtime/blob/8966d0885f9bca07b7b9588cbfee04398a17e83a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/ILCompilerRIDs.props#L5 which can cause build failures during project `Restore` as NuGet will not be able to find the required runtime package.  

IMPORTANT: This does not impact .NET9 as we now do have support for `linux-arm`.

### The customer issue - mobile scenario

In https://github.com/dotnet/runtime/issues/100929 customer reported build failures when trying out NativeAOT deployments with their MAUI apps targeting iOS platforms with .NET8 from Visual Studio.
 
The project build fails during the `Restore` target with the following error: 
```
_Unable to find a stable package runtime.linux-arm.Microsoft.DotNet.ILCompiler with version (>= 8.0.3)

Found 3 version(s) in nuget.org [ Nearest version: 9.0.0-preview.1.24080.9 ]
Found 0 version(s) in /usr/local/share/dotnet/library-packs_
```

### The internal find - desktop scenario

The same issue can occur with the following set up:

Project file:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
    <RuntimeIdentifiers>linux-x64;linux-arm</RuntimeIdentifiers>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <PublishAot>true</PublishAot>
  </PropertyGroup>

</Project>
```
Build with:
```
dotnet publish -f net8.0
```
Fails with:
```
/workspaces/tmp/naot.csproj : error NU1103: Unable to find a stable package runtime.linux-arm.Microsoft.DotNet.ILCompiler with version (>= 8.0.2)
/workspaces/tmp/naot.csproj : error NU1103:   - Found 3 version(s) in nuget.org [ Nearest version: 9.0.0-preview.1.24080.9 ]
```

## Regression

- [ ] Yes
- [X] No

As @MichalStrehovsky [noted](https://github.com/dotnet/runtime/issues/100929#issuecomment-2058433289) this seems to be a left over from: https://github.com/dotnet/runtimelab/pull/1530 and was not discovered until now.

## Testing

Manually verified that by removing the `linux-arm` entry from: `~/.nuget/packages/microsoft.dotnet.ilcompiler/8.0.2/runtime.json` which is a file generated from `ILCompilerRIDs.props`  fixes the issue and the project builds properly.

## Risk

Low.

---

Fixes https://github.com/dotnet/runtime/issues/100929