### PR TITLE
Fix zlib-ng policheck errors

### DIFF
--- a/src/native/external/patches/zlib-ng/zlib-ng_policheck_fixes.patch
+++ b/src/native/external/patches/zlib-ng/zlib-ng_policheck_fixes.patch
@@ -1,0 +1,50 @@
+diff --git a/src/native/external/zlib-ng/trees.c b/src/native/external/zlib-ng/trees.c
+index 5bb88389baa..2221c253851 100644
+--- a/src/native/external/zlib-ng/trees.c
++++ b/src/native/external/zlib-ng/trees.c
+@@ -743,9 +743,9 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
+  * Check if the data type is TEXT or BINARY, using the following algorithm:
+  * - TEXT if the two conditions below are satisfied:
+  *    a) There are no non-portable control characters belonging to the
+- *       "black list" (0..6, 14..25, 28..31).
++ *       "deny list" (0..6, 14..25, 28..31).
+  *    b) There is at least one printable character belonging to the
+- *       "white list" (9 {TAB}, 10 {LF}, 13 {CR}, 32..255).
++ *       "safe list" (9 {TAB}, 10 {LF}, 13 {CR}, 32..255).
+  * - BINARY otherwise.
+  * - The following partially-portable control characters form a
+  *   "gray list" that is ignored in this detection algorithm:
+@@ -753,26 +753,26 @@ static void compress_block(deflate_state *s, const ct_data *ltree, const ct_data
+  * IN assertion: the fields Freq of dyn_ltree are set.
+  */
+ static int detect_data_type(deflate_state *s) {
+-    /* black_mask is the bit mask of black-listed bytes
++    /* deny_mask is the bit mask of deny-listed bytes
+      * set bits 0..6, 14..25, and 28..31
+      * 0xf3ffc07f = binary 11110011111111111100000001111111
+      */
+-    unsigned long black_mask = 0xf3ffc07fUL;
++    unsigned long deny_mask = 0xf3ffc07fUL;
+     int n;
+ 
+-    /* Check for non-textual ("black-listed") bytes. */
+-    for (n = 0; n <= 31; n++, black_mask >>= 1)
+-        if ((black_mask & 1) && (s->dyn_ltree[n].Freq != 0))
++    /* Check for non-textual ("deny-listed") bytes. */
++    for (n = 0; n <= 31; n++, deny_mask >>= 1)
++        if ((deny_mask & 1) && (s->dyn_ltree[n].Freq != 0))
+             return Z_BINARY;
+ 
+-    /* Check for textual ("white-listed") bytes. */
++    /* Check for textual ("safe-listed") bytes. */
+     if (s->dyn_ltree[9].Freq != 0 || s->dyn_ltree[10].Freq != 0 || s->dyn_ltree[13].Freq != 0)
+         return Z_TEXT;
+     for (n = 32; n < LITERALS; n++)
+         if (s->dyn_ltree[n].Freq != 0)
+             return Z_TEXT;
+ 
+-    /* There are no "black-listed" or "white-listed" bytes:
++    /* There are no "deny-listed" or "safe-listed" bytes:
+      * this stream either is empty or has tolerated ("gray-listed") bytes only.
+      */
+     return Z_BINARY;


### PR DESCRIPTION
- Policheck error 79458: Term = black list; TermTranslation = English Translation; Severity: 2
- Policheck error 80409: Term = white list; TermTranslation = English Translation; Severity: 2

Includes a *.patch file to later submit the fix upstream.