### PR TITLE
[mono][interp] Fix type of args when inlining method

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -5143,7 +5143,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		arg_locals = (guint32*) g_malloc ((!!signature->hasthis + signature->param_count) * sizeof (guint32));
 		/* Allocate locals to store inlined method args from stack */
 		for (int i = signature->param_count - 1; i >= 0; i--) {
-			MonoType *type = td->vars [td->sp [-1].var].type;
+			MonoType *type = get_type_from_stack (td->sp [-1].type, td->sp [-1].klass);
 			local = interp_create_var (td, type);
 			arg_locals [i + !!signature->hasthis] = local;
 			store_local (td, local);


### PR DESCRIPTION
The vars allocated from pushing values on the execution stack might not reflect exactly the actual type of the var. Consider this pattern:

```
	condbr	BB0
	newobj	Derived // push var0 of type Derived
	br	BB1
BB0:
	newobj	Base	// push var1 of type Base
	// here we will end up inserting a `mov var1 -> var0`
BB1:
	// top of stack will be seen as being var0
	call
```

Because we first reach BB1 with the stack contents of var0, BB1 will end up accessing top of the stack as var0. However the type of var0 at this point is not Derived, since it can also be a Base object. We currently don't update the type of var0, but just update the type information of the top of stack entry when entering BB1. When inlining, after this commit, we use the type information from the stack, rather than the type of the var present on the stack.

In the future we might want to consider updating the type of var0 or creating a new var entirely with the correct type for consistency.

Fixes https://github.com/dotnet/runtime/issues/102046