### PR TITLE
2nd call to MemoryCache.Set() with the same key same size erases entry if cache is full

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -200,6 +200,22 @@ namespace Microsoft.Extensions.Caching.Memory
 
                 priorEntry?.InvokeEvictionCallbacks();
             }
+            else if (_options.HasSizeLimit && priorEntry != null && priorEntry.Size == entry.Size)
+            {
+                bool entryAdded = coherentState._entries.TryUpdate(entry.Key, entry, priorEntry);
+
+                if (entryAdded)
+                {
+                    entry.AttachTokens();
+                }
+                else
+                {
+                    entry.SetExpired(EvictionReason.Replaced);
+                    entry.InvokeEvictionCallbacks();
+                }
+
+                priorEntry.InvokeEvictionCallbacks();
+            }
             else
             {
                 entry.SetExpired(EvictionReason.Capacity);

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -294,6 +294,28 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        public void ReplaceOldEntryWithSameSizeNewEntryAtSizeLimitCapacity()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions
+            {
+                SizeLimit = 6
+            });
+
+            AssertCacheSize(0, cache);
+
+            cache.Set("key", "oldValue", new MemoryCacheEntryOptions { Size = 6 });
+
+            Assert.Equal("oldValue", cache.Get("key"));
+
+            AssertCacheSize(6, cache);
+
+            cache.Set("key", "newValue", new MemoryCacheEntryOptions { Size = 6 });
+
+            Assert.Equal("newValue", cache.Get("key"));
+            AssertCacheSize(6, cache);
+        }
+
+        [Fact]
         public void RemovingEntryDecreasesCacheSize()
         {
             var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -293,8 +293,11 @@ namespace Microsoft.Extensions.Caching.Memory
             AssertCacheSize(0, cache); // addition was rejected due to size, and previous item with the same key removed
         }
 
-        [Fact]
-        public void ReplaceOldEntryWithSameSizeNewEntryAtSizeLimitCapacity()
+        [Theory]
+        [InlineData(6)]
+        [InlineData(5)]
+        [InlineData(2)]
+        public void ReplaceOldEntryWithSameSizeOrLessNewEntryAtSizeLimitCapacity(int newValueSize)
         {
             var cache = new MemoryCache(new MemoryCacheOptions
             {
@@ -309,10 +312,10 @@ namespace Microsoft.Extensions.Caching.Memory
 
             AssertCacheSize(6, cache);
 
-            cache.Set("key", "newValue", new MemoryCacheEntryOptions { Size = 6 });
+            cache.Set("key", "newValue", new MemoryCacheEntryOptions { Size = newValueSize });
 
             Assert.Equal("newValue", cache.Get("key"));
-            AssertCacheSize(6, cache);
+            AssertCacheSize(newValueSize, cache);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #36039 