### PR TITLE
Delete empty DebugType property from test projects

### DIFF
--- a/src/tests/GC/API/Frozen/Frozen.csproj
+++ b/src/tests/GC/API/Frozen/Frozen.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect.csproj
+++ b/src/tests/GC/API/GC/Collect.csproj
@@ -5,7 +5,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect0.csproj
+++ b/src/tests/GC/API/GC/Collect0.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/Collect1.csproj
+++ b/src/tests/GC/API/GC/Collect1.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/Collect_Aggressive.csproj
+++ b/src/tests/GC/API/GC/Collect_Aggressive.csproj
@@ -7,7 +7,6 @@
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.csproj
+++ b/src/tests/GC/API/GC/Collect_Aggressive_MultipleParameters.csproj
@@ -7,7 +7,6 @@
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Default_1.csproj
+++ b/src/tests/GC/API/GC/Collect_Default_1.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Default_2.csproj
+++ b/src/tests/GC/API/GC/Collect_Default_2.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Default_3.csproj
+++ b/src/tests/GC/API/GC/Collect_Default_3.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Forced_1.csproj
+++ b/src/tests/GC/API/GC/Collect_Forced_1.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/Collect_Forced_2.csproj
+++ b/src/tests/GC/API/GC/Collect_Forced_2.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/Collect_Forced_3.csproj
+++ b/src/tests/GC/API/GC/Collect_Forced_3.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/Collect_Optimized_1.csproj
+++ b/src/tests/GC/API/GC/Collect_Optimized_1.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Optimized_2.csproj
+++ b/src/tests/GC/API/GC/Collect_Optimized_2.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments>1</CLRTestExecutionArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_Optimized_3.csproj
+++ b/src/tests/GC/API/GC/Collect_Optimized_3.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_fail.csproj
+++ b/src/tests/GC/API/GC/Collect_fail.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Collect_neg.csproj
+++ b/src/tests/GC/API/GC/Collect_neg.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/CollectionCountTest.csproj
+++ b/src/tests/GC/API/GC/CollectionCountTest.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/Finalize.csproj
+++ b/src/tests/GC/API/GC/Finalize.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetAllocatedBytesForCurrentThread.csproj
+++ b/src/tests/GC/API/GC/GetAllocatedBytesForCurrentThread.csproj
@@ -4,7 +4,6 @@
     <HeapVerifyIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/GetGCMemoryInfo.csproj
+++ b/src/tests/GC/API/GC/GetGCMemoryInfo.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/GetGeneration.csproj
+++ b/src/tests/GC/API/GC/GetGeneration.csproj
@@ -4,7 +4,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetGenerationWR.csproj
+++ b/src/tests/GC/API/GC/GetGenerationWR.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetGenerationWR2.csproj
+++ b/src/tests/GC/API/GC/GetGenerationWR2.csproj
@@ -6,7 +6,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetGeneration_box.csproj
+++ b/src/tests/GC/API/GC/GetGeneration_box.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetGeneration_fail.csproj
+++ b/src/tests/GC/API/GC/GetGeneration_fail.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments />
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytes.csproj
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytes.csproj
@@ -4,7 +4,6 @@
     <HeapVerifyIncompatible Condition="'$(TargetArchitecture)' == 'arm'">true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/GetTotalMemory.csproj
+++ b/src/tests/GC/API/GC/GetTotalMemory.csproj
@@ -6,7 +6,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
+++ b/src/tests/GC/API/GC/GetTotalPauseDuration.csproj
@@ -12,7 +12,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/KeepAlive.csproj
+++ b/src/tests/GC/API/GC/KeepAlive.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/KeepAliveNull.csproj
+++ b/src/tests/GC/API/GC/KeepAliveNull.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/KeepAliveRecur.csproj
+++ b/src/tests/GC/API/GC/KeepAliveRecur.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GC/MaxGeneration.csproj
+++ b/src/tests/GC/API/GC/MaxGeneration.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments />
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/ReRegisterForFinalize.csproj
+++ b/src/tests/GC/API/GC/ReRegisterForFinalize.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/ReRegisterForFinalize_null.csproj
+++ b/src/tests/GC/API/GC/ReRegisterForFinalize_null.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/SuppressFinalize.csproj
+++ b/src/tests/GC/API/GC/SuppressFinalize.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/SuppressFinalize_Null.csproj
+++ b/src/tests/GC/API/GC/SuppressFinalize_Null.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/TotalMemory.csproj
+++ b/src/tests/GC/API/GC/TotalMemory.csproj
@@ -9,7 +9,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GC/TotalMemory2.csproj
+++ b/src/tests/GC/API/GC/TotalMemory2.csproj
@@ -8,7 +8,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/AddrOfPinnedObject.csproj
+++ b/src/tests/GC/API/GCHandle/AddrOfPinnedObject.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/AddrOfPinnedObject_neg.csproj
+++ b/src/tests/GC/API/GCHandle/AddrOfPinnedObject_neg.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Alloc.csproj
+++ b/src/tests/GC/API/GCHandle/Alloc.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Alloc_neg.csproj
+++ b/src/tests/GC/API/GCHandle/Alloc_neg.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Alloc_neg2.csproj
+++ b/src/tests/GC/API/GCHandle/Alloc_neg2.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Casting.csproj
+++ b/src/tests/GC/API/GCHandle/Casting.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Equality.csproj
+++ b/src/tests/GC/API/GCHandle/Equality.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Free.csproj
+++ b/src/tests/GC/API/GCHandle/Free.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Free_neg.csproj
+++ b/src/tests/GC/API/GCHandle/Free_neg.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/HandleCopy.csproj
+++ b/src/tests/GC/API/GCHandle/HandleCopy.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/IsAllocated.csproj
+++ b/src/tests/GC/API/GCHandle/IsAllocated.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Normal.csproj
+++ b/src/tests/GC/API/GCHandle/Normal.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/PinObj_neg.csproj
+++ b/src/tests/GC/API/GCHandle/PinObj_neg.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Pinned.csproj
+++ b/src/tests/GC/API/GCHandle/Pinned.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Target.csproj
+++ b/src/tests/GC/API/GCHandle/Target.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Target_neg.csproj
+++ b/src/tests/GC/API/GCHandle/Target_neg.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/ToFromIntPtr.csproj
+++ b/src/tests/GC/API/GCHandle/ToFromIntPtr.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandle/Weak.csproj
+++ b/src/tests/GC/API/GCHandle/Weak.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/GC/API/GCHandleCollector/Count.csproj
+++ b/src/tests/GC/API/GCHandleCollector/Count.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandleCollector/CtorsAndProperties.csproj
+++ b/src/tests/GC/API/GCHandleCollector/CtorsAndProperties.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandleCollector/NegTests.csproj
+++ b/src/tests/GC/API/GCHandleCollector/NegTests.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/GCHandleCollector/Usage.csproj
+++ b/src/tests/GC/API/GCHandleCollector/Usage.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/GC/API/GCSettings/InputValidation.csproj
+++ b/src/tests/GC/API/GCSettings/InputValidation.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments />
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/NoGCRegion/NoGC.csproj
+++ b/src/tests/GC/API/NoGCRegion/NoGC.csproj
@@ -6,7 +6,6 @@
     <IsLongRunningGCTest>true</IsLongRunningGCTest>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/Refresh/Refresh.csproj
+++ b/src/tests/GC/API/Refresh/Refresh.csproj
@@ -7,7 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/Finalize.csproj
+++ b/src/tests/GC/API/WeakReference/Finalize.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/Finalize2.csproj
+++ b/src/tests/GC/API/WeakReference/Finalize2.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/IsAlive.csproj
+++ b/src/tests/GC/API/WeakReference/IsAlive.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tests/GC/API/WeakReference/IsAlive_neg.csproj
+++ b/src/tests/GC/API/WeakReference/IsAlive_neg.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/NullHandle.csproj
+++ b/src/tests/GC/API/WeakReference/NullHandle.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/Target.csproj
+++ b/src/tests/GC/API/WeakReference/Target.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/TrackResurrection.csproj
+++ b/src/tests/GC/API/WeakReference/TrackResurrection.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/multipleWRs.csproj
+++ b/src/tests/GC/API/WeakReference/multipleWRs.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments>10000</CLRTestExecutionArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/API/WeakReference/multipleWRs_1.csproj
+++ b/src/tests/GC/API/WeakReference/multipleWRs_1.csproj
@@ -4,7 +4,6 @@
     <CLRTestExecutionArguments>10000 track</CLRTestExecutionArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/GC/Features/HeapExpansion/bestfit_1.csproj
+++ b/src/tests/GC/Features/HeapExpansion/bestfit_1.csproj
@@ -5,7 +5,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/Misc/Concat/ConcatTest.csproj
+++ b/src/tests/JIT/Directed/Misc/Concat/ConcatTest.csproj
@@ -4,8 +4,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ConcatTest.cs" />

--- a/src/tests/JIT/Directed/Misc/gettype/gettypetypeofmatrix_gettype.csproj
+++ b/src/tests/JIT/Directed/Misc/gettype/gettypetypeofmatrix_gettype.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gettypetypeofmatrix.cs" />

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv1_PREFIX_cs_r.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv1_PREFIX_cs_r.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv1_PREFIX_cs_ro.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv1_PREFIX_cs_ro.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv2_PREFIX_cs_r.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv2_PREFIX_cs_r.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv2_PREFIX_cs_ro.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/callconv2_PREFIX_cs_ro.csproj
@@ -4,7 +4,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/PrimitiveVT/helper.csproj
+++ b/src/tests/JIT/Directed/PREFIX/PrimitiveVT/helper.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="helper.cs" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/add_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/add_unaligned_1.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="add.il" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/add_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/add_unaligned_4.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="add.il" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgdArray_r.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgdArray_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgdArray_ro.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgdArray_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgdStatic_r.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgdStatic_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgdStatic_ro.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgdStatic_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_r.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
+++ b/src/tests/JIT/Directed/VectorABI/VectorMgdMgd_ro.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'arm64'">true</JitOptimizationSensitive>

--- a/src/tests/JIT/Directed/coverage/importer/ldfldstatic1_importer_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/ldfldstatic1_importer_r.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldfldstatic1.il" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/coverage/importer/stfldstatic1_importer_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/stfldstatic1_importer_r.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="stfldstatic1_r.il" />
     <Compile Include="stfldstatic1.il" />

--- a/src/tests/JIT/Directed/coverage/importer/subovfun1_r.ilproj
+++ b/src/tests/JIT/Directed/coverage/importer/subovfun1_r.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="subovfun1_r.il" />
     <Compile Include="subovfun1.il" />

--- a/src/tests/JIT/Directed/coverage/oldtests/tls1.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tls1.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="tls1.il" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/coverage/oldtests/tls2.ilproj
+++ b/src/tests/JIT/Directed/coverage/oldtests/tls2.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="tls2.il" />
   </ItemGroup>

--- a/src/tests/JIT/Directed/forceinlining/LargeNumberOfArgs.csproj
+++ b/src/tests/JIT/Directed/forceinlining/LargeNumberOfArgs.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="LargeNumberOfArgs.cs" />

--- a/src/tests/JIT/Directed/forceinlining/NoMetaData.csproj
+++ b/src/tests/JIT/Directed/forceinlining/NoMetaData.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NoMetaData.cs" />

--- a/src/tests/JIT/Directed/forceinlining/Recursion.csproj
+++ b/src/tests/JIT/Directed/forceinlining/Recursion.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Recursion.cs" />

--- a/src/tests/JIT/Directed/gettypetypeof/gettypetypeofmatrix_gettypetypeof.csproj
+++ b/src/tests/JIT/Directed/gettypetypeof/gettypetypeofmatrix_gettypetypeof.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
-    <DebugType />
-    <!-- Set to 'True' if the Debug? column is marked in the spreadsheet, and 'False' otherwise. -->
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/nullabletypes/constructor_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/constructor_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/constructor_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/constructor_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/constructor_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/constructor_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/constructor_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/constructor_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hashcode_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hashcode_d.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hashcode_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hashcode_do.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hashcode_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hashcode_r.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hashcode_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hashcode_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hasvalue_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hasvalue_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hasvalue_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hasvalue_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hasvalue_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hasvalue_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/hasvalue_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/hasvalue_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/invocation_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/invocation_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/invocation_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/invocation_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/invocation_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/invocation_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/invocation_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/invocation_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/tostring_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/tostring_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/tostring_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/tostring_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/tostring_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/tostring_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/tostring_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/tostring_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Directed/nullabletypes/unboxnullable_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/unboxnullable_d.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unboxnullable.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/unboxnullable_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/unboxnullable_do.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unboxnullable.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/unboxnullable_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/unboxnullable_r.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unboxnullable.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/unboxnullable_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/unboxnullable_ro.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unboxnullable.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/value_d.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/value_d.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="value.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/value_do.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/value_do.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="value.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/value_r.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/value_r.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="value.cs" />

--- a/src/tests/JIT/Directed/nullabletypes/value_ro.csproj
+++ b/src/tests/JIT/Directed/nullabletypes/value_ro.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="value.cs" />

--- a/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_d.csproj
+++ b/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_d.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CCSE.cs" />

--- a/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_do.csproj
+++ b/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_do.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CCSE.cs" />

--- a/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_r.csproj
+++ b/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_r.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CCSE.cs" />

--- a/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_ro.csproj
+++ b/src/tests/JIT/Directed/perffix/commutativecse/ccse_cs_ro.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CCSE.cs" />

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_d.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_do.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_r.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_ro.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv1_perffix_cs_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_d.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_do.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_r.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_ro.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/callconv2_perffix_cs_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_d.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_d.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_do.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_do.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_r.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_r.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_ro.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed1_cs_ro.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_d.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_d.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_do.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_do.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_r.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_r.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_ro.csproj
+++ b/src/tests/JIT/Directed/perffix/primitivevt/mixed2_cs_ro.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int16_r.csproj
+++ b/src/tests/JIT/Directed/shift/int16_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int16_ro.csproj
+++ b/src/tests/JIT/Directed/shift/int16_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int32_r.csproj
+++ b/src/tests/JIT/Directed/shift/int32_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int32_ro.csproj
+++ b/src/tests/JIT/Directed/shift/int32_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int64_r.csproj
+++ b/src/tests/JIT/Directed/shift/int64_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/int64_ro.csproj
+++ b/src/tests/JIT/Directed/shift/int64_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint16_r.csproj
+++ b/src/tests/JIT/Directed/shift/uint16_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint16_ro.csproj
+++ b/src/tests/JIT/Directed/shift/uint16_ro.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint32_r.csproj
+++ b/src/tests/JIT/Directed/shift/uint32_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint32_ro.csproj
+++ b/src/tests/JIT/Directed/shift/uint32_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint64Opt_r.csproj
+++ b/src/tests/JIT/Directed/shift/uint64Opt_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint64Opt_ro.csproj
+++ b/src/tests/JIT/Directed/shift/uint64Opt_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint64_r.csproj
+++ b/src/tests/JIT/Directed/shift/uint64_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint64_ro.csproj
+++ b/src/tests/JIT/Directed/shift/uint64_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint8_r.csproj
+++ b/src/tests/JIT/Directed/shift/uint8_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/shift/uint8_ro.csproj
+++ b/src/tests/JIT/Directed/shift/uint8_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
+++ b/src/tests/JIT/Directed/tailcall/mutual_recursion.fsproj
@@ -7,8 +7,6 @@
     <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>

--- a/src/tests/JIT/Generics/Constraints/Call_instance01_r.csproj
+++ b/src/tests/JIT/Generics/Constraints/Call_instance01_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize />
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Generics/Constraints/Call_instance01_ro.csproj
+++ b/src/tests/JIT/Generics/Constraints/Call_instance01_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Generics/Fields/getclassfrommethodparam.csproj
+++ b/src/tests/JIT/Generics/Fields/getclassfrommethodparam.csproj
@@ -7,7 +7,6 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ConvDLL.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/ConvDLL.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ConvDLL.il" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/Boxing/xlang/sinlib_cs.csproj
+++ b/src/tests/JIT/Methodical/Boxing/xlang/sinlib_cs.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="sinlib.cs" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/Coverage/b39946.ilproj
+++ b/src/tests/JIT/Methodical/Coverage/b39946.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="b39946.il" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/Coverage/b518440.ilproj
+++ b/src/tests/JIT/Methodical/Coverage/b518440.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="b518440.il" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/Coverage/hole.ilproj
+++ b/src/tests/JIT/Methodical/Coverage/hole.ilproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hole.il" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/testlib_misc.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/testlib_misc.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_d.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_do.csproj
@@ -3,7 +3,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_r.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads1_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads1_cs_ro.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_d.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_d.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_do.csproj
@@ -5,7 +5,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_r.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_r.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/cctor/misc/threads2_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/cctor/misc/threads2_cs_ro.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Methodical/stringintern/test1-xassem.csproj
+++ b/src/tests/JIT/Methodical/stringintern/test1-xassem.csproj
@@ -4,7 +4,6 @@
     <DefineConstants>$(DefineConstants);XASSEM</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/stringintern/test2-xassem.csproj
+++ b/src/tests/JIT/Methodical/stringintern/test2-xassem.csproj
@@ -4,7 +4,6 @@
     <DefineConstants>$(DefineConstants);XASSEM</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/stringintern/test4-xassem.csproj
+++ b/src/tests/JIT/Methodical/stringintern/test4-xassem.csproj
@@ -4,7 +4,6 @@
     <DefineConstants>$(DefineConstants);XASSEM</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Methodical/stringintern/testgenstr.csproj
+++ b/src/tests/JIT/Methodical/stringintern/testgenstr.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="testgenstr.cs" />
   </ItemGroup>

--- a/src/tests/JIT/Methodical/stringintern/teststr.csproj
+++ b/src/tests/JIT/Methodical/stringintern/teststr.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="teststr.cs" />
   </ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M09.5-PDC/b14426/b14426.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M09.5-PDC/b14426/b14426.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b02353/b02353.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/v1-m10/b02353/b02353.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b12053/b12053.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b12053/b12053.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b14066/b14066.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b14066/b14066.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b14077/b14077.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b14077/b14077.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16345/b16345.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16345/b16345.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29456/b29456.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29456/b29456.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b31150/b31150.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b31150/b31150.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621.csproj
@@ -5,10 +5,7 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b13944/b13944.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b13944/b13944.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14228/b14228.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14228/b14228.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14323/b14323.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14323/b14323.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14475/b14475.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14475/b14475.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14779/b14779.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b14779/b14779.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b15307/b15307.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b15307/b15307.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b16102/b16102.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09/b16102/b16102.csproj
@@ -8,10 +8,7 @@
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <CLRTestExitCode>0</CLRTestExitCode>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b04914/b04914.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b04914/b04914.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b07483/b07483.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b07483/b07483.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b08172/b08172.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b08172/b08172.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b09246/b09246.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M10/b09246/b09246.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41990/b41990.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41990/b41990.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b43313/Desktop/b43313_Desktop.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b43313/Desktop/b43313_Desktop.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b43313/b43313.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b43313/b43313.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b11553/b11553.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b11553/b11553.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/b51875.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/b51875.csproj
@@ -3,10 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
-    <DebugType />
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53547/b53547.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53547/b53547.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b55197/Desktop/b55197_Desktop.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b55197/Desktop/b55197_Desktop.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b55197/b55197.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b55197/b55197.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b56772/b56772.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b56772/b56772.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b60600/b60600.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b60600/b60600.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b64579/b64579.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b64579/b64579.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71005/b71005.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71005/b71005.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71093/b71093.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71093/b71093.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72164/b72164.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72164/b72164.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72422/b72422.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72422/b72422.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72687/b72687.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72687/b72687.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72932/b72932.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72932/b72932.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72986/b72986.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b72986/b72986.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76267/b76267.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76267/b76267.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76511/b76511.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76511/b76511.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76717/b76717.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b76717/b76717.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b78694/b78694.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b78694/b78694.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79642/b79642.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79642/b79642.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b80764/b80764.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b80764/b80764.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b81618/b81618.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b81618/b81618.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b82048/b82048.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b82048/b82048.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b83702/b83702.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b83702/b83702.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b113239/b113239.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b113239/b113239.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b87285/b87285.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b87285/b87285.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b89797/b89797.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b89797/b89797.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b92714/b92714.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b92714/b92714.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b99222/b99222.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b99222/b99222.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b99235/b99235.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b99235/b99235.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b140902/b140902.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.1-M1-Beta1/b140902/b140902.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b103058/b103058.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharptester.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharptester.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b02762/b02762.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b02762/b02762.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b16570/b16570.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M01/b16570/b16570.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="pState.cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b31398/b31398.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b31398/b31398.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cs1.cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Repro.cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b449827/b449827.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b449827/b449827.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b491215/b491215.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b491215/b491215.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
-    <DebugType />
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/dev10/b393481/b393481.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/dev10/b393481/b393481.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/dev10/b402701/b402701.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/dev10/b402701/b402701.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b188478/b188478.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b188478/b188478.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b19679/b19679.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b19679/b19679.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b202743/b202743.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/DDB/b202743/b202743.csproj
@@ -7,10 +7,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b152292/b152292.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b152292/b152292.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b569942/b569942.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b569942/b569942.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.2/ddb/ddb188478/DDB188478.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.2/ddb/ddb188478/DDB188478.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DDB188478.cs" />

--- a/src/tests/JIT/Regression/Dev11/External/Dev11_243742/dll.csproj
+++ b/src/tests/JIT/Regression/Dev11/External/Dev11_243742/dll.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="dll.cs" />
   </ItemGroup>

--- a/src/tests/JIT/Regression/Dev11/External/dev11_132534/CSharpPart_132534.csproj
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_132534/CSharpPart_132534.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/Dev11/External/dev11_145295/CSharpPart_145295.csproj
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_145295/CSharpPart_145295.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_1206929/DevDiv_1206929.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_1206929/DevDiv_1206929.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_142976/DevDiv_142976.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_142976/DevDiv_142976.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_255294/DevDiv_255294.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <!-- It hits timeout with R2R and JitStress=1, issue 16573 -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_278365/DevDiv_278365.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_278375/DevDiv_278375.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_278376/DevDiv_278376.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_278526/DevDiv_278526.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_280120/DevDiv_280120.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_280120/DevDiv_280120.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_280123/DevDiv_280123.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_280127/DevDiv_280127.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_280127/DevDiv_280127.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_283795/DevDiv_283795.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_284785/DevDiv_284785.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_284785/DevDiv_284785.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_288222/DevDiv_288222.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_461649/DevDiv_461649.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_468732/DevDiv_468732.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_541653/DevDiv_541653.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_541653/DevDiv_541653.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_543057/DevDiv_543057.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_543057a/DevDiv_543057a.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_543057a/DevDiv_543057a.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_545504/DevDiv_545504.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_546018/DevDiv_546018.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_546018/DevDiv_546018.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_590358/DevDiv_590358.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_590358/DevDiv_590358.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_714266/DevDiv_714266.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.csproj
+++ b/src/tests/JIT/Regression/JitBlue/DevDiv_718151/DevDiv_718151.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10215/GitHub_10215.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10215/GitHub_10215.csproj
@@ -5,7 +5,6 @@
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10481/GitHub_10481.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10481/GitHub_10481.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10621/GitHub_10621.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10714/GitHub_10714.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10780/GitHub_10780.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_10940/GitHub_10940.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_1133/GitHub_1133.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11343/GitHub_11343.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11343/GitHub_11343.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11407/GitHub_11407.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11408/GitHub_11408.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_1161/GitHub_1161.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11689/GitHub_11689.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11733/GitHub_11733.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11733/GitHub_11733.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11814/GitHub_11814.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_11816/GitHub_11816.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12037/GitHub_12037.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12037/GitHub_12037.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12392/GitHub_12392.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12392/GitHub_12392.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12398/Github_12398.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12398/Github_12398.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_1.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_2.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_3.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_3.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_4.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_4.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_5.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_5.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_6.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_6.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_7.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_7.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_8.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12949/GitHub_12949_8.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_12950/GitHub_12950.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_12950/GitHub_12950.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_1296/GitHub_1296.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_1296/GitHub_1296.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13056/GitHub_13056.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13056/GitHub_13056.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13057/GitHub_13057.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_1323/GitHub_1323.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_1323/GitHub_1323.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13486/GitHub_13486.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13486/GitHub_13486.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13561/GitHub_13561.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13568/GitHub_13568.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13568/GitHub_13568.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13735/GitHub_13735.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13735/GitHub_13735.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13910/GitHub_13910.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_13919/GitHub_13919.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_14028/GitHub_14028.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_14028/GitHub_14028.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_14783/GitHub_14783.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_14783/GitHub_14783.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_15077/GitHub_15077.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_15077/GitHub_15077.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_15237/GitHub_15237.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_15237/GitHub_15237.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_15319/GitHub_15319.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_15718/GitHub_15718.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16210/GitHub_16210_3.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16254/GitHub_16254.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16377/GitHub_16377.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16377/GitHub_16377.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16443/GitHub_16443.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_16472/Github_16472.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_16472/Github_16472.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_17329/GitHub_17329.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_17777/GitHub_17777.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_17777/GitHub_17777.csproj
@@ -6,7 +6,6 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18232/GitHub_18232.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18235/GitHub_18235_2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18259/GitHub_18259.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18259/GitHub_18259.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18332/GitHub_18332.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18332/GitHub_18332.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18362/GitHub_18362.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18362/GitHub_18362.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18408/GitHub_18408.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18408/GitHub_18408.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18482/GitHub_18482.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18482/GitHub_18482.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18497/GitHub_18497.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_1.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_1.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_2.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_3.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_3.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_4.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_4.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_5.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_5.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_6.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_6.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_7.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_7.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_8.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18522/GitHub_18522_8.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18542/GitHub_18542.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18542/GitHub_18542.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18582/GitHub_18582.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18582/GitHub_18582.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18672/GitHub_18672.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18672/GitHub_18672.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18770/GitHub_18770.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18780/GitHub_18780.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18780/GitHub_18780.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18867/GitHub_18867.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18884/GitHub_18884.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18884/GitHub_18884.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_18887/GitHub_18887.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_18887/GitHub_18887.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19022/GitHub_19022.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19149/GitHub_19149.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19149/GitHub_19149.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19397/GitHub_19397.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19444/GitHub_19444.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19599/GitHub_19599.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19599/GitHub_19599.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19910/GitHub_19910.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19910/GitHub_19910.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_2003/GitHub_2003.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_20651/GitHub_20651.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_20651/GitHub_20651.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_20838/GitHub_20838.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_20838/GitHub_20838.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231a.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_21231/GitHub_21231b.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_21295/GitHub_21295.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_21295/GitHub_21295.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/GitHub_22583.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/GitHub_22583.csproj
@@ -6,7 +6,6 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/base.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_22583/lib.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23530/GitHub_23530.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23530/GitHub_23530.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23545/GitHub_23545.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23545/GitHub_23545.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23739/GitHub_23739.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23739/GitHub_23739.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_23794/GitHub_23794.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_23794/GitHub_23794.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_24159/GitHub_24159.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_24657/GitHub_24657.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_24657/GitHub_24657.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_24846/GitHub_24846.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_24846/GitHub_24846.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_25020/GitHub_25020.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_25020/GitHub_25020.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_2580/GitHub_2580.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_2580/GitHub_2580.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_2610/GitHub_2610.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_2610/GitHub_2610.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_27027/GitHub_27027.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_27027/GitHub_27027.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_27551/GitHub_27551.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_3449/GitHub_3449.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_3539/GitHub_3539.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_3539/GitHub_3539.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_4115/GitHub_4115.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_4115/GitHub_4115.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_5047/GitHub_5047.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_5047/GitHub_5047.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_5556/GitHub_5556.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_5696/GitHub_5696.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_6234/GitHub_6234.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_6234/GitHub_6234.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_6238/GitHub_6238.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_6238/GitHub_6238.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_6239/GitHub_6239.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_6239/GitHub_6239.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_6318/GitHub_6318.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_6649/GitHub_6649.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_7147/GitHub_7147.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_7508/Vector3Test.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_7508/Vector3Test.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_7906/GitHub_7906.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_8220/GitHub_8220.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_8460/GitHub_8460.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_8599/GitHub_8599.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_8599/GitHub_8599.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_9692/GitHub_9692.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/GitHub_9891/GitHub_9891.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_9891/GitHub_9891.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_1241/Runtime_1241.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_13417/Runtime_13417.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_13417/Runtime_13417.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_13669/Runtime_13669.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_13669/Runtime_13669.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_31673/Runtime_31673.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_31673/Runtime_31673.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34170/Runtime_34170.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34587/Runtime_34587.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_34937/Runtime_34937.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_35144/Runtime_35144.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35144/Runtime_35144.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_35976/Runtime_35976.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35976/Runtime_35976.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39737/Runtime_39737.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39737/Runtime_39737.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_40440/Runtime_40440.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_40440/Runtime_40440.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_40444/Runtime_40444.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_55107/Runtime_55107.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_72845/Runtime_72845.fsproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <GCStressIncompatible>True</GCStressIncompatible>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fsproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_87393/Runtime_87393.fsproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <!-- Needed for GCStressIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <GCStressIncompatible>True</GCStressIncompatible>

--- a/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.csproj
+++ b/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/b108129.csproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b108129/b108129.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test2.cs" />

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b15539/b15539.csproj
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M02/b15539/b15539.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="simple.cs" />

--- a/src/tests/JIT/Regression/clr-x64-JIT/v2.1/b601838/b601838.csproj
+++ b/src/tests/JIT/Regression/clr-x64-JIT/v2.1/b601838/b601838.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/common/localloc_common.ilproj
+++ b/src/tests/JIT/common/localloc_common.ilproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/ebvts/cs/generics/generics/repro52.csproj
+++ b/src/tests/JIT/jit64/ebvts/cs/generics/generics/repro52.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="repro52.cs" />

--- a/src/tests/JIT/jit64/hfa/main/dll/common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/common.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="common.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_common.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_interop_cpp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT32;NATIVE_CPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f32_managed.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_common.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_interop_cpp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT64;NATIVE_CPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_nested_f64_managed.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);NESTED_HFA;FLOAT64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_common.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_interop_cpp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT32;NATIVE_CPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f32_managed.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT32</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_common.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_common.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_interop_cpp.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_interop_cpp.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT64;NATIVE_CPP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_managed.csproj
+++ b/src/tests/JIT/jit64/hfa/main/dll/hfa_simple_f64_managed.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <DefineConstants>$(DefineConstants);SIMPLE_HFA;FLOAT64</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nd1A_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_nf1A_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sd1A_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testA/hfa_sf1A_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd0B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nd2B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf0B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_nf2B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd0B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sd2B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf0B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testB/hfa_sf2B_r.csproj
@@ -4,9 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hfa_testB.cs" />
   </ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nd1C_r.csproj
@@ -4,7 +4,6 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_nf1C_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sd1C_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testC/hfa_sf1C_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nd1E_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_nf1E_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sd1E_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testE/hfa_sf1E_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nd1G_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_nf1G_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sd1G_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_d.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>full</DebugType>
     <Optimize>False</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
+++ b/src/tests/JIT/jit64/hfa/main/testG/hfa_sf1G_r.csproj
@@ -5,7 +5,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/localloc/eh/eh01_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh01_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh01_large.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh01_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh01_small.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh01_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh02_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh02_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh02_large.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh02_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh02_small.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh02_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh05_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh05_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh05_large.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh05_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/eh/eh05_small.csproj
+++ b/src/tests/JIT/jit64/localloc/eh/eh05_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh09_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh09_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh09_large.csproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh09_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/ehverify/eh09_small.csproj
+++ b/src/tests/JIT/jit64/localloc/ehverify/eh09_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind01_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind01_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind01_large.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind01_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind01_small.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind01_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind02_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind02_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind02_large.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind02_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind02_small.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind02_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind03_dynamic.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind03_dynamic.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_DYNAMIC</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind03_large.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind03_large.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_LARGE</DefineConstants>

--- a/src/tests/JIT/jit64/localloc/unwind/unwind03_small.csproj
+++ b/src/tests/JIT/jit64/localloc/unwind/unwind03_small.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);LOCALLOC_SMALL</DefineConstants>

--- a/src/tests/JIT/jit64/opt/cprop/cprop001_d.csproj
+++ b/src/tests/JIT/jit64/opt/cprop/cprop001_d.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cprop001.cs" />

--- a/src/tests/JIT/jit64/opt/cprop/cprop001_do.csproj
+++ b/src/tests/JIT/jit64/opt/cprop/cprop001_do.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cprop001.cs" />

--- a/src/tests/JIT/jit64/opt/cprop/cprop001_r.csproj
+++ b/src/tests/JIT/jit64/opt/cprop/cprop001_r.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cprop001.cs" />

--- a/src/tests/JIT/jit64/opt/cprop/cprop001_ro.csproj
+++ b/src/tests/JIT/jit64/opt/cprop/cprop001_ro.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="cprop001.cs" />

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_add.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_add.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_and.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_and.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_AND</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_div.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_div.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mod.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mod.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MOD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mul.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_mul.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_or.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_or.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_OR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_shr.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_shr.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SHR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_sub.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_sub.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/VolatileTest_op_xor.csproj
+++ b/src/tests/JIT/jit64/opt/cse/VolatileTest_op_xor.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_XOR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/arrayexpr2_d_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/arrayexpr2_d_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/arrayexpr2_r_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/arrayexpr2_ro_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/arrayexpr2_ro_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/mixedexpr1_d_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/mixedexpr1_d_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/mixedexpr1_r_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/mixedexpr1_ro_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/mixedexpr1_ro_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/simpleexpr4_d_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/simpleexpr4_d_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/simpleexpr4_r_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/simpleexpr4_ro_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/simpleexpr4_ro_loop.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_d_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_d_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_loop_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_r_try.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_ro_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExpr1_ro_loop.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_d_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_d_loop_try.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_loop.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_loop_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_loop_try.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP;TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_try.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_r_try.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);TRY</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_ro_loop.csproj
+++ b/src/tests/JIT/jit64/opt/cse/staticFieldExprUnchecked1_ro_loop.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);LOOP</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/opt/rngchk/ArrayWithThread_o.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/ArrayWithThread_o.csproj
@@ -6,11 +6,8 @@
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayWithThread.cs" />

--- a/src/tests/JIT/jit64/regress/vsw/560402/opadd.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/560402/opadd.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/regress/vsw/560402/opmul.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/560402/opmul.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/regress/vsw/560402/opsub.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/560402/opsub.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/regress/vsw/568666/library1.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/568666/library1.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/regress/vsw/568666/library2.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/568666/library2.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/regress/vsw/568666/test_568666.csproj
+++ b/src/tests/JIT/jit64/regress/vsw/568666/test_568666.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow01_add.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow01_add.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow01_div.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow01_div.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow01_mul.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow01_mul.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow01_sub.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow01_sub.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow02_add.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow02_add.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow02_div.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow02_div.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow02_mul.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow02_mul.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow02_sub.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow02_sub.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow03_add.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow03_add.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow03_div.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow03_div.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow03_mul.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow03_mul.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow03_sub.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow03_sub.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow04_add.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow04_add.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_ADD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow04_div.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow04_div.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_DIV</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow04_mul.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow04_mul.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_MUL</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/jit64/rtchecks/overflow/overflow04_sub.csproj
+++ b/src/tests/JIT/jit64/rtchecks/overflow/overflow04_sub.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);OP_SUB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/AssertionPropagation/ArrBoundUnsigned.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/ArrBoundUnsigned.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrBoundUnsigned.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/ConstantProp.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/ConstantProp.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ConstantProp.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/CopyProp.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/CopyProp.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CopyProp.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion1.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion1.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion1.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion2.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion2.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion2.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion3.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion3.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion3.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion4.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion4.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion4.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion5.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion5.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion5.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion6.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion6.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion6.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion7.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/NullCheckAssertion7.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NullCheckAssertion7.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/TypeOfAssertion.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/TypeOfAssertion.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TypeOfAssertion.cs" />

--- a/src/tests/JIT/opt/AssertionPropagation/regression/dev10/bug573840/bug573840.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/regression/dev10/bug573840/bug573840.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
+++ b/src/tests/JIT/opt/FastTailCall/FastTailCallCandidates.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/FastTailCall/FastTailCallInlining.csproj
+++ b/src/tests/JIT/opt/FastTailCall/FastTailCallInlining.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/FastTailCall/GitHubIssue12479.csproj
+++ b/src/tests/JIT/opt/FastTailCall/GitHubIssue12479.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/FastTailCall/StackFixup.csproj
+++ b/src/tests/JIT/opt/FastTailCall/StackFixup.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/FastTailCall/StructPassingSimple.csproj
+++ b/src/tests/JIT/opt/FastTailCall/StructPassingSimple.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/ForwardSub/andnotcontained.csproj
+++ b/src/tests/JIT/opt/ForwardSub/andnotcontained.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/callArgInterference.csproj
+++ b/src/tests/JIT/opt/ForwardSub/callArgInterference.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/callArgInterference2.csproj
+++ b/src/tests/JIT/opt/ForwardSub/callArgInterference2.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/callArgInterference3.csproj
+++ b/src/tests/JIT/opt/ForwardSub/callArgInterference3.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/earlyLiveness.csproj
+++ b/src/tests/JIT/opt/ForwardSub/earlyLiveness.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/lowerContainCheckCompare.csproj
+++ b/src/tests/JIT/opt/ForwardSub/lowerContainCheckCompare.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/modOpt.csproj
+++ b/src/tests/JIT/opt/ForwardSub/modOpt.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/ForwardSub/switchWithSideEffects.csproj
+++ b/src/tests/JIT/opt/ForwardSub/switchWithSideEffects.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/GuardedDevirtualization/enumerablecloning.csproj
+++ b/src/tests/JIT/opt/GuardedDevirtualization/enumerablecloning.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/GuardedDevirtualization/typetestcloning.csproj
+++ b/src/tests/JIT/opt/GuardedDevirtualization/typetestcloning.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/Inline/regression/bug595776/bug595776.csproj
+++ b/src/tests/JIT/opt/Inline/regression/bug595776/bug595776.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/opt/Inline/tests/ArrayOfStructs.csproj
+++ b/src/tests/JIT/opt/Inline/tests/ArrayOfStructs.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayOfStructs.cs" />

--- a/src/tests/JIT/opt/Inline/tests/DelegInstanceFtn.csproj
+++ b/src/tests/JIT/opt/Inline/tests/DelegInstanceFtn.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DelegInstanceFtn.cs" />

--- a/src/tests/JIT/opt/Inline/tests/DelegStaticFtn.csproj
+++ b/src/tests/JIT/opt/Inline/tests/DelegStaticFtn.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DelegStaticFtn.cs" />

--- a/src/tests/JIT/opt/Inline/tests/GenericStructs.csproj
+++ b/src/tests/JIT/opt/Inline/tests/GenericStructs.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericStructs.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline.cs" />

--- a/src/tests/JIT/opt/Inline/tests/InlineThrow.csproj
+++ b/src/tests/JIT/opt/Inline/tests/InlineThrow.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inlinethrow.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_DelegateStruct.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_DelegateStruct.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_DelegateStruct.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_GenericMethods.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_GenericMethods.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_GenericMethods.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_Many.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_Many.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_Many.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_MultipleReturn.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_MultipleReturn.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_MultipleReturn.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_NewObj.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_NewObj.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_NewObj.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_NormalizeStack.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_NormalizeStack.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_NormalizeStack.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_Recursion.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_Recursion.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_Recursion.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_RecursiveMethod.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_RecursiveMethod.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_RecursiveMethod.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_RecursiveMethod21.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_RecursiveMethod21.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_RecursiveMethod21.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_STARG.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_STARG.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_STARG.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_SideAffects.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_SideAffects.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_SideAffects.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_Vars.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_Vars.csproj
@@ -2,10 +2,7 @@
   <PropertyGroup>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_Vars.cs" />

--- a/src/tests/JIT/opt/Inline/tests/Inline_handler.csproj
+++ b/src/tests/JIT/opt/Inline/tests/Inline_handler.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Inline_handler.cs" />

--- a/src/tests/JIT/opt/Inline/tests/LotsOfInlines.csproj
+++ b/src/tests/JIT/opt/Inline/tests/LotsOfInlines.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="LotsOfInlines.cs" />

--- a/src/tests/JIT/opt/Inline/tests/ReturnStruct_Method.csproj
+++ b/src/tests/JIT/opt/Inline/tests/ReturnStruct_Method.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ReturnStruct_Method.cs" />

--- a/src/tests/JIT/opt/Inline/tests/StructAsParam_Method.csproj
+++ b/src/tests/JIT/opt/Inline/tests/StructAsParam_Method.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StructAsParam_Method.cs" />

--- a/src/tests/JIT/opt/Inline/tests/StructInClass.csproj
+++ b/src/tests/JIT/opt/Inline/tests/StructInClass.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="StructInClass.cs" />

--- a/src/tests/JIT/opt/Inline/tests/UnsafeBlockCopy.csproj
+++ b/src/tests/JIT/opt/Inline/tests/UnsafeBlockCopy.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/Inline/tests/args1.csproj
+++ b/src/tests/JIT/opt/Inline/tests/args1.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="args1.cs" />

--- a/src/tests/JIT/opt/Inline/tests/args2.csproj
+++ b/src/tests/JIT/opt/Inline/tests/args2.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="args2.cs" />

--- a/src/tests/JIT/opt/Inline/tests/args3.csproj
+++ b/src/tests/JIT/opt/Inline/tests/args3.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="args3.cs" />

--- a/src/tests/JIT/opt/Inline/tests/array.csproj
+++ b/src/tests/JIT/opt/Inline/tests/array.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="array.cs" />

--- a/src/tests/JIT/opt/Inline/tests/debug.csproj
+++ b/src/tests/JIT/opt/Inline/tests/debug.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="debug.cs" />

--- a/src/tests/JIT/opt/Inline/tests/deepcall.csproj
+++ b/src/tests/JIT/opt/Inline/tests/deepcall.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deepcall.cs" />

--- a/src/tests/JIT/opt/Inline/tests/ifelse.csproj
+++ b/src/tests/JIT/opt/Inline/tests/ifelse.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ifelse.cs" />

--- a/src/tests/JIT/opt/Inline/tests/indexer.csproj
+++ b/src/tests/JIT/opt/Inline/tests/indexer.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="indexer.cs" />

--- a/src/tests/JIT/opt/Inline/tests/interfaceCall.csproj
+++ b/src/tests/JIT/opt/Inline/tests/interfaceCall.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="interfaceCall.cs" />

--- a/src/tests/JIT/opt/Inline/tests/interfaceproperty.csproj
+++ b/src/tests/JIT/opt/Inline/tests/interfaceproperty.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="interfaceProperty.cs" />

--- a/src/tests/JIT/opt/Inline/tests/mathfunc.csproj
+++ b/src/tests/JIT/opt/Inline/tests/mathfunc.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mathfunc.cs" />

--- a/src/tests/JIT/opt/Inline/tests/mthdimpl.csproj
+++ b/src/tests/JIT/opt/Inline/tests/mthdimpl.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mthdimpl.cs" />

--- a/src/tests/JIT/opt/Inline/tests/property.csproj
+++ b/src/tests/JIT/opt/Inline/tests/property.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="property.cs" />

--- a/src/tests/JIT/opt/Inline/tests/size.csproj
+++ b/src/tests/JIT/opt/Inline/tests/size.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="size.cs" />

--- a/src/tests/JIT/opt/Inline/tests/struct_opcodes.csproj
+++ b/src/tests/JIT/opt/Inline/tests/struct_opcodes.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="struct_opcodes.cs" />

--- a/src/tests/JIT/opt/Inline/tests/throwtest.csproj
+++ b/src/tests/JIT/opt/Inline/tests/throwtest.csproj
@@ -3,11 +3,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="throwTest.cs" />

--- a/src/tests/JIT/opt/Inline/tests/trycatch.csproj
+++ b/src/tests/JIT/opt/Inline/tests/trycatch.csproj
@@ -3,10 +3,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="trycatch.cs" />

--- a/src/tests/JIT/opt/OSR/Runtime_69032.csproj
+++ b/src/tests/JIT/opt/OSR/Runtime_69032.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/Runtime_89666.csproj
+++ b/src/tests/JIT/opt/OSR/Runtime_89666.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/addressexposedlocal.csproj
+++ b/src/tests/JIT/opt/OSR/addressexposedlocal.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/doublestackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/doublestackalloc.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/example.csproj
+++ b/src/tests/JIT/opt/OSR/example.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/exposure1.csproj
+++ b/src/tests/JIT/opt/OSR/exposure1.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/exposure2.csproj
+++ b/src/tests/JIT/opt/OSR/exposure2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/genericmethodpatchpoint.csproj
+++ b/src/tests/JIT/opt/OSR/genericmethodpatchpoint.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/handlerloop.csproj
+++ b/src/tests/JIT/opt/OSR/handlerloop.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/innerloop.csproj
+++ b/src/tests/JIT/opt/OSR/innerloop.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/integersumloop.csproj
+++ b/src/tests/JIT/opt/OSR/integersumloop.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/invalidpromotion.csproj
+++ b/src/tests/JIT/opt/OSR/invalidpromotion.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/largefuncletframe.csproj
+++ b/src/tests/JIT/opt/OSR/largefuncletframe.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/livelocaladdress.csproj
+++ b/src/tests/JIT/opt/OSR/livelocaladdress.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/livelocalstackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/livelocalstackalloc.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/mainloop.csproj
+++ b/src/tests/JIT/opt/OSR/mainloop.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/mainloop2.csproj
+++ b/src/tests/JIT/opt/OSR/mainloop2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/mainlooptry.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/mainlooptry2.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/mainlooptry3.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry3.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/mainlooptry4.csproj
+++ b/src/tests/JIT/opt/OSR/mainlooptry4.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/memoryargument.csproj
+++ b/src/tests/JIT/opt/OSR/memoryargument.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/nesteddoloops.csproj
+++ b/src/tests/JIT/opt/OSR/nesteddoloops.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/normalizeonload.csproj
+++ b/src/tests/JIT/opt/OSR/normalizeonload.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/originalstackalloc.csproj
+++ b/src/tests/JIT/opt/OSR/originalstackalloc.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/osrcontainstry.csproj
+++ b/src/tests/JIT/opt/OSR/osrcontainstry.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/pinnedlocal.csproj
+++ b/src/tests/JIT/opt/OSR/pinnedlocal.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/promoted.csproj
+++ b/src/tests/JIT/opt/OSR/promoted.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/shadowparam.csproj
+++ b/src/tests/JIT/opt/OSR/shadowparam.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
+++ b/src/tests/JIT/opt/OSR/shortenregisteredlocal.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/synchronized.csproj
+++ b/src/tests/JIT/opt/OSR/synchronized.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/tailpgo.csproj
+++ b/src/tests/JIT/opt/OSR/tailpgo.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/tailpgo2.csproj
+++ b/src/tests/JIT/opt/OSR/tailpgo2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/tailrecurse.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecurse.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/tailrecursetry.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecursetry.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/tailrecursetry2.csproj
+++ b/src/tests/JIT/opt/OSR/tailrecursetry2.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/tests/JIT/opt/OSR/twoosrmethods.csproj
+++ b/src/tests/JIT/opt/OSR/twoosrmethods.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/OSR/twoosrmethods1.csproj
+++ b/src/tests/JIT/opt/OSR/twoosrmethods1.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Needed for CLRTestEnvironmentVariable -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.csproj
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchAnd.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.csproj
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchOr.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/RedundantBranch/RedundantBranchUnsigned.csproj
+++ b/src/tests/JIT/opt/RedundantBranch/RedundantBranchUnsigned.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/perf/doublealign/Arrays.csproj
+++ b/src/tests/JIT/opt/perf/doublealign/Arrays.csproj
@@ -4,10 +4,7 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>

--- a/src/tests/JIT/opt/perf/doublealign/Locals.csproj
+++ b/src/tests/JIT/opt/perf/doublealign/Locals.csproj
@@ -5,10 +5,7 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
     <Optimize>True</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_d.csproj
@@ -8,11 +8,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_do.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_do.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_r.csproj
@@ -7,11 +7,8 @@
     <HeapVerifyIncompatible>true</HeapVerifyIncompatible>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_ro.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/bigvtbl/bigvtbl_cs_ro.csproj
@@ -1,10 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="bigvtbl.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
@@ -3,7 +3,6 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_d.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_d.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_do.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_do.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_r.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_r.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize />
   </PropertyGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_ro.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/hashcode/ctest1_cs_ro.csproj
@@ -3,7 +3,6 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest1.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest1.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest1.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest10.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest10.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest10.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest2.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest2.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest2.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest3.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest3.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest3.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest4.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest4.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest4.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest5.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest5.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest5.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest6.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest6.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest6.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest7.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest7.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest7.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest8.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest8.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest8.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest9.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/manyintf/itest9.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="itest9.cs" />
   </ItemGroup>

--- a/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_d.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_d.csproj
@@ -5,11 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mixed.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_do.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_do.csproj
@@ -5,11 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mixed.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_r.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_r.csproj
@@ -5,11 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mixed.cs" />

--- a/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_ro.csproj
+++ b/src/tests/JIT/opt/virtualstubdispatch/mixed/mixed_cs_ro.csproj
@@ -5,11 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
-    <NoStandardLib>True</NoStandardLib>
-    <Noconfig>True</Noconfig>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mixed.cs" />

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/diamondshape/diamondshape_r.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/diamondshape/diamondshape_r.ilproj
@@ -3,9 +3,6 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="diamondshape.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/sharedgenerics/sharedgenerics_r.ilproj
@@ -3,9 +3,6 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="sharedgenerics.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape_r.ilproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/DiamondShape/svm_diamondshape_r.ilproj
@@ -3,9 +3,6 @@
     <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="svm_diamondshape.il" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/GenericContext/GenericContextCommonCs.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="GenericContextCommonCs.cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/TypeHierarchy/TypeHierarchyCommonCs.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/TypeHierarchy/TypeHierarchyCommonCs.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
   </PropertyGroup>
-  <PropertyGroup>
-    <DebugType />
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="TypeHierarchyCommonCs.cs" />
   </ItemGroup>

--- a/src/tests/Regressions/coreclr/GitHub_17398/test17398.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_17398/test17398.csproj
@@ -5,7 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
-    <DebugType />
     <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Empty string is not a valid value for DebugType property.

Also deleted other unused properties and left-over comments.