### PR TITLE
Fix the definition of `RhGetCurrentThunkContext`

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -480,10 +480,11 @@ EXTERN_C intptr_t* RhpGetThunkData()
 }
 #endif //FEATURE_EMULATED_TLS
 
-EXTERN_C intptr_t RhGetCurrentThunkContext()
+FCIMPL0(intptr_t, RhGetCurrentThunkContext)
 {
     return tls_thunkData;
 }
+FCIMPLEND
 
 // Register the thread with OS to be notified when thread is about to be destroyed
 // It fails fast if a different thread was already registered.


### PR DESCRIPTION
This is an FCall - FCalls need `FCIMPL`-based calling convention munging.

Discovered downstream: https://github.com/dotnet/runtimelab/pull/2587.