### PR TITLE
Backport #102613 to preview 5

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3509,6 +3509,7 @@ namespace Mono.Linker.Steps
 		protected internal virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason, MessageOrigin origin)
 		{
 			origin = reason.Source is IMemberDefinition member ? new MessageOrigin (member) : origin;
+			DependencyKind dependencyKind = DependencyKind.EventMethod;
 
 			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (dependencyKind, evt), origin);
 			MarkMethodIfNotNull (evt.InvokeMethod, new DependencyInfo (dependencyKind, evt), origin);

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3508,10 +3508,7 @@ namespace Mono.Linker.Steps
 
 		protected internal virtual void MarkEvent (EventDefinition evt, in DependencyInfo reason, MessageOrigin origin)
 		{
-			Debug.Assert (reason.Source is IMemberDefinition or null);
-			// Use reason as the origin for the event methods unless it's from a descriptor
-			origin = reason.Source is null ? origin : new MessageOrigin ((IMemberDefinition)reason.Source);
-			DependencyKind dependencyKind = DependencyKind.EventMethod;
+			origin = reason.Source is IMemberDefinition member ? new MessageOrigin (member) : origin;
 
 			MarkMethodIfNotNull (evt.AddMethod, new DependencyInfo (dependencyKind, evt), origin);
 			MarkMethodIfNotNull (evt.InvokeMethod, new DependencyInfo (dependencyKind, evt), origin);


### PR DESCRIPTION
A bug made it into preview 5 right before the snap, and the fix didn't make it in time. It's blocking runtime flow to sdk in https://github.com/dotnet/sdk/pull/41166.

See https://github.com/dotnet/runtime/pull/102613 for additional context.

## Customer Impact:
https://github.com/dotnet/runtime/pull/102528 added an assumption/assertion that didn't consider marking that originates from assembly level attributes. This assumption leads to an invalid cast exception in Blazor AOT trimming tests in the sdk.

## Testing:
This isn't tested in runtime, but the original PR fixed the tests in SDK during flow from runtime's main to sdk's main. Since it was a hotfix, no tests have yet been added that exercise this code path.

## Risk:
Minimal. This reverts the assertion and returns to behavior that was previously in the .NET 8 release.