### PR TITLE
Implement `Console.Beep` via bell character instead of Windows API

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -677,6 +677,25 @@ namespace System
 
         public static void Beep()
         {
+            const char BellCharacter = '\u0007'; // Windows doesn't use terminfo, so the codepoint is hardcoded.
+
+            if (!Console.IsOutputRedirected)
+            {
+                Console.Out.Write(BellCharacter);
+                return;
+            }
+
+            if (!Console.IsErrorRedirected)
+            {
+                Console.Error.Write(BellCharacter);
+                return;
+            }
+
+            BeepFallback();
+        }
+
+        private static void BeepFallback()
+        {
             const int BeepFrequencyInHz = 800;
             const int BeepDurationInMs = 200;
             Interop.Kernel32.Beep(BeepFrequencyInHz, BeepDurationInMs);

--- a/src/libraries/System.Console/tests/BeepByBellChar.cs
+++ b/src/libraries/System.Console/tests/BeepByBellChar.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Xunit;
+
+[Collection(nameof(DisableParallelization))]
+public class BeepByBell
+{
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [PlatformSpecific(TestPlatforms.Windows)]
+    public void BeepDoesNotWriteToRedirectedOut(bool redirectOut, bool redirectError)
+    {
+        using var streamOut = new MemoryStream();
+        using var streamErr = new MemoryStream();
+        using var writerOut = new StreamWriter(streamOut);
+        using var writerErr = new StreamWriter(streamErr);
+
+        TextWriter originalOut = Console.Out;
+        TextWriter originalErr = Console.Error;
+
+        try
+        {
+            if (redirectOut)
+            {
+                Console.SetOut(writerOut);
+            }
+
+            if (redirectError)
+            {
+                Console.SetOut(writerErr);
+            }
+
+            Console.Beep();
+            Assert.Equal(0, streamOut.Length);
+            Assert.Equal(0, streamErr.Length);
+        }
+        finally
+        {
+            if (redirectOut)
+            {
+                Console.SetOut(originalOut);
+            }
+
+            if (redirectError)
+            {
+                Console.SetOut(originalErr);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Console/tests/System.Console.Tests.csproj
+++ b/src/libraries/System.Console/tests/System.Console.Tests.csproj
@@ -6,6 +6,7 @@
     <StringResourcesPath>..\src\Resources\Strings.resx</StringResourcesPath>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="BeepByBellChar.cs" />
     <Compile Include="CancelKeyPress.cs" />
     <Compile Include="Helpers.cs" />
     <Compile Include="ReadAndWrite.cs" />


### PR DESCRIPTION
Fix #102211

The behavioral breaking change would require a later document change.