### PR TITLE
ilasm support for methods with multiple documents

### DIFF
--- a/src/coreclr/ilasm/assembler.cpp
+++ b/src/coreclr/ilasm/assembler.cpp
@@ -1420,6 +1420,15 @@ void Assembler::EmitOpcode(Instr* instr)
                 pLPC->PC = m_CurPC;
 
                 pLPC->pOwnerDocument = instr->pOwnerDocument;
+                if(m_pCurMethod->m_FirstDocument == NULL)
+                {
+                    m_pCurMethod->m_FirstDocument = instr->pOwnerDocument;
+                }
+                else if (instr->pOwnerDocument != NULL && m_pCurMethod->m_FirstDocument != instr->pOwnerDocument)
+                {
+                    m_pCurMethod->m_HasMultipleDocuments = TRUE;
+                }
+                
                 if (0xfeefee == instr->linenum &&
                     0xfeefee == instr->linenum_end &&
                     0 == instr->column &&

--- a/src/coreclr/ilasm/method.cpp
+++ b/src/coreclr/ilasm/method.cpp
@@ -35,6 +35,8 @@ Method::Method(Assembler *pAssembler, Class *pClass, _In_ __nullterminated char 
     m_pbsBody = NULL;
     m_fNewBody = TRUE;
     m_fNew = TRUE;
+    m_FirstDocument = NULL;
+    m_HasMultipleDocuments = FALSE;
 
     // move the PInvoke descriptor (if any) from Assembler
     // (Assembler gets the descriptor BEFORE it calls new Method)

--- a/src/coreclr/ilasm/method.hpp
+++ b/src/coreclr/ilasm/method.hpp
@@ -337,6 +337,8 @@ public:
     unsigned m_LineNum;
     // debug info
     LinePCList m_LinePCList;
+    Document* m_FirstDocument;
+    BOOL m_HasMultipleDocuments;
     // custom values
     CustomDescrList m_CustomDescrList;
     // token relocs (used for OBJ generation only)

--- a/src/coreclr/ilasm/portable_pdb.cpp
+++ b/src/coreclr/ilasm/portable_pdb.cpp
@@ -209,6 +209,7 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
     ULONG localSigRid = 0;
     ULONG offset = 0;
     ULONG deltaLines = 0;
+    ULONG currDocumentRid = 0;
     LONG deltaColumns = 0;
     LONG deltaStartLine = 0;
     LONG deltaStartColumn = 0;
@@ -225,7 +226,11 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
         // LocalSignature
         localSigRid = RidFromToken(method->m_LocalsSig);
         CompressUnsignedLong(localSigRid, blob);
-        // InitialDocument TODO: skip this for now
+        currDocumentRid = RidFromToken(method->m_FirstDocument->GetToken());
+        if(method->m_HasMultipleDocuments)
+        {
+            CompressUnsignedLong(currDocumentRid, blob);
+        }
     }
 
     // SequencePointRecord :: = sequence-point-record | hidden-sequence-point-record
@@ -250,6 +255,15 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
 
         if (!currSeqPoint->IsHidden)
         {
+            //document
+            if(RidFromToken(currSeqPoint->pOwnerDocument->GetToken()) != currDocumentRid)
+            {
+                //document-record
+                currDocumentRid = RidFromToken(currSeqPoint->pOwnerDocument->GetToken());
+                CompressUnsignedLong(0, blob);
+                CompressUnsignedLong(currDocumentRid, blob);
+            }
+
             //offset
             offset = (i == 0) ? currSeqPoint->PC : currSeqPoint->PC - prevSeqPoint->PC;
             CompressUnsignedLong(offset, blob);
@@ -311,8 +325,8 @@ HRESULT PortablePdbWriter::DefineSequencePoints(Method* method)
     // finally define sequence points for the method
     if ((isValid && currSeqPoint != NULL) || hasEmptyMethodBody)
     {
-        mdDocument document = hasEmptyMethodBody ? m_currentDocument->GetToken() : currSeqPoint->pOwnerDocument->GetToken();
-        ULONG documentRid = RidFromToken(document);
+        mdDocument document = hasEmptyMethodBody ? m_currentDocument->GetToken() : method->m_FirstDocument->GetToken();
+        ULONG documentRid = method->m_HasMultipleDocuments ? 0 : RidFromToken(document);
         hr = m_pdbEmitter->DefineSequencePoints(documentRid, blob->ptr(), blob->length());
     }
 

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
@@ -148,11 +148,11 @@ namespace IlasmPortablePdbTests
         [Theory]
         [InlineData("TestMethodDebugInformation")]
         [InlineData("TestDocuments1")]
-        public void TestPortablePdbMethodDebugInformation2(string ilRoot)
+        public void TestPortablePdbMethodDebugInformation2(string testName)
         {
-            var ilSource = ilRoot + (IsUnix ? "_unix.il" : "_win.il");
+            var ilSource = testName + (IsUnix ? "_unix.il" : "_win.il");
 
-            var expected = IlasmPortablePdbTesterCommon.GetExpectedForTestMethodDebugInformation(ilSource);
+            var expected = IlasmPortablePdbTesterCommon.GetExpectedForTestMethodDebugInformation(testName, IsUnix);
             var ilasm = IlasmPortablePdbTesterCommon.GetIlasmFullPath(CoreRootVar, IlasmFile);
             IlasmPortablePdbTesterCommon.Assemble(ilasm, ilSource, TestDir, out string dll, out string pdb);
 

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTester.cs
@@ -145,10 +145,12 @@ namespace IlasmPortablePdbTests
 
         // Tests whether the portable PDB has appropriate sequence points defined
         // The test source file includes external source reference and thus has 2 variants depending on OS type
-        [Fact]
-        public void TestPortablePdbMethodDebugInformation2()
+        [Theory]
+        [InlineData("TestMethodDebugInformation")]
+        [InlineData("TestDocuments1")]
+        public void TestPortablePdbMethodDebugInformation2(string ilRoot)
         {
-            var ilSource = IsUnix ? "TestMethodDebugInformation_unix.il" : "TestMethodDebugInformation_win.il";
+            var ilSource = ilRoot + (IsUnix ? "_unix.il" : "_win.il");
 
             var expected = IlasmPortablePdbTesterCommon.GetExpectedForTestMethodDebugInformation(ilSource);
             var ilasm = IlasmPortablePdbTesterCommon.GetIlasmFullPath(CoreRootVar, IlasmFile);
@@ -174,10 +176,17 @@ namespace IlasmPortablePdbTests
 
                             // verify method debug information from portable pdb metadata
                             var methodDebugInformation = portablePdbMdReader.GetMethodDebugInformation(methodDefinitionHandle);
-                            var methodDocument = portablePdbMdReader.GetDocument(methodDebugInformation.Document);
-                            var methodDocumentName = portablePdbMdReader.GetString(methodDocument.Name);
-                            Assert.Equal(expectedMethodDbgInfo.Document.Name, methodDocumentName);
 
+                            if (expectedMethodDbgInfo.Document == null)
+                            {
+                                Assert.True(methodDebugInformation.Document.IsNil);
+                            }
+                            else
+                            {
+                                var methodDocument = portablePdbMdReader.GetDocument(methodDebugInformation.Document);
+                                var methodDocumentName = portablePdbMdReader.GetString(methodDocument.Name);
+                                Assert.Equal(expectedMethodDbgInfo.Document.Name, methodDocumentName);
+                            }
                             int i = 0;
                             foreach (var sequencePoint in methodDebugInformation.GetSequencePoints())
                             {

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
@@ -96,6 +96,7 @@ namespace IlasmPortablePdbTests
 
         public static Dictionary<string, MethodDebugInformationStub> GetExpectedForTestMethodDebugInformation(string testName)
         {
+            string structure;
             string method1;
             string method2;
             DocumentStub document1;
@@ -104,38 +105,52 @@ namespace IlasmPortablePdbTests
             switch (testName)
             {
                 case "TestMethodDebugInformation_unix.il":
+                    structure = "TestMethodDebugInformation";
                     method1 = ".ctor";
                     method2 = "Pow";
                     document1 = new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMath.cs");
                     document2 = new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMathMethods.cs");
                     break;
                 case "TestMethodDebugInformation_win.il":
+                    structure = "TestMethodDebugInformation";
                     method1 = ".ctor";
                     method2 = "Pow";
                     document1 = new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMath.cs");
                     document2 = new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMathMethods.cs");
                     break;
+                case "TestDocuments1_unix.il":
+                    structure = "TestDocuments1";
+                    method1 = "Foo";
+                    method2 = null;
+                    document1 = new DocumentStub("/tmp/non_existent_source1.cs");
+                    document2 = new DocumentStub("/tmp/non_existent_source2.cs");
+                    break;
+                case "TestDocuments1_win.il":
+                    structure = "TestDocuments1";
+                    method1 = "Foo";
+                    method2 = null;
+                    document1 = new DocumentStub("C:\\tmp\\non_existent_source1.cs");
+                    document2 = new DocumentStub("C:\\tmp\\non_existent_source2.cs");
+                    break;
                 default:
                     Assert.Fail();
                     return null;
             }
-
-            return new Dictionary<string, MethodDebugInformationStub>()
+            var result = new Dictionary<string, MethodDebugInformationStub>();
+            switch (structure)
             {
-                {
-                    method1,
-                    new MethodDebugInformationStub(method1, document1,
+                case "TestMethodDebugInformation":
+                    result.Add(method1,
+                        new MethodDebugInformationStub(method1, document1,
                         new List<SequencePointStub>()
                         {
                             new SequencePointStub(document1, false, 0x0, 6, 6, 9, 37),
                             new SequencePointStub(document1, false, 0x7, 7, 7, 9, 10),
                             new SequencePointStub(document1, false, 0x8, 8, 8, 13, 28),
                             new SequencePointStub(document1, false, 0xf, 9, 9, 9, 10),
-                        })
-                },
-                {
-                    method2,
-                    new MethodDebugInformationStub(method2, document2,
+                        }));
+                    result.Add(method2,
+                        new MethodDebugInformationStub(method2, document2,
                         new List<SequencePointStub>()
                         {
                             new SequencePointStub(document2, false, 0x0, 6, 6, 9, 10),
@@ -153,9 +168,19 @@ namespace IlasmPortablePdbTests
                             new SequencePointStub(document2, true,  0x1e),
                             new SequencePointStub(document2, false, 0x21, 15, 15, 13, 24),
                             new SequencePointStub(document2, false, 0x26, 16, 16, 9, 10),
-                        })
-                }
+                        }));
+                    break;
+                case "TestDocuments1":
+                    result.Add(method1,
+                        new MethodDebugInformationStub(method1, null,
+                        new List<SequencePointStub>()
+                        {
+                            new SequencePointStub(document1, false, 0x0, 1, 1, 9, 10),
+                            new SequencePointStub(document2, false, 0x1, 2, 2, 9, 10),
+                        }));
+                    break;
             };
+            return result;
         }
 
         public static List<LocalScopeStub> GetExpectedForTestLocalScopes(string testName)

--- a/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
+++ b/src/tests/ilasm/PortablePdb/IlasmPortablePdbTesterCommon.cs
@@ -94,9 +94,8 @@ namespace IlasmPortablePdbTests
             }
         }
 
-        public static Dictionary<string, MethodDebugInformationStub> GetExpectedForTestMethodDebugInformation(string testName)
+        public static Dictionary<string, MethodDebugInformationStub> GetExpectedForTestMethodDebugInformation(string testName, bool isUnix)
         {
-            string structure;
             string method1;
             string method2;
             DocumentStub document1;
@@ -104,40 +103,25 @@ namespace IlasmPortablePdbTests
 
             switch (testName)
             {
-                case "TestMethodDebugInformation_unix.il":
-                    structure = "TestMethodDebugInformation";
+                case "TestMethodDebugInformation":
                     method1 = ".ctor";
                     method2 = "Pow";
-                    document1 = new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMath.cs");
-                    document2 = new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMathMethods.cs");
+                    document1 = isUnix ? new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMath.cs") : new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMath.cs");
+                    document2 = isUnix ? new DocumentStub("/tmp/TestMethodDebugInformation/SimpleMathMethods.cs") : new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMathMethods.cs");
                     break;
-                case "TestMethodDebugInformation_win.il":
-                    structure = "TestMethodDebugInformation";
-                    method1 = ".ctor";
-                    method2 = "Pow";
-                    document1 = new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMath.cs");
-                    document2 = new DocumentStub("C:\\tmp\\TestMethodDebugInformation\\SimpleMathMethods.cs");
-                    break;
-                case "TestDocuments1_unix.il":
-                    structure = "TestDocuments1";
+                case "TestDocuments1":
                     method1 = "Foo";
                     method2 = null;
-                    document1 = new DocumentStub("/tmp/non_existent_source1.cs");
-                    document2 = new DocumentStub("/tmp/non_existent_source2.cs");
-                    break;
-                case "TestDocuments1_win.il":
-                    structure = "TestDocuments1";
-                    method1 = "Foo";
-                    method2 = null;
-                    document1 = new DocumentStub("C:\\tmp\\non_existent_source1.cs");
-                    document2 = new DocumentStub("C:\\tmp\\non_existent_source2.cs");
+                    document1 = isUnix ? new DocumentStub("/tmp/non_existent_source1.cs") : new DocumentStub("C:\\tmp\\non_existent_source1.cs");
+                    document2 = isUnix ? new DocumentStub("/tmp/non_existent_source2.cs") : new DocumentStub("C:\\tmp\\non_existent_source2.cs");
                     break;
                 default:
                     Assert.Fail();
                     return null;
             }
+
             var result = new Dictionary<string, MethodDebugInformationStub>();
-            switch (structure)
+            switch (testName)
             {
                 case "TestMethodDebugInformation":
                     result.Add(method1,


### PR DESCRIPTION
Make sure the SequencePoints produced in the PDB
reference the documents indicated on the .line directive.

Fix #102198