### PR TITLE
Fix build of coreclr test JIT/Regression/JitBlue/Runtime_1102138

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_1102138/Runtime_102138.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_1102138/Runtime_102138.cs
@@ -49,12 +49,11 @@ public class Runtime_102138
     public static byte[] s_11;
 
     [Fact]
-    public static int TestEntryPoint()
+    public static void TestEntryPoint()
     {
         var vr3 = new short[][][]{new short[][]{new short[]{0}}};
         var vr8 = new S5();
         s_10 = M8(vr8, ref s_11, vr3);
-        return 100;
     }
 
     public static ref S3 M8(S5 argThis, ref byte[] arg0, short[][][] arg1)


### PR DESCRIPTION
The coreclr test `JIT/Regression/JitBlue/Runtime_1102138/Runtime_102138.csproj` when build with `BuildAllTestsAsStandalone=true` environment variable set fails with an error:

`error XUW1002: Tests should not unconditionally return 100. Convert to a void return.`

The error message recommendation applied.

Part of #84834, cc @dotnet/samsung