### PR TITLE
Delete DebugSymbols=true setting for the repo build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -390,7 +390,6 @@
     <NoWarn>$(NoWarn),CS8969</NoWarn>
     <!-- Always pass portable to override arcade sdk which uses embedded for local builds -->
     <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == '' and '$(DotNetBuildSourceOnly)' == 'true'">true</KeepNativeSymbols>
     <KeepNativeSymbols Condition="'$(KeepNativeSymbols)' == ''">false</KeepNativeSymbols>
     <!-- Used for launchSettings.json and runtime config files. -->

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -34,7 +34,7 @@
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And (Exists('$(ILLinkSuppressionsXml)') Or Exists('$(ILLinkSuppressionsConfigurationSpecificXml)'))">false</EnableTrimAnalyzer>
 
     <!-- if building a PDB, tell illink to rewrite the symbols file -->
-    <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' and '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
+    <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == ''">true</ILLinkRewritePDBs>
 
     <ILLinkResourcesSubstitutionIntermediatePath>$(IntermediateOutputPath)ILLink.Resources.Substitutions.xml</ILLinkResourcesSubstitutionIntermediatePath>
     <GenerateResourcesSubstitutions Condition="'$(GenerateResourcesSubstitutions)' == '' and '$(StringResourcesPath)' != ''">true</GenerateResourcesSubstitutions>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -33,7 +33,7 @@
     <!-- Only run the trim analyzer on libraries which have been annotated. -->
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == '' And (Exists('$(ILLinkSuppressionsXml)') Or Exists('$(ILLinkSuppressionsConfigurationSpecificXml)'))">false</EnableTrimAnalyzer>
 
-    <!-- if building a PDB, tell illink to rewrite the symbols file -->
+    <!-- tell illink to rewrite the symbols file -->
     <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == ''">true</ILLinkRewritePDBs>
 
     <ILLinkResourcesSubstitutionIntermediatePath>$(IntermediateOutputPath)ILLink.Resources.Substitutions.xml</ILLinkResourcesSubstitutionIntermediatePath>

--- a/src/coreclr/nativeaot/Directory.Build.props
+++ b/src/coreclr/nativeaot/Directory.Build.props
@@ -13,7 +13,6 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
 
     <DebugType>Portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
 
     <OutputPath Condition="$(MSBuildProjectName.StartsWith('System.Private.'))">$(RuntimeBinDir)/aotsdk/</OutputPath>
     <Configurations>Debug;Release;Checked</Configurations>

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/Decoding/SignatureDecoderTests.cs
@@ -278,10 +278,14 @@ namespace System.Reflection.Metadata.Decoding.Tests
             public static unsafe int DoSomething()
             {
                 byte[] bytes = new byte[] { 1, 2, 3 };
+                Keep(ref bytes);
                 fixed (byte* bytePtr = bytes)
                 {
                     return *bytePtr;
                 }
+
+                // Reference local variables to prevent them from being optimized out by Roslyn
+                static void Keep<T>(ref T value) { };
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/MethodBaseTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/MethodBaseTests.cs
@@ -113,12 +113,18 @@ namespace System.Reflection.Tests
         public static void MyOtherMethod(object arg)
         {
             int var1 = 2;
+            Keep(ref var1);
+
             string var2 = "I am a string";
+            Keep(ref var2);
 
             if (arg == null)
             {
                 throw new ArgumentNullException("Input arg cannot be null.");
             }
+
+            // Reference local variables to prevent them from being optimized out by Roslyn
+            static void Keep<T>(ref T value) { };
         }
 #pragma warning restore xUnit1013 // Public method should be marked as test
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/MethodBodyTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/MethodBodyTests.cs
@@ -41,10 +41,10 @@ namespace System.Reflection.Tests
                 if (ehc.Flags != ExceptionHandlingClauseOptions.Finally && ehc.Flags != ExceptionHandlingClauseOptions.Filter)
                 {
                     Assert.Equal(typeof(Exception), ehc.CatchType);
-                    Assert.Equal(19, ehc.HandlerLength);
-                    Assert.Equal(70, ehc.HandlerOffset);
+                    Assert.Equal(27, ehc.HandlerLength);
+                    Assert.Equal(86, ehc.HandlerOffset);
                     Assert.Equal(61, ehc.TryLength);
-                    Assert.Equal(9, ehc.TryOffset);
+                    Assert.Equal(25, ehc.TryOffset);
                     return;
                 }
             }
@@ -64,10 +64,10 @@ namespace System.Reflection.Tests
                 if (ehc.Flags != ExceptionHandlingClauseOptions.Finally && ehc.Flags != ExceptionHandlingClauseOptions.Filter)
                 {
                     Assert.Equal(typeof(Exception), ehc.CatchType);
-                    Assert.Equal(14, ehc.HandlerLength);
-                    Assert.Equal(58, ehc.HandlerOffset);
+                    Assert.Equal(21, ehc.HandlerLength);
+                    Assert.Equal(72, ehc.HandlerOffset);
                     Assert.Equal(50, ehc.TryLength);
-                    Assert.Equal(8, ehc.TryOffset);
+                    Assert.Equal(22, ehc.TryOffset);
                     return;
                 }
             }
@@ -79,7 +79,10 @@ namespace System.Reflection.Tests
         private static void MethodBodyExample(object arg)
         {
             int var1 = 2;
+            Keep(ref var1);
+
             string var2 = "I am a string";
+            Keep(ref var2);
 
             try
             {
@@ -94,6 +97,7 @@ namespace System.Reflection.Tests
             }
             catch (Exception ex)
             {
+                Keep(ref ex);
                 Console.WriteLine(ex.Message);
             }
             finally
@@ -101,6 +105,9 @@ namespace System.Reflection.Tests
                 var1 = 3;
                 var2 = "I am a new string!";
             }
+
+            // Reference local variables to prevent them from being optimized out by Roslyn
+            static void Keep<T>(ref T value) { };
         }
     }
 }

--- a/src/tests/Loader/classloader/InlineArray/InlineArrayInvalid.csproj
+++ b/src/tests/Loader/classloader/InlineArray/InlineArrayInvalid.csproj
@@ -3,6 +3,8 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Make sure that invalid operations are not optimized out by Roslyn -->
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="InlineArrayInvalid.cs" />

--- a/src/tests/Loader/classloader/RefFields/Validate.csproj
+++ b/src/tests/Loader/classloader/RefFields/Validate.csproj
@@ -4,6 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MonoAotIncompatible>true</MonoAotIncompatible>
+    <!-- Make sure that invalid operations are not optimized out by Roslyn -->
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Validate.cs" />

--- a/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
+++ b/src/tests/baseservices/invalid_operations/InvalidOperations.csproj
@@ -3,6 +3,8 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Make sure that invalid operations are not optimized out by Roslyn -->
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ManagedPointers.cs" />


### PR DESCRIPTION
This property does not do what its name says. The symbols are generated regardless of whether this property is true or false. What this property actually does is that it disables C# peephole IL optimizations.

This change results in ~0.5% IL binary size improvement thanks to the Roslyn IL peephole optimizations that it enables. Also, this gets us closer to default build configuration used by our users.