### PR TITLE
Use Sdk not installer flow for wasm build tests

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -386,14 +386,14 @@
       <Sha>40e6b96cad11400acb5b8999057ac8ba748df940</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.ApiCompat.Task" Version="9.0.100-preview.5.24263.1">
+    <Dependency Name="Microsoft.DotNet.ApiCompat.Task" Version="9.0.100-preview.5.24272.19">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>190723c80d85721cdc58fd906e645c4029b947bb</Sha>
+      <Sha>a134a94cfb1209e4181072719d554eb232b51317</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.sdk" Version="9.0.100-preview.5.24263.1">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.sdk" Version="9.0.100-preview.5.24272.19">
       <Uri>https://github.com/dotnet/sdk</Uri>
-      <Sha>190723c80d85721cdc58fd906e645c4029b947bb</Sha>
+      <Sha>a134a94cfb1209e4181072719d554eb232b51317</Sha>
       <SourceBuild RepoName="sdk" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="optimization.windows_nt-arm64.MIBC.Runtime" Version="1.0.0-prerelease.24223.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -410,10 +410,6 @@
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>
       <Sha>8fef55f5a55a3b4f2c96cd1a9b5ddc51d4b927f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.5.24253.16">
-      <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>fa261b952d702c6bd604728fcbdb58ac071a22b1</Sha>
-    </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.Wasm.Node.Transport" Version="9.0.0-alpha.1.24175.1">
       <Uri>https://github.com/dotnet/node</Uri>
       <Sha>308c7d0f1fa19bd1e7b768ad13646f5206133cdb</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -81,7 +81,7 @@
   <PropertyGroup>
     <StaticCsVersion>0.2.0</StaticCsVersion>
     <!-- SDK dependencies (also used in wasm build tests -->
-    <MicrosoftDotNetApiCompatTaskVersion>9.0.100-preview.5.24263.1</MicrosoftDotNetApiCompatTaskVersion>
+    <MicrosoftDotNetApiCompatTaskVersion>9.0.100-preview.5.24272.19</MicrosoftDotNetApiCompatTaskVersion>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24272.5</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisVersion>9.0.0-beta.24272.5</MicrosoftDotNetCodeAnalysisVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,4 @@
-SdkI<Project>
+<Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
     <ProductVersion>9.0.0</ProductVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,4 +1,4 @@
-<Project>
+SdkI<Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
     <ProductVersion>9.0.0</ProductVersion>
@@ -80,7 +80,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <StaticCsVersion>0.2.0</StaticCsVersion>
-    <!-- SDK dependencies -->
+    <!-- SDK dependencies (also used in wasm build tests -->
     <MicrosoftDotNetApiCompatTaskVersion>9.0.100-preview.5.24263.1</MicrosoftDotNetApiCompatTaskVersion>
     <!-- Arcade dependencies -->
     <MicrosoftDotNetBuildTasksFeedVersion>9.0.0-beta.24272.5</MicrosoftDotNetBuildTasksFeedVersion>
@@ -253,9 +253,8 @@
     <!-- BrowserDebugProxy libs -->
     <MicrosoftExtensionsLoggingVersion>3.1.7</MicrosoftExtensionsLoggingVersion>
     <MicrosoftSymbolStoreVersion>1.0.406601</MicrosoftSymbolStoreVersion>
-    <!-- installer version, for testing workloads -->
-    <MicrosoftDotnetSdkInternalVersion>9.0.100-preview.5.24253.16</MicrosoftDotnetSdkInternalVersion>
-    <SdkVersionForWorkloadTesting>$(MicrosoftDotnetSdkInternalVersion)</SdkVersionForWorkloadTesting>
+    <!-- sdk version, for testing workloads -->
+    <SdkVersionForWorkloadTesting>$(MicrosoftDotNetApiCompatTaskVersion)</SdkVersionForWorkloadTesting>
     <runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>9.0.0-alpha.1.24175.1</runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion>
     <EmsdkPackageVersion>$(MicrosoftNETRuntimeEmscriptenVersion)</EmsdkPackageVersion>
     <NodePackageVersion>$(runtimewinx64MicrosoftNETCoreRuntimeWasmNodeTransportPackageVersion)</NodePackageVersion>


### PR DESCRIPTION
Now that installer is not producing the installer we need use sdk versions here.  We should probably remove the subscription from main once this is verified as well.