### PR TITLE
[NativeAOT] Do not emit safe point for TLS_GET_ADDR calls into native runtime.

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -506,7 +506,8 @@ protected:
                      MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                      const DebugInfo&      di,
                      regNumber             base,
-                     bool                  isJump);
+                     bool                  isJump,
+                     bool                  isNoGCframe = false);
     // clang-format on
 
     // clang-format off

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -507,7 +507,7 @@ protected:
                      const DebugInfo&      di,
                      regNumber             base,
                      bool                  isJump,
-                     bool                  isNoGCframe = false);
+                     bool                  noSafePoint = false);
     // clang-format on
 
     // clang-format off

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3599,6 +3599,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         // We just need to emit "call reg" in this case.
         //
         assert(genIsValidIntReg(target->GetRegNum()));
+        bool isNoGCframe = false;
 
 #ifdef TARGET_ARM64
         bool isTlsHandleTarget =
@@ -3612,6 +3613,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             GenTreeIntCon* iconNode = target->AsIntCon();
             methHnd                 = (CORINFO_METHOD_HANDLE)iconNode->gtIconVal;
             retSize                 = EA_SET_FLG(retSize, EA_CNS_TLSGD_RELOC);
+            isNoGCframe             = true;
 
             // For NativeAOT, linux/arm64, linker wants the following pattern, so we will generate
             // it as part of the call. Generating individual instructions is tricky to get it
@@ -3647,7 +3649,8 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize),
                     di,
                     target->GetRegNum(),
-                    call->IsFastTailCall());
+                    call->IsFastTailCall(),
+                    isNoGCframe);
 
 #ifdef TARGET_ARM64
         if (isTlsHandleTarget)

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3599,7 +3599,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         // We just need to emit "call reg" in this case.
         //
         assert(genIsValidIntReg(target->GetRegNum()));
-        bool isNoGCframe = false;
+        bool noSafePoint = false;
 
 #ifdef TARGET_ARM64
         bool isTlsHandleTarget =
@@ -3613,7 +3613,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
             GenTreeIntCon* iconNode = target->AsIntCon();
             methHnd                 = (CORINFO_METHOD_HANDLE)iconNode->gtIconVal;
             retSize                 = EA_SET_FLG(retSize, EA_CNS_TLSGD_RELOC);
-            isNoGCframe             = true;
+            noSafePoint             = true;
 
             // For NativeAOT, linux/arm64, linker wants the following pattern, so we will generate
             // it as part of the call. Generating individual instructions is tricky to get it
@@ -3650,7 +3650,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     di,
                     target->GetRegNum(),
                     call->IsFastTailCall(),
-                    isNoGCframe);
+                    noSafePoint);
 
 #ifdef TARGET_ARM64
         if (isTlsHandleTarget)

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2257,7 +2257,8 @@ void CodeGen::genEmitCall(int                   callType,
                           MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(emitAttr secondRetSize),
                           const DebugInfo& di,
                           regNumber             base,
-                          bool                  isJump)
+                          bool                  isJump,
+                          bool                  isNoGCframe)
 {
 #if !defined(TARGET_X86)
     int argSize = 0;
@@ -2277,7 +2278,7 @@ void CodeGen::genEmitCall(int                   callType,
                                gcInfo.gcVarPtrSetCur,
                                gcInfo.gcRegGCrefSetCur,
                                gcInfo.gcRegByrefSetCur,
-                               di, base, REG_NA, 0, 0, isJump);
+                               di, base, REG_NA, 0, 0, isJump, isNoGCframe);
 }
 // clang-format on
 

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -2246,6 +2246,7 @@ void CodeGen::genTransferRegGCState(regNumber dst, regNumber src)
 //     pass in 'addr' for a relative call or 'base' for a indirect register call
 //     methHnd - optional, only used for pretty printing
 //     retSize - emitter type of return for GC purposes, should be EA_BYREF, EA_GCREF, or EA_PTRSIZE(not GC)
+//     noSafePoint - force not making this call a safe point in partially interruptible code
 //
 // clang-format off
 void CodeGen::genEmitCall(int                   callType,
@@ -2258,7 +2259,7 @@ void CodeGen::genEmitCall(int                   callType,
                           const DebugInfo& di,
                           regNumber             base,
                           bool                  isJump,
-                          bool                  isNoGCframe)
+                          bool                  noSafePoint)
 {
 #if !defined(TARGET_X86)
     int argSize = 0;
@@ -2278,7 +2279,7 @@ void CodeGen::genEmitCall(int                   callType,
                                gcInfo.gcVarPtrSetCur,
                                gcInfo.gcRegGCrefSetCur,
                                gcInfo.gcRegByrefSetCur,
-                               di, base, REG_NA, 0, 0, isJump, isNoGCframe);
+                               di, base, REG_NA, 0, 0, isJump, noSafePoint);
 }
 // clang-format on
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6396,7 +6396,8 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
                             MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize),
                             di,
                             target->GetRegNum(),
-                            call->IsFastTailCall());
+                            call->IsFastTailCall(),
+                            true); // isNoGCframe
                 // clang-format on
             }
         }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -6397,7 +6397,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call X86_ARG(target_ssize_t stackA
                             di,
                             target->GetRegNum(),
                             call->IsFastTailCall(),
-                            true); // isNoGCframe
+                            true); // noSafePoint
                 // clang-format on
             }
         }

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -4677,7 +4677,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */)
+                           bool             isJump /* = false */,
+                           bool             isNoGCframe /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -4769,7 +4770,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -4660,6 +4660,8 @@ void emitter::emitIns_J_R(instruction ins, emitAttr attr, BasicBlock* dst, regNu
  *
  * For ARM xreg, xmul and disp are never used and should always be 0/REG_NA.
  *
+ * noSafePoint - force not making this call a safe point in partially interruptible code
+ * 
  *  Please consult the "debugger team notification" comment in genFnProlog().
  */
 
@@ -4678,7 +4680,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGCframe /* = false */)
+                           bool             noSafePoint /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -4770,7 +4772,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || noSafePoint || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -4661,7 +4661,7 @@ void emitter::emitIns_J_R(instruction ins, emitAttr attr, BasicBlock* dst, regNu
  * For ARM xreg, xmul and disp are never used and should always be 0/REG_NA.
  *
  * noSafePoint - force not making this call a safe point in partially interruptible code
- * 
+ *
  *  Please consult the "debugger team notification" comment in genFnProlog().
  */
 

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -335,7 +335,8 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg   = REG_NA,
                   unsigned         xmul   = 0,
                   ssize_t          disp   = 0,
-                  bool             isJump = false);
+                  bool             isJump = false,
+                  bool             isNoGCframe = false);
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -336,7 +336,7 @@ void emitIns_Call(EmitCallType          callType,
                   unsigned         xmul        = 0,
                   ssize_t          disp        = 0,
                   bool             isJump      = false,
-                  bool             isNoGCframe = false);
+                  bool             noSafePoint = false);
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/emitarm.h
+++ b/src/coreclr/jit/emitarm.h
@@ -330,12 +330,12 @@ void emitIns_Call(EmitCallType          callType,
                   VARSET_VALARG_TP ptrVars,
                   regMaskTP        gcrefRegs,
                   regMaskTP        byrefRegs,
-                  const DebugInfo& di     = DebugInfo(),
-                  regNumber        ireg   = REG_NA,
-                  regNumber        xreg   = REG_NA,
-                  unsigned         xmul   = 0,
-                  ssize_t          disp   = 0,
-                  bool             isJump = false,
+                  const DebugInfo& di          = DebugInfo(),
+                  regNumber        ireg        = REG_NA,
+                  regNumber        xreg        = REG_NA,
+                  unsigned         xmul        = 0,
+                  ssize_t          disp        = 0,
+                  bool             isJump      = false,
                   bool             isNoGCframe = false);
 
 /*****************************************************************************

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -8985,7 +8985,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */)
+                           bool             isJump /* = false */,
+                           bool             isNoGCframe /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -9079,7 +9080,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -8967,6 +8967,8 @@ void emitter::emitIns_J(instruction ins, BasicBlock* dst, int instrCount)
  *
  * For ARM xreg, xmul and disp are never used and should always be 0/REG_NA.
  *
+ * noSafePoint - force not making this call a safe point in partially interruptible code
+ * 
  *  Please consult the "debugger team notification" comment in genFnProlog().
  */
 
@@ -8986,7 +8988,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGCframe /* = false */)
+                           bool             noSafePoint /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -9080,7 +9082,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || noSafePoint || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitarm64.cpp
+++ b/src/coreclr/jit/emitarm64.cpp
@@ -8968,7 +8968,7 @@ void emitter::emitIns_J(instruction ins, BasicBlock* dst, int instrCount)
  * For ARM xreg, xmul and disp are never used and should always be 0/REG_NA.
  *
  * noSafePoint - force not making this call a safe point in partially interruptible code
- * 
+ *
  *  Please consult the "debugger team notification" comment in genFnProlog().
  */
 

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -1745,7 +1745,8 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg,
                   unsigned         xmul,
                   ssize_t          disp,
-                  bool             isJump);
+                  bool             isJump,
+                  bool             isNoGCframe = false);
 
 BYTE*    emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i);
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* i, code_t code);

--- a/src/coreclr/jit/emitarm64.h
+++ b/src/coreclr/jit/emitarm64.h
@@ -1746,7 +1746,7 @@ void emitIns_Call(EmitCallType          callType,
                   unsigned         xmul,
                   ssize_t          disp,
                   bool             isJump,
-                  bool             isNoGCframe = false);
+                  bool             noSafePoint = false);
 
 BYTE*    emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i);
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* i, code_t code);

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2392,7 +2392,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */)
+                           bool             isJump /* = false */,
+                           bool             isNoGCframe /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -2489,7 +2490,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2375,6 +2375,8 @@ void emitter::emitIns_I_la(emitAttr size, regNumber reg, ssize_t imm)
  *
  * For LOONGARCH xreg, xmul and disp are never used and should always be 0/REG_NA.
  *
+ * noSafePoint - force not making this call a safe point in partially interruptible code
+ *
  *  Please consult the "debugger team notification" comment in genFnProlog().
  */
 
@@ -2393,7 +2395,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGCframe /* = false */)
+                           bool             noSafePoint /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -2490,7 +2492,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || noSafePoint || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitloongarch64.h
+++ b/src/coreclr/jit/emitloongarch64.h
@@ -349,7 +349,8 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg   = REG_NA,
                   unsigned         xmul   = 0,
                   ssize_t          disp   = 0,
-                  bool             isJump = false);
+                  bool             isJump = false,
+                  bool             isNoGCframe = false);
 
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t code);
 

--- a/src/coreclr/jit/emitloongarch64.h
+++ b/src/coreclr/jit/emitloongarch64.h
@@ -350,7 +350,7 @@ void emitIns_Call(EmitCallType          callType,
                   unsigned         xmul        = 0,
                   ssize_t          disp        = 0,
                   bool             isJump      = false,
-                  bool             isNoGCframe = false);
+                  bool             noSafePoint = false);
 
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t code);
 

--- a/src/coreclr/jit/emitloongarch64.h
+++ b/src/coreclr/jit/emitloongarch64.h
@@ -345,11 +345,11 @@ void emitIns_Call(EmitCallType          callType,
                   regMaskTP        gcrefRegs,
                   regMaskTP        byrefRegs,
                   const DebugInfo& di,
-                  regNumber        ireg   = REG_NA,
-                  regNumber        xreg   = REG_NA,
-                  unsigned         xmul   = 0,
-                  ssize_t          disp   = 0,
-                  bool             isJump = false,
+                  regNumber        ireg        = REG_NA,
+                  regNumber        xreg        = REG_NA,
+                  unsigned         xmul        = 0,
+                  ssize_t          disp        = 0,
+                  bool             isJump      = false,
                   bool             isNoGCframe = false);
 
 unsigned emitOutputCall(insGroup* ig, BYTE* dst, instrDesc* id, code_t code);

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1303,7 +1303,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber        xreg /* = REG_NA */,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
-                           bool             isJump /* = false */)
+                           bool             isJump /* = false */,
+                           bool             isNoGCframe /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -1400,7 +1401,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1288,7 +1288,7 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
  * EC_INDIR_R          : "call ireg".
  *
  * noSafePoint - force not making this call a safe point in partially interruptible code
- * 
+ *
  */
 
 void emitter::emitIns_Call(EmitCallType          callType,

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -1287,6 +1287,8 @@ void emitter::emitLoadImmediate(emitAttr size, regNumber reg, ssize_t imm)
  * If callType is one of these emitCallTypes, addr has to be NULL.
  * EC_INDIR_R          : "call ireg".
  *
+ * noSafePoint - force not making this call a safe point in partially interruptible code
+ * 
  */
 
 void emitter::emitIns_Call(EmitCallType          callType,
@@ -1304,7 +1306,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned         xmul /* = 0     */,
                            ssize_t          disp /* = 0     */,
                            bool             isJump /* = false */,
-                           bool             isNoGCframe /* = false */)
+                           bool             noSafePoint /* = false */)
 {
     /* Sanity check the arguments depending on callType */
 
@@ -1401,7 +1403,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     emitThisByrefRegs = byrefRegs;
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || noSafePoint || emitNoGChelper(methHnd));
 
     /* Set the instruction - special case jumping a function */
     instruction ins;

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -335,7 +335,8 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber        xreg   = REG_NA,
                   unsigned         xmul   = 0,
                   ssize_t          disp   = 0,
-                  bool             isJump = false);
+                  bool             isJump = false,
+                  bool             isNoGCframe = false);
 
 unsigned emitOutputCall(const insGroup* ig, BYTE* dst, instrDesc* id, code_t code);
 

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -331,11 +331,11 @@ void emitIns_Call(EmitCallType          callType,
                   regMaskTP        gcrefRegs,
                   regMaskTP        byrefRegs,
                   const DebugInfo& di,
-                  regNumber        ireg   = REG_NA,
-                  regNumber        xreg   = REG_NA,
-                  unsigned         xmul   = 0,
-                  ssize_t          disp   = 0,
-                  bool             isJump = false,
+                  regNumber        ireg        = REG_NA,
+                  regNumber        xreg        = REG_NA,
+                  unsigned         xmul        = 0,
+                  ssize_t          disp        = 0,
+                  bool             isJump      = false,
                   bool             isNoGCframe = false);
 
 unsigned emitOutputCall(const insGroup* ig, BYTE* dst, instrDesc* id, code_t code);

--- a/src/coreclr/jit/emitriscv64.h
+++ b/src/coreclr/jit/emitriscv64.h
@@ -336,7 +336,7 @@ void emitIns_Call(EmitCallType          callType,
                   unsigned         xmul        = 0,
                   ssize_t          disp        = 0,
                   bool             isJump      = false,
-                  bool             isNoGCframe = false);
+                  bool             noSafePoint = false);
 
 unsigned emitOutputCall(const insGroup* ig, BYTE* dst, instrDesc* id, code_t code);
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9664,7 +9664,8 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            regNumber             xreg,
                            unsigned              xmul,
                            ssize_t               disp,
-                           bool                  isJump)
+                           bool                  isJump,
+                           bool                  isNoGCframe)
 // clang-format on
 {
     /* Sanity check the arguments depending on callType */
@@ -9790,7 +9791,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     id->idIns(ins);
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
 
     UNATIVE_OFFSET sz;
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9647,7 +9647,7 @@ void emitter::emitAdjustStackDepth(instruction ins, ssize_t val)
  * EC_INDIR_ARD        : "call [ireg+xreg*xmul+disp]"
  *
  * noSafePoint - force not making this call a safe point in partially interruptible code
- * 
+ *
  */
 
 // clang-format off

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -9646,6 +9646,8 @@ void emitter::emitAdjustStackDepth(instruction ins, ssize_t val)
  * EC_INDIR_C          : "call clsVar<disp>" (eg. call [clsVarAddr])
  * EC_INDIR_ARD        : "call [ireg+xreg*xmul+disp]"
  *
+ * noSafePoint - force not making this call a safe point in partially interruptible code
+ * 
  */
 
 // clang-format off
@@ -9665,7 +9667,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
                            unsigned              xmul,
                            ssize_t               disp,
                            bool                  isJump,
-                           bool                  isNoGCframe)
+                           bool                  noSafePoint)
 // clang-format on
 {
     /* Sanity check the arguments depending on callType */
@@ -9791,7 +9793,7 @@ void emitter::emitIns_Call(EmitCallType          callType,
     id->idIns(ins);
 
     // for the purpose of GC safepointing tail-calls are not real calls
-    id->idSetIsNoGC(isJump || isNoGCframe || emitNoGChelper(methHnd));
+    id->idSetIsNoGC(isJump || noSafePoint || emitNoGChelper(methHnd));
 
     UNATIVE_OFFSET sz;
 

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -1017,7 +1017,8 @@ void emitIns_Call(EmitCallType          callType,
                   regNumber             xreg     = REG_NA,
                   unsigned              xmul     = 0,
                   ssize_t               disp     = 0,
-                  bool                  isJump   = false);
+                  bool                  isJump   = false,
+                  bool                  isNoGCframe   = false);
 // clang-format on
 
 #ifdef TARGET_AMD64

--- a/src/coreclr/jit/emitxarch.h
+++ b/src/coreclr/jit/emitxarch.h
@@ -1018,7 +1018,7 @@ void emitIns_Call(EmitCallType          callType,
                   unsigned              xmul     = 0,
                   ssize_t               disp     = 0,
                   bool                  isJump   = false,
-                  bool                  isNoGCframe   = false);
+                  bool                  noSafePoint   = false);
 // clang-format on
 
 #ifdef TARGET_AMD64


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/102140

The reason for the failure is GC-reporting of uninitialized temp.

We declare a temp to hold the address to the managed TLS blob. The temp is initialized by indirecting into native TLS. In some cases fetching the native TLS involves a method call.

Roughly it looks like:
```
managed_ptr tlsRoot;

// unmanaged TLS pattern starts
...
...
unmanaged_ptr nativeTLS = TLS_GET_ADDR();   
nativeTLS += someAdjustment;                           // if this is a safe point, tlsRoot must be zero-inited
// unmanaged TLS pattern ends

// only here tlsRoot gets a real value
tlsRoot = nativeTLS[some indirection];
```

The optimizer assumes that if we did not see a safe point between prolog and the first assignment, then zero-initing is unnecessary. The problem is that optimizer does not know that TLS access may emit a call, and that call may introduce a safe point (as calls do by default).

A simplest fix would be to not emit safepoints for calls into native TLS. They cannot participate in GC stackwalks anyways.


