### PR TITLE
[release/8.0-staging] Fix calculation of channel bindings hash in managed NTLM implementation

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -416,10 +416,23 @@ namespace System.Net
             {
                 if (_channelBinding != null)
                 {
-                    IntPtr cbtData = _channelBinding.DangerousGetHandle();
-                    int cbtDataSize = _channelBinding.Size;
-                    int written = MD5.HashData(new Span<byte>((void*)cbtData, cbtDataSize), hashBuffer);
-                    Debug.Assert(written == MD5.HashSizeInBytes);
+                    int appDataOffset = sizeof(SecChannelBindings);
+                    IntPtr cbtData = (nint)_channelBinding.DangerousGetHandle() + appDataOffset;
+                    int cbtDataSize = _channelBinding.Size - appDataOffset;
+
+                    // Channel bindings are calculated according to RFC 4121, section 4.1.1.2,
+                    // so we need to include zeroed initiator fields and length prefix for the
+                    // application data.
+                    Span<byte> prefix = stackalloc byte[sizeof(uint) * 5];
+                    prefix.Clear();
+                    BinaryPrimitives.WriteInt32LittleEndian(prefix.Slice(sizeof(uint) * 4), cbtDataSize);
+                    using (var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5))
+                    {
+                        md5.AppendData(prefix);
+                        md5.AppendData(new Span<byte>((void*)cbtData, cbtDataSize));
+                        int written = md5.GetHashAndReset(hashBuffer);
+                        Debug.Assert(written == MD5.HashSizeInBytes);
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -551,7 +551,7 @@ namespace System.Net
                 }
             }
 
-            private NegotiateAuthenticationStatusCode InitializeSecurityContext(
+            private unsafe NegotiateAuthenticationStatusCode InitializeSecurityContext(
                 ref SafeGssCredHandle credentialsHandle,
                 ref SafeGssContextHandle? contextHandle,
                 ref SafeGssNameHandle? targetNameHandle,
@@ -594,7 +594,7 @@ namespace System.Net
                     {
                         // If a TLS channel binding token (cbt) is available then get the pointer
                         // to the application specific data.
-                        int appDataOffset = Marshal.SizeOf<SecChannelBindings>();
+                        int appDataOffset = sizeof(SecChannelBindings);
                         Debug.Assert(appDataOffset < channelBinding.Size);
                         IntPtr cbtAppData = channelBinding.DangerousGetHandle() + appDataOffset;
                         int cbtAppDataSize = channelBinding.Size - appDataOffset;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Managed/SafeChannelBindingHandle.cs
@@ -11,7 +11,7 @@ namespace System.Net.Security
     internal sealed class SafeChannelBindingHandle : ChannelBinding
     {
         private const int CertHashMaxSize = 128;
-        private static readonly int s_secChannelBindingSize = Marshal.SizeOf<SecChannelBindings>();
+        private static unsafe int SecChannelBindingSize => sizeof(SecChannelBindings);
 
         private readonly int _cbtPrefixByteArraySize;
         internal int Length { get; private set; }
@@ -36,8 +36,8 @@ namespace System.Net.Security
                 "tls-unique:"u8;
 
             _cbtPrefixByteArraySize = cbtPrefix.Length;
-            handle = Marshal.AllocHGlobal(s_secChannelBindingSize + _cbtPrefixByteArraySize + CertHashMaxSize);
-            IntPtr cbtPrefixPtr = handle + s_secChannelBindingSize;
+            handle = Marshal.AllocHGlobal(SecChannelBindingSize + _cbtPrefixByteArraySize + CertHashMaxSize);
+            IntPtr cbtPrefixPtr = handle + SecChannelBindingSize;
             cbtPrefix.CopyTo(new Span<byte>((byte*)cbtPrefixPtr, cbtPrefix.Length));
             CertHashPtr = cbtPrefixPtr + _cbtPrefixByteArraySize;
             Length = CertHashMaxSize;
@@ -46,12 +46,12 @@ namespace System.Net.Security
         internal void SetCertHashLength(int certHashLength)
         {
             int cbtLength = _cbtPrefixByteArraySize + certHashLength;
-            Length = s_secChannelBindingSize + cbtLength;
+            Length = SecChannelBindingSize + cbtLength;
 
             SecChannelBindings channelBindings = new SecChannelBindings()
             {
                 ApplicationDataLength = cbtLength,
-                ApplicationDataOffset = s_secChannelBindingSize
+                ApplicationDataOffset = SecChannelBindingSize
             };
             Marshal.StructureToPtr(channelBindings, handle, true);
         }


### PR DESCRIPTION
Backport of #95898 to release/8.0-staging

Fixes #95725

## Customer Impact

Reported by customers in issue #95898 and by eM Client in https://github.com/dotnet/runtime/issues/95725#issuecomment-1875531103 - they cannot connect to Microsoft Exchange and quite a few other host providers on Android client (which uses ManagedNtlm by default).

Authenticating to HTTPS servers using NTLM fails with "Unauthorized" error code when Extended Authentication option is enabled on the server. This is an increasingly common setting on Microsoft Exchange deployments. The bug affects primarily the Android platform where the Managed NTLM implementation is used. We also allow the Managed NTLM as opt-in on macOS and Linux which would be likewise affected if the developer chooses to enable the `System.Net.Security.UseManagedNtlm` app context switch (which is rare).

## Regression

No

## Testing

Validated by eM Client on private Exchange instance in Azure VM + against one of the largest host providers in Germany.
The fix has been in .NET 9 since December 2023 and there were no observed issues.

Note: There are no unit tests, the set up is too complicated to test it meaningfully.

## Risk

Low; the modified code path is in platform specific code for a single authentication scheme.