### PR TITLE
Update version of code coverage report generator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.0.2",
+      "version": "5.3.0",
       "commands": [
         "reportgenerator"
       ]


### PR DESCRIPTION
The currently used version is over two years old and is missing a lot of improvements from the interim.