### PR TITLE
Introduce `SwiftSelf<T>` and `SwiftIndirectResult` structs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -39,6 +39,42 @@ namespace System.Runtime.InteropServices.Swift
     }
 
     /// <summary>
+    /// Represents the Swift frozen struct T, which is either enregistered into multiple registers,
+    /// or passed by reference in the 'self' register.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This struct is used to pass the Swift frozen struct T to Swift functions in the context of interop with .NET.
+    /// </para>
+    /// <para>
+    /// Here's an example of how a SwiftSelf&lt;T&gt; context can be declared:
+    /// <code lang="csharp">
+    /// [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    /// [DllImport("SwiftLibrary", EntryPoint = "export")]
+    /// public static extern void swiftFunction(SwiftSelf&lt;T&gt; self);
+    /// </code>
+    /// </para>
+    /// </remarks>
+    [CLSCompliant(false)]
+    [Intrinsic]
+    public readonly unsafe struct SwiftSelf<T> where T: unmanaged
+    {
+        /// <summary>
+        /// Creates a new instance of the SwiftSelf struct with the specified value.
+        /// </summary>
+        /// <param name="value">The value representing the self context.</param>
+        public SwiftSelf(T value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets the value representing the Swift frozen struct.
+        /// </summary>
+        public T Value { get; }
+    }
+
+    /// <summary>
     /// Represents the Swift error context, indicating that the argument is the error context.
     /// </summary>
     /// <remarks>
@@ -68,6 +104,42 @@ namespace System.Runtime.InteropServices.Swift
         }
         /// <summary>
         /// Gets the pointer of the error context.
+        /// </summary>
+        public void* Value { get; }
+    }
+
+    /// <summary>
+    /// Represents the Swift return buffer context.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This struct is used to access the return buffer when interoping with Swift functions that return non-frozen structs.
+    /// It provides a pointer to the memory location where the result should be stored.
+    /// </para>
+    /// <para>
+    /// Here's an example of how a SwiftIndirectResult can be declared:
+    /// <code lang="csharp">
+    /// [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
+    /// [DllImport("SwiftLibrary", EntryPoint = "export")]
+    /// public static extern void swiftFunction(SwiftIndirectResult result);
+    /// </code>
+    /// </para>
+    /// </remarks>
+    [CLSCompliant(false)]
+    [Intrinsic]
+    public readonly unsafe struct SwiftIndirectResult
+    {
+        /// <summary>
+        /// Creates a new instance of the SwiftIndirectResult struct with the specified pointer value.
+        /// </summary>
+        /// <param name="value">The pointer value representing return buffer context.</param>
+        public SwiftIndirectResult(void* value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// Gets the pointer of the return buffer register.
         /// </summary>
         public void* Value { get; }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -120,7 +120,7 @@ namespace System.Runtime.InteropServices.Swift
     /// Here's an example of how a SwiftIndirectResult can be declared:
     /// <code lang="csharp">
     /// [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
-    /// [DllImport("SwiftLibrary", EntryPoint = "export")]
+    /// [LibraryImport("SwiftLibrary", EntryPoint = "export")]
     /// public static extern void swiftFunction(SwiftIndirectResult result);
     /// </code>
     /// </para>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -50,7 +50,7 @@ namespace System.Runtime.InteropServices.Swift
     /// Here's an example of how a SwiftSelf&lt;T&gt; context can be declared:
     /// <code lang="csharp">
     /// [UnmanagedCallConv(CallConvs = [typeof(CallConvSwift)])]
-    /// [DllImport("SwiftLibrary", EntryPoint = "export")]
+    /// [LibraryImport("SwiftLibrary", EntryPoint = "export")]
     /// public static extern void swiftFunction(SwiftSelf&lt;T&gt; self);
     /// </code>
     /// </para>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -55,7 +55,6 @@ namespace System.Runtime.InteropServices.Swift
     /// </code>
     /// </para>
     /// </remarks>
-    [CLSCompliant(false)]
     [Intrinsic]
     public readonly unsafe struct SwiftSelf<T> where T: unmanaged
     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Swift/SwiftTypes.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.InteropServices.Swift
     }
 
     /// <summary>
-    /// Represents the Swift frozen struct T, which is either enregistered into multiple registers,
+    /// Represents the Swift 'self' context when the argument is Swift frozen struct T, which is either enregistered into multiple registers,
     /// or passed by reference in the 'self' register.
     /// </summary>
     /// <remarks>

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13906,7 +13906,7 @@ namespace System.Runtime.InteropServices.Swift
     }
     public readonly partial struct SwiftSelf<T> where T: unmanaged
     {
-        private readonly int _dummyPrimitive;
+        private readonly T _dummyPrimitive;
         public unsafe SwiftSelf(T value) { throw null; }
         public unsafe T Value { get { throw null; } }
     }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13904,6 +13904,20 @@ namespace System.Runtime.InteropServices.Swift
         public unsafe SwiftSelf(void* value) { throw null; }
         public unsafe void* Value { get { throw null; } }
     }
+    [System.CLSCompliantAttribute(false)]
+    public readonly partial struct SwiftSelf<T> where T: unmanaged
+    {
+        private readonly int _dummyPrimitive;
+        public unsafe SwiftSelf(T value) { throw null; }
+        public unsafe T Value { get { throw null; } }
+    }
+    [System.CLSCompliantAttribute(false)]
+    public readonly partial struct SwiftIndirectResult
+    {
+        private readonly int _dummyPrimitive;
+        public unsafe SwiftIndirectResult(void* value) { throw null; }
+        public unsafe void* Value { get { throw null; } }
+    }
 }
 namespace System.Runtime.Remoting
 {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -13904,7 +13904,6 @@ namespace System.Runtime.InteropServices.Swift
         public unsafe SwiftSelf(void* value) { throw null; }
         public unsafe void* Value { get { throw null; } }
     }
-    [System.CLSCompliantAttribute(false)]
     public readonly partial struct SwiftSelf<T> where T: unmanaged
     {
         private readonly int _dummyPrimitive;


### PR DESCRIPTION
## Description

This PR introduces `SwiftSelf<T>` and `SwiftIndirectResult` structs to facilitate interop with Swift structs. Runtime support along with the corresponding test cases (https://github.com/dotnet/runtime/issues/102079 and https://github.com/dotnet/runtime/issues/102082) will be added in subsequent PRs.

The idea is to keep both `SwiftSelf` and `SwiftSelf<T>` for now, as `SwiftSelf` will be utilized for class support and closure context.

Fixes https://github.com/dotnet/runtime/issues/100543