### PR TITLE
JIT: Refactor IV opts a bit

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -87,6 +87,7 @@ class OptBoolsDsc;           // defined in optimizer.cpp
 struct RelopImplicationInfo; // defined in redundantbranchopts.cpp
 struct JumpThreadInfo;       // defined in redundantbranchopts.cpp
 class ProfileSynthesis;      // defined in profilesynthesis.h
+class LoopLocalOccurrences;  // defined in inductionvariableopts.cpp
 #ifdef DEBUG
 struct IndentStack;
 #endif
@@ -7510,14 +7511,19 @@ public:
 #endif
 
     PhaseStatus optInductionVariables();
-    bool        optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop);
-    bool        optIsIVWideningProfitable(unsigned                lclNum,
-                                          BasicBlock*             initBlock,
-                                          bool                    initedToConstant,
-                                          FlowGraphNaturalLoop*   loop,
-                                          ArrayStack<Statement*>& ivUses);
-    void        optBestEffortReplaceNarrowIVUses(
-               unsigned lclNum, unsigned ssaNum, unsigned newLclNum, BasicBlock* block, Statement* firstStmt);
+    bool        optWidenPrimaryIV(FlowGraphNaturalLoop* loop,
+                                  unsigned              lclNum,
+                                  ScevAddRec*           addRec,
+                                  LoopLocalOccurrences* loopLocals);
+
+    bool optCanSinkWidenedIV(unsigned lclNum, FlowGraphNaturalLoop* loop);
+    bool optIsIVWideningProfitable(unsigned              lclNum,
+                                   BasicBlock*           initBlock,
+                                   bool                  initedToConstant,
+                                   FlowGraphNaturalLoop* loop,
+                                   LoopLocalOccurrences* loopLocals);
+    void optBestEffortReplaceNarrowIVUses(
+        unsigned lclNum, unsigned ssaNum, unsigned newLclNum, BasicBlock* block, Statement* firstStmt);
     void optReplaceWidenedIV(unsigned lclNum, unsigned ssaNum, unsigned newLclNum, Statement* stmt);
     void optSinkWidenedIV(unsigned lclNum, unsigned newLclNum, FlowGraphNaturalLoop* loop);
 

--- a/src/coreclr/jit/scev.cpp
+++ b/src/coreclr/jit/scev.cpp
@@ -935,7 +935,10 @@ Scev* ScalarEvolutionContext::Simplify(Scev* scev)
             {
                 // TODO-Cleanup: This requires some proof that it is ok, but
                 // currently we do not rely on this.
-                return op1;
+                ScevAddRec* addRec   = (ScevAddRec*)op1;
+                Scev*       newStart = Simplify(NewExtension(unop->Oper, TYP_LONG, addRec->Start));
+                Scev*       newStep  = Simplify(NewExtension(unop->Oper, TYP_LONG, addRec->Step));
+                return NewAddRec(newStart, newStep);
             }
 
             return (op1 == unop->Op1) ? unop : NewExtension(unop->Oper, unop->Type, op1);


### PR DESCRIPTION
Introduce a general data structure to track local occurrences inside the loops, to be used for future IV optimizations. Switch IV widening to utilize this data structure as well.

Also extract widening into a separate function and fix a bug in `Scev::Simplify`.

No diffs are expected. Some TP regressions expected since tracking all the locals is a bit more expensive than what the existing code is doing.