### PR TITLE
[cdac] Implement GetThreadStoreData in cDAC

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -2,15 +2,16 @@
 
 This contract is for reading and iterating the threads of the process.
 
-## Data structures defined by contract
+## APIs of contract
+
 ``` csharp
-record struct DacThreadStoreData (
+record struct ThreadStoreData (
     int ThreadCount,
     TargetPointer FirstThread,
     TargetPointer FinalizerThread,
     TargetPointer GcThread);
 
-record struct DacThreadStoreCounts (
+record struct ThreadStoreCounts (
     int UnstartedThreadCount,
     int BackgroundThreadCount,
     int PendingThreadCount,
@@ -75,7 +76,7 @@ enum ThreadState
     TS_Detached               = 0x80000000,    // Thread was detached by DllMain
 }
 
-record struct DacThreadData (
+record struct ThreadData (
     uint ThreadId;
     TargetNUint OsThreadId;
     ThreadState State;
@@ -90,11 +91,10 @@ record struct DacThreadData (
 );
 ```
 
-## Apis of contract
 ``` csharp
-DacThreadStoreData GetThreadStoreData();
-DacThreadStoreCounts GetThreadCounts();
-DacThreadData GetThreadData(TargetPointer threadPointer);
+ThreadStoreData GetThreadStoreData();
+ThreadStoreCounts GetThreadCounts();
+ThreadData GetThreadData(TargetPointer threadPointer);
 TargetPointer GetNestedExceptionInfo(TargetPointer nestedExceptionPointer, out TargetPointer nextNestedException);
 TargetPointer GetManagedThreadObject(TargetPointer threadPointer);
 ```
@@ -106,26 +106,26 @@ TargetPointer GetManagedThreadObject(TargetPointer threadPointer);
 ``` csharp
 SListReader ThreadListReader = Contracts.SList.GetReader("Thread");
 
-DacThreadStoreData GetThreadStoreData()
+ThreadStoreData GetThreadStoreData()
 {
-    TargetPointer threadStore = Target.ReadGlobalTargetPointer("s_pThreadStore");
+    TargetPointer threadStore = Target.ReadGlobalPointer("s_pThreadStore");
     var runtimeThreadStore = new ThreadStore(Target, threadStore);
 
     TargetPointer firstThread = ThreadListReader.GetHead(runtimeThreadStore.SList.Pointer);
 
-    return new DacThreadStoreData(
+    return new ThreadStoreData(
         ThreadCount : runtimeThreadStore.m_ThreadCount,
         FirstThread: firstThread,
-        FinalizerThread: Target.ReadGlobalTargetPointer("g_pFinalizerThread"),
-        GcThread: Target.ReadGlobalTargetPointer("g_pSuspensionThread"));
+        FinalizerThread: Target.ReadGlobalPointer("g_pFinalizerThread"),
+        GCThread: Target.ReadGlobalPointer("g_pSuspensionThread"));
 }
 
 DacThreadStoreCounts GetThreadCounts()
 {
-    TargetPointer threadStore = Target.ReadGlobalTargetPointer("s_pThreadStore");
+    TargetPointer threadStore = Target.ReadGlobalPointer("s_pThreadStore");
     var runtimeThreadStore = new ThreadStore(Target, threadStore);
 
-    return new DacThreadStoreCounts(
+    return new ThreadStoreCounts(
         ThreadCount : runtimeThreadStore.m_ThreadCount,
         UnstartedThreadCount : runtimeThreadStore.m_UnstartedThreadCount,
         BackgroundThreadCount : runtimeThreadStore.m_BackgroundThreadCount,
@@ -133,7 +133,7 @@ DacThreadStoreCounts GetThreadCounts()
         DeadThreadCount: runtimeThreadStore.m_DeadThreadCount,
 }
 
-DacThreadData GetThreadData(TargetPointer threadPointer)
+ThreadData GetThreadData(TargetPointer threadPointer)
 {
     var runtimeThread = new Thread(Target, threadPointer);
 
@@ -150,7 +150,7 @@ DacThreadData GetThreadData(TargetPointer threadPointer)
         firstNestedException = runtimeThread.m_ExceptionState.m_currentExInfo.m_pPrevNestedInfo;
     }
 
-    return new DacThread(
+    return new ThreadData(
         ThreadId : runtimeThread.m_ThreadId,
         OsThreadId : (OsThreadId)runtimeThread.m_OSThreadId,
         State : (ThreadState)runtimeThread.m_State,

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -159,7 +159,7 @@ ThreadData GetThreadData(TargetPointer threadPointer)
         AllocContextLimit : thread.m_alloc_context.alloc_limit,
         Frame : thread.m_pFrame,
         TEB : thread.Has_m_pTEB ? thread.m_pTEB : TargetPointer.Null,
-        LastThreadObjectHandle : new DacGCHandle(thread.m_LastThrownObjectHandle),
+        LastThrownObjectHandle : new DacGCHandle(thread.m_LastThrownObjectHandle),
         FirstNestedException : firstNestedException,
         NextThread : ThreadListReader.GetHead.GetNext(threadPointer)
     );

--- a/docs/design/datacontracts/contract_csharp_api_design.cs
+++ b/docs/design/datacontracts/contract_csharp_api_design.cs
@@ -40,7 +40,7 @@ namespace DataContracts
     struct TargetNInt
     {
         public long Value;
-        // Add a full set of operators to support arithmetic as well as casting to/from TargetPointer 
+        // Add a full set of operators to support arithmetic as well as casting to/from TargetPointer
     }
 
     struct TargetNUInt
@@ -72,99 +72,43 @@ namespace DataContracts
         public FieldType Type;
     }
 
-    interface IAlgorithmContract
-    {
-        void Init();
-    }
-
     interface IContract
     {
         string Name { get; }
         uint Version { get; }
     }
-        class Target
+
+    class Target
     {
         // Users of the data contract may adjust this number to force re-reading of all data
         public int CurrentEpoch = 0;
 
-        sbyte ReadInt8(TargetPointer pointer);
-        byte ReadUInt8(TargetPointer pointer);
-        short ReadInt16(TargetPointer pointer);
-        ushort ReadUInt16(TargetPointer pointer);
-        int ReadInt32(TargetPointer pointer);
-        uint ReadUInt32(TargetPointer pointer);
-        long ReadInt64(TargetPointer pointer);
-        ulong ReadUInt64(TargetPointer pointer);
-        TargetPointer ReadTargetPointer(TargetPointer pointer);
-        TargetNInt ReadNInt(TargetPointer pointer);
-        TargetNUInt ReadNUint(TargetPointer pointer);
+        public T Read<T>(ulong address) where T : unmanaged, IBinaryInteger<T>, IMinMaxValue<T>;
+        TargetPointer ReadPointer(ulong address);
+
         byte[] ReadByteArray(TargetPointer pointer, ulong size);
         void FillByteArray(TargetPointer pointer, byte[] array, ulong size);
-
-        bool TryReadInt8(TargetPointer pointer, out sbyte value);
-        bool TryReadUInt8(TargetPointer pointer, out byte value);
-        bool TryReadInt16(TargetPointer pointer, out short value);
-        bool TryReadUInt16(TargetPointer pointer, out ushort value);
-        bool TryReadInt32(TargetPointer pointer, out int value);
-        bool TryReadUInt32(TargetPointer pointer, out uint value);
-        bool TryReadInt64(TargetPointer pointer, out long value);
-        bool TryReadUInt64(TargetPointer pointer, out ulong value);
-        bool TryReadTargetPointer(TargetPointer pointer, out TargetPointer value);
-        bool TryReadNInt(TargetPointer pointer, out TargetNInt value);
-        bool TryReadNUInt(TargetPointer pointer, out TargetNUInt value);
-        bool TryReadByteArray(TargetPointer pointer, ulong size, out byte[] value);
-        bool TryFillByteArray(TargetPointer pointer, byte[] array, ulong size);
 
         // If pointer is 0, then the return value will be 0
         TargetPointer GetTargetPointerForField(TargetPointer pointer, FieldLayout fieldLayout);
 
-        sbyte ReadGlobalInt8(string globalName);
-        byte ReadGlobalUInt8(string globalName);
-        short ReadGlobalInt16(string globalName);
-        ushort ReadGlobalUInt16(string globalName);
-        int ReadGlobalInt32(string globalName);
-        uint ReadGlobalUInt32(string globalName);
-        long ReadGlobalInt64(string globalName);
-        ulong ReadGlobalUInt64(string globalName);
-        TargetPointer ReadGlobalTargetPointer(string globalName);
+        T ReadGlobal<T>(string globalName) where T : unmanaged, IBinaryInteger<T>, IMinMaxValue<T>;
+        TargetPointer ReadGlobalPointer(string globalName);
 
-        bool TryReadGlobalInt8(string globalName, out sbyte value);
-        bool TryReadGlobalUInt8(string globalName, out byte value);
-        bool TryReadGlobalInt16(string globalName, out short value);
-        bool TryReadGlobalUInt16(string globalName, out ushort value);
-        bool TryReadGlobalInt32(string globalName, out int value);
-        bool TryReadGlobalUInt32(string globalName, out uint value);
-        bool TryReadGlobalInt64(string globalName, out long value);
-        bool TryReadGlobalUInt64(string globalName, out ulong value);
-        bool TryReadGlobalTargetPointer(string globalName, out TargetPointer value);
+        Contracts.Registry Contracts { get; }
+    }
 
-        Contracts Contract { get; }
-
-        partial class Contracts
+    // Types defined by contracts live here
+    namespace Contracts
+    {
+        class Registry
         {
-            FieldLayout GetFieldLayout(string typeName, string fieldName);
-            bool TryGetFieldLayout(string typeName, string fieldName, out FieldLayout layout);
-            int GetTypeSize(string typeName);
-            bool TryGetTypeSize(string typeName, out int size);
-
-            object GetContract(string contractName);
-            bool TryGetContract(string contractName, out object contract);
-
             // Every contract that is defined has a field here. As an example this document defines a MethodTableContract
             // If the contract is not supported by the runtime in use, then the implementation of the contract will be the base type which
             // is defined to throw if it is ever used.
 
             // List of contracts will be inserted here by source generator
             MethodTableContract MethodTableContract;
-        }
-    }
-
-    // Types defined by contracts live here
-    namespace ContractDefinitions
-    {
-        class CompositeContract
-        {
-            List<Tuple<string, uint>> Subcontracts;
         }
 
         class DataStructureContract
@@ -173,8 +117,8 @@ namespace DataContracts
             List<Tuple<string, FieldLayout>> FieldData;
         }
 
-        // Insert Algorithmic Contract definitions here
-        class MethodTableContract
+        // Insert contract definitions here
+        interface MethodTableContract : IContract
         {
             public virtual int DynamicTypeID(TargetPointer methodTablePointer) { throw new NotImplementedException(); }
             public virtual int BaseSize(TargetPointer methodTablePointer) { throw new NotImplementedException(); }
@@ -207,7 +151,7 @@ namespace DataContracts
         }
 
         [DataContractAlgorithm(1)]
-        class MethodTableContract_1 : ContractDefinitions.MethodTableContract, IAlgorithmContract
+        readonly struct MethodTableContract_1 : Contracts.MethodTableContract
         {
             DataContracts.Target Target;
             readonly uint ContractVersion;
@@ -219,7 +163,7 @@ namespace DataContracts
 
         // This is used for version 2 and 3 of the contract, where the dynamic type id is no longer present, and baseSize has a new limitation in that it can only be a value up to 0x1FFFFFFF in v3
         [DataContractAlgorithm(2, 3)]
-        class MethodTableContract_2 : ContractDefinitions.MethodTableContract, IAlgorithmContract
+        readonly struct MethodTableContract_2 : Contracts.MethodTableContract
         {
             DataContracts.Target Target;
             readonly uint ContractVersion;

--- a/docs/design/datacontracts/contract_csharp_api_design.cs
+++ b/docs/design/datacontracts/contract_csharp_api_design.cs
@@ -78,7 +78,7 @@ namespace DataContracts
         uint Version { get; }
     }
 
-    class Target
+    sealed class Target
     {
         // Users of the data contract may adjust this number to force re-reading of all data
         public int CurrentEpoch = 0;

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -1229,6 +1229,7 @@ public:
 
     HRESULT Initialize(void);
 
+    HRESULT GetThreadDataImpl(CLRDATA_ADDRESS threadAddr, struct DacpThreadData *threadData);
     HRESULT GetThreadStoreDataImpl(struct DacpThreadStoreData *data);
 
     BOOL IsExceptionFromManagedCode(EXCEPTION_RECORD * pExceptionRecord);

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -105,7 +105,10 @@ CDAC_TYPES_BEGIN()
 
 CDAC_TYPE_BEGIN(Thread)
 CDAC_TYPE_INDETERMINATE(Thread)
+CDAC_TYPE_FIELD(Thread, /*uint32*/, Id, cdac_offsets<Thread>::Id)
+CDAC_TYPE_FIELD(Thread, /*nuint*/, OSId, cdac_offsets<Thread>::OSId)
 CDAC_TYPE_FIELD(Thread, GCHandle, GCHandle, cdac_offsets<Thread>::ExposedObject)
+CDAC_TYPE_FIELD(Thread, GCHandle, LastThrownObject, cdac_offsets<Thread>::LastThrownObject)
 CDAC_TYPE_FIELD(Thread, pointer, LinkNext, cdac_offsets<Thread>::Link)
 CDAC_TYPE_END(Thread)
 

--- a/src/coreclr/debug/runtimeinfo/datadescriptor.h
+++ b/src/coreclr/debug/runtimeinfo/datadescriptor.h
@@ -111,8 +111,12 @@ CDAC_TYPE_END(Thread)
 
 CDAC_TYPE_BEGIN(ThreadStore)
 CDAC_TYPE_INDETERMINATE(ThreadStore)
-CDAC_TYPE_FIELD(ThreadStore, /*omit type*/, ThreadCount, cdac_offsets<ThreadStore>::ThreadCount)
-CDAC_TYPE_FIELD(ThreadStore, /*omit type*/, ThreadList, cdac_offsets<ThreadStore>::ThreadList)
+CDAC_TYPE_FIELD(ThreadStore, /*SLink*/, FirstThreadLink, cdac_offsets<ThreadStore>::FirstThreadLink)
+CDAC_TYPE_FIELD(ThreadStore, /*int32*/, ThreadCount, cdac_offsets<ThreadStore>::ThreadCount)
+CDAC_TYPE_FIELD(ThreadStore, /*int32*/, UnstartedCount, cdac_offsets<ThreadStore>::UnstartedCount)
+CDAC_TYPE_FIELD(ThreadStore, /*int32*/, BackgroundCount, cdac_offsets<ThreadStore>::BackgroundCount)
+CDAC_TYPE_FIELD(ThreadStore, /*int32*/, PendingCount, cdac_offsets<ThreadStore>::PendingCount)
+CDAC_TYPE_FIELD(ThreadStore, /*int32*/, DeadCount, cdac_offsets<ThreadStore>::DeadCount)
 CDAC_TYPE_END(ThreadStore)
 
 CDAC_TYPE_BEGIN(GCHandle)
@@ -123,6 +127,8 @@ CDAC_TYPES_END()
 
 CDAC_GLOBALS_BEGIN()
 CDAC_GLOBAL_POINTER(ThreadStore, &ThreadStore::s_pThreadStore)
+CDAC_GLOBAL_POINTER(FinalizerThread, &::g_pFinalizerThread)
+CDAC_GLOBAL_POINTER(GCThread, &::g_pSuspensionThread)
 #if FEATURE_EH_FUNCLETS
 CDAC_GLOBAL(FeatureEHFunclets, uint8, 1)
 #else

--- a/src/coreclr/inc/slist.h
+++ b/src/coreclr/inc/slist.h
@@ -26,6 +26,8 @@
 #ifndef _H_SLIST_
 #define _H_SLIST_
 
+#include "cdacoffsets.h"
+
 //------------------------------------------------------------------
 // struct SLink, to use a singly linked list
 // have a data member m_Link of type SLink in your class
@@ -117,6 +119,8 @@ protected:
     SLink  m_link; // slink.m_pNext == Null
     PTR_SLink m_pHead;
     PTR_SLink m_pTail;
+
+    template<typename U> friend struct ::cdac_offsets;
 
     // get the list node within the object
     static SLink* GetLink (T* pLink)

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4307,8 +4307,12 @@ public:
 template<>
 struct cdac_offsets<ThreadStore>
 {
-    static constexpr size_t ThreadList = offsetof(ThreadStore, m_ThreadList);
+    static constexpr size_t FirstThreadLink = offsetof(ThreadStore, m_ThreadList) + offsetof(ThreadList, m_link);
     static constexpr size_t ThreadCount = offsetof(ThreadStore, m_ThreadCount);
+    static constexpr size_t UnstartedCount = offsetof(ThreadStore, m_UnstartedThreadCount);
+    static constexpr size_t BackgroundCount = offsetof(ThreadStore, m_BackgroundThreadCount);
+    static constexpr size_t PendingCount = offsetof(ThreadStore, m_PendingThreadCount);
+    static constexpr size_t DeadCount = offsetof(ThreadStore, m_DeadThreadCount);
 };
 
 struct TSSuspendHelper {

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -4044,7 +4044,10 @@ private:
 template<>
 struct cdac_offsets<Thread>
 {
+    static constexpr size_t Id = offsetof(Thread, m_ThreadId);
+    static constexpr size_t OSId = offsetof(Thread, m_OSThreadId);
     static constexpr size_t ExposedObject = offsetof(Thread, m_ExposedObject);
+    static constexpr size_t LastThrownObject = offsetof(Thread, m_LastThrownObjectHandle);
     static constexpr size_t Link = offsetof(Thread, m_Link);
 };
 

--- a/src/native/managed/cdacreader/src/Constants.cs
+++ b/src/native/managed/cdacreader/src/Constants.cs
@@ -9,6 +9,9 @@ internal static class Constants
     {
         // See src/coreclr/debug/runtimeinfo/datadescriptor.h
         internal const string ThreadStore = nameof(ThreadStore);
+        internal const string FinalizerThread = nameof(FinalizerThread);
+        internal const string GCThread = nameof(GCThread);
+
         internal const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
     }
 }

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -5,17 +5,25 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-// TODO: [cdac] Add other counts / threads
 internal record struct ThreadStoreData(
     int ThreadCount,
-    TargetPointer FirstThread);
+    TargetPointer FirstThread,
+    TargetPointer FinalizerThread,
+    TargetPointer GCThread);
+
+internal record struct ThreadStoreCounts(
+    int UnstartedThreadCount,
+    int BackgroundThreadCount,
+    int PendingThreadCount,
+    int DeadThreadCount);
 
 internal interface IThread : IContract
 {
     static string IContract.Name { get; } = nameof(Thread);
     static IContract IContract.Create(Target target, int version)
     {
-        TargetPointer threadStore = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
+        TargetPointer threadStorePointer = target.ReadGlobalPointer(Constants.Globals.ThreadStore);
+        TargetPointer threadStore = target.ReadPointer(threadStorePointer);
         return version switch
         {
             1 => new Thread_1(target, threadStore),
@@ -24,6 +32,7 @@ internal interface IThread : IContract
     }
 
     public virtual ThreadStoreData GetThreadStoreData() => throw new NotImplementedException();
+    public virtual ThreadStoreCounts GetThreadCounts() => throw new NotImplementedException();
 }
 
 internal readonly struct Thread : IThread
@@ -35,24 +44,50 @@ internal readonly struct Thread_1 : IThread
 {
     private readonly Target _target;
     private readonly TargetPointer _threadStoreAddr;
+    private readonly ulong _threadLinkOffset;
 
     internal Thread_1(Target target, TargetPointer threadStore)
     {
         _target = target;
         _threadStoreAddr = threadStore;
+
+        Target.TypeInfo type = _target.GetTypeInfo(DataType.Thread);
+        _threadLinkOffset = (ulong)type.Fields["LinkNext"].Offset;
     }
 
     ThreadStoreData IThread.GetThreadStoreData()
     {
         Data.ThreadStore? threadStore;
-        if (!_target.ProcessedData.TryGet(_threadStoreAddr.Value, out threadStore))
+        if (!_target.ProcessedData.TryGet(_threadStoreAddr, out threadStore))
         {
             threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
 
             // Still okay if processed data is already registered by someone else
-            _ = _target.ProcessedData.TryRegister(_threadStoreAddr.Value, threadStore);
+            _ = _target.ProcessedData.TryRegister(_threadStoreAddr, threadStore);
         }
 
-        return new ThreadStoreData(threadStore.ThreadCount, threadStore.FirstThread);
+        return new ThreadStoreData(
+            threadStore.ThreadCount,
+            new TargetPointer(threadStore.FirstThreadLink - _threadLinkOffset),
+            _target.ReadGlobalPointer(Constants.Globals.FinalizerThread),
+            _target.ReadGlobalPointer(Constants.Globals.GCThread));
+    }
+
+    ThreadStoreCounts IThread.GetThreadCounts()
+    {
+        Data.ThreadStore? threadStore;
+        if (!_target.ProcessedData.TryGet(_threadStoreAddr, out threadStore))
+        {
+            threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
+
+            // Still okay if processed data is already registered by someone else
+            _ = _target.ProcessedData.TryRegister(_threadStoreAddr, threadStore);
+        }
+
+        return new ThreadStoreCounts(
+            threadStore.UnstartedCount,
+            threadStore.BackgroundCount,
+            threadStore.PendingCount,
+            threadStore.DeadCount);
     }
 }

--- a/src/native/managed/cdacreader/src/Contracts/Thread.cs
+++ b/src/native/managed/cdacreader/src/Contracts/Thread.cs
@@ -64,15 +64,7 @@ internal readonly struct Thread_1 : IThread
 
     ThreadStoreData IThread.GetThreadStoreData()
     {
-        Data.ThreadStore? threadStore;
-        if (!_target.ProcessedData.TryGet(_threadStoreAddr, out threadStore))
-        {
-            threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
-
-            // Still okay if processed data is already registered by someone else
-            _ = _target.ProcessedData.TryRegister(_threadStoreAddr, threadStore);
-        }
-
+        Data.ThreadStore threadStore = _target.ProcessedData.GetOrAdd<Data.ThreadStore>(_threadStoreAddr);
         return new ThreadStoreData(
             threadStore.ThreadCount,
             GetThreadFromLink(threadStore.FirstThreadLink),
@@ -82,15 +74,7 @@ internal readonly struct Thread_1 : IThread
 
     ThreadStoreCounts IThread.GetThreadCounts()
     {
-        Data.ThreadStore? threadStore;
-        if (!_target.ProcessedData.TryGet(_threadStoreAddr, out threadStore))
-        {
-            threadStore = new Data.ThreadStore(_target, _threadStoreAddr);
-
-            // Still okay if processed data is already registered by someone else
-            _ = _target.ProcessedData.TryRegister(_threadStoreAddr, threadStore);
-        }
-
+        Data.ThreadStore threadStore = _target.ProcessedData.GetOrAdd<Data.ThreadStore>(_threadStoreAddr);
         return new ThreadStoreCounts(
             threadStore.UnstartedCount,
             threadStore.BackgroundCount,
@@ -100,15 +84,7 @@ internal readonly struct Thread_1 : IThread
 
     ThreadData IThread.GetThreadData(TargetPointer threadPointer)
     {
-        Data.Thread? thread;
-        if (!_target.ProcessedData.TryGet(threadPointer, out thread))
-        {
-            thread = new Data.Thread(_target, threadPointer);
-
-            // Still okay if processed data is already registered by someone else.
-            _ = _target.ProcessedData.TryRegister(threadPointer, thread);
-        }
-
+        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
         return new ThreadData(
             thread.Id,
             GetThreadFromLink(thread.LinkNext));

--- a/src/native/managed/cdacreader/src/Data/IData.cs
+++ b/src/native/managed/cdacreader/src/Data/IData.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal interface IData<TSelf> where TSelf : IData<TSelf>
+{
+    static abstract TSelf Create(Target target, TargetPointer address);
+}

--- a/src/native/managed/cdacreader/src/Data/Thread.cs
+++ b/src/native/managed/cdacreader/src/Data/Thread.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class Thread
+{
+    public Thread(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.Thread);
+
+        Id = target.Read<uint>(address + (ulong)type.Fields[nameof(Id)].Offset);
+        LinkNext = target.ReadPointer(address + (ulong)type.Fields[nameof(LinkNext)].Offset);
+    }
+
+    public uint Id { get; init; }
+    internal TargetPointer LinkNext { get; init; }
+}

--- a/src/native/managed/cdacreader/src/Data/Thread.cs
+++ b/src/native/managed/cdacreader/src/Data/Thread.cs
@@ -3,8 +3,11 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal sealed class Thread
+internal sealed class Thread : IData<Thread>
 {
+    static Thread IData<Thread>.Create(Target target, TargetPointer address)
+        => new Thread(target, address);
+
     public Thread(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.Thread);

--- a/src/native/managed/cdacreader/src/Data/Thread.cs
+++ b/src/native/managed/cdacreader/src/Data/Thread.cs
@@ -14,5 +14,5 @@ internal sealed class Thread
     }
 
     public uint Id { get; init; }
-    internal TargetPointer LinkNext { get; init; }
+    public TargetPointer LinkNext { get; init; }
 }

--- a/src/native/managed/cdacreader/src/Data/ThreadStore.cs
+++ b/src/native/managed/cdacreader/src/Data/ThreadStore.cs
@@ -5,16 +5,22 @@ namespace Microsoft.Diagnostics.DataContractReader.Data;
 
 internal sealed class ThreadStore
 {
-    public ThreadStore(Target target, TargetPointer pointer)
+    public ThreadStore(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.ThreadStore);
-        TargetPointer addr = target.ReadPointer(pointer.Value);
 
-        ThreadCount = target.Read<int>(addr.Value + (ulong)type.Fields[nameof(ThreadCount)].Offset);
-        FirstThread = TargetPointer.Null;
+        ThreadCount = target.Read<int>(address + (ulong)type.Fields[nameof(ThreadCount)].Offset);
+        FirstThreadLink = target.ReadPointer(address + (ulong)type.Fields[nameof(FirstThreadLink)].Offset);
+        UnstartedCount = target.Read<int>(address + (ulong)type.Fields[nameof(UnstartedCount)].Offset);
+        BackgroundCount = target.Read<int>(address + (ulong)type.Fields[nameof(BackgroundCount)].Offset);
+        PendingCount = target.Read<int>(address + (ulong)type.Fields[nameof(PendingCount)].Offset);
+        DeadCount = target.Read<int>(address + (ulong)type.Fields[nameof(DeadCount)].Offset);
     }
 
     public int ThreadCount { get; init; }
-
-    public TargetPointer FirstThread { get; init; }
+    public TargetPointer FirstThreadLink { get; init; }
+    public int UnstartedCount { get; init; }
+    public int BackgroundCount { get; init; }
+    public int PendingCount { get; init; }
+    public int DeadCount { get; init; }
 }

--- a/src/native/managed/cdacreader/src/Data/ThreadStore.cs
+++ b/src/native/managed/cdacreader/src/Data/ThreadStore.cs
@@ -3,8 +3,11 @@
 
 namespace Microsoft.Diagnostics.DataContractReader.Data;
 
-internal sealed class ThreadStore
+internal sealed class ThreadStore : IData<ThreadStore>
 {
+    static ThreadStore IData<ThreadStore>.Create(Target target, TargetPointer address)
+        => new ThreadStore(target, address);
+
     public ThreadStore(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.ThreadStore);

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 /// Implementation of ISOSDacInterface* interfaces intended to be passed out to consumers
 /// interacting with the DAC via those COM interfaces.
 /// </summary>
+/// <remarks>
+/// Functions on <see cref="ISOSDacInterface"/> are defined with PreserveSig. Target and Contracts
+/// throw on errors. Implementations in this class should wrap logic in a try-catch and return the
+/// corresponding error code.
+/// </remarks>
 [GeneratedComClass]
 internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
 {
@@ -114,15 +119,24 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
             Contracts.IThread thread = _target.Contracts.Thread;
             Contracts.ThreadStoreData threadStoreData = thread.GetThreadStoreData();
             data->threadCount = threadStoreData.ThreadCount;
-            data->firstThread = threadStoreData.FirstThread.Value;
-            data->fHostConfig = 0;
+            data->firstThread = threadStoreData.FirstThread;
+            data->finalizerThread = threadStoreData.FinalizerThread;
+            data->gcThread = threadStoreData.GCThread;
+
+            Contracts.ThreadStoreCounts threadCounts = thread.GetThreadCounts();
+            data->unstartedThreadCount = threadCounts.UnstartedThreadCount;
+            data->backgroundThreadCount = threadCounts.BackgroundThreadCount;
+            data->pendingThreadCount = threadCounts.PendingThreadCount;
+            data->deadThreadCount = threadCounts.DeadThreadCount;
+
+            data->fHostConfig = 0; // Always 0 for non-Framework
         }
         catch (Exception ex)
         {
             return ex.HResult;
         }
 
-        return HResults.E_NOTIMPL;
+        return HResults.S_OK;
     }
 
     public unsafe int GetTLSIndex(uint* pIndex) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdacreader/src/Legacy/SOSDacImpl.cs
@@ -107,7 +107,24 @@ internal sealed partial class SOSDacImpl : ISOSDacInterface, ISOSDacInterface9
     public unsafe int GetSyncBlockCleanupData(ulong addr, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetSyncBlockData(uint number, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetThreadAllocData(ulong thread, void* data) => HResults.E_NOTIMPL;
-    public unsafe int GetThreadData(ulong thread, DacpThreadData* data) => HResults.E_NOTIMPL;
+
+    public unsafe int GetThreadData(ulong thread, DacpThreadData* data)
+    {
+        try
+        {
+            Contracts.IThread contract = _target.Contracts.Thread;
+            Contracts.ThreadData threadData = contract.GetThreadData(thread);
+            data->corThreadId = (int)threadData.Id;
+            data->nextThread = threadData.NextThread;
+        }
+        catch (Exception ex)
+        {
+            return ex.HResult;
+        }
+
+        // TODO: [cdac] Implement/populate rest of thread data fields
+        return HResults.E_NOTIMPL;
+    }
     public unsafe int GetThreadFromThinlockID(uint thinLockId, ulong* pThread) => HResults.E_NOTIMPL;
     public unsafe int GetThreadLocalModuleData(ulong thread, uint index, void* data) => HResults.E_NOTIMPL;
     public unsafe int GetThreadpoolData(void* data) => HResults.E_NOTIMPL;

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -15,8 +15,20 @@ public struct TargetPointer
 
     public ulong Value;
     public TargetPointer(ulong value) => Value = value;
+
+    public static implicit operator ulong(TargetPointer p) => p.Value;
+    public static implicit operator TargetPointer(ulong v) => new TargetPointer(v);
 }
 
+/// <summary>
+/// Representation of the target under inspection
+/// </summary>
+/// <remarks>
+/// This class provides APIs used by contracts for reading from the target and getting type and globals
+/// information based on the target's contract descriptor. Like the contracts themselves in cdacreader,
+/// these are throwing APIs. Any callers at the boundaries (for example, unmanaged entry points, COM)
+/// should handle any exceptions.
+/// </remarks>
 public sealed unsafe class Target
 {
     public record struct TypeInfo

--- a/src/native/managed/cdacreader/src/Target.cs
+++ b/src/native/managed/cdacreader/src/Target.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using Microsoft.Diagnostics.DataContractReader.Data;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
@@ -63,7 +65,7 @@ public sealed unsafe class Target
     private readonly Dictionary<string, TypeInfo> _types = [];
 
     internal Contracts.Registry Contracts { get; }
-    internal DataCache ProcessedData { get; } = new DataCache();
+    internal DataCache ProcessedData { get; }
 
     public static bool TryCreate(ulong contractDescriptor, delegate* unmanaged<ulong, byte*, uint, void*, int> readFromTarget, void* readContext, out Target? target)
     {
@@ -81,6 +83,7 @@ public sealed unsafe class Target
     private Target(Configuration config, ContractDescriptorParser.ContractDescriptor descriptor, TargetPointer[] pointerData, Reader reader)
     {
         Contracts = new Contracts.Registry(this);
+        ProcessedData = new DataCache(this);
         _config = config;
         _reader = reader;
 
@@ -340,14 +343,29 @@ public sealed unsafe class Target
     /// </summary>
     internal sealed class DataCache
     {
+        private readonly Target _target;
         private readonly Dictionary<(ulong, Type), object?> _readDataByAddress = [];
 
-        public bool TryRegister<T>(ulong address, T data)
+        public DataCache(Target target)
         {
-            return _readDataByAddress.TryAdd((address, typeof(T)), data);
+            _target = target;
         }
 
-        public bool TryGet<T>(ulong address, [NotNullWhen(true)] out T? data)
+        public T GetOrAdd<T>(TargetPointer address) where T : IData<T>
+        {
+            if (TryGet(address, out T? result))
+                return result;
+
+            T constructed = T.Create(_target, address);
+            if (_readDataByAddress.TryAdd((address, typeof(T)), constructed))
+                return constructed;
+
+            bool found = TryGet(address, out result);
+            Debug.Assert(found);
+            return result!;
+        }
+
+        private bool TryGet<T>(ulong address, [NotNullWhen(true)] out T? data)
         {
             data = default;
             if (!_readDataByAddress.TryGetValue((address, typeof(T)), out object? dataObj))


### PR DESCRIPTION
- Implement `GetThreadStoreData` and `GetThreadCounts` in `Thread` contract
- Finish implementing `ISOSDacInterface::GetThreadStoreData` in cDAC
  - Add specific threads (first in thread store, Finalizer, GC) and counts
- Make existing DAC call into cDAC for `GetThreadData` if available
  - Only fills out managed thread ID and next thread right now - always returns E_NOTIMPL
- Update the example C# API in docs to be closer to what we have now

Contributes to https://github.com/dotnet/runtime/issues/99298

cc @lambdageek 