### PR TITLE
[release/8.0] Use V5 ESRP task with backing MI + AKV

### DIFF
--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -12,10 +12,15 @@ steps:
       version: '6.0.x'
       installationPath: '$(Agent.TempDirectory)/dotnet'
 
-  - task: EsrpCodeSigning@1
+  - task: EsrpCodeSigning@5
     displayName: Sign Diagnostic Binaries
     inputs:
-      ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
+      ConnectedServiceName: 'diagnostics-esrp-kvcertuser'
+      AppRegistrationClientId: '2234cdec-a13f-4bb2-aa63-04c57fd7a1f9'
+      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+      AuthAKVName: 'clrdiag-esrp-id'
+      AuthCertName: 'dotnetesrp-diagnostics-aad-ssl-cert'
+      AuthSignCertName: 'dotnet-diagnostics-esrp-pki-onecert'
       FolderPath: ${{ parameters.basePath }}
       Pattern: |
         **/mscordaccore*.dll
@@ -48,6 +53,7 @@ steps:
       SessionTimeout: ${{ parameters.timeoutInMinutes }}
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
+      PendingAnalysisWaitTimeoutMinutes: '5'
     env:
       DOTNET_MULTILEVEL_LOOKUP: 0
       DOTNET_ROOT: '$(Agent.TempDirectory)/dotnet'


### PR DESCRIPTION
main PR: https://github.com/dotnet/runtime/pull/102542

# Description

This PR moves to using WIF + AKV RBAC to support signing diagnostic files without need of manual cert or secret rotation.

# Customer Impact

None. Infra change

# Regression

None

# Testing

Internal test build.

# Risk

Low, expansion reqs not changes and same template has signing validation script. 