### PR TITLE
Build against Y2038-compatible glibc for linux arm32

### DIFF
--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -17,7 +17,7 @@ extends:
 
     containers:
       linux_arm:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm-net9.0-20240507035943-1390eea
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-cross-arm-net9.0
         env:
           ROOTFS_DIR: /crossrootfs/arm
 

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -63,9 +63,9 @@ jobs:
     # Linux arm
     - ${{ if eq(parameters.platform, 'linux_arm') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - (Ubuntu.1804.Arm32.Open)Ubuntu.2004.Armarch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7
+        - (Debian.12.Arm32.Open)Ubuntu.2004.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm32v7
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - (Ubuntu.1804.Arm32)Ubuntu.2004.Armarch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7
+        - (Debian.12.Arm32)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm32v7
 
     # Linux arm64
     - ${{ if eq(parameters.platform, 'linux_arm64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -26,7 +26,7 @@ jobs:
     # Linux arm
     - ${{ if eq(parameters.platform, 'linux_arm') }}:
       - ${{ if or(eq(parameters.jobParameters.isExtraPlatformsBuild, true), eq(parameters.jobParameters.includeAllPlatforms, true)) }}:
-        - (Debian.11.Arm32.Open)Ubuntu.2004.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-11-helix-arm32v7
+        - (Debian.12.Arm32.Open)Ubuntu.2004.ArmArch.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm32v7
 
     # Linux armv6
     - ${{ if eq(parameters.platform, 'linux_armv6') }}:

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -972,10 +972,7 @@ int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
             return 0;
         }
 
-        // Builds of openssl that use 32-bit time_t expect it to be passed to X509_VERIFY_PARAM_set_time in r1.
-        // Builds that use 64-bit time_t expect it to be passed in r2:r3, because the ARM ABI specifies:
-        // > If the argument requires double-word alignment (8-byte), the NCRN is rounded up to the next even register number.
-        // Casting to a signature that takes int32_t ensures it will be passed in r1, not r2:r3.
+        // Cast to a signature that takes a 32-bit value for the time.
         ((void (*)(X509_VERIFY_PARAM*, int32_t))(void*)(X509_VERIFY_PARAM_set_time))(verifyParams, (int32_t)verifyTime);
         return 1;
     }

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -7,7 +7,10 @@
 #include "pal_safecrt.h"
 #include "pal_x509.h"
 #include "openssl.h"
+
+#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 #include "opensslshim.h"
+#endif
 
 #include <assert.h>
 #include <limits.h>

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -965,20 +965,23 @@ int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
     }
 
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
-    // We support ARM32 linux distros that have Y2038-compatible glibc (those which support _TIME_BITS).
-    // Some such distros have not yet switched to _TIME_BITS=64 by default, so we may be running against an openssl
-    // that expects 32-bit time_t even though our time_t is 64-bit.
+    if (g_libSslUses32BitTime)
+    {
+        if (verifyTime > INT_MAX || verifyTime < INT_MIN)
+        {
+            return 0;
+        }
 
-    // Builds of openssl that use 32-bit time_t expect it to be passed to X509_VERIFY_PARAM_set_time in r1.
-    // Builds that use 64-bit time_t expect it to be passed in r2:r3, because the ARM ABI specifies:
-    // > If the argument requires double-word alignment (8-byte), the NCRN is rounded up to the next even register number.
-
-    // Let's pretend we're calling a function that takes both an int32_t and a time_t. This ensures that we set both
-    // r1 (to the low bits of our time_t) and r2:r3 (to the full time_t) which will satisfy either ABI.
-    ((void (*)(X509_VERIFY_PARAM*, int32_t, time_t))(void*)(X509_VERIFY_PARAM_set_time))(verifyParams, (int32_t)verifyTime, verifyTime);
-#else
-    X509_VERIFY_PARAM_set_time(verifyParams, verifyTime);
+        // Builds of openssl that use 32-bit time_t expect it to be passed to X509_VERIFY_PARAM_set_time in r1.
+        // Builds that use 64-bit time_t expect it to be passed in r2:r3, because the ARM ABI specifies:
+        // > If the argument requires double-word alignment (8-byte), the NCRN is rounded up to the next even register number.
+        // Casting to a signature that takes int32_t ensures it will be passed in r1, not r2:r3.
+        ((void (*)(X509_VERIFY_PARAM*, int32_t))(void*)(X509_VERIFY_PARAM_set_time))(verifyParams, (int32_t)verifyTime);
+        return 1;
+    }
 #endif
+
+    X509_VERIFY_PARAM_set_time(verifyParams, verifyTime);
     return 1;
 }
 

--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -7,10 +7,7 @@
 #include "pal_safecrt.h"
 #include "pal_x509.h"
 #include "openssl.h"
-
-#ifdef FEATURE_DISTRO_AGNOSTIC_SSL
 #include "opensslshim.h"
-#endif
 
 #include <assert.h>
 #include <limits.h>
@@ -964,7 +961,7 @@ int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
         return 0;
     }
 
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
     if (g_libSslUses32BitTime)
     {
         if (verifyTime > INT_MAX || verifyTime < INT_MIN)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -226,12 +226,14 @@ void InitializeOpenSSLShim(void)
     }
 
 #if defined(TARGET_ARM) && defined(TARGET_LINUX)
-    // Detect whether openssl uses 32-bit or 64-bit time_t.
     // This value will represent a time in year 2038 if 64-bit time is used,
     // or 1901 if the lower 32 bits are interpreted as a 32-bit time_t value.
     time_t timeVal = (time_t)INT_MAX + 1;
     struct tm tmVal = { 0 };
 
+    // Detect whether openssl is using 32-bit or 64-bit time_t.
+    // If it uses 32-bit time_t, little-endianness means that the pointer
+    // will be interpreted as a pointer to the lower 32 bits of timeVal.
     // tm_year is the number of years since 1900.
     if (!OPENSSL_gmtime(&timeVal, &tmVal) || (tmVal.tm_year != 138 && tmVal.tm_year != 1))
     {

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -25,6 +25,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION_110
 #undef REQUIRED_FUNCTION
+#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+TYPEOF(OPENSSL_gmtime) OPENSSL_gmtime_ptr;
+#endif
 
 // x.x.x, considering the max number of decimal digits for each component
 #define MaxVersionStringLength 32
@@ -214,6 +217,10 @@ void InitializeOpenSSLShim(void)
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION_110
 #undef REQUIRED_FUNCTION
+#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+    if (!(OPENSSL_gmtime_ptr = (TYPEOF(OPENSSL_gmtime))(dlsym(libssl, "OPENSSL_gmtime")))) { fprintf(stderr, "Cannot get required symbol OPENSSL_gmtime from libssl\n"); abort(); }
+#endif
+
 
     // Sanity check that we have at least one functioning way of reporting errors.
     if (ERR_put_error_ptr == &local_ERR_put_error)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -623,7 +623,6 @@ extern bool g_libSslUses32BitTime;
     REQUIRED_FUNCTION(SSL_version) \
     FALLBACK_FUNCTION(X509_check_host) \
     REQUIRED_FUNCTION(X509_check_purpose) \
-    REQUIRED_FUNCTION(X509_cmp_current_time) \
     REQUIRED_FUNCTION(X509_cmp_time) \
     REQUIRED_FUNCTION(X509_CRL_free) \
     FALLBACK_FUNCTION(X509_CRL_get0_nextUpdate) \
@@ -1155,7 +1154,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define TLS_method TLS_method_ptr
 #define X509_check_host X509_check_host_ptr
 #define X509_check_purpose X509_check_purpose_ptr
-#define X509_cmp_current_time X509_cmp_current_time_ptr
 #define X509_cmp_time X509_cmp_time_ptr
 #define X509_CRL_free X509_CRL_free_ptr
 #define X509_CRL_get0_nextUpdate X509_CRL_get0_nextUpdate_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -187,6 +187,10 @@ int EVP_DigestSqueeze(EVP_MD_CTX *ctx, unsigned char *out, size_t outlen);
 
 #define API_EXISTS(fn) (fn != NULL)
 
+#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+extern bool g_libSslUses32BitTime;
+#endif
+
 // List of all functions from the libssl that are used in the System.Security.Cryptography.Native.
 // Forgetting to add a function here results in build failure with message reporting the function
 // that needs to be added.
@@ -490,6 +494,7 @@ int EVP_DigestSqueeze(EVP_MD_CTX *ctx, unsigned char *out, size_t outlen);
     REQUIRED_FUNCTION(OCSP_RESPONSE_new) \
     LEGACY_FUNCTION(OPENSSL_add_all_algorithms_conf) \
     REQUIRED_FUNCTION(OPENSSL_cleanse) \
+    REQUIRED_FUNCTION(OPENSSL_gmtime) \
     REQUIRED_FUNCTION_110(OPENSSL_init_ssl) \
     RENAMED_FUNCTION(OPENSSL_sk_free, sk_free) \
     RENAMED_FUNCTION(OPENSSL_sk_new_null, sk_new_null) \
@@ -1018,6 +1023,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define OCSP_RESPONSE_new OCSP_RESPONSE_new_ptr
 #define OPENSSL_add_all_algorithms_conf OPENSSL_add_all_algorithms_conf_ptr
 #define OPENSSL_cleanse OPENSSL_cleanse_ptr
+#define OPENSSL_gmtime OPENSSL_gmtime_ptr
 #define OPENSSL_init_ssl OPENSSL_init_ssl_ptr
 #define OPENSSL_sk_free OPENSSL_sk_free_ptr
 #define OPENSSL_sk_new_null OPENSSL_sk_new_null_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -187,7 +187,7 @@ int EVP_DigestSqueeze(EVP_MD_CTX *ctx, unsigned char *out, size_t outlen);
 
 #define API_EXISTS(fn) (fn != NULL)
 
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
 extern bool g_libSslUses32BitTime;
 #endif
 

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -494,7 +494,6 @@ extern bool g_libSslUses32BitTime;
     REQUIRED_FUNCTION(OCSP_RESPONSE_new) \
     LEGACY_FUNCTION(OPENSSL_add_all_algorithms_conf) \
     REQUIRED_FUNCTION(OPENSSL_cleanse) \
-    REQUIRED_FUNCTION(OPENSSL_gmtime) \
     REQUIRED_FUNCTION_110(OPENSSL_init_ssl) \
     RENAMED_FUNCTION(OPENSSL_sk_free, sk_free) \
     RENAMED_FUNCTION(OPENSSL_sk_new_null, sk_new_null) \
@@ -721,7 +720,9 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION_110
 #undef REQUIRED_FUNCTION
-
+#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
+#endif
 // Redefine all calls to OpenSSL functions as calls through pointers that are set
 // to the functions from the libssl.so selected by the shim.
 #define a2d_ASN1_OBJECT a2d_ASN1_OBJECT_ptr

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -960,7 +960,7 @@ static X509VerifyStatusCode CheckOcspGetExpiry(OCSP_REQUEST* req,
             {
                 time_t currentTime = time(NULL);
                 int nextUpdComparison = 0;
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
                 // If openssl uses 32-bit time_t and the current time doesn't fit in 32 bits,
                 // skip checking the status/nextupd, and fall through to return PAL_X509_V_ERR_UNABLE_TO_GET_CRL.
                 if (!g_libSslUses32BitTime || (currentTime >= INT_MIN && currentTime <= INT_MAX))

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -999,7 +999,22 @@ static X509VerifyStatusCode CheckOcspGetExpiry(OCSP_REQUEST* req,
                 {
                     time_t oldest = GetIssuanceWindowStart();
 
-                    if (X509_cmp_time(thisupd, &oldest) > 0)
+                    int cmp = 0;
+#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+                    if (g_libSslUses32BitTime)
+                    {
+                        if (oldest <= INT_MAX && oldest >= INT_MIN)
+                        {
+                            cmp  = X509_cmp_time(thisupd, &oldest);
+                        }
+                    }
+                    else
+#endif
+                    {
+                        cmp = X509_cmp_time(thisupd, &oldest);
+                    }
+
+                    if (cmp > 0)
                     {
                         *canCache = 1;
 

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -966,28 +966,28 @@ static X509VerifyStatusCode CheckOcspGetExpiry(OCSP_REQUEST* req,
                 if (!g_libSslUses32BitTime || (currentTime >= INT_MIN && currentTime <= INT_MAX))
 #endif
                 {
-                // X509_cmp_current_time uses 0 for error already, so we can use it when there's a null value.
-                // 1 means the nextupd value is in the future, -1 means it is now-or-in-the-past.
-                // Following with OpenSSL conventions, we'll accept "now" as "the past".
+                    // X509_cmp_current_time uses 0 for error already, so we can use it when there's a null value.
+                    // 1 means the nextupd value is in the future, -1 means it is now-or-in-the-past.
+                    // Following with OpenSSL conventions, we'll accept "now" as "the past".
                     nextUpdComparison = nextupd == NULL ? 0 : X509_cmp_time(nextupd, &currentTime);
 
-                // Un-revoking is rare, so reporting revoked on an expired response has a low chance
-                // of a false-positive.
-                //
-                // For non-revoked responses, a next-update value in the past counts as expired.
-                if (status == V_OCSP_CERTSTATUS_REVOKED)
-                {
-                    ret = PAL_X509_V_ERR_CERT_REVOKED;
-                }
-                else
-                {
-                    if (nextupd != NULL && nextUpdComparison <= 0)
+                    // Un-revoking is rare, so reporting revoked on an expired response has a low chance
+                    // of a false-positive.
+                    //
+                    // For non-revoked responses, a next-update value in the past counts as expired.
+                    if (status == V_OCSP_CERTSTATUS_REVOKED)
                     {
-                        ret = PAL_X509_V_ERR_CRL_HAS_EXPIRED;
+                        ret = PAL_X509_V_ERR_CERT_REVOKED;
                     }
-                    else if (status == V_OCSP_CERTSTATUS_GOOD)
+                    else
                     {
-                        ret = PAL_X509_V_OK;
+                        if (nextupd != NULL && nextUpdComparison <= 0)
+                        {
+                            ret = PAL_X509_V_ERR_CRL_HAS_EXPIRED;
+                        }
+                        else if (status == V_OCSP_CERTSTATUS_GOOD)
+                        {
+                            ret = PAL_X509_V_OK;
                         }
                     }
                 }


### PR DESCRIPTION
Reintroduces the fix for Y2038 support on arm32 linux (https://github.com/dotnet/runtime/pull/102059), which was reverted due to problems running against openssl built with _TIME_BITS=32. Thanks to @davidwrighton for help diagnosing the issue.

Fixes https://github.com/dotnet/runtime/issues/101444 (both the originally reported issue, and the test failures mentioned in https://github.com/dotnet/runtime/issues/101444#issuecomment-2111415106).

Supports: https://github.com/dotnet/runtime/issues/91826
