### PR TITLE
LSRA: Refactor some of the methods around creating kill set

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2009,9 +2009,17 @@ private:
     int          BuildIndirUses(GenTreeIndir* indirTree, regMaskTP candidates = RBM_NONE);
     int          BuildAddrUses(GenTree* addr, regMaskTP candidates = RBM_NONE);
     void         HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs);
+
     RefPosition* BuildDef(GenTree* tree, regMaskTP dstCandidates = RBM_NONE, int multiRegIdx = 0);
     void         BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates = RBM_NONE);
-    void         BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
+    void         BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates);
+    void         BuildKills(GenTree* tree, regMaskTP killMask);
+#ifdef TARGET_ARMARCH
+    void BuildDefWithKills(GenTree* tree, regMaskTP dstCandidates, regMaskTP killMask);
+#else
+    void BuildDefWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
+#endif
+    void BuildCallDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
 
     int BuildReturn(GenTree* tree);
 #ifdef TARGET_XARCH

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -2014,11 +2014,11 @@ private:
     void         BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates = RBM_NONE);
     void         BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates);
     void         BuildKills(GenTree* tree, regMaskTP killMask);
-#ifdef TARGET_ARMARCH
+#if defined(TARGET_ARMARCH) || defined(TARGET_RISCV64)
     void BuildDefWithKills(GenTree* tree, regMaskTP dstCandidates, regMaskTP killMask);
 #else
     void BuildDefWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
-#endif
+#endif // TARGET_ARMARCH || TARGET_RISCV64
     void BuildCallDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask);
 
     int BuildReturn(GenTree* tree);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1051,8 +1051,7 @@ private:
     void buildRefPositionsForNode(GenTree* tree, LsraLocation loc);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-    void buildUpperVectorSaveRefPositions(GenTree*                tree,
-                                          LsraLocation currentLoc DEBUG_ARG(regMaskTP fpCalleeKillSet));
+    void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc DEBUG_ARG(regMaskTP fpCalleeKillSet));
     void buildUpperVectorRestoreRefPosition(
         Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node, bool isUse, unsigned multiRegIdx);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
@@ -2000,16 +1999,16 @@ private:
     void getTgtPrefOperands(GenTree* tree, GenTree* op1, GenTree* op2, bool* prefOp1, bool* prefOp2);
     bool supportsSpecialPutArg();
 
-    int          BuildSimple(GenTree* tree);
-    int          BuildOperandUses(GenTree* node, regMaskTP candidates = RBM_NONE);
-    void         AddDelayFreeUses(RefPosition* refPosition, GenTree* rmwNode);
-    int          BuildDelayFreeUses(GenTree*      node,
-                                    GenTree*      rmwNode        = nullptr,
-                                    regMaskTP     candidates     = RBM_NONE,
-                                    RefPosition** useRefPosition = nullptr);
-    int          BuildIndirUses(GenTreeIndir* indirTree, regMaskTP candidates = RBM_NONE);
-    int          BuildAddrUses(GenTree* addr, regMaskTP candidates = RBM_NONE);
-    void         HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs);
+    int  BuildSimple(GenTree* tree);
+    int  BuildOperandUses(GenTree* node, regMaskTP candidates = RBM_NONE);
+    void AddDelayFreeUses(RefPosition* refPosition, GenTree* rmwNode);
+    int  BuildDelayFreeUses(GenTree*      node,
+                            GenTree*      rmwNode        = nullptr,
+                            regMaskTP     candidates     = RBM_NONE,
+                            RefPosition** useRefPosition = nullptr);
+    int  BuildIndirUses(GenTreeIndir* indirTree, regMaskTP candidates = RBM_NONE);
+    int  BuildAddrUses(GenTree* addr, regMaskTP candidates = RBM_NONE);
+    void HandleFloatVarArgs(GenTreeCall* call, GenTree* argNode, bool* callHasFloatRegArgs);
 
     RefPosition* BuildDef(GenTree* tree, regMaskTP dstCandidates = RBM_NONE, int multiRegIdx = 0);
     void         BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates = RBM_NONE);

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1051,7 +1051,8 @@ private:
     void buildRefPositionsForNode(GenTree* tree, LsraLocation loc);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-    void buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet);
+    void buildUpperVectorSaveRefPositions(GenTree*                tree,
+                                          LsraLocation currentLoc DEBUG_ARG(regMaskTP fpCalleeKillSet));
     void buildUpperVectorRestoreRefPosition(
         Interval* lclVarInterval, LsraLocation currentLoc, GenTree* node, bool isUse, unsigned multiRegIdx);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -373,7 +373,7 @@ int LinearScan::BuildNode(GenTree* tree)
             assert(dstCount == 0);
             BuildUse(tree->gtGetOp1());
             killMask = compiler->compHelperCallKillSet(CORINFO_HELP_STOP_FOR_GC);
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 
         case GT_MUL:
@@ -422,7 +422,7 @@ int LinearScan::BuildNode(GenTree* tree)
             // This kills GC refs in callee save regs
             srcCount = 0;
             assert(dstCount == 0);
-            BuildDefsWithKills(tree, 0, RBM_NONE, RBM_NONE);
+            BuildKills(tree, RBM_NONE);
             break;
 
         case GT_LONG:
@@ -469,7 +469,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_RETURN:
             srcCount = BuildReturn(tree);
             killMask = getKillSetForReturn();
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 
         case GT_RETFILT:

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -666,14 +666,14 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = 0;
             assert(dstCount == 0);
             killMask = getKillSetForProfilerHook();
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 
         case GT_START_PREEMPTGC:
             // This kills GC refs in callee save regs
             srcCount = 0;
             assert(dstCount == 0);
-            BuildDefsWithKills(tree, 0, RBM_NONE, RBM_NONE);
+            BuildKills(tree, RBM_NONE);
             break;
 
         case GT_CNS_DBL:
@@ -738,7 +738,7 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_RETURN:
             srcCount = BuildReturn(tree);
             killMask = getKillSetForReturn();
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 
 #ifdef SWIFT_SUPPORT
@@ -747,7 +747,7 @@ int LinearScan::BuildNode(GenTree* tree)
             // Plus one for error register
             srcCount = BuildReturn(tree) + 1;
             killMask = getKillSetForReturn();
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 #endif // SWIFT_SUPPORT
 
@@ -839,7 +839,7 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount = 1;
             assert(dstCount == 0);
             killMask = compiler->compHelperCallKillSet(CORINFO_HELP_STOP_FOR_GC);
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 
         case GT_MOD:
@@ -1927,11 +1927,11 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
 
     if ((dstCount == 1) || (dstCount == 2))
     {
-        BuildDef(intrinsicTree, dstCandidates);
+        BuildDef(intrinsicTree);
 
         if (dstCount == 2)
         {
-            BuildDef(intrinsicTree, dstCandidates, 1);
+            BuildDef(intrinsicTree, RBM_NONE, 1);
         }
     }
     else

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -431,30 +431,6 @@ int LinearScan::BuildCall(GenTreeCall* call)
 }
 
 //------------------------------------------------------------------------
-// BuildDefWithKills: Build one RefTypeDef RefPositions for the given node,
-//           as well as kills as specified by the given mask.
-//
-// Arguments:
-//    tree          - The call node that defines a register
-//    dstCandidates - The candidate registers for the definition
-//    killMask      - The mask of registers killed by this node
-//
-// Notes:
-//    Adds the RefInfo for the definitions to the defList.
-//    The def and kill functionality is folded into a single method so that the
-//    save and restores of upper vector registers can be bracketed around the def.
-//
-void LinearScan::BuildDefWithKills(GenTree* tree, regMaskTP dstCandidates, regMaskTP killMask)
-{
-    assert(!tree->AsCall()->HasMultiRegRetVal());
-    assert((int)genCountBits(dstCandidates) == 1);
-
-    // Build the kill RefPositions
-    BuildKills(tree, killMask);
-    BuildDef(tree, dstCandidates);
-}
-
-//------------------------------------------------------------------------
 // BuildPutArgStk: Set the NodeInfo for a GT_PUTARG_STK node
 //
 // Arguments:

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -127,8 +127,8 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
 //
 int LinearScan::BuildCall(GenTreeCall* call)
 {
-    bool                  hasMultiRegRetVal = false;
-    const ReturnTypeDesc* retTypeDesc       = nullptr;
+    bool                  hasMultiRegRetVal   = false;
+    const ReturnTypeDesc* retTypeDesc         = nullptr;
     regMaskTP             singleDstCandidates = RBM_NONE;
 
     int srcCount = 0;

--- a/src/coreclr/jit/lsraarmarch.cpp
+++ b/src/coreclr/jit/lsraarmarch.cpp
@@ -129,7 +129,6 @@ int LinearScan::BuildCall(GenTreeCall* call)
 {
     bool                  hasMultiRegRetVal = false;
     const ReturnTypeDesc* retTypeDesc       = nullptr;
-    regMaskTP             multiDstCandidates;
     regMaskTP             singleDstCandidates = RBM_NONE;
 
     int srcCount = 0;
@@ -228,26 +227,24 @@ int LinearScan::BuildCall(GenTreeCall* call)
     {
         // The ARM CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
         // TCB in REG_PINVOKE_TCB. fgMorphCall() sets the correct argument registers.
-        dstCandidates = RBM_PINVOKE_TCB;
+        singleDstCandidates = RBM_PINVOKE_TCB;
     }
     else
 #endif // TARGET_ARM
-        if (hasMultiRegRetVal)
+        if (!hasMultiRegRetVal)
         {
-            assert(retTypeDesc != nullptr);
-            multiDstCandidates = retTypeDesc->GetABIReturnRegs(call->GetUnmanagedCallConv());
-        }
-        else if (varTypeUsesFloatArgReg(registerType))
-        {
-            singleDstCandidates = RBM_FLOATRET;
-        }
-        else if (registerType == TYP_LONG)
-        {
-            singleDstCandidates = RBM_LNGRET;
-        }
-        else
-        {
-            singleDstCandidates = RBM_INTRET;
+            if (varTypeUsesFloatArgReg(registerType))
+            {
+                singleDstCandidates = RBM_FLOATRET;
+            }
+            else if (registerType == TYP_LONG)
+            {
+                singleDstCandidates = RBM_LNGRET;
+            }
+            else
+            {
+                singleDstCandidates = RBM_INTRET;
+            }
         }
 
     // First, count reg args
@@ -404,7 +401,9 @@ int LinearScan::BuildCall(GenTreeCall* call)
     {
         if (hasMultiRegRetVal)
         {
-            assert(multiDstCandidates.Count() > 0);
+            assert(retTypeDesc != nullptr);
+            regMaskTP multiDstCandidates = retTypeDesc->GetABIReturnRegs(call->GetUnmanagedCallConv());
+            assert(genCountBits(multiDstCandidates) > 0);
             BuildCallDefsWithKills(call, dstCount, multiDstCandidates, killMask);
         }
         else

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3148,7 +3148,11 @@ void LinearScan::BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandida
     assert(tree->IsMultiRegCall());
 
     const ReturnTypeDesc* retTypeDesc = tree->AsCall()->GetReturnTypeDesc();
-    noway_assert(retTypeDesc != nullptr);
+    assert(retTypeDesc != nullptr);
+    if (retTypeDesc == nullptr)
+    {
+        return;
+    }
 
     for (int i = 0; i < dstCount; i++)
     {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3148,14 +3148,14 @@ void LinearScan::BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandida
     assert(tree->IsMultiRegCall());
 
     const ReturnTypeDesc* retTypeDesc = tree->AsCall()->GetReturnTypeDesc();
-    assert(retTypeDesc != nullptr);
+    noway_assert(retTypeDesc != nullptr);
 
     for (int i = 0; i < dstCount; i++)
     {
         // In case of multi-reg call node, we have to query the i'th position return register.
         // For all other cases of multi-reg definitions, the registers must be in sequential order.
         regMaskTP thisDstCandidates =
-            genRegMask(tree->AsCall()->GetReturnTypeDesc()->GetABIReturnReg(i, tree->AsCall()->GetUnmanagedCallConv()));
+            genRegMask(retTypeDesc->GetABIReturnReg(i, tree->AsCall()->GetUnmanagedCallConv()));
 
         assert((dstCandidates & thisDstCandidates) != RBM_NONE);
         dstCandidates &= ~thisDstCandidates;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3037,7 +3037,7 @@ void setTgtPref(Interval* interval, RefPosition* tgtPrefUse)
 #endif // !TARGET_ARM
 
 //------------------------------------------------------------------------
-// BuildDef: Build a RefTypeDef RefPosition for the given node
+// BuildDef: Build one RefTypeDef RefPosition for the given node at given index
 //
 // Arguments:
 //    tree          - The node that defines a register
@@ -3130,7 +3130,7 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, regMaskTP dstCandidates, int mu
 }
 
 //------------------------------------------------------------------------
-// BuildDef: Build one or more RefTypeDef RefPositions for the given node
+// BuildDef: Build one or more RefTypeDef RefPositions for the given call node
 //
 // Arguments:
 //    tree          - The node that defines a register
@@ -3140,61 +3140,74 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, regMaskTP dstCandidates, int mu
 // Notes:
 //    Adds the RefInfo for the definitions to the defList.
 //
-void LinearScan::BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates)
+void LinearScan::BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates)
 {
-    bool fixedReg = false;
-    if ((dstCount > 1) && (dstCandidates != RBM_NONE) && ((int)genCountBits(dstCandidates) == dstCount))
-    {
-        fixedReg = true;
-    }
-    const ReturnTypeDesc* retTypeDesc = nullptr;
-    if (tree->IsMultiRegCall())
-    {
-        retTypeDesc = tree->AsCall()->GetReturnTypeDesc();
-    }
+    assert(dstCount > 0);
+#ifdef TARGET_ARM64
+    assert((int)dstCandidates.Count() == dstCount);
+#endif
+    assert(tree->IsMultiRegCall());
+
+    const ReturnTypeDesc* retTypeDesc = tree->AsCall()->GetReturnTypeDesc();
+    assert(retTypeDesc != nullptr);
+
     for (int i = 0; i < dstCount; i++)
     {
-        regMaskTP thisDstCandidates;
-        if (fixedReg)
-        {
-            // In case of multi-reg call node, we have to query the i'th position return register.
-            // For all other cases of multi-reg definitions, the registers must be in sequential order.
-            if (retTypeDesc != nullptr)
-            {
-                thisDstCandidates = genRegMask(
-                    tree->AsCall()->GetReturnTypeDesc()->GetABIReturnReg(i, tree->AsCall()->GetUnmanagedCallConv()));
-                assert((dstCandidates & thisDstCandidates) != RBM_NONE);
-            }
-            else
-            {
-                thisDstCandidates = genFindLowestBit(dstCandidates);
-            }
-            dstCandidates &= ~thisDstCandidates;
-        }
-        else
-        {
-            thisDstCandidates = dstCandidates;
-        }
+        // In case of multi-reg call node, we have to query the i'th position return register.
+        // For all other cases of multi-reg definitions, the registers must be in sequential order.
+        regMaskTP thisDstCandidates =
+            genRegMask(tree->AsCall()->GetReturnTypeDesc()->GetABIReturnReg(i, tree->AsCall()->GetUnmanagedCallConv()));
+
+        assert((dstCandidates & thisDstCandidates) != RBM_NONE);
+        dstCandidates &= ~thisDstCandidates;
+
         BuildDef(tree, thisDstCandidates, i);
     }
 }
 
 //------------------------------------------------------------------------
-// BuildDef: Build one or more RefTypeDef RefPositions for the given node,
-//           as well as kills as specified by the given mask.
+// BuildDef: Build one or more RefTypeDef RefPositions for the given node
 //
 // Arguments:
 //    tree          - The node that defines a register
 //    dstCount      - The number of registers defined by the node
-//    dstCandidates - The candidate registers for the definition
-//    killMask      - The mask of registers killed by this node
+//    dstCandidates - the candidate registers for the definition
 //
 // Notes:
 //    Adds the RefInfo for the definitions to the defList.
-//    The def and kill functionality is folded into a single method so that the
-//    save and restores of upper vector registers can be bracketed around the def.
+//    Also, the `dstCandidates` is assumed to be of "onlyOne" type. If there are
+//    both gpr and float registers, use `BuildDefs` that takes `AllRegsMask`
 //
-void LinearScan::BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask)
+void LinearScan::BuildDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates)
+{
+    assert(dstCount > 0);
+
+    if ((dstCandidates == RBM_NONE) || ((int)genCountBits(dstCandidates) != dstCount))
+    {
+        // This is not fixedReg case, so just create definitions based on dstCandidates
+        for (int i = 0; i < dstCount; i++)
+        {
+            BuildDef(tree, dstCandidates, i);
+        }
+        return;
+    }
+
+    for (int i = 0; i < dstCount; i++)
+    {
+        regMaskTP thisDstCandidates = genFindLowestBit(dstCandidates);
+        BuildDef(tree, thisDstCandidates, i);
+        dstCandidates &= ~thisDstCandidates;
+    }
+}
+
+//------------------------------------------------------------------------
+// BuildDef: Build Kills RefPositions as specified by the given mask.
+//
+// Arguments:
+//    tree          - The node that defines a register
+//    killMask      - The mask of registers killed by this node
+//
+void LinearScan::BuildKills(GenTree* tree, regMaskTP killMask)
 {
     assert(killMask == getKillSetForNode(tree));
 
@@ -3217,13 +3230,77 @@ void LinearScan::BuildDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCa
         //
         if ((killMask & RBM_FLT_CALLEE_TRASH) != RBM_NONE)
         {
-            buildUpperVectorSaveRefPositions(tree, currentLoc + 1, killMask);
+            buildUpperVectorSaveRefPositions(tree, currentLoc + 1 DEBUG_ARG(killMask & RBM_FLT_CALLEE_TRASH));
         }
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     }
+}
 
-    // Now, create the Def(s)
-    BuildDefs(tree, dstCount, dstCandidates);
+#ifndef TARGET_ARMARCH
+//------------------------------------------------------------------------
+// BuildDefWithKills: Build one or two (for 32-bit) RefTypeDef RefPositions for the given node,
+//           as well as kills as specified by the given mask.
+//
+// Arguments:
+//    tree          - The call node that defines a register
+//    dstCandidates - The candidate registers for the definition
+//    killMask      - The mask of registers killed by this node
+//
+// Notes:
+//    Adds the RefInfo for the definitions to the defList.
+//    The def and kill functionality is folded into a single method so that the
+//    save and restores of upper vector registers can be bracketed around the def.
+//
+void LinearScan::BuildDefWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask)
+{
+    // Build the kill RefPositions
+    BuildKills(tree, killMask);
+
+#ifdef TARGET_64BIT
+    // For 64 bits,
+    assert(dstCount == 1);
+    BuildDef(tree, dstCandidates);
+#else
+    if (dstCount == 1)
+    {
+        BuildDef(tree, dstCandidates);
+    }
+    else
+    {
+        assert(dstCount == 2);
+        BuildDefs(tree, 2, dstCandidates);
+    }
+#endif // TARGET_64BIT
+}
+#endif
+
+//------------------------------------------------------------------------
+// BuildCallDefsWithKills: Build one or more RefTypeDef RefPositions for the given node,
+//           as well as kills as specified by the given mask.
+//
+// Arguments:
+//    tree          - The node that defines a register
+//    dstCount      - The number of registers defined by the node
+//    dstCandidates - The candidate registers for the definition
+//    killMask      - The mask of registers killed by this node
+//
+// Notes:
+//    Adds the RefInfo for the definitions to the defList.
+//    The def and kill functionality is folded into a single method so that the
+//    save and restores of upper vector registers can be bracketed around the def.
+//
+void LinearScan::BuildCallDefsWithKills(GenTree*        tree,
+                                        int             dstCount,
+                                        regMaskTP dstCandidates, regMaskTP killMask)
+{
+    assert(dstCount > 0);
+    assert(dstCandidates != RBM_NONE);
+
+    // Build the kill RefPositions
+    BuildKills(tree, killMask);
+
+    // And then the Def(s)
+    BuildCallDefs(tree, dstCount, dstCandidates);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1459,7 +1459,7 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 //        But we will use as a proxy any node that kills floating point registers.
 //        (Note that some calls are masquerading as other nodes at this point so we can't just check for calls.)
 //
-void LinearScan::buildUpperVectorSaveRefPositions(GenTree*     tree,
+void LinearScan::buildUpperVectorSaveRefPositions(GenTree*                tree,
                                                   LsraLocation currentLoc DEBUG_ARG(regMaskTP fpCalleeKillSet))
 {
     if ((tree != nullptr) && tree->IsCall())
@@ -3288,9 +3288,7 @@ void LinearScan::BuildDefWithKills(GenTree* tree, int dstCount, regMaskTP dstCan
 //    The def and kill functionality is folded into a single method so that the
 //    save and restores of upper vector registers can be bracketed around the def.
 //
-void LinearScan::BuildCallDefsWithKills(GenTree*        tree,
-                                        int             dstCount,
-                                        regMaskTP dstCandidates, regMaskTP killMask)
+void LinearScan::BuildCallDefsWithKills(GenTree* tree, int dstCount, regMaskTP dstCandidates, regMaskTP killMask)
 {
     assert(dstCount > 0);
     assert(dstCandidates != RBM_NONE);

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3235,7 +3235,33 @@ void LinearScan::BuildKills(GenTree* tree, regMaskTP killMask)
     }
 }
 
-#ifndef TARGET_ARMARCH
+#if defined(TARGET_ARMARCH) || defined(TARGET_RISCV64)
+
+//------------------------------------------------------------------------
+// BuildDefWithKills: Build one RefTypeDef RefPositions for the given node,
+//           as well as kills as specified by the given mask.
+//
+// Arguments:
+//    tree          - The call node that defines a register
+//    dstCandidates - The candidate registers for the definition
+//    killMask      - The mask of registers killed by this node
+//
+// Notes:
+//    Adds the RefInfo for the definitions to the defList.
+//    The def and kill functionality is folded into a single method so that the
+//    save and restores of upper vector registers can be bracketed around the def.
+//
+void LinearScan::BuildDefWithKills(GenTree* tree, regMaskTP dstCandidates, regMaskTP killMask)
+{
+    assert(!tree->AsCall()->HasMultiRegRetVal());
+    assert((int)genCountBits(dstCandidates) == 1);
+
+    // Build the kill RefPositions
+    BuildKills(tree, killMask);
+    BuildDef(tree, dstCandidates);
+}
+
+#else
 //------------------------------------------------------------------------
 // BuildDefWithKills: Build one or two (for 32-bit) RefTypeDef RefPositions for the given node,
 //           as well as kills as specified by the given mask.

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1459,7 +1459,8 @@ Interval* LinearScan::getUpperVectorInterval(unsigned varIndex)
 //        But we will use as a proxy any node that kills floating point registers.
 //        (Note that some calls are masquerading as other nodes at this point so we can't just check for calls.)
 //
-void LinearScan::buildUpperVectorSaveRefPositions(GenTree* tree, LsraLocation currentLoc, regMaskTP fpCalleeKillSet)
+void LinearScan::buildUpperVectorSaveRefPositions(GenTree*     tree,
+                                                  LsraLocation currentLoc DEBUG_ARG(regMaskTP fpCalleeKillSet))
 {
     if ((tree != nullptr) && tree->IsCall())
     {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3143,9 +3143,7 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, regMaskTP dstCandidates, int mu
 void LinearScan::BuildCallDefs(GenTree* tree, int dstCount, regMaskTP dstCandidates)
 {
     assert(dstCount > 0);
-#ifdef TARGET_ARM64
-    assert((int)dstCandidates.Count() == dstCount);
-#endif
+    assert((int)genCountBits(dstCandidates) == dstCount);
     assert(tree->IsMultiRegCall());
 
     const ReturnTypeDesc* retTypeDesc = tree->AsCall()->GetReturnTypeDesc();

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1185,7 +1185,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         // The x86 CORINFO_HELP_INIT_PINVOKE_FRAME helper uses a custom calling convention that returns with
         // TCB in REG_PINVOKE_TCB. AMD64/ARM64 use the standard calling convention. fgMorphCall() sets the
         // correct argument registers.
-        dstCandidates = RBM_PINVOKE_TCB;
+        singleDstCandidates = RBM_PINVOKE_TCB;
     }
     else
 #endif // TARGET_X86

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -1147,10 +1147,10 @@ int LinearScan::BuildShiftRotate(GenTree* tree)
 //
 int LinearScan::BuildCall(GenTreeCall* call)
 {
-    bool                  hasMultiRegRetVal = false;
-    const ReturnTypeDesc* retTypeDesc       = nullptr;
-    int                   srcCount          = 0;
-    int                   dstCount          = 0;
+    bool                  hasMultiRegRetVal   = false;
+    const ReturnTypeDesc* retTypeDesc         = nullptr;
+    int                   srcCount            = 0;
+    int                   dstCount            = 0;
     regMaskTP             singleDstCandidates = RBM_NONE;
 
     assert(!call->isContained());
@@ -1197,7 +1197,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
                 // The return value will be on the X87 stack, and we will need to move it.
                 singleDstCandidates = allRegs(registerType);
 #else  // !TARGET_X86
-                singleDstCandidates = RBM_FLOATRET;
+            singleDstCandidates = RBM_FLOATRET;
 #endif // !TARGET_X86
             }
             else

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -199,7 +199,7 @@ int LinearScan::BuildNode(GenTree* tree)
             // Plus one for error register
             srcCount = BuildReturn(tree) + 1;
             killMask = getKillSetForReturn();
-            BuildDefsWithKills(tree, 0, RBM_NONE, killMask);
+            BuildKills(tree, killMask);
             break;
 #endif // SWIFT_SUPPORT
 

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -249,6 +249,11 @@ public:
     {
         return low;
     }
+
+    unsigned Count() const
+    {
+        return BitOperations::PopCount(getLow());
+    }
 };
 
 static regMaskTP operator^(regMaskTP first, regMaskTP second)

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -249,11 +249,6 @@ public:
     {
         return low;
     }
-
-    //unsigned Count() const
-    //{
-    //    return BitOperations::PopCount(getLow());
-    //}
 };
 
 static regMaskTP operator^(regMaskTP first, regMaskTP second)

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -250,10 +250,10 @@ public:
         return low;
     }
 
-    unsigned Count() const
-    {
-        return BitOperations::PopCount(getLow());
-    }
+    //unsigned Count() const
+    //{
+    //    return BitOperations::PopCount(getLow());
+    //}
 };
 
 static regMaskTP operator^(regMaskTP first, regMaskTP second)

--- a/src/coreclr/jit/targetriscv64.cpp
+++ b/src/coreclr/jit/targetriscv64.cpp
@@ -132,7 +132,7 @@ ABIPassingInformation RiscV64Classifier::Classify(Compiler*    comp,
 
             return {2, new (comp, CMK_ABI)
                            ABIPassingSegment[2]{ABIPassingSegment::InRegister(firstReg, 0, firstSize),
-                                               ABIPassingSegment::InRegister(secondReg, offset, secondSize)}};
+                                                ABIPassingSegment::InRegister(secondReg, offset, secondSize)}};
         }
     }
     else
@@ -163,7 +163,7 @@ ABIPassingInformation RiscV64Classifier::Classify(Compiler*    comp,
             assert(varTypeIsStruct(type));
             return {2, new (comp, CMK_ABI)
                            ABIPassingSegment[2]{passSlot(0, TARGET_POINTER_SIZE),
-                                               passSlot(TARGET_POINTER_SIZE, passedSize - TARGET_POINTER_SIZE)}};
+                                                passSlot(TARGET_POINTER_SIZE, passedSize - TARGET_POINTER_SIZE)}};
         }
     }
 }

--- a/src/coreclr/jit/targetriscv64.cpp
+++ b/src/coreclr/jit/targetriscv64.cpp
@@ -131,7 +131,7 @@ ABIPassingInformation RiscV64Classifier::Classify(Compiler*    comp,
             regNumber secondReg = (isSecondFloat ? m_floatRegs : m_intRegs).Dequeue();
 
             return {2, new (comp, CMK_ABI)
-                           ABIPassingSegment[]{ABIPassingSegment::InRegister(firstReg, 0, firstSize),
+                           ABIPassingSegment[2]{ABIPassingSegment::InRegister(firstReg, 0, firstSize),
                                                ABIPassingSegment::InRegister(secondReg, offset, secondSize)}};
         }
     }
@@ -162,7 +162,7 @@ ABIPassingInformation RiscV64Classifier::Classify(Compiler*    comp,
         {
             assert(varTypeIsStruct(type));
             return {2, new (comp, CMK_ABI)
-                           ABIPassingSegment[]{passSlot(0, TARGET_POINTER_SIZE),
+                           ABIPassingSegment[2]{passSlot(0, TARGET_POINTER_SIZE),
                                                passSlot(TARGET_POINTER_SIZE, passedSize - TARGET_POINTER_SIZE)}};
         }
     }


### PR DESCRIPTION
I did some refactoring and separated out the methods for the ones that create multiple defs vs. single def as well the one with create defs for call, and the ones that just build the `killMask.` This is in preparation for the upcoming work I am doing to add support for predicate registers. This patch is extracted out from https://github.com/dotnet/runtime/pull/98258