### PR TITLE
Add support for exported types in illink XML formats

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ProcessLinkerXmlBase.cs
+++ b/src/coreclr/tools/Common/Compiler/ProcessLinkerXmlBase.cs
@@ -217,9 +217,10 @@ namespace ILCompiler
                         continue;
                 }
 
-                // TODO: Process exported types
+                MetadataType? type = CecilCompatibleTypeParser.GetType(assembly, fullname);
 
-                TypeDesc? type = CecilCompatibleTypeParser.GetType(assembly, fullname);
+                if (type != null && type.Module != assembly)
+                    type = ProcessExportedType(type, assembly, typeNav);
 
                 if (type == null)
                 {
@@ -233,6 +234,8 @@ namespace ILCompiler
                 ProcessType(type, typeNav);
             }
         }
+
+        protected virtual MetadataType? ProcessExportedType(MetadataType exported, ModuleDesc assembly, XPathNavigator nav) => exported;
 
         private void MatchType(TypeDesc type, Regex regex, XPathNavigator nav)
         {
@@ -759,7 +762,7 @@ namespace ILCompiler
 
     public class CecilCompatibleTypeParser
     {
-        public static TypeDesc? GetType(ModuleDesc assembly, string fullName)
+        public static MetadataType? GetType(ModuleDesc assembly, string fullName)
         {
             Debug.Assert(!string.IsNullOrEmpty(fullName));
             var position = fullName.IndexOf('/');

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
@@ -40,7 +40,7 @@ namespace ILCompiler
             ProcessTypes(assembly, nav, warnOnUnresolvedTypes);
         }
 
-        // protected override TypeDesc? ProcessExportedType(ExportedType exported, ModuleDesc assembly, XPathNavigator nav) => null;
+        protected override MetadataType ProcessExportedType(MetadataType exported, ModuleDesc assembly, XPathNavigator nav) => null;
 
         protected override bool ProcessTypePattern(string fullname, ModuleDesc assembly, XPathNavigator nav) => false;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DescriptorMarker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DescriptorMarker.cs
@@ -162,6 +162,14 @@ namespace ILCompiler
         }
 #endif
 
+        protected override MetadataType? ProcessExportedType(MetadataType exported, ModuleDesc assembly, XPathNavigator nav)
+        {
+            // Rooting module metadata roots type forwarder metadata for all types in the module that are reflection visible.
+            // (We don't track individual type forwarders right now.)
+            _dependencies.Add(_factory.ModuleMetadata(assembly), "Type used through forwarder");
+            return base.ProcessExportedType(exported, assembly, nav);
+        }
+
         protected override void ProcessType(TypeDesc type, XPathNavigator nav)
         {
             Debug.Assert(ShouldProcessElement(nav));

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ILLinkDescriptor.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ILLinkDescriptor.cs
@@ -17,6 +17,7 @@ class ILLinkDescriptor
         ThrowIfMemberNotPresent(typeof(ILLinkDescriptor), nameof(PropertyKeptViaDescriptor));
         ThrowIfMemberNotPresent(typeof(ILLinkDescriptor), nameof(EventKeptViaDescriptor));
         ThrowIfTypeNotPresent(typeof(ILLinkDescriptor), nameof(NestedTypeKeptViaDescriptor));
+        ThrowIfTypeNotPresent("LibraryClass, ShimLibrary");
         ThrowIfTypePresent(typeof(ILLinkDescriptor), nameof(NestedTypeNonKept));
         return 100;
     }
@@ -51,6 +52,10 @@ class ILLinkDescriptor
         Justification = "That's the point")]
     private static bool IsTypePresent(Type testType, string typeName) => testType.GetNestedType(typeName, BindingFlags.NonPublic | BindingFlags.Public) != null;
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2057:UnrecognizedReflectionPattern",
+        Justification = "That's the point")]
+    private static bool IsTypePresent(string typeName) => Type.GetType(typeName) != null;
+
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",
         Justification = "That's the point")]
     private static bool IsMemberPresent(Type testType, string memberName) {
@@ -65,6 +70,14 @@ class ILLinkDescriptor
     private static void ThrowIfTypeNotPresent(Type testType, string typeName)
     {
         if (!IsTypePresent(testType, typeName))
+        {
+            throw new Exception(typeName);
+        }
+    }
+
+    private static void ThrowIfTypeNotPresent(string typeName)
+    {
+        if (!IsTypePresent(typeName))
         {
             throw new Exception(typeName);
         }

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.cs
@@ -1,0 +1,4 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public class LibraryClass { }

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/Library.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Library.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/NonEmbedded.ILLink.Descriptor.xml
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/NonEmbedded.ILLink.Descriptor.xml
@@ -4,4 +4,8 @@
       <method name="methodKeptViaStandaloneDescriptor"/>
     </type>
   </assembly>
+
+  <assembly fullname="ShimLibrary">
+    <type fullname="LibraryClass" />
+  </assembly>
 </linker>

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: TypeForwardedTo(typeof(LibraryClass))]

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/ShimLibrary.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ShimLibrary.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="Library.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/TrimmingBehaviors.csproj
@@ -8,6 +8,11 @@
     <!-- We don't run the scanner in optimized builds -->
     <CLRTestTargetUnsupported Condition="'$(IlcMultiModule)' == 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="ShimLibrary.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="Dataflow.cs" />
     <Compile Include="DeadCodeElimination.cs" />


### PR DESCRIPTION
Addresses the TODO in the native AOT port.

Ran into inability of rooting things from mscorlib with the illink XML format on native AOT so decided to fix the TODO.

(It was possible to work around with `Type.GetType` (that's a supported pattern) or rd.xml, but this should work with the descriptors too.)

Cc @dotnet/ilc-contrib 