### PR TITLE
Minimally allow Vector.Shuffle to expand for values that become constant by global morph

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3354,10 +3354,13 @@ public:
                                                    NamedIntrinsic hwIntrinsicID);
     GenTreeHWIntrinsic* gtNewScalarHWIntrinsicNode(
         var_types type, GenTree* op1, GenTree* op2, GenTree* op3, NamedIntrinsic hwIntrinsicID);
-    CorInfoType getBaseJitTypeFromArgIfNeeded(NamedIntrinsic       intrinsic,
+    var_types getRetTypeAndBaseJitTypeFromSig(NamedIntrinsic       intrinsic,
                                               CORINFO_CLASS_HANDLE clsHnd,
                                               CORINFO_SIG_INFO*    sig,
-                                              CorInfoType          simdBaseJitType);
+                                              CorInfoType*         simdBaseJitType);
+    CorInfoType getBaseJitTypeFromArgIfNeeded(NamedIntrinsic    intrinsic,
+                                              CORINFO_SIG_INFO* sig,
+                                              CorInfoType       simdBaseJitType);
 
 #ifdef TARGET_ARM64
     GenTreeFieldList* gtConvertTableOpToFieldList(GenTree* op, unsigned fieldCount);
@@ -3615,6 +3618,9 @@ public:
     GenTree* gtFoldExprCall(GenTreeCall* call);
     GenTree* gtFoldTypeCompare(GenTree* tree);
     GenTree* gtFoldTypeEqualityCall(bool isEq, GenTree* op1, GenTree* op2);
+#if defined(FEATURE_HW_INTRINSICS)
+    GenTree* gtFoldHWIntrinsicCall(GenTreeCall* call, NamedIntrinsic intrinsic);
+#endif // FEATURE_HW_INTRINSICS
 
     // Options to control behavior of gtTryRemoveBoxUpstreamEffects
     enum BoxRemovalOptions
@@ -4573,6 +4579,9 @@ protected:
                                         bool                  mustExpand);
 
 #ifdef FEATURE_HW_INTRINSICS
+    static bool isSupportedBaseType(NamedIntrinsic intrinsic, CorInfoType baseJitType);
+    bool IsValidForShuffle(GenTreeVecCon* vecCon, unsigned simdSize, var_types simdBaseType) const;
+
     GenTree* impHWIntrinsic(NamedIntrinsic        intrinsic,
                             CORINFO_CLASS_HANDLE  clsHnd,
                             CORINFO_METHOD_HANDLE method,

--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -355,22 +355,136 @@ const TernaryLogicInfo& TernaryLogicInfo::lookup(uint8_t control)
 #endif // TARGET_XARCH
 
 //------------------------------------------------------------------------
-// getBaseJitTypeFromArgIfNeeded: Get simdBaseJitType of intrinsic from 1st or 2nd argument depending on the flag
+// getRetTypeAndBaseJitTypeFromSig: Get retType and simdBaseJitType of intrinsic from signature
 //
 // Arguments:
 //    intrinsic       -- id of the intrinsic function.
 //    clsHnd          -- class handle containing the intrinsic function.
-//    method          -- method handle of the intrinsic function.
+//    sig             -- signature of the intrinsic call.
+//    simdBaseJitType -- [Out] The determined simdBaseJitType, could be CORINFO_TYPE_UNDEF
+//
+// Return Value:
+//    The retType of intrinsic if it can be fetched from the signature
+//
+var_types Compiler::getRetTypeAndBaseJitTypeFromSig(NamedIntrinsic       intrinsic,
+                                                    CORINFO_CLASS_HANDLE clsHnd,
+                                                    CORINFO_SIG_INFO*    sig,
+                                                    CorInfoType*         simdBaseJitType)
+{
+    assert(sig != nullptr);
+    assert(simdBaseJitType != nullptr);
+
+    HWIntrinsicCategory    category = HWIntrinsicInfo::lookupCategory(intrinsic);
+    CORINFO_InstructionSet isa      = HWIntrinsicInfo::lookupIsa(intrinsic);
+    var_types              retType  = genActualType(JITtype2varType(sig->retType));
+
+    if (retType == TYP_STRUCT)
+    {
+        unsigned int sizeBytes;
+        *simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(sig->retTypeSigClass, &sizeBytes);
+
+        if (HWIntrinsicInfo::IsMultiReg(intrinsic))
+        {
+            assert(sizeBytes == 0);
+        }
+
+#ifdef TARGET_ARM64
+        else if ((intrinsic == NI_AdvSimd_LoadAndInsertScalar) || (intrinsic == NI_AdvSimd_Arm64_LoadAndInsertScalar))
+        {
+            CorInfoType pSimdBaseJitType = CORINFO_TYPE_UNDEF;
+            var_types   retFieldType     = impNormStructType(sig->retTypeSigClass, &pSimdBaseJitType);
+
+            if (retFieldType == TYP_STRUCT)
+            {
+                CORINFO_CLASS_HANDLE structType;
+                unsigned int         sizeBytes = 0;
+
+                // LoadAndInsertScalar that returns 2,3 or 4 vectors
+                assert(pSimdBaseJitType == CORINFO_TYPE_UNDEF);
+                unsigned fieldCount = info.compCompHnd->getClassNumInstanceFields(sig->retTypeSigClass);
+                assert(fieldCount > 1);
+                CORINFO_FIELD_HANDLE fieldHandle = info.compCompHnd->getFieldInClass(sig->retTypeClass, 0);
+                CorInfoType          fieldType   = info.compCompHnd->getFieldType(fieldHandle, &structType);
+                *simdBaseJitType                 = getBaseJitTypeAndSizeOfSIMDType(structType, &sizeBytes);
+                switch (fieldCount)
+                {
+                    case 2:
+                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x2
+                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x2;
+                        break;
+                    case 3:
+                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x3
+                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x3;
+                        break;
+                    case 4:
+                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x4
+                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x4;
+                        break;
+                    default:
+                        assert("unsupported");
+                }
+            }
+            else
+            {
+                assert((retFieldType == TYP_SIMD8) || (retFieldType == TYP_SIMD16));
+                assert(isSupportedBaseType(intrinsic, *simdBaseJitType));
+                retType = getSIMDTypeForSize(sizeBytes);
+            }
+        }
+#endif
+        else
+        {
+            // We want to return early here for cases where retType was TYP_STRUCT as per method signature and
+            // rather than deferring the decision after getting the simdBaseJitType of arg.
+            if (!isSupportedBaseType(intrinsic, *simdBaseJitType))
+            {
+                return TYP_UNKNOWN;
+            }
+
+            assert(sizeBytes != 0);
+            retType = getSIMDTypeForSize(sizeBytes);
+        }
+    }
+
+    *simdBaseJitType = getBaseJitTypeFromArgIfNeeded(intrinsic, sig, *simdBaseJitType);
+
+    if (*simdBaseJitType == CORINFO_TYPE_UNDEF)
+    {
+        if ((category == HW_Category_Scalar) || HWIntrinsicInfo::isScalarIsa(isa))
+        {
+            *simdBaseJitType = sig->retType;
+
+            if (*simdBaseJitType == CORINFO_TYPE_VOID)
+            {
+                *simdBaseJitType = CORINFO_TYPE_UNDEF;
+            }
+        }
+        else
+        {
+            unsigned int sizeBytes;
+
+            *simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(clsHnd, &sizeBytes);
+            assert((category == HW_Category_Special) || (category == HW_Category_Helper) || (sizeBytes != 0));
+        }
+    }
+
+    return retType;
+}
+
+//------------------------------------------------------------------------
+// getBaseJitTypeFromArgIfNeeded: Get simdBaseJitType of intrinsic from 1st or 2nd argument depending on the flag
+//
+// Arguments:
+//    intrinsic       -- id of the intrinsic function.
 //    sig             -- signature of the intrinsic call.
 //    simdBaseJitType -- Predetermined simdBaseJitType, could be CORINFO_TYPE_UNDEF
 //
 // Return Value:
 //    The basetype of intrinsic of it can be fetched from 1st or 2nd argument, else return baseType unmodified.
 //
-CorInfoType Compiler::getBaseJitTypeFromArgIfNeeded(NamedIntrinsic       intrinsic,
-                                                    CORINFO_CLASS_HANDLE clsHnd,
-                                                    CORINFO_SIG_INFO*    sig,
-                                                    CorInfoType          simdBaseJitType)
+CorInfoType Compiler::getBaseJitTypeFromArgIfNeeded(NamedIntrinsic    intrinsic,
+                                                    CORINFO_SIG_INFO* sig,
+                                                    CorInfoType       simdBaseJitType)
 {
     if (HWIntrinsicInfo::BaseTypeFromSecondArg(intrinsic) || HWIntrinsicInfo::BaseTypeFromFirstArg(intrinsic))
     {
@@ -932,7 +1046,7 @@ static bool impIsTableDrivenHWIntrinsic(NamedIntrinsic intrinsicId, HWIntrinsicC
 // Return Value:
 //    returns true if the baseType is supported for given intrinsic.
 //
-static bool isSupportedBaseType(NamedIntrinsic intrinsic, CorInfoType baseJitType)
+bool Compiler::isSupportedBaseType(NamedIntrinsic intrinsic, CorInfoType baseJitType)
 {
     if (baseJitType == CORINFO_TYPE_UNDEF)
     {
@@ -1151,98 +1265,13 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
     HWIntrinsicCategory    category        = HWIntrinsicInfo::lookupCategory(intrinsic);
     CORINFO_InstructionSet isa             = HWIntrinsicInfo::lookupIsa(intrinsic);
     int                    numArgs         = sig->numArgs;
-    var_types              retType         = genActualType(JITtype2varType(sig->retType));
     CorInfoType            simdBaseJitType = CORINFO_TYPE_UNDEF;
+    var_types              retType         = getRetTypeAndBaseJitTypeFromSig(intrinsic, clsHnd, sig, &simdBaseJitType);
     GenTree*               retNode         = nullptr;
 
-    if (retType == TYP_STRUCT)
+    if (retType == TYP_UNKNOWN)
     {
-        unsigned int sizeBytes;
-        simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(sig->retTypeSigClass, &sizeBytes);
-
-        if (HWIntrinsicInfo::IsMultiReg(intrinsic))
-        {
-            assert(sizeBytes == 0);
-        }
-
-#ifdef TARGET_ARM64
-        else if ((intrinsic == NI_AdvSimd_LoadAndInsertScalar) || (intrinsic == NI_AdvSimd_Arm64_LoadAndInsertScalar))
-        {
-            CorInfoType pSimdBaseJitType = CORINFO_TYPE_UNDEF;
-            var_types   retFieldType     = impNormStructType(sig->retTypeSigClass, &pSimdBaseJitType);
-
-            if (retFieldType == TYP_STRUCT)
-            {
-                CORINFO_CLASS_HANDLE structType;
-                unsigned int         sizeBytes = 0;
-
-                // LoadAndInsertScalar that returns 2,3 or 4 vectors
-                assert(pSimdBaseJitType == CORINFO_TYPE_UNDEF);
-                unsigned fieldCount = info.compCompHnd->getClassNumInstanceFields(sig->retTypeSigClass);
-                assert(fieldCount > 1);
-                CORINFO_FIELD_HANDLE fieldHandle = info.compCompHnd->getFieldInClass(sig->retTypeClass, 0);
-                CorInfoType          fieldType   = info.compCompHnd->getFieldType(fieldHandle, &structType);
-                simdBaseJitType                  = getBaseJitTypeAndSizeOfSIMDType(structType, &sizeBytes);
-                switch (fieldCount)
-                {
-                    case 2:
-                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x2
-                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x2;
-                        break;
-                    case 3:
-                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x3
-                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x3;
-                        break;
-                    case 4:
-                        intrinsic = sizeBytes == 8 ? NI_AdvSimd_LoadAndInsertScalarVector64x4
-                                                   : NI_AdvSimd_Arm64_LoadAndInsertScalarVector128x4;
-                        break;
-                    default:
-                        assert("unsupported");
-                }
-            }
-            else
-            {
-                assert((retFieldType == TYP_SIMD8) || (retFieldType == TYP_SIMD16));
-                assert(isSupportedBaseType(intrinsic, simdBaseJitType));
-                retType = getSIMDTypeForSize(sizeBytes);
-            }
-        }
-#endif
-        else
-        {
-            // We want to return early here for cases where retType was TYP_STRUCT as per method signature and
-            // rather than deferring the decision after getting the simdBaseJitType of arg.
-            if (!isSupportedBaseType(intrinsic, simdBaseJitType))
-            {
-                return nullptr;
-            }
-
-            assert(sizeBytes != 0);
-            retType = getSIMDTypeForSize(sizeBytes);
-        }
-    }
-
-    simdBaseJitType = getBaseJitTypeFromArgIfNeeded(intrinsic, clsHnd, sig, simdBaseJitType);
-
-    if (simdBaseJitType == CORINFO_TYPE_UNDEF)
-    {
-        if ((category == HW_Category_Scalar) || HWIntrinsicInfo::isScalarIsa(isa))
-        {
-            simdBaseJitType = sig->retType;
-
-            if (simdBaseJitType == CORINFO_TYPE_VOID)
-            {
-                simdBaseJitType = CORINFO_TYPE_UNDEF;
-            }
-        }
-        else
-        {
-            unsigned int sizeBytes;
-
-            simdBaseJitType = getBaseJitTypeAndSizeOfSIMDType(clsHnd, &sizeBytes);
-            assert((category == HW_Category_Special) || (category == HW_Category_Helper) || (sizeBytes != 0));
-        }
+        return nullptr;
     }
 
     // Immediately return if the category is other than scalar/special and this is not a supported base type.

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -1867,7 +1867,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             GenTree* indices = impStackTop(0).val;
 
-            if (!indices->IsVectorConst())
+            if (!indices->IsVectorConst() && !IsValidForShuffle(indices->AsVecCon(), simdSize, simdBaseType))
             {
                 // TODO-ARM64-CQ: Handling non-constant indices is a bit more complex
                 break;

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -2888,77 +2888,10 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             GenTree* indices = impStackTop(0).val;
 
-            if (!indices->IsVectorConst())
+            if (!indices->IsVectorConst() || !IsValidForShuffle(indices->AsVecCon(), simdSize, simdBaseType))
             {
                 // TODO-XARCH-CQ: Handling non-constant indices is a bit more complex
                 break;
-            }
-
-            size_t elementSize  = genTypeSize(simdBaseType);
-            size_t elementCount = simdSize / elementSize;
-
-            if (simdSize == 32)
-            {
-                if (!compOpportunisticallyDependsOn(InstructionSet_AVX2))
-                {
-                    // While we could accelerate some functions on hardware with only AVX support
-                    // it's likely not worth it overall given that IsHardwareAccelerated reports false
-                    break;
-                }
-                else if ((varTypeIsByte(simdBaseType) &&
-                          !compOpportunisticallyDependsOn(InstructionSet_AVX512VBMI_VL)) ||
-                         (varTypeIsShort(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_AVX512BW_VL)))
-                {
-                    bool crossLane = false;
-
-                    for (size_t index = 0; index < elementCount; index++)
-                    {
-                        uint64_t value = indices->GetIntegralVectorConstElement(index, simdBaseType);
-
-                        if (value >= elementCount)
-                        {
-                            continue;
-                        }
-
-                        if (index < (elementCount / 2))
-                        {
-                            if (value >= (elementCount / 2))
-                            {
-                                crossLane = true;
-                                break;
-                            }
-                        }
-                        else if (value < (elementCount / 2))
-                        {
-                            crossLane = true;
-                            break;
-                        }
-                    }
-
-                    if (crossLane)
-                    {
-                        // TODO-XARCH-CQ: We should emulate cross-lane shuffling for byte/sbyte and short/ushort
-                        break;
-                    }
-                }
-            }
-            else if (simdSize == 64)
-            {
-                if (varTypeIsByte(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_AVX512VBMI))
-                {
-                    // TYP_BYTE, TYP_UBYTE need AVX512VBMI.
-                    break;
-                }
-            }
-            else
-            {
-                assert(simdSize == 16);
-
-                if (varTypeIsSmall(simdBaseType) && !compOpportunisticallyDependsOn(InstructionSet_SSSE3))
-                {
-                    // TYP_BYTE, TYP_UBYTE, TYP_SHORT, and TYP_USHORT need SSSE3 to be able to shuffle any operation
-                    break;
-                }
             }
 
             if (sig->numArgs == 2)


### PR DESCRIPTION
This changes:
```csharp
private static Vector128<float> Test()
{
    var y = Vector128.Create(3, 2, 1, 0);
    return Vector128.Shuffle(Vector128.Create(1.0f, 2.0f, 3.0f, 4.0f), y);
}
```

From generating:
```asm
; Method Program:Test():System.Runtime.Intrinsics.Vector128`1[float] (FullOpts)
G_M000_IG01:                ;; offset=0x0000
       push     rbx
       sub      rsp, 64
       mov      rbx, rcx

G_M000_IG02:                ;; offset=0x0008
       vmovups  xmm0, xmmword ptr [reloc @RWD00]
       vmovaps  xmmword ptr [rsp+0x30], xmm0
       vmovups  xmm0, xmmword ptr [reloc @RWD16]
       vmovaps  xmmword ptr [rsp+0x20], xmm0
       lea      rdx, [rsp+0x30]
       lea      r8, [rsp+0x20]
       mov      rcx, rbx
       call     [System.Runtime.Intrinsics.Vector128:Shuffle(System.Runtime.Intrinsics.Vector128`1[float],System.Runtime.Intrinsics.Vector128`1[int]):System.Runtime.Intrinsics.Vector128`1[float]]
       mov      rax, rbx

G_M000_IG03:                ;; offset=0x003A
       add      rsp, 64
       pop      rbx
       ret      
RWD00  	dq	400000003F800000h, 4080000040400000h
RWD16  	dq	0000000200000003h, 0000000000000001h
; Total bytes of code: 64
```

to instead generate:
```asm
; Method Program:Test():System.Runtime.Intrinsics.Vector128`1[float] (FullOpts)
G_M40807_IG01:  ;; offset=0x0000
						;; size=0 bbWeight=1 PerfScore 0.00

G_M40807_IG02:  ;; offset=0x0000
       vpermilps xmm0, xmmword ptr [reloc @RWD00], 27
       vmovups  xmmword ptr [rcx], xmm0
       mov      rax, rcx
						;; size=17 bbWeight=1 PerfScore 4.25

G_M40807_IG03:  ;; offset=0x0011
       ret      
						;; size=1 bbWeight=1 PerfScore 1.00
RWD00  	dq	400000003F800000h, 4080000040400000h
; Total bytes of code: 18

```

------------------

Due to limitations in forward sub, this does not handle some other cases where other statements interfere with the ability to substitute.

Doing this post global morph is much more difficult as the call gets rewritten to spilled locals, such as:
```csharp
fgMorphTree BB01, STMT00002 (after)
               [000016] SACXG+-----                         *  CALL      void   System.Runtime.Intrinsics.Vector128:Shuffle(System.Runtime.Intrinsics.Vector128`1[float],System.Runtime.Intrinsics.Vector128`1[int]):System.Runtime.Intrinsics.Vector128`1[float]
               [000021] DA--------- arg1 setup              +--*  STORE_LCL_VAR simd16<System.Runtime.Intrinsics.Vector128`1>(AX) V04 tmp2         
               [000014] -----+-----                         |  \--*  HWINTRINSIC simd16 float Add
               [000012] -----+-----                         |     +--*  LCL_VAR   simd16 V03 tmp1         
               [000013] -----+-----                         |     \--*  LCL_VAR   simd16 V03 tmp1          (last use)
               [000022] ----------- arg1 in rdx             +--*  LCL_ADDR  long   V04 tmp2         [+0]
               [000015] -----+----- arg2 in r8              +--*  LCL_ADDR  long   V01 loc0         [+0]
               [000017] -----+----- retbuf in rcx           \--*  LCL_VAR   byref  V00 RetBuf       
```

This is basically the same reason we can't do what `GT_INTRINSIC` does by just carrying a `GT_HWINTRINSIC` down to rationalization and rewriting it back to a call. The ABI handling around return buffers and parameter passing happens very early today (return buffers around import and parameter passing in global morph). If the ABI handling were moved down, then we could move this logic later (such as post VN) and catch essentially all cases instead.