### PR TITLE
Add using so we can use PlatformDetection

### DIFF
--- a/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
+++ b/src/tests/CoreMangLib/system/reflection/emit/DynMethodJumpStubTests/DynMethodJumpStubTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Threading;
+using TestLibrary;
 using Xunit;
 
 public static class DynamicMethodJumpStubTests

--- a/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
+++ b/src/tests/CoreMangLib/system/span/SlowTailCallArgs.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
+using TestLibrary;
 using Xunit;
 
 public static class Program


### PR DESCRIPTION
`PlatformDetection` is in the System namespace in the libraries test so that nobody needs to think about it, but of course it's in TestLibrary namespace in the runtime tests. Adding extra ceremony to it was apparently a conscious decision: https://github.com/dotnet/runtime/pull/65862#discussion_r814220365.

Should resolve the break: https://github.com/dotnet/runtime/pull/102648#issuecomment-2134185147