### PR TITLE
Optimize allocations in HttpUtility.UrlDecodeToBytes for smaller inputs.

### DIFF
--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -209,7 +209,6 @@ namespace System.Web
                 return HttpEncoder.UrlDecode(bytes.Slice(0, encodedBytes));
             }
 
-            // no optimization possible, let Encoding allocate byte[]
             return UrlDecodeToBytes(e.GetBytes(str));
         }
 

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -195,17 +195,15 @@ namespace System.Web
         [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlDecodeToBytes(string? str, Encoding e)
         {
-            const int maxAllowedStackAllowedEncodingBytes = 512;
+            const int StackallocThreshold = 512;
             if (str == null)
             {
                 return null;
             }
 
-            int maxBytesCount = e.GetMaxByteCount(str.Length);
-            if (maxBytesCount <= maxAllowedStackAllowedEncodingBytes)
+            if (e.GetMaxByteCount(str.Length) <= StackallocThreshold)
             {
-                // do not allocate byte[] when getting bytes from Encoding if less than stackalloc limit
-                Span<byte> bytes = stackalloc byte[maxAllowedStackAllowedEncodingBytes];
+                Span<byte> bytes = stackalloc byte[StackallocThreshold];
                 int encodedBytes = e.GetBytes(str, bytes);
 
                 return HttpEncoder.UrlDecode(bytes.Slice(0, encodedBytes));

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -218,30 +218,30 @@ namespace System.Web.Util
 
         internal static byte[] UrlDecode(ReadOnlySpan<byte> bytes)
         {
-            const int maxAllowedStackAllowedDecodedBytes = 512;
+            const int StackallocThreshold = 512;
 
             int decodedBytesCount = 0;
             int count = bytes.Length;
-            Span<byte> decodedBytes = count <= maxAllowedStackAllowedDecodedBytes ? stackalloc byte[maxAllowedStackAllowedDecodedBytes] : new byte[count];
+            Span<byte> decodedBytes = count <= StackallocThreshold ? stackalloc byte[StackallocThreshold] : new byte[count];
 
-            for (int pos = 0; pos < count; pos++)
+            for (int i = 0; i < count; i++)
             {
-                byte b = bytes[pos];
+                byte b = bytes[i];
 
                 if (b == '+')
                 {
                     b = (byte)' ';
                 }
-                else if (b == '%' && pos < count - 2)
+                else if (b == '%' && i < count - 2)
                 {
-                    int h1 = HexConverter.FromChar(bytes[pos + 1]);
-                    int h2 = HexConverter.FromChar(bytes[pos + 2]);
+                    int h1 = HexConverter.FromChar(bytes[i + 1]);
+                    int h2 = HexConverter.FromChar(bytes[i + 2]);
 
                     if ((h1 | h2) != 0xFF)
                     {
                         // valid 2 hex chars
                         b = (byte)((h1 << 4) | h2);
-                        pos += 2;
+                        i += 2;
                     }
                 }
 

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -212,8 +212,14 @@ namespace System.Web.Util
                 return null;
             }
 
+            return UrlDecode(bytes.AsSpan(), offset, count);
+        }
+
+
+        internal static byte[] UrlDecode(ReadOnlySpan<byte> bytes, int offset, int count)
+        {
             int decodedBytesCount = 0;
-            byte[] decodedBytes = new byte[count];
+            Span<byte> decodedBytes = count < 256 ? stackalloc byte[256] : new byte[count];
 
             for (int i = 0; i < count; i++)
             {
@@ -240,14 +246,14 @@ namespace System.Web.Util
                 decodedBytes[decodedBytesCount++] = b;
             }
 
-            if (decodedBytesCount < decodedBytes.Length)
+            if (decodedBytesCount < count)
             {
                 byte[] newDecodedBytes = new byte[decodedBytesCount];
-                Array.Copy(decodedBytes, newDecodedBytes, decodedBytesCount);
-                decodedBytes = newDecodedBytes;
+                decodedBytes.Slice(0, decodedBytesCount).CopyTo(newDecodedBytes);
+                return newDecodedBytes;
             }
 
-            return decodedBytes;
+            return decodedBytes.ToArray();
         }
 
         [return: NotNullIfNotNull(nameof(bytes))]

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -215,7 +215,6 @@ namespace System.Web.Util
             return UrlDecode(bytes.AsSpan(offset, count));
         }
 
-
         internal static byte[] UrlDecode(ReadOnlySpan<byte> bytes)
         {
             const int StackallocThreshold = 512;

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -253,7 +253,7 @@ namespace System.Web.Util
                 return newDecodedBytes;
             }
 
-            return decodedBytes.ToArray();
+            return decodedBytes.Slice(0, count).ToArray();
         }
 
         [return: NotNullIfNotNull(nameof(bytes))]


### PR DESCRIPTION
Optimize byte[] allocation when:

1. input string is less than 256 chars(might change after review)
2. maximum encoded bytes according Encoding is less than 512(might change after review)

If a "happy" path is taken, we will have allocations equals to the returned byte[].
Drawback: method will be a bit slower as we need to calculate Encoding.GetMaxByteCount(xxx)