### PR TITLE
[release/8.0][Apple] Use NSLocale.preferredLanguages on for default locale name

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_locale.m
+++ b/src/native/libs/System.Globalization.Native/pal_locale.m
@@ -16,24 +16,34 @@
 
 char* DetectDefaultAppleLocaleName(void)
 {
-    NSLocale *currentLocale = [NSLocale currentLocale];
-    NSString *localeName = @"";
-
-    if (!currentLocale)
+    @autoreleasepool
     {
-        return strdup([localeName UTF8String]);
-    }
+        if (NSLocale.preferredLanguages.count > 0)
+        {
+            return strdup([NSLocale.preferredLanguages[0] UTF8String]);
+        }
+        else
+        {
+            NSLocale *currentLocale = [NSLocale currentLocale];
+            NSString *localeName = @"";
 
-    if ([currentLocale.languageCode length] > 0 && [currentLocale.countryCode length] > 0)
-    {
-        localeName = [NSString stringWithFormat:@"%@-%@", currentLocale.languageCode, currentLocale.countryCode];
-    }
-    else
-    {
-        localeName = currentLocale.localeIdentifier;
-    }
+            if (!currentLocale)
+            {
+                return strdup([localeName UTF8String]);
+            }
 
-    return strdup([localeName UTF8String]);
+            if ([currentLocale.languageCode length] > 0 && [currentLocale.countryCode length] > 0)
+            {
+                localeName = [NSString stringWithFormat:@"%@-%@", currentLocale.languageCode, currentLocale.countryCode];
+            }
+            else
+            {
+                localeName = currentLocale.localeIdentifier;
+            }
+
+            return strdup([localeName UTF8String]);
+        }
+    }
 }
 
 #if defined(TARGET_MACCATALYST) || defined(TARGET_IOS) || defined(TARGET_TVOS)


### PR DESCRIPTION
## Description
In this PR, we change the `DetectDefaultAppleLocaleName` to use the ObjC `preferredLanguages` API to retrieve the device's primary language. This will make sure that users can retrieve the correct locale and use localized strings as expected.

Note, this doesn't change the specific whitelisting done for mobile .NET 8 ICU https://github.com/dotnet/icu/blob/dotnet/main/icu-filters/icudt_mobile.json#L8-L194. Users will be able retrieve the underlining ICU data (e.g. `DateTimeFormat`) only for the locales specifically included the ICU pack.

## Customer Impact

- [X] Customer reported https://github.com/dotnet/runtime/issues/102560
- [ ] Found internally

Customer reported incorrect locale returned when setting iPhone region to "China mainland" and language to "Chinese Traditional". Returned `zh-CN` instead of `zh-Hant-CN`.

## Regression
- [ ] Yes
- [x] No

## Testing
Tested locally on iOS simulator by copying new `libSystem.Globalization.Native.dylib` and `libmonosgen-2.0.dylib` into a local version of dotnet and building customer provided MAUI repro app. Verified that the MAUI repro works as expected with the fix included in this PR.

## Risk
Affects Globalization code on Apple mobile scenario.