### PR TITLE
Fix some assertions that fail when using `Lock` instances with `Monitor`

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Monitor.NativeAot.cs
@@ -30,8 +30,8 @@ namespace System.Threading
         private static Condition GetCondition(object obj)
         {
             Debug.Assert(
-                !(obj is Condition || obj is Lock),
-                "Do not use Monitor.Pulse or Wait on a Lock or Condition instance; use the methods on Condition instead.");
+                !(obj is Condition),
+                "Do not use Monitor.Pulse or Wait on a Condition instance; use the methods on Condition instead.");
             return s_conditionTable.GetValue(obj, s_createCondition);
         }
         #endregion

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/ObjectHeader.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/ObjectHeader.cs
@@ -298,9 +298,6 @@ namespace System.Threading
         {
             ArgumentNullException.ThrowIfNull(obj);
 
-            Debug.Assert(!(obj is Lock),
-                "Do not use Monitor.Enter or TryEnter on a Lock instance; use Lock methods directly instead.");
-
             // if thread ID is uninitialized or too big, we do "uncommon" part.
             if ((uint)(currentThreadID - 1) <= (uint)SBLK_MASK_LOCK_THREADID)
             {
@@ -440,9 +437,6 @@ namespace System.Threading
         {
             ArgumentNullException.ThrowIfNull(obj);
 
-            Debug.Assert(!(obj is Lock),
-                "Do not use Monitor.Enter or TryEnter on a Lock instance; use Lock methods directly instead.");
-
             int currentThreadID = ManagedThreadId.CurrentManagedThreadIdUnchecked;
             // transform uninitialized ID into -1, so it will not match any possible lock owner
             currentThreadID |= (currentThreadID - 1) >> 31;
@@ -492,9 +486,6 @@ namespace System.Threading
         public static unsafe bool IsAcquired(object obj)
         {
             ArgumentNullException.ThrowIfNull(obj);
-
-            Debug.Assert(!(obj is Lock),
-                "Do not use Monitor.Enter or TryEnter on a Lock instance; use Lock methods directly instead.");
 
             int currentThreadID = ManagedThreadId.CurrentManagedThreadIdUnchecked;
             // transform uninitialized ID into -1, so it will not match any possible lock owner


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102321