### PR TITLE
Add some more `#ifdef BACKGROUND_GC` to enable compilation for Wasm

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -18480,6 +18480,7 @@ bool gc_heap::should_retry_other_heap (int gen_number, size_t size)
     }
 }
 
+#ifdef BACKGROUND_GC
 void gc_heap::bgc_record_uoh_allocation(int gen_number, size_t size)
 {
     assert((gen_number >= uoh_start_generation) && (gen_number < total_generation_count));
@@ -18502,6 +18503,7 @@ void gc_heap::bgc_record_uoh_allocation(int gen_number, size_t size)
         uoh_a_no_bgc[gen_number - uoh_start_generation] += size;
     }
 }
+#endif //BACKGROUND_GC
 
 allocation_state gc_heap::allocate_uoh (int gen_number,
                                           size_t size,
@@ -50043,6 +50045,7 @@ void gc_heap::check_and_adjust_bgc_tuning (int gen_number, size_t physical_size,
 }
 #endif //BGC_SERVO_TUNING
 
+#ifdef BACKGROUND_GC
 void gc_heap::get_and_reset_uoh_alloc_info()
 {
     total_uoh_a_last_bgc = 0;
@@ -50084,6 +50087,7 @@ void gc_heap::get_and_reset_uoh_alloc_info()
 
     total_uoh_a_last_bgc = total_uoh_a_no_bgc + total_uoh_a_bgc_marking + total_uoh_a_bgc_planning;
 }
+#endif //BACKGROUND_GC
 
 bool gc_heap::is_pm_ratio_exceeded()
 {

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1764,7 +1764,9 @@ private:
 
     PER_HEAP_ISOLATED_METHOD void add_to_history();
 
+#ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED_METHOD void get_and_reset_uoh_alloc_info();
+#endif //BACKGROUND_GC
 
 #ifdef BGC_SERVO_TUNING
     // Currently BGC servo tuning is an experimental feature.


### PR DESCRIPTION
This PR `#ifdef`s out a few more functions and headers that don't compile when `BACKGROUND_GC` is `false`.  From downstream https://github.com/dotnet/runtimelab/pull/2591
