### PR TITLE
[LoongArch64] Fix the register conflict of the `REG_GSCOOKIE_TMP` and the `FastTailCall target register`.

### DIFF
--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -723,7 +723,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         {
             // Fast tail call - make sure that call target is always computed in volatile registers
             // that will not be overridden by epilog sequence.
-            ctrlExprCandidates = allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH;
+            ctrlExprCandidates = (allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH) ^ RBM_GSCOOKIE_TMP;
             assert(ctrlExprCandidates != RBM_NONE);
         }
     }
@@ -734,7 +734,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         regMaskTP candidates = RBM_NONE;
         if (call->IsFastTailCall())
         {
-            candidates = allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH;
+            candidates = (allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH) ^ RBM_GSCOOKIE_TMP;
             assert(candidates != RBM_NONE);
         }
 

--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -723,7 +723,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         {
             // Fast tail call - make sure that call target is always computed in volatile registers
             // that will not be overridden by epilog sequence.
-            ctrlExprCandidates = (allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH) ^ RBM_GSCOOKIE_TMP;
+            ctrlExprCandidates = (allRegs(TYP_INT) & (RBM_INT_CALLEE_TRASH & ~RBM_GSCOOKIE_TMP));
             assert(ctrlExprCandidates != RBM_NONE);
         }
     }

--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -734,7 +734,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         regMaskTP candidates = RBM_NONE;
         if (call->IsFastTailCall())
         {
-            candidates = (allRegs(TYP_INT) & RBM_INT_CALLEE_TRASH) ^ RBM_GSCOOKIE_TMP;
+            candidates = (allRegs(TYP_INT) & (RBM_INT_CALLEE_TRASH & ~RBM_GSCOOKIE_TMP));
             assert(candidates != RBM_NONE);
         }
 

--- a/src/coreclr/jit/targetloongarch64.h
+++ b/src/coreclr/jit/targetloongarch64.h
@@ -110,6 +110,7 @@
   // Temporary registers used for the GS cookie check.
   #define REG_GSCOOKIE_TMP_0       REG_T0
   #define REG_GSCOOKIE_TMP_1       REG_T1
+  #define RBM_GSCOOKIE_TMP         (RBM_T0|RBM_T1)
 
   // register to hold shift amount; no special register is required on LOONGARCH64.
   #define REG_SHIFT                REG_NA


### PR DESCRIPTION
Fix the register conflict of the `REG_GSCOOKIE_TMP` and the `FastTailCall target register` for LA64.
* This PR mainly fixes the `SIGBUS error` for `Methodical_r2.sh - 25param3c_r.dll` under `DOTNET_JitStress=1/2/4`.
* Also fixes the `Methodical_d2.sh, JIT.performance.sh` under `jitStress=1/2/4` which may meet the same error.