### PR TITLE
[release/8.0] Update DIA to 17.10.0-beta1.24272.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -165,7 +165,7 @@
     <optimizationlinuxarm64MIBCRuntimeVersion>1.0.0-prerelease.23566.3</optimizationlinuxarm64MIBCRuntimeVersion>
     <optimizationPGOCoreCLRVersion>1.0.0-prerelease.23566.3</optimizationPGOCoreCLRVersion>
     <!-- Not auto-updated. -->
-    <MicrosoftDiaSymReaderNativeVersion>17.8.7-beta1.24113.1</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
     <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
     <TraceEventVersion>3.0.3</TraceEventVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>


### PR DESCRIPTION
main PR https://github.com/dotnet/runtime/pull/102639

# Description

Update to DIA to version shipped in MSVC equivalent of dev17.10.

# Customer Impact

Code cleanliness - DIA has had several CVEs fixed. While the .NET runtime doesn't use any of the vulnerable APIs, detection software might flag the dll. This helps our customers maintain clean reports

# Regression

No

# Testing

Manual validation of basic scenarios.

# Risk

Low - limited runtime scenarios use this and targeted fixes to the library shouldn't affect us