### PR TITLE
Use BoundsCheckNoThrow assertion in optAssertionProp_RangeProperties

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3930,6 +3930,18 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
     {
         AssertionDsc* curAssertion = optGetAssertion(GetAssertionIndex(index));
 
+        // if treeVN has a bound-check assertion where it's an index, then
+        // it means it's not negative, example:
+        //
+        //   array[idx] = 42; // creates 'BoundsCheckNoThrow' assertion
+        //   return idx % 8;  // idx is known to be never negative here, hence, MOD->UMOD
+        //
+        if (curAssertion->IsBoundsCheckNoThrow() && (curAssertion->op1.bnd.vnIdx == treeVN))
+        {
+            *isKnownNonNegative = true;
+            continue;
+        }
+
         // First, analyze possible X ==/!= CNS assertions.
         if (curAssertion->IsConstantInt32Assertion() && (curAssertion->op1.vn == treeVN))
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/102088

```cs
int Test(Span<int> x, int y) => x[y] + (y % 8);
```
```diff
; Method Bench:Test(System.Span`1[int],int):int:this (FullOpts)
       sub      rsp, 40
       cmp      r8d, dword ptr [rdx+0x08]
       jae      SHORT G_M45212_IG04
       mov      rax, bword ptr [rdx]
       mov      ecx, r8d
-      mov      edx, r8d
-      sar      edx, 31
-      and      edx, 7
-      add      edx, r8d
-      and      edx, -8
-      sub      r8d, edx
+      and      r8d, 7
       add      r8d, dword ptr [rax+4*rcx]
       mov      eax, r8d
       add      rsp, 40
       ret      
G_M45212_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
-; Total bytes of code: 52
+; Total bytes of code: 38
```