### PR TITLE
Propagate the 'this' keyword in LibraryImports

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -426,6 +426,12 @@ namespace Microsoft.Interop
                 }
             }
 
+            if (typeInfo.IsExplicitThis)
+            {
+                tokens = tokens.Add(Token(SyntaxKind.ThisKeyword));
+            }
+
+
             return tokens;
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Marshalling/MarshallerHelpers.cs
@@ -431,7 +431,6 @@ namespace Microsoft.Interop
                 tokens = tokens.Add(Token(SyntaxKind.ThisKeyword));
             }
 
-
             return tokens;
         }
 

--- a/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/TypePositionInfo.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Interop
@@ -77,6 +78,7 @@ namespace Microsoft.Interop
 
         public int ManagedIndex { get; init; } = UnsetIndex;
         public int NativeIndex { get; init; } = UnsetIndex;
+        public bool IsExplicitThis { get; init; }
 
         public static TypePositionInfo CreateForParameter(IParameterSymbol paramSymbol, MarshallingInfo marshallingInfo, Compilation compilation)
         {
@@ -88,7 +90,8 @@ namespace Microsoft.Interop
                 RefKind = paramSymbol.RefKind,
                 ByValueContentsMarshalKind = byValueContentsMarshalKind,
                 ByValueMarshalAttributeLocations = (inLocation, outLocation),
-                ScopedKind = paramSymbol.ScopedKind
+                ScopedKind = paramSymbol.ScopedKind,
+                IsExplicitThis = ((ParameterSyntax)paramSymbol.DeclaringSyntaxReferences[0].GetSyntax()).Modifiers.Any(SyntaxKind.ThisKeyword)
             };
 
             return typeInfo;

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/BlittableStructTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/BlittableStructTests.cs
@@ -41,6 +41,16 @@ namespace LibraryImportGenerator.IntegrationTests
             PointerFields input,
             ref PointerFields result);
     }
+    public static partial class IntStructExtensions
+    {
+        [LibraryImport(NativeExportsNE.NativeExportsNE_Binary, EntryPoint = "blittablestructs_return_instance")]
+        public static partial IntFields DoubleIntFields(this IntFields result);
+        
+        [LibraryImport(NativeExportsNE.NativeExportsNE_Binary, EntryPoint = "blittablestructs_double_intfields_refreturn")]
+        public static partial void DoubleIntFieldsOutReturn(
+            this IntFields input,
+            out IntFields result);
+    }
 
     public class BlittableStructTests
     {
@@ -68,6 +78,11 @@ namespace LibraryImportGenerator.IntegrationTests
                 Assert.Equal(expected, result);
             }
             {
+                var result = input.DoubleIntFields();
+                Assert.Equal(initial, input);
+                Assert.Equal(expected, result);
+            }
+            {
                 var result = new IntFields();
                 NativeExportsNE.DoubleIntFieldsRefReturn(input, ref result);
                 Assert.Equal(initial, input);
@@ -77,6 +92,12 @@ namespace LibraryImportGenerator.IntegrationTests
             {
                 IntFields result;
                 NativeExportsNE.DoubleIntFieldsOutReturn(input, out result);
+                Assert.Equal(initial, input);
+                Assert.Equal(expected, result);
+            }
+            {
+                IntFields result;
+                input.DoubleIntFieldsOutReturn(out result);
                 Assert.Equal(initial, input);
                 Assert.Equal(expected, result);
             }

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -541,7 +541,6 @@ namespace LibraryImportGenerator.UnitTests
             }
             """;
 
-
         public static string BasicParametersAndModifiers<T>(string preDeclaration = "") => BasicParametersAndModifiers(typeof(T).ToString(), preDeclaration);
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/CodeSnippets.cs
@@ -532,6 +532,16 @@ namespace LibraryImportGenerator.UnitTests
             }
             """;
 
+        public static string ExplicitThis => $$"""
+            using System.Runtime.InteropServices;
+            static partial class StringNativeExtensions
+            {
+                [LibraryImport("DoesNotExist")]
+                public static partial void Method(this int t);
+            }
+            """;
+
+
         public static string BasicParametersAndModifiers<T>(string preDeclaration = "") => BasicParametersAndModifiers(typeof(T).ToString(), preDeclaration);
 
         /// <summary>

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -29,11 +29,6 @@ namespace LibraryImportGenerator.UnitTests
             [CallerFilePath] string? filePath = null)
             => TestUtils.GetFileLineName(lineNumber, filePath);
 
-        public static IEnumerable<object[]> CodeSnippetsToCompile2()
-        {
-            yield return new[] { ID(), CodeSnippets.ExplicitThis };
-        }
-
         public static IEnumerable<object[]> CodeSnippetsToCompile()
         {
             yield return new[] { ID(), CodeSnippets.TrivialClassDeclarations };

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/Compiles.cs
@@ -29,6 +29,11 @@ namespace LibraryImportGenerator.UnitTests
             [CallerFilePath] string? filePath = null)
             => TestUtils.GetFileLineName(lineNumber, filePath);
 
+        public static IEnumerable<object[]> CodeSnippetsToCompile2()
+        {
+            yield return new[] { ID(), CodeSnippets.ExplicitThis };
+        }
+
         public static IEnumerable<object[]> CodeSnippetsToCompile()
         {
             yield return new[] { ID(), CodeSnippets.TrivialClassDeclarations };
@@ -42,6 +47,7 @@ namespace LibraryImportGenerator.UnitTests
             yield return new[] { ID(), CodeSnippets.DefaultParameters };
             yield return new[] { ID(), CodeSnippets.UseCSharpFeaturesForConstants };
             yield return new[] { ID(), CodeSnippets.LibraryImportInRefStruct };
+            yield return new[] { ID(), CodeSnippets.ExplicitThis };
 
             // Parameter / return types
             yield return new[] { ID(), CodeSnippets.BasicParametersAndModifiers<byte>() };
@@ -719,7 +725,7 @@ namespace LibraryImportGenerator.UnitTests
 
         [Theory]
         [MemberData(nameof(CodeSnippetsToVerifyNoTreesProduced))]
-        public async Task ValidateNoGeneratedOuptutForNoImport(string id, string source, TestTargetFramework framework)
+        public async Task ValidateNoGeneratedOutputForNoImport(string id, string source, TestTargetFramework framework)
         {
             TestUtils.Use(id);
             var test = new NoChangeTest(framework)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102690

Since Roslyn just lowers the extension methods to a call to the static method there's no reason we shouldn't support creating extension methods that are also `LibraryImport` methods. This adds the `IsExplicitThis` property to `TypePositionInfo` and copies `this` to the generated signature if it is `true`.