### PR TITLE
Avoid MakeGenericMethod in XmlSerializer

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -2117,6 +2117,7 @@ namespace System.Xml.Serialization
 
         public static SetMemberValueDelegate GetSetMemberValueDelegateWithType<TObj, TParam>(MemberInfo memberInfo)
         {
+            Debug.Assert(!typeof(TObj).IsValueType);
             Action<TObj, TParam>? setTypedDelegate = null;
             if (memberInfo is PropertyInfo propInfo)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -635,24 +635,44 @@ namespace System.Xml.Serialization
                     {
                         MemberInfo memberInfo = ReflectionXmlSerializationHelper.GetEffectiveSetInfo(o.GetType(), memberName);
                         Debug.Assert(memberInfo != null, "memberInfo could not be retrieved");
-                        Type memberType;
-                        if (memberInfo is PropertyInfo propInfo)
+
+                        if (type.IsValueType || !RuntimeFeature.IsDynamicCodeSupported)
                         {
-                            memberType = propInfo.PropertyType;
-                        }
-                        else if (memberInfo is FieldInfo fieldInfo)
-                        {
-                            memberType = fieldInfo.FieldType;
+                            if (memberInfo is PropertyInfo propInfo)
+                            {
+                                result = new ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate(propInfo.SetValue);
+                            }
+                            else if (memberInfo is FieldInfo fieldInfo)
+                            {
+                                result = new ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate(fieldInfo.SetValue);
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException(SR.XmlInternalError);
+                            }
                         }
                         else
                         {
-                            throw new InvalidOperationException(SR.XmlInternalError);
+                            Type memberType;
+                            if (memberInfo is PropertyInfo propInfo)
+                            {
+                                memberType = propInfo.PropertyType;
+                            }
+                            else if (memberInfo is FieldInfo fieldInfo)
+                            {
+                                memberType = fieldInfo.FieldType;
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException(SR.XmlInternalError);
+                            }
+
+                            MethodInfo getSetMemberValueDelegateWithTypeGenericMi = typeof(ReflectionXmlSerializationReaderHelper).GetMethod("GetSetMemberValueDelegateWithType", BindingFlags.Static | BindingFlags.Public)!;
+                            MethodInfo getSetMemberValueDelegateWithTypeMi = getSetMemberValueDelegateWithTypeGenericMi.MakeGenericMethod(o.GetType(), memberType);
+                            var getSetMemberValueDelegateWithType = getSetMemberValueDelegateWithTypeMi.CreateDelegate<Func<MemberInfo, ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate>>();
+                            result = getSetMemberValueDelegateWithType(memberInfo);
                         }
 
-                        MethodInfo getSetMemberValueDelegateWithTypeGenericMi = typeof(ReflectionXmlSerializationReaderHelper).GetMethod("GetSetMemberValueDelegateWithType", BindingFlags.Static | BindingFlags.Public)!;
-                        MethodInfo getSetMemberValueDelegateWithTypeMi = getSetMemberValueDelegateWithTypeGenericMi.MakeGenericMethod(o.GetType(), memberType);
-                        var getSetMemberValueDelegateWithType = getSetMemberValueDelegateWithTypeMi.CreateDelegate<Func<MemberInfo, ReflectionXmlSerializationReaderHelper.SetMemberValueDelegate>>();
-                        result = getSetMemberValueDelegateWithType(memberInfo);
                         delegateCacheForType[memberName] = result;
                     }
                 }
@@ -2097,46 +2117,30 @@ namespace System.Xml.Serialization
 
         public static SetMemberValueDelegate GetSetMemberValueDelegateWithType<TObj, TParam>(MemberInfo memberInfo)
         {
-            if (typeof(TObj).IsValueType)
+            Action<TObj, TParam>? setTypedDelegate = null;
+            if (memberInfo is PropertyInfo propInfo)
             {
-                if (memberInfo is PropertyInfo propInfo)
+                var setMethod = propInfo.GetSetMethod(true);
+                if (setMethod == null)
                 {
                     return propInfo.SetValue;
                 }
-                else if (memberInfo is FieldInfo fieldInfo)
-                {
-                    return fieldInfo.SetValue;
-                }
 
-                throw new InvalidOperationException(SR.XmlInternalError);
+                setTypedDelegate = setMethod.CreateDelegate<Action<TObj, TParam>>();
             }
-            else
+            else if (memberInfo is FieldInfo fieldInfo)
             {
-                Action<TObj, TParam>? setTypedDelegate = null;
-                if (memberInfo is PropertyInfo propInfo)
-                {
-                    var setMethod = propInfo.GetSetMethod(true);
-                    if (setMethod == null)
-                    {
-                        return propInfo.SetValue;
-                    }
-
-                    setTypedDelegate = setMethod.CreateDelegate<Action<TObj, TParam>>();
-                }
-                else if (memberInfo is FieldInfo fieldInfo)
-                {
-                    var objectParam = Expression.Parameter(typeof(TObj));
-                    var valueParam = Expression.Parameter(typeof(TParam));
-                    var fieldExpr = Expression.Field(objectParam, fieldInfo);
-                    var assignExpr = Expression.Assign(fieldExpr, valueParam);
-                    setTypedDelegate = Expression.Lambda<Action<TObj, TParam>>(assignExpr, objectParam, valueParam).Compile();
-                }
-
-                return delegate (object? o, object? p)
-                {
-                    setTypedDelegate!((TObj)o!, (TParam)p!);
-                };
+                var objectParam = Expression.Parameter(typeof(TObj));
+                var valueParam = Expression.Parameter(typeof(TParam));
+                var fieldExpr = Expression.Field(objectParam, fieldInfo);
+                var assignExpr = Expression.Assign(fieldExpr, valueParam);
+                setTypedDelegate = Expression.Lambda<Action<TObj, TParam>>(assignExpr, objectParam, valueParam).Compile();
             }
+
+            return delegate (object? o, object? p)
+            {
+                setTypedDelegate!((TObj)o!, (TParam)p!);
+            };
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -636,7 +636,7 @@ namespace System.Xml.Serialization
                         MemberInfo memberInfo = ReflectionXmlSerializationHelper.GetEffectiveSetInfo(o.GetType(), memberName);
                         Debug.Assert(memberInfo != null, "memberInfo could not be retrieved");
 
-                        if (type.IsValueType || !RuntimeFeature.IsDynamicCodeSupported)
+                        if (type.IsValueType || RuntimeFeature.IsDynamicCodeSupported)
                         {
                             if (memberInfo is PropertyInfo propInfo)
                             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationReader.cs
@@ -636,7 +636,7 @@ namespace System.Xml.Serialization
                         MemberInfo memberInfo = ReflectionXmlSerializationHelper.GetEffectiveSetInfo(o.GetType(), memberName);
                         Debug.Assert(memberInfo != null, "memberInfo could not be retrieved");
 
-                        if (type.IsValueType || RuntimeFeature.IsDynamicCodeSupported)
+                        if (type.IsValueType || !RuntimeFeature.IsDynamicCodeSupported)
                         {
                             if (memberInfo is PropertyInfo propInfo)
                             {


### PR DESCRIPTION
I pulled out the `IsValueType` part of the generic method into the non-generic method since it doesn't use anything from the generic context. This should be an improvement irrespective of AOT.

Then I made us take the IsValueType path if `IsDynamicCodeSupported` is false. This has two consequences:

* Avoids `MakeGenericType` that may or may not succeed with `IsDynamicCodeSupported=false`
* Avoids LINQ expressions in the field case. This is will be a throughput improvement.
* There might be a small throughput regression for the property case when IsDynamicCodeSupported is false, but we get reliability in return.

Cc @dotnet/ilc-contrib 