### PR TITLE
Check for newlines in email address.

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -7,6 +7,9 @@ namespace System.ComponentModel.DataAnnotations
         AllowMultiple = false)]
     public sealed class EmailAddressAttribute : DataTypeAttribute
     {
+        private static bool EnableFullDomainLiterals { get; } =
+            AppContext.TryGetSwitch("System.Net.AllowFullDomainLiterals", out bool enable) ? enable : false;
+
         public EmailAddressAttribute()
             : base(DataType.EmailAddress)
         {
@@ -23,6 +26,11 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             if (!(value is string valueAsString))
+            {
+                return false;
+            }
+
+            if (!EnableFullDomainLiterals && (valueAsString.Contains('\r') || valueAsString.Contains('\n')))
             {
                 return false;
             }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -30,7 +30,7 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            if (!EnableFullDomainLiterals && (valueAsString.Contains('\r') || valueAsString.Contains('\n')))
+            if (!EnableFullDomainLiterals && valueAsString.AsSpan().ContainsAny('\r', '\n'))
             {
                 return false;
             }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -7,9 +7,6 @@ namespace System.ComponentModel.DataAnnotations
         AllowMultiple = false)]
     public sealed class EmailAddressAttribute : DataTypeAttribute
     {
-        private static bool EnableFullDomainLiterals { get; } =
-            AppContext.TryGetSwitch("System.Net.AllowFullDomainLiterals", out bool enable) ? enable : false;
-
         public EmailAddressAttribute()
             : base(DataType.EmailAddress)
         {
@@ -30,7 +27,7 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            if (!EnableFullDomainLiterals && valueAsString.AsSpan().ContainsAny('\r', '\n'))
+            if (valueAsString.AsSpan().ContainsAny('\r', '\n'))
             {
                 return false;
             }

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/EmailAddressAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/EmailAddressAttributeTests.cs
@@ -29,6 +29,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
             yield return new TestCase(new EmailAddressAttribute(), 0);
             yield return new TestCase(new EmailAddressAttribute(), "");
             yield return new TestCase(new EmailAddressAttribute(), " \r \t \n" );
+            yield return new TestCase(new EmailAddressAttribute(), "someName@[\r\n\tsomeDomain]");
             yield return new TestCase(new EmailAddressAttribute(), "@someDomain.com");
             yield return new TestCase(new EmailAddressAttribute(), "@someDomain@abc.com");
             yield return new TestCase(new EmailAddressAttribute(), "someName");

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
@@ -15,6 +15,9 @@ namespace System.Net.Mail
     //
     public partial class MailAddress
     {
+        private static bool EnableFullDomainLiterals { get; } =
+            AppContext.TryGetSwitch("System.Net.AllowFullDomainLiterals", out bool enable) ? enable : false;
+
         // These components form an e-mail address when assembled as follows:
         // "EncodedDisplayname" <userName@host>
         private readonly Encoding _displayNameEncoding;
@@ -216,6 +219,12 @@ namespace System.Net.Mail
                     throw new SmtpException(SR.Format(SR.SmtpInvalidHostName, Address), argEx);
                 }
             }
+
+            if (!EnableFullDomainLiterals && domain.AsSpan().IndexOfAny('\r', '\n') >= 0)
+            {
+                throw new SmtpException(SR.Format(SR.SmtpInvalidHostName, Address));
+            }
+
             return domain;
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
@@ -15,9 +15,6 @@ namespace System.Net.Mail
     //
     public partial class MailAddress
     {
-        private static bool EnableFullDomainLiterals { get; } =
-            AppContext.TryGetSwitch("System.Net.AllowFullDomainLiterals", out bool enable) ? enable : false;
-
         // These components form an e-mail address when assembled as follows:
         // "EncodedDisplayname" <userName@host>
         private readonly Encoding _displayNameEncoding;
@@ -220,7 +217,7 @@ namespace System.Net.Mail
                 }
             }
 
-            if (!EnableFullDomainLiterals && domain.AsSpan().ContainsAny('\r', '\n'))
+            if (domain.AsSpan().ContainsAny('\r', '\n'))
             {
                 throw new SmtpException(SR.Format(SR.SmtpInvalidHostName, Address));
             }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailAddress.cs
@@ -220,7 +220,7 @@ namespace System.Net.Mail
                 }
             }
 
-            if (!EnableFullDomainLiterals && domain.AsSpan().IndexOfAny('\r', '\n') >= 0)
+            if (!EnableFullDomainLiterals && domain.AsSpan().ContainsAny('\r', '\n'))
             {
                 throw new SmtpException(SR.Format(SR.SmtpInvalidHostName, Address));
             }

--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -578,25 +578,6 @@ namespace System.Net.Mail.Tests
             Assert.Equal("GSSAPI", server.AuthMethodUsed, StringComparer.OrdinalIgnoreCase);
         }
 
-        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [InlineData("foo@[\r\n bar]")]
-        [InlineData("foo@[bar\r\n ]")]
-        [InlineData("foo@[bar\r\n baz]")]
-        public void MultiLineDomainLiterals_Enabled_Success(string input)
-        {
-            RemoteExecutor.Invoke(static (string @input) =>
-            {
-                AppContext.SetSwitch("System.Net.AllowFullDomainLiterals", true);
-
-                var address = new MailAddress(@input);
-
-                // Using address with new line breaks the protocol so we cannot easily use LoopbackSmtpServer
-                // Instead we call internal method that does the extra validation.
-                string? host = (string?)typeof(MailAddress).InvokeMember("GetAddress", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.InvokeMethod, null, address, new object[] { true });
-                Assert.Equal(input, host);
-            }, input).Dispose();
-        }
-
         [Theory]
         [MemberData(nameof(SendMail_MultiLineDomainLiterals_Data))]
         public async Task SendMail_MultiLineDomainLiterals_Disabled_Throws(string from, string to, bool asyncSend)


### PR DESCRIPTION
This adds validation for embedded newlines in email addresses.
There is opt-in System.Net.Mail.EnableFullDomainLiterals switch to allow previous behavior.