### PR TITLE
Optimize HttpUtility.UrlEncodeToBytes for (string, Encoding) overload.

### DIFF
--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -216,19 +216,10 @@ namespace System.Web
         public static byte[]? UrlDecodeToBytes(byte[]? bytes) => bytes == null ? null : HttpEncoder.UrlDecode(bytes.AsSpan(0, bytes.Length));
 
         [return: NotNullIfNotNull(nameof(str))]
-        public static byte[]? UrlEncodeToBytes(string? str, Encoding e)
-        {
-            if (str == null)
-            {
-                return null;
-            }
-
-            byte[] bytes = e.GetBytes(str);
-            return HttpEncoder.UrlEncode(bytes, 0, bytes.Length, alwaysCreateNewReturnValue: false);
-        }
+        public static byte[]? UrlEncodeToBytes(string? str, Encoding e) => str == null ? null : HttpEncoder.UrlEncode(str, e);
 
         [return: NotNullIfNotNull(nameof(bytes))]
-        public static byte[]? UrlEncodeToBytes(byte[]? bytes, int offset, int count) => HttpEncoder.UrlEncode(bytes, offset, count, alwaysCreateNewReturnValue: true);
+        public static byte[]? UrlEncodeToBytes(byte[]? bytes, int offset, int count) => HttpEncoder.UrlEncode(bytes, offset, count);
 
         [Obsolete("This method produces non-standards-compliant output and has interoperability issues. The preferred alternative is UrlEncode(String).")]
         [return: NotNullIfNotNull(nameof(str))]

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -213,7 +213,7 @@ namespace System.Web
         }
 
         [return: NotNullIfNotNull(nameof(bytes))]
-        public static byte[]? UrlDecodeToBytes(byte[]? bytes) => bytes == null ? null : HttpEncoder.UrlDecode(bytes.AsSpan(0, bytes.Length));
+        public static byte[]? UrlDecodeToBytes(byte[]? bytes) => bytes == null ? null : HttpEncoder.UrlDecode(bytes);
 
         [return: NotNullIfNotNull(nameof(str))]
         public static byte[]? UrlEncodeToBytes(string? str, Encoding e) => str == null ? null : HttpEncoder.UrlEncode(str, e);

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Web.Util
@@ -484,14 +485,20 @@ namespace System.Web.Util
                 return UrlEncode(byteSpan.Slice(0, encodedBytes));
             }
 
-            byte[] bytes = e.GetBytes(str);
-            if (!NeedsEncoding(bytes, out int cUnsafe))
-            {
-                // return encoded byte[] if nothing to expand
-                return bytes;
-            }
+            return Fallback(str, e);
 
-            return UrlEncode(bytes, cUnsafe);
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static byte[] Fallback(string str, Encoding e)
+            {
+                byte[] bytes = e.GetBytes(str);
+                if (!NeedsEncoding(bytes, out int cUnsafe))
+                {
+                    // return encoded byte[] if nothing to expand
+                    return bytes;
+                }
+
+                return UrlEncode(bytes, cUnsafe);
+            }
         }
 
         //  Helper to encode the non-ASCII url characters only

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -7,7 +7,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Net;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Web.Util
@@ -486,16 +485,10 @@ namespace System.Web.Util
                 return UrlEncode(byteSpan.Slice(0, encodedBytes));
             }
 
-            return Fallback(str, e);
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            static byte[] Fallback(string str, Encoding e)
-            {
-                byte[] bytes = e.GetBytes(str);
-                return NeedsEncoding(bytes, out int cUnsafe)
-                    ? UrlEncode(bytes, cUnsafe)
-                    : bytes;
-            }
+            byte[] bytes = e.GetBytes(str);
+            return NeedsEncoding(bytes, out int cUnsafe)
+                ? UrlEncode(bytes, cUnsafe)
+                : bytes;
         }
 
         //  Helper to encode the non-ASCII url characters only

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -431,13 +431,11 @@ namespace System.Web.Util
 
             foreach (byte b in bytes)
             {
-                char ch = (char)b;
-
-                if (HttpEncoderUtility.IsUrlSafeChar(ch))
+                if (s_urlSafeBytes.Contains(b))
                 {
                     expandedBytes[pos++] = b;
                 }
-                else if (ch == ' ')
+                else if (b == 32) // ' '
                 {
                     expandedBytes[pos++] = (byte)'+';
                 }
@@ -452,6 +450,7 @@ namespace System.Web.Util
             return expandedBytes;
         }
 
+        // Set of safe chars, from RFC 1738.4 minus '+'
         private static readonly SearchValues<byte> s_urlSafeBytes = SearchValues.Create(
             "!()*-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"u8);
         private static bool NeedsEncoding(ReadOnlySpan<byte> bytes, out int cUnsafe)
@@ -565,7 +564,7 @@ namespace System.Web.Util
 
                 if ((ch & 0xff80) == 0)
                 {  // 7 bit?
-                    if (HttpEncoderUtility.IsUrlSafeChar(ch))
+                    if (s_urlSafeBytes.Contains((byte)ch))
                     {
                         sb.Append(ch);
                     }

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoderUtility.cs
@@ -8,29 +8,6 @@ namespace System.Web.Util
 {
     internal static class HttpEncoderUtility
     {
-        // Set of safe chars, from RFC 1738.4 minus '+'
-        public static bool IsUrlSafeChar(char ch)
-        {
-            if (char.IsAsciiLetterOrDigit(ch))
-            {
-                return true;
-            }
-
-            switch (ch)
-            {
-                case '-':
-                case '_':
-                case '.':
-                case '!':
-                case '*':
-                case '(':
-                case ')':
-                    return true;
-            }
-
-            return false;
-        }
-
         //  Helper to encode spaces only
         [return: NotNullIfNotNull(nameof(str))]
         internal static string? UrlEncodeSpaces(string? str) => str != null && str.Contains(' ') ? str.Replace(" ", "%20") : str;


### PR DESCRIPTION
Do not allocate byte[] if Encoding.GetMaxByteCount for the string parameter is less than 512 characters.
In this case just encode in stackalloc array.