### PR TITLE
Treat a couple more switches as output for make-repro-path

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -286,7 +286,7 @@ namespace ILCompiler
 #pragma warning disable CA1861 // Avoid constant arrays as arguments. Only executed once during the execution of the program.
                         Helpers.MakeReproPackage(makeReproPath, result.GetValue(OutputFilePath), args, result,
                             inputOptions : new[] { "-r", "--reference", "-m", "--mibc", "--rdxml", "--directpinvokelist", "--descriptor", "--satellite" },
-                            outputOptions : new[] { "-o", "--out", "--exportsfile" });
+                            outputOptions : new[] { "-o", "--out", "--exportsfile", "--dgmllog", "--scandgmllog", "--mstat" });
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
                     }
 


### PR DESCRIPTION
Without these, the output of `--make-repro-path` will refer to a non-existent `obj/...` path.

Cc @dotnet/ilc-contrib 