### PR TITLE
Use the static libc++ with libstdc++ ABI our docker images now provide

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -307,7 +307,8 @@
                             PgoInstrument=false;
                             NoPgoOptimize=true;
                             CrossBuild=$(CrossBuild);
-                            BuildSubdirectory=unsanitized"
+                            BuildSubdirectory=unsanitized;
+                            $(TargetCxxLibraryProperties)"
       UndefineProperties="EnableNativeSanitizers"
       Category="clr" />
   </ItemGroup>

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -43,6 +43,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux armv6
@@ -90,6 +93,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl x64
@@ -112,6 +118,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm
@@ -134,6 +143,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux musl arm64
@@ -156,6 +168,9 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        cxxStandardLibrary: libc++
+        cxxStandardLibraryStatic: true
+        cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 # Linux Bionic arm
@@ -251,6 +266,10 @@ jobs:
         buildConfig: ${{ parameters.buildConfig }}
         helixQueueGroup: ${{ parameters.helixQueueGroup }}
         crossBuild: true
+        ${{ if eq(parameters.container, '') }}:
+          cxxStandardLibrary: libc++
+          cxxStandardLibraryStatic: true
+          cxxAbiLibrary: libstdc++
         ${{ insert }}: ${{ parameters.jobParameters }}
 
 - ${{ if containsValue(parameters.platforms, 'linux_x64_sanitizer') }}:


### PR DESCRIPTION
We're going to switch our Microsoft shipping builds to statically link to a live-built libc++ with a dynamically-linked libstdc++ as the C++ ABI. We're doing this change to address the concerns in https://github.com/dotnet/runtime/pull/101088#discussion_r1566580872. This change will allow us to use servicable/supported C++ headers in our product with the smallest possible size increase (+~53kB size on disk for libcoreclr.so on our linux-x64 images).

This PR updates our jobs to use the libc++ standard library.