### PR TITLE
[mono][interp] Update mono struct lowering to use MonoMemoryManager

### DIFF
--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1010,7 +1010,7 @@ MonoMethodSignature  *mono_metadata_signature_dup_mempool (MonoMemPool *mp, Mono
 MonoMethodSignature  *mono_metadata_signature_dup_mem_manager (MonoMemoryManager *mem_manager, MonoMethodSignature *sig);
 MonoMethodSignature  *mono_metadata_signature_dup_add_this (MonoImage *image, MonoMethodSignature *sig, MonoClass *klass);
 MonoMethodSignature  *mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig);
-MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
+MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
 
 MonoGenericInst *
 mono_get_shared_generic_inst (MonoGenericContainer *container);

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1011,7 +1011,7 @@ MonoMethodSignature  *mono_metadata_signature_dup_mem_manager (MonoMemoryManager
 MonoMethodSignature  *mono_metadata_signature_dup_add_this (MonoImage *image, MonoMethodSignature *sig, MonoClass *klass);
 MonoMethodSignature  *mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig);
 MonoMethodSignature  *mono_metadata_signature_allocate_internal (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, size_t sig_size);
-MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
+MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
 
 MonoGenericInst *
 mono_get_shared_generic_inst (MonoGenericContainer *container);

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -1010,7 +1010,8 @@ MonoMethodSignature  *mono_metadata_signature_dup_mempool (MonoMemPool *mp, Mono
 MonoMethodSignature  *mono_metadata_signature_dup_mem_manager (MonoMemoryManager *mem_manager, MonoMethodSignature *sig);
 MonoMethodSignature  *mono_metadata_signature_dup_add_this (MonoImage *image, MonoMethodSignature *sig, MonoClass *klass);
 MonoMethodSignature  *mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig);
-MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
+MonoMethodSignature  *mono_metadata_signature_allocate_internal (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, size_t sig_size);
+MonoMethodSignature  *mono_metadata_signature_dup_new_params (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params);
 
 MonoGenericInst *
 mono_get_shared_generic_inst (MonoGenericContainer *container);

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2563,7 +2563,6 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
 
 /**
  * mono_metadata_signature_dup_new_params:
- * @param image The image to allocate the new signature from.
  * @param mp The mempool to allocate the new signature from.
  * @param mem_manager The memory manager to allocate the new signature from.
  * @param sig The original method signature.
@@ -2576,13 +2575,13 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
  * @return the new \c MonoMethodSignature structure.
  */
 MonoMethodSignature*
-mono_metadata_signature_dup_new_params (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
+mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
 {
 	size_t new_sig_size = MONO_SIZEOF_METHOD_SIGNATURE + num_params * sizeof (MonoType*);
 	if (sig->ret)
 		new_sig_size += mono_sizeof_type (sig->ret);
 
-	MonoMethodSignature *res = mono_metadata_signature_allocate_internal (image, mp, mem_manager, new_sig_size);
+	MonoMethodSignature *res = mono_metadata_signature_allocate_internal (NULL, mp, mem_manager, new_sig_size);
 	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
 	res->param_count = GUINT32_TO_UINT16 (num_params);
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2435,15 +2435,7 @@ mono_metadata_signature_dup_internal (MonoImage *image, MonoMemPool *mp, MonoMem
 	if (sig->ret)
 		sigsize += mono_sizeof_type (sig->ret);
 
-	if (image) {
-		ret = (MonoMethodSignature *)mono_image_alloc (image, (guint)sigsize);
-	} else if (mp) {
-		ret = (MonoMethodSignature *)mono_mempool_alloc (mp, (unsigned int)sigsize);
-	} else if (mem_manager) {
-		ret = (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, (guint)sigsize);
-	} else {
-		ret = (MonoMethodSignature *)g_malloc (sigsize);
-	}
+	ret = mono_metadata_signature_allocate_internal (image, mp, mem_manager, sigsize);
 
 	memcpy (ret, sig, sig_header_size - padding);
 
@@ -2456,6 +2448,29 @@ mono_metadata_signature_dup_internal (MonoImage *image, MonoMemPool *mp, MonoMem
 	}
 
 	return ret;
+}
+
+/**
+ * Allocates memory for a MonoMethodSignature based on the provided parameters.
+ * 
+ * @param image MonoImage for allocation.
+ * @param mp MonoMemPool for allocation.
+ * @param mem_manager MonoMemoryManager for allocation.
+ * @param sig_size Size of the signature to allocate.
+ * @return Pointer to the allocated MonoMethodSignature.
+ */
+MonoMethodSignature*
+mono_metadata_signature_allocate_internal (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, size_t sig_size)
+{
+    if (image) {
+        return (MonoMethodSignature *)mono_image_alloc (image, (guint)sig_size);
+    } else if (mp) {
+        return (MonoMethodSignature *)mono_mempool_alloc (mp, (unsigned int)sig_size);
+    } else if (mem_manager) {
+        return (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, (guint)sig_size);
+    } else {
+        return (MonoMethodSignature *)g_malloc (sig_size);
+    }
 }
 
 /*
@@ -2548,7 +2563,9 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
 
 /**
  * mono_metadata_signature_dup_new_params:
- * @param mp The memory pool to allocate the duplicated signature from.
+ * @param image The image to allocate the new signature from.
+ * @param mp The mempool to allocate the new signature from.
+ * @param mem_manager The memory manager to allocate the new signature from.
  * @param sig The original method signature.
  * @param num_params The number parameters in the new signature.
  * @param new_params An array of MonoType pointers representing the new parameters.
@@ -2559,13 +2576,13 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
  * @return the new \c MonoMethodSignature structure.
  */
 MonoMethodSignature*
-mono_metadata_signature_dup_new_params (MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
+mono_metadata_signature_dup_new_params (MonoImage *image, MonoMemPool *mp, MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
 {
 	size_t new_sig_size = MONO_SIZEOF_METHOD_SIGNATURE + num_params * sizeof (MonoType*);
 	if (sig->ret)
 		new_sig_size += mono_sizeof_type (sig->ret);
-	
-	MonoMethodSignature *res = (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, (unsigned int)new_sig_size);
+
+	MonoMethodSignature *res = mono_metadata_signature_allocate_internal (image, mp, mem_manager, new_sig_size);
 	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
 	res->param_count = GUINT32_TO_UINT16 (num_params);
 

--- a/src/mono/mono/metadata/metadata.c
+++ b/src/mono/mono/metadata/metadata.c
@@ -2559,13 +2559,13 @@ mono_metadata_signature_dup_delegate_invoke_to_target (MonoMethodSignature *sig)
  * @return the new \c MonoMethodSignature structure.
  */
 MonoMethodSignature*
-mono_metadata_signature_dup_new_params (MonoMemPool *mp, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
+mono_metadata_signature_dup_new_params (MonoMemoryManager *mem_manager, MonoMethodSignature *sig, uint32_t num_params, MonoType **new_params)
 {
 	size_t new_sig_size = MONO_SIZEOF_METHOD_SIGNATURE + num_params * sizeof (MonoType*);
 	if (sig->ret)
 		new_sig_size += mono_sizeof_type (sig->ret);
 	
-	MonoMethodSignature *res = (MonoMethodSignature *)mono_mempool_alloc0 (mp, (unsigned int)new_sig_size);
+	MonoMethodSignature *res = (MonoMethodSignature *)mono_mem_manager_alloc (mem_manager, (unsigned int)new_sig_size);
 	memcpy (res, sig, MONO_SIZEOF_METHOD_SIGNATURE);
 	res->param_count = GUINT32_TO_UINT16 (num_params);
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3401,7 +3401,7 @@ interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *c
 	++td->sp;
 
 	// Create a new dummy signature with the lowered arguments
-	new_csignature = mono_metadata_signature_dup_new_params (td->mem_manager, csignature, new_param_count, (MonoType**)new_params->data);
+	new_csignature = mono_metadata_signature_dup_new_params (NULL, NULL, td->mem_manager, csignature, new_param_count, (MonoType**)new_params->data);
 
 	// Deallocate temp array
 	g_array_free (new_params, TRUE);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3401,7 +3401,7 @@ interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *c
 	++td->sp;
 
 	// Create a new dummy signature with the lowered arguments
-	new_csignature = mono_metadata_signature_dup_new_params (td->mempool, csignature, new_param_count, (MonoType**)new_params->data);
+	new_csignature = mono_metadata_signature_dup_new_params (td->mem_manager, csignature, new_param_count, (MonoType**)new_params->data);
 
 	// Deallocate temp array
 	g_array_free (new_params, TRUE);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -3401,7 +3401,7 @@ interp_emit_swiftcall_struct_lowering (TransformData *td, MonoMethodSignature *c
 	++td->sp;
 
 	// Create a new dummy signature with the lowered arguments
-	new_csignature = mono_metadata_signature_dup_new_params (NULL, NULL, td->mem_manager, csignature, new_param_count, (MonoType**)new_params->data);
+	new_csignature = mono_metadata_signature_dup_new_params (NULL, td->mem_manager, csignature, new_param_count, (MonoType**)new_params->data);
 
 	// Deallocate temp array
 	g_array_free (new_params, TRUE);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7585,7 +7585,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 
 				// Create a new dummy signature with the lowered arguments				
-				fsig = mono_metadata_signature_dup_new_params (NULL, cfg->mempool, NULL, fsig, new_param_count, (MonoType**)new_params->data);
+				fsig = mono_metadata_signature_dup_new_params (cfg->mempool, NULL, fsig, new_param_count, (MonoType**)new_params->data);
 
 				// Deallocate temp array
 				g_array_free (new_params, TRUE);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7585,7 +7585,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 
 				// Create a new dummy signature with the lowered arguments				
-				fsig = mono_metadata_signature_dup_new_params (cfg->mem_manager, fsig, new_param_count, (MonoType**)new_params->data);
+				fsig = mono_metadata_signature_dup_new_params (NULL, cfg->mempool, NULL, fsig, new_param_count, (MonoType**)new_params->data);
 
 				// Deallocate temp array
 				g_array_free (new_params, TRUE);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -7585,7 +7585,7 @@ mono_method_to_ir (MonoCompile *cfg, MonoMethod *method, MonoBasicBlock *start_b
 				}
 
 				// Create a new dummy signature with the lowered arguments				
-				fsig = mono_metadata_signature_dup_new_params (cfg->mempool, fsig, new_param_count, (MonoType**)new_params->data);
+				fsig = mono_metadata_signature_dup_new_params (cfg->mem_manager, fsig, new_param_count, (MonoType**)new_params->data);
 
 				// Deallocate temp array
 				g_array_free (new_params, TRUE);


### PR DESCRIPTION
## Description

This PR updates `mono_metadata_signature_dup_new_params` to use `MonoMemoryManager` instead of `MonoMemPool`. The mempool can be detroyed after method is compiled.

Fixes https://github.com/dotnet/runtime/issues/102478