### PR TITLE
Revert "Avoid clearing thread local handles for already unloaded loader"

### DIFF
--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -964,10 +964,12 @@ void LoaderAllocator::SetHandleValue(LOADERHANDLE handle, OBJECTREF value)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        MODE_COOPERATIVE;
+        MODE_ANY;
         PRECONDITION(handle != NULL);
     }
     CONTRACTL_END;
+
+    GCX_COOP();
 
     GCPROTECT_BEGIN(value);
 

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -52,22 +52,13 @@ void ThreadLocalBlock::FreeTLM(SIZE_T i, BOOL isThreadShuttingdown)
                         ThreadLocalModule::CollectibleDynamicEntry *entry = (ThreadLocalModule::CollectibleDynamicEntry*)pThreadLocalModule->m_pDynamicClassTable[k].m_pDynamicEntry;
                         PTR_LoaderAllocator pLoaderAllocator = entry->m_pLoaderAllocator;
 
-                        // LoaderAllocator may be collected when the thread is shutting down.
-                        // We enter coop mode to ensure that we get a valid value of the exposed object and
-                        // can safely clean up handles if it is not yet collected.
-                        GCX_COOP();
-
-                        LOADERALLOCATORREF loaderAllocator = pLoaderAllocator->GetExposedObject();
-                        if (loaderAllocator != NULL)
+                        if (entry->m_hGCStatics != 0)
                         {
-                            if (entry->m_hGCStatics != 0)
-                            {
-                                pLoaderAllocator->FreeHandle(entry->m_hGCStatics);
-                            }
-                            if (entry->m_hNonGCStatics != 0)
-                            {
-                                pLoaderAllocator->FreeHandle(entry->m_hNonGCStatics);
-                            }
+                            pLoaderAllocator->FreeHandle(entry->m_hGCStatics);
+                        }
+                        if (entry->m_hNonGCStatics != 0)
+                        {
+                            pLoaderAllocator->FreeHandle(entry->m_hNonGCStatics);
                         }
                     }
                     delete pThreadLocalModule->m_pDynamicClassTable[k].m_pDynamicEntry;


### PR DESCRIPTION
Reverts dotnet/runtime#99998

Fixes https://github.com/dotnet/runtime/issues/102719