### PR TITLE
fix crossgen2determinism test

### DIFF
--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current" InitialTargets="PrepareDLLs">
   <PropertyGroup>
     <!-- Needed for CLRTestTargetUnsupported, GCStressIncompatible, CrossGenTest -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
@@ -14,20 +14,26 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
+
+  <Target Name="PrepareDLLs">
+    <MSBuild Projects="..\crossgen2\crossgen2smoke.csproj" Properties="OutputPath=$(OutputPath)\crossgen2smoke" />
+    <Delete Files="$(OutputPath)\crossgen2smoke\crossgen2smoke.sh" />
+  </Target>
+
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set CoreRT_DeterminismSeed=1
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke1.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.dll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:.\crossgen2smoke\helperdll.dll -r:.\crossgen2smoke\helperildll.dll -o:crossgen2smoke1.ildll .\crossgen2smoke\crossgen2smoke.dll
 set CoreRT_DeterminismSeed=2
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:..\..\crossgen2\crossgen2smoke\helperdll.dll -r:..\..\crossgen2\crossgen2smoke\helperildll.dll -o:crossgen2smoke2.ildll ..\..\crossgen2\crossgen2smoke\crossgen2smoke.dll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --map -r:%Core_Root%\*.dll -r:.\crossgen2smoke\helperdll.dll -r:.\crossgen2smoke\helperildll.dll -o:crossgen2smoke2.ildll .\crossgen2smoke\crossgen2smoke.dll
 ]]></CLRTestBatchPreCommands>
     <CLRTestBashPreCommands><![CDATA[
 $(CLRTestBashPreCommands)
 export CoreRT_DeterminismSeed=1
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke1.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.dll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:./crossgen2smoke/helperdll.dll -r:./crossgen2smoke/helperildll.dll -o:crossgen2smoke1.ildll ./crossgen2smoke/crossgen2smoke.dll
 export CoreRT_DeterminismSeed=2
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:../../crossgen2/crossgen2smoke/helperdll.dll -r:../../crossgen2/crossgen2smoke/helperildll.dll -o:crossgen2smoke2.ildll ../../crossgen2/crossgen2smoke/crossgen2smoke.dll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --map -r:$CORE_ROOT/*.dll -r:./crossgen2smoke/helperdll.dll -r:./crossgen2smoke/helperildll.dll -o:crossgen2smoke2.ildll ./crossgen2smoke/crossgen2smoke.dll
 ]]></CLRTestBashPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The race condition sometimes occurred when `crossgen2determinism.sh` was trying to crossgen2 `crossgen2smoke.dll` in the same time with `crossgen2smoke.sh` script. This error occurs very rarely and only when running tests in parallel.

Part of #84834, cc @dotnet/samsung 