### PR TITLE
Tweaks for renting buffer from the array pool in INumberBase

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/INumberBase.cs
@@ -306,7 +306,7 @@ namespace System.Numerics
             scoped Span<char> utf16Text;
             int textMaxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Text.Length);
 
-            if (textMaxCharCount < 256)
+            if (textMaxCharCount <= 256)
             {
                 utf16TextArray = null;
                 utf16Text = stackalloc char[256];
@@ -314,7 +314,7 @@ namespace System.Numerics
             else
             {
                 utf16TextArray = ArrayPool<char>.Shared.Rent(textMaxCharCount);
-                utf16Text = utf16TextArray.AsSpan(0, textMaxCharCount);
+                utf16Text = utf16TextArray;
             }
 
             OperationStatus utf8TextStatus = Utf8.ToUtf16(utf8Text, utf16Text, out _, out int utf16TextLength, replaceInvalidSequences: false);
@@ -440,7 +440,7 @@ namespace System.Numerics
             scoped Span<char> utf16Text;
             int textMaxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Text.Length);
 
-            if (textMaxCharCount < 256)
+            if (textMaxCharCount <= 256)
             {
                 utf16TextArray = null;
                 utf16Text = stackalloc char[256];
@@ -448,7 +448,7 @@ namespace System.Numerics
             else
             {
                 utf16TextArray = ArrayPool<char>.Shared.Rent(textMaxCharCount);
-                utf16Text = utf16TextArray.AsSpan(0, textMaxCharCount);
+                utf16Text = utf16TextArray;
             }
 
             OperationStatus utf8TextStatus = Utf8.ToUtf16(utf8Text, utf16Text, out _, out int utf16TextLength, replaceInvalidSequences: false);
@@ -486,7 +486,7 @@ namespace System.Numerics
             scoped Span<char> utf16Destination;
             int destinationMaxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Destination.Length);
 
-            if (destinationMaxCharCount < 256)
+            if (destinationMaxCharCount <= 256)
             {
                 utf16DestinationArray = null;
                 utf16Destination = stackalloc char[256];
@@ -494,7 +494,7 @@ namespace System.Numerics
             else
             {
                 utf16DestinationArray = ArrayPool<char>.Shared.Rent(destinationMaxCharCount);
-                utf16Destination = utf16DestinationArray.AsSpan(0, destinationMaxCharCount);
+                utf16Destination = utf16DestinationArray;
             }
 
             if (!TryFormat(utf16Destination, out int charsWritten, format, provider))
@@ -542,7 +542,7 @@ namespace System.Numerics
             scoped Span<char> utf16Text;
             int textMaxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Text.Length);
 
-            if (textMaxCharCount < 256)
+            if (textMaxCharCount <= 256)
             {
                 utf16TextArray = null;
                 utf16Text = stackalloc char[256];
@@ -550,7 +550,7 @@ namespace System.Numerics
             else
             {
                 utf16TextArray = ArrayPool<char>.Shared.Rent(textMaxCharCount);
-                utf16Text = utf16TextArray.AsSpan(0, textMaxCharCount);
+                utf16Text = utf16TextArray;
             }
 
             OperationStatus utf8TextStatus = Utf8.ToUtf16(utf8Text, utf16Text, out _, out int utf16TextLength, replaceInvalidSequences: false);
@@ -589,7 +589,7 @@ namespace System.Numerics
             scoped Span<char> utf16Text;
             int textMaxCharCount = Encoding.UTF8.GetMaxCharCount(utf8Text.Length);
 
-            if (textMaxCharCount < 256)
+            if (textMaxCharCount <= 256)
             {
                 utf16TextArray = null;
                 utf16Text = stackalloc char[256];
@@ -597,7 +597,7 @@ namespace System.Numerics
             else
             {
                 utf16TextArray = ArrayPool<char>.Shared.Rent(textMaxCharCount);
-                utf16Text = utf16TextArray.AsSpan(0, textMaxCharCount);
+                utf16Text = utf16TextArray;
             }
 
             OperationStatus utf8TextStatus = Utf8.ToUtf16(utf8Text, utf16Text, out _, out int utf16TextLength, replaceInvalidSequences: false);


### PR DESCRIPTION
Basically it's
```diff
-if (textMaxCharCount < 256)
+if (textMaxCharCount <= 256)
```
to use stack-alloc when the count is the same as the stack threshold, and
```diff
-utf16Text = utf16TextArray.AsSpan(0, textMaxCharCount);
+utf16Text = utf16TextArray;
```
to avoid the slicing as the buffer in the to be called methods can be larger than needed thus to avoid some unnecessary work.