### PR TITLE
Fix VirtualCallStubManager stats capturing on EE shutdown

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1248,6 +1248,8 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         // This will check a flag and do nothing if not enabled.
         Interpreter::PrintPostMortemData();
 #endif // FEATURE_INTERPRETER
+        VirtualCallStubManager::LogFinalStats();
+        WriteJitHelperCountToSTRESSLOG();
 
 #ifdef PROFILING_SUPPORTED
         // If profiling is enabled, then notify of shutdown first so that the
@@ -1326,8 +1328,6 @@ part2:
 
         {
             CONTRACT_VIOLATION(ModeViolation);
-            // At the moment, this doesn't do anything more than log statistics.
-            VirtualCallStubManager::UninitStatic();
 
             // On the new plan, we only do the tear-down under the protection of the loader
             // lock -- after the OS has stopped all other threads.
@@ -1350,7 +1350,6 @@ part2:
                 // Terminate the debugging services.
                 TerminateDebugger();
 #endif // DEBUGGING_SUPPORTED
-                WriteJitHelperCountToSTRESSLOG();
 
                 STRESS_LOG0(LF_STARTUP, LL_INFO10, "EEShutdown shutting down logging");
 

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1326,6 +1326,8 @@ part2:
 
         {
             CONTRACT_VIOLATION(ModeViolation);
+            // At the moment, this doesn't do anything more than log statistics.
+            VirtualCallStubManager::UninitStatic();
 
             // On the new plan, we only do the tear-down under the protection of the loader
             // lock -- after the OS has stopped all other threads.
@@ -1348,10 +1350,6 @@ part2:
                 // Terminate the debugging services.
                 TerminateDebugger();
 #endif // DEBUGGING_SUPPORTED
-
-                //@TODO: find the right place for this
-                VirtualCallStubManager::UninitStatic();
-
                 WriteJitHelperCountToSTRESSLOG();
 
                 STRESS_LOG0(LF_STARTUP, LL_INFO10, "EEShutdown shutting down logging");

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -769,9 +769,7 @@ void VirtualCallStubManager::InitStatic()
     VirtualCallStubManagerManager::InitStatic();
 }
 
-// Static shutdown code.
-// At the moment, this doesn't do anything more than log statistics.
-void VirtualCallStubManager::UninitStatic()
+void VirtualCallStubManager::LogFinalStats()
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/virtualcallstub.h
+++ b/src/coreclr/vm/virtualcallstub.h
@@ -236,13 +236,13 @@ public:
 
     // Set up static data structures - called during EEStartup
     static void InitStatic();
-    static void UninitStatic();
+    static void LogFinalStats();
 
     // Per instance initialization - called during AppDomain::Init and ::Uninit and for collectible loader allocators
     void Init(BaseDomain* pDomain, LoaderAllocator *pLoaderAllocator);
     void Uninit();
 
-    //@TODO: the logging should be tied into the VMs normal loggin mechanisms,
+    //@TODO: the logging should be tied into the VMs normal logging mechanisms,
     //@TODO: for now we just always write a short log file called "StubLog_<pid>.log"
     static void StartupLogging();
     static void LoggingDump();


### PR DESCRIPTION
Before this change logging stats to StubLog file doesn't work because on EE shutdown we don't shut down manager. Since it's only about logging we can perform uninit earlier.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung