### PR TITLE
ARM64: Recognize more STP patterns

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2377,7 +2377,6 @@ void Compiler::optAssertionGen(GenTree* tree)
             break;
 
         case GT_IND:
-        case GT_LOCKADD:
         case GT_XAND:
         case GT_XORR:
         case GT_XADD:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2377,13 +2377,7 @@ void Compiler::optAssertionGen(GenTree* tree)
             break;
 
         case GT_IND:
-            // Dynamic block copy sources could be zero-sized and so should not generate assertions.
-            if (tree->TypeIs(TYP_STRUCT))
-            {
-                break;
-            }
-            FALLTHROUGH;
-
+        case GT_LOCKADD:
         case GT_XAND:
         case GT_XORR:
         case GT_XADD:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8683,8 +8683,13 @@ void Lowering::LowerStoreIndirCoalescing(GenTreeIndir* ind)
         // At this point we know that the 2nd (current) STOREIND has the same side-effects as the previous STOREIND
         // We can move the address part before the previous STOREIND to make STP friendly
         auto makeStpFriendly = [&]() {
-            LIR::Range Range = BlockRange().Remove(currData.rangeStart, currData.rangeEnd->gtPrev);
-            BlockRange().InsertBefore(prevData.rangeEnd, std::move(Range));
+#ifdef TARGET_ARM64
+            if (!GenTree::Compare(prevData.value, currData.value) || currData.value->IsVectorZero())
+            {
+                LIR::Range Range = BlockRange().Remove(currData.rangeStart, ind->gtPrev);
+                BlockRange().InsertBefore(prevInd, std::move(Range));
+            }
+#endif
         };
 
         // For now, only constants are supported for data.


### PR DESCRIPTION
When `LowerStoreIndirCoalescing` fails to merge two stores it should at least make the stores STP-friendly (when it's legal). Example:
```cs
static void Test(ref Vector128<byte> g)
{
    Unsafe.Add(ref g, 0) = default;
    Unsafe.Add(ref g, 1) = default;
}
```
Codegen diff (on arm64):
```diff
; Method Bench:Test(byref) (FullOpts)
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
            movi    v16.4s, #0
-           str     q16, [x0]
-           movi    v16.4s, #0
-           str     q16, [x0, #0x10]
+           movi    v17.4s, #0
+           stp     q16, q17, [x0]
            ldp     fp, lr, [sp], #0x10
            ret     lr
-; Total bytes of code: 32
+; Total bytes of code: 28
```

+ remove quirk from assertprop.