### PR TITLE
Remove debug symbols from non-symbols ilc package

### DIFF
--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -66,7 +66,7 @@
   <!--
     Finds symbol files and injects them into the package build.
   -->
-  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles" Condition="'$(IncludeSymbolsInPackage)' != 'false'">
+  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
     <ItemGroup Condition="'$(SymbolsSuffix)' != ''">
       <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolsSuffix)"/>
     </ItemGroup>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -66,7 +66,7 @@
   <!--
     Finds symbol files and injects them into the package build.
   -->
-  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles">
+  <Target Name="GetSymbolPackageFiles" BeforeTargets="GetPackageFiles" Condition="'$(IncludeSymbolsInPackage)' != 'false'">
     <ItemGroup Condition="'$(SymbolsSuffix)' != ''">
       <AdditionalLibPackageExcludes Include="%2A%2A\%2A$(SymbolsSuffix)"/>
     </ItemGroup>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <GeneratePackage>true</GeneratePackage>
-    <IncludeSymbolsInPackage>false</IncludeSymbolsInPackage>
     <PackageDescription>Provides a native AOT compiler and runtime for .NET</PackageDescription>
   </PropertyGroup>
 

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -35,8 +35,9 @@
       <LibPackageExcludes Include="tools\%2A%2A\%2A.pdb"/>
 
       <LibPackageExcludes Include="%2A%2A\%2A.dbg"/>
-      <LibPackageExcludes Include="%2A%2A\%2A.dSYM"/>
       <LibPackageExcludes Include="%2A%2A\%2A.debug"/>
+      <LibPackageExcludes Include="%2A%2A\%2A.dSYM"/>
+      <LibPackageExcludes Include="%2A%2A\%2A.dwarf"/>
     </ItemGroup>
 
   </Target>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -32,7 +32,7 @@
     <!-- exclude native symbols from ilc package (they are included in symbols package) -->
     <ItemGroup>
        <!-- on windows, remove the pdbs only from tools directory (both managed and native) -->
-      <LibPackageExcludes Include="$(CoreCLRILCompilerDir)%2A%2A\%2A.pdb"/>
+      <LibPackageExcludes Include="tools\%2A%2A\%2A.pdb"/>
 
       <LibPackageExcludes Include="%2A%2A\%2A.dbg"/>
       <LibPackageExcludes Include="%2A%2A\%2A.dSYM"/>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -16,6 +16,7 @@
       <File Include="$(CoreCLRAotSdkDir)*" TargetPath="sdk" />
       <File Include="$(MibcOptimizationDataDir)/$(TargetOS)/$(TargetArchitecture)/**/*.mibc" TargetPath="mibc" />
     </ItemGroup>
+
     <ItemGroup Condition="'$(PackageTargetRuntime)' != '' and '$(TargetOS)' == 'linux'">
       <File Include="$(SharedNativeRoot)libs\System.Globalization.Native\*" TargetPath="native/src/libs/System.Globalization.Native"/>
       <File Include="$(SharedNativeRoot)libs\System.Security.Cryptography.Native\*" TargetPath="native/src/libs/System.Security.Cryptography.Native"/>
@@ -28,6 +29,14 @@
       <File Include="$(CoreCLRBuildIntegrationDir)*" TargetPath="build" />
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
     </ItemGroup>
+
+    <!-- exclude unix-y native symbols from ilc package (they are included in symbols package) -->
+    <ItemGroup>
+      <LibPackageExcludes Include="%2A%2A\%2A.dbg"/>
+      <LibPackageExcludes Include="%2A%2A\%2A.dSYM"/>
+      <LibPackageExcludes Include="%2A%2A\%2A.debug"/>
+    </ItemGroup>
+
   </Target>
 
 </Project>

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GeneratePackage>true</GeneratePackage>
-    <IncludeSymbolsInPackage>true</IncludeSymbolsInPackage>
+    <IncludeSymbolsInPackage>false</IncludeSymbolsInPackage>
     <PackageDescription>Provides a native AOT compiler and runtime for .NET</PackageDescription>
   </PropertyGroup>
 

--- a/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
+++ b/src/installer/pkg/projects/Microsoft.DotNet.ILCompiler/Microsoft.DotNet.ILCompiler.pkgproj
@@ -29,8 +29,11 @@
       <File Include="$(CoreCLRILCompilerDir)netstandard\*" TargetPath="tools/netstandard" />
     </ItemGroup>
 
-    <!-- exclude unix-y native symbols from ilc package (they are included in symbols package) -->
+    <!-- exclude native symbols from ilc package (they are included in symbols package) -->
     <ItemGroup>
+       <!-- on windows, remove the pdbs only from tools directory (both managed and native) -->
+      <LibPackageExcludes Include="$(CoreCLRILCompilerDir)%2A%2A\%2A.pdb"/>
+
       <LibPackageExcludes Include="%2A%2A\%2A.dbg"/>
       <LibPackageExcludes Include="%2A%2A\%2A.dSYM"/>
       <LibPackageExcludes Include="%2A%2A\%2A.debug"/>


### PR DESCRIPTION
The packs subsets creates two packages:

`Microsoft.DotNet.ILCompiler.9.0.0-<VersionSuffix>.nupkg`
`Microsoft.DotNet.ILCompiler.9.0.0-<VersionSuffix>.symbols.nupkg`

The non-symbols package also contain debug symbols files which increases the size of the package.

This PR uses the existing, unused, property `IncludeSymbolsInPackage` to filter out symbol files from non-symbols package.

Fixes #102684