### PR TITLE
Fixed the discrepancy between applicationName between normal app launch and HostFactoryResolver launch

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -163,9 +163,9 @@ namespace Microsoft.Extensions.Hosting
                         => arg.Equals("--applicationName", StringComparison.OrdinalIgnoreCase) ||
                             arg.Equals("/applicationName", StringComparison.OrdinalIgnoreCase);
 
-                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly.FullName is null
+                    args = args.Any(arg => IsApplicationNameArg(arg)) || assembly?.GetName().Name is null
                         ? args
-                        : args.Concat(new[] { "--applicationName", assembly.FullName }).ToArray();
+                        : args.Concat(new[] { "--applicationName", assembly.GetName().Name }).ToArray();
 
                     var host = hostFactory(args);
                     return GetServiceProvider(host);

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             IServiceProvider? serviceProvider = factory(Array.Empty<string>());
 
             var configuration = (IConfiguration)serviceProvider.GetService(typeof(IConfiguration));
-            Assert.Contains("ApplicationNameSetFromArgument", configuration["applicationName"]);
+            Assert.Equal("ApplicationNameSetFromArgument", configuration["applicationName"]);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupportedOrBrowserBackgroundExec))]


### PR DESCRIPTION
Fixed the discrepancy between applicationName between normal app launch and HostFactoryResolver launch

https://github.com/dotnet/runtime/issues/96596