### PR TITLE
Fix Mono.Linker.Tests build

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -162,6 +162,8 @@ jobs:
     - subset: tools_illink
       include:
       - src/tools/illink/*
+      - src/coreclr/tools/aot/ILCompiler.DependencyAnalysisFramework/*
+      - src/coreclr/tools/ILVerification/*
       - global.json
 
     - subset: tools_cdacreader

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerification/ILVerifier.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerification/ILVerifier.cs
@@ -33,7 +33,7 @@ public class ILVerifier : IResolver, IDisposable
 				IncludeMetadataTokensInErrorMessages = true
 			});
 
-		_verifier.SetSystemModuleName (new AssemblyName (systemModuleName));
+		_verifier.SetSystemModuleName (new AssemblyNameInfo (systemModuleName));
 	}
 
 	public ILVerifierResult[] VerifyByName (string assemblyName)
@@ -132,10 +132,10 @@ public class ILVerifier : IResolver, IDisposable
 		return null;
 	}
 
-	PEReader? IResolver.ResolveAssembly (AssemblyName assemblyName)
+	PEReader? IResolver.ResolveAssembly (AssemblyNameInfo assemblyName)
 		=> Resolve (assemblyName.Name ?? assemblyName.FullName);
 
-	PEReader? IResolver.ResolveModule (AssemblyName referencingModule, string fileName)
+	PEReader? IResolver.ResolveModule (AssemblyNameInfo referencingModule, string fileName)
 		=> Resolve (Path.GetFileNameWithoutExtension (fileName));
 
 	public void Dispose ()

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerifier.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerifier.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Runtime.Loader;
 using ILVerify;
@@ -42,7 +43,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					SanityChecks = true,
 					IncludeMetadataTokensInErrorMessages = true
 				});
-			_verifier.SetSystemModuleName (new AssemblyName ("mscorlib"));
+			_verifier.SetSystemModuleName (new AssemblyNameInfo ("mscorlib"));
 
 			var allResults = _verifier.Verify (Resolve (assemblyName))
 				?? Enumerable.Empty<VerificationResult> ();
@@ -118,10 +119,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			return null;
 		}
 
-		PEReader? ILVerify.IResolver.ResolveAssembly (AssemblyName assemblyName)
+		PEReader? ILVerify.IResolver.ResolveAssembly (AssemblyNameInfo assemblyName)
 			=> Resolve (assemblyName.Name ?? assemblyName.FullName);
 
-		PEReader? ILVerify.IResolver.ResolveModule (AssemblyName referencingModule, string fileName)
+		PEReader? ILVerify.IResolver.ResolveModule (AssemblyNameInfo referencingAssembly, string fileName)
 			=> Resolve (Path.GetFileNameWithoutExtension (fileName));
 
 		public static string GetErrorMessage (VerificationResult result)


### PR DESCRIPTION
And ensure changes to ProjectReferences trigger linker tests.

The Mono.Linker.Tests build was broken by https://github.com/dotnet/runtime/pull/102036 but we didn't catch it because we didn't trigger the illink test run for that change.