### PR TITLE
[mono] Migrate more ghashtables to simdhash

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -50,6 +50,8 @@
 #include <mono/utils/unlocked.h>
 #include <mono/utils/bsearch.h>
 #include <mono/utils/checked-build.h>
+// for dn_simdhash_ght_t
+#include "../native/containers/dn-simdhash-specializations.h"
 
 MonoStats mono_stats;
 

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -175,8 +175,7 @@ struct _MonoMemoryManager {
 	MonoAssemblyLoadContext **alcs;
 
 	// Generic-specific caches
-	GHashTable *gsignature_cache;
-	dn_simdhash_ght_t *ginst_cache, *gmethod_cache;
+	dn_simdhash_ght_t *ginst_cache, *gmethod_cache, *gsignature_cache;
 	MonoConcurrentHashTable *gclass_cache;
 
 	/* mirror caches of ones already on MonoImage. These ones contain generics */

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -240,7 +240,7 @@ memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
 		mono_conc_hashtable_destroy (mm->gclass_cache);
 	free_simdhash (&mm->ginst_cache);
 	free_simdhash (&mm->gmethod_cache);
-	free_hash (&mm->gsignature_cache);
+	free_simdhash (&mm->gsignature_cache);
 	free_hash (&mm->szarray_cache);
 	free_hash (&mm->array_cache);
 	free_hash (&mm->ptr_cache);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2452,7 +2452,7 @@ mono_metadata_signature_dup_internal (MonoImage *image, MonoMemPool *mp, MonoMem
 
 /**
  * Allocates memory for a MonoMethodSignature based on the provided parameters.
- * 
+ *
  * @param image MonoImage for allocation.
  * @param mp MonoMemPool for allocation.
  * @param mem_manager MonoMemoryManager for allocation.
@@ -2568,10 +2568,10 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
  * @param sig The original method signature.
  * @param num_params The number parameters in the new signature.
  * @param new_params An array of MonoType pointers representing the new parameters.
- * 
+ *
  * Duplicate an existing \c MonoMethodSignature but with a new set of parameters.
  * This is a Mono runtime internal function.
- * 
+ *
  * @return the new \c MonoMethodSignature structure.
  */
 MonoMethodSignature*
@@ -3339,7 +3339,7 @@ MonoMethodSignature *
 mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericContext *context)
 {
 	MonoInflatedMethodSignature helper;
-	MonoInflatedMethodSignature *res;
+	MonoInflatedMethodSignature *res = NULL;
 	CollectData data;
 
 	helper.sig = sig;
@@ -3354,16 +3354,19 @@ mono_metadata_get_inflated_signature (MonoMethodSignature *sig, MonoGenericConte
 	mono_mem_manager_lock (mm);
 
 	if (!mm->gsignature_cache)
-		mm->gsignature_cache = g_hash_table_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature);
+		// FIXME: Pick a better pre-reserved size
+		mm->gsignature_cache = dn_simdhash_ght_new_full (inflated_signature_hash, inflated_signature_equal, NULL, (GDestroyNotify)free_inflated_signature, 256, NULL);
+
 	// FIXME: The lookup is done on the newly allocated sig so it always fails
-	res = (MonoInflatedMethodSignature *)g_hash_table_lookup (mm->gsignature_cache, &helper);
+	dn_simdhash_ght_try_get_value (mm->gsignature_cache, &helper, (gpointer *)&res);
 	if (!res) {
 		res = mono_mem_manager_alloc0 (mm, sizeof (MonoInflatedMethodSignature));
 		// FIXME: sig is an inflated signature not owned by the mem manager
 		res->sig = sig;
 		res->context.class_inst = context->class_inst;
 		res->context.method_inst = context->method_inst;
-		g_hash_table_insert (mm->gsignature_cache, res, res);
+		// FIXME: We're wasting memory and cpu by storing key and value redundantly for this table
+		dn_simdhash_ght_insert (mm->gsignature_cache, res, res);
 	}
 
 	mono_mem_manager_unlock (mm);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3417,8 +3417,8 @@ decode_exception_debug_info (MonoAotModule *amodule,
 			jit_mm_lock (jit_mm);
 			/* This could be set already since this function can be called more than once for the same method */
 			MonoSeqPointInfo *existing_seq_points = NULL;
-			if (!g_hash_table_lookup_extended (jit_mm->seq_points, method, NULL, (gpointer *)&existing_seq_points)) {
-				g_hash_table_insert (jit_mm->seq_points, method, seq_points);
+			if (!dn_simdhash_ght_try_get_value (jit_mm->seq_points, method, (void **)&existing_seq_points)) {
+				dn_simdhash_ght_insert (jit_mm->seq_points, method, seq_points);
 			} else {
 				mono_seq_point_info_free (seq_points);
 				seq_points = existing_seq_points;

--- a/src/mono/mono/mini/interp/tiering.c
+++ b/src/mono/mono/mini/interp/tiering.c
@@ -1,14 +1,16 @@
 #include "tiering.h"
 
 static mono_mutex_t tiering_mutex;
-static GHashTable *patch_sites_table;
+// FIXME: The add/remove traffic on this table may require dn_simdhash to implement cascade flag cleanup
+//  and compaction
+static dn_simdhash_ptr_ptr_t *patch_sites_table;
 static gboolean enable_tiering;
 
 void
 mono_interp_tiering_init (void)
 {
 	mono_os_mutex_init_recursive (&tiering_mutex);
-	patch_sites_table = g_hash_table_new (NULL, NULL);
+	patch_sites_table = dn_simdhash_ptr_ptr_new (0, NULL);
 	enable_tiering = TRUE;
 }
 
@@ -61,11 +63,12 @@ patch_imethod_site (gpointer data, gpointer user_data)
 static void
 patch_interp_data_items (InterpMethod *old_imethod, InterpMethod *new_imethod)
 {
-	GSList *sites = g_hash_table_lookup (patch_sites_table, old_imethod);
-	g_slist_foreach (sites, patch_imethod_site, new_imethod);
-
-	g_hash_table_remove (patch_sites_table, old_imethod);
-	g_slist_free (sites);
+	GSList *sites = NULL;
+	if (dn_simdhash_ptr_ptr_try_get_value (patch_sites_table, old_imethod, (void **)&sites)) {
+		g_slist_foreach (sites, patch_imethod_site, new_imethod);
+		dn_simdhash_ptr_ptr_try_remove (patch_sites_table, old_imethod);
+		g_slist_free (sites);
+	}
 }
 
 static InterpMethod*
@@ -100,9 +103,13 @@ static void
 register_imethod_patch_site (InterpMethod *imethod, gpointer *ptr)
 {
 	g_assert (!imethod->optimized);
-	GSList *sites = g_hash_table_lookup (patch_sites_table, imethod);
+	GSList *sites = NULL;
+	guint8 found = dn_simdhash_ptr_ptr_try_get_value (patch_sites_table, imethod, (void **)&sites);
 	sites = g_slist_prepend (sites, ptr);
-	g_hash_table_insert_replace (patch_sites_table, imethod, sites, TRUE);
+	if (found)
+		dn_simdhash_ptr_ptr_try_replace_value (patch_sites_table, imethod, sites);
+	else
+		dn_simdhash_ptr_ptr_try_add (patch_sites_table, imethod, sites);
 }
 
 static void

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1146,7 +1146,8 @@ init_last_ins_call (TransformData *td)
 static guint32
 get_data_item_wide_index (TransformData *td, void *ptr, gboolean *new_slot)
 {
-	gpointer p = g_hash_table_lookup (td->data_hash, ptr);
+	gpointer p = NULL;
+	guint8 found = dn_simdhash_ptr_ptr_try_get_value (td->data_hash, ptr, (void **)&p);
 	guint32 index;
 	if (p != NULL) {
 		if (new_slot)
@@ -1160,7 +1161,10 @@ get_data_item_wide_index (TransformData *td, void *ptr, gboolean *new_slot)
 	index = td->n_data_items;
 	td->data_items [index] = ptr;
 	++td->n_data_items;
-	g_hash_table_insert (td->data_hash, ptr, GUINT_TO_POINTER (index + 1));
+	if (found)
+		dn_simdhash_ptr_ptr_try_replace_value (td->data_hash, ptr, GUINT_TO_POINTER (index + 1));
+	else
+		dn_simdhash_ptr_ptr_try_add (td->data_hash, ptr, GUINT_TO_POINTER (index + 1));
 	if (new_slot)
 		*new_slot = TRUE;
 	return index;
@@ -2998,7 +3002,7 @@ interp_inline_method (TransformData *td, MonoMethod *target_method, MonoMethodHe
 
 		/* Remove any newly added items */
 		for (i = prev_n_data_items; i < td->n_data_items; i++) {
-			g_hash_table_remove (td->data_hash, td->data_items [i]);
+			dn_simdhash_ptr_ptr_try_remove (td->data_hash, td->data_items [i]);
 		}
 		td->n_data_items = prev_n_data_items;
 		/* Also remove any added indexes from the imethod list */
@@ -3969,7 +3973,8 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			if (MINT_IS_PATCHABLE_CALL (td->last_ins->opcode)) {
 				g_assert (!calli && !is_virtual);
 				td->last_ins->flags |= INTERP_INST_FLAG_RECORD_CALL_PATCH;
-				g_hash_table_insert (td->patchsite_hash, td->last_ins, target_method);
+				if (!dn_simdhash_ptr_ptr_try_add (td->patchsite_hash, td->last_ins, target_method))
+					dn_simdhash_ptr_ptr_try_replace (td->patchsite_hash, td->last_ins, target_method);
 			}
 #endif
 		}
@@ -8983,9 +8988,10 @@ emit_compacted_instruction (TransformData *td, guint16* start_ip, InterpInst *in
 		g_assert (MINT_IS_PATCHABLE_CALL (opcode));
 
 		/* TODO: could `ins` be removed by any interp optimization? */
-		MonoMethod *target_method = (MonoMethod *) g_hash_table_lookup (td->patchsite_hash, ins);
+		MonoMethod *target_method = NULL;
+		dn_simdhash_ptr_ptr_try_get_value (td->patchsite_hash, ins, (void **)&target_method);
 		g_assert (target_method);
-		g_hash_table_remove (td->patchsite_hash, ins);
+		dn_simdhash_ptr_ptr_try_remove (td->patchsite_hash, ins);
 
 		mini_tiered_record_callsite (start_ip, target_method, TIERED_PATCH_KIND_INTERP);
 
@@ -9275,9 +9281,9 @@ retry:
 	td->dummy_var = -1;
 	td->ref_handle_var = -1;
 	td->data_items = NULL;
-	td->data_hash = g_hash_table_new (NULL, NULL);
+	td->data_hash = dn_simdhash_ptr_ptr_new (0, NULL);
 #ifdef ENABLE_EXPERIMENT_TIERED
-	td->patchsite_hash = g_hash_table_new (NULL, NULL);
+	td->patchsite_hash = dn_simdhash_ptr_ptr_new (0, NULL);
 #endif
 	td->gen_seq_points = !mini_debug_options.no_seq_points_compact_data || mini_debug_options.gen_sdb_seq_points;
 	td->gen_sdb_seq_points = mini_debug_options.gen_sdb_seq_points;
@@ -9498,9 +9504,9 @@ exit:
 	g_free (td->renamable_vars);
 	g_free (td->renamed_fixed_vars);
 	g_free (td->local_ref_count);
-	g_hash_table_destroy (td->data_hash);
+	dn_simdhash_free (td->data_hash);
 #ifdef ENABLE_EXPERIMENT_TIERED
-	g_hash_table_destroy (td->patchsite_hash);
+	dn_simdhash_free (td->patchsite_hash);
 #endif
 	g_ptr_array_free (td->seq_points, TRUE);
 	if (td->line_numbers)
@@ -9681,9 +9687,10 @@ mono_interp_transform_method (InterpMethod *imethod, ThreadContext *context, Mon
 
 		// FIXME Publishing of seq points seems to be racy with tiereing. We can have both tiered and untiered method
 		// running at the same time. We could therefore get the optimized imethod seq points for the unoptimized method.
-		gpointer seq_points = g_hash_table_lookup (jit_mm->seq_points, imethod->method);
+		gpointer seq_points = NULL;
+		dn_simdhash_ght_try_get_value (jit_mm->seq_points, imethod->method, (void **)&seq_points);
 		if (!seq_points || seq_points != imethod->jinfo->seq_points)
-			g_hash_table_replace (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
+			dn_simdhash_ght_replace (jit_mm->seq_points, imethod->method, imethod->jinfo->seq_points);
 	}
 	jit_mm_unlock (jit_mm);
 

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -311,10 +311,12 @@ typedef struct
 	int n_data_items;
 	int max_data_items;
 	void **data_items;
-	GHashTable *data_hash;
+	// FIXME: ptr_u32
+	dn_simdhash_ptr_ptr_t *data_hash;
 	GSList *imethod_items;
 #ifdef ENABLE_EXPERIMENT_TIERED
-	GHashTable *patchsite_hash;
+	// FIXME: ptr_u32
+	dn_simdhash_ptr_ptr_t *patchsite_hash;
 #endif
 	int *clause_indexes;
 	int *clause_vars;
@@ -504,7 +506,7 @@ interp_dump_ins (InterpInst *ins, gpointer *data_items);
 InterpInst*
 interp_get_ldc_i4_from_const (TransformData *td, InterpInst *ins, gint32 ct, int dreg);
 
-gint32 
+gint32
 interp_get_const_from_ldc_i4 (InterpInst *ins);
 
 int

--- a/src/mono/mono/mini/interp/whitebox.c
+++ b/src/mono/mono/mini/interp/whitebox.c
@@ -165,7 +165,7 @@ transform_method (MonoDomain *domain, MonoImage *image, TestItem *ti)
 	td->rtm = rtm;
 	td->clause_indexes = (int*)g_malloc (header->code_size * sizeof (int));
 	td->data_items = NULL;
-	td->data_hash = g_hash_table_new (NULL, NULL);
+	td->data_hash = dn_simdhash_ptr_ptr_new (0, NULL);
 	/* TODO: init more fields of `td` */
 
 	mono_test_interp_method_compute_offsets (td, rtm, signature, header);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3027,7 +3027,7 @@ mono_jit_free_method (MonoMethod *method)
 	//seq_points are always on get_default_jit_mm
 	jit_mm = get_default_jit_mm ();
 	jit_mm_lock (jit_mm);
-	g_hash_table_remove (jit_mm->seq_points, method);
+	dn_simdhash_ght_try_remove (jit_mm->seq_points, method);
 	jit_mm_unlock (jit_mm);
 
 	jit_mm = jit_mm_for_method (method);
@@ -3043,7 +3043,7 @@ mono_jit_free_method (MonoMethod *method)
 	mono_conc_hashtable_remove (jit_mm->runtime_invoke_hash, method);
 	g_hash_table_remove (jit_mm->dynamic_code_hash, method);
 	g_hash_table_remove (jit_mm->jump_trampoline_hash, method);
-	g_hash_table_remove (jit_mm->seq_points, method);
+	dn_simdhash_ght_try_remove (jit_mm->seq_points, method);
 
 	g_hash_table_iter_init (&iter, jit_mm->jump_target_hash);
 	while (g_hash_table_iter_next (&iter, NULL, (void**)&jlist)) {
@@ -4380,7 +4380,7 @@ init_jit_mem_manager (MonoMemoryManager *mem_manager)
 	info->jump_target_hash = g_hash_table_new (NULL, NULL);
 	info->jit_trampoline_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	info->delegate_info_hash = g_hash_table_new (delegate_class_method_pair_hash, delegate_class_method_pair_equal);
-	info->seq_points = g_hash_table_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free);
+	info->seq_points = dn_simdhash_ght_new_full (mono_aligned_addr_hash, NULL, NULL, mono_seq_point_info_free, 0, NULL);
 	info->runtime_invoke_hash = mono_conc_hashtable_new_full (mono_aligned_addr_hash, NULL, NULL, runtime_invoke_info_free);
 	info->arch_seq_points = g_hash_table_new (mono_aligned_addr_hash, NULL);
 	mono_jit_code_hash_init (&info->jit_code_hash);
@@ -4453,7 +4453,7 @@ free_jit_mem_manager (MonoMemoryManager *mem_manager)
 	g_hash_table_destroy (info->static_rgctx_trampoline_hash);
 	g_hash_table_destroy (info->mrgctx_hash);
 	mono_conc_hashtable_destroy (info->runtime_invoke_hash);
-	g_hash_table_destroy (info->seq_points);
+	dn_simdhash_free (info->seq_points);
 	g_hash_table_destroy (info->arch_seq_points);
 	if (info->agent_info)
 		mono_component_debugger ()->free_mem_manager (info);
@@ -5602,4 +5602,11 @@ mono_jit_call_can_be_supported_by_interp (MonoMethod *method, MonoMethodSignatur
 		return FALSE;
 
 	return TRUE;
+}
+
+void
+mono_jit_memory_manager_foreach_seq_point (dn_simdhash_ght_t *seq_points, dn_simdhash_ght_foreach_func func, gpointer user_data)
+{
+	g_assert (seq_points);
+	dn_simdhash_ght_foreach (seq_points, func, user_data);
 }

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -37,7 +37,7 @@ typedef struct {
 	MonoConcurrentHashTable *runtime_invoke_hash;
 	/* Maps MonoMethod to a GPtrArray containing sequence point locations */
 	/* Protected by the domain lock */
-	GHashTable *seq_points;
+	dn_simdhash_ght_t *seq_points;
 	/* Debugger agent data */
 	gpointer agent_info;
 	/* Maps MonoMethod to an arch-specific structure */
@@ -659,6 +659,9 @@ mono_is_addr_implicit_null_check (void *addr);
 
 gboolean
 mono_jit_call_can_be_supported_by_interp (MonoMethod *method, MonoMethodSignature *sig, gboolean is_llvm_only);
+
+MONO_COMPONENT_API void
+mono_jit_memory_manager_foreach_seq_point (dn_simdhash_ght_t *seq_points, dn_simdhash_ght_foreach_func func, gpointer user_data);
 
 /*
  * Signal handling

--- a/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
+++ b/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
@@ -318,6 +318,7 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
             string resourceId = tuple.registeredName;
 
             // Generate Preloaded MonoBundled*Resource structs
+            // See bundled-resources-internals.h
             string preloadedStruct;
             switch (tuple.resourceType)
             {


### PR DESCRIPTION
Migrates various GHashTables in the mono runtime over to dn_simdhash, and optimizes a couple specific spots in the process.

There are more hash tables in mono that might be profitable to migrate based on profiling, but they're more complex scenarios, i.e. internal hash tables or concurrent hash tables, so I opted not to do them in this PR. In one case when I tried migrating one of them, things actually got slower.
