### PR TITLE
[tests] InstallWorkloadFromArtifacts: handle a stable band version

### DIFF
--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -292,8 +292,13 @@ namespace Microsoft.Workload.Build.Tasks
             string packagePreleaseVersion = bandVersionRegex().Match(version).Groups[1].Value;
             string bandPreleaseVersion = bandVersionRegex().Match(bandVersion).Groups[1].Value;
 
-            if (packagePreleaseVersion != bandPreleaseVersion && packagePreleaseVersion != "-dev" && packagePreleaseVersion != "-ci")
+            if (!string.IsNullOrEmpty(bandPreleaseVersion) &&
+                packagePreleaseVersion != bandPreleaseVersion &&
+                packagePreleaseVersion != "-dev" &&
+                packagePreleaseVersion != "-ci")
+            {
                 bandVersion = bandVersion.Replace (bandPreleaseVersion, packagePreleaseVersion);
+            }
 
             PackageReference pkgRef = new(Name: $"{name}.Manifest-{bandVersion}",
                                           Version: version,


### PR DESCRIPTION
If the sdk band version is like `8.0.100` (stable, with no
preview/ci/dev suffixes), then `bandPreleaseVersion`:

`string bandPreleaseVersion = bandVersionRegex().Match(bandVersion).Groups[1].Value;`

.. is `""` which breaks:

` bandVersion = bandVersion.Replace (bandPreleaseVersion, packagePreleaseVersion);`

```
System.ArgumentException: The value cannot be an empty string. (Parameter 'oldValue')
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at System.String.Replace(String oldValue, String newValue)
   at Microsoft.Workload.Build.Tasks.InstallWorkloadFromArtifacts.InstallWorkloadManifest(ITaskItem workloadId, Strin
   at Microsoft.Workload.Build.Tasks.InstallWorkloadFromArtifacts.InstallAllManifests()
   at Microsoft.Workload.Build.Tasks.InstallWorkloadFromArtifacts.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingCo
```

This adds a null/empty string check on the local.