### PR TITLE
Fix WhiteSpace validation in HttpHeaders

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -147,9 +147,6 @@
   <data name="net_http_headers_invalid_host_header" xml:space="preserve">
     <value>The specified value is not a valid 'Host' header string.</value>
   </data>
-  <data name="net_http_headers_invalid_etag_name" xml:space="preserve">
-    <value>The specified value is not a valid quoted string.</value>
-  </data>
   <data name="net_http_headers_invalid_range" xml:space="preserve">
     <value>Invalid range. At least one of the two parameters must not be null.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ContentDispositionHeaderValue.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -35,7 +34,7 @@ namespace System.Net.Http.Headers
             get { return _dispositionType; }
             set
             {
-                CheckDispositionTypeFormat(value);
+                HeaderUtilities.CheckValidToken(value);
                 _dispositionType = value;
             }
         }
@@ -125,7 +124,7 @@ namespace System.Net.Http.Headers
 
         #region Constructors
 
-        internal ContentDispositionHeaderValue()
+        private ContentDispositionHeaderValue()
         {
             // Used by the parser to create a new instance of this type.
         }
@@ -140,7 +139,8 @@ namespace System.Net.Http.Headers
 
         public ContentDispositionHeaderValue(string dispositionType)
         {
-            CheckDispositionTypeFormat(dispositionType);
+            HeaderUtilities.CheckValidToken(dispositionType);
+
             _dispositionType = dispositionType;
         }
 
@@ -269,19 +269,6 @@ namespace System.Net.Http.Headers
 
             dispositionType = input.Substring(startIndex, typeLength);
             return typeLength;
-        }
-
-        private static void CheckDispositionTypeFormat(string dispositionType, [CallerArgumentExpression(nameof(dispositionType))] string? parameterName = null)
-        {
-            ArgumentException.ThrowIfNullOrWhiteSpace(dispositionType, parameterName);
-
-            // When adding values using strongly typed objects, no leading/trailing LWS (whitespace) are allowed.
-            int dispositionTypeLength = GetDispositionTypeExpressionLength(dispositionType, 0, out string? tempDispositionType);
-            if ((dispositionTypeLength == 0) || (tempDispositionType!.Length != dispositionType.Length))
-            {
-                throw new FormatException(SR.Format(System.Globalization.CultureInfo.InvariantCulture,
-                    SR.net_http_headers_invalid_value, dispositionType));
-            }
         }
 
         #endregion Parsing

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -142,9 +142,9 @@ namespace System.Net.Http.Headers
 
         internal static void CheckValidToken(string value, [CallerArgumentExpression(nameof(value))] string? parameterName = null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+            ArgumentException.ThrowIfNullOrEmpty(value, parameterName);
 
-            if (HttpRuleParser.GetTokenLength(value, 0) != value.Length)
+            if (!HttpRuleParser.IsToken(value))
             {
                 throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
             }
@@ -152,10 +152,9 @@ namespace System.Net.Http.Headers
 
         internal static void CheckValidComment(string value, [CallerArgumentExpression(nameof(value))] string? parameterName = null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+            ArgumentException.ThrowIfNullOrEmpty(value, parameterName);
 
-            int length;
-            if ((HttpRuleParser.GetCommentLength(value, 0, out length) != HttpParseResult.Parsed) ||
+            if ((HttpRuleParser.GetCommentLength(value, 0, out int length) != HttpParseResult.Parsed) ||
                 (length != value.Length)) // no trailing spaces allowed
             {
                 throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));
@@ -164,10 +163,9 @@ namespace System.Net.Http.Headers
 
         internal static void CheckValidQuotedString(string value, [CallerArgumentExpression(nameof(value))] string? parameterName = null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+            ArgumentException.ThrowIfNullOrEmpty(value, parameterName);
 
-            int length;
-            if ((HttpRuleParser.GetQuotedStringLength(value, 0, out length) != HttpParseResult.Parsed) ||
+            if ((HttpRuleParser.GetQuotedStringLength(value, 0, out int length) != HttpParseResult.Parsed) ||
                 (length != value.Length)) // no trailing spaces allowed
             {
                 throw new FormatException(SR.Format(CultureInfo.InvariantCulture, SR.net_http_headers_invalid_value, value));

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1026,7 +1026,7 @@ namespace System.Net.Http.Headers
 
         private HeaderDescriptor GetHeaderDescriptor(string name)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             if (!HeaderDescriptor.TryGet(name, out HeaderDescriptor descriptor))
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/MediaTypeHeaderValue.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
-using static System.HexConverter;
 
 namespace System.Net.Http.Headers
 {
@@ -275,7 +274,7 @@ namespace System.Net.Http.Headers
 
         private static void CheckMediaTypeFormat(string mediaType, [CallerArgumentExpression(nameof(mediaType))] string? parameterName = null)
         {
-            ArgumentException.ThrowIfNullOrWhiteSpace(mediaType, parameterName);
+            ArgumentException.ThrowIfNullOrEmpty(mediaType, parameterName);
 
             // When adding values using strongly typed objects, no leading/trailing LWS (whitespace) are allowed.
             // Also no LWS between type and subtype are allowed.

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/HttpHeadersTest.cs
@@ -441,23 +441,20 @@ namespace System.Net.Http.Tests
             Assert.Throws<ArgumentNullException>(() => { headers.TryAddWithoutValidation(headers.Descriptor, values); });
         }
 
-        [Theory]
-        [InlineData(null)]
-        public void Add_SingleUseNullHeaderName_Throw(string headerName)
+        [Fact]
+        public void Add_SingleUseNullHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Add(headerName, "value"); });
+            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Add(null, "value"); });
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(" \t\r\n ")]
-        public void Add_SingleUseWhiteSpaceHeaderName_Throw(string headerName)
+        [Fact]
+        public void Add_SingleUseWhiteSpaceHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Add(headerName, "value"); });
+            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Add("", "value"); });
         }
 
         [Theory]
@@ -1071,23 +1068,20 @@ namespace System.Net.Http.Tests
             Assert.Equal(2, headers.Parser.TryParseValueCallCount);
         }
 
-        [Theory]
-        [InlineData(null)]
-        public void Remove_UseNullHeaderName_Throw(string headerName)
+        [Fact]
+        public void Remove_UseNullHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Remove(headerName); });
+            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Remove(null); });
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(" \t\r\n ")]
-        public void Remove_UseWhiteSpaceHeaderName_Throw(string headerName)
+        [Fact]
+        public void Remove_UseEmptyHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Remove(headerName); });
+            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Remove(""); });
         }
 
         [Theory]
@@ -1227,23 +1221,20 @@ namespace System.Net.Http.Tests
             Assert.Equal(parsedPrefix + "2", values.ElementAt(1));
         }
 
-        [Theory]
-        [InlineData(null)]
-        public void GetValues_UseNullHeaderName_Throw(string headerName)
+        [Fact]
+        public void GetValues_UseNullHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.GetValues(headerName); });
+            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.GetValues(null); });
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(" \t\r\n ")]
-        public void GetValues_UseWhiteSpaceHeaderName_Throw(string headerName)
+        [Fact]
+        public void GetValues_UseEmptyHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentException>("name", () => { headers.GetValues(headerName); });
+            AssertExtensions.Throws<ArgumentException>("name", () => { headers.GetValues(""); });
         }
 
         [Theory]
@@ -1601,23 +1592,20 @@ namespace System.Net.Http.Tests
             }
         }
 
-        [Theory]
-        [InlineData(null)]
-        public void Contains_UseNullHeaderName_Throw(string headerName)
+        [Fact]
+        public void Contains_UseNullHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Contains(headerName); });
+            AssertExtensions.Throws<ArgumentNullException>("name", () => { headers.Contains(null); });
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(" \t\r\n ")]
-        public void Contains_UseEmptyHeaderName_Throw(string headerName)
+        [Fact]
+        public void Contains_UseEmptyHeaderName_Throw()
         {
             MockHeaders headers = new MockHeaders();
 
-            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Contains(headerName); });
+            AssertExtensions.Throws<ArgumentException>("name", () => { headers.Contains(""); });
         }
 
         [Theory]
@@ -2578,6 +2566,7 @@ namespace System.Net.Http.Tests
             yield return new object[] { "invalid=header" };
             yield return new object[] { "invalid{header" };
             yield return new object[] { "invalid}header" };
+            yield return new object[] { " \t\r\n " };
         }
 
         public static IEnumerable<object[]> HeaderValuesWithNewLines()

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/ViaHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/ViaHeaderValueTest.cs
@@ -200,6 +200,8 @@ namespace System.Net.Http.Tests
             CheckGetViaLength(null, 0, 0, null);
             CheckGetViaLength(string.Empty, 0, 0, null);
             CheckGetViaLength("  ", 0, 0, null);
+
+            CheckGetViaLength("a\t\u2000", 0, 3, new ViaHeaderValue("a", "\u2000"));
         }
 
         [Fact]

--- a/src/libraries/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Headers/WarningHeaderValueTest.cs
@@ -213,6 +213,7 @@ namespace System.Net.Http.Tests
                 new WarningHeaderValue(1, "h", "\"t\"",
                     new DateTimeOffset(2010, 7, 20, 1, 2, 3, TimeSpan.Zero)));
             CheckValidParse("1 \u4F1A \"t\" ", new WarningHeaderValue(1, "\u4F1A", "\"t\""));
+            CheckValidParse("1 \u2000 \"\"", new WarningHeaderValue(1, "\u2000", "\"\""));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #102584

#86007 added a bit too much validation for header values. In a couple of places it was redundant with the checks we would do anyway (e.g. right before calling `HeaderDescriptor.TryGet` or `HeaderUtilities.CheckValidToken`), and in a few others it was more strict than the parsing validation that only looks for the ASCII space and horizontal tab.

In a couple of places we were also calling into validating constructors right after parsing, thus wasting cycles on validating twice.