### PR TITLE
Use stackalloc char&byte arrays for decoding Url values in HttpUtiliy.ParseQueryString

### DIFF
--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -117,7 +117,7 @@ namespace System.Web
                 }
                 else
                 {
-                    name = UrlDecode(query.Substring(namePos, valuePos - namePos - 1), encoding);
+                    name = UrlDecode(query.AsSpan(namePos, valuePos - namePos - 1), encoding);
                 }
 
                 if (valueEnd < 0)
@@ -126,7 +126,7 @@ namespace System.Web
                 }
 
                 namePos = valueEnd + 1;
-                string value = UrlDecode(query.Substring(valuePos, valueEnd - valuePos), encoding);
+                string value = UrlDecode(query.AsSpan(valuePos, valueEnd - valuePos), encoding);
                 result.Add(name, value);
             }
 
@@ -219,6 +219,8 @@ namespace System.Web
 
         [return: NotNullIfNotNull(nameof(str))]
         public static string? UrlDecode(string? str, Encoding e) => HttpEncoder.UrlDecode(str, e);
+
+        private static string UrlDecode(ReadOnlySpan<char> str, Encoding e) => HttpEncoder.UrlDecode(str, e);
 
         [return: NotNullIfNotNull(nameof(bytes))]
         public static string? UrlDecode(byte[]? bytes, int offset, int count, Encoding e) =>

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -12,6 +12,7 @@ namespace System.Web.Util
 {
     internal static class HttpEncoder
     {
+        private const int MaxStackAllocUrlLength = 256;
         private static void AppendCharAsUnicodeJavaScript(StringBuilder builder, char c)
         {
             builder.Append($"\\u{(int)c:x4}");
@@ -258,8 +259,8 @@ namespace System.Web.Util
                 return null;
             }
 
-            UrlDecoder helper = count < 256
-                ? new UrlDecoder(stackalloc char[count], stackalloc byte[count], encoding)
+            UrlDecoder helper = count <= MaxStackAllocUrlLength
+                ? new UrlDecoder(stackalloc char[MaxStackAllocUrlLength], stackalloc byte[MaxStackAllocUrlLength], encoding)
                 : new UrlDecoder(new char[count], new byte[count], encoding);
 
             // go through the bytes collapsing %XX and %uXXXX and appending
@@ -334,8 +335,8 @@ namespace System.Web.Util
             }
 
             int count = value.Length;
-            UrlDecoder helper = count < 256
-                ? new UrlDecoder(stackalloc char[count], stackalloc byte[count], encoding)
+            UrlDecoder helper = count <= MaxStackAllocUrlLength
+                ? new UrlDecoder(stackalloc char[MaxStackAllocUrlLength], stackalloc byte[MaxStackAllocUrlLength], encoding)
                 : new UrlDecoder(new char[count], new byte[count], encoding);
 
             // go through the string's chars collapsing %XX and %uXXXX and

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -703,7 +703,7 @@ namespace System.Web.Util
                     FlushBytes();
                 }
 
-                return _numChars > 0 ? _charBuffer.Slice(0, _numChars).ToString() : "";
+                return _charBuffer.Slice(0, _numChars).ToString();
             }
         }
     }


### PR DESCRIPTION
1. Convert UrlDecoder to ref struct
2. If Url is less than 256 characters, do no allocate char&byte arrays
3. Replace substring operation with Span