### PR TITLE
JIT: Canonicalize entry BB early

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -15245,7 +15245,9 @@ PhaseStatus Compiler::fgRetypeImplicitByRefArgs()
                 if (!undoPromotion)
                 {
                     // Insert IR that initializes the temp from the parameter.
-                    fgEnsureFirstBBisScratch();
+                    // The first BB should already be a valid insertion point,
+                    // which is a precondition for this phase when optimizing.
+                    assert(fgFirstBB->bbPreds == nullptr);
                     GenTree* addr  = gtNewLclvNode(lclNum, TYP_BYREF);
                     GenTree* data  = (varDsc->TypeGet() == TYP_STRUCT) ? gtNewBlkIndir(varDsc->GetLayout(), addr)
                                                                        : gtNewIndir(varDsc->TypeGet(), addr);

--- a/src/coreclr/jit/promotion.cpp
+++ b/src/coreclr/jit/promotion.cpp
@@ -1926,8 +1926,8 @@ void ReplaceVisitor::StartBlock(BasicBlock* block)
 #endif
 
     // OSR locals and parameters may need an initial read back, which we mark
-    // when we start the scratch BB.
-    if (!m_compiler->fgBBisScratch(block))
+    // when we start the initial BB.
+    if (block != m_compiler->fgFirstBB)
     {
         return;
     }
@@ -1940,7 +1940,7 @@ void ReplaceVisitor::StartBlock(BasicBlock* block)
             continue;
         }
 
-        JITDUMP("Marking fields of %s V%02u as needing read-back in scratch " FMT_BB "\n",
+        JITDUMP("Marking fields of %s V%02u as needing read-back in entry BB " FMT_BB "\n",
                 dsc->lvIsParam ? "parameter" : "OSR-local", agg->LclNum, block->bbNum);
 
         for (size_t i = 0; i < agg->Replacements.size(); i++)
@@ -1954,7 +1954,7 @@ void ReplaceVisitor::StartBlock(BasicBlock* block)
             }
             else
             {
-                JITDUMP("  V%02u (%s) not marked (not live-in to scratch BB)\n", rep.LclNum, rep.Description);
+                JITDUMP("  V%02u (%s) not marked (not live-in to entry BB)\n", rep.LclNum, rep.Description);
             }
         }
     }
@@ -2840,21 +2840,9 @@ PhaseStatus Promotion::Run()
         return PhaseStatus::MODIFIED_NOTHING;
     }
 
-    // Check for parameters and OSR locals that need to be read back on entry
-    // to the function.
-    for (AggregateInfo* agg : aggregates)
-    {
-        LclVarDsc* dsc = m_compiler->lvaGetDesc(agg->LclNum);
-        if (dsc->lvIsParam || dsc->lvIsOSRLocal)
-        {
-            // We will need an initial readback. We create the scratch BB ahead
-            // of time so that we get correct liveness and mark the
-            // parameters/OSR-locals as requiring read-back as part of
-            // ReplaceVisitor::StartBlock when we get to the scratch block.
-            m_compiler->fgEnsureFirstBBisScratch();
-            break;
-        }
-    }
+    // We should have a proper entry BB where we can put IR that will only be
+    // run once into. This is a precondition of the phase.
+    assert(m_compiler->fgFirstBB->bbPreds == nullptr);
 
     // Compute liveness for the fields and remainders.
     PromotionLiveness liveness(m_compiler, aggregates);
@@ -3010,8 +2998,8 @@ void Promotion::ExplicitlyZeroInitReplacementLocals(unsigned                    
 
 //------------------------------------------------------------------------
 // Promotion::InsertInitStatement:
-//   Insert a new statement after the specified statement in the scratch block,
-//   or at the beginning of the scratch block if no other statements were
+//   Insert a new statement after the specified statement in the entry block,
+//   or at the beginning of the entry block if no other statements were
 //   inserted yet.
 //
 // Parameters:
@@ -3020,7 +3008,6 @@ void Promotion::ExplicitlyZeroInitReplacementLocals(unsigned                    
 //
 void Promotion::InsertInitStatement(Statement** prevStmt, GenTree* tree)
 {
-    m_compiler->fgEnsureFirstBBisScratch();
     Statement* stmt = m_compiler->fgNewStmtFromTree(tree);
     if (*prevStmt != nullptr)
     {


### PR DESCRIPTION
Canonicalize entry BB before the early transformations instead of doing it as part of the transformations. This allows us to move the morph DFS even earlier, which will be useful for other phases as well.

This is a prerequisite for the fix to #87072 and #102273; I expect to use an RPO traversal during local morph to do early propagation of `LCL_ADDR` nodes. This change makes the RPO available during local morph.