### PR TITLE
Disable W^X in Rosetta emulated x64 containers on macOS

### DIFF
--- a/src/coreclr/minipal/CMakeLists.txt
+++ b/src/coreclr/minipal/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(.)
+include_directories(${CLR_SRC_NATIVE_DIR})
 if (CLR_CMAKE_HOST_UNIX)
     add_subdirectory(Unix)
 else (CLR_CMAKE_HOST_UNIX)

--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -22,7 +22,11 @@
 #include "minipal.h"
 #include "minipal/cpufeatures.h"
 
-#ifndef TARGET_OSX
+#ifdef TARGET_OSX
+
+#include <mach/mach.h>
+
+#else // TARGET_OSX
 
 #ifdef TARGET_64BIT
 static const off_t MaxDoubleMappedSize = 2048ULL*1024*1024*1024;
@@ -34,9 +38,9 @@ static const off_t MaxDoubleMappedSize = UINT_MAX;
 
 bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecutableCodeSize)
 {
-    if (minipal_detect_emulation())
+    if (minipal_detect_rosetta())
     {
-        // Rosetta or QEMU doesn't support double mapping correctly
+        // Rosetta doesn't support double mapping correctly
         return false;
     }
 

--- a/src/coreclr/minipal/Unix/doublemapping.cpp
+++ b/src/coreclr/minipal/Unix/doublemapping.cpp
@@ -47,6 +47,90 @@ static const off_t MaxDoubleMappedSize = UINT_MAX;
 
 #endif // TARGET_OSX
 
+#if defined(TARGET_AMD64) && !defined(TARGET_OSX)
+
+extern "C" int VerifyDoubleMapping1();
+extern "C" void VerifyDoubleMapping1_End();
+extern "C" int VerifyDoubleMapping2();
+extern "C" void VerifyDoubleMapping2_End();
+
+// Verify that the double mapping works correctly, including cases when the executable code page is modified after
+// the code is executed. 
+bool VerifyDoubleMapping(int fd)
+{
+    bool result = false;
+    void *mapperHandle = (void*)(size_t)fd;
+    void *pCommittedPage = NULL;
+    void *pWriteablePage = NULL;
+    int testCallResult;
+
+    typedef int (*VerificationFunctionPtr)();
+    VerificationFunctionPtr pVerificationFunction;
+
+    size_t pageSize = getpagesize();
+
+    void *pExecutablePage = VMToOSInterface::ReserveDoubleMappedMemory(mapperHandle, 0, pageSize, NULL, NULL);
+    
+    if (pExecutablePage == NULL)
+    {
+        goto Cleanup;
+    }
+
+    pCommittedPage = VMToOSInterface::CommitDoubleMappedMemory(pExecutablePage, pageSize, true);
+    if (pCommittedPage == NULL)
+    {
+        goto Cleanup;
+    }
+
+    pWriteablePage = VMToOSInterface::GetRWMapping(mapperHandle, pCommittedPage, 0, pageSize);
+    if (pWriteablePage == NULL)
+    {
+        goto Cleanup;
+    }
+
+    // First copy a method of a simple function that returns 1 into the writeable mapping
+    memcpy(pWriteablePage, (void*)VerifyDoubleMapping1, (char*)VerifyDoubleMapping1_End - (char*)VerifyDoubleMapping1);
+    pVerificationFunction = (VerificationFunctionPtr)pExecutablePage;
+    // Invoke the function via the executable mapping. It should return 1.
+    testCallResult = pVerificationFunction();
+    if (testCallResult != 1)
+    {
+        goto Cleanup;
+    }
+
+    VMToOSInterface::ReleaseRWMapping(pWriteablePage, pageSize);
+    pWriteablePage = VMToOSInterface::GetRWMapping(mapperHandle, pCommittedPage, 0, pageSize);
+    if (pWriteablePage == NULL)
+    {
+        goto Cleanup;
+    }
+
+    // Now overwrite the first function by a second one that returns 2 using the writeable mapping
+    memcpy(pWriteablePage, (void*)VerifyDoubleMapping2, (char*)VerifyDoubleMapping2_End - (char*)VerifyDoubleMapping2);
+    pVerificationFunction = (VerificationFunctionPtr)pExecutablePage;
+    testCallResult = pVerificationFunction();
+    // Invoke the function via the executable mapping again. It should return 2 now.
+    // This doesn't work when running x64 code in docker on macOS Arm64 where the code is not re-translated by Rosetta
+    if (testCallResult == 2)
+    {
+        result = true;
+    }
+
+Cleanup:
+    if (pWriteablePage != NULL)
+    {
+        VMToOSInterface::ReleaseRWMapping(pWriteablePage, pageSize);
+    }
+
+    if (pExecutablePage != NULL)
+    {
+        VMToOSInterface::ReleaseDoubleMappedMemory(mapperHandle, pExecutablePage, 0, pageSize);
+    }
+
+    return result;
+}
+#endif // TARGET_AMD64 && !TARGET_OSX
+
 bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecutableCodeSize)
 {
 #ifndef TARGET_OSX
@@ -73,6 +157,14 @@ bool VMToOSInterface::CreateDoubleMemoryMapper(void** pHandle, size_t *pMaxExecu
         close(fd);
         return false;
     }
+
+#if defined(TARGET_AMD64) && !defined(TARGET_OSX)
+    if (!VerifyDoubleMapping(fd))
+    {
+        close(fd);
+        return false;
+    }
+#endif // TARGET_AMD64 && !TARGET_OSX
 
     *pMaxExecutableCodeSize = MaxDoubleMappedSize;
     *pHandle = (void*)(size_t)fd;

--- a/src/coreclr/minipal/Windows/doublemapping.cpp
+++ b/src/coreclr/minipal/Windows/doublemapping.cpp
@@ -6,6 +6,7 @@
 #include <inttypes.h>
 #include <assert.h>
 #include "minipal.h"
+#include "minipal/cpufeatures.h"
 
 #define HIDWORD(_qw)    ((ULONG)((_qw) >> 32))
 #define LODWORD(_qw)    ((ULONG)(_qw))
@@ -60,6 +61,12 @@ inline void *GetBotMemoryAddress(void)
 
 bool VMToOSInterface::CreateDoubleMemoryMapper(void **pHandle, size_t *pMaxExecutableCodeSize)
 {
+    if (minipal_detect_emulation())
+    {
+        // Rosetta or QEMU doesn't support double mapping correctly
+        return false;
+    }
+
     *pMaxExecutableCodeSize = (size_t)MaxDoubleMappedSize;
     *pHandle = CreateFileMapping(
                  INVALID_HANDLE_VALUE,    // use paging file

--- a/src/coreclr/minipal/Windows/doublemapping.cpp
+++ b/src/coreclr/minipal/Windows/doublemapping.cpp
@@ -61,9 +61,9 @@ inline void *GetBotMemoryAddress(void)
 
 bool VMToOSInterface::CreateDoubleMemoryMapper(void **pHandle, size_t *pMaxExecutableCodeSize)
 {
-    if (minipal_detect_emulation())
+    if (minipal_detect_rosetta())
     {
-        // Rosetta or QEMU doesn't support double mapping correctly
+        // Rosetta doesn't support double mapping correctly
         return false;
     }
 

--- a/src/coreclr/minipal/Windows/doublemapping.cpp
+++ b/src/coreclr/minipal/Windows/doublemapping.cpp
@@ -63,7 +63,7 @@ bool VMToOSInterface::CreateDoubleMemoryMapper(void **pHandle, size_t *pMaxExecu
 {
     if (minipal_detect_rosetta())
     {
-        // Rosetta doesn't support double mapping correctly
+        // Rosetta doesn't support double mapping correctly. WINE on macOS ARM64 can be running under Rosetta.
         return false;
     }
 

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -311,14 +311,3 @@ LEAF_ENTRY GetTlsIndexObjectDescOffset, _TEXT
         int 3
 LEAF_END GetTlsIndexObjectDescOffset, _TEXT
 #endif
-
-# These functions are used to verify that double mapping used to implement W^X works.
-LEAF_ENTRY VerifyDoubleMapping1, _TEXT
-  mov rax, 1
-  ret
-LEAF_END_MARKED VerifyDoubleMapping1, _TEXT
-
-LEAF_ENTRY VerifyDoubleMapping2, _TEXT
-  mov rax, 2
-  ret
-LEAF_END_MARKED VerifyDoubleMapping2, _TEXT

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -311,3 +311,14 @@ LEAF_ENTRY GetTlsIndexObjectDescOffset, _TEXT
         int 3
 LEAF_END GetTlsIndexObjectDescOffset, _TEXT
 #endif
+
+# These functions are used to verify that double mapping used to implement W^X works.
+LEAF_ENTRY VerifyDoubleMapping1, _TEXT
+  mov rax, 1
+  ret
+LEAF_END_MARKED VerifyDoubleMapping1, _TEXT
+
+LEAF_ENTRY VerifyDoubleMapping2, _TEXT
+  mov rax, 2
+  ret
+LEAF_END_MARKED VerifyDoubleMapping2, _TEXT

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -476,7 +476,8 @@ int minipal_getcpufeatures(void)
     return result;
 }
 
-bool minipal_detect_emulation(void)
+// Detect if the current process is running under the Apple Rosetta x64 emulator
+bool minipal_detect_rosetta(void)
 {
 #ifdef HOST_AMD64
     // Check for CPU brand indicating emulation
@@ -499,25 +500,11 @@ bool minipal_detect_emulation(void)
     brand[sizeof(brand) - 1] = '\0';
 
     // Check if CPU brand indicates emulation
-    if (strstr(brand, "VirtualApple") != NULL || strstr(brand, "QEMU") != NULL)
+    if (strstr(brand, "VirtualApple") != NULL)
     {
         return true;
     }
 #endif
-
-    // Check for process name of PID 1 indicating emulation
-    char cmdline[256];
-    FILE *cmdline_file = fopen("/proc/1/cmdline", "r");
-    if (cmdline_file != NULL)
-    {
-        fgets(cmdline, sizeof(cmdline), cmdline_file);
-        fclose(cmdline_file);
-
-        if (strstr(cmdline, "qemu") != NULL || strstr(cmdline, "rosetta") != NULL)
-        {
-            return true;
-        }
-    }
 
     return false;
 }

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -479,7 +479,7 @@ int minipal_getcpufeatures(void)
 // Detect if the current process is running under the Apple Rosetta x64 emulator
 bool minipal_detect_rosetta(void)
 {
-#ifdef HOST_AMD64
+#if defined(HOST_AMD64) || defined(HOST_X86)
     // Check for CPU brand indicating emulation
     int regs[4];
     char brand[49];
@@ -504,7 +504,7 @@ bool minipal_detect_rosetta(void)
     {
         return true;
     }
-#endif
+#endif // HOST_AMD64 || HOST_X86
 
     return false;
 }

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "cpufeatures.h"
 #include "cpuid.h"
@@ -472,4 +474,50 @@ int minipal_getcpufeatures(void)
 #endif // HOST_ARM64
 
     return result;
+}
+
+bool minipal_detect_emulation(void)
+{
+#ifdef HOST_AMD64
+    // Check for CPU brand indicating emulation
+    int regs[4];
+    char brand[49];
+
+    // Get the maximum value for extended function CPUID info
+    __cpuid(regs, (int)0x80000000);
+    if ((unsigned int)regs[0] < 0x80000004)
+    {
+        return false; // Extended CPUID not supported
+    }
+
+    // Retrieve the CPU brand string
+    for (unsigned int i = 0x80000002; i <= 0x80000004; ++i)
+    {
+        __cpuid(regs, (int)i);
+        memcpy(brand + (i - 0x80000002) * sizeof(regs), regs, sizeof(regs));
+    }
+    brand[sizeof(brand) - 1] = '\0';
+
+    // Check if CPU brand indicates emulation
+    if (strstr(brand, "VirtualApple") != NULL || strstr(brand, "QEMU") != NULL)
+    {
+        return true;
+    }
+#endif
+
+    // Check for process name of PID 1 indicating emulation
+    char cmdline[256];
+    FILE *cmdline_file = fopen("/proc/1/cmdline", "r");
+    if (cmdline_file != NULL)
+    {
+        fgets(cmdline, sizeof(cmdline), cmdline_file);
+        fclose(cmdline_file);
+
+        if (strstr(cmdline, "qemu") != NULL || strstr(cmdline, "rosetta") != NULL)
+        {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/native/minipal/cpufeatures.h
+++ b/src/native/minipal/cpufeatures.h
@@ -77,7 +77,7 @@ extern "C"
 #endif // __cplusplus
 
 int minipal_getcpufeatures(void);
-bool minipal_detect_emulation(void);
+bool minipal_detect_rosetta(void);
 
 #ifdef __cplusplus
 }

--- a/src/native/minipal/cpufeatures.h
+++ b/src/native/minipal/cpufeatures.h
@@ -77,6 +77,7 @@ extern "C"
 #endif // __cplusplus
 
 int minipal_getcpufeatures(void);
+bool minipal_detect_emulation(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The docker on macOS Arm64 uses Rosetta to run x64 containers. That has an effect on the double mapping. The Rosetta is unable to detect when an already executed code page is modified. So we cannot use double mapping on those containers. To detect that case, this change adds check that verifies that the double mapping works even when the code is modified.

Close #102226