### PR TITLE
Allow non-IMemberDefinition sources to be origin for event methods

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3508,9 +3508,7 @@ namespace Mono.Linker.Steps
 
 		protected internal virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason, MessageOrigin origin)
 		{
-			Debug.Assert (reason.Source is IMemberDefinition or null);
-			// Use reason as the origin for the event methods unless it's from a descriptor
-			origin = reason.Source is null ? origin : new MessageOrigin ((IMemberDefinition)reason.Source);
+			origin = reason.Source is IMemberDefinition ? new MessageOrigin((IMemberDefinition)reason.Source) : origin;
 			DependencyKind dependencyKind = DependencyKind.EventMethod;
 
 			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (dependencyKind, evt), origin);

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3508,7 +3508,7 @@ namespace Mono.Linker.Steps
 
 		protected internal virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason, MessageOrigin origin)
 		{
-			origin = reason.Source is IMemberDefinition ? new MessageOrigin((IMemberDefinition)reason.Source) : origin;
+			origin = reason.Source is IMemberDefinition member ? new MessageOrigin (member) : origin;
 			DependencyKind dependencyKind = DependencyKind.EventMethod;
 
 			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (dependencyKind, evt), origin);


### PR DESCRIPTION
From https://github.com/dotnet/sdk/pull/41096#issuecomment-2126814077.

Should fix the issues arising in https://github.com/dotnet/sdk/pull/41096. We should follow this up with a test that exercises this code path.