### PR TITLE
Avoid allocations in HTTP/1.1 connection pool

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -179,6 +179,7 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\HttpConnectionPool.Http1.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\HttpConnectionPool.Http2.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\HttpConnectionPool.Http3.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\HttpConnectionStack.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\HttpConnectionWaiter.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\ConnectionPool\RequestQueue.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\AuthenticationHelper.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -305,12 +305,12 @@ namespace System.Net.Http
         {
             get
             {
-                Debug.Assert(!Monitor.IsEntered(_http11Connections));
-                return _http11Connections;
+                Debug.Assert(!Monitor.IsEntered(_originAuthority));
+                return _originAuthority;
             }
         }
 
-        public bool HasSyncObjLock => Monitor.IsEntered(_http11Connections);
+        public bool HasSyncObjLock => Monitor.IsEntered(_originAuthority);
 
         // Overview of connection management (mostly HTTP version independent):
         //
@@ -946,7 +946,7 @@ namespace System.Net.Http
                 // will be purged next time around.
                 _usedSinceLastCleanup = false;
 
-                ScavengeHttp11ConnectionStack(this, _http11Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
+                ScavengeHttp11ConnectionStack(this, ref _http11Connections, ref toDispose, nowTicks, pooledConnectionLifetime, pooledConnectionIdleTimeout);
 
                 if (_availableHttp2Connections is not null)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionStack.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionStack.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// A <see cref="ConcurrentStack{T}"/> with an extra head pointer to opportunistically avoid allocations on pushes.
+    /// In situations where Push/Pop operations frequently occur in pairs (common under steady load), this avoids most allocations.
+    /// We treat <see langword="null"/> as a sentinel to indicate no value, so we can't store <see langword="null"/> values.
+    /// </summary>
+    internal struct HttpConnectionStack<T> where T : HttpConnectionBase
+    {
+        private readonly ConcurrentStack<T> _stack;
+        private T? _head;
+
+        public HttpConnectionStack()
+        {
+            _stack = new ConcurrentStack<T>();
+        }
+
+        public readonly int Count => _stack.Count + (_head is null ? 0 : 1);
+
+        public readonly bool DebugContains(T item) =>
+            ReferenceEquals(_head, item) ||
+            Array.IndexOf([.. _stack], item) >= 0;
+
+        public void Push(T item)
+        {
+            Debug.Assert(item is not null);
+
+            if (Interlocked.Exchange(ref _head, item) is T previousHead)
+            {
+                _stack.Push(previousHead);
+            }
+        }
+
+        public bool TryPop([MaybeNullWhen(false)] out T result)
+        {
+            if (Interlocked.Exchange(ref _head, null) is T head)
+            {
+                result = head;
+                return true;
+            }
+
+            return _stack.TryPop(out result);
+        }
+
+        public readonly void PushRange(T[] items, int startIndex, int count)
+        {
+            _stack.PushRange(items, startIndex, count);
+        }
+    }
+}


### PR DESCRIPTION
#99364 switched the H1 connection pool to using a `ConcurrentStack` as the store of connections.
While that change significantly improved throughout (particularly under contention), it does mean we're allocating an [extra 32 bytes](https://github.com/dotnet/runtime/blob/34e65b9e6c3100bbbebcd78fd03f3b2e88cdc9f0/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs#L44) every time we push to the connection stack (lack of DCAS).

This PR tweaks the backing store to use an extra `head` pointer we hit first before falling back to the `ConcurrentStack`. Because we're never storing `null` connections, we can use `null` as a sentinel for unset, and skip the allocations on the happy path.
That makes alternating push/pops (which is quite common) alloc-free.

| Method    | Toolchain | Mean     | Error   | Ratio | Allocated | Alloc Ratio |
|---------- |---------- |---------:|--------:|------:|----------:|------------:|
| SendAsync | main      | 484.9 ns | 0.82 ns |  1.00 |     584 B |        1.00 |
| SendAsync | pr        | 473.5 ns | 0.94 ns |  0.98 |     552 B |        0.95 |

Throughput-wise it's within noise for both YARP and HttpClient crank scenarios.

Under very high contention (5 cores doing the in-memory connection pool stress (`SendAsync` above)), results vary greatly between runs. But averaged out the updated variant does come out on top.

Average over 50 runs each: `main=3046k` `pr=3569k`. (blue == main)

![image](https://github.com/dotnet/runtime/assets/25307628/ba19cc1c-e30c-4235-9990-7a92325ea83d)


My guess is that this is happening because we're splitting the contention over two memory locations (some push/pops would be served by the new head without going into spin loops on the stack).

---

While this isn't that much code, we'd likely delete it whenever #31911 gets implemented and we start using it in `ConcurrentStack`.

