### PR TITLE
Avoid new constraint with structs in ILLink analyzer

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/FeatureContextLattice.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/FeatureContextLattice.cs
@@ -52,6 +52,15 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		{
 			return new FeatureContext (ValueSet<string>.Union (EnabledFeatures, other.EnabledFeatures));
 		}
+
+		public override string ToString ()
+		{
+			if (EnabledFeatures.IsUnknown ())
+				return "All";
+			if (EnabledFeatures.IsEmpty ())
+				return "None";
+			return string.Join (", ", EnabledFeatures.GetKnownValues ());
+		}
 	}
 
 	public readonly struct FeatureContextLattice : ILattice<FeatureContext>

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/DataFlow/LocalDataFlowAnalysis.cs
@@ -29,8 +29,8 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		>
 		where TValue : struct, IEquatable<TValue>
 		where TContext : struct, IEquatable<TContext>
-		where TLattice : ILattice<TValue>, new()
-		where TContextLattice : ILattice<TContext>, new()
+		where TLattice : ILattice<TValue>
+		where TContextLattice : ILattice<TContext>
 		where TTransfer : LocalDataFlowVisitor<TValue, TContext, TLattice, TContextLattice, TConditionValue>
 		where TConditionValue : struct, INegate<TConditionValue>
 	{
@@ -39,18 +39,25 @@ namespace ILLink.RoslynAnalyzer.DataFlow
 		readonly IOperation OperationBlock;
 
 		static LocalStateAndContextLattice<TValue, TContext, TLattice, TContextLattice> GetLatticeAndEntryValue(
+			TLattice lattice,
+			TContextLattice contextLattice,
 			TContext initialContext,
 			out LocalStateAndContext<TValue, TContext> entryValue)
 		{
-			LocalStateAndContextLattice<TValue, TContext, TLattice, TContextLattice> lattice = new (new (new TLattice ()), new TContextLattice ());
+			LocalStateAndContextLattice<TValue, TContext, TLattice, TContextLattice> localStateAndContextLattice = new (new (lattice), contextLattice);
 			entryValue = new LocalStateAndContext<TValue, TContext> (default (LocalState<TValue>), initialContext);
-			return lattice;
+			return localStateAndContextLattice;
 		}
 
 		// The initial value of the local dataflow is the empty local state (no tracked assignments),
 		// with an initial context that must be specified by the derived class.
-		protected LocalDataFlowAnalysis (OperationBlockAnalysisContext context, IOperation operationBlock, TContext initialContext)
-			: base (GetLatticeAndEntryValue (initialContext, out var entryValue), entryValue)
+		protected LocalDataFlowAnalysis (
+			OperationBlockAnalysisContext context,
+			IOperation operationBlock,
+			TLattice lattice,
+			TContextLattice contextLattice,
+			TContext initialContext)
+			: base (GetLatticeAndEntryValue (lattice, contextLattice, initialContext, out var entryValue), entryValue)
 		{
 			Context = context;
 			OperationBlock = operationBlock;

--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/TrimDataFlowAnalysis.cs
@@ -41,7 +41,12 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 			OperationBlockAnalysisContext context,
 			DataFlowAnalyzerContext dataFlowAnalyzerContext,
 			IOperation operationBlock)
-			: base (context, operationBlock, initialContext: FeatureContext.None)
+			: base (
+				context,
+				operationBlock,
+				default (ValueSetLattice<SingleValue>),
+				new FeatureContextLattice (),
+				initialContext: FeatureContext.None)
 		{
 			TrimAnalysisPatterns = new TrimAnalysisPatternStore (lattice.LocalStateLattice.Lattice.ValueLattice, lattice.ContextLattice);
 			_dataFlowAnalyzerContext = dataFlowAnalyzerContext;
@@ -169,6 +174,18 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
 						TraceWriteLine (line);
 					}
 				}
+			}
+		}
+
+		public override void TraceEdgeInput (
+			IControlFlowGraph<BlockProxy, RegionProxy>.ControlFlowBranch branch,
+			LocalStateValue state
+		) {
+			if (trace && showStates) {
+				var source = branch.Source.Block.Ordinal;
+				var target = branch.Destination?.Block.Ordinal;
+				WriteIndented ($"--- Edge from [{source}] to [{target}] ---", 1);
+				WriteIndented (state.ToString (), 2);
 			}
 		}
 

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/ForwardDataFlowAnalysis.cs
@@ -164,6 +164,9 @@ namespace ILLink.Shared.DataFlow
 		public virtual void TraceVisitBlock (TBlock block) { }
 
 		[Conditional ("DEBUG")]
+		public virtual void TraceEdgeInput (IControlFlowGraph<TBlock, TRegion>.ControlFlowBranch branch, TValue state) { }
+
+		[Conditional ("DEBUG")]
 		public virtual void TraceBlockInput (TValue normalState, TValue? exceptionState, TValue? exceptionFinallyState) { }
 
 		[Conditional ("DEBUG")]
@@ -280,7 +283,7 @@ namespace ILLink.Shared.DataFlow
 						TValue predecessorState = cfgState.Get (predecessor).Current;
 
 						FlowStateThroughExitedFinallys (predecessor, ref predecessorState);
-
+						TraceEdgeInput (predecessor, predecessorState);
 						currentState = lattice.Meet (currentState, predecessorState);
 					}
 					// State at start of a catch also includes the exceptional state from

--- a/src/tools/illink/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
+++ b/src/tools/illink/src/ILLink.Shared/DataFlow/IControlFlowGraph.cs
@@ -45,7 +45,7 @@ namespace ILLink.Shared.DataFlow
 		public readonly struct ControlFlowBranch : IEquatable<ControlFlowBranch>
 		{
 			public readonly TBlock Source;
-			private readonly TBlock? Destination;
+			public readonly TBlock? Destination;
 
 			// The finally regions exited when control flows through this edge.
 			// For example:


### PR DESCRIPTION
@simonrozsival reported an issue where the trim analyzer was producing warnings inside Visual Studio, but not from a command-line build, for code similar to the following:

```csharp
var typeName = Console.ReadLine() ?? string.Empty;

if (RuntimeFeature.IsEnabled)
{
    var type = Type.GetType(typeName); // warning IL2057: Unrecognized value passed to the parameter 'typeName'...'System.Type.GetType'...
} else
{
    Console.WriteLine($"Cannot lookup {typeName} because the feature id disabled.");
}

internal static class RuntimeFeature
{
#pragma warning disable IL4000
    [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
    internal static bool IsEnabled => AppContext.TryGetSwitch("RuntimeFeature.IsEnabled", out bool enabled) ? enabled : true;
#pragma warning restore IL4000
}
```

I tracked this down to https://github.com/dotnet/runtime/issues/6536 that was fixed in .NET Core, but still exists in .NET Framework. It means that we can't rely the parameterless struct constructor being called for struct types used through a generic parameter with a `new()` constraint.

This fixes the issue by avoiding use of the `new()` constraint for generic parameters that might be structs. I confirmed locally that this fixes the reported warning, but there are no tests because we don't run tests on full framework.

Includes some unrelated debug helpers I found useful while investigating this.