### PR TITLE
Avoid reporting new callstack chain on exceptions

### DIFF
--- a/src/coreclr/debug/di/shimstackwalk.cpp
+++ b/src/coreclr/debug/di/shimstackwalk.cpp
@@ -152,7 +152,7 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
 
     // In the case the thread is throwing a managed exception, 
     // TS_SyncSuspended might not yet be set, resulting in IsThreadSuspendedOrHijacked 
-    // returning true above. We need to check the exception state to make sure we don't
+    // returning false above. We need to check the exception state to make sure we don't
     // track the chain in this case. Since we know the type of Frame we are dealing with, 
     // we can make a more accurate determination of whether we should track the chain.
     if (GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION) 

--- a/src/coreclr/debug/di/shimstackwalk.cpp
+++ b/src/coreclr/debug/di/shimstackwalk.cpp
@@ -150,6 +150,14 @@ BOOL ShimStackWalk::ShouldTrackUMChain(StackWalkInfo * pswInfo)
     if (m_pProcess->IsThreadSuspendedOrHijacked(m_pThread))
         return FALSE;
 
+    // In the case the thread is throwing a managed exception, 
+    // TS_SyncSuspended might not yet be set, resulting in IsThreadSuspendedOrHijacked 
+    // returning true above. We need to check the exception state to make sure we don't
+    // track the chain in this case. Since we know the type of Frame we are dealing with, 
+    // we can make a more accurate determination of whether we should track the chain.
+    if (GetInternalFrameType(pswInfo->GetCurrentInternalFrame()) == STUBFRAME_EXCEPTION) 
+        return FALSE;
+
     return TRUE;
 }
 


### PR DESCRIPTION
The debugger stackwalker breaks managed and unmanaged groups of frames into chains.  The detection mechanism for a managed/unmanaged boundary uses a set of tests to determine if the thread is stopped in managed code or has exited and is in unmanaged code.  This is done by inspecting the thread state when we see an internal frame (e.g. stub) at the top of the stack, located in `ShimStackWalk::ShouldTrackUMChain`.  If the thread state has `TS_SyncSuspended` then we assume the stub is not an unmanaged frame stub and will therefore not create a new frame chain.  However, sometimes there is a timing issue where the debugger quickly reads the thread state before the exception processing thread has called `Thread::WaitSuspendEventsHelper` and therefore the `TS_SyncSuspended` state is not yet set.  When this occurs, the stackwalker breaks the top frame into a new frame chain, leading to `CordbThread::GetActiveFrame` returning `nullptr` for the current frame chain.  Since we know the type of Frame we are dealing with, we can make a more accurate determination of whether we should track the chain.   