### PR TITLE
Re-enable CertificateValidationClientServer_EndToEnd_Ok in Windows Native AOT

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -112,13 +112,10 @@ namespace System.Net.Security.Tests
             CertificateContext
         }
 
-        public static bool IsWindowsAOT => PlatformDetection.IsWindows && PlatformDetection.IsNativeAot;
-
         [Theory]
         [InlineData(ClientCertSource.ClientCertificate)]
         [InlineData(ClientCertSource.SelectionCallback)]
         [InlineData(ClientCertSource.CertificateContext)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88832", typeof(CertificateValidationClientServer), nameof(IsWindowsAOT))]
         public async Task CertificateValidationClientServer_EndToEnd_Ok(ClientCertSource clientCertSource)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/88832

Tentative re-enable to see if the failures still reproduce.

This reverts commit 0a1adcd089245c6020e8d32efe788ddce7e0f0b0.