### PR TITLE
Fix assembly name parsing in dotnet-pgo tool

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         return null;
                     }
 
-                    minfo.Module = _context.ResolveAssembly(new AssemblyNameInfo(minfo.AssemblyName), throwIfNotFound);
+                    minfo.Module = _context.ResolveAssembly(AssemblyNameInfo.Parse(minfo.AssemblyName), throwIfNotFound);
                     return minfo.Module;
                 }
                 else


### PR DESCRIPTION
Fixes #102630