### PR TITLE
[release/8.0-staging] Backport 1ES templates

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -30,9 +30,10 @@ parameters:
   extraVariablesTemplates: []
   isManualCodeQLBuild: false
   preBuildSteps: []
+  templatePath: 'templates'
 
 jobs:
-- template: /eng/common/templates/job/job.yml
+- template: /eng/common/${{ parameters.templatePath }}/job/job.yml
   parameters:
     ${{ if eq(parameters.hostedOs, '') }}:
       name: ${{ format('build_{0}{1}_{2}_{3}_{4}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig, parameters.nameSuffix) }}
@@ -141,6 +142,7 @@ jobs:
 
       - ${{ each variable in parameters.variables }}:
         - ${{ variable }}
+
     steps:
     - ${{ if eq(parameters.osGroup, 'windows') }}:
       - template: /eng/pipelines/common/templates/disable-vsupdate-or-failfast.yml
@@ -181,7 +183,7 @@ jobs:
           path: '$(Build.SourcesDirectory)/artifacts/obj/mono/offsetfiles'
 
     - ${{ if eq(parameters.isSourceBuild, true) }}:
-      - template: /eng/common/templates/steps/source-build.yml
+      - template: /eng/common/${{ parameters.templatePath }}/steps/source-build.yml
         parameters:
           platform:
             baseOS: ${{ parameters.baseOS }}
@@ -285,14 +287,16 @@ jobs:
           displayName: Collect vslogs on exit
           condition: always()
 
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
-        PublishLocation: Container
-        ${{ if notin(parameters.osGroup, 'browser', 'wasi') }}:
-          ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
-        ${{ if in(parameters.osGroup, 'browser', 'wasi') }}:
-          ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.archType }}_${{ parameters.hostedOs }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
-      continueOnError: true
-      condition: always()
+    - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
+      parameters:
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        displayName: Publish Logs
+        inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
+          PublishLocation: Container
+          ${{ if notin(parameters.osGroup, 'browser', 'wasi') }}:
+            ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
+          ${{ if in(parameters.osGroup, 'browser', 'wasi') }}:
+            ArtifactName: Logs_Build_Attempt$(System.JobAttempt)_${{ parameters.osGroup }}_${{ parameters.archType }}_${{ parameters.hostedOs }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
+          continueOnError: true
+        condition: always()

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -101,7 +101,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/x64
 
     - container: tizen_armel
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-armel-tizen
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen
       env:
         ROOTFS_DIR: /crossrootfs/armel
 

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -96,7 +96,7 @@ resources:
         ROOTFS_DIR: /crossrootfs/x64
 
     - container: freebsd_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-freebsd-12
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-freebsd-13
       env:
         ROOTFS_DIR: /crossrootfs/x64
 

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -15,8 +15,9 @@ resources:
         ROOTFS_DIR: /crossrootfs/armv6
 
     - container: linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64
+      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-biarch-amd64-arm64
       env:
+        ROOTFS_HOST_DIR: /crossrootfs/x64
         ROOTFS_DIR: /crossrootfs/arm64
 
     - container: linux_musl_x64

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -1,114 +1,124 @@
 parameters:
   - name: stages
     type: stageList
+  - name: isOfficialBuild
+    type: boolean
+    default: false
 
-resources:
-  containers:
-    - container: linux_arm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm
-      env:
-        ROOTFS_DIR: /crossrootfs/arm
+extends:
+  template: templateDispatch.yml
+  parameters:
+    ${{ if parameters.isOfficialBuild }}:
+      templatePath: template1es.yml
+    ${{ else }}:
+      templatePath: templatePublic.yml
 
-    - container: linux_armv6
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-armv6-raspbian-10
-      env:
-        ROOTFS_DIR: /crossrootfs/armv6
+    stages: ${{ parameters.stages }}
 
-    - container: linux_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-biarch-amd64-arm64
-      env:
-        ROOTFS_HOST_DIR: /crossrootfs/x64
-        ROOTFS_DIR: /crossrootfs/arm64
+    containers:
+      linux_arm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm
+        env:
+          ROOTFS_DIR: /crossrootfs/arm
 
-    - container: linux_musl_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
-      env:
-        ROOTFS_DIR: /crossrootfs/x64
+      linux_armv6:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-armv6-raspbian-10
+        env:
+          ROOTFS_DIR: /crossrootfs/armv6
 
-    - container: linux_musl_arm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine
-      env:
-        ROOTFS_DIR: /crossrootfs/arm
+      linux_arm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-biarch-amd64-arm64
+        env:
+          ROOTFS_HOST_DIR: /crossrootfs/x64
+          ROOTFS_DIR: /crossrootfs/arm64
 
-    - container: linux_musl_arm64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
-      env:
-        ROOTFS_DIR: /crossrootfs/arm64
+      linux_musl_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-alpine
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
 
-    # This container contains all required toolsets to build for Android and for Linux with bionic libc.
-    - container: linux_bionic
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-android-amd64
+      linux_musl_arm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm-alpine
+        env:
+          ROOTFS_DIR: /crossrootfs/arm
 
-    # This container contains all required toolsets to build for Android as well as tooling to build docker images.
-    - container: android_docker
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-docker
+      linux_musl_arm64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-arm64-alpine
+        env:
+          ROOTFS_DIR: /crossrootfs/arm64
 
-    - container: linux_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
-      env:
-        ROOTFS_DIR: /crossrootfs/x64
+      # This container contains all required toolsets to build for Android and for Linux with bionic libc.
+      linux_bionic:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-android-amd64
 
-    - container: linux_x86
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-x86
-      env:
-        ROOTFS_DIR: /crossrootfs/x86
+      # This container contains all required toolsets to build for Android as well as tooling to build docker images.
+      android_docker:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-android-docker
 
-    - container: linux_x64_dev_innerloop
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
+      linux_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
 
-    # We use a CentOS Stream 9 image here to test building from source on CentOS Stream 9.
-    - container: SourceBuild_centos_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
+      linux_x86:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-x86
+        env:
+          ROOTFS_DIR: /crossrootfs/x86
 
-    # AlmaLinux 8 is a RHEL 8 rebuild, so we use it to test building from source on RHEL 8.
-    - container: SourceBuild_linux_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-source-build
+      linux_x64_dev_innerloop:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04
 
-    - container: linux_s390x
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-s390x
-      env:
-        ROOTFS_DIR: /crossrootfs/s390x
+      # We use a CentOS Stream 9 image here to test building from source on CentOS Stream 9.
+      SourceBuild_centos_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
 
-    - container: linux_ppc64le
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-ppc64le
-      env:
-        ROOTFS_DIR: /crossrootfs/ppc64le
+      # AlmaLinux 8 is a RHEL 8 rebuild, so we use it to test building from source on RHEL 8.
+      SourceBuild_linux_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:almalinux-8-source-build
 
-    - container: linux_riscv64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-riscv64
-      env:
-        ROOTFS_DIR: /crossrootfs/riscv64
+      linux_s390x:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-s390x
+        env:
+          ROOTFS_DIR: /crossrootfs/s390x
 
-    - container: debian-12-gcc13-amd64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc13-amd64
+      linux_ppc64le:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-ppc64le
+        env:
+          ROOTFS_DIR: /crossrootfs/ppc64le
 
-    - container: linux_x64_llvmaot
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
+      linux_riscv64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-riscv64
+        env:
+          ROOTFS_DIR: /crossrootfs/riscv64
 
-    - container: browser_wasm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
-      env:
-        ROOTFS_DIR: /crossrootfs/x64
+      debian-12-gcc13-amd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-gcc13-amd64
 
-    - container: wasi_wasm
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
-      env:
-        ROOTFS_DIR: /crossrootfs/x64
+      linux_x64_llvmaot:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:centos-stream9
 
-    - container: freebsd_x64
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-freebsd-13
-      env:
-        ROOTFS_DIR: /crossrootfs/x64
+      browser_wasm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
 
-    - container: tizen_armel
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen
-      env:
-        ROOTFS_DIR: /crossrootfs/armel
+      wasi_wasm:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-webassembly-20230913040940-1edc1c6
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
 
-    - container: debpkg
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+      freebsd_x64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-cross-amd64-freebsd-13
+        env:
+          ROOTFS_DIR: /crossrootfs/x64
 
-    - container: rpmpkg
-      image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm
+      tizen_armel:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen
+        env:
+          ROOTFS_DIR: /crossrootfs/armel
 
-stages: ${{ parameters.stages }}
+      debpkg:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-debpkg
+
+      rpmpkg:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:cbl-mariner-2.0-fpm

--- a/eng/pipelines/common/templates/publish-build-artifacts.yml
+++ b/eng/pipelines/common/templates/publish-build-artifacts.yml
@@ -1,0 +1,22 @@
+parameters:
+  - name: isOfficialBuild
+    type: boolean
+  - name: displayName
+    type: string
+  - name: inputs
+    type: object
+  - name: condition
+    type: string
+    default: ''
+
+steps:
+  - ${{ if parameters.isOfficialBuild }}:
+    - task: 1ES.PublishBuildArtifacts@1
+      displayName: ${{ parameters.displayName }}
+      inputs: ${{ parameters.inputs }}
+      condition: ${{ parameters.condition }}
+  - ${{ else }}:
+    - task: PublishBuildArtifacts@1
+      displayName: ${{ parameters.displayName }}
+      inputs: ${{ parameters.inputs }}
+      condition: ${{ parameters.condition }}

--- a/eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+++ b/eng/pipelines/common/templates/publish-pipeline-artifacts.yml
@@ -1,0 +1,17 @@
+parameters:
+- name: displayName
+  type: string
+- name: inputs
+  type: object
+- name: isOfficialBuild
+  type: boolean
+
+steps:
+  - ${{ if parameters.isOfficialBuild }}:
+    - task: 1ES.PublishPipelineArtifact@1
+      displayName: ${{ parameters.displayName }}
+      inputs: ${{ parameters.inputs }}
+  - ${{ else }}:
+    - task: PublishPipelineArtifact@1
+      displayName: ${{ parameters.displayName }}
+      inputs: ${{ parameters.inputs }}

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -14,6 +14,7 @@ parameters:
   dependsOn: []
   dependOnEvaluatePaths: false
   crossBuild: false
+  isOfficialBuild: false
 
 ### Build managed test components (native components are getting built as part
 ### of the product build job).
@@ -142,12 +143,13 @@ jobs:
         artifactName: $(microsoftNetSdkIlArtifactName)
         displayName: 'Microsoft.NET.Sdk.IL package'
 
-
     # Publish Logs
-    - task: PublishPipelineArtifact@1
-      displayName: Publish Logs
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_Attempt$(System.JobAttempt)_AnyOS_AnyCPU_$(buildConfig)_${{ parameters.testGroup }}'
-      continueOnError: true
-      condition: always()
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+      parameters:
+        displayName: Publish Logs
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/artifacts/log
+          ArtifactName: '${{ parameters.runtimeFlavor }}_Common_Runtime_TestBuildLogs_Attempt$(System.JobAttempt)_AnyOS_AnyCPU_$(buildConfig)_${{ parameters.testGroup }}'
+          continueOnError: true
+          condition: always()

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -20,11 +20,12 @@ parameters:
   enableMicrobuild: ''
   gatherAssetManifests: false
   disableComponentGovernance: false
+  templatePath: 'templates'
 
   variables: {} ## any extra variables to add to the defaults defined below
 
 jobs:
-- template: /eng/common/templates/job/job.yml
+- template: /eng/common/${{ parameters.templatePath }}/job/job.yml
   parameters:
 
     name: ${{ parameters.name }}

--- a/eng/pipelines/common/templates/template1es.yml
+++ b/eng/pipelines/common/templates/template1es.yml
@@ -1,0 +1,31 @@
+
+
+parameters:
+  - name: templatePath
+    type: string
+    default: 'templates-official'
+  - name: stages
+    type: stageList
+  - name: containers
+    type: object
+
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
+
+    containers:
+      ${{ parameters.containers }}
+
+    stages: ${{ parameters.stages }}

--- a/eng/pipelines/common/templates/templateDispatch.yml
+++ b/eng/pipelines/common/templates/templateDispatch.yml
@@ -1,0 +1,13 @@
+parameters:
+  - name: templatePath
+    type: string
+  - name: stages
+    type: stageList
+  - name: containers
+    type: object
+
+extends:
+  template: ${{ parameters.templatePath }}
+  parameters:
+    stages: ${{ parameters.stages }}
+    containers: ${{ parameters.containers }}

--- a/eng/pipelines/common/templates/templatePublic.yml
+++ b/eng/pipelines/common/templates/templatePublic.yml
@@ -1,0 +1,21 @@
+
+parameters:
+  - name: templatePath
+    type: string
+    default: 'templates'
+  - name: stages
+    type: stageList
+  - name: containers
+    type: object
+
+resources:
+  containers:
+    - ${{ each container_pair in parameters.containers }}:
+      - ${{ if container_pair.value.image }}:
+        - container: ${{ container_pair.key }}
+          ${{ each pair in container_pair.value }}:
+            ${{ if notIn(pair.key, 'tenantId', 'identityType', 'registry') }}:
+              ${{ pair.key }}: ${{ pair.value }}
+
+
+stages: ${{ parameters.stages }}

--- a/eng/pipelines/common/upload-artifact-step.yml
+++ b/eng/pipelines/common/upload-artifact-step.yml
@@ -7,6 +7,7 @@ parameters:
   artifactName: ''
   displayName: ''
   condition: succeeded()
+  isOfficialBuild: false
 
 steps:
   # Zip Artifact
@@ -20,9 +21,11 @@ steps:
       includeRootFolder: ${{ parameters.includeRootFolder }}
     condition: ${{ parameters.condition }}
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish ${{ parameters.displayName }}'
-    inputs:
-      pathtoPublish: $(Build.StagingDirectory)/${{ parameters.artifactName }}${{ parameters.archiveExtension }}
-      artifactName:  ${{ parameters.artifactName }}
-    condition: ${{ parameters.condition }}
+  - template: /eng/pipelines/common/templates/publish-build-artifacts.yml
+    parameters:
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
+      displayName: 'Publish ${{ parameters.displayName }}'
+      inputs:
+        PathtoPublish: $(Build.StagingDirectory)/${{ parameters.artifactName }}${{ parameters.archiveExtension }}
+        artifactName:  ${{ parameters.artifactName }}
+      condition: ${{ parameters.condition }}

--- a/eng/pipelines/common/upload-intermediate-artifacts-step.yml
+++ b/eng/pipelines/common/upload-intermediate-artifacts-step.yml
@@ -25,9 +25,11 @@ steps:
     TargetFolder: '$(Build.StagingDirectory)/IntermediateArtifacts/${{ parameters.name }}'
     CleanTargetFolder: true
 
-- task: PublishBuildArtifacts@1
-  displayName: Publish intermediate artifacts
-  inputs:
-    pathToPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
-    artifactName: IntermediateArtifacts
-    artifactType: container
+- template: /eng/pipelines/common/templates/publish-build-artifacts.yml
+  parameters:
+    isOfficialBuild: true
+    displayName: Publish intermediate artifacts
+    inputs:
+      PathtoPublish: '$(Build.StagingDirectory)/IntermediateArtifacts'
+      ArtifactName: IntermediateArtifacts
+      ArtifactType: container

--- a/eng/pipelines/common/variables.yml
+++ b/eng/pipelines/common/variables.yml
@@ -1,3 +1,8 @@
+parameters:
+  - name: templatePath
+    type: string
+    default: 'templates'
+
 variables:
 
 # These values enable longer delays, configurable number of retries, and special understanding of TCP hang-up 
@@ -54,3 +59,5 @@ variables:
                 eq(variables['isRollingBuild'], true))) ]
 
 - template: /eng/pipelines/common/perf-variables.yml
+
+- template: /eng/common/${{ parameters.templatePath }}/variables/pool-providers.yml

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -22,7 +22,7 @@ jobs:
     dependOnEvaluatePaths: ${{ and(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.DefinitionName'], 'runtime', 'runtime-community', 'runtime-extra-platforms', 'runtime-wasm', 'runtime-wasm-libtests', 'runtime-wasm-non-libtests', 'dotnet-linker-tests', 'runtime-dev-innerloop', 'runtime-coreclr superpmi-replay', 'runtime-coreclr superpmi-diffs')) }}
 
     variables:
-      - template: /eng/common/templates/variables/pool-providers.yml
+      - template: /eng/common/${{ coalesce(parameters.jobParameters.templatePath, 'templates') }}/variables/pool-providers.yml
       # Disable component governance in our CI builds. These builds are not shipping nor
       # are they a service. Also the component governance jobs issue lots of inconsequential
       # warnings and errors into our build timelines that make it hard to track down
@@ -168,11 +168,18 @@ jobs:
         # Official Build Linux Pool
         ${{ if and(or(in(parameters.osGroup, 'linux', 'freebsd', 'android', 'tizen'), eq(parameters.jobParameters.hostedOs, 'linux')), ne(variables['System.TeamProject'], 'public')) }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+          demands: ImageOverride -equals 1es-ubuntu-2204
+          os: linux
 
-        # OSX Build Pool (we don't have on-prem OSX BuildPool).
-        ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
+        # OSX Public Build Pool (we don't have on-prem OSX BuildPool).
+        ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(variables['System.TeamProject'], 'public')) }}:
           vmImage: 'macos-12'
+
+        # OSX Internal Pool
+        ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), ne(variables['System.TeamProject'], 'public')) }}:
+          name: "Azure Pipelines"
+          vmImage: 'macOS-12'
+          os: macOS
 
         # Official Build Windows Pool
         ${{ if and(or(eq(parameters.osGroup, 'windows'), eq(parameters.jobParameters.hostedOs, 'windows')), ne(variables['System.TeamProject'], 'public')) }}:

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -11,6 +11,7 @@ parameters:
   liveLibrariesBuildConfig: ''
   strategy: ''
   pool: ''
+  templatePath: 'templates'
 
   # arcade-specific parameters
   condition: true
@@ -28,6 +29,7 @@ parameters:
 jobs:
 - template: /eng/pipelines/common/templates/runtimes/xplat-job.yml
   parameters:
+    templatePath: ${{ parameters.templatePath }}
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -30,6 +30,7 @@ variables:
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:
+    isOfficialBuild: false
     stages:
     - stage: Build
       jobs:

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -178,3 +178,97 @@ extends:
             timeoutInMinutes: 95
             condition:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true)
+
+      #
+      # Build CoreCLR as a non-portable build
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: checked
+          runtimeFlavor: coreclr
+          platforms:
+          - tizen_armel
+          jobParameters:
+            testScope: innerloop
+            nameSuffix: CoreCLR_NonPortable
+            buildArgs: -s clr.native+clr.tools+clr.corelib+clr.nativecorelib+clr.aot+clr.packages -c $(_BuildConfig) /p:PortableBuild=false
+            timeoutInMinutes: 120
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build CoreCLR with no R2R
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+          buildConfig: checked
+          runtimeFlavor: coreclr
+          platforms:
+          - linux_x86
+          jobParameters:
+            testScope: innerloop
+            nameSuffix: CoreCLR_NoR2R
+            buildArgs: -s clr.runtime+clr.jit+clr.iltools+clr.spmi+clr.corelib -c $(_BuildConfig)
+            timeoutInMinutes: 120
+            condition: >-
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build CoreCLR release
+      # Always as they are needed by Installer and we always build and test the Installer.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/coreclr/templates/build-job.yml
+          buildConfig: release
+          platforms:
+          - freebsd_x64
+          jobParameters:
+            testGroup: innerloop
+            # Mono/runtimetests also need this, but skip for wasm
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/libraries/build-job.yml
+          buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+          platforms:
+          - freebsd_x64
+          jobParameters:
+            testScope: innerloop
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_installer.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_runtimetests.containsChange'], true),
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/installer/jobs/build-job.yml
+          buildConfig: Release
+          platforms:
+            - freebsd_x64
+          jobParameters:
+            liveRuntimeBuildConfig: release
+            liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+            runOnlyIfDependenciesSucceeded: true
+            condition:
+              or(
+                eq(dependencies.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/mono/templates/generate-offsets.yml
+++ b/eng/pipelines/mono/templates/generate-offsets.yml
@@ -9,11 +9,13 @@ parameters:
   pool: ''
   condition: true
   isOfficialBuild: false
+  templatePath: 'templates'
 
 ### Product build
 jobs:
 - template: xplat-pipeline-job.yml
   parameters:
+    templatePath: ${{ parameters.templatePath }}
     buildConfig: ${{ parameters.buildConfig }}
     osGroup: ${{ parameters.osGroup }}
     osSubGroup: ${{ parameters.osSubGroup }}
@@ -76,17 +78,21 @@ jobs:
         contents: '**/offsets-*.h'
         targetFolder: '$(Build.SourcesDirectory)/artifacts/obj/mono/offsetfiles/'
 
-    - task: PublishPipelineArtifact@1
-      displayName: Upload offset files
-      inputs:
-        targetPath: '$(Build.SourcesDirectory)/artifacts/obj/mono/offsetfiles'
-        artifactName: 'Mono_Offsets_$(osGroup)$(osSubGroup)'
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+      parameters:
+        displayName: Upload offset files
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        inputs:
+          targetPath: '$(Build.SourcesDirectory)/artifacts/obj/mono/offsetfiles'
+          artifactName: 'Mono_Offsets_$(osGroup)$(osSubGroup)'
 
     # Publish Logs
-    - task: PublishPipelineArtifact@1
-      displayName: Publish Logs
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'BuildLogs_Attempt$(System.JobAttempt)_Mono_Offsets_$(osGroup)$(osSubGroup)'
-      continueOnError: true
-      condition: always()
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+      parameters:
+        displayName: Publish Logs
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/artifacts/log
+          artifactName: 'BuildLogs_Attempt$(System.JobAttempt)_Mono_Offsets_$(osGroup)$(osSubGroup)'
+          continueOnError: true
+          condition: always()

--- a/eng/pipelines/mono/templates/workloads-build.yml
+++ b/eng/pipelines/mono/templates/workloads-build.yml
@@ -12,11 +12,13 @@ parameters:
   runtimeVariant: ''
   testGroup: ''
   timeoutInMinutes: ''
+  templatePath: 'templates'
   variables: {}
 
 jobs:
 - template: xplat-pipeline-job.yml
   parameters:
+    templatePath: ${{ parameters.templatePath }}
     archType: ${{ parameters.archType }}
     buildConfig: ${{ parameters.buildConfig }}
     container: ${{ parameters.container }}
@@ -92,13 +94,15 @@ jobs:
         name: workloads
 
     # Publish Logs
-    - task: PublishPipelineArtifact@1
-      displayName: Publish Logs
-      inputs:
-        targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: 'WorkloadLogs_Attempt$(System.JobAttempt)'
-      continueOnError: true
-      condition: always()
+    - template: /eng/pipelines/common/templates/publish-pipeline-artifacts.yml
+      parameters:
+        displayName: Publish Logs
+        isOfficialBuild: ${{ parameters.isOfficialBuild }}
+        inputs:
+          targetPath: $(Build.SourcesDirectory)/artifacts/log
+          artifactName: 'WorkloadLogs_Attempt$(System.JobAttempt)'
+          continueOnError: true
+          condition: always()
 
     # Delete wixpdb files before they are uploaded to artifacts
     - task: DeleteFiles@1

--- a/eng/pipelines/mono/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/mono/templates/xplat-pipeline-job.yml
@@ -12,6 +12,7 @@ parameters:
   pool: ''
   runtimeVariant: ''
   liveRuntimeBuildConfig: 'release'
+  templatePath: 'templates'
 
   # arcade-specific parameters
   condition: true
@@ -28,6 +29,7 @@ parameters:
 jobs:
 - template: /eng/pipelines/common/templates/runtimes/xplat-job.yml
   parameters:
+    templatePath: ${{ parameters.templatePath }}
     buildConfig: ${{ parameters.buildConfig }}
     archType: ${{ parameters.archType }}
     osGroup: ${{ parameters.osGroup }}

--- a/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
+++ b/eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -20,6 +20,14 @@ jobs:
   - name: SignType
     value: $[ coalesce(variables.OfficialSignType, 'real') ]
 
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: 'Publish BuildLogs'
+      condition: succeededOrFailed()
+      targetPath: '$(Build.StagingDirectory)\BuildLogs'
+      artifactName: ${{ parameters.logArtifactName }}
+
   steps:
   - checkout: self
     clean: true
@@ -65,11 +73,4 @@ jobs:
         **/*.binlog
       TargetFolder: '$(Build.StagingDirectory)\BuildLogs'
     continueOnError: true
-    condition: succeededOrFailed()
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish BuildLogs
-    inputs:
-      targetPath: '$(Build.StagingDirectory)\BuildLogs'
-      artifactName: ${{ parameters.logArtifactName }}
     condition: succeededOrFailed()

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -7,7 +7,7 @@ stages:
 - stage: PrepareForPublish
   displayName: Prepare for Publish
   variables:
-  - template: /eng/common/templates/variables/pool-providers.yml
+  - template: /eng/common/templates-official/variables/pool-providers.yml
   jobs:
   # Prep artifacts: sign them and upload pipeline artifacts expected by stages-based publishing.
   - template: /eng/pipelines/official/jobs/prepare-signed-artifacts.yml
@@ -15,7 +15,7 @@ stages:
       PublishRidAgnosticPackagesFromPlatform: ${{ parameters.PublishRidAgnosticPackagesFromPlatform }}
 
   # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-  - template: /eng/common/templates/job/publish-build-assets.yml
+  - template: /eng/common/templates-official/job/publish-build-assets.yml
     parameters:
       publishUsingPipelines: true
       publishAssetsImmediately: true
@@ -26,7 +26,7 @@ stages:
       symbolPublishingAdditionalParameters: '/p:PublishSpecialClrFiles=true'
 
 # Stages-based publishing entry point
-- template: /eng/common/templates/post-build/post-build.yml
+- template: /eng/common/templates-official/post-build/post-build.yml
   parameters:
     publishingInfraVersion: ${{ parameters.publishingInfraVersion }}
     validateDependsOn:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -23,6 +23,8 @@ pr: none
 
 variables:
 - template: /eng/pipelines/common/variables.yml
+  parameters:
+    templatePath: 'templates-official'
 - template: /eng/pipelines/common/internal-variables.yml
   parameters:
     teamName: dotnet-core-acquisition

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -41,13 +41,12 @@ extends:
       # Localization build
       #
 
-      - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/release/8.0') }}:
-        - template: /eng/common/templates/job/onelocbuild.yml
-          parameters:
-            MirrorRepo: runtime
-            MirrorBranch: release/8.0
-            LclSource: lclFilesfromPackage
-            LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: runtime
+          MirrorBranch: main
+          LclSource: lclFilesfromPackage
+          LclPackageId: 'LCL-JUNO-PROD-RUNTIME'
 
       #
       # Source Index Build

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -33,6 +33,7 @@ variables:
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:
+    isOfficialBuild: true
     stages:
     - stage: Build
       jobs:
@@ -41,7 +42,7 @@ extends:
       # Localization build
       #
 
-      - template: /eng/common/templates/job/onelocbuild.yml
+      - template: /eng/common/templates-official/job/onelocbuild.yml
         parameters:
           MirrorRepo: runtime
           MirrorBranch: main
@@ -52,7 +53,7 @@ extends:
       # Source Index Build
       #
       - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-        - template: /eng/common/templates/job/source-index-stage1.yml
+        - template: /eng/common/templates-official/job/source-index-stage1.yml
           parameters:
             sourceIndexBuildCommand: build.cmd -subset libs.sfx+libs.oob -binarylog -os linux -ci /p:SkipLibrariesNativeRuntimePackages=true
 
@@ -69,6 +70,7 @@ extends:
           - windows_x64
           - windows_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.runtime+clr.alljits+clr.nativeaotruntime -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
             nameSuffix: CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -104,6 +106,7 @@ extends:
           platforms:
           - windows_x86
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.runtime+clr.alljits -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
             nameSuffix: CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -137,6 +140,7 @@ extends:
           - osx_arm64
           - osx_x64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.runtime+clr.alljits+clr.nativeaotruntime+host.native -c $(_BuildConfig) /bl:$(Build.SourcesDirectory)/artifacts/logs/$(_BuildConfig)/CoreClrNativeBuild.binlog
             nameSuffix: CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -196,6 +200,7 @@ extends:
           - linux_musl_arm
           - linux_musl_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.aot+clr.packages+libs+host+packs -c $(_BuildConfig)
             nameSuffix: CoreCLR
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -208,12 +213,12 @@ extends:
                   SourceFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(_BuildConfig)
                   Contents: libcoreclr.so
                   TargetFolder: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts/$(osGroup)$(osSubgroup).$(archType).$(_BuildConfig)/$(crossDacHostArch)
-              - task: PublishBuildArtifacts@1
+              - task: 1ES.PublishBuildArtifacts@1
                 displayName: Publish runtime for CrossDac
                 inputs:
-                  pathToPublish: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts
+                  PathtoPublish: $(Build.SourcesDirectory)/artifacts/CoreCLRCrossDacArtifacts
                   PublishLocation: Container
-                  artifactName: CoreCLRCrossDacArtifacts
+                  ArtifactName: CoreCLRCrossDacArtifacts
               # Create RPMs and DEBs
               - template: /eng/pipelines/installer/jobs/steps/build-linux-package.yml
                 parameters:
@@ -249,6 +254,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s crossdacpack -c $(_BuildConfig) /p:CrossDacArtifactsDir=$(crossDacArtifactsPath)
             nameSuffix: CrossDac
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -319,6 +325,7 @@ extends:
           - linux_bionic_arm64
           - linux_bionic_x64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.nativeaotlibs+clr.nativeaotruntime+libs+packs -c $(_BuildConfig) /p:BuildNativeAOTRuntimePack=true /p:SkipLibrariesNativeRuntimePackages=true
             nameSuffix: NativeAOT
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -362,6 +369,7 @@ extends:
           - windows_x86
           # - windows_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:BuildMonoAOTCrossCompiler=false
             nameSuffix: Mono
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -379,6 +387,7 @@ extends:
           - browser_wasm
           - wasi_wasm
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
             nameSuffix: Mono
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -395,6 +404,7 @@ extends:
           platforms:
           - browser_wasm
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+libs+host+packs -c $(_BuildConfig) /p:MonoWasmBuildVariant=multithread /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
             nameSuffix: Mono_multithread
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -417,6 +427,7 @@ extends:
           - ios_arm64
           - maccatalyst_x64
           jobParameters:
+            templatePath: 'templates-official'
             isOfficialBuild: ${{ variables.isOfficialBuild }}
 
       #
@@ -433,6 +444,7 @@ extends:
           - linux_arm64
           - linux_musl_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+packs -c $(_BuildConfig)
                       /p:MonoCrossAOTTargetOS=android+browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
             nameSuffix: CrossAOT_Mono
@@ -457,6 +469,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+packs -c $(_BuildConfig)
                       /p:MonoCrossAOTTargetOS=android+browser /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
             nameSuffix: CrossAOT_Mono
@@ -482,6 +495,7 @@ extends:
           - osx_x64
           - osx_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s mono+packs -c $(_BuildConfig)
                       /p:MonoCrossAOTTargetOS=android+browser+tvos+ios+maccatalyst /p:SkipMonoCrossJitConfigure=true /p:BuildMonoAOTCrossCompilerOnly=true
             nameSuffix: CrossAOT_Mono
@@ -525,6 +539,7 @@ extends:
             buildConfig: release
             runtimeFlavor: mono
             jobParameters:
+              templatePath: 'templates-official'
               buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
                         /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=false
               nameSuffix: Mono_LLVMJIT
@@ -539,6 +554,7 @@ extends:
             buildConfig: release
             runtimeFlavor: mono
             jobParameters:
+              templatePath: 'templates-official'
               buildArgs: -s mono+libs+host+packs -c $(_BuildConfig)
                           /p:MonoEnableLLVM=true /p:MonoAOTEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
               nameSuffix: Mono_LLVMAOT
@@ -559,6 +575,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s tools+libs -allConfigurations -c $(_BuildConfig) /p:TestAssemblies=false /p:TestPackages=true
             nameSuffix: Libraries_AllConfigurations
             isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -578,7 +595,9 @@ extends:
           platforms:
           - SourceBuild_linux_x64
           jobParameters:
+            templatePath: 'templates-official'
             nameSuffix: PortableSourceBuild
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
@@ -600,6 +619,7 @@ extends:
           - windows_arm64
           - linux_arm64
           jobParameters:
+            templatePath: 'templates-official'
             buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument /p:SkipLibrariesNativeRuntimePackages=true
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             nameSuffix: PGO
@@ -619,6 +639,7 @@ extends:
           platforms:
           - windows_x64
           jobParameters:
+            templatePath: 'templates-official'
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             timeoutInMinutes: 120
             dependsOn:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -601,7 +601,7 @@ extends:
           - windows_arm64
           - linux_arm64
           jobParameters:
-            buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument
+            buildArgs: -s clr.native+clr.corelib+clr.tools+clr.nativecorelib+libs+host+packs -c $(_BuildConfig) -pgoinstrument /p:SkipLibrariesNativeRuntimePackages=true
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             nameSuffix: PGO
             postBuildSteps:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -156,7 +156,6 @@ extends:
           - windows_x64
           - windows_x86
           - windows_arm64
-          - freebsd_x64
           jobParameters:
             testGroup: innerloop
             # Mono/runtimetests also need this, but skip for wasm
@@ -187,48 +186,6 @@ extends:
                 or(
                   eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr_jit.containsChange'], true),
                   eq(variables['isRollingBuild'], true)))
-
-      #
-      # Build CoreCLR with no R2R
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: checked
-          runtimeFlavor: coreclr
-          platforms:
-          - linux_x86
-          jobParameters:
-            testScope: innerloop
-            nameSuffix: CoreCLR_NoR2R
-            buildArgs: -s clr.runtime+clr.jit+clr.iltools+clr.spmi+clr.corelib -c $(_BuildConfig)
-            timeoutInMinutes: 120
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build CoreCLR as a non-portable build
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: checked
-          runtimeFlavor: coreclr
-          platforms:
-          - tizen_armel
-          jobParameters:
-            testScope: innerloop
-            nameSuffix: CoreCLR_NonPortable
-            buildArgs: -s clr.native+clr.tools+clr.corelib+clr.nativecorelib+clr.aot+clr.packages -c $(_BuildConfig) /p:PortableBuild=false
-            timeoutInMinutes: 120
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
 
       #
       # CoreCLR NativeAOT debug build and smoke tests
@@ -1061,7 +1018,6 @@ extends:
           - osx_arm64
           - osx_x64
           - windows_x64
-          - freebsd_x64
           jobParameters:
             testScope: innerloop
             condition:
@@ -1185,7 +1141,6 @@ extends:
             - linux_arm64
             - linux_musl_x64
             - windows_x64
-            - freebsd_x64
           jobParameters:
             liveRuntimeBuildConfig: release
             liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -52,6 +52,7 @@ variables:
 extends:
   template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:
+    isOfficialBuild: false
     stages:
     - stage: Build
       jobs:
@@ -428,6 +429,7 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/mono/templates/generate-offsets.yml
+          templatePath: 'templates'
           buildConfig: release
           platforms:
           - android_x64

--- a/src/coreclr/debug/daccess/CMakeLists.txt
+++ b/src/coreclr/debug/daccess/CMakeLists.txt
@@ -53,7 +53,7 @@ if(CLR_CMAKE_HOST_FREEBSD OR CLR_CMAKE_HOST_NETBSD OR CLR_CMAKE_HOST_SUNOS)
     DEPENDS coreclr
     VERBATIM
     COMMAND_EXPAND_LISTS
-    COMMAND ${CLR_DIR}/pal/tools/gen-dactable-rva.sh ${args}
+    COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} ${CLR_DIR}/pal/tools/gen-dactable-rva.sh ${args}
     COMMENT Generating ${GENERATED_INCLUDE_DIR}/dactablerva.h
   )
 

--- a/src/coreclr/vm/arm/thunktemplates.S
+++ b/src/coreclr/vm/arm/thunktemplates.S
@@ -11,7 +11,7 @@
 
 PAGE_SIZE = 4096
 
-#define DATA_SLOT(stub, field) stub##Code + PAGE_SIZE + stub##Data__##field
+#define DATA_SLOT(stub, field) . - (. - stub##Code) + PAGE_SIZE + stub##Data__##field
 
     LEAF_ENTRY StubPrecodeCode
         ldr r12, DATA_SLOT(StubPrecode, MethodDesc)

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -810,6 +810,16 @@
       <MonoAotCrossOffsetsToolParams Condition="'$(TargetsWasi)' == 'true'" Include="--wasi-sdk=&quot;$([MSBuild]::NormalizePath('$(WASI_SDK_PATH)'))&quot;" />
     </ItemGroup>
 
+    <!--
+    When cross-building, this PropertyGroup sets the MonoCrossDir to use the ROOTFS_HOST_DIR.
+    This is specifically for linux_arm64 image that has both x64 and arm64 rootfs.
+    The runtime is built using the 'ROOTFS_DIR' which points to '/crossrootfs/arm64'.
+    The 'mono-aot-cross' is built using the 'ROOTFS_HOST_DIR' which points to '/crossrootfs/x64'.
+    -->
+    <PropertyGroup Condition="'$(CrossBuild)' == 'true' and '$(ROOTFS_HOST_DIR)' != '' and $(ROOTFS_HOST_DIR.Contains('$(AotHostArchitecture)'))">
+        <MonoCrossDir>$(ROOTFS_HOST_DIR)</MonoCrossDir>
+    </PropertyGroup>
+
     <!-- AOT compiler cross-build options  -->
     <ItemGroup Condition="'$(MonoCrossDir)' != ''">
       <MonoAOTCMakeArgs Include="-DCMAKE_TOOLCHAIN_FILE=$(CrossToolchainFile)" />
@@ -859,7 +869,7 @@
       <_MonoSkipInitCompiler Condition="'$(CrossBuild)' == 'true'">false</_MonoSkipInitCompiler>
       <_MonoAotCrossOffsetsCommand Condition="'$(MonoUseCrossTool)' == 'true'">$(PythonCmd) $(MonoProjectRoot)mono/tools/offsets-tool/offsets-tool.py @(MonoAotCrossOffsetsToolParams, ' ')</_MonoAotCrossOffsetsCommand>
       <_MonoAotCMakeConfigureCommand>cmake @(MonoAOTCMakeArgs, ' ') $(MonoCMakeExtraArgs) &quot;$(MonoProjectRoot.TrimEnd('\/'))&quot;</_MonoAotCMakeConfigureCommand>
-      <_MonoAotCMakeConfigureCommand Condition="'$(_MonoSkipInitCompiler)' != 'true' and '$(HostOS)' != 'windows'">sh -c 'build_arch=&quot;$(_CompilerTargetArch)&quot; compiler=&quot;$(MonoCCompiler)&quot; . &quot;$(RepositoryEngineeringCommonDir)native/init-compiler.sh&quot; &amp;&amp; @(_MonoAotBuildEnv, ' ') $(_MonoAotCMakeConfigureCommand)'</_MonoAotCMakeConfigureCommand>
+      <_MonoAotCMakeConfigureCommand Condition="'$(_MonoSkipInitCompiler)' != 'true' and '$(HostOS)' != 'windows'">sh -c 'build_arch=&quot;$(_CompilerTargetArch)&quot; ROOTFS_DIR=&quot;$(MonoCrossDir)&quot; compiler=&quot;$(MonoCCompiler)&quot; . &quot;$(RepositoryEngineeringCommonDir)native/init-compiler.sh&quot; &amp;&amp; @(_MonoAotBuildEnv, ' ') $(_MonoAotCMakeConfigureCommand)'</_MonoAotCMakeConfigureCommand>
       <_MonoAotCMakeConfigureCommand Condition="'$(_MonoSkipInitCompiler)' == 'true' and '$(HostOS)' != 'windows'">$(_MonoAOTCCOption) $(_MonoAOTCXXOption) @(_MonoAotBuildEnv, ' ') $(_MonoAotCMakeConfigureCommand)</_MonoAotCMakeConfigureCommand>
       <_MonoAotCMakeConfigureCommand Condition="'$(HostOS)' == 'windows'">call &quot;$(RepositoryEngineeringDir)native\init-vs-env.cmd&quot; $(_CompilerTargetArch) &amp;&amp; cd /D &quot;$(MonoObjCrossDir)&quot; &amp;&amp; @(_MonoAotBuildEnv, ' ') $(_MonoAotCMakeConfigureCommand)</_MonoAotCMakeConfigureCommand>
       <_MonoAotCMakeBuildCommand>cmake --build . --target install --config $(Configuration)</_MonoAotCMakeBuildCommand>


### PR DESCRIPTION
This PR mainly backports https://github.com/dotnet/runtime/pull/99433 (the 1ES templates).

The changes that were needed with this PR were cherry-picked for clarity. Also, as originally the maximum YAML size was exceeded in the runtime pipeline, the linux_x86, tizen_armel, and freebsd_x64 jobs were moved to the global-build pipeline. 

Official build link (0f15d9e): https://dev.azure.com/dnceng/internal/_build/results?buildId=2462127&view=results

Cc @jkoritzinsky @agocke @amanasifkhalid 