### PR TITLE
[mono][swift-interop] Support for Swift frozen struct lowering in mini-JIT/AOT/interpreter

### DIFF
--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6732,11 +6732,6 @@ mono_marshal_get_swift_physical_lowering (MonoType *type, gboolean native_layout
 	}
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	// SwiftSelf and SwiftError are special cases where we need to preserve the class information for the codegen to handle them correctly.
-	if (klass == mono_class_try_get_swift_self_class () || klass == mono_class_try_get_swift_error_class ()) {
-		lowering.by_reference = TRUE;
-		return lowering;
-	}
 	int vtype_size = mono_class_value_size (klass, NULL);
 	// TODO: We currently don't support vector types, so we can say that the maximum size of a non-by_reference struct
 	// is 4 * PointerSize.

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6603,7 +6603,8 @@ typedef enum {
 	SWIFT_DOUBLE,
 } SwiftPhysicalLoweringKind;
 
-static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind) {
+static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind) 
+{
 	switch (kind) {
 	case SWIFT_INT64:
 	case SWIFT_DOUBLE:
@@ -6615,7 +6616,8 @@ static int get_swift_lowering_alignment (SwiftPhysicalLoweringKind kind) {
 	}
 }
 
-static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 size, SwiftPhysicalLoweringKind kind) {
+static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 size, SwiftPhysicalLoweringKind kind) 
+{
 	bool force_opaque = false;
 	
 	if (offset != ALIGN_TO(offset, get_swift_lowering_alignment(kind))) {
@@ -6646,7 +6648,8 @@ static void set_lowering_range(guint8* lowered_bytes, guint32 offset, guint32 si
 
 static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset);
 
-static void record_inlinearray_struct_physical_lowering (guint8* lowered_bytes, MonoClass* klass, guint32 offset) {
+static void record_inlinearray_struct_physical_lowering (guint8* lowered_bytes, MonoClass* klass, guint32 offset) 
+{
 	// Get the first field and record its physical lowering N times
 	MonoClassField* field = mono_class_get_fields_internal (klass, NULL);
 	MonoType* fieldType = field->type;
@@ -6676,7 +6679,10 @@ static void record_struct_physical_lowering (guint8* lowered_bytes, MonoClass* k
 	}
 }
 
-static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset) {
+static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoType* type, guint32 offset) 
+{
+	int align;
+
 	// Normalize pointer types to IntPtr and resolve generic classes.
 	// We don't need to care about specific pointer types at this ABI level.
 	if (type->type == MONO_TYPE_PTR || type->type == MONO_TYPE_FNPTR) {
@@ -6704,7 +6710,6 @@ static void record_struct_field_physical_lowering (guint8* lowered_bytes, MonoTy
 			kind = SWIFT_DOUBLE;
 		}
 
-		int align;
 		set_lowering_range(lowered_bytes, offset, mono_type_size(type, &align), kind);
 	}
 }

--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -744,8 +744,8 @@ GENERATE_TRY_GET_CLASS_WITH_CACHE_DECL (swift_error)
 
 typedef struct {
 	gboolean by_reference;
-	int num_lowered_elements;
-	MonoTypeEnum lowered_elements[4];
+	uint32_t num_lowered_elements;
+	MonoType *lowered_elements[4];
 	uint32_t offsets[4];
 } SwiftPhysicalLowering;
 

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1010,6 +1010,7 @@ MonoMethodSignature  *mono_metadata_signature_dup_mempool (MonoMemPool *mp, Mono
 MonoMethodSignature  *mono_metadata_signature_dup_mem_manager (MonoMemoryManager *mem_manager, MonoMethodSignature *sig);
 MonoMethodSignature  *mono_metadata_signature_dup_add_this (MonoImage *image, MonoMethodSignature *sig, MonoClass *klass);
 MonoMethodSignature  *mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig);
+MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
 
 MonoGenericInst *
 mono_get_shared_generic_inst (MonoGenericContainer *container);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2546,6 +2546,37 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
 	return res;
 }
 
+/**
+ * mono_metadata_signature_dup_new_params:
+ * @param mp The memory pool to allocate the duplicated signature from.
+ * @param sig The original method signature.
+ * @param num_params The number parameters in the new signature.
+ * @param new_params An array of MonoType pointers representing the new parameters.
+ * 
+ * Duplicate an existing \c MonoMethodSignature but with a new set of parameters.
+ * This is a Mono runtime internal function.
+ * 
+ * @return the new \c MonoMethodSignature structure.
+ */
+MonoMethodSignature*
+mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
+{
+	size_t new_sig_size = MONO_SIZEOF_METHOD_SIGNATURE + num_params * sizeof (MonoType*);
+	if (sig->ret)
+		new_sig_size += mono_sizeof_type (sig->ret);
+	
+	MonoMethodSignature *res = (MonoMethodSignature *)mono_mempool_alloc0 (mp, new_sig_size);
+	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
+	res->param_count = GUINT32_TO_UINT16 (num_params);
+
+	for (int i = 0; i < num_params; i++) {
+		res->params [i] = new_params [i];
+	}
+	res->ret = sig->ret;
+
+	return res;
+}
+
 /*
  * mono_metadata_signature_size:
  *

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2565,11 +2565,11 @@ mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMethodSignature *si
 	if (sig->ret)
 		new_sig_size += mono_sizeof_type (sig->ret);
 	
-	MonoMethodSignature *res = (MonoMethodSignature *)mono_mempool_alloc0 (mp, new_sig_size);
+	MonoMethodSignature *res = (MonoMethodSignature *)mono_mempool_alloc0 (mp, (unsigned int)new_sig_size);
 	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
 	res->param_count = GUINT32_TO_UINT16 (num_params);
 
-	for (int i = 0; i < num_params; i++) {
+	for (uint16_t i = 0; i < res->param_count; i++) {
 		res->params [i] = new_params [i];
 	}
 	res->ret = sig->ret;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3421,7 +3421,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 		StackInfo *sp_old_params = (StackInfo*) mono_mempool_alloc (td->mempool, sizeof (StackInfo) * csignature->param_count);
 		memcpy (sp_old_params, td->sp, sizeof (StackInfo) * csignature->param_count);
 
-		GArray *new_params = g_array_new (FALSE, FALSE, sizeof (MonoType*));
+		GArray *new_params = g_array_sized_new (FALSE, FALSE, sizeof (MonoType*), csignature->param_count);
 		uint32_t new_param_count = 0;
 		int align;
 		MonoClass *swift_self = mono_class_try_get_swift_self_class ();
@@ -3479,15 +3479,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 		++td->sp;
 
 		// Create a new dummy signature with the lowered arguments
-		MonoMethodSignature *swiftcall_signature = mono_metadata_signature_alloc (m_class_get_image (method->klass), new_param_count);
-		for (uint32_t idx_param = 0; idx_param < new_param_count; ++idx_param) {
-			swiftcall_signature->params [idx_param] = g_array_index (new_params, MonoType *, idx_param);
-		}
-		swiftcall_signature->ret = csignature->ret;
-		swiftcall_signature->pinvoke = csignature->pinvoke;
-		swiftcall_signature->ext_callconv = csignature->ext_callconv;
-		
-		csignature = swiftcall_signature;	
+		csignature = mono_metadata_signature_dup_new_params (td->mempool, csignature, new_param_count, (MonoType**)new_params->data);
 	}
 #endif
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3320,6 +3320,81 @@ interp_try_devirt (MonoClass *this_klass, MonoMethod *target_method)
 	return NULL;
 }
 
+static MonoMethodSignature*
+interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *csignature)
+{
+	g_assert (!csignature->hasthis); // P/Invoke calls shouldn't contain 'this'
+
+	// Save the function pointer
+	StackInfo sp_fp = td->sp [-1];
+	--td->sp;
+
+	// Save the old arguments				
+	td->sp -= csignature->param_count;
+	StackInfo *sp_old_params = (StackInfo*) mono_mempool_alloc (td->mempool, sizeof (StackInfo) * csignature->param_count);
+	memcpy (sp_old_params, td->sp, sizeof (StackInfo) * csignature->param_count);
+
+	GArray *new_params = g_array_sized_new (FALSE, FALSE, sizeof (MonoType*), csignature->param_count);
+	uint32_t new_param_count = 0;
+	int align;
+	MonoClass *swift_self = mono_class_try_get_swift_self_class ();
+	MonoClass *swift_error = mono_class_try_get_swift_error_class ();
+	/*
+	* Go through the lowered arguments, if the argument is a struct, 
+	* we need to replace it with a sequence of lowered arguments.
+	* Also record the updated parameters for the new signature.
+	*/
+	for (int idx_param = 0; idx_param < csignature->param_count; ++idx_param) {
+		MonoType *ptype = csignature->params [idx_param];
+		MonoClass *klass = mono_class_from_mono_type_internal (ptype);
+		// SwiftSelf and SwiftError are special cases where we need to preserve the class information for the codegen to handle them correctly.
+		if (mono_type_is_struct (ptype) && !(klass == swift_self || klass == swift_error)) {
+			SwiftPhysicalLowering lowered_swift_struct = mono_marshal_get_swift_physical_lowering (ptype, FALSE);
+			if (!lowered_swift_struct.by_reference) {
+				for (uint32_t idx_lowered = 0; idx_lowered < lowered_swift_struct.num_lowered_elements; ++idx_lowered) {
+					int mt_lowered = mono_mint_type (lowered_swift_struct.lowered_elements [idx_lowered]);
+					int lowered_elem_size = mono_type_size (lowered_swift_struct.lowered_elements [idx_lowered], &align); 
+					// Load the lowered elements of the struct
+					interp_add_ins (td, MINT_MOV_SRC_OFF);
+					interp_ins_set_sreg (td->last_ins, sp_old_params [idx_param].var);
+					td->last_ins->data [0] = lowered_swift_struct.offsets [idx_lowered];
+					td->last_ins->data [1] = GINT_TO_UINT16 (mt_lowered);
+					td->last_ins->data [2] = GINT_TO_UINT16 (lowered_elem_size);
+					push_mono_type (td, lowered_swift_struct.lowered_elements [idx_lowered], mt_lowered, mono_class_from_mono_type_internal (lowered_swift_struct.lowered_elements [idx_lowered]));
+					interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+					
+					++new_param_count;
+					g_array_append_val (new_params, lowered_swift_struct.lowered_elements [idx_lowered]);
+				}
+			} else {
+				// For structs that cannot be lowered, we change the argument to byref type
+				ptype = mono_class_get_byref_type (mono_defaults.typed_reference_class);
+				// Load the address of the struct
+				interp_add_ins (td, MINT_LDLOCA_S);
+				interp_ins_set_sreg (td->last_ins, sp_old_params [idx_param].var);
+				push_simple_type (td, STACK_TYPE_I);
+				interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+
+				++new_param_count;
+				g_array_append_val (new_params, ptype);
+			}
+		} else {
+			// Copy over non-struct arguments
+			memcpy (td->sp, &sp_old_params [idx_param], sizeof (StackInfo));
+			++td->sp;
+
+			++new_param_count;
+			g_array_append_val (new_params, ptype);
+		}
+	}
+	// Restore the function pointer
+	memcpy (td->sp, &sp_fp, sizeof (StackInfo));
+	++td->sp;
+
+	// Create a new dummy signature with the lowered arguments
+	return mono_metadata_signature_dup_new_params (td->mempool, csignature, new_param_count, (MonoType**)new_params->data);
+}
+
 /* Return FALSE if error, including inline failure */
 static gboolean
 interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target_method, MonoGenericContext *generic_context, MonoClass *constrained_class, gboolean readonly, MonoError *error, gboolean check_visibility, gboolean save_last_error, gboolean tailcall)
@@ -3410,76 +3485,7 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 	* This is done by replacing struct arguments on stack with a lowered sequence and updating the signature.
 	*/
 	if (csignature->pinvoke && mono_method_signature_has_ext_callconv (csignature, MONO_EXT_CALLCONV_SWIFTCALL)) {
-		g_assert (!csignature->hasthis); // P/Invoke calls shouldn't contain 'this'
-
-		// Save the function pointer
-		StackInfo sp_fp = td->sp [-1];
-		--td->sp;
-
-		// Save the old arguments				
-		td->sp -= csignature->param_count;
-		StackInfo *sp_old_params = (StackInfo*) mono_mempool_alloc (td->mempool, sizeof (StackInfo) * csignature->param_count);
-		memcpy (sp_old_params, td->sp, sizeof (StackInfo) * csignature->param_count);
-
-		GArray *new_params = g_array_sized_new (FALSE, FALSE, sizeof (MonoType*), csignature->param_count);
-		uint32_t new_param_count = 0;
-		int align;
-		MonoClass *swift_self = mono_class_try_get_swift_self_class ();
-		MonoClass *swift_error = mono_class_try_get_swift_error_class ();
-		/*
-		* Go through the lowered arguments, if the argument is a struct, 
-		* we need to replace it with a sequence of lowered arguments.
-		* Also record the updated parameters for the new signature.
-		*/
-		for (int idx_param = 0; idx_param < csignature->param_count; ++idx_param) {
-			MonoType *ptype = csignature->params [idx_param];
-			MonoClass *klass = mono_class_from_mono_type_internal (ptype);
-			// SwiftSelf and SwiftError are special cases where we need to preserve the class information for the codegen to handle them correctly.
-			if (mono_type_is_struct (ptype) && !(klass == swift_self || klass == swift_error)) {
-				SwiftPhysicalLowering lowered_swift_struct = mono_marshal_get_swift_physical_lowering (ptype, FALSE);
-				if (!lowered_swift_struct.by_reference) {
-					for (uint32_t idx_lowered = 0; idx_lowered < lowered_swift_struct.num_lowered_elements; ++idx_lowered) {
-						int mt_lowered = mono_mint_type (lowered_swift_struct.lowered_elements [idx_lowered]);
-						int lowered_elem_size = mono_type_size (lowered_swift_struct.lowered_elements [idx_lowered], &align); 
-						// Load the lowered elements of the struct
-						interp_add_ins (td, MINT_MOV_SRC_OFF);
-						interp_ins_set_sreg (td->last_ins, sp_old_params [idx_param].var);
-						td->last_ins->data [0] = lowered_swift_struct.offsets [idx_lowered];
-						td->last_ins->data [1] = GINT_TO_UINT16 (mt_lowered);
-						td->last_ins->data [2] = GINT_TO_UINT16 (lowered_elem_size);
-						push_mono_type (td, lowered_swift_struct.lowered_elements [idx_lowered], mt_lowered, mono_class_from_mono_type_internal (lowered_swift_struct.lowered_elements [idx_lowered]));
-						interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
-						
-						++new_param_count;
-						g_array_append_val (new_params, lowered_swift_struct.lowered_elements [idx_lowered]);
-					}
-				} else {
-					// For structs that cannot be lowered, we change the argument to byref type
-					ptype = mono_class_get_byref_type (mono_defaults.typed_reference_class);
-					// Load the address of the struct
-					interp_add_ins (td, MINT_LDLOCA_S);
-					interp_ins_set_sreg (td->last_ins, sp_old_params [idx_param].var);
-					push_simple_type (td, STACK_TYPE_I);
-					interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
-
-					++new_param_count;
-					g_array_append_val (new_params, ptype);
-				}
-			} else {
-				// Copy over non-struct arguments
-				memcpy (td->sp, &sp_old_params [idx_param], sizeof (StackInfo));
-				++td->sp;
-
-				++new_param_count;
-				g_array_append_val (new_params, ptype);
-			}
-		}
-		// Restore the function pointer
-		memcpy (td->sp, &sp_fp, sizeof (StackInfo));
-		++td->sp;
-
-		// Create a new dummy signature with the lowered arguments
-		csignature = mono_metadata_signature_dup_new_params (td->mempool, csignature, new_param_count, (MonoType**)new_params->data);
+		csignature = interp_emit_swiftcall_struct_lowering (td, csignature);
 	}
 #endif
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3359,7 +3359,7 @@ interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *c
 					// Load the lowered elements of the struct
 					interp_add_ins (td, MINT_MOV_SRC_OFF);
 					interp_ins_set_sreg (td->last_ins, sp_old_params [idx_param].var);
-					td->last_ins->data [0] = lowered_swift_struct.offsets [idx_lowered];
+					td->last_ins->data [0] = (guint16) lowered_swift_struct.offsets [idx_lowered];
 					td->last_ins->data [1] = GINT_TO_UINT16 (mt_lowered);
 					td->last_ins->data [2] = GINT_TO_UINT16 (lowered_elem_size);
 					push_mono_type (td, lowered_swift_struct.lowered_elements [idx_lowered], mt_lowered, mono_class_from_mono_type_internal (lowered_swift_struct.lowered_elements [idx_lowered]));

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3323,9 +3323,16 @@ interp_try_devirt (MonoClass *this_klass, MonoMethod *target_method)
 static MonoMethodSignature*
 interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *csignature)
 {
-	MonoMethodSignature *new_csignature;
-	g_assert (!csignature->hasthis); // P/Invoke calls shouldn't contain 'this'
+	// P/Invoke calls shouldn't contain 'this'
+	g_assert (!csignature->hasthis);
+ 	
+	/*
+	 * Argument reordering here doesn't handle on the fly offset allocation 
+	 * and requires the full var offset allocator pass that is only ran for optimized code
+	 */ 
+	g_assert (td->optimized);
 
+	MonoMethodSignature *new_csignature;
 	// Save the function pointer
 	StackInfo sp_fp = td->sp [-1];
 	--td->sp;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7530,7 +7530,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					old_args [idx_param] = sp [idx_param];
 				}
 
-				GArray *new_params = g_array_new (FALSE, FALSE, sizeof (MonoType*));
+				GArray *new_params = g_array_sized_new (FALSE, FALSE, sizeof (MonoType*), n);
 				uint32_t new_param_count = 0;
 				MonoClass *swift_self = mono_class_try_get_swift_self_class ();
 				MonoClass *swift_error = mono_class_try_get_swift_error_class ();
@@ -7584,16 +7584,8 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 					}
 				}
 
-				// Create a new dummy signature with the lowered arguments
-				MonoMethodSignature *swiftcall_signature = mono_metadata_signature_alloc (m_class_get_image (method->klass), new_param_count);
-				for (uint32_t idx_param = 0; idx_param < new_param_count; ++idx_param) {
-					swiftcall_signature->params [idx_param] = g_array_index (new_params, MonoType *, idx_param);
-				}
-				swiftcall_signature->ret = fsig->ret;
-				swiftcall_signature->pinvoke = fsig->pinvoke;
-				swiftcall_signature->ext_callconv = fsig->ext_callconv;
-				
-				fsig = swiftcall_signature;	
+				// Create a new dummy signature with the lowered arguments				
+				fsig = mono_metadata_signature_dup_new_params (cfg->mempool, fsig, new_param_count, (MonoType**)new_params->data);			
 			}
 #endif
 

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7525,9 +7525,9 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				n = fsig->param_count;
 				sp -= n;
 				// Save the old arguments				
-				MonoInst **old_args = g_newa (MonoInst*, n);
+				MonoInst **old_params = (MonoInst**) mono_mempool_alloc (cfg->mempool, sizeof (MonoInst*) * n);
 				for (int idx_param = 0; idx_param < n; ++idx_param) {
-					old_args [idx_param] = sp [idx_param];
+					old_params [idx_param] = sp [idx_param];
 				}
 
 				GArray *new_params = g_array_sized_new (FALSE, FALSE, sizeof (MonoType*), n);
@@ -7577,7 +7577,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 						}
 					} else {
 						// Copy over non-struct arguments
-						*sp++ = old_args [idx_param];
+						*sp++ = old_params [idx_param];
 
 						++new_param_count;
 						g_array_append_val (new_params, ptype);
@@ -7585,7 +7585,10 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 
 				// Create a new dummy signature with the lowered arguments				
-				fsig = mono_metadata_signature_dup_new_params (cfg->mempool, fsig, new_param_count, (MonoType**)new_params->data);			
+				fsig = mono_metadata_signature_dup_new_params (cfg->mempool, fsig, new_param_count, (MonoType**)new_params->data);
+
+				// Deallocate temp array
+				g_array_free (new_params, TRUE);
 			}
 #endif
 

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1919,9 +1919,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/Structs/MemsetMemcpyNullref/*">
             <Issue>https://github.com/dotnet/runtime/issues/98628</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/Swift/SwiftAbiStress/**">
-            <Issue>https://github.com/dotnet/runtime/issues/93631: Swift frozen struct support is not implemented on Mono yet</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/Swift/SwiftRetAbiStress/**">
             <Issue>https://github.com/dotnet/runtime/issues/93631: Swift frozen struct support is not implemented on Mono yet</Issue>
         </ExcludeList>


### PR DESCRIPTION
## Description
This PR adds support for lowering of Swift `@frozen` structs in P/Invoke arguments. In short, in Swift calls, `@frozen` structs can be passed as a sequence of up to 4 primitives using registers or stack (see [Swift Calling Convention](https://github.com/apple/swift/blob/main/docs/ABI/CallingConvention.rst#general-expansion-algorithm)). The general algorithm was implemented in https://github.com/dotnet/runtime/pull/99439 and this PR connects it to the Mono codegen backends. This PR doesn't handle returns of Swift `@frozen` structs and reverse P/Invoke scenarios (tracked at https://github.com/dotnet/runtime/issues/102077).

## Changes
The connection to codegen is done at Mono IR level. First, in `method-to-ir.c` for connection to JIT and AOT backends. Second, in `transform.c` for interpreter. Both connection are similar. 

Before doing call to native Swift code, we explore the signature for any struct types. If struct encountered (not `SwiftSelf` or `SwiftError` which are handled individually), we execute the lowering algorithm. Based on the result we have 2 outcomes:
1. **Structure can be lowered into a sequence of up to 4 primitives:**
The structs argument in signature is replaced by the lowered sequence. The sequence elements are taken from the original structs at previously calculated offsets (struct base address + element offset). For detail how are the offsets calculated see `mono_marshal_get_swift_physical_lowering`.

2. **Structure must be passed by reference:**
The structs argument in signature is replaced by a byref type that represents address of the structs.

Non-struct types are preserved. The modified signature is used just for the call to native Swift code (for non-P/Invoke calls original signature is used).

---

Lastly, refactoring and bug fixes for marshaling inside `mono_marshal_get_swift_physical_lowering`.
- changing returned lowering from `MonoTypeEnum` to `MonoType*` as this is the most common representation of types in the later Mono code flow
- fixing and refactoring algorithm for merging opaque intervals (previous version wasn't respecting correctly block boundaries)
- use correct field offset and value type size (taking into account `MONO_ABI_SIZEOF (MonoObject)`)
- fix `remaining_interval_size` for final lowering loop

## Verification
Currently, Mono CI only has coverage for JIT/interpreter but fullAOT verification was done locally. This PR passes an extended `SwiftAbiStressTest` of 5000 signature locally both on x64 and arm64 with JIT/interpreter/fullAOT backends.

## Alternatives
During preparation of this PR, several alternatives were explore and decided not to further proceed.
1. Implementing the lowering at the lower codegen level (`mini-<arch>.c` files). This option was discarded because Mini currently doesn't provide representation for value types that can be passed via registers and stack simultaneously. While handling it manually for this PR would be possibly, the final code was long and error prone. Additionally, the code would have to be duplicated for each architecture.
2. Implementing the lowering at IL-gen level (`marshal-lightweight.c`). This option was successfully implemented and provided a shared implementation for both Mini and interpreter. However, we decided to rather implement it at the Mono IR level. This has two benefits, firstly we get better control over the resulting assembly as we are closer to the Mono codegen. Secondly, we are able to keep interpreter code more independent for potential deployment of interpreter outside Mono.

---

FYI: @jakobbotsch  @amanasifkhalid @jkurdek @vitek-karas 