### PR TITLE
Align reflection name formatting with CoreCLR-JIT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/CustomAttributes/RuntimeCustomAttributeData.cs
@@ -62,7 +62,7 @@ namespace System.Reflection.Runtime.CustomAttributes
                     ComputeTypedArgumentString(namedArgument.TypedValue, typed));
             }
 
-            return string.Format("[{0}({1}{2})]", AttributeType.FormatTypeNameForReflection(), ctorArgs, namedArgs);
+            return string.Format("[{0}({1}{2})]", AttributeType.FormatTypeName(), ctorArgs, namedArgs);
         }
 
         protected static ConstructorInfo ResolveAttributeConstructor(

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/EventInfos/RuntimeEventInfo.cs
@@ -114,7 +114,7 @@ namespace System.Reflection.Runtime.EventInfos
             if (parameters.Length == 0)
                 throw new InvalidOperationException(); // Legacy: Why is a ToString() intentionally throwing an exception?
             RuntimeParameterInfo runtimeParameterInfo = (RuntimeParameterInfo)(parameters[0]);
-            return runtimeParameterInfo.ParameterType.FormatTypeNameForReflection() + " " + this.Name;
+            return runtimeParameterInfo.ParameterType.FormatTypeName() + " " + this.Name;
         }
 
         protected RuntimeEventInfo WithDebugName()

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/FieldInfos/NativeFormat/NativeFormatRuntimeFieldInfo.cs
@@ -86,7 +86,7 @@ namespace System.Reflection.Runtime.FieldInfos.NativeFormat
 
         public sealed override string ToString()
         {
-            return FieldRuntimeType.ToType().FormatTypeNameForReflection() + " " + this.Name;
+            return FieldRuntimeType.ToType().FormatTypeName() + " " + this.Name;
         }
 
         public sealed override bool HasSameMetadataDefinitionAs(MemberInfo other)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeMethodHelpers.cs
@@ -73,7 +73,7 @@ namespace System.Reflection.Runtime.MethodInfos
             {
                 if (i != 0)
                     sb.Append(", ");
-                string parameterTypeString = parameters[i].ParameterType.FormatTypeNameForReflection();
+                string parameterTypeString = parameters[i].ParameterType.FormatTypeName();
 
                 // Legacy: Why use "ByRef" for by ref parameters? What language is this?
                 // VB uses "ByRef" but it should precede (not follow) the parameter name.
@@ -94,7 +94,7 @@ namespace System.Reflection.Runtime.MethodInfos
         internal static string ComputeToString(MethodBase contextMethod, RuntimeTypeInfo[] methodTypeArguments, RuntimeParameterInfo[] parameters, RuntimeParameterInfo returnParameter)
         {
             StringBuilder sb = new StringBuilder(30);
-            sb.Append(returnParameter == null ? "Void" : returnParameter.ParameterType.FormatTypeNameForReflection());  // ConstructorInfos allowed to pass in null rather than craft a ReturnParameterInfo that's always of type void.
+            sb.Append(returnParameter == null ? "Void" : returnParameter.ParameterType.FormatTypeName());  // ConstructorInfos allowed to pass in null rather than craft a ReturnParameterInfo that's always of type void.
             sb.Append(' ');
             sb.Append(contextMethod.Name);
             if (methodTypeArguments.Length != 0)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/ParameterInfos/RuntimeParameterInfo.cs
@@ -72,7 +72,7 @@ namespace System.Reflection.Runtime.ParameterInfos
 
         public sealed override string ToString()
         {
-            return this.ParameterType.FormatTypeNameForReflection() + " " + this.Name;
+            return this.ParameterType.FormatTypeName() + " " + this.Name;
         }
 
         private readonly MemberInfo _member;

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/PropertyInfos/RuntimePropertyInfo.cs
@@ -214,7 +214,7 @@ namespace System.Reflection.Runtime.PropertyInfos
         {
             StringBuilder sb = new StringBuilder(30);
 
-            sb.Append(PropertyType.FormatTypeNameForReflection());
+            sb.Append(PropertyType.FormatTypeName());
             sb.Append(' ');
             sb.Append(this.Name);
             ParameterInfo[] indexParameters = this.GetIndexParameters();

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Type.NativeAot.cs
@@ -56,35 +56,6 @@ namespace System
             }
         }
 
-        //
-        // This is a port of the desktop CLR's RuntimeType.FormatTypeName() routine. This routine is used by various Reflection ToString() methods
-        // to display the name of a type. Do not use for any other purpose as it inherits some pretty quirky desktop behavior.
-        //
-        internal string FormatTypeNameForReflection()
-        {
-            // Legacy: this doesn't make sense, why use only Name for nested types but otherwise
-            // ToString() which contains namespace.
-            Type rootElementType = this;
-            while (rootElementType.HasElementType)
-                rootElementType = rootElementType.GetElementType()!;
-            if (rootElementType.IsNested)
-            {
-                return Name!;
-            }
-
-            // Legacy: why removing "System"? Is it just because C# has keywords for these types?
-            // If so why don't we change it to lower case to match the C# keyword casing?
-            string typeName = ToString();
-            if (typeName.StartsWith("System."))
-            {
-                if (rootElementType.IsPrimitive || rootElementType == typeof(void))
-                {
-                    typeName = typeName.Substring("System.".Length);
-                }
-            }
-            return typeName;
-        }
-
         [Intrinsic]
         [RequiresUnreferencedCode("The type might be removed")]
         public static Type GetType(string typeName) => GetType(typeName, throwOnError: false, ignoreCase: false);


### PR DESCRIPTION
There was an observable difference between FormatTypeNameForReflection and FormatTypeName for TypedReference.

Cc @dotnet/ilc-contrib 