### PR TITLE
Optimize "(vec & cns) == zero" on arm64

### DIFF
--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -1471,7 +1471,7 @@ GenTree* Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cm
             {
                 GenTreeVecCon* andMask = op->AsHWIntrinsic()->Op(2)->AsVecCon();
                 simd16_t       val     = andMask->gtSimd16Val;
-                if (val.u64[0] == val.u64[1])
+                if ((val.u64[0] == val.u64[1]) && emitter::emitIns_valid_imm_for_alu(val.i64[0], EA_8BYTE))
                 {
                     scalarAndMask = val.u64[0];
                     BlockRange().Remove(op);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/100922 regression - it was regressed by https://github.com/dotnet/runtime/pull/99982

```cs
bool AllAscii(Vector128<byte> vector) => 
    (vector & Vector128.Create((byte)0x80)).Equals(Vector128<byte>.Zero);
```
Main:
```asm
; Method Proga:AllAscii
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
            movi    v16.16b, #0x80
            and     v16.16b, v0.16b, v16.16b
            umaxp   v16.4s, v16.4s, v16.4s
            umov    x0, v16.d[0]
            cmp     x0, #0
            cset    x0, eq
            ldp     fp, lr, [sp], #0x10
            ret     lr
; Total bytes of code: 40
```
PR:
```asm
; Method Proga:AllAscii
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp
            umaxp   v16.4s, v0.4s, v0.4s
            umov    x0, v16.d[0]
            tst     x0, #0x8080808080808080
            cset    x0, eq
            ldp     fp, lr, [sp], #0x10
            ret     lr
; Total bytes of code: 32
```