### PR TITLE
[release/6.0] Update DIA to 17.10.0-beta1.24272.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -126,7 +126,7 @@
     <optimizationlinuxx64MIBCRuntimeVersion>1.0.0-prerelease.21416.5</optimizationlinuxx64MIBCRuntimeVersion>
     <optimizationPGOCoreCLRVersion>1.0.0-prerelease.21416.5</optimizationPGOCoreCLRVersion>
     <!-- Not auto-updated. -->
-    <MicrosoftDiaSymReaderNativeVersion>16.11.29-beta1.23404.4</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <SystemCommandLineVersion>2.0.0-beta1.20253.1</SystemCommandLineVersion>
     <TraceEventVersion>2.0.65</TraceEventVersion>
     <CommandLineParserVersion>2.2.0</CommandLineParserVersion>


### PR DESCRIPTION
main PR https://github.com/dotnet/runtime/pull/102639

# Description

Update to DIA to version shipped in MSVC equivalent of dev17.10.

# Customer Impact

Code cleanliness - DIA has had several CVEs fixed. While the .NET runtime doesn't use any of the vulnerable APIs, detection software might flag the dll. This helps our customers maintain clean reports

# Regression

No

# Testing

Manual validation of basic scenarios.

# Risk

Low - limited runtime scenarios use this and targeted fixes to the library shouldn't affect us