### PR TITLE
[release/6.0] Use V5 ESRP task with backing MI + AKV

### DIFF
--- a/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
+++ b/eng/pipelines/coreclr/templates/sign-diagnostic-files.yml
@@ -5,10 +5,15 @@ parameters:
 
 steps:
 - ${{ if and(eq(parameters.isOfficialBuild, true), ne(variables['Build.Reason'], 'PullRequest'), or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'))) }}:
-  - task: EsrpCodeSigning@1
+  - task: EsrpCodeSigning@5
     displayName: Sign Diagnostic Binaries
     inputs:
-      ConnectedServiceName: 'dotnetesrp-diagnostics-dnceng'
+      ConnectedServiceName: 'diagnostics-esrp-kvcertuser'
+      AppRegistrationClientId: '2234cdec-a13f-4bb2-aa63-04c57fd7a1f9'
+      AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+      AuthAKVName: 'clrdiag-esrp-id'
+      AuthCertName: 'dotnetesrp-diagnostics-aad-ssl-cert'
+      AuthSignCertName: 'dotnet-diagnostics-esrp-pki-onecert'
       FolderPath: ${{ parameters.basePath }}
       Pattern: |
         **/mscordaccore*.dll
@@ -41,6 +46,7 @@ steps:
       SessionTimeout: ${{ parameters.timeoutInMinutes }}
       MaxConcurrency: '50'
       MaxRetryAttempts: '5'
+      PendingAnalysisWaitTimeoutMinutes: '5'
 
   - powershell: |
       $filesToSign = $(Get-ChildItem -Recurse ${{ parameters.basePath }} -Include mscordaccore*.dll, mscordbi*.dll)


### PR DESCRIPTION
main PR: https://github.com/dotnet/runtime/pull/102542

# Description

This PR moves to using WIF + AKV RBAC to support signing diagnostic files without need of manual cert or secret rotation.

# Customer Impact

None. Infra change

# Regression

None

# Testing

Internal test build.

# Risk

Low, expansion reqs not changes and same template has signing validation script. 