### PR TITLE
Update HTTP2 KeepAlive/Ping Timeout Exception

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -417,6 +417,9 @@
   <data name="net_http_http2_connection_not_established" xml:space="preserve">
     <value>An HTTP/2 connection could not be established because the server did not complete the HTTP/2 handshake.</value>
   </data>
+  <data name="net_http_http2_keepalive_ping_timeout" xml:space="preserve">
+    <value>The HTTP/2 connection keepalive ping did not respond within timeout {0}ms.</value>
+  </data>
   <data name="net_http_http2_invalidinitialstreamwindowsize" xml:space="preserve">
     <value>The initial HTTP/2 stream window size must be between {0} and {1}.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -2136,7 +2136,7 @@ namespace System.Net.Http
                     break;
                 case KeepAliveState.PingSent:
                     if (now > _keepAlivePingTimeoutTimestamp)
-                        ThrowProtocolError();
+                        ThrowKeepAlivePingTimeoutError(_keepAlivePingTimeout);
                     break;
                 default:
                     Debug.Fail($"Unexpected keep alive state ({_keepAliveState})");
@@ -2175,5 +2175,9 @@ namespace System.Net.Http
         [DoesNotReturn]
         private static void ThrowProtocolError(Http2ProtocolErrorCode errorCode, string? message = null) =>
             throw HttpProtocolException.CreateHttp2ConnectionException(errorCode, message);
+
+        [DoesNotReturn]
+        private static void ThrowKeepAlivePingTimeoutError(long keepAlivePingTimeout) =>
+            ThrowProtocolError(Http2ProtocolErrorCode.ProtocolError, SR.Format(SR.net_http_http2_keepalive_ping_timeout, keepAlivePingTimeout));
     }
 }


### PR DESCRIPTION
Update HTTP2 KeepAlive Ping timeout exception message to `The HTTP/2 connection keepalive ping did not respond within timeout {0}ms.`

Fix #102623