### PR TITLE
Minimize System.Version formatting buffer's length

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -170,7 +170,9 @@ namespace System
 
         public string ToString(int fieldCount)
         {
-            Span<char> dest = stackalloc char[(4 * (Number.Int32NumberBufferLength - 1)) + 3]; // at most 4 non-negative Int32s and 3 periods
+            // at most 4 non-negative Int32s and 3 periods: 2147483647.2147483647.2147483647.2147483647
+            const int MaximumVersionLength = 43;
+            Span<char> dest = stackalloc char[MaximumVersionLength];
             bool success = TryFormat(dest, fieldCount, out int charsWritten);
             Debug.Assert(success);
             return dest.Slice(0, charsWritten).ToString();

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -170,7 +170,7 @@ namespace System
 
         public string ToString(int fieldCount)
         {
-            Span<char> dest = stackalloc char[(4 * Number.UInt32NumberBufferLength) + 3]; // at most 4 non-negative Int32s and 3 periods
+            Span<char> dest = stackalloc char[(4 * (Number.Int32NumberBufferLength - 1)) + 3]; // at most 4 non-negative Int32s and 3 periods
             bool success = TryFormat(dest, fieldCount, out int charsWritten);
             Debug.Assert(success);
             return dest.Slice(0, charsWritten).ToString();

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -170,7 +170,7 @@ namespace System
 
         public string ToString(int fieldCount)
         {
-            Span<char> dest = stackalloc char[(4 * Number.Int32NumberBufferLength) + 3]; // at most 4 Int32s and 3 periods
+            Span<char> dest = stackalloc char[(4 * Number.UInt32NumberBufferLength) + 3]; // at most 4 non-negative Int32s and 3 periods
             bool success = TryFormat(dest, fieldCount, out int charsWritten);
             Debug.Assert(success);
             return dest.Slice(0, charsWritten).ToString();


### PR DESCRIPTION
Change the length of the char buffer used in `Version.ToString()` from 47 to 43 chars (4 non-negative `Int32`s + 3 periods). `2147483647.2147483647.2147483647.2147483647`. Even if a version has invalid internal state (any component less than -1), the `TryFormat` method just casts them to `UInt32` anyway.