### PR TITLE
make SocketAddress useable after receive timeout

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1909,8 +1909,6 @@ namespace System.Net.Sockets
 
             int bytesTransferred;
             SocketError errorCode = SocketPal.ReceiveFrom(_handle, buffer, socketFlags, receivedAddress.Buffer, out int socketAddressSize, out bytesTransferred);
-            receivedAddress.Size = socketAddressSize;
-
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred);
             // If the native call fails we'll throw a SocketException.
             if (errorCode != SocketError.Success)
@@ -1927,6 +1925,7 @@ namespace System.Net.Sockets
                 if (SocketType == SocketType.Dgram) SocketsTelemetry.Log.DatagramReceived();
             }
 
+            receivedAddress.Size = socketAddressSize;
             return bytesTransferred;
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
@@ -283,5 +283,41 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(0, receiver.Available);
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReceiveFrom_MultipleRounds_Success(bool async)
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
+            {
+                socket.ReceiveTimeout = 100;
+                socket.BindToAnonymousPort(IPAddress.Loopback);
+
+                var address = new SocketAddress(AddressFamily.InterNetwork);
+                var buffer = new byte[100];
+                int receivedLength;
+
+                for (int i = 0; i < 5; i++)
+                {
+                    try
+                    {
+                        if (async)
+                        {
+                            var cts = new CancellationTokenSource();
+                            cts.CancelAfter(100);
+                            receivedLength = socket.ReceiveFromAsync(buffer, SocketFlags.None, address, cts.Token).AsTask().GetAwaiter().GetResult();
+                        }
+                        else
+                        {
+                            receivedLength = socket.ReceiveFrom(buffer, SocketFlags.None, address);
+                        }
+                        Assert.Equal(0, receivedLength);
+                    }
+                    catch (SocketException ex) when (ex.SocketErrorCode == SocketError.TimedOut) { }
+                    catch (OperationCanceledException) { }
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive/SendReceiveMisc.cs
@@ -304,7 +304,7 @@ namespace System.Net.Sockets.Tests
                     {
                         if (async)
                         {
-                            var cts = new CancellationTokenSource();
+                            using var cts = new CancellationTokenSource();
                             cts.CancelAfter(100);
                             receivedLength = socket.ReceiveFromAsync(buffer, SocketFlags.None, address, cts.Token).AsTask().GetAwaiter().GetResult();
                         }


### PR DESCRIPTION
fixes #96237
do not touch `SocketAddress` on receiving error. That makes is useable for some other use. 
On Unix we would currently string it to `Size` 0 and subsequent attempt to use it would fail with`ArgumentOutOfRangeException`.