### PR TITLE
Revert "[release/8.0-staging] Pin net7.0 to 7.0.19"

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,8 +7,8 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>6</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
-    <PackageVersionNet7>7.0.19</PackageVersionNet7>
-    <PackageVersionNet6>6.0.$([MSBuild]::Add($(PatchVersion),25))</PackageVersionNet6>
+    <PackageVersionNet7>7.0.$([MSBuild]::Add($(PatchVersion),14))</PackageVersionNet7>
+    <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet7)').Build),11))</PackageVersionNet6>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>


### PR DESCRIPTION
Reverts dotnet/runtime#101823 looks like there will be a 7.0.20 after all