### PR TITLE
Fix incorrect metadata token written for array, pointer populated from TypeBuilder

### DIFF
--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -261,7 +261,7 @@ namespace System.Reflection.Emit
         public override System.Reflection.ConstructorInfo[] GetConstructors(System.Reflection.BindingFlags bindingAttr) { throw null; }
         public override object[] GetCustomAttributes(bool inherit) { throw null; }
         public override object[] GetCustomAttributes(System.Type attributeType, bool inherit) { throw null; }
-        public override System.Type GetElementType() { throw null; }
+        public override System.Type? GetElementType() { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicEvents | System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]
         public override System.Reflection.EventInfo GetEvent(string name, System.Reflection.BindingFlags bindingAttr) { throw null; }
         [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/GenericTypeParameterBuilderImpl.cs
@@ -95,7 +95,7 @@ namespace System.Reflection.Emit
         protected override bool IsCOMObjectImpl() => false;
         protected override bool HasElementTypeImpl() => false;
         protected override TypeAttributes GetAttributeFlagsImpl() => TypeAttributes.Public;
-        public override Type GetElementType() => throw new NotSupportedException();
+        public override Type? GetElementType() => null;
         public override object[] GetCustomAttributes(bool inherit) => throw new NotSupportedException();
         public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotSupportedException();
         public override bool IsDefined(Type attributeType, bool inherit) => throw new NotSupportedException();

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -688,7 +688,8 @@ namespace System.Reflection.Emit
         {
             if (!_typeReferences.TryGetValue(type, out var typeHandle))
             {
-                if (type.IsArray || type.IsGenericParameter || (type.IsGenericType && !type.IsGenericTypeDefinition))
+                if (type.IsArray || type.IsPointer || type.IsGenericParameter ||
+                    (type.IsGenericType && !type.IsGenericTypeDefinition))
                 {
                     typeHandle = AddTypeSpecification(type);
                 }
@@ -1127,13 +1128,18 @@ namespace System.Reflection.Emit
                 return eb._typeBuilder._handle;
             }
 
-            if (IsConstructedFromTypeBuilder(type))
+            if (IsConstructedFromTypeBuilder(type) ||
+                HasElementTypeOfTypeBuilder(type))
             {
                 return default;
             }
 
             return GetTypeReferenceOrSpecificationHandle(type);
         }
+
+        private bool HasElementTypeOfTypeBuilder(Type type) => type.HasElementType &&
+            (type.GetElementType() is TypeBuilderImpl tba && Equals(tba.Module) ||
+             IsConstructedFromTypeBuilder(type.GetElementType()!));
 
         public override int GetMethodMetadataToken(ConstructorInfo constructor) => GetTokenForHandle(TryGetConstructorHandle(constructor));
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -1107,7 +1107,8 @@ namespace System.Reflection.Emit
                     return true;
                 }
 
-                if (IsConstructedFromTypeBuilder(type))
+                if (IsConstructedFromTypeBuilder(type) ||
+                    HasElementTypeOfTypeBuilderOrConstructedFromTypeBuilder(type))
                 {
                     return true;
                 }
@@ -1129,7 +1130,7 @@ namespace System.Reflection.Emit
             }
 
             if (IsConstructedFromTypeBuilder(type) ||
-                HasElementTypeOfTypeBuilder(type))
+                HasElementTypeOfTypeBuilderOrConstructedFromTypeBuilder(type))
             {
                 return default;
             }
@@ -1137,9 +1138,8 @@ namespace System.Reflection.Emit
             return GetTypeReferenceOrSpecificationHandle(type);
         }
 
-        private bool HasElementTypeOfTypeBuilder(Type type) => type.HasElementType &&
-            (type.GetElementType() is TypeBuilderImpl tba && Equals(tba.Module) ||
-             IsConstructedFromTypeBuilder(type.GetElementType()!));
+        private static bool HasElementTypeOfTypeBuilderOrConstructedFromTypeBuilder(Type type) => type.HasElementType &&
+            (type.GetElementType() is TypeBuilderImpl || IsConstructedFromTypeBuilder(type.GetElementType()!));
 
         public override int GetMethodMetadataToken(ConstructorInfo constructor) => GetTokenForHandle(TryGetConstructorHandle(constructor));
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -688,7 +688,7 @@ namespace System.Reflection.Emit
         {
             if (!_typeReferences.TryGetValue(type, out var typeHandle))
             {
-                if (type.IsArray || type.IsPointer || type.IsGenericParameter ||
+                if (type.HasElementType || type.IsGenericParameter ||
                     (type.IsGenericType && !type.IsGenericTypeDefinition))
                 {
                     typeHandle = AddTypeSpecification(type);

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -2547,6 +2547,15 @@ internal class Dummy
                 il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Cgt_Un);
                 il.Emit(OpCodes.Ret);
+
+                mb = typeBuilder.DefineMethod("MultiDimensionalArray", MethodAttributes.Static | MethodAttributes.Public, typeof(bool), [typeof(object)]);
+                il = mb.GetILGenerator();
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Isinst, typeBuilder.MakeArrayType(3));
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Cgt_Un);
+                il.Emit(OpCodes.Ret);
+
                 typeBuilder.CreateType();
                 ab.Save(file.Path);
 
@@ -2555,6 +2564,11 @@ internal class Dummy
                 MethodInfo method = typeFromDisk.GetMethod("Break")!;
                 Assert.False((bool)method.Invoke(null, [typeFromDisk]));
                 object arrInst = Array.CreateInstance(typeFromDisk, 2)!;
+                Assert.True((bool)method.Invoke(null, [arrInst]));
+
+                method = typeFromDisk.GetMethod("MultiDimensionalArray")!;
+                Assert.False((bool)method.Invoke(null, [arrInst]));
+                arrInst = Array.CreateInstance(typeFromDisk, 3, 2, 1)!;
                 Assert.True((bool)method.Invoke(null, [arrInst]));
                 tlc.Unload();
             }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -2533,7 +2533,7 @@ internal class Dummy
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))]
         public void TypeBuilderArrayReferencedInIL()
         {
             using (TempFile file = TempFile.Create())
@@ -2558,17 +2558,17 @@ internal class Dummy
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime)]
+        [Fact]
         public void TypeBuilderPointerReferencedInIL()
         {
             using (TempFile file = TempFile.Create())
             {
                 PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilderAndTypeBuilder(out TypeBuilder typeBuilder);
                 typeBuilder.DefineDefaultConstructor(MethodAttributes.Public);
-                MethodBuilder mb = typeBuilder.DefineMethod("IsPointer", MethodAttributes.Static | MethodAttributes.Public, typeof(bool), [typeof(object)]);
+                MethodBuilder mb = typeBuilder.DefineMethod("IsPointer", MethodAttributes.Static | MethodAttributes.Public, typeof(Type), null);
                 ILGenerator il = mb.GetILGenerator();
-                il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Isinst, typeBuilder.MakePointerType());
+                il.Emit(OpCodes.Ldtoken, typeBuilder.MakePointerType());
+                il.Emit(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle")!);
                 il.Emit(OpCodes.Ret);
                 typeBuilder.CreateType();
                 ab.Save(file.Path);
@@ -2576,13 +2576,13 @@ internal class Dummy
                 TestAssemblyLoadContext tlc = new TestAssemblyLoadContext();
                 Type typeFromDisk = tlc.LoadFromAssemblyPath(file.Path).GetType("MyType");
                 MethodInfo method = typeFromDisk.GetMethod("IsPointer")!;
-                object result = method.Invoke(null, [typeFromDisk]);
-                Assert.False((bool)result);
+                Type result = (Type)method.Invoke(null, null);
+                Assert.Equal("MyType*", result.Name);
                 tlc.Unload();
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime)]
+        [Fact]
         public void TypeBuilderByRefReferencedInIL()
         {
             using (TempFile file = TempFile.Create())


### PR DESCRIPTION
When array or pointer type created from `TypeBuilder` instance and referenced in IL `ILGenerator` writes incorrect/default token when it should reserve the token and fill in on assembly save. Fix the issue, for array and pointer types, looks ByRef types do not need to be covered.

Fixes https://github.com/dotnet/runtime/issues/102687