### PR TITLE
`CodeVersionManager` updates

### DIFF
--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -12313,13 +12313,14 @@ HRESULT Debugger::DeoptimizeMethodHelper(Module* pModule, mdMethodDef methodDef)
     ILCodeVersion ilCodeVersion;
     CodeVersionManager *pCodeVersionManager = pModule->GetCodeVersionManager();
 
+    LOG((LF_TIEREDCOMPILATION, LL_INFO100, "Debugger::DeoptimizeMethodHelper Module=%p Method=0x%08x\n",
+        pModule, methodDef));
+
     {
         CodeVersionManager::LockHolder codeVersioningLockHolder;
         if (FAILED(hr = pCodeVersionManager->AddILCodeVersion(pModule, methodDef, &ilCodeVersion, TRUE)))
         {
-            LOG((LF_TIEREDCOMPILATION, LL_INFO100, "TieredCompilationManager::DeOptimizeMethodHelper Module=0x%x Method=0x%x, AddILCodeVersion returned hr 0x%x\n",
-                pModule, methodDef,
-                hr));
+            LOG((LF_TIEREDCOMPILATION, LL_INFO100, "Debugger::DeoptimizeMethodHelper AddILCodeVersion returned hr 0x%x\n", hr));
             return hr;
         }
 
@@ -12335,8 +12336,7 @@ HRESULT Debugger::DeoptimizeMethodHelper(Module* pModule, mdMethodDef methodDef)
     {
         if (FAILED(hr = pCodeVersionManager->SetActiveILCodeVersions(&ilCodeVersion, 1, NULL)))
         {
-            LOG((LF_TIEREDCOMPILATION, LL_INFO100, "TieredCompilationManager::DeOptimizeMethodHelper Module=0x%x Method=0x%x, SetActiveILCodeVersions returned hr 0x%x\n",
-                pModule, methodDef,
+            LOG((LF_TIEREDCOMPILATION, LL_INFO100, "Debugger::DeoptimizeMethodHelper SetActiveILCodeVersions returned hr 0x%x\n",
                 hr));
             return hr;
         }
@@ -12358,7 +12358,7 @@ HRESULT Debugger::DeoptimizeMethod(Module* pModule, mdMethodDef methodDef)
     HRESULT hr = DeoptimizeMethodHelper(pModule, methodDef);
     if (FAILED(hr))
     {
-        LOG((LF_TIEREDCOMPILATION, LL_INFO100, "TieredCompilationManager::DeOptimizeMethod Module=0x%x Method=0x%x,, initial ReJIT returned hr 0x%x, aborting\n",
+        LOG((LF_TIEREDCOMPILATION, LL_INFO100, "Debugger::DeoptimizeMethod Module=%p Method=0x%08x, initial ReJIT returned hr 0x%x, aborting\n",
             pModule, methodDef, hr));
         return hr;
     }

--- a/src/coreclr/inc/dacvars.h
+++ b/src/coreclr/inc/dacvars.h
@@ -123,6 +123,7 @@ DEFINE_DACVAR(BOOL, dac__g_isNewExceptionHandlingEnabled, ::g_isNewExceptionHand
 DEFINE_DACVAR(PTR_SString, SString__s_Empty, SString::s_Empty)
 
 DEFINE_DACVAR(INT32, ArrayBase__s_arrayBoundsZero, ArrayBase::s_arrayBoundsZero)
+DEFINE_DACVAR(BOOL, CodeVersionManager__s_HasNonDefaultILVersions, CodeVersionManager::s_HasNonDefaultILVersions)
 
 DEFINE_DACVAR(PTR_JITNotification, dac__g_pNotificationTable, ::g_pNotificationTable)
 DEFINE_DACVAR(ULONG32, dac__g_dacNotificationFlags, ::g_dacNotificationFlags)

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -98,14 +98,6 @@ ASMCONSTANTS_C_ASSERT(SIZEOF__ComPrestubMethodFrame
 ASMCONSTANTS_C_ASSERT(SIZEOF__ComMethodFrame
                     == sizeof(ComMethodFrame));
 
-#define               OFFSETOF__ComPlusCallMethodDesc__m_pComPlusCallInfo        DBG_FRE(0x30, 0x08)
-ASMCONSTANTS_C_ASSERT(OFFSETOF__ComPlusCallMethodDesc__m_pComPlusCallInfo
-                    == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo));
-
-#define               OFFSETOF__ComPlusCallInfo__m_pILStub                       0x0
-ASMCONSTANTS_C_ASSERT(OFFSETOF__ComPlusCallInfo__m_pILStub
-                      == offsetof(ComPlusCallInfo, m_pILStub));
-
 #endif // FEATURE_COMINTEROP
 
 #define               OFFSETOF__Thread__m_fPreemptiveGCDisabled     0x04

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -1215,7 +1215,7 @@ public:
     }
 #endif // !DACCESS_COMPILE
 
-    MethodDesc *LookupMethodDef(mdMethodDef token);
+    PTR_MethodDesc LookupMethodDef(mdMethodDef token);
 
 #ifndef DACCESS_COMPILE
     void EnsureMethodDefCanBeStored(mdMethodDef token)

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -41,6 +41,7 @@
 #endif
 
 #include "ilinstrumentation.h"
+#include "codeversion.h"
 
 class Stub;
 class MethodDesc;
@@ -63,7 +64,6 @@ class SString;
 class Pending;
 class MethodTable;
 class DynamicMethodTable;
-class CodeVersionManager;
 class TieredCompilationManager;
 class JITInlineTrackingMap;
 
@@ -581,8 +581,7 @@ private:
 
 };
 
-// A code:Module represents a DLL or EXE file loaded from the disk. It could either be a IL module or a
-// Native code (NGEN module). A module live in a code:Assembly
+// A code:Module represents a DLL or EXE file loaded from the disk. A module live in a code:Assembly
 //
 // Some important fields are
 //    * code:Module.m_pPEAssembly - this points at a code:PEAssembly that understands the layout of a PE assembly. The most
@@ -726,6 +725,10 @@ private:
     // Linear mapping from MethodDef token to MethodDesc *
     // For generic methods, IsGenericTypeDefinition() is true i.e. instantiation at formals
     LookupMap<PTR_MethodDesc>       m_MethodDefToDescMap;
+
+    // Linear mapping from MethodDef token to ILCodeVersioningState *
+    // This is used for Code Versioning logic
+    LookupMap<PTR_ILCodeVersioningState>    m_ILCodeVersioningStateMap;
 
     // Linear mapping from FieldDef token to FieldDesc*
     LookupMap<PTR_FieldDesc>        m_FieldDefToDescMap;
@@ -1230,6 +1233,25 @@ public:
 
         _ASSERTE(TypeFromToken(token) == mdtMethodDef);
         m_MethodDefToDescMap.SetElement(RidFromToken(token), value);
+    }
+#endif // !DACCESS_COMPILE
+
+    PTR_ILCodeVersioningState LookupILCodeVersioningState(mdMethodDef token);
+
+#ifndef DACCESS_COMPILE
+    void EnsureILCodeVersioningStateCanBeStored(mdMethodDef token)
+    {
+        WRAPPER_NO_CONTRACT; // THROWS/GC_NOTRIGGER/INJECT_FAULT()/MODE_ANY
+        _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
+        m_ILCodeVersioningStateMap.EnsureElementCanBeStored(this, RidFromToken(token));
+    }
+
+    void EnsuredStoreILCodeVersioningState(mdMethodDef token, PTR_ILCodeVersioningState value)
+    {
+        WRAPPER_NO_CONTRACT; // NOTHROW/GC_NOTRIGGER/FORBID_FAULT/MODE_ANY
+        _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
+        _ASSERTE(TypeFromToken(token) == mdtMethodDef);
+        m_ILCodeVersioningStateMap.SetElement(RidFromToken(token), value);
     }
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -259,7 +259,7 @@ inline PTR_Assembly Module::GetAssembly() const
     return m_pAssembly;
 }
 
-inline MethodDesc *Module::LookupMethodDef(mdMethodDef token)
+inline PTR_MethodDesc Module::LookupMethodDef(mdMethodDef token)
 {
     CONTRACTL
     {

--- a/src/coreclr/vm/ceeload.inl
+++ b/src/coreclr/vm/ceeload.inl
@@ -274,6 +274,22 @@ inline PTR_MethodDesc Module::LookupMethodDef(mdMethodDef token)
     return m_MethodDefToDescMap.GetElement(RidFromToken(token));
 }
 
+inline PTR_ILCodeVersioningState Module::LookupILCodeVersioningState(mdMethodDef token)
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+        SUPPORTS_DAC;
+    }
+    CONTRACTL_END
+
+    _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
+    _ASSERTE(TypeFromToken(token) == mdtMethodDef);
+    return m_ILCodeVersioningStateMap.GetElement(RidFromToken(token));
+}
+
 inline MethodDesc *Module::LookupMemberRefAsMethod(mdMemberRef token)
 {
     LIMITED_METHOD_DAC_CONTRACT;

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1311,7 +1311,7 @@ PTR_ILCodeVersioningState CodeVersionManager::GetILCodeVersioningState(PTR_Modul
     LIMITED_METHOD_DAC_CONTRACT;
 
     PTR_MethodDesc pMethod = pModule->LookupMethodDef(methodDef);
-    _ASSERTE(pMethod != (TADDR)NULL);
+    _ASSERTE(pMethod != NULL);
     return pMethod->GetILCodeVersionState();
 }
 
@@ -1338,7 +1338,7 @@ HRESULT CodeVersionManager::GetOrCreateILCodeVersioningState(Module* pModule, md
 
     LOG((LF_TIEREDCOMPILATION, LL_INFO100, "CVM::GetOrCreateILCodeVersioningState Module=%p Method=0x%08x\n", pModule, methodDef));
     PTR_MethodDesc pMethod = pModule->LookupMethodDef(methodDef);
-    _ASSERTE(pMethod != (TADDR)NULL);
+    _ASSERTE(pMethod != NULL);
     _ASSERTE(pMethod->IsTypicalMethodDefinition());
 
     ILCodeVersioningState* pILCodeVersioningState = pMethod->GetILCodeVersionState();
@@ -1419,7 +1419,7 @@ ILCodeVersion CodeVersionManager::GetActiveILCodeVersion(PTR_MethodDesc pMethod)
     _ASSERTE(IsLockOwnedByCurrentThread());
 
     PTR_ILCodeVersioningState pILCodeVersioningState = pMethod->GetILCodeVersionState();
-    if (pILCodeVersioningState == (TADDR)NULL)
+    if (pILCodeVersioningState == NULL)
         return ILCodeVersion(dac_cast<PTR_Module>(pMethod->GetModule()), pMethod->GetMemberDef());
 
     return pILCodeVersioningState->GetActiveVersion();
@@ -1431,7 +1431,7 @@ ILCodeVersion CodeVersionManager::GetActiveILCodeVersion(PTR_Module pModule, mdM
     _ASSERTE(IsLockOwnedByCurrentThread());
 
     PTR_MethodDesc pMethod = pModule->LookupMethodDef(methodDef);
-    if (pMethod == (TADDR)NULL)
+    if (pMethod == NULL)
         return ILCodeVersion(pModule, methodDef);
 
     return GetActiveILCodeVersion(pMethod);

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1306,9 +1306,6 @@ void ILCodeVersioningState::LinkILCodeVersionNode(ILCodeVersionNode* pILCodeVers
 bool CodeVersionManager::s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion = false;
 #endif
 
-CodeVersionManager::CodeVersionManager()
-{}
-
 PTR_ILCodeVersioningState CodeVersionManager::GetILCodeVersioningState(PTR_Module pModule, mdMethodDef methodDef) const
 {
     LIMITED_METHOD_DAC_CONTRACT;
@@ -1319,7 +1316,7 @@ PTR_ILCodeVersioningState CodeVersionManager::GetILCodeVersioningState(PTR_Modul
 PTR_MethodDescVersioningState CodeVersionManager::GetMethodDescVersioningState(PTR_MethodDesc pClosedMethodDesc) const
 {
     LIMITED_METHOD_DAC_CONTRACT;
-    return m_methodDescVersioningStateMap.Lookup(pClosedMethodDesc);
+    return pClosedMethodDesc->GetMethodDescVersionState();
 }
 
 #ifndef DACCESS_COMPILE
@@ -1354,28 +1351,26 @@ HRESULT CodeVersionManager::GetOrCreateILCodeVersioningState(Module* pModule, md
 
 HRESULT CodeVersionManager::GetOrCreateMethodDescVersioningState(MethodDesc* pMethod, MethodDescVersioningState** ppMethodVersioningState)
 {
-    LIMITED_METHOD_CONTRACT;
-    HRESULT hr = S_OK;
-    MethodDescVersioningState* pMethodVersioningState = m_methodDescVersioningStateMap.Lookup(pMethod);
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        PRECONDITION(pMethod != NULL);
+        PRECONDITION(ppMethodVersioningState != NULL);
+    }
+    CONTRACTL_END;
+
+    MethodDescVersioningState* pMethodVersioningState = pMethod->GetMethodDescVersionState();
     if (pMethodVersioningState == NULL)
     {
         pMethodVersioningState = new (nothrow) MethodDescVersioningState(pMethod);
         if (pMethodVersioningState == NULL)
-        {
             return E_OUTOFMEMORY;
-        }
-        EX_TRY
-        {
-            // This throws when out of memory, but remains internally
-            // consistent (without adding the new element)
-            m_methodDescVersioningStateMap.Add(pMethodVersioningState);
-        }
-        EX_CATCH_HRESULT(hr);
-        if (FAILED(hr))
-        {
+
+        if (!pMethod->SetMethodDescVersionState(pMethodVersioningState))
             delete pMethodVersioningState;
-            return hr;
-        }
+
+        pMethodVersioningState = pMethod->GetMethodDescVersionState();
     }
     *ppMethodVersioningState = pMethodVersioningState;
     return S_OK;

--- a/src/coreclr/vm/codeversion.cpp
+++ b/src/coreclr/vm/codeversion.cpp
@@ -1376,6 +1376,7 @@ HRESULT CodeVersionManager::GetOrCreateMethodDescVersioningState(MethodDesc* pMe
     }
     CONTRACTL_END;
 
+    HRESULT hr;
     MethodDescVersioningState* pMethodVersioningState = pMethod->GetMethodDescVersionState();
     if (pMethodVersioningState == NULL)
     {
@@ -1383,7 +1384,8 @@ HRESULT CodeVersionManager::GetOrCreateMethodDescVersioningState(MethodDesc* pMe
         if (pMethodVersioningState == NULL)
             return E_OUTOFMEMORY;
 
-        if (!pMethod->SetMethodDescVersionState(pMethodVersioningState))
+        IfFailRet(pMethod->SetMethodDescVersionState(pMethodVersioningState));
+        if (hr == S_FALSE)
             delete pMethodVersioningState;
 
         pMethodVersioningState = pMethod->GetMethodDescVersionState();

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -507,44 +507,17 @@ private:
     mdMethodDef m_methodDef;
 };
 
-class ILCodeVersioningStateHashTraits : public NoRemoveSHashTraits<DefaultSHashTraits<PTR_ILCodeVersioningState>>
-{
-public:
-    typedef typename DefaultSHashTraits<PTR_ILCodeVersioningState>::element_t element_t;
-    typedef typename DefaultSHashTraits<PTR_ILCodeVersioningState>::count_t count_t;
-
-    typedef const ILCodeVersioningState::Key key_t;
-
-    static key_t GetKey(element_t e)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return e->GetKey();
-    }
-    static BOOL Equals(key_t k1, key_t k2)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return k1 == k2;
-    }
-    static count_t Hash(key_t k)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (count_t)k.Hash();
-    }
-
-    static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_ILCodeVersioningState>(nullptr); }
-    static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
-};
-
-typedef SHash<ILCodeVersioningStateHashTraits> ILCodeVersioningStateHash;
-
 class CodeVersionManager
 {
     friend class ILCodeVersion;
+    friend struct _DacGlobals;
+
+    SVAL_DECL(BOOL, s_HasNonDefaultILVersions);
 
 public:
     CodeVersionManager() = default;
 
-    DWORD GetNonDefaultILVersionCount();
+    BOOL HasNonDefaultILVersions();
     ILCodeVersionCollection GetILCodeVersions(PTR_MethodDesc pMethod);
     ILCodeVersionCollection GetILCodeVersions(PTR_Module pModule, mdMethodDef methodDef);
     ILCodeVersion GetActiveILCodeVersion(PTR_MethodDesc pMethod);
@@ -572,9 +545,13 @@ public:
         CallerGCMode callerGCMode,
         bool *doBackpatchRef,
         bool *doFullBackpatchRef);
+
+private:
     HRESULT PublishNativeCodeVersion(MethodDesc* pMethodDesc, NativeCodeVersion nativeCodeVersion);
     HRESULT GetOrCreateMethodDescVersioningState(MethodDesc* pMethod, MethodDescVersioningState** ppMethodDescVersioningState);
     HRESULT GetOrCreateILCodeVersioningState(Module* pModule, mdMethodDef methodDef, ILCodeVersioningState** ppILCodeVersioningState);
+
+public:
     HRESULT SetActiveILCodeVersions(ILCodeVersion* pActiveVersions, DWORD cActiveVersions, CDynArray<CodePublishError> * pPublishErrors);
     static HRESULT AddCodePublishError(Module* pModule, mdMethodDef methodDef, MethodDesc* pMD, HRESULT hrStatus, CDynArray<CodePublishError> * pErrors);
     static HRESULT AddCodePublishError(NativeCodeVersion nativeCodeVersion, HRESULT hrStatus, CDynArray<CodePublishError> * pErrors);
@@ -614,9 +591,6 @@ private:
 
     static bool s_initialNativeCodeVersionMayNotBeTheDefaultNativeCodeVersion;
 #endif
-
-    //Module,MethodDef -> ILCodeVersioningState
-    ILCodeVersioningStateHash m_ilCodeVersioningStateMap;
 
 private:
     static CrstStatic s_lock;

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -475,36 +475,6 @@ private:
     PTR_NativeCodeVersionNode m_pFirstVersionNode;
 };
 
-class MethodDescVersioningStateHashTraits : public NoRemoveSHashTraits<DefaultSHashTraits<PTR_MethodDescVersioningState>>
-{
-public:
-    typedef typename DefaultSHashTraits<PTR_MethodDescVersioningState>::element_t element_t;
-    typedef typename DefaultSHashTraits<PTR_MethodDescVersioningState>::count_t count_t;
-
-    typedef const PTR_MethodDesc key_t;
-
-    static key_t GetKey(element_t e)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return e->GetMethodDesc();
-    }
-    static BOOL Equals(key_t k1, key_t k2)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return k1 == k2;
-    }
-    static count_t Hash(key_t k)
-    {
-        LIMITED_METHOD_CONTRACT;
-        return (count_t)dac_cast<TADDR>(k);
-    }
-
-    static element_t Null() { LIMITED_METHOD_CONTRACT; return dac_cast<PTR_MethodDescVersioningState>(nullptr); }
-    static bool IsNull(const element_t &e) { LIMITED_METHOD_CONTRACT; return e == NULL; }
-};
-
-typedef SHash<MethodDescVersioningStateHashTraits> MethodDescVersioningStateHash;
-
 class ILCodeVersioningState
 {
 public:
@@ -572,7 +542,7 @@ class CodeVersionManager
     friend class ILCodeVersion;
 
 public:
-    CodeVersionManager();
+    CodeVersionManager() = default;
 
     DWORD GetNonDefaultILVersionCount();
     ILCodeVersionCollection GetILCodeVersions(PTR_MethodDesc pMethod);
@@ -647,9 +617,6 @@ private:
 
     //Module,MethodDef -> ILCodeVersioningState
     ILCodeVersioningStateHash m_ilCodeVersioningStateMap;
-
-    //closed MethodDesc -> MethodDescVersioningState
-    MethodDescVersioningStateHash m_methodDescVersioningStateMap;
 
 private:
     static CrstStatic s_lock;

--- a/src/coreclr/vm/i386/asmconstants.h
+++ b/src/coreclr/vm/i386/asmconstants.h
@@ -233,7 +233,7 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__FrameHandlerExRecord__m_pEntryFrame == offsetof(
 
 #endif
 
-#define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x1C, 0x8)
+#define ComPlusCallMethodDesc__m_pComPlusCallInfo DBG_FRE(0x20, 0xC)
 ASMCONSTANTS_C_ASSERT(ComPlusCallMethodDesc__m_pComPlusCallInfo == offsetof(ComPlusCallMethodDesc, m_pComPlusCallInfo))
 
 #define ComPlusCallInfo__m_pRetThunk 0x10

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -231,13 +231,6 @@ bool MethodDesc::SetMethodDescVersionState(PTR_MethodDescVersioningState state)
     return InterlockedCompareExchangeT(&m_codeData->MDState, state, NULL) == NULL;
 }
 
-bool MethodDesc::SetILCodeVersionState(PTR_ILCodeVersioningState state)
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(m_codeData != NULL);
-    return InterlockedCompareExchangeT(&m_codeData->ILCodeState, state, NULL) == NULL;
-}
-
 #endif //!DACCESS_COMPILE
 
 PTR_MethodDescVersioningState MethodDesc::GetMethodDescVersionState()
@@ -245,13 +238,6 @@ PTR_MethodDescVersioningState MethodDesc::GetMethodDescVersionState()
     WRAPPER_NO_CONTRACT;
     _ASSERTE(m_codeData != NULL);
     return m_codeData->MDState;
-}
-
-PTR_ILCodeVersioningState MethodDesc::GetILCodeVersionState()
-{
-    WRAPPER_NO_CONTRACT;
-    _ASSERTE(m_codeData != NULL);
-    return m_codeData->ILCodeState;
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -228,7 +228,7 @@ bool MethodDesc::SetMethodDescVersionState(PTR_MethodDescVersioningState state)
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(m_codeData != NULL);
-    return InterlockedCompareExchangeT(&m_codeData->MDState, state, NULL) == NULL;
+    return InterlockedCompareExchangeT(&m_codeData->VersioningState, state, NULL) == NULL;
 }
 
 #endif //!DACCESS_COMPILE
@@ -237,7 +237,7 @@ PTR_MethodDescVersioningState MethodDesc::GetMethodDescVersionState()
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(m_codeData != NULL);
-    return m_codeData->MDState;
+    return m_codeData->VersioningState;
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -231,6 +231,13 @@ bool MethodDesc::SetMethodDescVersionState(PTR_MethodDescVersioningState state)
     return InterlockedCompareExchangeT(&m_codeData->MDState, state, NULL) == NULL;
 }
 
+bool MethodDesc::SetILCodeVersionState(PTR_ILCodeVersioningState state)
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(m_codeData != NULL);
+    return InterlockedCompareExchangeT(&m_codeData->ILCodeState, state, NULL) == NULL;
+}
+
 #endif //!DACCESS_COMPILE
 
 PTR_MethodDescVersioningState MethodDesc::GetMethodDescVersionState()
@@ -238,6 +245,13 @@ PTR_MethodDescVersioningState MethodDesc::GetMethodDescVersionState()
     WRAPPER_NO_CONTRACT;
     _ASSERTE(m_codeData != NULL);
     return m_codeData->MDState;
+}
+
+PTR_ILCodeVersioningState MethodDesc::GetILCodeVersionState()
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(m_codeData != NULL);
+    return m_codeData->ILCodeState;
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -221,19 +221,12 @@ HRESULT MethodDesc::EnsureCodeDataExists()
     if (m_codeData != NULL)
         return S_OK;
 
-    AllocMemTracker amTracker;
-    MethodDescCodeData* alloc = NULL;
-
     LoaderHeap* heap = GetLoaderAllocator()->GetHighFrequencyHeap();
 
-    HRESULT hr = S_OK;
-    EX_TRY
-    {
-        alloc = (MethodDescCodeData*)amTracker.Track(heap->AllocMem(S_SIZE_T(sizeof(MethodDescCodeData))));
-    }
-    EX_CATCH_HRESULT(hr);
-    if (FAILED(hr))
-        return hr;
+    AllocMemTracker amTracker;
+    MethodDescCodeData* alloc = (MethodDescCodeData*)amTracker.Track(heap->AllocMem_NoThrow(S_SIZE_T(sizeof(MethodDescCodeData))));
+    if (alloc == NULL)
+        return E_OUTOFMEMORY;
 
     // Try to set the field. Suppress clean-up if we win the race.
     if (InterlockedCompareExchangeT(&m_codeData, (MethodDescCodeData*)alloc, NULL) == NULL)

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -224,7 +224,7 @@ HRESULT MethodDesc::EnsureCodeDataExists()
     LoaderHeap* heap = GetLoaderAllocator()->GetHighFrequencyHeap();
 
     AllocMemTracker amTracker;
-    MethodDescCodeData* alloc = (MethodDescCodeData*)amTracker.Track(heap->AllocMem_NoThrow(S_SIZE_T(sizeof(MethodDescCodeData))));
+    MethodDescCodeData* alloc = (MethodDescCodeData*)amTracker.Track_NoThrow(heap->AllocMem_NoThrow(S_SIZE_T(sizeof(MethodDescCodeData))));
     if (alloc == NULL)
         return E_OUTOFMEMORY;
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -158,9 +158,12 @@ enum MethodDescFlags
     mdfIsIntrinsic                      = 0x8000  // Jit may expand method as an intrinsic
 };
 
-struct MethodDescCodeData
+// Used for storing additional items related to native code
+struct MethodDescCodeData final
 {
-    PTR_MethodDescVersioningState MDState;
+    PTR_MethodDescVersioningState VersioningState;
+
+    // [TODO] Move temporary entry points here.
 };
 using PTR_MethodDescCodeData = DPTR(MethodDescCodeData);
 

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -161,7 +161,6 @@ enum MethodDescFlags
 struct MethodDescCodeData
 {
     PTR_MethodDescVersioningState MDState;
-    PTR_ILCodeVersioningState ILCodeState;
 };
 using PTR_MethodDescCodeData = DPTR(MethodDescCodeData);
 
@@ -1642,11 +1641,9 @@ public:
     void AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker);
 
     bool SetMethodDescVersionState(PTR_MethodDescVersioningState state);
-    bool SetILCodeVersionState(PTR_ILCodeVersioningState state);
 #endif //!DACCESS_COMPILE
 
     PTR_MethodDescVersioningState GetMethodDescVersionState();
-    PTR_ILCodeVersioningState GetILCodeVersionState();
 
 public:
     inline DWORD GetClassification() const

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -161,6 +161,7 @@ enum MethodDescFlags
 struct MethodDescCodeData
 {
     PTR_MethodDescVersioningState MDState;
+    PTR_ILCodeVersioningState ILCodeState;
 };
 using PTR_MethodDescCodeData = DPTR(MethodDescCodeData);
 
@@ -1641,9 +1642,11 @@ public:
     void AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker);
 
     bool SetMethodDescVersionState(PTR_MethodDescVersioningState state);
+    bool SetILCodeVersionState(PTR_ILCodeVersioningState state);
 #endif //!DACCESS_COMPILE
 
     PTR_MethodDescVersioningState GetMethodDescVersionState();
+    PTR_ILCodeVersioningState GetILCodeVersionState();
 
 public:
     inline DWORD GetClassification() const

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1641,9 +1641,9 @@ public:
     }
 
 #ifndef DACCESS_COMPILE
-    void AllocateCodeData(LoaderHeap* pHeap, AllocMemTracker* pamTracker);
+    HRESULT EnsureCodeDataExists();
 
-    bool SetMethodDescVersionState(PTR_MethodDescVersioningState state);
+    HRESULT SetMethodDescVersionState(PTR_MethodDescVersioningState state);
 #endif //!DACCESS_COMPILE
 
     PTR_MethodDescVersioningState GetMethodDescVersionState();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7039,8 +7039,9 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
         PRECONDITION(sizeOfMethodDescs <= MethodDescChunk::MaxSizeOfMethodDescs);
     } CONTRACTL_END;
 
+    PTR_LoaderHeap pHeap = GetLoaderAllocator()->GetHighFrequencyHeap();
     void * pMem = GetMemTracker()->Track(
-        GetLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(TADDR) + sizeof(MethodDescChunk) + sizeOfMethodDescs)));
+        pHeap->AllocMem(S_SIZE_T(sizeof(TADDR) + sizeof(MethodDescChunk) + sizeOfMethodDescs)));
 
     // Skip pointer to temporary entrypoints
     MethodDescChunk * pChunk = (MethodDescChunk *)((BYTE*)pMem + sizeof(TADDR));
@@ -7065,6 +7066,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
 
         pMD->SetChunkIndex(pChunk);
         pMD->SetMethodDescIndex(methodDescCount);
+        pMD->AllocateCodeData(pHeap, GetMemTracker());
 
         InitNewMethodDesc(pMDMethod, pMD);
 
@@ -7109,6 +7111,7 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // Reset the chunk index
             pUnboxedMD->SetChunkIndex(pChunk);
             pUnboxedMD->SetMethodDescIndex(methodDescCount);
+            pUnboxedMD->AllocateCodeData(pHeap, GetMemTracker());
 
             if (bmtGenerics->GetNumGenericArgs() == 0) {
                 pUnboxedMD->SetHasNonVtableSlot();

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -7066,7 +7066,6 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
 
         pMD->SetChunkIndex(pChunk);
         pMD->SetMethodDescIndex(methodDescCount);
-        pMD->AllocateCodeData(pHeap, GetMemTracker());
 
         InitNewMethodDesc(pMDMethod, pMD);
 
@@ -7111,7 +7110,6 @@ VOID MethodTableBuilder::AllocAndInitMethodDescChunk(COUNT_T startIndex, COUNT_T
             // Reset the chunk index
             pUnboxedMD->SetChunkIndex(pChunk);
             pUnboxedMD->SetMethodDescIndex(methodDescCount);
-            pUnboxedMD->AllocateCodeData(pHeap, GetMemTracker());
 
             if (bmtGenerics->GetNumGenericArgs() == 0) {
                 pUnboxedMD->SetHasNonVtableSlot();

--- a/src/coreclr/vm/rejit.cpp
+++ b/src/coreclr/vm/rejit.cpp
@@ -1134,7 +1134,7 @@ ReJITID ReJitManager::GetReJitId(PTR_MethodDesc pMD, PCODE pCodeStart)
     // of a lock to impact our caller (the prestub worker) as little as possible. If the
     // map is nonempty, we'll acquire the lock at that point and do the lookup for real.
     CodeVersionManager* pCodeVersionManager = pMD->GetCodeVersionManager();
-    if (pCodeVersionManager->GetNonDefaultILVersionCount() == 0)
+    if (!pCodeVersionManager->HasNonDefaultILVersions())
     {
         return 0;
     }


### PR DESCRIPTION
Remove maps on `CodeVersionManager` and places native version data on the `MethodDesc` and the IL version data on the `Module`. There is no functional change intended here. The change is simply to remove two currently unnecessary map data structures. The contract API has change slightly but remains semantically the same.

This is a simplification for the cDAC effort.