### PR TITLE
Do not allow generic inlining of delegate creation

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1005,6 +1005,10 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 // New inliner morph it in impImportCall.
                 // This will allow us to inline the call to the delegate constructor.
                 call = fgOptimizeDelegateConstructor(call->AsCall(), &exactContextHnd, ldftnInfo);
+                if (compDonotInline())
+                {
+                    return TYP_UNDEF;
+                }
             }
 
             if (!bIntrinsicImported)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -436,10 +436,17 @@ namespace Internal.JitInterface
             {
                 pLookup.lookupKind.needsRuntimeLookup = true;
 
-                MethodDesc contextMethod = HandleToObject(callerHandle);
-                pLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(contextMethod);
-                pLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.DelegateCtor;
-                pLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(delegateInfo);
+                if (pTargetMethod.tokenContext != contextFromMethodBeingCompiled())
+                {
+                    pLookup.lookupKind.runtimeLookupKind = CORINFO_RUNTIME_LOOKUP_KIND.CORINFO_LOOKUP_NOT_SUPPORTED;
+                }
+                else
+                {
+                    MethodDesc contextMethod = HandleToObject(callerHandle);
+                    pLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(contextMethod);
+                    pLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.DelegateCtor;
+                    pLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(delegateInfo);
+                }
             }
             else
             {

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -56,6 +56,7 @@ class Generics
         TestRecursionInFields.Run();
         TestGvmLookupDependency.Run();
         Test99198Regression.Run();
+        Test102259Regression.Run();
         TestInvokeMemberCornerCaseInGenerics.Run();
         TestRefAny.Run();
         TestNullableCasting.Run();
@@ -3555,6 +3556,26 @@ class Generics
         }
     }
 
+    class Test102259Regression
+    {
+        class Gen<T>
+        {
+            static Func<T, object> _theval;
+
+            public static object TheFunc(object obj) => obj;
+
+            static Gen()
+            {
+                _theval = typeof(Gen<T>).GetMethod(nameof(TheFunc), BindingFlags.Public | BindingFlags.Static).CreateDelegate<Func<T, object>>().WithObjectTResult();
+            }
+        }
+
+        public static void Run()
+        {
+            new Gen<object>();
+        }
+    }
+
     class TestInvokeMemberCornerCaseInGenerics
     {
         class Generic<T>
@@ -3599,5 +3620,18 @@ class Generics
             if (TestAll(ref structValue, typeof(int)) != structValue)
                 throw new Exception();
         }
+    }
+}
+
+static class Ext
+{
+    public static Func<T, object> WithObjectTResult<T, TResult>(this Func<T, TResult> function)
+    {
+        return function.InvokeWithObjectTResult;
+    }
+
+    private static object InvokeWithObjectTResult<T, TResult>(this Func<T, TResult> func, T arg)
+    {
+        return func(arg);
     }
 }


### PR DESCRIPTION
Fixes #102259.

Delegate creation requires form of lookups that are hard to express across inlined generics.

This was introduced when we started doing more generic inlining in #99265. I [suspected](https://github.com/dotnet/runtime/pull/99265#discussion_r1522601601) things might not be correct here but assumed we'd have test coverage for sure. _Now_ we have test coverage.

Cc @dotnet/ilc-contrib 