### PR TITLE
fix connect test extension

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -1098,10 +1098,11 @@ namespace System.Net.Sockets.Tests
             saea.SetBuffer(buffer);
             saea.RemoteEndPoint = ep;
             saea.Completed += (_, __) => re.Set();
-            if (!socket.ConnectAsync(saea))
+            if (socket.ConnectAsync(saea))
             {
                 re.Wait(timeout);
             }
+            Assert.True(socket.Connected);
         }
 
         internal static Task ConnectAsync(this Socket socket, EndPoint ep, Memory<byte> buffer, CancellationToken cancellationToken = default)


### PR DESCRIPTION
fixes #102650

It seems like the condition was swapped. `socket.ConnectAsync(saea)` returned `false` when operation finished synchronously. So we need to wait if `true`.