### PR TITLE
[wasm] Fix WebSocket failures on wasm test runs

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -43,7 +43,7 @@
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
 
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
+    <_withCategories Condition="'$(TestScope)' == 'all'">$(_withCategories);OuterLoop</_withCategories>
     <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -43,7 +43,7 @@
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
 
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    <_withCategories Condition="'$(TestScope)' == 'all'">$(_withCategories);OuterLoop</_withCategories>
+    <_withCategories Condition="'$(TestScope)' == 'all' or '$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
     <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -43,7 +43,7 @@
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
 
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    <_withCategories Condition="'$(TestScope)' == 'all' or '$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
+    <_withCategories Condition="'$(TestScope)' == 'outerloop'">OuterLoop;$(_withCategories)</_withCategories>
     <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -43,7 +43,7 @@
     <_withoutCategories Condition="'$(WithoutCategories)' != ''">;$(WithoutCategories.Trim(';'))</_withoutCategories>
 
     <TestScope Condition="'$(TestScope)' == '' and '$(Outerloop)' == 'true'">all</TestScope>
-    <_withCategories Condition="'$(TestScope)' == 'outerloop'">OuterLoop;$(_withCategories)</_withCategories>
+    <_withCategories Condition="'$(TestScope)' == 'outerloop'">$(_withCategories);OuterLoop</_withCategories>
     <_withoutCategories Condition="'$(ArchiveTests)' == 'true'">$(_withoutCategories);IgnoreForCI</_withoutCategories>
     <_withoutCategories Condition="'$(TestScope)' == '' or '$(TestScope)' == 'innerloop'">$(_withoutCategories);OuterLoop</_withoutCategories>
     <_withoutCategories Condition="!$(_withCategories.Contains('failing'))">$(_withoutCategories);failing</_withoutCategories>

--- a/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
+++ b/src/libraries/Common/tests/StreamConformanceTests/System/IO/StreamConformanceTests.cs
@@ -1742,7 +1742,8 @@ namespace System.IO.Tests
             from startWithFlush in new[] { false, true }
             select new object[] { mode, writeSize, startWithFlush };
 
-        [OuterLoop]
+        [OuterLoop("May take several seconds", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         [Theory]
         [MemberData(nameof(ReadWrite_Success_Large_MemberData))]
         public virtual async Task ReadWrite_Success_Large(ReadWriteMode mode, int writeSize, bool startWithFlush) =>
@@ -2438,7 +2439,8 @@ namespace System.IO.Tests
             from useAsync in new bool[] { true, false }
             select new object[] { byteCount, useAsync };
 
-        [OuterLoop]
+        [OuterLoop("May take several seconds", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAXml.cs
@@ -415,7 +415,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [ConditionalFact(typeof(DSAFactory), nameof(DSAFactory.SupportsKeyGeneration))]
-        [OuterLoop("DSA key generation is very slow")]
+        [OuterLoop("DSA key generation is very slow", ~TestPlatforms.Browser)]
         public static void FromToXml()
         {
             using (DSA dsa = DSAFactory.Create())

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -277,7 +277,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [OuterLoop] // makes noise, not very inner-loop friendly
+    [OuterLoop("makes noise, not very inner-loop friendly", ~TestPlatforms.Browser)]
     [PlatformSpecific(TestPlatforms.Windows)]
     public static void BeepWithFrequency_Invoke_Success()
     {

--- a/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
@@ -41,6 +41,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(DegreeData), new[] { 1024 }, new[] { 1, 4, 512 })]
         [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         public static void DegreeOfParallelism(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             Assert.Equal(Functions.SumRange(0, count), labeled.Item.WithDegreeOfParallelism(degree).Sum());
@@ -94,6 +95,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
         [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         public static void DegreeOfParallelism_Aggregate_Accumulator(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -112,6 +114,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
         [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         public static void DegreeOfParallelism_Aggregate_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
@@ -41,6 +41,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(DegreeData), new[] { 1024 }, new[] { 1, 4, 512 })]
         [OuterLoop]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public static void DegreeOfParallelism(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             Assert.Equal(Functions.SumRange(0, count), labeled.Item.WithDegreeOfParallelism(degree).Sum());
@@ -94,6 +95,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
         [OuterLoop]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public static void DegreeOfParallelism_Aggregate_Accumulator(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -112,6 +114,7 @@ namespace System.Linq.Parallel.Tests
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
         [OuterLoop]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public static void DegreeOfParallelism_Aggregate_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/DegreeOfParallelismTests.cs
@@ -40,8 +40,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(DegreeData), new[] { 1024 }, new[] { 1, 4, 512 })]
-        [OuterLoop]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
+        [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
         public static void DegreeOfParallelism(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             Assert.Equal(Functions.SumRange(0, count), labeled.Item.WithDegreeOfParallelism(degree).Sum());
@@ -94,8 +93,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
-        [OuterLoop]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
+        [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
         public static void DegreeOfParallelism_Aggregate_Accumulator(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -113,8 +111,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 1, 4 }, new int[] { /* same as count */ })]
         [MemberData(nameof(NotLoadBalancedDegreeData), new[] { 32, 512, 1024 }, new[] { 4, 16 })]
-        [OuterLoop]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
+        [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
         public static void DegreeOfParallelism_Aggregate_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -180,6 +180,7 @@ namespace System.Linq.Parallel.Tests
         // This is included as a regression test for that particular repro.
         [Theory]
         [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on browser")]
         [MemberData(nameof(ZipThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
         public static void Zip_AsOrdered_ThreadedDeadlock(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int degree)
         {

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -181,6 +181,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(ZipThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
+        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public static void Zip_AsOrdered_ThreadedDeadlock(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int degree)
         {
             _ = leftCount;

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -179,9 +179,8 @@ namespace System.Linq.Parallel.Tests
         // Zip with ordering on showed issues, but it was due to the ordering component.
         // This is included as a regression test for that particular repro.
         [Theory]
-        [OuterLoop]
+        [OuterLoop("Resource-intensive due to parallel processing", ~TestPlatforms.Browser)]
         [MemberData(nameof(ZipThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
-        [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser.")]
         public static void Zip_AsOrdered_ThreadedDeadlock(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int degree)
         {
             _ = leftCount;

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketCreateTest.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketCreateTest.cs
@@ -37,7 +37,7 @@ namespace System.Net.WebSockets.Tests
             Assert.NotNull(CreateFromStream(new MemoryStream(), true, null, Timeout.InfiniteTimeSpan));
         }
 
-        [OuterLoop("Uses external servers")]
+        [OuterLoop("Uses external servers", ~TestPlatforms.Browser)]
         [Theory]
         [MemberData(nameof(EchoServers))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform.")]
@@ -230,7 +230,7 @@ namespace System.Net.WebSockets.Tests
             }
         }
 
-        [OuterLoop("Uses external servers")]
+        [OuterLoop("Uses external servers", ~TestPlatforms.Browser)]
         [Theory]
         [MemberData(nameof(EchoServersAndBoolean))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform.")]
@@ -272,7 +272,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/28957")]
-        [OuterLoop("Uses external servers")]
+        [OuterLoop("Uses external servers", ~TestPlatforms.Browser)]
         [Theory]
         [MemberData(nameof(EchoServersAndBoolean))]
         [SkipOnPlatform(TestPlatforms.Browser, "System.Net.Sockets is not supported on this platform.")]

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Delete.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Directory/Delete.cs
@@ -267,7 +267,7 @@ namespace System.IO.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [OuterLoop("This test is very slow.")]
+        [OuterLoop("This test is very slow.", ~TestPlatforms.Browser)]
         public void RecursiveDelete_DeepNesting()
         {
             // Create a 2000 level deep directory and recursively delete from the root.

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/EncryptDecrypt.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/File/EncryptDecrypt.cs
@@ -29,7 +29,7 @@ namespace System.IO.Tests
         // because EFS (Encrypted File System), its underlying technology, is not available on these operating systems.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer), nameof(PlatformDetection.IsNotWindowsHomeEdition))]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [OuterLoop] // Occasional failures: https://github.com/dotnet/runtime/issues/12339
+        [OuterLoop("Occasional failures", ~TestPlatforms.Browser)] // Occasional failures: https://github.com/dotnet/runtime/issues/12339
         public void EncryptDecrypt_Read()
         {
             string tmpFileName = Path.GetTempFileName();

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertTests.cs
@@ -425,7 +425,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/26213")]
         [ConditionalFact]
-        [OuterLoop("May require using the network, to download CRLs and intermediates")]
+        [OuterLoop("May require using the network, to download CRLs and intermediates", ~TestPlatforms.Browser)]
         public void TestVerify()
         {
             bool success;
@@ -861,7 +861,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalP256))]
-        [OuterLoop("Hardware backed key generation takes several seconds.")]
+        [OuterLoop("Hardware backed key generation takes several seconds.", ~TestPlatforms.Browser)]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_EcdsaKey()
         {
             using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.ECDsaP256))
@@ -882,7 +882,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [ConditionalFact(typeof(PlatformSupport), nameof(PlatformSupport.PlatformCryptoProviderFunctionalRsa))]
-        [OuterLoop("Hardware backed key generation takes several seconds.")]
+        [OuterLoop("Hardware backed key generation takes several seconds.", ~TestPlatforms.Browser)]
         public static void CreateCertificate_MicrosoftPlatformCryptoProvider_RsaKey()
         {
             using (CngPlatformProviderKey platformKey = new CngPlatformProviderKey(CngAlgorithm.Rsa))

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ChainTests.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         /// and trusted root. It will fail to build any chain if those are not valid.
         /// </summary>
         [Fact]
-        [OuterLoop]
+        [OuterLoop("May take a long time on some platforms", ~TestPlatforms.Browser)]
         [SkipOnPlatform(TestPlatforms.Android, "Not supported on Android.")]
         public static void BuildChainExtraStoreUntrustedRoot()
         {
@@ -656,7 +656,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [ConditionalFact(nameof(TrustsMicrosoftDotComRoot))]
-        [OuterLoop(/* Modifies user certificate store */)]
+        [OuterLoop("Modifies user certificate store", ~TestPlatforms.Browser)]
         [SkipOnPlatform(PlatformSupport.MobileAppleCrypto, "Root certificate store is not accessible")]
         public static void BuildChain_MicrosoftDotCom_WithRootCertInUserAndSystemRootCertStores()
         {

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -173,7 +173,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
-        [OuterLoop("Modifies user-persisted state")]
+        [OuterLoop("Modifies user-persisted state", ~TestPlatforms.Browser)]
         public static void ExportDoesNotCorruptPrivateKeyMethods()
         {
             string keyName = $"clrtest.{Guid.NewGuid():D}";

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/DynamicRevocationTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
-    [OuterLoop("These tests run serially at about 1 second each, and the code shouldn't change that often.")]
+    [OuterLoop("These tests run serially at about 1 second each, and the code shouldn't change that often.", ~TestPlatforms.Browser)]
     [ConditionalClass(typeof(DynamicRevocationTests), nameof(SupportsDynamicRevocation))]
     [SkipOnPlatform(TestPlatforms.Browser, "Browser doesn't support X.509 certificates")]
     public static partial class DynamicRevocationTests

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/TimeoutTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/RevocationTests/TimeoutTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests.RevocationTests
 {
-    [OuterLoop("These tests exercise timeout properties which take a lot of time.")]
+    [OuterLoop("These tests exercise timeout properties which take a lot of time.", ~TestPlatforms.Browser)]
     [SkipOnPlatform(TestPlatforms.Browser, "Browser doesn't support X.509 certificates")]
     public static class TimeoutTests
     {

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexIgnoreCaseTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexIgnoreCaseTests.cs
@@ -149,7 +149,7 @@ namespace System.Text.RegularExpressions.Tests
 
         // This test takes a long time to run since it needs to compute all possible lowercase mappings across
         // 3 different cultures and then creates Regex matches for all of our engines for each mapping.
-        [OuterLoop]
+        [OuterLoop("Takes long time to run", ~TestPlatforms.Browser)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/67793")]
         [Theory]
         [MemberData(nameof(Unicode_IgnoreCase_TestData))]


### PR DESCRIPTION
OuterLoop tests that are disabled still are running when `/p:TestScope=outerloop`.
Xharness ignores `-notrait category=failing` and runs tests cases marked with `SkipOnPlatform`,`ActiveIssue`


Fixes https://github.com/dotnet/runtime/issues/102157