### PR TITLE
Use SIMD for block inits with GC fields

### DIFF
--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3231,6 +3231,18 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
     assert(size <= INT32_MAX);
     assert(dstOffset < (INT32_MAX - static_cast<int>(size)));
 
+    auto emitStore = [&](instruction ins, unsigned width, regNumber target) {
+        if (dstLclNum != BAD_VAR_NUM)
+        {
+            emit->emitIns_S_R(ins, EA_ATTR(width), target, dstLclNum, dstOffset);
+        }
+        else
+        {
+            emit->emitIns_ARX_R(ins, EA_ATTR(width), target, dstAddrBaseReg, dstAddrIndexReg, dstAddrIndexScale,
+                                dstOffset);
+        }
+    };
+
 #ifdef FEATURE_SIMD
     if (willUseSimdMov)
     {
@@ -3244,18 +3256,6 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         instruction simdMov      = simdUnalignedMovIns();
         unsigned    bytesWritten = 0;
 
-        auto emitSimdMovs = [&]() {
-            if (dstLclNum != BAD_VAR_NUM)
-            {
-                emit->emitIns_S_R(simdMov, EA_ATTR(regSize), srcXmmReg, dstLclNum, dstOffset);
-            }
-            else
-            {
-                emit->emitIns_ARX_R(simdMov, EA_ATTR(regSize), srcXmmReg, dstAddrBaseReg, dstAddrIndexReg,
-                                    dstAddrIndexScale, dstOffset);
-            }
-        };
-
         while (bytesWritten < size)
         {
             if (bytesWritten + regSize > size)
@@ -3264,7 +3264,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
                 break;
             }
 
-            emitSimdMovs();
+            emitStore(simdMov, regSize, srcXmmReg);
             dstOffset += regSize;
             bytesWritten += regSize;
         }
@@ -3279,9 +3279,70 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
             // Rewind dstOffset so we can fit a vector for the while remainder
             dstOffset -= (regSize - size);
-            emitSimdMovs();
+            emitStore(simdMov, regSize, srcXmmReg);
             size = 0;
         }
+    }
+    else if (node->IsOnHeapAndContainsReferences() && ((internalRegisters.GetAll(node) & RBM_ALLFLOAT) != 0))
+    {
+        // For block with GC refs we still can use SIMD, but only for continuous
+        // non-GC parts where atomicity guarantees are not that strict.
+        assert(!willUseSimdMov);
+        ClassLayout* layout      = node->GetLayout();
+        regNumber    simdZeroReg = REG_NA;
+        unsigned     slots       = layout->GetSlotCount();
+        unsigned     slot        = 0;
+        while (slot < slots)
+        {
+            if (!layout->IsGCPtr(slot))
+            {
+                // How many continuous non-GC slots do we have?
+                unsigned nonGcSlotCount = 0;
+                do
+                {
+                    nonGcSlotCount++;
+                    slot++;
+                } while ((slot < slots) && !layout->IsGCPtr(slot));
+
+                for (unsigned nonGcSlot = 0; nonGcSlot < nonGcSlotCount; nonGcSlot++)
+                {
+                    // Are continuous nongc slots enough to use SIMD?
+                    unsigned simdSize = compiler->roundDownSIMDSize((nonGcSlotCount - nonGcSlot) * REGSIZE_BYTES);
+                    if (simdSize > 0)
+                    {
+                        // Initialize simdZeroReg with zero on demand, it's enough to use TYP_SIMD16
+                        // regardless of the SIMD size we're going to use.
+                        if (simdZeroReg == REG_NA)
+                        {
+                            simdZeroReg = internalRegisters.GetSingle(node, RBM_ALLFLOAT);
+                            simd_t vecCon;
+                            memset(&vecCon, (uint8_t)src->AsIntCon()->IconValue(), sizeof(simd_t));
+                            genSetRegToConst(simdZeroReg, TYP_SIMD16, &vecCon);
+                        }
+
+                        emitStore(simdUnalignedMovIns(), simdSize, simdZeroReg);
+                        dstOffset += (int)simdSize;
+                        nonGcSlot += (simdSize / REGSIZE_BYTES) - 1;
+                    }
+                    else
+                    {
+                        emitStore(INS_mov, REGSIZE_BYTES, srcIntReg);
+                        dstOffset += REGSIZE_BYTES;
+                    }
+                }
+            }
+            else
+            {
+                // GC slot - update atomically
+                emitStore(INS_mov, REGSIZE_BYTES, srcIntReg);
+                dstOffset += REGSIZE_BYTES;
+                slot++;
+            }
+        }
+
+        // There are no trailing elements
+        assert((layout->GetSize() % TARGET_POINTER_SIZE) == 0);
+        size = 0;
     }
 #endif // FEATURE_SIMD
 
@@ -3298,15 +3359,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
 
     for (; size > regSize; size -= regSize, dstOffset += regSize)
     {
-        if (dstLclNum != BAD_VAR_NUM)
-        {
-            emit->emitIns_S_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstLclNum, dstOffset);
-        }
-        else
-        {
-            emit->emitIns_ARX_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstAddrBaseReg, dstAddrIndexReg,
-                                dstAddrIndexScale, dstOffset);
-        }
+        emitStore(INS_mov, regSize, srcIntReg);
     }
 
     // Handle the non-SIMD remainder by overlapping with previously processed data if needed
@@ -3322,15 +3375,7 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         assert(shiftBack <= regSize);
         dstOffset -= shiftBack;
 
-        if (dstLclNum != BAD_VAR_NUM)
-        {
-            emit->emitIns_S_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstLclNum, dstOffset);
-        }
-        else
-        {
-            emit->emitIns_ARX_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstAddrBaseReg, dstAddrIndexReg,
-                                dstAddrIndexScale, dstOffset);
-        }
+        emitStore(INS_mov, regSize, srcIntReg);
     }
 #else // TARGET_X86
     for (unsigned regSize = REGSIZE_BYTES; size > 0; size -= regSize, dstOffset += regSize)
@@ -3339,15 +3384,8 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         {
             regSize /= 2;
         }
-        if (dstLclNum != BAD_VAR_NUM)
-        {
-            emit->emitIns_S_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstLclNum, dstOffset);
-        }
-        else
-        {
-            emit->emitIns_ARX_R(INS_mov, EA_ATTR(regSize), srcIntReg, dstAddrBaseReg, dstAddrIndexReg,
-                                dstAddrIndexScale, dstOffset);
-        }
+
+        emitStore(INS_mov, regSize, srcIntReg);
     }
 #endif
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3311,13 +3311,12 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
                     unsigned simdSize = compiler->roundDownSIMDSize((nonGcSlotCount - nonGcSlot) * REGSIZE_BYTES);
                     if (simdSize > 0)
                     {
-                        // Initialize simdZeroReg with zero on demand, it's enough to use TYP_SIMD16
-                        // regardless of the SIMD size we're going to use.
+                        // Initialize simdZeroReg with zero on demand
                         if (simdZeroReg == REG_NA)
                         {
                             simdZeroReg = internalRegisters.GetSingle(node, RBM_ALLFLOAT);
-                            simd_t vecCon;
-                            memset(&vecCon, (uint8_t)src->AsIntCon()->IconValue(), sizeof(simd_t));
+                            // SIMD16 is sufficient for any SIMD size
+                            simd_t vecCon = {};
                             genSetRegToConst(simdZeroReg, TYP_SIMD16, &vecCon);
                         }
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -3288,10 +3288,11 @@ void CodeGen::genCodeForInitBlkUnroll(GenTreeBlk* node)
         // For block with GC refs we still can use SIMD, but only for continuous
         // non-GC parts where atomicity guarantees are not that strict.
         assert(!willUseSimdMov);
-        ClassLayout* layout      = node->GetLayout();
-        regNumber    simdZeroReg = REG_NA;
-        unsigned     slots       = layout->GetSlotCount();
-        unsigned     slot        = 0;
+        ClassLayout* layout = node->GetLayout();
+
+        regNumber simdZeroReg = REG_NA;
+        unsigned  slots       = layout->GetSlotCount();
+        unsigned  slot        = 0;
         while (slot < slots)
         {
             if (!layout->IsGCPtr(slot))

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1430,9 +1430,37 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
         {
             case GenTreeBlk::BlkOpKindUnroll:
             {
-                const bool canUse16BytesSimdMov =
-                    !blkNode->IsOnHeapAndContainsReferences() && compiler->IsBaselineSimdIsaSupported();
-                const bool willUseSimdMov = canUse16BytesSimdMov && (size >= XMM_REGSIZE_BYTES);
+                const bool canUse16BytesSimdMov = compiler->IsBaselineSimdIsaSupported();
+                bool       willUseSimdMov       = canUse16BytesSimdMov && (size >= XMM_REGSIZE_BYTES);
+                if (willUseSimdMov && blkNode->IsOnHeapAndContainsReferences())
+                {
+                    ClassLayout* layout = blkNode->GetLayout();
+                    unsigned     slots  = layout->GetSlotCount();
+                    unsigned     slot   = 0;
+                    unsigned     simds  = 0;
+                    while (slot < slots)
+                    {
+                        if (!layout->IsGCPtr(slot))
+                        {
+                            // How many continuous non-GC slots do we have?
+                            unsigned nonGcSlotCount = 0;
+                            do
+                            {
+                                nonGcSlotCount++;
+                                slot++;
+                            } while ((slot < slots) && !layout->IsGCPtr(slot));
+                            simds += (nonGcSlotCount * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES;
+                        }
+                        else
+                        {
+                            // GC slot
+                            slot++;
+                        }
+                    }
+
+                    // Just one XMM candidate is not profitable
+                    willUseSimdMov = simds > 1;
+                }
 
                 if (willUseSimdMov)
                 {

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1435,14 +1435,13 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                 {
                     ClassLayout* layout = blkNode->GetLayout();
 
-                    unsigned slot            = 0;
                     unsigned xmmCandidates   = 0;
                     unsigned continuousNonGc = 0;
-                    for (unsigned i = 0; i < layout->GetSlotCount(); i++)
+                    for (unsigned slot = 0; slot < layout->GetSlotCount(); slot++)
                     {
                         if (layout->IsGCPtr(slot))
                         {
-                            xmmCandidates += (continuousNonGc * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES;
+                            xmmCandidates += ((continuousNonGc * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES);
                             continuousNonGc = 0;
                         }
                         else
@@ -1450,7 +1449,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                             continuousNonGc++;
                         }
                     }
-                    xmmCandidates += (continuousNonGc * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES;
+                    xmmCandidates += ((continuousNonGc * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES);
 
                     // Just one XMM candidate is not profitable
                     willUseSimdMov = xmmCandidates > 1;

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1450,6 +1450,7 @@ int LinearScan::BuildBlockStore(GenTreeBlk* blkNode)
                             continuousNonGc++;
                         }
                     }
+                    xmmCandidates += (continuousNonGc * TARGET_POINTER_SIZE) / XMM_REGSIZE_BYTES;
 
                     // Just one XMM candidate is not profitable
                     willUseSimdMov = xmmCandidates > 1;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/83297

Currently, we conservatively give up on using SIMDs for structs (blocks) with GC references since SIMD (on x86/64 arch) has certain requirements to provide atomicity guarantees (data needs to be 16 byte aligned, CPU must support AVX2 and we must use aligned store instructions). Let's at least use SIMD for continuous non-GC parts of such structs, example:

```cs
struct MyStruct
{
    string gc1;
    long a;
    long b;
    long c;
    long d;
    long e;
    long f;
    long g;
    long h;
}

MyStruct Test() => new();
```
Codegen diff:
```diff
; Method Bench:Test():Bench+MyStruct:this (FullOpts)
       xor      eax, eax
       mov      qword ptr [rdx], rax ;; <-- GC slot
-      mov      qword ptr [rdx+0x08], rax
-      mov      qword ptr [rdx+0x10], rax
-      mov      qword ptr [rdx+0x18], rax
-      mov      qword ptr [rdx+0x20], rax
-      mov      qword ptr [rdx+0x28], rax
-      mov      qword ptr [rdx+0x30], rax
-      mov      qword ptr [rdx+0x38], rax
-      mov      qword ptr [rdx+0x40], rax
+      vxorps   xmm0, xmm0, xmm0
+      vmovdqu32 zmmword ptr [rdx+0x08], zmm0
       mov      rax, rdx
       ret      
-; Total bytes of code: 41
+; Total bytes of code: 23
```