### PR TITLE
MeterListener.Dispose always disables measurements

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/MeterListener.cs
@@ -258,14 +258,17 @@ namespace System.Diagnostics.Metrics
                 s_allStartedListeners.Remove(this);
 
                 DiagNode<Instrument>? current = _enabledMeasurementInstruments.First;
-                if (current is not null && measurementsCompleted is not null)
+                if (current is not null)
                 {
-                    callbacksArguments = new Dictionary<Instrument, object?>();
+                    if (measurementsCompleted is not null)
+                    {
+                        callbacksArguments = new Dictionary<Instrument, object?>();
+                    }
 
                     do
                     {
                         object? state = current.Value.DisableMeasurements(this);
-                        callbacksArguments.Add(current.Value, state);
+                        callbacksArguments?.Add(current.Value, state);
                         current = current.Next;
                     } while (current is not null);
 


### PR DESCRIPTION
Have `MeterListener.Dispose()` call `Instrument.DisableMeasurements()` regardless of `MeterListener.MeasurementsCompleted` being set so that the listener stops receiving measurements. It still only builds up the dictionary needed to make the calls to `MeasurementsCompleted` if there's a delegate to invoke.

The new test is a copy of `ListenerDisposalsTest` minus the part where it sets and verifies `MeasurementsCompleted`. It fails without this change to `MeterListener`.

Fixes #102465