### PR TITLE
Releveling CrstDynamicMT and CrstCodeVersioning to fix a stress bug.

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -193,7 +193,7 @@ Crst DynamicIL
 End
 
 Crst DynamicMT
-    AcquiredBefore IbcProfile
+    AcquiredBefore IbcProfile CodeVersioning
 End
 
 Crst EventStore

--- a/src/coreclr/inc/crsttypes_generated.h
+++ b/src/coreclr/inc/crsttypes_generated.h
@@ -172,7 +172,7 @@ int g_rgCrstLevelMap[] =
     0,          // CrstDelegateToFPtrHash
     18,         // CrstDomainLocalBlock
     0,          // CrstDynamicIL
-    3,          // CrstDynamicMT
+    10,         // CrstDynamicMT
     0,          // CrstEtwTypeLogHash
     20,         // CrstEventPipe
     0,          // CrstEventStore


### PR DESCRIPTION
Should fix: https://github.com/dotnet/runtime/issues/100694

Re: discussion in https://github.com/dotnet/runtime/issues/100694#issuecomment-2117833747

There is no relationship between these locks, so it should be ok to take CrstCodeVersioning while holding CrstDynamicMT