### PR TITLE
Enumerable.Index/Select((T, int)) iterator classes

### DIFF
--- a/src/libraries/System.Linq/src/System.Linq.csproj
+++ b/src/libraries/System.Linq/src/System.Linq.csproj
@@ -24,6 +24,7 @@
     <Compile Include="System\Linq\DefaultIfEmpty.SpeedOpt.cs" />
     <Compile Include="System\Linq\Distinct.SpeedOpt.cs" />
     <Compile Include="System\Linq\Grouping.SpeedOpt.cs" />
+    <Compile Include="System\Linq\Index.SpeedOpt.cs" />
     <Compile Include="System\Linq\Iterator.SpeedOpt.cs" />
     <Compile Include="System\Linq\Lookup.SpeedOpt.cs" />
     <Compile Include="System\Linq\OfType.SpeedOpt.cs" />

--- a/src/libraries/System.Linq/src/System/Linq/Index.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Index.SpeedOpt.cs
@@ -1,0 +1,213 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using static System.Linq.Utilities;
+
+namespace System.Linq
+{
+    public static partial class Enumerable
+    {
+        private sealed partial class IEnumerableIndexIterator<TSource> : Iterator<(int Index, TSource Item)>
+        {
+            private readonly IEnumerable<TSource> _source;
+            private int _index;
+            private IEnumerator<TSource>? _enumerator;
+
+            public IEnumerableIndexIterator(IEnumerable<TSource> source)
+            {
+                Debug.Assert(source is not null);
+                _source = source;
+            }
+
+            private protected override Iterator<(int Index, TSource Item)> Clone() =>
+                new IEnumerableIndexIterator<TSource>(_source);
+
+            public override void Dispose()
+            {
+                if (_enumerator is not null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+
+                base.Dispose();
+            }
+
+            public override bool MoveNext()
+            {
+                switch (_state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        _index = -1;
+                        _state = 2;
+                        goto case 2;
+                    case 2:
+                        Debug.Assert(_enumerator is not null);
+
+                        if (_enumerator.MoveNext())
+                        {
+                            _current = (checked(++_index), _enumerator.Current);
+                            return true;
+                        }
+
+                        Dispose();
+                        break;
+                }
+
+                return false;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<(int Index, TSource Item), TResult2> selector) =>
+                new IEnumerableSelect2Iterator<TSource, TResult2>(_source, CombineSelectors((TSource x, int i) => (i, x), selector));
+
+            public override (int Index, TSource Item)[] ToArray()
+            {
+                int index = -1;
+
+                if (_source.TryGetNonEnumeratedCount(out int known))
+                {
+                    var array = new (int Index, TSource Item)[known];
+
+                    foreach (TSource item in _source)
+                    {
+                        array[checked(++index)] = (index, item);
+                    }
+
+                    return array;
+                }
+
+                SegmentedArrayBuilder<(int Index, TSource Item)>.ScratchBuffer scratch = default;
+                SegmentedArrayBuilder<(int Index, TSource Item)> builder = new(scratch);
+
+                foreach (TSource item in _source)
+                {
+                    builder.Add((checked(++index), item));
+                }
+
+                (int Index, TSource Item)[] result = builder.ToArray();
+                builder.Dispose();
+                return result;
+            }
+
+            public override List<(int Index, TSource Item)> ToList()
+            {
+                List<(int Index, TSource Item)> list = _source.TryGetNonEnumeratedCount(out int known) ? new(known) : [];
+                int index = -1;
+
+                foreach (TSource item in _source)
+                {
+                    list.Add((checked(++index), item));
+                }
+
+                return list;
+            }
+
+            public override int GetCount(bool onlyIfCheap)
+            {
+                // In case someone uses Count() to force evaluation of
+                // the selector, run it provided `onlyIfCheap` is false.
+                if (onlyIfCheap)
+                {
+                    return _source.TryGetNonEnumeratedCount(out int known) ? known : -1;
+                }
+
+                int count = 0;
+
+                foreach (TSource item in _source)
+                {
+                    checked
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
+
+            public override (int Index, TSource Item) TryGetElementAt(int index, out bool found)
+            {
+                if (_source is Iterator<TSource> iterator)
+                {
+                    return iterator.TryGetElementAt(index, out found) is var element && found ? (0, element!) : default;
+                }
+
+                if (index >= 0)
+                {
+                    IEnumerator<TSource> e = _source.GetEnumerator();
+                    int enumeratorIndex = -1;
+
+                    try
+                    {
+                        while (e.MoveNext())
+                        {
+                            if (index == 0)
+                            {
+                                found = true;
+                                return (checked(++enumeratorIndex), e.Current);
+                            }
+
+                            index--;
+                        }
+                    }
+                    finally
+                    {
+                        (e as IDisposable)?.Dispose();
+                    }
+                }
+
+                found = false;
+                return default;
+            }
+
+            public override (int Index, TSource Item) TryGetFirst(out bool found)
+            {
+                if (_source is Iterator<TSource> iterator)
+                {
+                    return iterator.TryGetFirst(out found) is var first && found ? (0, first!) : default;
+                }
+
+                using IEnumerator<TSource> e = _source.GetEnumerator();
+
+                if (e.MoveNext())
+                {
+                    found = true;
+                    return (0, e.Current);
+                }
+
+                found = false;
+                return default;
+            }
+
+            public override (int Index, TSource Item) TryGetLast(out bool found)
+            {
+                if (_source is Iterator<TSource> iterator && iterator.GetCount(true) is not -1 and var count)
+                {
+                    return iterator.TryGetLast(out found) is var last && found ? (count - 1, last!) : default;
+                }
+
+                using IEnumerator<TSource> e = _source.GetEnumerator();
+
+                if (e.MoveNext())
+                {
+                    found = true;
+                    TSource lastElement = e.Current;
+                    int lastIndex = -1;
+
+                    while (e.MoveNext())
+                    {
+                        lastElement = e.Current;
+                        lastIndex++;
+                    }
+
+                    return (lastIndex, lastElement);
+                }
+
+                found = false;
+                return default;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Linq/src/System/Linq/Index.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Index.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
+using static System.Linq.Utilities;
 
 namespace System.Linq
 {
@@ -22,22 +24,11 @@ namespace System.Linq
             {
                 return [];
             }
-
-            return IndexIterator(source);
-        }
-
-        private static IEnumerable<(int Index, TSource Item)> IndexIterator<TSource>(IEnumerable<TSource> source)
-        {
-            int index = -1;
-            foreach (TSource element in source)
-            {
-                checked
-                {
-                    index++;
-                }
-
-                yield return (index, element);
-            }
+#if OPTIMIZE_FOR_SIZE
+            return new IEnumerableSelect2Iterator<TSource, (int Index, TSource Item)>(source, (x, i) => (i, x));
+#else
+            return new IEnumerableIndexIterator<TSource>(source);
+#endif
         }
     }
 }

--- a/src/libraries/System.Linq/src/System/Linq/Utilities.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Utilities.cs
@@ -69,5 +69,19 @@ namespace System.Linq
         /// </returns>
         public static Func<TSource, TResult> CombineSelectors<TSource, TMiddle, TResult>(Func<TSource, TMiddle> selector1, Func<TMiddle, TResult> selector2) =>
             x => selector2(selector1(x));
+
+        /// <summary>
+        /// Combines two selectors.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the first selector's argument.</typeparam>
+        /// <typeparam name="TMiddle">The type of the second selector's argument.</typeparam>
+        /// <typeparam name="TResult">The type of the second selector's return value.</typeparam>
+        /// <param name="selector1">The first selector to run.</param>
+        /// <param name="selector2">The second selector to run.</param>
+        /// <returns>
+        /// A new selector that represents the composition of the first selector with the second selector.
+        /// </returns>
+        public static Func<TSource, int, TResult> CombineSelectors<TSource, TMiddle, TResult>(Func<TSource, int, TMiddle> selector1, Func<TMiddle, TResult> selector2) =>
+            (x, i) => selector2(selector1(x, i));
     }
 }


### PR DESCRIPTION
This PR addresses #102252 by replacing the iterator methods for `Enumerable.Index` and `Enumerable.Select` (`Func<TSource, int, TResult>` overload) with iterator classes, which allows the number of elements to be extracted using `Enumerable.TryGetNonEnumeratedCount`.

There are two considerations to this change to focus on, which is how it affects binary size and enumeration performance compared to before.

### Binary Size

To make up for the added iterator class, `Size` compromises by reusing the iterator class for `Index`, which has a slight overhead in delegate invocation. This happens to perfectly balance out, keeping the file size the same.

|       | Before  |   After | Delta |
|-------|:-------:|--------:|-------|
| Size  | 136.2kB | 136.2kB |     0 |
| Speed | 170.5kB | 172.5kB |  +2kB |

### Performance

The following benchmarks were ran on the following specs:

- OS: Fedora Linux 40 (Workstation Edition) x86_64 
- Kernel: 6.8.9-300.fc40.x86_64 
- CPU: AMD Ryzen 5 3600 (12) @ 3.6GHz 
- GPU: NVIDIA GeForce RTX 2070 SUPER 
- Memory: 31.24 GiB
- BIOS: American Megatrends Inc. 5.17 (06/15/2023)

For clarity, here are the two benchmarks I had to add to `System.Linq` which can also be found in [this PR](https://github.com/dotnet/performance/pull/4220):

```csharp
[Benchmark]
[ArgumentsSource(nameof(SelectArguments))]
public void SelectTwoArgs(LinqTestData input) => input.Collection.Select((i, _) => i + 1).Consume(_consumer);

[Benchmark]
[ArgumentsSource(nameof(SelectArguments))]
public void Index(LinqTestData input) => input.Collection.Index().Consume(_consumer);
```

Before:

| Method        | Job        | OutlierMode | MemoryRandomization | input1 | input2 | input       |       Mean |     Error |     StdDev |     Median |        Min |        Max |   Gen0 | Gen1 | Allocated |
|---------------|------------|-------------|---------------------|--------|--------|-------------|-----------:|----------:|-----------:|-----------:|-----------:|-----------:|-------:|-----:|----------:|
| SelectTwoArgs | Job-OHSSWX | Default     | Default             | ?      | ?      | Array       | 289.393 ns | 0.7792 ns |  0.6084 ns | 289.638 ns | 288.361 ns | 290.241 ns | 0.0105 |    - |      88 B |
| Index         | Job-OHSSWX | Default     | Default             | ?      | ?      | Array       | 442.137 ns | 7.3575 ns |  6.1439 ns | 439.917 ns | 435.546 ns | 453.958 ns | 0.0107 |    - |      96 B |
| SelectTwoArgs | Job-OHSSWX | Default     | Default             | ?      | ?      | IEnumerable | 297.529 ns | 2.1482 ns |  2.0095 ns | 297.319 ns | 293.311 ns | 300.414 ns | 0.0095 |    - |      88 B |
| Index         | Job-OHSSWX | Default     | Default             | ?      | ?      | IEnumerable | 399.280 ns | 1.6105 ns |  1.4277 ns | 398.921 ns | 397.490 ns | 402.281 ns | 0.0111 |    - |      96 B |
| SelectTwoArgs | Job-OHSSWX | Default     | Default             | ?      | ?      | IList       | 295.300 ns | 1.0585 ns |  0.8839 ns | 295.175 ns | 293.870 ns | 296.760 ns | 0.0095 |    - |      88 B |
| Index         | Job-OHSSWX | Default     | Default             | ?      | ?      | IList       | 448.469 ns | 9.8079 ns | 11.2948 ns | 442.788 ns | 437.454 ns | 471.771 ns | 0.0106 |    - |      96 B |
| SelectTwoArgs | Job-OHSSWX | Default     | Default             | ?      | ?      | List        | 326.419 ns | 6.2312 ns |  5.8287 ns | 324.128 ns | 320.319 ns | 341.352 ns | 0.0106 |    - |      96 B |
| Index         | Job-OHSSWX | Default     | Default             | ?      | ?      | List        | 420.871 ns | 3.7947 ns |  3.5495 ns | 419.996 ns | 415.642 ns | 427.337 ns | 0.0120 |    - |     104 B |

After (Size):

| Method        | Job        | OutlierMode | MemoryRandomization | input1 | input2 | input       |       Mean |     Error |    StdDev |     Median |        Min |        Max |   Gen0 | Gen1 | Allocated |
|---------------|------------|-------------|---------------------|--------|--------|-------------|-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|-----:|----------:|
| SelectTwoArgs | Job-HHHSDK | Default     | Default             | ?      | ?      | Array       | 305.939 ns | 5.0186 ns | 4.6944 ns | 306.782 ns | 297.635 ns | 314.629 ns | 0.0099 |    - |      88 B |
| Index         | Job-HHHSDK | Default     | Default             | ?      | ?      | Array       | 447.542 ns | 5.2369 ns | 4.8986 ns | 447.845 ns | 438.340 ns | 456.185 ns | 0.0107 |    - |      96 B |
| SelectTwoArgs | Job-HHHSDK | Default     | Default             | ?      | ?      | IEnumerable | 295.164 ns | 5.1138 ns | 4.2703 ns | 293.172 ns | 291.494 ns | 306.610 ns | 0.0096 |    - |      88 B |
| Index         | Job-HHHSDK | Default     | Default             | ?      | ?      | IEnumerable | 447.696 ns | 4.5719 ns | 4.0529 ns | 446.909 ns | 443.248 ns | 455.190 ns | 0.0108 |    - |      96 B |
| SelectTwoArgs | Job-HHHSDK | Default     | Default             | ?      | ?      | IList       | 299.786 ns | 2.4750 ns | 2.3151 ns | 300.205 ns | 296.367 ns | 304.496 ns | 0.0096 |    - |      88 B |
| Index         | Job-HHHSDK | Default     | Default             | ?      | ?      | IList       | 446.041 ns | 1.8207 ns | 1.6140 ns | 445.544 ns | 444.221 ns | 449.126 ns | 0.0106 |    - |      96 B |
| SelectTwoArgs | Job-HHHSDK | Default     | Default             | ?      | ?      | List        | 331.369 ns | 5.1637 ns | 4.8301 ns | 331.554 ns | 325.195 ns | 342.152 ns | 0.0108 |    - |      96 B |
| Index         | Job-HHHSDK | Default     | Default             | ?      | ?      | List        | 428.238 ns | 4.7347 ns | 3.9537 ns | 428.055 ns | 421.260 ns | 434.336 ns | 0.0121 |    - |     104 B |

After (Speed):

| Method        | Job        | OutlierMode | MemoryRandomization | input1 | input2 | input       |       Mean |     Error |    StdDev |     Median |        Min |        Max |   Gen0 | Gen1 | Allocated |
|---------------|------------|-------------|---------------------|--------|--------|-------------|-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|-----:|----------:|
| SelectTwoArgs | Job-YLOCZA | Default     | Default             | ?      | ?      | Array       | 309.608 ns | 3.4150 ns | 2.8517 ns | 309.068 ns | 304.499 ns | 315.975 ns | 0.0100 |    - |      88 B |
| Index         | Job-YLOCZA | Default     | Default             | ?      | ?      | Array       | 397.406 ns | 5.8171 ns | 5.1567 ns | 396.914 ns | 391.216 ns | 409.981 ns | 0.0095 |    - |      88 B |
| SelectTwoArgs | Job-YLOCZA | Default     | Default             | ?      | ?      | IEnumerable | 316.334 ns | 5.6888 ns | 5.0429 ns | 314.942 ns | 309.132 ns | 325.836 ns | 0.0099 |    - |      88 B |
| Index         | Job-YLOCZA | Default     | Default             | ?      | ?      | IEnumerable | 399.424 ns | 4.5314 ns | 4.2387 ns | 399.317 ns | 392.139 ns | 406.830 ns | 0.0095 |    - |      88 B |
| SelectTwoArgs | Job-YLOCZA | Default     | Default             | ?      | ?      | IList       | 294.247 ns | 1.2717 ns | 1.0619 ns | 294.200 ns | 292.499 ns | 296.539 ns | 0.0095 |    - |      88 B |
| Index         | Job-YLOCZA | Default     | Default             | ?      | ?      | IList       | 352.187 ns | 0.9567 ns | 0.7469 ns | 352.286 ns | 351.089 ns | 353.619 ns | 0.0099 |    - |      88 B |
| SelectTwoArgs | Job-YLOCZA | Default     | Default             | ?      | ?      | List        | 325.543 ns | 1.5635 ns | 1.3056 ns | 325.214 ns | 324.163 ns | 328.834 ns | 0.0104 |    - |      96 B |
| Index         | Job-YLOCZA | Default     | Default             | ?      | ?      | List        | 392.757 ns | 1.2555 ns | 1.0484 ns | 392.946 ns | 390.955 ns | 394.513 ns | 0.0111 |    - |      96 B |

Before vs After (Size):

| Slower                                                        | diff/base | Base Median (ns) | Diff Median (ns) | Modality |
|---------------------------------------------------------------|----------:|-----------------:|-----------------:|----------|
| System.Linq.Tests.Perf_Enumerable.Index(input: IEnumerable)   |      1.13 |           398.92 |           451.83 |          |
| System.Linq.Tests.Perf_Enumerable.SelectTwoArgs(input: IList) |      1.02 |           295.17 |           302.00 |          |

| Faster                                                | base/diff | Base Median (ns) | Diff Median (ns) | Modality |
|-------------------------------------------------------|----------:|-----------------:|-----------------:|---------:|
| System.Linq.Tests.Perf_Enumerable.Index(input: IList) |      1.10 |           442.79 |           403.82 |          |

Before vs After (Speed):

| Slower                                                              | diff/base | Base Median (ns) | Diff Median (ns) | Modality |
|---------------------------------------------------------------------|----------:|-----------------:|-----------------:|----------|
| System.Linq.Tests.Perf_Enumerable.SelectTwoArgs(input: Array)       |      1.07 |           289.64 |           309.07 |          |
| System.Linq.Tests.Perf_Enumerable.SelectTwoArgs(input: IEnumerable) |      1.06 |           297.32 |           314.94 |          |

| Faster                                                | base/diff | Base Median (ns) | Diff Median (ns) | Modality |
|-------------------------------------------------------|----------:|-----------------:|-----------------:|----------|
| System.Linq.Tests.Perf_Enumerable.Index(input: IList) |      1.26 |           442.79 |           352.29 |          |
| System.Linq.Tests.Perf_Enumerable.Index(input: Array) |      1.11 |           439.92 |           396.91 |          |
| System.Linq.Tests.Perf_Enumerable.Index(input: List)  |      1.07 |           420.00 |           392.95 |          |

I am admittedly very confused on why `SelectTwoArgs` performs much worse in `Speed` when both are compiled identically.

### Personal Opinion

`Enumerable.Index` very clearly benefits from this, and I think it's a pretty open-and-shut case to include this change. The same cannot be said for `Select`, or perhaps we need more hardware to benchmark this. If the new implementation proves insufficient, we can scrap the `Select` implementation but keep the `Index` iterator class.

Hopefully I did everything correctly, and by all means I welcome any suggestions or changes to make this better or faster.
