### PR TITLE
JIT: Handle GT_SWIFT_ERROR_RET in LinearScan::getKillSetForNode

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -1063,6 +1063,7 @@ regMaskTP LinearScan::getKillSetForNode(GenTree* tree)
         // profiler callback would trash these registers. See vm\amd64\asmhelpers.asm for
         // more details.
         case GT_RETURN:
+        case GT_SWIFT_ERROR_RET:
             killMask = getKillSetForReturn();
             break;
 


### PR DESCRIPTION
Fixes #102349. In `LinearScan::getKillSetForNode`, `GT_SWIFT_ERROR_RET` (which represents the regular return value, alongside the Swift error register value to be loaded) needs to be handled like `GT_RETURN` if `Compiler::compIsProfilerHookNeeded` is true, which is possible under some JitStress scenarios.

This failure was found by `runtime-coreclr jitstress-random` setting `DOTNET_JitStress=da` -- I'm not sure how (or if) I can force CI to use the same env to verify correctness...

cc @dotnet/jit-contrib