### PR TITLE
JIT: Move backward jumps to before their successors after RPO-based layout

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6097,7 +6097,7 @@ public:
     void fgMoveColdBlocks();
 
     template <bool hasEH>
-    void fgMoveBlocksToHottestSuccessors();
+    void fgMoveBackwardJumpsToSuccessors();
 
     bool fgFuncletsAreCold();
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6095,7 +6095,7 @@ public:
     bool fgReorderBlocks(bool useProfile);
     void fgDoReversePostOrderLayout();
     void fgMoveColdBlocks();
-    
+
     template <bool hasEH>
     void fgMoveBlocksToHottestSuccessors();
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6095,6 +6095,9 @@ public:
     bool fgReorderBlocks(bool useProfile);
     void fgDoReversePostOrderLayout();
     void fgMoveColdBlocks();
+    
+    template <bool hasEH>
+    void fgMoveBlocksToHottestSuccessors();
 
     bool fgFuncletsAreCold();
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -6154,7 +6154,7 @@ BasicBlock* Compiler::fgNewBBFromTreeAfter(
  */
 void Compiler::fgInsertBBbefore(BasicBlock* insertBeforeBlk, BasicBlock* newBlk)
 {
-    if (insertBeforeBlk->IsFirst())
+    if (fgFirstBB == insertBeforeBlk)
     {
         newBlk->SetNext(fgFirstBB);
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4644,15 +4644,11 @@ void Compiler::fgMoveBlocksToHottestSuccessors()
         }
 
         // block is the hottest predecessor of likelySucc, but before we move block,
-        // make sure any fallthrough we are breaking is worth losing.
-        // We make an exception for loop heads: If a loop is not entered from the top,
-        // the RPO-based layout may not place the loop head at the top of the loop,
-        // so fix that here.
+        // make sure any fallthrough we are breaking is worth losing
         //
         assert(!block->IsFirst());
         FlowEdge* const fallthroughEdge = fgGetPredForBlock(block, block->Prev());
-        if ((fallthroughEdge != nullptr) && (fallthroughEdge->getLikelyWeight() >= likelySuccEdgeWeight) &&
-            !block->HasFlag(BBF_LOOP_HEAD))
+        if ((fallthroughEdge != nullptr) && (fallthroughEdge->getLikelyWeight() >= likelySuccEdgeWeight))
         {
             continue;
         }

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4692,6 +4692,11 @@ void Compiler::fgDoReversePostOrderLayout()
             fgInsertBBafter(block, blockToMove);
         }
 
+        // The RPO established a good base layout, but in some cases, it might not place the hottest predecessor
+        // behind a block.
+        // If a block isn't placed before its most-likely successor, and it is that successor's hottest predecessor,
+        // try creating fallthrough between them.
+        //
         fgMoveBlocksToHottestSuccessors</* hasEH */ false>();
 
         return;

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -4644,11 +4644,15 @@ void Compiler::fgMoveBlocksToHottestSuccessors()
         }
 
         // block is the hottest predecessor of likelySucc, but before we move block,
-        // make sure any fallthrough we are breaking is worth losing
+        // make sure any fallthrough we are breaking is worth losing.
+        // We make an exception for loop heads: If a loop is not entered from the top,
+        // the RPO-based layout may not place the loop head at the top of the loop,
+        // so fix that here.
         //
         assert(!block->IsFirst());
         FlowEdge* const fallthroughEdge = fgGetPredForBlock(block, block->Prev());
-        if ((fallthroughEdge != nullptr) && (fallthroughEdge->getLikelyWeight() >= likelySuccEdgeWeight))
+        if ((fallthroughEdge != nullptr) && (fallthroughEdge->getLikelyWeight() >= likelySuccEdgeWeight) &&
+            !block->HasFlag(BBF_LOOP_HEAD))
         {
             continue;
         }


### PR DESCRIPTION
Part of #93020. In #102343, we noticed the RPO-based layout sometimes makes suboptimal decisions in terms of placing a block's hottest predecessor before it -- in particular, this affects loops that aren't entered at the top ([comment](https://github.com/dotnet/runtime/pull/102343#issuecomment-2117072617)). To address this, after establishing a baseline RPO layout, `fgMoveBackwardJumpsToSuccessors` will try to move backward unconditional jumps to right behind their targets to create fallthrough, if the predecessor block is sufficiently hot.

Since the new layout isn't enabled in CI yet, here are the diffs with the baseline using the new RPO layout, on Windows x64: [gist](https://gist.github.com/amanasifkhalid/a658c5dc527fca980519c3d32c6e108b). This change is a net size regression, though the PerfScore diffs look promising, and I see many instances of the inverted loop shape fixed. TP impact is <=0.03% over doing just the RPO-based layout.

cc @dotnet/jit-contrib