### PR TITLE
Fix test results publishing for host and illink tests

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -79,6 +79,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             enablePublishTestResults: true
+            testResultsFormat: 'vstest'
             timeoutInMinutes: 120
             nameSuffix: ILLink_Runtime_Testing
             condition:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1412,6 +1412,7 @@ extends:
                   unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
                   displayName: 'unified artifacts'
             enablePublishTestResults: true
+            testResultsFormat: 'vstest'
             testRunTitle: Installer-$(osGroup)$(osSubgroup)_$(archType)
             postBuildSteps:
               - template: /eng/pipelines/installer/steps/upload-job-artifacts.yml
@@ -1444,6 +1445,7 @@ extends:
                   unpackFolder: $(Build.SourcesDirectory)/artifacts/bin
                   displayName: 'unified artifacts'
             enablePublishTestResults: true
+            testResultsFormat: 'vstest'
             testRunTitle: Installer-$(osGroup)$(osSubgroup)_$(archType)
             postBuildSteps:
               - template: /eng/pipelines/installer/steps/upload-job-artifacts.yml


### PR DESCRIPTION
This may not be necessary, depending on how https://github.com/dotnet/arcade/issues/14786 is resolved.
If we go back to the behaviour of empty `testResultsFormat` means publish both xunit and trx results, we don't need to change anything on our side.

cc @dotnet/appmodel 