### PR TITLE
[release/8.0] [mono][interp] Fix type of args when inlining method

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4983,7 +4983,7 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 		arg_locals = (guint32*) g_malloc ((!!signature->hasthis + signature->param_count) * sizeof (guint32));
 		/* Allocate locals to store inlined method args from stack */
 		for (int i = signature->param_count - 1; i >= 0; i--) {
-			MonoType *type = td->locals [td->sp [-1].local].type;
+			MonoType *type = get_type_from_stack (td->sp [-1].type, td->sp [-1].klass);
 			local = create_interp_local (td, type);
 			arg_locals [i + !!signature->hasthis] = local;
 			store_local (td, local);


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/102570 to release/8.0-staging. Fix for https://github.com/dotnet/runtime/issues/102046

## Customer Impact

When using interpreter, inlining a method that has its argument the result of a ternary conditional operator, could lead to an assumption that the argument is of the wrong type. This is a regression from NET7 because in this release we started to devirtualize calls based on the type of objects and when inlining we attempt to get the real type of arguments from the parent method. This issue was reported by customer in BlazorWasm with a simple repro consisting of a list of items so it looks like it can be easily hit. Since reproduction of this issue relies on inlining to happen, it was probably noticed this late in the release cycle since it needs for the problematic method to be tiered up.

## Testing
Tested the fix locally on top of 8.0 release branch with the customer provided sample. CI PR testing without issues.

## Risk
Low. There are other more conservative fixes like obtaining the type of the arg from the inlined method signature (like it was done in .NET7) or completely disabling devirtualization. In my opinion the fix in this PR is simple enough that reverting behavior is not necessary.