### PR TITLE
Replace handwritten lookup computation with shared helper

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1430,20 +1430,11 @@ namespace Internal.JitInterface
 
                 pResult->kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
 
-                if (pResult->exactContextNeedsRuntimeLookup)
-                {
-                    pResult->codePointerOrStubLookup.lookupKind.needsRuntimeLookup = true;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupFlags = 0;
-                    pResult->codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(HandleToObject(callerHandle));
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodEntry;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(GetRuntimeDeterminedObjectForToken(ref pResolvedToken));
-                }
-                else
-                {
-                    pResult->codePointerOrStubLookup.constLookup =
-                        CreateConstLookupToSymbol(_compilation.NodeFactory.FatFunctionPointer(targetMethod));
-                }
+                ComputeLookup(ref pResolvedToken,
+                    GetRuntimeDeterminedObjectForToken(ref pResolvedToken),
+                    ReadyToRunHelperId.MethodEntry,
+                    HandleToObject(callerHandle),
+                    ref pResult->codePointerOrStubLookup);
             }
             else if (directCall)
             {


### PR DESCRIPTION
Noticed this when working on #102299. This is bypassing the `CORINFO_LOOKUP_NOT_SUPPORTED` backout logic. Didn't actually test this, I'll let CI decide if this is a good change.

Cc @dotnet/ilc-contrib 