### PR TITLE
Move Disposal of QuicStream to the Http3Connection Prototype

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -107,7 +107,6 @@ namespace System.Net.Http
                 if (_firstRejectedStreamId == -1)
                 {
                     _firstRejectedStreamId = long.MaxValue;
-                    Task.WhenAll(_streamDisposals).GetAwaiter().GetResult();
                     CheckForShutdown();
                 }
             }
@@ -129,6 +128,10 @@ namespace System.Net.Http
 
             if (_connection != null)
             {
+                // Make sure we've disposed every stream before closing the connection.
+
+                Task.WhenAll(_streamDisposals).GetAwaiter().GetResult();
+
                 // Close the QuicConnection in the background.
 
                 _connectionClosedTask ??= _connection.CloseAsync((long)Http3ErrorCode.NoError).AsTask();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http
             {
                 _disposed = true;
                 AbortStream();
-                _stream.Dispose();
+                _connection.QueueStreamForDisposal(_stream);
                 DisposeSyncHelper();
             }
         }
@@ -101,17 +101,15 @@ namespace System.Net.Http
             }
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             if (!_disposed)
             {
                 _disposed = true;
                 AbortStream();
-                _connection.QueueStreamForDisposal(_stream);
+                await _stream.DisposeAsync().ConfigureAwait(false);
                 DisposeSyncHelper();
             }
-
-            return ValueTask.CompletedTask;
         }
 
         private void DisposeSyncHelper()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -101,15 +101,17 @@ namespace System.Net.Http
             }
         }
 
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             if (!_disposed)
             {
                 _disposed = true;
                 AbortStream();
-                await _stream.DisposeAsync().ConfigureAwait(false);
+                _connection.QueueStreamForDisposal(_stream);
                 DisposeSyncHelper();
             }
+
+            return ValueTask.CompletedTask;
         }
 
         private void DisposeSyncHelper()


### PR DESCRIPTION
Trying the idea of [#102571 (comment)](https://github.com/dotnet/runtime/issues/102571#issuecomment-2125291298).