### PR TITLE
fix dn_vector_custom_resize

### DIFF
--- a/src/native/containers/dn-vector.c
+++ b/src/native/containers/dn-vector.c
@@ -312,7 +312,7 @@ dn_vector_custom_resize (
 {
 	DN_ASSERT (vector);
 
-	if (size == vector->_internal._capacity)
+	if (size == vector->size)
 		return true;
 
 	if (size > vector->_internal._capacity)


### PR DESCRIPTION
there is a bug when the size == capacity without set the vector->size