### PR TITLE
Use BinaryPrimitives for `ObjectDataBuilder` primitive emit logic

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -86,37 +86,27 @@ namespace ILCompiler.DependencyAnalysis
 
         public void EmitShort(short emit)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16LittleEndian(buffer, emit);
-            _data.Append(buffer);
+            BinaryPrimitives.WriteInt16LittleEndian(_data.GetSpan(sizeof(short)), emit);
         }
 
         public void EmitUShort(ushort emit)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16LittleEndian(buffer, emit);
-            _data.Append(buffer);
+            BinaryPrimitives.WriteUInt16LittleEndian(_data.GetSpan(sizeof(ushort)), emit);
         }
 
         public void EmitInt(int emit)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32LittleEndian(buffer, emit);
-            _data.Append(buffer);
+            BinaryPrimitives.WriteInt32LittleEndian(_data.GetSpan(sizeof(int)), emit);
         }
 
         public void EmitUInt(uint emit)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer, emit);
-            _data.Append(buffer);
+            BinaryPrimitives.WriteUInt32LittleEndian(_data.GetSpan(sizeof(uint)), emit);
         }
 
         public void EmitLong(long emit)
         {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64LittleEndian(buffer, emit);
-            _data.Append(buffer);
+            BinaryPrimitives.WriteInt64LittleEndian(_data.GetSpan(sizeof(long)), emit);
         }
 
         public void EmitNaturalInt(int emit)
@@ -176,7 +166,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void EmitBytes(scoped ReadOnlySpan<byte> bytes)
+        public void EmitBytes(byte[] bytes)
         {
             _data.Append(bytes);
         }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using Internal.TypeSystem;
 
@@ -85,42 +86,37 @@ namespace ILCompiler.DependencyAnalysis
 
         public void EmitShort(short emit)
         {
-            EmitByte((byte)(emit & 0xFF));
-            EmitByte((byte)((emit >> 8) & 0xFF));
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16LittleEndian(buffer, emit);
+            _data.Append(buffer);
         }
 
         public void EmitUShort(ushort emit)
         {
-            EmitByte((byte)(emit & 0xFF));
-            EmitByte((byte)((emit >> 8) & 0xFF));
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer, emit);
+            _data.Append(buffer);
         }
 
         public void EmitInt(int emit)
         {
-            EmitByte((byte)(emit & 0xFF));
-            EmitByte((byte)((emit >> 8) & 0xFF));
-            EmitByte((byte)((emit >> 16) & 0xFF));
-            EmitByte((byte)((emit >> 24) & 0xFF));
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, emit);
+            _data.Append(buffer);
         }
 
         public void EmitUInt(uint emit)
         {
-            EmitByte((byte)(emit & 0xFF));
-            EmitByte((byte)((emit >> 8) & 0xFF));
-            EmitByte((byte)((emit >> 16) & 0xFF));
-            EmitByte((byte)((emit >> 24) & 0xFF));
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer, emit);
+            _data.Append(buffer);
         }
 
         public void EmitLong(long emit)
         {
-            EmitByte((byte)(emit & 0xFF));
-            EmitByte((byte)((emit >> 8) & 0xFF));
-            EmitByte((byte)((emit >> 16) & 0xFF));
-            EmitByte((byte)((emit >> 24) & 0xFF));
-            EmitByte((byte)((emit >> 32) & 0xFF));
-            EmitByte((byte)((emit >> 40) & 0xFF));
-            EmitByte((byte)((emit >> 48) & 0xFF));
-            EmitByte((byte)((emit >> 56) & 0xFF));
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(buffer, emit);
+            _data.Append(buffer);
         }
 
         public void EmitNaturalInt(int emit)
@@ -180,7 +176,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public void EmitBytes(byte[] bytes)
+        public void EmitBytes(scoped ReadOnlySpan<byte> bytes)
         {
             _data.Append(bytes);
         }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -241,8 +241,7 @@ namespace ILCompiler.DependencyAnalysis
         public void EmitShort(Reservation reservation, short emit)
         {
             int offset = ReturnReservationTicket(reservation);
-            _data[offset] = (byte)(emit & 0xFF);
-            _data[offset + 1] = (byte)((emit >> 8) & 0xFF);
+            BinaryPrimitives.WriteInt16LittleEndian(_data.AsSpan(offset), emit);
         }
 
         public Reservation ReserveInt()
@@ -253,19 +252,13 @@ namespace ILCompiler.DependencyAnalysis
         public void EmitInt(Reservation reservation, int emit)
         {
             int offset = ReturnReservationTicket(reservation);
-            _data[offset] = (byte)(emit & 0xFF);
-            _data[offset + 1] = (byte)((emit >> 8) & 0xFF);
-            _data[offset + 2] = (byte)((emit >> 16) & 0xFF);
-            _data[offset + 3] = (byte)((emit >> 24) & 0xFF);
+            BinaryPrimitives.WriteInt32LittleEndian(_data.AsSpan(offset), emit);
         }
 
         public void EmitUInt(Reservation reservation, uint emit)
         {
             int offset = ReturnReservationTicket(reservation);
-            _data[offset] = (byte)(emit & 0xFF);
-            _data[offset + 1] = (byte)((emit >> 8) & 0xFF);
-            _data[offset + 2] = (byte)((emit >> 16) & 0xFF);
-            _data[offset + 3] = (byte)((emit >> 24) & 0xFF);
+            BinaryPrimitives.WriteUInt32LittleEndian(_data.AsSpan(offset), emit);
         }
 
         public void EmitReloc(ISymbolNode symbol, RelocType relocType, int delta = 0)

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ObjectDataBuilder.cs
@@ -86,27 +86,27 @@ namespace ILCompiler.DependencyAnalysis
 
         public void EmitShort(short emit)
         {
-            BinaryPrimitives.WriteInt16LittleEndian(_data.GetSpan(sizeof(short)), emit);
+            BinaryPrimitives.WriteInt16LittleEndian(_data.AppendSpan(sizeof(short)), emit);
         }
 
         public void EmitUShort(ushort emit)
         {
-            BinaryPrimitives.WriteUInt16LittleEndian(_data.GetSpan(sizeof(ushort)), emit);
+            BinaryPrimitives.WriteUInt16LittleEndian(_data.AppendSpan(sizeof(ushort)), emit);
         }
 
         public void EmitInt(int emit)
         {
-            BinaryPrimitives.WriteInt32LittleEndian(_data.GetSpan(sizeof(int)), emit);
+            BinaryPrimitives.WriteInt32LittleEndian(_data.AppendSpan(sizeof(int)), emit);
         }
 
         public void EmitUInt(uint emit)
         {
-            BinaryPrimitives.WriteUInt32LittleEndian(_data.GetSpan(sizeof(uint)), emit);
+            BinaryPrimitives.WriteUInt32LittleEndian(_data.AppendSpan(sizeof(uint)), emit);
         }
 
         public void EmitLong(long emit)
         {
-            BinaryPrimitives.WriteInt64LittleEndian(_data.GetSpan(sizeof(long)), emit);
+            BinaryPrimitives.WriteInt64LittleEndian(_data.AppendSpan(sizeof(long)), emit);
         }
 
         public void EmitNaturalInt(int emit)

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -15,14 +15,10 @@ namespace System.Collections.Generic
         private T[] _items;
         private int _count;
 
-        public ArrayBuilder()
-        {
-            _items = Array.Empty<T>();
-            _count = 0;
-        }
-
         public T[] ToArray()
         {
+            if (_items == null)
+                return Array.Empty<T>();
             if (_count != _items.Length)
                 Array.Resize(ref _items, _count);
             return _items;
@@ -30,7 +26,7 @@ namespace System.Collections.Generic
 
         public void Add(T item)
         {
-            if (_count == _items.Length)
+            if (_items == null || _count == _items.Length)
                 Array.Resize(ref _items, 2 * _count + 1);
             _items[_count++] = item;
         }
@@ -84,7 +80,7 @@ namespace System.Collections.Generic
 
         public void EnsureCapacity(int requestedCapacity)
         {
-            if (requestedCapacity > _items.Length)
+            if (requestedCapacity > ((_items != null) ? _items.Length : 0))
             {
                 Grow(requestedCapacity);
             }

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -30,6 +30,8 @@ namespace System.Collections.Generic
         }
 
 #if NET
+        public readonly Span<T> AsSpan(int start) => _items.AsSpan(start);
+
         public void Append(scoped ReadOnlySpan<T> newItems)
         {
             if (newItems.Length == 0)

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -86,27 +86,15 @@ namespace System.Collections.Generic
             }
         }
 
-        public int Count
+        public readonly int Count => _count;
+
+        public readonly T this[int index]
         {
-            get
-            {
-                return _count;
-            }
+            get => _items[index];
+            set => _items[index] = value;
         }
 
-        public T this[int index]
-        {
-            get
-            {
-                return _items[index];
-            }
-            set
-            {
-                _items[index] = value;
-            }
-        }
-
-        public bool Contains(T t)
+        public readonly bool Contains(T t)
         {
             for (int i = 0; i < _count; i++)
             {
@@ -119,7 +107,7 @@ namespace System.Collections.Generic
             return false;
         }
 
-        public bool Any(Func<T, bool> func)
+        public readonly bool Any(Func<T, bool> func)
         {
             for (int i = 0; i < _count; i++)
             {

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -15,10 +15,14 @@ namespace System.Collections.Generic
         private T[] _items;
         private int _count;
 
+        public ArrayBuilder()
+        {
+            _items = Array.Empty<T>();
+            _count = 0;
+        }
+
         public T[] ToArray()
         {
-            if (_items == null)
-                return Array.Empty<T>();
             if (_count != _items.Length)
                 Array.Resize(ref _items, _count);
             return _items;
@@ -26,7 +30,7 @@ namespace System.Collections.Generic
 
         public void Add(T item)
         {
-            if (_items == null || _count == _items.Length)
+            if (_count == _items.Length)
                 Array.Resize(ref _items, 2 * _count + 1);
             _items[_count++] = item;
         }
@@ -80,7 +84,7 @@ namespace System.Collections.Generic
 
         public void EnsureCapacity(int requestedCapacity)
         {
-            if (requestedCapacity > ((_items != null) ? _items.Length : 0))
+            if (requestedCapacity > _items.Length)
             {
                 Grow(requestedCapacity);
             }

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace System.Collections.Generic
@@ -80,9 +82,15 @@ namespace System.Collections.Generic
         {
             if (requestedCapacity > ((_items != null) ? _items.Length : 0))
             {
-                int newCount = Math.Max(2 * _count + 1, requestedCapacity);
-                Array.Resize(ref _items, newCount);
+                Grow(requestedCapacity);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int requestedCapacity)
+        {
+            int newCount = Math.Max(2 * _count + 1, requestedCapacity);
+            Array.Resize(ref _items, newCount);
         }
 
         public readonly int Count => _count;

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -29,6 +29,18 @@ namespace System.Collections.Generic
             _items[_count++] = item;
         }
 
+#if NET
+        public void Append(scoped ReadOnlySpan<T> newItems)
+        {
+            if (newItems.Length == 0)
+                return;
+
+            EnsureCapacity(_count + newItems.Length);
+            newItems.CopyTo(_items.AsSpan(_count));
+            _count += newItems.Length;
+        }
+#endif
+
         public void Append(T[] newItems)
         {
             Append(newItems, 0, newItems.Length);

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -32,13 +32,13 @@ namespace System.Collections.Generic
 #if NET
         public readonly Span<T> AsSpan(int start) => _items.AsSpan(start);
 
-        public Span<T> GetSpan(int size)
+        public Span<T> AppendSpan(int length)
         {
-            EnsureCapacity(_count + size);
+            int origCount = _count;
+            EnsureCapacity(origCount + length);
 
-            Span<T> buffer = _items.AsSpan(_count, size);
-            _count += size;
-            return buffer;
+            _count = origCount + length;
+            return _items.AsSpan(origCount, length);
         }
 #endif
 

--- a/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
+++ b/src/coreclr/tools/Common/System/Collections/Generic/ArrayBuilder.cs
@@ -32,14 +32,13 @@ namespace System.Collections.Generic
 #if NET
         public readonly Span<T> AsSpan(int start) => _items.AsSpan(start);
 
-        public void Append(scoped ReadOnlySpan<T> newItems)
+        public Span<T> GetSpan(int size)
         {
-            if (newItems.Length == 0)
-                return;
+            EnsureCapacity(_count + size);
 
-            EnsureCapacity(_count + newItems.Length);
-            newItems.CopyTo(_items.AsSpan(_count));
-            _count += newItems.Length;
+            Span<T> buffer = _items.AsSpan(_count, size);
+            _count += size;
+            return buffer;
         }
 #endif
 


### PR DESCRIPTION
To allow more efficient use of the shared `ArrayBuilder<T>`, I added some `Span<T>` overloads under `#if NET` preprocessor.

These new `ArrayBuilder<T>` overloads will allow future improvements in other projects that utilize it.