### PR TITLE
Modify error message for failed RW mappings

### DIFF
--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -905,7 +905,7 @@ void* ExecutableAllocator::MapRW(void* pRX, size_t size, CacheableMapping cacheM
 
             if (pRW == NULL)
             {
-                g_fatalErrorHandler(COR_E_EXECUTIONENGINE, W("Failed to create RW mapping for RX memory"));
+                g_fatalErrorHandler(COR_E_EXECUTIONENGINE, W("Failed to create RW mapping for RX memory. This can be caused by insufficient memory or hitting the limit of memory mappings on Linux (vm.map_max_count)."));
             }
 
             AddRWBlock(pRW, (BYTE*)pBlock->baseRX + mapOffset, mapSize, cacheMapping);


### PR DESCRIPTION
The executable allocator can fail to create a RW mapping for an existing RX mapping due to both being out of memory and exceeding maximum number of memory mappings. People were getting confused by the original error message.
This change updates it to explicitly mention the cases when it can occur.