### PR TITLE
[release/8.0-staging] Switch off HybridGlobalization lane on v8 on CI

### DIFF
--- a/src/libraries/System.Globalization.Calendars/tests/Hybrid/System.Globalization.Calendars.Hybrid.WASM.Tests.csproj
+++ b/src/libraries/System.Globalization.Calendars/tests/Hybrid/System.Globalization.Calendars.Hybrid.WASM.Tests.csproj
@@ -5,6 +5,14 @@
     <TestRuntime>true</TestRuntime>
     <HybridGlobalization>true</HybridGlobalization>
   </PropertyGroup>
+   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <!-- This doesn't run on V8 because https://github.com/dotnet/runtime/pull/101671 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+    <XunitShowProgress>true</XunitShowProgress>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\System\Globalization\CalendarTestBase.cs" />
     <Compile Include="..\System\Globalization\ChineseLunisolarCalendarTests.cs" />

--- a/src/libraries/System.Globalization/tests/Hybrid/System.Globalization.Hybrid.WASM.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/Hybrid/System.Globalization.Hybrid.WASM.Tests.csproj
@@ -6,6 +6,14 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <HybridGlobalization>true</HybridGlobalization>
   </PropertyGroup>
+   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <!-- This doesn't run on V8 because https://github.com/dotnet/runtime/pull/101671 -->
+    <Scenario>WasmTestOnBrowser</Scenario>
+    <TestArchiveTestsRoot>$(TestArchiveRoot)browserornodejs/</TestArchiveTestsRoot>
+    <TestArchiveTestsDir>$(TestArchiveTestsRoot)$(OSPlatformConfig)/</TestArchiveTestsDir>
+    <DefineConstants>$(DefineConstants);TARGET_BROWSER</DefineConstants>
+    <XunitShowProgress>true</XunitShowProgress>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\CompareInfo\CompareInfoTestsBase.cs" />
     <Compile Include="..\System\Globalization\TextInfoTests.cs" />


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/101671 to release/8.0-staging.

This PR removes `HybridGlobalization` tests on v8.

## Customer Impact

None, it's CI testing.
Fixes https://github.com/dotnet/runtime/issues/102348.

## Regression

No.

We always tested v8.

## Testing, Risk

No testing planned, low risk - customers don't use HG on v8.
Maintaining `HybridGlobalization` tests takes considerable effort - the API response might change with each host version and it does not mean that they are incorrect. As the result, with each version change we have to update expected test results.
`HybridGlobalization` is primarily targeting browser and node. While updating the tests for browser and node makes sense - to catch any changes that are indeed invalid - updating it for v8 is a not necessary effort.
