### PR TITLE
couple tweaks to optRemoveRedundantZeroInits

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5918,7 +5918,7 @@ void Compiler::optRemoveRedundantZeroInits()
             {
                 if (((tree->gtFlags & GTF_CALL) != 0))
                 {
-                    // if this is not a No-GC heleper
+                    // if this is not a No-GC helper
                     if (!tree->IsCall() || !emitter::emitNoGChelper(tree->AsCall()->GetHelperNum()))
                     {
                         // assume that we have a safe point.

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -5918,7 +5918,12 @@ void Compiler::optRemoveRedundantZeroInits()
             {
                 if (((tree->gtFlags & GTF_CALL) != 0))
                 {
-                    hasGCSafePoint = true;
+                    // if this is not a No-GC heleper
+                    if (!tree->IsCall() || !emitter::emitNoGChelper(tree->AsCall()->GetHelperNum()))
+                    {
+                        // assume that we have a safe point.
+                        hasGCSafePoint = true;
+                    }
                 }
 
                 hasImplicitControlFlow |= hasEHSuccs && ((tree->gtFlags & GTF_EXCEPT) != 0);
@@ -6071,9 +6076,10 @@ void Compiler::optRemoveRedundantZeroInits()
                             (!hasImplicitControlFlow || (lclDsc->lvTracked && !lclDsc->lvLiveInOutOfHndlr)))
                         {
                             // If compMethodRequiresPInvokeFrame() returns true, lower may later
-                            // insert a call to CORINFO_HELP_INIT_PINVOKE_FRAME which is a gc-safe point.
-                            if (!lclDsc->HasGCPtr() ||
-                                (!GetInterruptible() && !hasGCSafePoint && !compMethodRequiresPInvokeFrame()))
+                            // insert a call to CORINFO_HELP_INIT_PINVOKE_FRAME but that is not a gc-safe point.
+                            assert(emitter::emitNoGChelper(CORINFO_HELP_INIT_PINVOKE_FRAME));
+
+                            if (!lclDsc->HasGCPtr() || (!GetInterruptible() && !hasGCSafePoint))
                             {
                                 // The local hasn't been used and won't be reported to the gc between
                                 // the prolog and this explicit initialization. Therefore, it doesn't


### PR DESCRIPTION
Make the optimizer for GC locals be aware that:

- CORINFO_HELP_INIT_PINVOKE_FRAME is not a GC safe point (not any more)
- there are other helpers that are not GC safe points

This removes some unnecessary initializations.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=683630&view=ms.vss-build-web.run-extensions-tab)