### PR TITLE
Add overload on First and Last methods to improve performance

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -8,6 +8,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        public static TSource First<TSource>(this IList<TSource> source) => source[0];
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
             TSource? first = source.TryGetFirst(out bool found);

--- a/src/libraries/System.Linq/src/System/Linq/Last.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Last.cs
@@ -8,6 +8,7 @@ namespace System.Linq
 {
     public static partial class Enumerable
     {
+        public static TSource Last<TSource>(this IList<TSource> source) => source[source.Count - 1];
         public static TSource Last<TSource>(this IEnumerable<TSource> source)
         {
             TSource? last = source.TryGetLast(out bool found);


### PR DESCRIPTION
With these two methos we could improve performance from this:
![image](https://github.com/dotnet/runtime/assets/57623565/e8298d61-5319-49b1-a6ea-e78d04ee88f1)

To this:
![image](https://github.com/dotnet/runtime/assets/57623565/1fb94d85-7b82-4f2b-8257-3e708b386c53)
