### PR TITLE
[mono][debugger] Fix inspect gchandle

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -3286,6 +3286,7 @@ dbg_path_get_basename (const char *filename)
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (hidden_klass, "System.Diagnostics", "DebuggerHiddenAttribute")
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (step_through_klass, "System.Diagnostics", "DebuggerStepThroughAttribute")
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (non_user_klass, "System.Diagnostics", "DebuggerNonUserCodeAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (intptr_klass, "System", "IntPtr")
 
 static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)
@@ -5578,6 +5579,7 @@ decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *bu
 	int ret = 0;
 	if (type != t->type && !MONO_TYPE_IS_REFERENCE (t) &&
 		!(t->type == MONO_TYPE_I && type == MONO_TYPE_VALUETYPE) &&
+		!(t->type == MONO_TYPE_I && type == MONO_TYPE_I8) &&
 		!(type == VALUE_TYPE_ID_FIXED_ARRAY) &&
 		!(type == MDBGPROT_VALUE_TYPE_ID_NULL) &&
 		!(t->type == MONO_TYPE_U && type == MONO_TYPE_VALUETYPE) &&
@@ -5640,7 +5642,13 @@ decode_value_compute_size (MonoType *t, int type, MonoDomain *domain, guint8 *bu
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
 		/* We send these as vtypes, so we get them back as such */
-		g_assert (type == MONO_TYPE_VALUETYPE);
+		if (type == MONO_TYPE_I8)
+		{
+			ret += sizeof(guint64);
+			goto end;
+		}
+		else
+			g_assert (type == MONO_TYPE_VALUETYPE);
 		/* Fall through */
 		handle_vtype:
 	case MONO_TYPE_VALUETYPE:
@@ -5697,6 +5705,7 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 
 	if (type != t->type && !MONO_TYPE_IS_REFERENCE (t) &&
 		!(t->type == MONO_TYPE_I && type == MONO_TYPE_VALUETYPE) &&
+		!(t->type == MONO_TYPE_I && type == MONO_TYPE_I8) &&
 		!(type == VALUE_TYPE_ID_FIXED_ARRAY) &&
 		!(t->type == MONO_TYPE_U && type == MONO_TYPE_VALUETYPE) &&
 		!(t->type == MONO_TYPE_PTR && type == MONO_TYPE_I8) &&
@@ -5769,8 +5778,31 @@ decode_value_internal (MonoType *t, int type, MonoDomain *domain, guint8 *addr, 
 		break;
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
-		/* We send these as vtypes, so we get them back as such */
-		g_assert (type == MONO_TYPE_VALUETYPE);
+		if (type == MONO_TYPE_I8) //sometimes we send as a PTR because it's a IntPtr then the debugger will send back as I8
+		{
+			MonoClassField *f = NULL;
+			gpointer iter = NULL;
+			MonoClass *intptr_klass = mono_class_try_get_intptr_klass_class ();
+			while ((f = mono_class_get_fields_internal (intptr_klass, &iter))) {
+				if (G_UNLIKELY (!f->type)) {
+					ERROR_DECL(error);
+					mono_field_resolve_type (f, error);
+					mono_error_cleanup (error);
+					if (!f->type)
+						continue;
+				}
+				if (f->type->attrs & FIELD_ATTRIBUTE_STATIC)
+					continue;
+				if (mono_field_is_deleted (f))
+					continue;
+				guint8 * fieldAddr = mono_vtype_get_field_addr (addr, f);
+				*(gint64*)fieldAddr = decode_long (buf, &buf, limit);
+			}
+			*endbuf = buf;
+			return ERR_NONE;
+		}
+		else /* We send these as vtypes, so we get them back as such */
+			g_assert (type == MONO_TYPE_VALUETYPE);
 		/* Fall through */
 		handle_vtype:
 	case MONO_TYPE_VALUETYPE:


### PR DESCRIPTION
We are not sending IntPtr as ValueType anymore because it was causing an infinity recursion because IntPtr has a field pointing to itself. So we need support receiving the IntPtr as I8.


Without the PR:
New Debugger Engine:
![image](https://github.com/dotnet/runtime/assets/4503299/5d6b823c-e2d8-41f1-bc6b-a56e351345a2)
Old Debugger Engine:
![image](https://github.com/dotnet/runtime/assets/4503299/9c1ecb1e-59f9-4076-9c3e-1d2214da2fe5)

With the PR:
New Debugger Engine:
![image](https://github.com/dotnet/runtime/assets/4503299/4f173132-9bf2-45c7-b6aa-0de8ef4a5224)
Old Debugger Engine:
![image](https://github.com/dotnet/runtime/assets/4503299/fd7fe0eb-5efb-4064-8550-064364a0ff4f)
