### PR TITLE
[release/6.0-staging] Allow setting ZipArchiveEntry general-purpose flag bits

### DIFF
--- a/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
+++ b/src/libraries/Microsoft.Windows.Compatibility/src/Microsoft.Windows.Compatibility.csproj
@@ -5,8 +5,8 @@
     <!-- Reference the outputs for the dependency nodes calculation. -->
     <NoTargetsDoNotReferenceOutputAssemblies>false</NoTargetsDoNotReferenceOutputAssemblies>
     <IsPackable>true</IsPackable>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>8</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>9</ServicingVersion>
     <!-- This is a meta package and doesn't contain any libs. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageDescription>This Windows Compatibility Pack provides access to APIs that were previously available only for .NET Framework. It can be used from both .NET Core as well as .NET Standard.</PackageDescription>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -79,7 +79,7 @@ namespace System.IO.Compression
             _cdUnknownExtraFields = cd.ExtraFields;
             _fileComment = cd.FileComment;
 
-            _compressionLevel = null;
+            _compressionLevel = GetCompressionLevel(_generalPurposeBitFlag);
         }
 
         // Initializes new entry
@@ -91,6 +91,7 @@ namespace System.IO.Compression
             {
                 CompressionMethod = CompressionMethodValues.Stored;
             }
+            _generalPurposeBitFlag = MapDeflateCompressionOption(_generalPurposeBitFlag, _compressionLevel);
         }
 
         // Initializes new entry
@@ -104,7 +105,8 @@ namespace System.IO.Compression
             _versionMadeByPlatform = CurrentZipPlatform;
             _versionMadeBySpecification = ZipVersionNeededValues.Default;
             _versionToExtract = ZipVersionNeededValues.Default; // this must happen before following two assignment
-            _generalPurposeBitFlag = 0;
+            _compressionLevel = null;
+            _generalPurposeBitFlag = MapDeflateCompressionOption(0, _compressionLevel);
             CompressionMethod = CompressionMethodValues.Deflate;
             _lastModified = DateTimeOffset.Now;
 
@@ -126,8 +128,6 @@ namespace System.IO.Compression
             _cdUnknownExtraFields = null;
             _lhUnknownExtraFields = null;
             _fileComment = null;
-
-            _compressionLevel = null;
 
             if (_storedEntryNameBytes.Length > ushort.MaxValue)
                 throw new ArgumentException(SR.EntryNamesTooLong);
@@ -783,6 +783,35 @@ namespace System.IO.Compression
         }
 
         private bool SizesTooLarge() => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
+
+        private static CompressionLevel? GetCompressionLevel(BitFlagValues generalPurposeBitFlag)
+        {
+            // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
+            int deflateCompressionOption = (int)generalPurposeBitFlag & 0x6;
+
+            return deflateCompressionOption switch
+            {
+                0 => CompressionLevel.Optimal,
+                2 => CompressionLevel.SmallestSize,
+                4 => CompressionLevel.Fastest,
+                6 => CompressionLevel.NoCompression,
+                _ => null
+            };
+        }
+
+        private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel? compressionLevel)
+        {
+            ushort deflateCompressionOptions = compressionLevel switch
+            {
+                CompressionLevel.Optimal => 0,
+                CompressionLevel.SmallestSize => 2,
+                CompressionLevel.Fastest => 4,
+                CompressionLevel.NoCompression => 6,
+                _ => 0
+            };
+
+            return (BitFlagValues)(((int)generalPurposeBitFlag & ~0x6) | deflateCompressionOptions);
+        }
 
         // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
         private bool WriteLocalFileHeader(bool isEmptyFile)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -788,18 +788,21 @@ namespace System.IO.Compression
         {
             // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
             // If the compression method is not Deflate, the Deflate compression option is invalid - default to NoCompression.
-            int deflateCompressionOption = compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64
-                ? (int)generalPurposeBitFlag & 0x6
-                : 6;
-
-            return  deflateCompressionOption switch
+            if (compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64)
             {
-                0 => CompressionLevel.Optimal,
-                2 => CompressionLevel.SmallestSize,
-                4 => CompressionLevel.Fastest,
-                6 => CompressionLevel.NoCompression,
-                _ => CompressionLevel.Optimal
-            };
+                return ((int)generalPurposeBitFlag & 0x6) switch
+                {
+                    0 => CompressionLevel.Optimal,
+                    2 => CompressionLevel.SmallestSize,
+                    4 => CompressionLevel.Fastest,
+                    6 => CompressionLevel.Fastest,
+                    _ => CompressionLevel.Optimal
+                };
+            }
+            else
+            {
+                return CompressionLevel.NoCompression;
+            }
         }
 
         private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel compressionLevel, CompressionMethodValues compressionMethod)
@@ -812,7 +815,7 @@ namespace System.IO.Compression
                     {
                         CompressionLevel.Optimal => 0,
                         CompressionLevel.SmallestSize => 2,
-                        CompressionLevel.Fastest => 4,
+                        CompressionLevel.Fastest => 6,
                         CompressionLevel.NoCompression => 6,
                         _ => 0
                     }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -79,7 +79,7 @@ namespace System.IO.Compression
             _cdUnknownExtraFields = cd.ExtraFields;
             _fileComment = cd.FileComment;
 
-            _compressionLevel = GetCompressionLevel(_generalPurposeBitFlag);
+            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag);
         }
 
         // Initializes new entry
@@ -784,7 +784,7 @@ namespace System.IO.Compression
 
         private bool SizesTooLarge() => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
 
-        private static CompressionLevel? GetCompressionLevel(BitFlagValues generalPurposeBitFlag)
+        private static CompressionLevel? MapCompressionLevel(BitFlagValues generalPurposeBitFlag)
         {
             // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
             int deflateCompressionOption = (int)generalPurposeBitFlag & 0x6;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -41,7 +41,7 @@ namespace System.IO.Compression
         private List<ZipGenericExtraField>? _cdUnknownExtraFields;
         private List<ZipGenericExtraField>? _lhUnknownExtraFields;
         private readonly byte[]? _fileComment;
-        private readonly CompressionLevel? _compressionLevel;
+        private readonly CompressionLevel _compressionLevel;
 
         // Initializes, attaches it to archive
         internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd)
@@ -79,7 +79,7 @@ namespace System.IO.Compression
             _cdUnknownExtraFields = cd.ExtraFields;
             _fileComment = cd.FileComment;
 
-            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag);
+            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, CompressionMethod);
         }
 
         // Initializes new entry
@@ -91,7 +91,7 @@ namespace System.IO.Compression
             {
                 CompressionMethod = CompressionMethodValues.Stored;
             }
-            _generalPurposeBitFlag = MapDeflateCompressionOption(_generalPurposeBitFlag, _compressionLevel);
+            _generalPurposeBitFlag = MapDeflateCompressionOption(_generalPurposeBitFlag, _compressionLevel, CompressionMethod);
         }
 
         // Initializes new entry
@@ -105,9 +105,9 @@ namespace System.IO.Compression
             _versionMadeByPlatform = CurrentZipPlatform;
             _versionMadeBySpecification = ZipVersionNeededValues.Default;
             _versionToExtract = ZipVersionNeededValues.Default; // this must happen before following two assignment
-            _compressionLevel = null;
-            _generalPurposeBitFlag = MapDeflateCompressionOption(0, _compressionLevel);
+            _compressionLevel = CompressionLevel.Optimal;
             CompressionMethod = CompressionMethodValues.Deflate;
+            _generalPurposeBitFlag = MapDeflateCompressionOption(0, _compressionLevel, CompressionMethod);
             _lastModified = DateTimeOffset.Now;
 
             _compressedSize = 0; // we don't know these yet
@@ -617,7 +617,7 @@ namespace System.IO.Compression
                 case CompressionMethodValues.Deflate:
                 case CompressionMethodValues.Deflate64:
                 default:
-                    compressorStream = new DeflateStream(backingStream, _compressionLevel ?? CompressionLevel.Optimal, leaveBackingStreamOpen);
+                    compressorStream = new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen);
                     break;
 
             }
@@ -784,31 +784,39 @@ namespace System.IO.Compression
 
         private bool SizesTooLarge() => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
 
-        private static CompressionLevel? MapCompressionLevel(BitFlagValues generalPurposeBitFlag)
+        private static CompressionLevel MapCompressionLevel(BitFlagValues generalPurposeBitFlag, CompressionMethodValues compressionMethod)
         {
             // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
-            int deflateCompressionOption = (int)generalPurposeBitFlag & 0x6;
+            // If the compression method is not Deflate, the Deflate compression option is invalid - default to NoCompression.
+            int deflateCompressionOption = compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64
+                ? (int)generalPurposeBitFlag & 0x6
+                : 6;
 
-            return deflateCompressionOption switch
+            return  deflateCompressionOption switch
             {
                 0 => CompressionLevel.Optimal,
                 2 => CompressionLevel.SmallestSize,
                 4 => CompressionLevel.Fastest,
                 6 => CompressionLevel.NoCompression,
-                _ => null
+                _ => CompressionLevel.Optimal
             };
         }
 
-        private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel? compressionLevel)
+        private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel compressionLevel, CompressionMethodValues compressionMethod)
         {
-            ushort deflateCompressionOptions = compressionLevel switch
-            {
-                CompressionLevel.Optimal => 0,
-                CompressionLevel.SmallestSize => 2,
-                CompressionLevel.Fastest => 4,
-                CompressionLevel.NoCompression => 6,
-                _ => 0
-            };
+            ushort deflateCompressionOptions = (ushort)(
+                // The Deflate compression level is only valid if the compression method is actually Deflate (or Deflate64). If it's not, the
+                // value of the two bits is undefined and they should be zeroed out.
+                compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64
+                    ? compressionLevel switch
+                    {
+                        CompressionLevel.Optimal => 0,
+                        CompressionLevel.SmallestSize => 2,
+                        CompressionLevel.Fastest => 4,
+                        CompressionLevel.NoCompression => 6,
+                        _ => 0
+                    }
+                    : 0);
 
             return (BitFlagValues)(((int)generalPurposeBitFlag & ~0x6) | deflateCompressionOptions);
         }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -148,7 +148,8 @@ namespace System.IO.Compression.Tests
         // bit flags correctly. It verifies that these have been set by reading from the MemoryStream manually, and by
         // reopening the generated file to confirm that the compression levels match.
         [Theory]
-        [InlineData(CompressionLevel.NoCompression, 6)]
+        // Special-case NoCompression: in this case, the CompressionMethod becomes Stored and the bits are unset.
+        [InlineData(CompressionLevel.NoCompression, 0)]
         [InlineData(CompressionLevel.Optimal, 0)]
         [InlineData(CompressionLevel.SmallestSize, 2)]
         [InlineData(CompressionLevel.Fastest, 4)]

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -154,16 +154,17 @@ namespace System.IO.Compression.Tests
         [InlineData(CompressionLevel.Fastest, 4)]
         public static void CreateArchiveEntriesWithBitFlags(CompressionLevel compressionLevel, ushort expectedGeneralBitFlags)
         {
-            byte[] fileContent;
+            var testfilename = "testfile";
+            var testFileContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+            var utf8WithoutBom = new Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+            byte[] zipFileContent;
 
             using (var testStream = new MemoryStream())
             {
-                var testfilename = "testfile";
-                var testFileContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
 
                 using (var zip = new ZipArchive(testStream, ZipArchiveMode.Create))
                 {
-                    var utf8WithoutBom = new Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
                     ZipArchiveEntry newEntry = zip.CreateEntry(testfilename, compressionLevel);
                     using (var writer = new StreamWriter(newEntry.Open(), utf8WithoutBom))
                     {
@@ -174,15 +175,15 @@ namespace System.IO.Compression.Tests
                     ZipArchiveEntry secondNewEntry = zip.CreateEntry(testFileContent + "_post", CompressionLevel.NoCompression);
                 }
 
-                fileContent = testStream.ToArray();
+                zipFileContent = testStream.ToArray();
             }
 
             // expected bit flags are at position 6 in the file header
-            var generalBitFlags = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(fileContent.AsSpan(6));
+            var generalBitFlags = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(zipFileContent.AsSpan(6));
 
             Assert.Equal(expectedGeneralBitFlags, generalBitFlags);
 
-            using (var reReadStream = new MemoryStream(fileContent))
+            using (var reReadStream = new MemoryStream(zipFileContent))
             {
                 using (var reReadZip = new ZipArchive(reReadStream, ZipArchiveMode.Read))
                 {
@@ -199,6 +200,17 @@ namespace System.IO.Compression.Tests
 
                     reReadCompressionLevel = (CompressionLevel)compressionLevelFieldInfo.GetValue(secondArchive);
                     Assert.Equal(CompressionLevel.NoCompression, reReadCompressionLevel);
+
+                    using (var strm = firstArchive.Open())
+                    {
+                        var readBuffer = new byte[firstArchive.Length];
+
+                        strm.Read(readBuffer);
+
+                        var readText = Text.Encoding.UTF8.GetString(readBuffer);
+
+                        Assert.Equal(readText, testFileContent);
+                    }
                 }
             }
         }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -144,6 +144,65 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        // This test checks to ensure that setting the compression level of an archive entry sets the general-purpose
+        // bit flags correctly. It verifies that these have been set by reading from the MemoryStream manually, and by
+        // reopening the generated file to confirm that the compression levels match.
+        [Theory]
+        [InlineData(CompressionLevel.NoCompression, 6)]
+        [InlineData(CompressionLevel.Optimal, 0)]
+        [InlineData(CompressionLevel.SmallestSize, 2)]
+        [InlineData(CompressionLevel.Fastest, 4)]
+        public static void CreateArchiveEntriesWithBitFlags(CompressionLevel compressionLevel, ushort expectedGeneralBitFlags)
+        {
+            byte[] fileContent;
+
+            using (var testStream = new MemoryStream())
+            {
+                var testfilename = "testfile";
+                var testFileContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+
+                using (var zip = new ZipArchive(testStream, ZipArchiveMode.Create))
+                {
+                    var utf8WithoutBom = new Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+                    ZipArchiveEntry newEntry = zip.CreateEntry(testfilename, compressionLevel);
+                    using (var writer = new StreamWriter(newEntry.Open(), utf8WithoutBom))
+                    {
+                        writer.Write(testFileContent);
+                        writer.Flush();
+                    }
+
+                    ZipArchiveEntry secondNewEntry = zip.CreateEntry(testFileContent + "_post", CompressionLevel.NoCompression);
+                }
+
+                fileContent = testStream.ToArray();
+            }
+
+            // expected bit flags are at position 6 in the file header
+            var generalBitFlags = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(fileContent.AsSpan(6));
+
+            Assert.Equal(expectedGeneralBitFlags, generalBitFlags);
+
+            using (var reReadStream = new MemoryStream(fileContent))
+            {
+                using (var reReadZip = new ZipArchive(reReadStream, ZipArchiveMode.Read))
+                {
+                    var firstArchive = reReadZip.Entries[0];
+                    var secondArchive = reReadZip.Entries[1];
+                    var compressionLevelFieldInfo = typeof(ZipArchiveEntry).GetField("_compressionLevel", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    var generalBitFlagsFieldInfo = typeof(ZipArchiveEntry).GetField("_generalPurposeBitFlag", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+                    var reReadCompressionLevel = (CompressionLevel)compressionLevelFieldInfo.GetValue(firstArchive);
+                    var reReadGeneralBitFlags = (ushort)generalBitFlagsFieldInfo.GetValue(firstArchive);
+
+                    Assert.Equal(compressionLevel, reReadCompressionLevel);
+                    Assert.Equal(expectedGeneralBitFlags, reReadGeneralBitFlags);
+
+                    reReadCompressionLevel = (CompressionLevel)compressionLevelFieldInfo.GetValue(secondArchive);
+                    Assert.Equal(CompressionLevel.NoCompression, reReadCompressionLevel);
+                }
+            }
+        }
+
         [Fact]
         public static void CreateNormal_VerifyDataDescriptor()
         {

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -152,7 +152,7 @@ namespace System.IO.Compression.Tests
         [InlineData(CompressionLevel.NoCompression, 0)]
         [InlineData(CompressionLevel.Optimal, 0)]
         [InlineData(CompressionLevel.SmallestSize, 2)]
-        [InlineData(CompressionLevel.Fastest, 4)]
+        [InlineData(CompressionLevel.Fastest, 6)]
         public static void CreateArchiveEntriesWithBitFlags(CompressionLevel compressionLevel, ushort expectedGeneralBitFlags)
         {
             var testfilename = "testfile";

--- a/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
+++ b/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
@@ -7,8 +7,8 @@
     <NoWarn>$(NoWarn);CA1847</NoWarn>
     <IsPackable>true</IsPackable>
     <!-- If you enable GeneratePackageOnBuild for this package and bump ServicingVersion, make sure to also bump ServicingVersion in Microsoft.Windows.Compatibility.csproj once for the next release. -->
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <ServicingVersion>0</ServicingVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ServicingVersion>1</ServicingVersion>
     <PackageDescription>Provides classes that support storage of multiple data objects in a single container.</PackageDescription>
   </PropertyGroup>
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -404,7 +404,7 @@ namespace System.IO.Packaging
                     break;
                 case CompressionOption.Maximum:
                     {
-#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+#if NET
                         compressionLevel = CompressionLevel.SmallestSize;
 #else
                         compressionLevel = CompressionLevel.Optimal;

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -404,7 +404,11 @@ namespace System.IO.Packaging
                     break;
                 case CompressionOption.Maximum:
                     {
+#if (!NETSTANDARD2_0 && !NETFRAMEWORK)
+                        compressionLevel = CompressionLevel.SmallestSize;
+#else
                         compressionLevel = CompressionLevel.Optimal;
+#endif
                     }
                     break;
                 case CompressionOption.Fast:
@@ -414,7 +418,7 @@ namespace System.IO.Packaging
                     break;
                 case CompressionOption.SuperFast:
                     {
-                        compressionLevel = CompressionLevel.Fastest;
+                        compressionLevel = CompressionLevel.NoCompression;
                     }
                     break;
 

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/ZipPackage.cs
@@ -418,7 +418,7 @@ namespace System.IO.Packaging
                     break;
                 case CompressionOption.SuperFast:
                     {
-                        compressionLevel = CompressionLevel.NoCompression;
+                        compressionLevel = CompressionLevel.Fastest;
                     }
                     break;
 

--- a/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
@@ -34,7 +34,7 @@ public class ReflectionTests
                 FieldInfo fieldInfo = typeof(ZipArchiveEntry).GetField("_generalPurposeBitFlag", BindingFlags.Instance | BindingFlags.NonPublic);
                 object fieldObject = fieldInfo.GetValue(entry);
                 ushort shortField = (ushort)fieldObject;
-                Assert.Equal(0, shortField); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
+                Assert.Equal(0, shortField & 0x800); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
                 CheckCharacters(entry.Name);
                 CheckCharacters(entry.Comment); // Unavailable in .NET Framework
             }

--- a/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Packaging.Tests;
+
+public class ReflectionTests
+{
+    [Fact]
+    public void Verify_GeneralPurposeBitFlag_NotSetTo_Unicode()
+    {
+        using MemoryStream ms = new();
+
+        using (ZipPackage package = (ZipPackage)Package.Open(ms, FileMode.Create, FileAccess.Write))
+        {
+            Uri uri = PackUriHelper.CreatePartUri(new Uri("document.xml", UriKind.Relative));
+            ZipPackagePart part = (ZipPackagePart)package.CreatePart(uri, Tests.Mime_MediaTypeNames_Text_Xml, CompressionOption.NotCompressed);
+            using (Stream partStream = part.GetStream())
+            {
+                using StreamWriter sw = new(partStream);
+                sw.Write(Tests.s_DocumentXml);
+            }
+            package.CreateRelationship(part.Uri, TargetMode.Internal, "http://packageRelType", "rId1234");
+        }
+
+        ms.Position = 0;
+        using (ZipArchive archive = new ZipArchive(ms, ZipArchiveMode.Read, leaveOpen: false))
+        {
+            foreach (ZipArchiveEntry entry in archive.Entries)
+            {
+                FieldInfo fieldInfo = typeof(ZipArchiveEntry).GetField("_generalPurposeBitFlag", BindingFlags.Instance | BindingFlags.NonPublic);
+                object fieldObject = fieldInfo.GetValue(entry);
+                ushort shortField = (ushort)fieldObject;
+                Assert.Equal(0, shortField); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
+                CheckCharacters(entry.Name);
+                CheckCharacters(entry.Comment); // Unavailable in .NET Framework
+            }
+        }
+
+        void CheckCharacters(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                Assert.True(c >= 32 && c <= 126, $"ZipArchiveEntry name character {c} requires UTF8");
+            }
+        }
+    }
+
+}

--- a/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
@@ -30,7 +30,7 @@ public class ReflectionTests
         using (ZipArchive archive = new ZipArchive(ms, ZipArchiveMode.Read, leaveOpen: false))
         {
             FieldInfo archiveEncodingFieldInfo = typeof(ZipArchive).GetField("_entryNameAndCommentEncoding", BindingFlags.Instance | BindingFlags.NonPublic);
-            System.Text.Encoding archiveEncoding = (archiveEncodingFieldInfo.GetValue(archive) as System.Text.Encoding?) ?? System.Text.Encoding.UTF8;
+            System.Text.Encoding archiveEncoding = (archiveEncodingFieldInfo.GetValue(archive) as System.Text.Encoding) ?? System.Text.Encoding.UTF8;
             
             foreach (ZipArchiveEntry entry in archive.Entries)
             {
@@ -40,7 +40,7 @@ public class ReflectionTests
                 Assert.Equal(0, shortField & 0x800); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
                 CheckCharacters(entry.Name);
                 fieldInfo = typeof(ZipArchiveEntry).GetField("_fileComment", BindingFlags.Instance | BindingFlags.NonPublic);
-                byte[]? commentBytes = (byte[]?)fieldInfo.GetValue(archiveEntry);
+                byte[]? commentBytes = (byte[]?)fieldInfo.GetValue(entry);
                 
                 CheckCharacters(archiveEncoding.GetString(commentBytes));
             }

--- a/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
+++ b/src/libraries/System.IO.Packaging/tests/ReflectionTests.cs
@@ -29,7 +29,7 @@ public class ReflectionTests
         ms.Position = 0;
         using (ZipArchive archive = new ZipArchive(ms, ZipArchiveMode.Read, leaveOpen: false))
         {
-            FieldInfo archiveEncodingFieldInfo = typeof(ZipArchive).GetField("_entryNameAndCommentEncoding", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo archiveEncodingFieldInfo = typeof(ZipArchive).GetField("_entryNameEncoding", BindingFlags.Instance | BindingFlags.NonPublic);
             System.Text.Encoding archiveEncoding = (archiveEncodingFieldInfo.GetValue(archive) as System.Text.Encoding) ?? System.Text.Encoding.UTF8;
             
             foreach (ZipArchiveEntry entry in archive.Entries)
@@ -40,7 +40,7 @@ public class ReflectionTests
                 Assert.Equal(0, shortField & 0x800); // If it was UTF8, we would set the general purpose bit flag to 0x800 (UnicodeFileNameAndComment)
                 CheckCharacters(entry.Name);
                 fieldInfo = typeof(ZipArchiveEntry).GetField("_fileComment", BindingFlags.Instance | BindingFlags.NonPublic);
-                byte[]? commentBytes = (byte[]?)fieldInfo.GetValue(entry);
+                byte[] commentBytes = (byte[]?)fieldInfo.GetValue(entry) ?? Array.Empty<byte>();
                 
                 CheckCharacters(archiveEncoding.GetString(commentBytes));
             }

--- a/src/libraries/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
+++ b/src/libraries/System.IO.Packaging/tests/System.IO.Packaging.Tests.csproj
@@ -5,6 +5,9 @@
   <ItemGroup>
     <Compile Include="Tests.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <Compile Include="ReflectionTests.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Packaging.TestData" Version="$(SystemIOPackagingTestDataVersion)" />
     <ProjectReference Include="..\src\System.IO.Packaging.csproj" />

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -12,9 +12,9 @@ namespace System.IO.Packaging.Tests
 {
     public class Tests : FileCleanupTestBase
     {
-        private const string Mime_MediaTypeNames_Text_Xml = "text/xml";
+        internal const string Mime_MediaTypeNames_Text_Xml = "text/xml";
         private const string Mime_MediaTypeNames_Image_Jpeg = "image/jpeg"; // System.Net.Mime.MediaTypeNames.Image.Jpeg
-        private const string s_DocumentXml = @"<Hello>Test</Hello>";
+        internal const string s_DocumentXml = @"<Hello>Test</Hello>";
         private const string s_ResourceXml = @"<Resource>Test</Resource>";
 
         private FileInfo GetTempFileInfoFromExistingFile(string existingFileName, [CallerMemberName] string memberName = null, [CallerLineNumber] int lineNumber = 0)

--- a/src/libraries/System.IO.Packaging/tests/Tests.cs
+++ b/src/libraries/System.IO.Packaging/tests/Tests.cs
@@ -4019,7 +4019,7 @@ namespace System.IO.Packaging.Tests
                 ms.Seek(0, SeekOrigin.Begin);
 
                 var zipBytes = ms.ToArray();
-                var generalBitFlags = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(6));
+                var generalBitFlags = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(6)) & 0x6;
 
                 package = Package.Open(ms, FileMode.Open, FileAccess.Read);
                 part = package.GetPart(partUriDocument);


### PR DESCRIPTION
Backport of #98278 to release/6.0-staging

/cc @carlossanlop @edwardneal

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Originally reported in dotnet/Open-XML-SDK.

.NET Framework allows consumers of `System.IO.Packaging.ZipPackage` to use `CompressionOption` to update bits 1 & 2 in the ZIP archive header's general purpose bitfield. This functionality was lost in .NET Core.

OpenXML is affected because when a document like XSLX is created with our APIs, it is not compliant with the OpenXML specification ISO/IEC 29500-2, as the standard bits 1 and 2 are mandatory and are not reflecting the applied zip compression. Full discussions in https://github.com/dotnet/runtime/issues/88812 and  https://github.com/dotnet/Open-XML-SDK/issues/1443

Specifying the `CompressionLevel` of `System.IO.Compression.ZipArchive` will now change these bits, and the `ZipArchive`'s `CompressionLevel` value will be read from the bitfield.

## Regression

- [x] Yes
- [ ] No

This PR also introduces a breaking change which is reported in detail here: https://github.com/dotnet/docs/issues/40299 . Summarized, the `CompressionOption` values from `System.IO.Packaging` will map to different `CompressionLevel` levels in `System.IO.Compression` depending if using .NET Framework or .NET Core.

## Testing

New tests were added to both `System.IO.Compression` and `System.IO.Packaging` to verify that setting the `CompressionLevel` sets the expected bits, that they can be re-read correctly and that the file data can still be decompressed correctly.

## Risk

Low.

Thanks to @edwardneal for fixing the issue and @maedula for the detailed report of this problem.