### PR TITLE
[mono] Disable fullAOT-llvm job on x64 due to OOM errors

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-other.yml
@@ -355,40 +355,41 @@ jobs:
 # Mono CoreCLR runtime Test executions using live libraries and LLVM Full AOT
 # Only when Mono is changed
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
-    buildConfig: Release
-    runtimeFlavor: mono
-    platforms:
-      - linux_x64
-      # - linux_arm64
-    variables:
-      - name: timeoutPerTestInMinutes
-        value: 60
-      - name: timeoutPerTestCollectionInMinutes
-        value: 180
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
-      runtimeVariant: llvmfullaot
-      buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-      timeoutInMinutes: 300
+# Disabled due to OOM errors: https://github.com/dotnet/runtime/issues/90427
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+#     buildConfig: Release
+#     runtimeFlavor: mono
+#     platforms:
+#       - linux_x64
+#       # - linux_arm64
+#     variables:
+#       - name: timeoutPerTestInMinutes
+#         value: 60
+#       - name: timeoutPerTestCollectionInMinutes
+#         value: 180
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_Mono_LLVMFullAot_RuntimeTests
+#       runtimeVariant: llvmfullaot
+#       buildArgs: -s mono+libs+clr.hosts+clr.iltools -c Release /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+#       timeoutInMinutes: 300
 
-      condition: >-
-        or(
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-          eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
-          eq(variables['isRollingBuild'], true))
-      postBuildSteps:
-        - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
-          parameters:
-            creator: dotnet-bot
-            llvmAotStepContainer: linux_x64_llvmaot
-            testRunNamePrefixSuffix: Mono_Release
-      extraVariablesTemplates:
-        - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+#       condition: >-
+#         or(
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+#           eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+#           eq(variables['isRollingBuild'], true))
+#       postBuildSteps:
+#         - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+#           parameters:
+#             creator: dotnet-bot
+#             llvmAotStepContainer: linux_x64_llvmaot
+#             testRunNamePrefixSuffix: Mono_Release
+#       extraVariablesTemplates:
+#         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
 
 #
 # Mono CoreCLR runtime Test executions using live libraries in interpreter mode


### PR DESCRIPTION
## Description

Disabling `linux-x64 Release AllSubsets_Mono_LLVMFullAot_RuntimeTests llvmfullaot` job from `runtime-extra-platforms` CI due to OOM errors. These are the same errors we were experiencing on main CI and are tracked https://github.com/dotnet/runtime/issues/90427. We plan to backport the fix to re-enable this job in the future together with a fix for arm64 architecture.

## Risk
No impact to shipping product.
