### PR TITLE
[wasm] mmap/lock free allocator optimizations

### DIFF
--- a/src/mono/mono/sgen/sgen-internal.c
+++ b/src/mono/mono/sgen/sgen-internal.c
@@ -15,6 +15,7 @@
 
 #include "mono/sgen/sgen-gc.h"
 #include "mono/utils/lock-free-alloc.h"
+#include "mono/utils/options.h"
 #include "mono/sgen/sgen-memory-governor.h"
 #include "mono/sgen/sgen-client.h"
 

--- a/src/mono/mono/utils/lock-free-alloc.c
+++ b/src/mono/mono/utils/lock-free-alloc.c
@@ -125,7 +125,7 @@ static unsigned long
 prot_flags_for_activate (int activate)
 {
 	unsigned long prot_flags = activate? MONO_MMAP_READ|MONO_MMAP_WRITE: MONO_MMAP_NONE;
-	return prot_flags | MONO_MMAP_PRIVATE | MONO_MMAP_ANON;
+	return prot_flags | MONO_MMAP_PRIVATE | MONO_MMAP_ANON | MONO_MMAP_NOZERO;
 }
 
 static gpointer

--- a/src/mono/mono/utils/lock-free-alloc.h
+++ b/src/mono/mono/utils/lock-free-alloc.h
@@ -45,8 +45,11 @@ typedef struct {
 	MonoMemAccountType account_type;
 } MonoLockFreeAllocator;
 
-// FIXME: On WASM the page size is 64KB, so this isn't enough.
+#ifdef HOST_WASM
+#define LOCK_FREE_ALLOC_SB_MAX_SIZE					(mono_opt_wasm_mmap ? 65536 : 16384)
+#else
 #define LOCK_FREE_ALLOC_SB_MAX_SIZE					16384
+#endif
 #define LOCK_FREE_ALLOC_SB_HEADER_SIZE				(sizeof (gpointer))
 #define LOCK_FREE_ALLOC_SB_USABLE_SIZE(block_size)	((block_size) - LOCK_FREE_ALLOC_SB_HEADER_SIZE)
 

--- a/src/mono/mono/utils/mono-mmap-wasm.c
+++ b/src/mono/mono/utils/mono-mmap-wasm.c
@@ -119,7 +119,7 @@ valloc_impl (void *addr, size_t size, int flags, MonoMemAccountType type)
 		if ((flags & MONO_MMAP_FIXED) && addr)
 			return NULL;
 
-		ptr = mwpm_alloc_range (size, 1);
+		ptr = mwpm_alloc_range (size, (flags & MONO_MMAP_NOZERO) == 0);
 		if (!ptr)
 			return NULL;
 	} else

--- a/src/mono/mono/utils/mono-mmap.h
+++ b/src/mono/mono/utils/mono-mmap.h
@@ -23,6 +23,7 @@ enum {
 	MONO_MMAP_FIXED   = 1 << 7,
 	MONO_MMAP_32BIT   = 1 << 8,
 	MONO_MMAP_JIT     = 1 << 9,
+	/* do not zero the new pages */
 	MONO_MMAP_NOZERO  = 1 << 10,
 };
 


### PR DESCRIPTION
Right now on WASM we ask mmap for 16KB pages in the lock-free allocator, and mmap hands us 64KB pages that we end up wasting 3/4 of.

We also ask for zeroed pages, but we don't need zeroed pages because all of the lock-free allocator's callers memset or fully initialize their allocations anyway.

Partially fixes https://github.com/dotnet/perf-autofiling-issues/issues/34303 and fixes https://github.com/dotnet/perf-autofiling-issues/issues/34274