### PR TITLE
Fix issue where the IPC server can fully consume a CPU core and prevent incoming connections

### DIFF
--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -173,6 +173,16 @@ ds_ipc_free (DiagnosticsIpc *ipc)
 	ep_rt_object_free (ipc);
 }
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc)
+{
+	if (!ipc)
+		return;
+
+	ipc->pipe = INVALID_HANDLE_VALUE;
+	ipc->is_listening = false;
+}
+
 int32_t
 ds_ipc_poll (
 	DiagnosticsIpcPollHandle *poll_handles_data,
@@ -192,6 +202,10 @@ ds_ipc_poll (
 			// SERVER
 			EP_ASSERT (poll_handles_data [i].ipc->mode == DS_IPC_CONNECTION_MODE_LISTEN);
 			handles [i] = poll_handles_data [i].ipc->overlap.hEvent;
+			if (handles [i] == INVALID_HANDLE_VALUE) {
+				// Invalid handle, wait will fail. Signal error
+				poll_handles_data [i].events = DS_IPC_POLL_EVENTS_ERR;
+			}
 		} else {
 			// CLIENT
 			bool success = true;

--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -179,7 +179,16 @@ ds_ipc_reset (DiagnosticsIpc *ipc)
 	if (!ipc)
 		return;
 
-	ipc->pipe = INVALID_HANDLE_VALUE;
+	if (ipc->pipe != INVALID_HANDLE_VALUE) {
+		CloseHandle (ipc->pipe);
+		ipc->pipe = INVALID_HANDLE_VALUE;
+	}
+
+	if (ipc->overlap.hEvent != INVALID_HANDLE_VALUE) {
+		CloseHandle (ipc->overlap.hEvent);
+		ipc->overlap.hEvent = INVALID_HANDLE_VALUE;
+	}
+
 	ipc->is_listening = false;
 }
 

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -1064,6 +1064,11 @@ ds_ipc_free (DiagnosticsIpc *ipc)
 	ep_rt_object_free (ipc);
 }
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc)
+{
+}
+
 int32_t
 ds_ipc_poll (
 	DiagnosticsIpcPollHandle *poll_handles_data,

--- a/src/native/eventpipe/ds-ipc-pal.h
+++ b/src/native/eventpipe/ds-ipc-pal.h
@@ -35,6 +35,9 @@ ds_ipc_alloc (
 void
 ds_ipc_free (DiagnosticsIpc *ipc);
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc);
+
 // Poll
 // Parameters:
 // - IpcPollHandle * poll_handles_data: Array of IpcPollHandles to poll


### PR DESCRIPTION
If the call to CreateNamedPipe fails here: https://github.com/dotnet/runtime/blob/af11dbc1a34538d9a38d39a7c96ddd5e7fc6907b/src/native/eventpipe/ds-ipc-pal-namedpipe.c#L372-L387

We will end up with an invalid handle for the pipe and the overlapped IO event. There currently is no code that tries to reset the connection and we will repeatedly try to poll an invalid handle, leading to one core being pegged as the wait fails due to an invalid handle and we keep waiting.

This PR makes it so we will call `ds_ipc_listen` when we run in to an error, which will reconnect to the named pipe. It also adds a delay when we detect an error, so if there are undetected cases that cause the same issue we will at least not consume the whole core we are running on.