### PR TITLE
Enable repackaging of NETStandard 2.1 Targeting Pack

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -507,6 +507,7 @@
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' != 'Mono' and '$(PgoInstrument)' != 'true'" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\Microsoft.NETCore.App.Crossgen2.sfxproj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-host.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-hostfxr.proj" />
+        <SharedFrameworkProjectToBuild Condition="'$(BuildNETStandard21TargetingPack)' == 'true' and '$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\netstandard2.1.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\sfx\installers\dotnet-runtime-deps\*.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(RuntimeFlavor)' == '$(PrimaryRuntimeFlavor)'" Include="$(InstallerProjectRoot)pkg\archives\dotnet-nethost.proj" />
         <SharedFrameworkProjectToBuild Condition="'$(MonoCrossAOTTargetOS)' != ''" Include="$(InstallerProjectRoot)pkg\sfx\Microsoft.NETCore.App\monocrossaot.sfxproj" Pack="true" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -264,8 +264,8 @@
     <!--
       Targeting pack package for NETStandard 2.1 gets rebuilt on demand.
 
-      Set to rebuild with 8.0.6 release, and automatically disabled after that.
+      Set to rebuild with 8.0.7 release, and automatically disabled after that.
     -->
-    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '6'">true</BuildNETStandard21TargetingPack>
+    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '7'">true</BuildNETStandard21TargetingPack>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -261,11 +261,11 @@
     <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting>
   </PropertyGroup>
   <PropertyGroup>
-      <!--
+    <!--
       Targeting pack package for NETStandard 2.1 gets rebuilt on demand.
 
       Set to rebuild with 8.0.6 release, and automatically disabled after that.
     -->
-    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '0'">true</BuildNETStandard21TargetingPack>
+    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '6'">true</BuildNETStandard21TargetingPack>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -260,4 +260,12 @@
     <MicrosoftDotnetSdkInternalVersion>8.0.101</MicrosoftDotnetSdkInternalVersion>
     <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting>
   </PropertyGroup>
+  <PropertyGroup>
+      <!--
+      Targeting pack package for NETStandard 2.1 gets rebuilt on demand.
+
+      Set to rebuild with 8.0.6 release, and automatically disabled after that.
+    -->
+    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '0'">true</BuildNETStandard21TargetingPack>
+  </PropertyGroup>
 </Project>

--- a/src/installer/pkg/sfx/installers.proj
+++ b/src/installer/pkg/sfx/installers.proj
@@ -22,6 +22,10 @@
     <InstallerProjectReference Include="installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.12.proj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(BuildNETStandard21TargetingPack)' == 'true' and '$(BuildRpmPackage)' == 'true'">
+    <InstallerProjectReference Include="installers/netstandard2.1.proj" />
+  </ItemGroup>
+
   <Target Name="BuildInstallerProjects" BeforeTargets="Build">
     <MSBuild Projects="@(InstallerProjectReference)"
              Targets="GenerateInstallers"

--- a/src/installer/pkg/sfx/installers/netstandard2.1.proj
+++ b/src/installer/pkg/sfx/installers/netstandard2.1.proj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+  <PropertyGroup>
+    <SkipBuild Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)' or '$(TargetsMobile)' == 'true'">true</SkipBuild>
+    <GenerateInstallers>true</GenerateInstallers>
+    <InstallerName>netstandard-targeting-pack-2.1</InstallerName>
+    <PackageBrandNameSuffix>NETStandard.Library.Ref</PackageBrandNameSuffix>
+    <ProductBrandName>NETStandard.Library.Ref 2.1.0</ProductBrandName>
+    <VersionInstallerName>false</VersionInstallerName>
+    <PlatformPackageType>ToolPack</PlatformPackageType>
+    <UseBrandingNameInLinuxPackageDescription>true</UseBrandingNameInLinuxPackageDescription>
+    <OriginalNETStandard21PkgFilename>netstandard-targeting-pack-2.1.0-x64.rpm</OriginalNETStandard21PkgFilename>
+    <NETStandard21PkgDownloadUrl>https://dotnetcli.blob.core.windows.net/dotnet/Runtime/3.1.0/$(OriginalNETStandard21PkgFilename)</NETStandard21PkgDownloadUrl>
+    <NETStandard21TempDir>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', 'download'))</NETStandard21TempDir>
+    <NETStandard21PkgDestinationPath>$(NETStandard21TempDir)$(OriginalNETStandard21PkgFilename)</NETStandard21PkgDestinationPath>
+    <NETStandard21PkgDownloadSemaphore>$(NETStandard21TempDir)netstandard21.semaphore</NETStandard21PkgDownloadSemaphore>
+  </PropertyGroup>
+
+  <UsingTask TaskName="DownloadFile" AssemblyFile="$(ArcadeSdkBuildTasksAssembly)" />
+
+  <Target Name="AcquireNETStandard21PackageContents"
+          Inputs="$(NETStandard21PkgDestinationPath)"
+          Outputs="$(NETStandard21PkgDownloadSemaphore)">
+
+    <RemoveDir Directories="$(NETStandard21TempDir)" />
+
+    <DownloadFile
+      Uri="$(NETStandard21PkgDownloadUrl)"
+      DestinationPath="$(NETStandard21PkgDestinationPath)"
+      Overwrite="true"
+      TimeoutInSeconds="9999" />
+
+    <Exec Command="rpm2cpio $(NETStandard21PkgDestinationPath) | cpio -idmv"
+          WorkingDirectory="$(NETStandard21TempDir)" />
+
+    <WriteLinesToFile
+      File="$(NETStandard21PkgDownloadSemaphore)"
+      Lines="$(NETStandard21PkgDownloadUrl)"
+      Overwrite="true"
+      Encoding="Unicode" />
+
+  </Target>
+
+  <Target Name="PublishToDisk"
+          DependsOnTargets="AcquireNETStandard21PackageContents">
+    <Error Condition="'$(OutputPath)' == ''" Text="Publishing to disk requires the OutputPath to be set to the root of the path to write to." />
+
+    <ItemGroup>
+      <Content Include="$(NETStandard21TempDir)usr/share/dotnet/**/*" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(Content)"
+          DestinationFolder="$(OutputPath)/%(RecursiveDir)" />
+  </Target>
+
+  <Target Name="AddLinuxPackageInformation" BeforeTargets="GetRpmInstallerJsonProperties">
+    <ItemGroup>
+      <RpmJsonProperty Include="directories" Object="[ &quot;/usr/share/dotnet/packs/NETStandard.Library.Ref/2.1.0&quot;, &quot;/usr/share/doc/netstandard-targeting-pack-2.1&quot; ]" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/installer/pkg/sfx/installers/netstandard2.1.proj
+++ b/src/installer/pkg/sfx/installers/netstandard2.1.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <SkipBuild Condition="'$(RuntimeFlavor)' != '$(PrimaryRuntimeFlavor)' or '$(TargetsMobile)' == 'true'">true</SkipBuild>
-    <GenerateInstallers>true</GenerateInstallers>
+    <GenerateInstallers Condition="'$(BuildRpmPackage)' != 'true'">false</GenerateInstallers>
     <InstallerName>netstandard-targeting-pack-2.1</InstallerName>
     <PackageBrandNameSuffix>NETStandard.Library.Ref</PackageBrandNameSuffix>
     <ProductBrandName>NETStandard.Library.Ref 2.1.0</ProductBrandName>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/99610

This PR has the same changes as https://github.com/dotnet/runtime/pull/101518, with the additional small change, to fix the issue with official CI. Original PR was reverted. This is now targeting 8.0.7 release. Validation build was successful: https://dev.azure.com/dnceng/internal/_build/results?buildId=2447965&view=results

Current NETStandard 2.1 targeting pack package does not support installation on FIPS-enabled systems. Original repo and branch (core-setup, release/3.1) have been deprecated and cannot be used for building this package anymore.

The solution is to repackage it. Extraction is done using `rpm2cpio <original-package> | cpio -idmv` which preserves original content and file modification time. Packaging is done with FPM, using regular tooling for RPM package creation. This tooling supports FIPS, by enabling sha256 package digest.

There are some small differences in metadata - description and packager fields, as well as copyright. Details are available in the appropriate sections.

### Naming and versioning

Old package name was `netstandard-targeting-pack-2.1.0-x64.rpm` as it did not get renamed during publishing to PMC. New packages will get renamed to follow common naming schema. New package name will be: `netstandard-targeting-pack-2.1-8.0.6-1.x86_64.rpm`

### Copyright differences

There is a minor difference in the comment section of the copyright file that ships with this package. It is picked up from new packaging infra. I've attached old and new copyright files, for review. I've outlined the differences.

||Old copyright|New copyright|
|-|-|-|
|Comment|Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. **See the LICENSE file in the project root for more information.**|Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license.|

### Package metadata differences

`Version` difference is intentional as a result of building in 8.0 servicing branch. This can likely be tweaked if needed, but it is a correct model as this is how distros version the same package, in their servicing releases.

`Packager` and `Description` values are coming from new package infra - shared with all packages produced in 8.0 release. This can likely be tweaked if needed. I've outlined the differences.

| |Old package|New package|
|-|-|-|
|Version|**2.1.0**|**8.0.6**|
|Release|1|1|
|Packager|.NET **Core** Team <dotnetpackages@dotnetfoundation.org>|.NET Team <dotnetpackages@dotnetfoundation.org>
|Description|.NET **Core** is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.|.NET is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.|

I've attached the full metadata content as files, for review.

### Testing

- Verified installation on FIPS-enabled system.
- Verified package upgrade.
- Verified that applications targeting NETStandard 2.1 can build against new package content.

[metadata.new.txt](https://github.com/dotnet/runtime/files/15099946/metadata.new.txt)
[metadata.original.txt](https://github.com/dotnet/runtime/files/15099947/metadata.original.txt)
[copyright.new.txt](https://github.com/dotnet/runtime/files/15099996/copyright.new.txt)
[copyright.original.txt](https://github.com/dotnet/runtime/files/15099997/copyright.original.txt)
