### PR TITLE
Fix name mangling for CoreLib

### DIFF
--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -202,6 +202,8 @@ namespace ILCompiler
                                 containingType = containingType.ContainingType;
                             }
 
+                            name = prependAssemblyName + "_" + SanitizeName(name, true);
+
                             // If this is one of the well known types, use a shorter name
                             // We know this won't conflict because all the other types are
                             // prefixed by the assembly name.
@@ -230,10 +232,6 @@ namespace ILCompiler
                                             name = "String";
                                         break;
                                 }
-                            }
-                            else
-                            {
-                                name = prependAssemblyName + "_" + SanitizeName(name, true);
                             }
 
                             // Ensure that name is unique and update our tables accordingly.


### PR DESCRIPTION
#96983 broke name mangling within corelib - we were not prepending the assembly name and not replacing dots with underscores.