### PR TITLE
[Mono] added simple reverse pinvoke support to interpreter

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -155,6 +155,7 @@ struct InterpMethod {
 	MonoProfilerCallInstrumentationFlags prof_flags;
 	InterpMethodCodeType code_type;
 	int ref_slot_offset; // GC visible pointer slot
+	int swift_error_offset; // swift error struct
 	MonoBitSet *ref_slots;
 #ifdef ENABLE_EXPERIMENT_TIERED
 	MiniTieredCounter tiered_counter;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3211,9 +3211,8 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 			size = MINT_STACK_SLOT_SIZE;
 		}
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
-		if (swift_error_arg_index >= 0 && swift_error_arg_index == i) {
-			newsp->data.p = swift_error_pointer;	
-		}
+		if (swift_error_arg_index >= 0 && swift_error_arg_index == i)
+			newsp->data.p = swift_error_pointer;
 #endif
 		newsp = STACK_ADD_BYTES (newsp, size);
 	}
@@ -3226,9 +3225,8 @@ interp_entry_from_trampoline (gpointer ccontext_untyped, gpointer rmethod_untype
 	MONO_EXIT_GC_UNSAFE;
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
-	if (swift_error_arg_index >= 0) {
+	if (swift_error_arg_index >= 0)
 		*(gpointer*)swift_error_data = *(gpointer*)swift_error_pointer;
-	}
 #endif
 
 	context->stack_pointer = (guchar*)sp;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3501,8 +3501,9 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 		skipWrapper = true;
 #endif
 
+	MonoMethod *wrapper;
 	if (!skipWrapper) {
-		MonoMethod *wrapper = mini_get_interp_in_wrapper (sig);
+		wrapper = mini_get_interp_in_wrapper (sig);
 		entry_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
 	}
 #endif

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3501,7 +3501,7 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 		skipWrapper = true;
 #endif
 
-	MonoMethod *wrapper;
+	MonoMethod *wrapper = NULL;
 	if (!skipWrapper) {
 		wrapper = mini_get_interp_in_wrapper (sig);
 		entry_wrapper = mono_jit_compile_method_jit_only (wrapper, error);

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3494,15 +3494,15 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 	 * if we really care about those architectures (arm).
 	 */
 
-	bool skipWrapper = false;
+	bool skip_wrapper = false;
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL))
 		/* Methods with Swift cconv should go to trampoline */
-		skipWrapper = true;
+		skip_wrapper = true;
 #endif
 
 	MonoMethod *wrapper = NULL;
-	if (!skipWrapper) {
+	if (!skip_wrapper) {
 		wrapper = mini_get_interp_in_wrapper (sig);
 		entry_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
 	}

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -3494,15 +3494,12 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 	 * if we really care about those architectures (arm).
 	 */
 
-	bool skip_wrapper = false;
-#ifdef MONO_ARCH_HAVE_SWIFTCALL
-	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL))
-		/* Methods with Swift cconv should go to trampoline */
-		skip_wrapper = true;
-#endif
-
 	MonoMethod *wrapper = NULL;
-	if (!skip_wrapper) {
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	/* Methods with Swift cconv should go to trampoline */
+	if (!mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL))
+#endif
+	{
 		wrapper = mini_get_interp_in_wrapper (sig);
 		entry_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
 	}

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4436,7 +4436,7 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && swift_error_index >= 0) {
 		MonoType* type =  mono_method_signature_internal (td->method)->params [swift_error_index - sig->hasthis];
-		int var = interp_create_var_explicit(td, type, sizeof(gpointer));
+		int var = interp_create_var_explicit (td, type, sizeof(gpointer));
 		td->vars [var].global = TRUE;
 		interp_alloc_global_var_offset (td, var);
 		imethod->swift_error_offset = td->vars [var].offset;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4395,9 +4395,8 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	if (swift_error_index < 0 && mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL)) {
 		MonoClass *klass = mono_class_from_mono_type_internal (type);
-		if (klass == swift_error_ptr) {
+		if (klass == swift_error_ptr)
 			swift_error_index = i;
-		}
 	}
 #endif
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4360,6 +4360,13 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 	td->renamable_vars_capacity = target_vars_capacity;
 	offset = 0;
 
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	int swift_error_index = -1;
+	imethod->swift_error_offset = -1;
+	MonoClass *swift_error = mono_class_try_get_swift_error_class ();
+	MonoClass *swift_error_ptr = mono_class_create_ptr (m_class_get_this_arg (swift_error));
+#endif
+
 	/*
 	 * We will load arguments as if they are locals. Unlike normal locals, every argument
 	 * is stored in a stackval sized slot and valuetypes have special semantics since we
@@ -4384,6 +4391,16 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 		td->vars [i].offset = offset;
 		interp_mark_ref_slots_for_var (td, i);
 		offset += size;
+
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	if (swift_error_index < 0 && mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL)) {
+		MonoClass *klass = mono_class_from_mono_type_internal (type);
+		if (klass == swift_error_ptr) {
+			swift_error_index = i;
+		}
+	}
+#endif
+
 	}
 	offset = ALIGN_TO (offset, MINT_STACK_ALIGNMENT);
 
@@ -4418,39 +4435,12 @@ interp_method_compute_offsets (TransformData *td, InterpMethod *imethod, MonoMet
 	td->total_locals_size = offset;
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
-	// Allocate SwiftError
-	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL)) {
-		imethod->swift_error_offset = -1;
-
-		MonoClass *swift_error = mono_class_try_get_swift_error_class ();
-		MonoClass *swift_error_ptr = mono_class_create_ptr (m_class_get_this_arg (swift_error));
-
-		int swift_error_index = -1;
-		for (int i = 0; i < sig->param_count; i++) {
-			MonoClass *klass = mono_class_from_mono_type_internal (sig->params [i]);
-			if (klass == swift_error_ptr) {
-				swift_error_index = i;
-				break;
-			}
-		}
-
-		if (swift_error_index >= 0)
-		{
-			MonoType* type =  mono_method_signature_internal (td->method)->params [swift_error_index - sig->hasthis];
-			int index = num_args + num_il_locals;
-			int mt = mono_mint_type (type);
-
-			td->vars [index].type = type;
-			td->vars [index].global = TRUE;
-			td->vars [index].offset = offset;
-			size = mono_interp_type_size (type, mt, &align);
-			td->vars [index].size = size;
-			interp_mark_ref_slots_for_var (td, index);
-
-			offset += size;
-			offset = ALIGN_TO (offset, MINT_STACK_ALIGNMENT);
-			imethod->swift_error_offset = td->vars [index].offset;
-		}
+	if (mono_method_signature_has_ext_callconv (sig, MONO_EXT_CALLCONV_SWIFTCALL) && swift_error_index >= 0) {
+		MonoType* type =  mono_method_signature_internal (td->method)->params [swift_error_index - sig->hasthis];
+		int var = interp_create_var_explicit(td, type, sizeof(gpointer));
+		td->vars [var].global = TRUE;
+		interp_alloc_global_var_offset (td, var);
+		imethod->swift_error_offset = td->vars [var].offset;
 	}
 #endif
 

--- a/src/mono/mono/mini/mini-amd64.c
+++ b/src/mono/mono/mini/mini-amd64.c
@@ -1324,7 +1324,7 @@ mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 			storage = alloca (temp_size);
 		else
 			storage = arg_get_storage (ccontext, ainfo);
-		memset (ccontext, 0, sizeof (CallContext)); // FIXME
+
 		interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, -1, storage);
 		if (temp_size)
 			arg_set_val (ccontext, ainfo, storage);

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -2082,23 +2082,9 @@ mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 		else
 			storage = arg_get_storage (ccontext, ainfo);
 
-#ifdef MONO_ARCH_HAVE_SWIFTCALL
-		int swift_error_preserved_val = 0;
-		if (ccontext->gregs [PARAM_REGS + 2]) {
-			swift_error_preserved_val = ccontext->gregs [PARAM_REGS + 2];
-		}
-#endif
-
-		memset (ccontext, 0, sizeof (CallContext)); // FIXME
 		interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, -1, storage);
 		if (temp_size)
 			arg_set_val (ccontext, ainfo, storage);
-
-#ifdef MONO_ARCH_HAVE_SWIFTCALL
-	if (swift_error_preserved_val > 0) {
-		ccontext->gregs [PARAM_REGS + 2] = swift_error_preserved_val;
-	}
-#endif
 	}
 }
 

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -2081,10 +2081,24 @@ mono_arch_set_native_call_context_ret (CallContext *ccontext, gpointer frame, Mo
 			storage = alloca (temp_size);
 		else
 			storage = arg_get_storage (ccontext, ainfo);
+
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+		int swift_error_preserved_val = 0;
+		if (ccontext->gregs [PARAM_REGS + 2]) {
+			swift_error_preserved_val = ccontext->gregs [PARAM_REGS + 2];
+		}
+#endif
+
 		memset (ccontext, 0, sizeof (CallContext)); // FIXME
 		interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, -1, storage);
 		if (temp_size)
 			arg_set_val (ccontext, ainfo, storage);
+
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	if (swift_error_preserved_val > 0) {
+		ccontext->gregs [PARAM_REGS + 2] = swift_error_preserved_val;
+	}
+#endif
 	}
 }
 

--- a/src/mono/mono/mini/tramp-amd64.c
+++ b/src/mono/mono/mini/tramp-amd64.c
@@ -1263,6 +1263,13 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	for (i = 0; i < FLOAT_PARAM_REGS; i++)
 		amd64_sse_movsd_membase_reg (code, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, fregs) + i * sizeof (double), i);
 
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	/* set context registers to CallContext */
+	for (i = 0; i < CTX_REGS; i++) {
+		amd64_mov_membase_reg (code, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + (i + CTX_REGS_OFFSET) * sizeof (target_mgreg_t), i + CTX_REGS_OFFSET, sizeof (target_mgreg_t));
+	}
+#endif
+
 	/* set the stack pointer to the value at call site */
 	amd64_mov_reg_reg (code, AMD64_R11, AMD64_RBP, sizeof (target_mgreg_t));
 	amd64_alu_reg_imm (code, X86_ADD, AMD64_R11, 2 * sizeof (target_mgreg_t));
@@ -1282,6 +1289,13 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 	for (i = 0; i < FLOAT_RETURN_REGS; i++)
 		amd64_sse_movsd_reg_membase (code, i, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, fregs) + i * sizeof (double));
+
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	/* set the context registers from CallContext */
+	for (i = 0; i < CTX_REGS; i++) {
+		amd64_mov_reg_membase (code, i + CTX_REGS_OFFSET, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + (i + CTX_REGS_OFFSET) * sizeof (target_mgreg_t), sizeof (target_mgreg_t));
+	}
+#endif
 
 	/* reset stack and return */
 #if TARGET_WIN32

--- a/src/mono/mono/mini/tramp-amd64.c
+++ b/src/mono/mono/mini/tramp-amd64.c
@@ -1265,9 +1265,8 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	/* set context registers to CallContext */
-	for (i = 0; i < CTX_REGS; i++) {
+	for (i = 0; i < CTX_REGS; i++)
 		amd64_mov_membase_reg (code, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + (i + CTX_REGS_OFFSET) * sizeof (target_mgreg_t), i + CTX_REGS_OFFSET, sizeof (target_mgreg_t));
-	}
 #endif
 
 	/* set the stack pointer to the value at call site */
@@ -1292,9 +1291,8 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	/* set the context registers from CallContext */
-	for (i = 0; i < CTX_REGS; i++) {
+	for (i = 0; i < CTX_REGS; i++)
 		amd64_mov_reg_membase (code, i + CTX_REGS_OFFSET, AMD64_RSP, ctx_offset + MONO_STRUCT_OFFSET (CallContext, gregs) + (i + CTX_REGS_OFFSET) * sizeof (target_mgreg_t), sizeof (target_mgreg_t));
-	}
 #endif
 
 	/* reset stack and return */

--- a/src/mono/mono/mini/tramp-arm64.c
+++ b/src/mono/mono/mini/tramp-arm64.c
@@ -848,9 +848,8 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	/* set context registers to CallContext */
-	for (i = 0; i < CTX_REGS; i++) {
+	for (i = 0; i < CTX_REGS; i++)
 		arm_strx (code, i + CTX_REGS_OFFSET, ARMREG_FP, ccontext_offset +  MONO_STRUCT_OFFSET (CallContext, gregs) + (i + PARAM_REGS + 1) * sizeof (host_mgreg_t));
-	}
 #endif
 
 	/* set the stack pointer to the value at call site */
@@ -872,9 +871,8 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 
 #ifdef MONO_ARCH_HAVE_SWIFTCALL
 	/* set the context registers from CallContext */
-	for (i = 0; i < CTX_REGS; i++) {
+	for (i = 0; i < CTX_REGS; i++)
 		arm_ldrx (code, i + CTX_REGS_OFFSET, ARMREG_FP, ccontext_offset +  MONO_STRUCT_OFFSET (CallContext, gregs) + (i + PARAM_REGS + 1) * sizeof (host_mgreg_t));
-	}
 #endif
 	/* reset stack and return */
 	arm_ldpx (code, ARMREG_FP, ARMREG_LR, ARMREG_SP, 0);

--- a/src/mono/mono/mini/tramp-arm64.c
+++ b/src/mono/mono/mini/tramp-arm64.c
@@ -846,6 +846,13 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	for (i = 0; i < FP_PARAM_REGS; i++)
 		arm_strfpx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, fregs) + i * sizeof (double));
 
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	/* set context registers to CallContext */
+	for (i = 0; i < CTX_REGS; i++) {
+		arm_strx (code, i + CTX_REGS_OFFSET, ARMREG_FP, ccontext_offset +  MONO_STRUCT_OFFSET (CallContext, gregs) + (i + PARAM_REGS + 1) * sizeof (host_mgreg_t));
+	}
+#endif
+
 	/* set the stack pointer to the value at call site */
 	arm_addx_imm (code, ARMREG_R0, ARMREG_FP, framesize);
 	arm_strp (code, ARMREG_R0, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, stack));
@@ -863,6 +870,12 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	for (i = 0; i < FP_PARAM_REGS; i++)
 		arm_ldrfpx (code, i, ARMREG_FP, ccontext_offset + MONO_STRUCT_OFFSET (CallContext, fregs) + i * sizeof (double));
 
+#ifdef MONO_ARCH_HAVE_SWIFTCALL
+	/* set the context registers from CallContext */
+	for (i = 0; i < CTX_REGS; i++) {
+		arm_ldrx (code, i + CTX_REGS_OFFSET, ARMREG_FP, ccontext_offset +  MONO_STRUCT_OFFSET (CallContext, gregs) + (i + PARAM_REGS + 1) * sizeof (host_mgreg_t));
+	}
+#endif
 	/* reset stack and return */
 	arm_ldpx (code, ARMREG_FP, ARMREG_LR, ARMREG_SP, 0);
 	arm_addx_imm (code, ARMREG_SP, ARMREG_SP, framesize);

--- a/src/mono/mono/mini/tramp-arm64.c
+++ b/src/mono/mono/mini/tramp-arm64.c
@@ -874,6 +874,7 @@ mono_arch_get_native_to_interp_trampoline (MonoTrampInfo **info)
 	for (i = 0; i < CTX_REGS; i++)
 		arm_ldrx (code, i + CTX_REGS_OFFSET, ARMREG_FP, ccontext_offset +  MONO_STRUCT_OFFSET (CallContext, gregs) + (i + PARAM_REGS + 1) * sizeof (host_mgreg_t));
 #endif
+
 	/* reset stack and return */
 	arm_ldpx (code, ARMREG_FP, ARMREG_LR, ARMREG_SP, 0);
 	arm_addx_imm (code, ARMREG_SP, ARMREG_SP, framesize);

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -2145,9 +2145,6 @@
         <ExcludeList Include = "$(XUnitTestBinBase)/JIT/Directed/Arrays/nintindexoutofrange/**">
             <Issue>https://github.com/dotnet/runtime/issues/71656</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/Interop/Swift/SwiftErrorHandling/**">
-            <Issue>Reverse P/Invokes not supported yet</Issue>
-        </ExcludeList>
         <!-- End interpreter issues -->
     </ItemGroup>
 


### PR DESCRIPTION
Adds simple (no structs) Swift reverse pinvoke support to mono interpreter.