### PR TITLE
ILLink: Check for all expected warnings, then fail if any are unmatched

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -972,7 +972,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				int? unexpectedWarningCodeNumber = unexpectedWarningCode == null ? null : int.Parse (unexpectedWarningCode.Substring (2));
 
 				MessageContainer? unexpectedWarningMessage = null;
-				foreach (var mc in allMessages) {
+				foreach (var mc in loggedMessages) {
 					if (mc.Category != MessageCategory.Warning)
 						continue;
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -66,12 +66,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 						throw new NotImplementedException ($"Unexpected scope type '{exportedType.Scope.GetType ()}' for exported type '{exportedType.FullName}'");
 					}
 					continue;
-				case AssemblyNameReference: {
-						// There should be an AssemblyRef row for this assembly
-						var assemblyRef = linked.MainModule.AssemblyReferences.Single (ar => ar.Name == typeRef.Scope.Name);
-						Assert.IsNotNull (assemblyRef, $"Type reference '{typeRef.FullName}' has a reference to assembly '{typeRef.Scope.Name}' which is not a reference of '{linked.FullName}'");
-						continue;
-					}
+				case AssemblyNameReference:
+				{
+					// There should be an AssemblyRef row for this assembly
+					var assemblyRef = linked.MainModule.AssemblyReferences.Single (ar => ar.Name == typeRef.Scope.Name);
+					Assert.IsNotNull (assemblyRef, $"Type reference '{typeRef.FullName}' has a reference to assembly '{typeRef.Scope.Name}' which is not a reference of '{linked.FullName}'");
+					continue;
+				}
 				default:
 					throw new NotImplementedException ($"Unexpected scope type '{typeRef.Scope.GetType ()}' for type reference '{typeRef.FullName}'");
 				}
@@ -97,10 +98,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					PerformOutputAssemblyChecks (original, linkResult.OutputAssemblyPath.Parent);
 					PerformOutputSymbolChecks (original, linkResult.OutputAssemblyPath.Parent);
 
-					if (!HasActiveSkipKeptItemsValidationAttribute (linkResult.TestCase.FindTypeDefinition (original))) {
+					if (!HasActiveSkipKeptItemsValidationAttribute(linkResult.TestCase.FindTypeDefinition (original))) {
 						CreateAssemblyChecker (original, linked, linkResult).Verify ();
 					}
-					CreateILChecker ().Check (linkResult, original);
+					CreateILChecker ().Check(linkResult, original);
 				}
 
 				VerifyLinkingOfOtherAssemblies (original);
@@ -217,12 +218,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		void VerifyExitCode (TrimmedTestCaseResult linkResult, AssemblyDefinition original)
 		{
-			if (TryGetCustomAttribute (original, nameof (ExpectNonZeroExitCodeAttribute), out var attr)) {
+			if (TryGetCustomAttribute (original, nameof(ExpectNonZeroExitCodeAttribute), out var attr)) {
 				var expectedExitCode = (int) attr.ConstructorArguments[0].Value;
-				Assert.AreEqual (expectedExitCode, linkResult.ExitCode, $"Expected exit code {expectedExitCode} but got {linkResult.ExitCode}.  Output was:\n{FormatLinkerOutput ()}");
+				Assert.AreEqual (expectedExitCode, linkResult.ExitCode, $"Expected exit code {expectedExitCode} but got {linkResult.ExitCode}.  Output was:\n{FormatLinkerOutput()}");
 			} else {
 				if (linkResult.ExitCode != 0) {
-					Assert.Fail ($"Linker exited with an unexpected non-zero exit code of {linkResult.ExitCode} and output:\n{FormatLinkerOutput ()}");
+					Assert.Fail ($"Linker exited with an unexpected non-zero exit code of {linkResult.ExitCode} and output:\n{FormatLinkerOutput()}");
 				}
 			}
 
@@ -734,7 +735,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 		static bool IsProducedByLinker (CustomAttribute attr)
 		{
 			if (attr.Constructor.Parameters.Count > 2 && attr.ConstructorArguments[^2].Type.Name == "Tool") {
-				return ((Tool) attr.ConstructorArguments[^2].Value).HasFlag (Tool.Trimmer) == true;
+				return ((Tool)attr.ConstructorArguments[^2].Value).HasFlag (Tool.Trimmer) == true;
 			}
 			var producedBy = attr.GetPropertyValue ("ProducedBy");
 			return producedBy is null ? true : ((Tool) producedBy).HasFlag (Tool.Trimmer);
@@ -787,19 +788,18 @@ namespace Mono.Linker.Tests.TestCasesRunner
 					case nameof (LogDoesNotContainAttribute): {
 							var unexpectedMessage = (string) attr.ConstructorArguments[0].Value;
 							foreach (var loggedMessage in loggedMessages) {
-								bool foundMatch;
-								if ((bool) attr.ConstructorArguments[1].Value)
-									foundMatch = !Regex.IsMatch (loggedMessage.ToString (), unexpectedMessage);
-								else
-									foundMatch = !loggedMessage.ToString ().Contains (unexpectedMessage);
+								bool isRegex = (bool) attr.ConstructorArguments[1].Value;
+								bool foundMatch = isRegex
+									? Regex.IsMatch (loggedMessage.ToString (), unexpectedMessage)
+									: loggedMessage.ToString ().Contains (unexpectedMessage);
 
-								if (!foundMatch)
+								if (foundMatch)
 									unexpectedMessageWarnings.Add ($"Expected to not find logged message matching `{unexpectedMessage}`, but found:{Environment.NewLine}{loggedMessage.ToString ()}");
 							}
 						}
 						break;
 
-					case nameof (ExpectedWarningAttribute) or nameof (UnexpectedWarningAttribute): {
+					case nameof (ExpectedWarningAttribute) or nameof(UnexpectedWarningAttribute): {
 							var expectedWarningCode = (string) attr.GetConstructorArgumentValue (0);
 							if (!expectedWarningCode.StartsWith ("IL")) {
 								Assert.Fail ($"The warning code specified in {attr.AttributeType.Name} must start with the 'IL' prefix. Specified value: '{expectedWarningCode}'.");
@@ -809,18 +809,18 @@ namespace Mono.Linker.Tests.TestCasesRunner
 								// ExpectedWarningAttribute(string warningCode, params string[] expectedMessages)
 								// ExpectedWarningAttribute(string warningCode, string[] expectedMessages, Tool producedBy, string issueLink)
 								[_, { ParameterType.IsArray: true }, ..]
-									=> ((CustomAttributeArgument[]) attr.ConstructorArguments[1].Value)
-										.Select (caa => (string) caa.Value),
+									=> ((CustomAttributeArgument[])attr.ConstructorArguments[1].Value)
+										.Select(caa => (string)caa.Value),
 								// ExpectedWarningAttribute(string warningCode, string expectedMessage1, string expectedMessage2, Tool producedBy, string issueLink)
 								[_, { ParameterType.Name: "String" }, { ParameterType.Name: "String" }, { ParameterType.Name: "Tool" }, _]
-										=> [(string) attr.GetConstructorArgumentValue (1), (string) attr.GetConstructorArgumentValue (2)],
+									=> [(string)attr.GetConstructorArgumentValue(1), (string)attr.GetConstructorArgumentValue(2)],
 								// ExpectedWarningAttribute(string warningCode, string expectedMessage, Tool producedBy, string issueLink)
 								[_, { ParameterType.Name: "String" }, { ParameterType.Name: "Tool" }, _]
-									=> [(string) attr.GetConstructorArgumentValue (1)],
+									=> [(string)attr.GetConstructorArgumentValue(1)],
 								// ExpectedWarningAttribute(string warningCode, Tool producedBy, string issueLink)
 								[_, { ParameterType.Name: "Tool" }, _]
-										=> [],
-								_ => throw new UnreachableException (),
+									=> [],
+								_ => throw new UnreachableException(),
 							};
 							string fileName = (string) attr.GetPropertyValue ("FileName");
 							int? sourceLine = (int?) attr.GetPropertyValue ("SourceLine");

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -987,7 +987,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 				if (unexpectedWarningMessage is not null)
 				{
-					unexpectedMessageWarnings.Add($"Unexpected warning found: {unexpectedWarningMessage}")
+					unexpectedMessageWarnings.Add($"Unexpected warning found: {unexpectedWarningMessage}");
 				}
 			}
 
@@ -996,7 +996,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				missingMessageWarnings.Add ("Unexpected Messages:" + Environment.NewLine);
 				missingMessageWarnings.AddRange (loggedMessages.Select (m => m.ToString ()));
 				missingMessageWarnings.Add (Environment.NewLine + "All Messages:" + Environment.NewLine);
-				missingMessageWarnings.AddRange (logger.GetLoggedMessages ());
+				missingMessageWarnings.AddRange (logger.GetLoggedMessages ().Select (m => m.ToString ()));
 				Assert.Fail (string.Join (Environment.NewLine, missingMessageWarnings));
 			}
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ResultChecker.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -758,7 +759,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 		void VerifyLoggedMessages (AssemblyDefinition original, TrimmingTestLogger logger, bool checkRemainingErrors)
 		{
-			List<MessageContainer> loggedMessages = logger.GetLoggedMessages ();
+			ImmutableArray<MessageContainer> allMessages = logger.GetLoggedMessages ();
+			List<MessageContainer> loggedMessages = [..allMessages];
 			List<(ICustomAttributeProvider, CustomAttribute)> expectedNoWarningsAttributes = new ();
 			List<string> missingMessageWarnings = [];
 			List<string> unexpectedMessageWarnings = [];
@@ -970,7 +972,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 				int? unexpectedWarningCodeNumber = unexpectedWarningCode == null ? null : int.Parse (unexpectedWarningCode.Substring (2));
 
 				MessageContainer? unexpectedWarningMessage = null;
-				foreach (var mc in logger.GetLoggedMessages ()) {
+				foreach (var mc in allMessages) {
 					if (mc.Category != MessageCategory.Warning)
 						continue;
 
@@ -993,10 +995,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
 			if (missingMessageWarnings.Any ())
 			{
-				missingMessageWarnings.Add ("Unexpected Messages:" + Environment.NewLine);
+				missingMessageWarnings.Add ("Unmatched Messages:" + Environment.NewLine);
 				missingMessageWarnings.AddRange (loggedMessages.Select (m => m.ToString ()));
 				missingMessageWarnings.Add (Environment.NewLine + "All Messages:" + Environment.NewLine);
-				missingMessageWarnings.AddRange (logger.GetLoggedMessages ().Select (m => m.ToString ()));
+				missingMessageWarnings.AddRange (allMessages.Select (m => m.ToString ()));
 				Assert.Fail (string.Join (Environment.NewLine, missingMessageWarnings));
 			}
 

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TrimmingTestLogger.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TrimmingTestLogger.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Mono.Linker.Tests.TestCasesRunner
 {
@@ -14,9 +16,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
 			MessageContainers = new List<MessageContainer> ();
 		}
 
-		public List<MessageContainer> GetLoggedMessages ()
+		public ImmutableArray<MessageContainer> GetLoggedMessages ()
 		{
-			return MessageContainers;
+			return MessageContainers.ToImmutableArray();
 		}
 
 		public void LogMessage (MessageContainer message)


### PR DESCRIPTION
In Linker tests, we fail at the first ExpectedWarning that isn't matched, and print all the messages that haven't been matched yet, even though they may match another ExpectedWarning that just hasn't been processed yet.

Instead, we should keep a list of all expected warnings that were missing report them at once along with all unmatched warnings. This makes it much easier to debug when a test is failing.