### PR TITLE
Make CreateAppHost test use TestArtifact instead of its own class

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
@@ -207,7 +207,8 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
             using (TestArtifact artifact = CreateTestDirectory())
             {
                 string testDirectory = Path.Combine(artifact.Location, subdir);
-                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
+                Directory.CreateDirectory(testDirectory);
+                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
                 File.SetAttributes(sourceAppHostMock, FileAttributes.ReadOnly);
                 string destinationFilePath = Path.Combine(testDirectory, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
@@ -231,7 +231,7 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
                 {
                     p.Start();
                     p.StandardError.ReadToEnd()
-                        .Should().Contain($"Executable=/private{Path.GetFullPath(destinationFilePath)}");
+                        .Should().Contain($"Executable={Path.GetFullPath(destinationFilePath)}");
                     p.WaitForExit();
                     // Successfully signed the apphost.
                     Assert.True(p.ExitCode == 0, $"Expected exit code was '0' but '{codesign}' returned '{p.ExitCode}' instead.");

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost/CreateAppHost.cs
@@ -26,10 +26,10 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void EmbedAppBinaryPath()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
                 HostWriter.CreateAppHost(
@@ -55,14 +55,14 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void PlaceholderHashNotFound_Fails()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location, content =>
                 {
                     // Corrupt the hash value
                     content[WindowsFileHeader.Length + 1]++;
                 });
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
                 Assert.Throws<PlaceHolderNotFoundInAppHostException>(() =>
@@ -78,10 +78,10 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void AppBinaryPathTooLong_Fails()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = new string('a', 1024 + 5);
 
                 Assert.Throws<AppNameTooLongException>(() =>
@@ -97,10 +97,10 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void GUISubsystem_WindowsPEFile()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
                 HostWriter.CreateAppHost(
@@ -121,15 +121,15 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void GUISubsystem_NonWindowsPEFile_Fails()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location, content =>
                 {
                     // Windows PE files must start with 0x5A4D, so write some other value here.
                     content[0] = 1;
                     content[1] = 2;
                 });
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
                 Assert.Throws<AppHostNotPEFileException>(() =>
@@ -146,14 +146,14 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [Fact]
         public void GUISubsystem_WrongDefault_Fails()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory, content =>
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location, content =>
                 {
                     // Corrupt the value of the subsystem (the default should be 3)
                     content[SubsystemOffset] = 42;
                 });
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
                 Assert.Equal(42, PEUtils.GetWindowsGraphicalUserInterfaceBit(sourceAppHostMock));
@@ -172,9 +172,9 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void ExecutableImage()
         {
-            using TestDirectory testDirectory = TestDirectory.Create();
-            string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
-            string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+            using TestArtifact artifact = CreateTestDirectory();
+            string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
+            string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
             string appBinaryFilePath = "Test/App/Binary/Path.dll";
 
             // strip executable permissions from this AppHost template binary
@@ -204,11 +204,12 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [InlineData("dir with spaces")]
         public void CodeSignAppHostOnMacOS(string subdir)
         {
-            using (TestDirectory testDirectory = TestDirectory.Create(subdir))
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string testDirectory = Path.Combine(artifact.Location, subdir);
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
                 File.SetAttributes(sourceAppHostMock, FileAttributes.ReadOnly);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(testDirectory, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
                 HostWriter.CreateAppHost(
                    sourceAppHostMock,
@@ -241,11 +242,11 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [PlatformSpecific(TestPlatforms.OSX)]
         public void DoesNotCodeSignAppHostByDefault()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
                 File.SetAttributes(sourceAppHostMock, FileAttributes.ReadOnly);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
                 HostWriter.CreateAppHost(
                    sourceAppHostMock,
@@ -275,11 +276,11 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
         [PlatformSpecific(TestPlatforms.OSX)]
         public void CodeSigningFailuresThrow()
         {
-            using (TestDirectory testDirectory = TestDirectory.Create())
+            using (TestArtifact artifact = CreateTestDirectory())
             {
-                string sourceAppHostMock = PrepareAppHostMockFile(testDirectory);
+                string sourceAppHostMock = PrepareAppHostMockFile(artifact.Location);
                 File.SetAttributes(sourceAppHostMock, FileAttributes.ReadOnly);
-                string destinationFilePath = Path.Combine(testDirectory.Path, "DestinationAppHost.exe.mock");
+                string destinationFilePath = Path.Combine(artifact.Location, "DestinationAppHost.exe.mock");
                 string appBinaryFilePath = "Test/App/Binary/Path.dll";
                 HostWriter.CreateAppHost(
                    sourceAppHostMock,
@@ -312,7 +313,7 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
             }
         }
 
-        private string PrepareAppHostMockFile(TestDirectory testDirectory, Action<byte[]> customize = null)
+        private string PrepareAppHostMockFile(string directory, Action<byte[]> customize = null)
         {
             // For now we're testing the AppHost on Windows PE files only.
             // The only customization which we do on non-Windows files is the embedding
@@ -325,7 +326,7 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
 
             customize?.Invoke(content);
 
-            string filePath = Path.Combine(testDirectory.Path, "SourceAppHost.exe.mock");
+            string filePath = Path.Combine(directory, "SourceAppHost.exe.mock");
             File.WriteAllBytes(filePath, content);
             return filePath;
         }
@@ -358,32 +359,7 @@ namespace Microsoft.NET.HostModel.AppHost.Tests
             0, 112, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 3, 0, 96, 193, 0, 0, 24,
             0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0 };
 
-        private class TestDirectory : IDisposable
-        {
-            public string Path { get; private set; }
-
-            private TestDirectory(string path)
-            {
-                Path = path;
-                Directory.CreateDirectory(path);
-            }
-
-            public static TestDirectory Create([CallerMemberName] string callingMethod = "", string subDir = "")
-            {
-                string path = System.IO.Path.Combine(
-                    System.IO.Path.GetTempPath(),
-                    "dotNetSdkUnitTest_" + callingMethod + (Guid.NewGuid().ToString().Substring(0, 8)),
-                    subDir);
-                return new TestDirectory(path);
-            }
-
-            public void Dispose()
-            {
-                if (Directory.Exists(Path))
-                {
-                    Directory.Delete(Path, true);
-                }
-            }
-        }
+        private TestArtifact CreateTestDirectory([CallerMemberName] string callingMethod = "")
+            => TestArtifact.Create(callingMethod);
     }
 }


### PR DESCRIPTION
The `CreateAppHost` test class had its own `TestDirectory` class that provided the same functionality as the `TestArtifact` utility used by the rest of the host tests. Switch it to the shared helper.

Found this while looking at what we'd have to do for testing the upcoming work for CET compat enable/disable in the hosts.

cc @dotnet/appmodel 