### PR TITLE
Fix 2 issues when triggering a garbage collection via EventPipe

### DIFF
--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -2403,8 +2403,10 @@ VOID EtwCallbackCommon(
     // Special check for the runtime provider's ManagedHeapCollectKeyword.  Profilers
     // flick this to force a full GC.
     if (g_fEEStarted && !g_fEEShutDown && bIsPublicTraceHandle &&
-        ((MatchAnyKeyword & CLR_MANAGEDHEAPCOLLECT_KEYWORD) != 0) &&
-        (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER) // only when the provider is enabled
+#if !defined(HOST_UNIX)
+        (ControlCode == EVENT_CONTROL_CODE_ENABLE_PROVIDER) && // only when the provider is enabled
+#endif
+        ((MatchAnyKeyword & CLR_MANAGEDHEAPCOLLECT_KEYWORD) != 0)
         )
     {
         // Profilers may (optionally) specify extra data in the filter parameter

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -673,6 +673,7 @@ disable_helper (EventPipeSessionID id)
 
 		while (ep_provider_callback_data_queue_try_dequeue (provider_callback_data_queue, &provider_callback_data)) {
 			ep_rt_prepare_provider_invoke_callback (&provider_callback_data);
+			provider_callback_data.enabled = false;
 			provider_invoke_callback (&provider_callback_data);
 			ep_provider_callback_data_fini (&provider_callback_data);
 		}


### PR DESCRIPTION
Fix the following issues:
- https://github.com/dotnet/runtime/issues/99487: avoid double GC
- https://github.com/dotnet/runtime/issues/102572: handle client sequence number

I've tested with dotnet-gcstats (for the client sequence number + number of GCs) and dotnet-fullgc (to trigger a GC with a custom client sequence number)

@noahfalk / @brianrob: I'm not sure to understand why the enabled/disabled state was based on the number of session being > 0 because this number is always >= 1 when the functions are called.