### PR TITLE
[wasm] Intrinsics for blazor

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2271,9 +2271,9 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			g_assert (ctx->method_inst->type_argc == 1);
 			MonoType *t = ctx->method_inst->type_argv [0];
 
-			int base_var = td->sp[-2].var,
-				offset_var = td->sp[-1].var,
-				temp, align, esize;
+			int base_var = td->sp [-2].var,
+				offset_var = td->sp [-1].var,
+				align, esize;
 
 #if SIZEOF_VOID_P == 8
 			if (td->sp [-1].type == STACK_TYPE_I4) {
@@ -2283,21 +2283,19 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			}
 #endif
 
-			push_simple_type (td, STACK_TYPE_I);
-			temp = td->sp [-1].var;
-			td->sp -= 3;
+			td->sp -= 2;
 
-			// temp = (ldarg 1) mul (sizeof !!T)
 			esize = mono_type_size (t, &align);
-			g_assert (esize <= 32767);
-			interp_add_ins (td, MINT_MUL_P_IMM);
-			td->last_ins->data[0] = (gint16)esize;
-			interp_ins_set_sreg (td->last_ins, offset_var);
-			interp_ins_set_dreg (td->last_ins, temp);
+			if (esize != 1) {
+				g_assert (esize <= 32767);
+				interp_add_ins (td, MINT_MUL_P_IMM);
+				td->last_ins->data [0] = (gint16)esize;
+				interp_ins_set_sreg (td->last_ins, offset_var);
+				interp_ins_set_dreg (td->last_ins, offset_var);
+			}
 
-			// (ldarg 0) add temp
 			interp_add_ins (td, MINT_ADD_P);
-			interp_ins_set_sregs2 (td->last_ins, base_var, temp);
+			interp_ins_set_sregs2 (td->last_ins, base_var, offset_var);
 			push_simple_type (td, STACK_TYPE_MP);
 			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2264,7 +2264,7 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 #else
 			*op = MINT_LDC_I8_0;
 #endif
-		} /* else if (!strcmp (tm, "Add")) {
+		} else if (!strcmp (tm, "Add")) {
 			MonoGenericContext *ctx = mono_method_get_context (target_method);
 			g_assert (ctx);
 			g_assert (ctx->method_inst);
@@ -2286,17 +2286,17 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 			td->last_ins->data[0] = (gint16)esize;
 			interp_ins_set_sreg (td->last_ins, offset_var);
 			interp_ins_set_dreg (td->last_ins, temp);
-			td->ip += 4;
 
 			// (ldarg 0) add temp
 			interp_add_ins (td, MINT_ADD_P);
 			interp_ins_set_sregs2 (td->last_ins, base_var, temp);
 			push_simple_type (td, STACK_TYPE_MP);
 			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
-			td->ip += 4;
+
+			td->ip += 5;
 
 			return TRUE;
-		} */
+		}
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Runtime.CompilerServices") && !strcmp (klass_name, "RuntimeHelpers")) {
 		if (!strcmp (tm, "get_OffsetToStringData")) {
 			g_assert (csignature->param_count == 0);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2275,6 +2275,14 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 				offset_var = td->sp[-1].var,
 				temp, align, esize;
 
+#if SIZEOF_VOID_P == 8
+			if (td->sp [-1].type == STACK_TYPE_I4) {
+				interp_add_ins (td, MINT_CONV_I8_I4);
+				interp_ins_set_sreg (td->last_ins, offset_var);
+				interp_ins_set_dreg (td->last_ins, offset_var);
+			}
+#endif
+
 			push_simple_type (td, STACK_TYPE_I);
 			temp = td->sp [-1].var;
 			td->sp -= 3;

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2252,7 +2252,38 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 #endif
 		} else if (!strcmp (tm, "InitBlockUnaligned") || !strcmp (tm, "InitBlock")) {
 			*op = MINT_INITBLK;
+		} else if (!strcmp (tm, "IsNullRef")) {
+			*op = MINT_CEQ0_I4;
+		} else if (!strcmp (tm, "NullRef")) {
+			*op = MINT_LDC_I4_0;
 		}
+		/*
+		} else if (!strcmp (tm, "Add")) {
+			MonoGenericContext *ctx = mono_method_get_context (target_method);
+			g_assert (ctx);
+			g_assert (ctx->method_inst);
+			g_assert (ctx->method_inst->type_argc == 1);
+
+			// (ldarg 1) = (ldarg 1) mul (sizeof !!T)
+			MonoType *t = ctx->method_inst->type_argv [0];
+			int align;
+			int esize = mono_type_size (t, &align);
+			interp_add_ins (td, MINT_MUL_I4_IMM);
+			interp_ins_set_sreg (td->last_ins, td->sp [1].var);
+			push_simple_type (td, STACK_TYPE_I4);
+			interp_ins_set_dreg (td->last_ins, td->sp [1].var);
+			td->ip += 4;
+
+			// (ldarg 0) add (ldarg 1)
+			interp_add_ins (td, MINT_ADD_I4);
+			push_simple_type (td, STACK_TYPE_I4);
+			interp_ins_set_sregs2 (td->last_ins, td->sp [0].var, td->sp [1].var);
+			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+
+			return TRUE;
+		}
+		*/
+		// FIXME: ReadUnaligned
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Runtime.CompilerServices") && !strcmp (klass_name, "RuntimeHelpers")) {
 		if (!strcmp (tm, "get_OffsetToStringData")) {
 			g_assert (csignature->param_count == 0);

--- a/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/InterpPgoTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/TestAppScenarios/InterpPgoTests.cs
@@ -28,9 +28,9 @@ public class InterpPgoTests : AppTestBase
     [InlineData("Release")]
     public async Task FirstRunGeneratesTableAndSecondRunLoadsIt(string config)
     {
-        // We need to invoke Greeting enough times to cause BCL code to tier so we can exercise interpreter PGO
+        // We need to invoke Random enough times to cause BCL code to tier so we can exercise interpreter PGO
         // Invoking it too many times makes the test meaningfully slower.
-        const int iterationCount = 70;
+        const int iterationCount = 50;
 
         _testOutput.WriteLine("/// Creating project");
         CopyTestAsset("WasmBasicTestApp", "InterpPgoTest", "App");
@@ -61,13 +61,13 @@ public class InterpPgoTests : AppTestBase
             lock (runner.OutputLines)
                 output = string.Join(Environment.NewLine, runner.OutputLines);
 
-            Assert.Contains("Hello, World!", output);
+            Assert.Contains("I filled a buffer with random items", output);
             // Verify that no PGO table was located in cache
             Assert.Contains("Failed to load interp_pgo table", output);
             // Verify that the table was saved after the app ran
             Assert.Contains("Saved interp_pgo table", output);
             // Verify that a specific method was tiered by the Greeting calls and recorded by PGO
-            Assert.Contains("added System.Runtime.CompilerServices.Unsafe:Add<byte> (byte&,int) to table", output);
+            Assert.Contains(" System.Random:Next () to table", output);
         }
 
         {
@@ -81,7 +81,7 @@ public class InterpPgoTests : AppTestBase
             lock (runner.OutputLines)
                 output = string.Join(Environment.NewLine, runner.OutputLines);
 
-            Assert.Contains("Hello, World!", output);
+            Assert.Contains("I filled a buffer with random items", output);
             // Verify that table data was loaded from cache
             // if this breaks, it could be caused by change in config which affects the config hash and the cache storage hash key
             Assert.Contains(" bytes of interp_pgo data (table size == ", output);
@@ -90,7 +90,7 @@ public class InterpPgoTests : AppTestBase
             // Verify that method(s) were found in the table and eagerly tiered
             Assert.Contains("because it was in the interp_pgo table", output);
             // Verify that a specific method was tiered by the Greeting calls and recorded by PGO
-            Assert.Contains("added System.Runtime.CompilerServices.Unsafe:Add<byte> (byte&,int) to table", output);
+            Assert.Contains(" System.Random:Next () to table", output);
         }
 
         _testOutput.WriteLine("/// Done");

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/InterpPgoTest.cs
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/InterpPgoTest.cs
@@ -12,10 +12,15 @@ public partial class InterpPgoTest
     internal static partial string GetHRef();
     
     [JSExport]
-    internal static string Greeting()
+    internal static void TryToTier(int iterationCount)
     {
-        var text = $"Hello, World! Greetings from {GetHRef()}";
+        var buffer = new int[4096];
+        var random = new Random();
+        for (int i = 0; i < iterationCount; i++) {
+            for (int j = 0; j < buffer.Length; j++)
+                buffer[j] = random.Next();
+        }
+        var text = $"Greetings from {GetHRef()}. I filled a buffer with random items {iterationCount} times.";
         Console.WriteLine(text);
-        return text;
     }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -139,10 +139,8 @@ try {
                     }
                 }
             });
-            const iterationCount = params.get("iterationCount") ?? 70;
-            for (let i = 0; i < iterationCount; i++) {
-                exports.InterpPgoTest.Greeting();
-            };
+            const iterationCount = params.get("iterationCount") ?? "70";
+            exports.InterpPgoTest.TryToTier(parseInt(iterationCount));
             await INTERNAL.interp_pgo_save_data();
             exit(0);
             break;


### PR DESCRIPTION
During blazor startup these 3 methods account for a bit over 100 compiled methods if I analyzed the trace correctly. Since interp codegen dominates blazor startup (50-75% depending on how you measure it) my hope is that pruning methods out will reduce overall startup time. These three seemed like easy targets.

~Add is commented out because I can't get it to work. Will be relying on help for that one unless a flash of insight helps me figure out how to fix it.~

Should I add a CEQ0_I8 for IsNullRef? I'm not sure it's worth adding a new opcode just for that.