### PR TITLE
don't return ConnectOperation as we are not pooling it

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -676,11 +676,6 @@ namespace System.Net.Sockets
                 SocketError ec = ErrorCode;
                 Memory<byte> buffer = Buffer;
 
-                if (allowPooling)
-                {
-                    AssociatedContext.ReturnOperation(this);
-                }
-
                 if (buffer.Length == 0)
                 {
                     // Invoke callback only when we are completely done.


### PR DESCRIPTION
this fixes problem introduced by #99490. (reported by @rzikm) 

The operation now inherits from `BufferMemorySendOperation`. So when we return it the instance can be used for seeing and that can lead to unexpected behavior. 

We are not pooling the ConnectOperation anyway 
https://github.com/dotnet/runtime/blob/9daa4b41eb9f157e79eaf05e2f7451c9c8f6dbdc/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs#L1561

so there is no need to return it. 