### PR TITLE
Update condition for NETStandard 2.1 Targeting Pack build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -264,8 +264,8 @@
     <!--
       Targeting pack package for NETStandard 2.1 gets rebuilt on demand.
 
-      Set to rebuild with 8.0.7 release, and automatically disabled after that.
+      Set to rebuild with 8.0.8 release, and automatically disabled after that.
     -->
-    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '7'">true</BuildNETStandard21TargetingPack>
+    <BuildNETStandard21TargetingPack Condition="'$(PatchVersion)' == '8'">true</BuildNETStandard21TargetingPack>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This needs to build for July release. The PR is updating the property that enables rebuild of NETStandard 2.1 Targeting Pack.

This was already approved and main changes merged in https://github.com/dotnet/runtime/pull/102081