### PR TITLE
Update ARM64 LLVM AOT runtime builds to use the generic libclang.so file

### DIFF
--- a/eng/pipelines/coreclr/perf_slow.yml
+++ b/eng/pipelines/coreclr/perf_slow.yml
@@ -121,7 +121,7 @@ extends:
             platforms:
             - linux_arm64
             jobParameters:
-              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so.16" /p:AotHostArchitecture=arm64 /p:AotHostOS=linux
+              buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoAOTEnableLLVM=true /p:MonoEnableLLVM=true /p:BuildMonoAOTCrossCompiler=true /p:MonoLibClang="/usr/local/lib/libclang.so" /p:AotHostArchitecture=arm64 /p:AotHostOS=linux
               nameSuffix: AOT
               isOfficialBuild: false
               postBuildSteps:


### PR DESCRIPTION
The new container updated in https://github.com/dotnet/runtime/pull/101946 that is used when building the Linux Arm64 AOT LLVM Mono artifacts (perf_slow) does not have libclang.so.16, instead having libclang.so.18.1. This updates builds to use the generic libclang.so next to the libclang.so.18.1 file to fix this and help future proof.
 
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2450460&view=results