### PR TITLE
TimeSpanConverter: Less restrict in-range check to allow more timespan formats that would be accepted by Utf8Parser.TryParse

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/TimeSpanConverter.cs
@@ -8,7 +8,7 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class TimeSpanConverter : JsonPrimitiveConverter<TimeSpan>
     {
-        private const int MinimumTimeSpanFormatLength = 8; // hh:mm:ss
+        private const int MinimumTimeSpanFormatLength = 1; // d
         private const int MaximumTimeSpanFormatLength = 26; // -dddddddd.hh:mm:ss.fffffff
         private const int MaximumEscapedTimeSpanFormatLength = JsonConstants.MaxExpansionFactorWhileEscaping * MaximumTimeSpanFormatLength;
 

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Serialization/Value.ReadTests.cs
@@ -488,6 +488,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
+        [InlineData("1:00:00")]
+        [InlineData("1")]
+        [InlineData("10")]
+        [InlineData("00:01")]
+        [InlineData("0:00:02")]
+        [InlineData("0:00:00.0000001")]
+        [InlineData("0:00:00.0000010")]
+        [InlineData("0:00:00.0000100")]
+        [InlineData("0:00:00.0001000")]
+        [InlineData("0:00:00.0010000")]
+        [InlineData("0:00:00.0100000")]
+        [InlineData("0:00:00.1000000")]
         [InlineData("23:59:59")]
         [InlineData("\\u002D23:59:59", "-23:59:59")]
         [InlineData("\\u0032\\u0033\\u003A\\u0035\\u0039\\u003A\\u0035\\u0039", "23:59:59")]
@@ -546,13 +558,13 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("00:00:60")]
         [InlineData("00:00:00.00000009")]
         [InlineData("900000000.00:00:00")]
-        [InlineData("1:00:00")] // 'g' Format
         [InlineData("1:2:00:00")] // 'g' Format
         [InlineData("+00:00:00")]
         [InlineData("2021-06-18")]
         [InlineData("1$")]
         [InlineData("10675199.02:48:05.4775808")] // TimeSpan.MaxValue + 1
         [InlineData("-10675199.02:48:05.4775809")] // TimeSpan.MinValue - 1
+        [InlineData("")]
         [InlineData("1234", false)]
         [InlineData("{}", false)]
         [InlineData("[]", false)]


### PR DESCRIPTION
Fix #100538