### PR TITLE
Fix ROR(x, 32) on arm64

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -305,6 +305,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
+        GenTree* rotateOperand    = childNode->gtGetOp1();
         GenTree* rotateAmountNode = childNode->gtGetOp2();
 
         if (!rotateAmountNode->IsCnsIntOrI())
@@ -313,7 +314,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
-        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(parentNode)) * BITS_PER_BYTE);
+        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(rotateOperand)) * BITS_PER_BYTE);
         assert((wrapAmount == 32) || (wrapAmount == 64));
 
         // Rotation is circular, so normalize to [0, wrapAmount - 1]

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -305,7 +305,6 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
-        GenTree* rotateOpNode     = childNode->gtGetOp1();
         GenTree* rotateAmountNode = childNode->gtGetOp2();
 
         if (!rotateAmountNode->IsCnsIntOrI())
@@ -314,7 +313,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
-        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(rotateOpNode)) * BITS_PER_BYTE);
+        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(childNode)) * BITS_PER_BYTE);
         assert((wrapAmount == 32) || (wrapAmount == 64));
 
         // Rotation is circular, so normalize to [0, wrapAmount - 1]

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -305,7 +305,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
-        GenTree* rotateOperand    = childNode->gtGetOp1();
+        GenTree* rotateOpNode     = childNode->gtGetOp1();
         GenTree* rotateAmountNode = childNode->gtGetOp2();
 
         if (!rotateAmountNode->IsCnsIntOrI())
@@ -314,7 +314,7 @@ bool Lowering::IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childN
             return false;
         }
 
-        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(rotateOperand)) * BITS_PER_BYTE);
+        const ssize_t wrapAmount = (static_cast<ssize_t>(genTypeSize(rotateOpNode)) * BITS_PER_BYTE);
         assert((wrapAmount == 32) || (wrapAmount == 64));
 
         // Rotation is circular, so normalize to [0, wrapAmount - 1]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102285

Minimal repro:
```cs
static bool Test(long x) => 
    long.RotateLeft(x, 32) == 3886722753596608508;
```
the previous logic folded `GT_ROR(x, 32)` to `GT_ROR(x, 0)` because it took `parentNode` (which is `(int)GT_EQ`) into account to calculate max rotation width.