### PR TITLE
JIT: Propagate `LCL_ADDR` nodes during local morph

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6756,6 +6756,8 @@ private:
 
     PhaseStatus fgMarkAddressExposedLocals();
     void fgSequenceLocals(Statement* stmt);
+    bool fgExposeUnpropagatedLocals(bool propagatedAny, class LocalEqualsLocalAddrAssertions* assertions);
+    void fgExposeLocalsInBitVec(BitVec_ValArg_T bitVec);
 
     PhaseStatus PhysicalPromotion();
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -567,6 +567,7 @@ OPT_CONFIG_STRING(JitOnlyOptimizeRange,
 OPT_CONFIG_STRING(JitEnablePhysicalPromotionRange, W("JitEnablePhysicalPromotionRange"))
 OPT_CONFIG_STRING(JitEnableCrossBlockLocalAssertionPropRange, W("JitEnableCrossBlockLocalAssertionPropRange"))
 OPT_CONFIG_STRING(JitEnableInductionVariableOptsRange, W("JitEnableInductionVariableOptsRange"))
+OPT_CONFIG_STRING(JitEnableLocalAddrPropagationRange, W("JitEnableLocalAddrPropagationRange"))
 
 OPT_CONFIG_INTEGER(JitDoSsa, W("JitDoSsa"), 1) // Perform Static Single Assignment (SSA) numbering on the variables
 OPT_CONFIG_INTEGER(JitDoValueNumber, W("JitDoValueNumber"), 1) // Perform value numbering on method expressions

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1912,10 +1912,14 @@ private:
             m_lclAddrAssertions->Clear(store->GetLclNum(), store->GetLclOffs(), storeSize);
         }
 
-        if (data.IsAddress() && !m_compiler->lvaGetDesc(store)->IsAddressExposed() &&
-            !m_lclAddrAssertions->IsMarkedForExposure(store->GetLclNum()))
+        if (data.IsAddress())
         {
-            m_lclAddrAssertions->Record(store->GetLclNum(), store->GetLclOffs(), data.LclNum(), data.Offset());
+            LclVarDsc* dsc = m_compiler->lvaGetDesc(store);
+            if (!dsc->lvHasLdAddrOp &&
+                (!dsc->lvIsStructField || !m_compiler->lvaGetDesc(dsc->lvParentLcl)->lvHasLdAddrOp))
+            {
+                m_lclAddrAssertions->Record(store->GetLclNum(), store->GetLclOffs(), data.LclNum(), data.Offset());
+            }
         }
     }
 

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -283,7 +283,7 @@ public:
     //
     void StartBlock(BasicBlock* block)
     {
-        if (m_comp->bbIsHandlerBeg(block) || (block->bbPreds == nullptr))
+        if ((m_assertions.Height() == 0) || (block->bbPreds == nullptr) || m_comp->bbIsHandlerBeg(block))
         {
             m_currentAssertions = 0;
             return;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -372,7 +372,7 @@ public:
             unsigned* pIndex = m_map.LookupPointerOrAdd(assertion, UINT_MAX);
             if (*pIndex == UINT_MAX)
             {
-                index = (unsigned)m_assertions.Height();
+                index   = (unsigned)m_assertions.Height();
                 *pIndex = index;
                 m_assertions.Push(assertion);
                 m_lclAssertions[dstLclNum] |= uint64_t(1) << index;

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -2257,7 +2257,7 @@ bool Compiler::fgExposeUnpropagatedLocals(bool propagatedAny, LocalEqualsLocalAd
 
         const LocalEqualsLocalAddrAssertion& assertion = assertions->GetAssertionByIndex(index);
         LclVarDsc*                           dsc       = lvaGetDesc(assertion.DestLclNum);
-        if (dsc->IsAddressExposed())
+        if (dsc->IsAddressExposed() || assertions->IsMarkedForExposure(assertion.DestLclNum))
         {
             uint64_t relevantAssertions = assertions->GetDestAssertions(assertion.DestLclNum);
             assert((relevantAssertions & (uint64_t(1) << index)) != 0);

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -179,9 +179,9 @@ struct LocalEqualsLocalAddrAssertion
 {
     // Local num on the LHS
     unsigned DestLclNum;
-    // Local address is taken of
+    // Local num on the RHS (having its adress taken)
     unsigned AddressLclNum;
-    // Offset into local
+    // Offset into RHS local
     unsigned AddressOffset;
 
     LocalEqualsLocalAddrAssertion(unsigned destLclNum, unsigned addressLclNum, unsigned addressOffset)
@@ -348,7 +348,6 @@ public:
     //
     // Arguments:
     //   dstLclNum - Destination local
-    //   dstOffs   - Offset into the local
     //   srcLclNum - Local having its address taken
     //   srcOffs   - Offset into the source local of the address being taken
     //

--- a/src/coreclr/jit/lclmorph.cpp
+++ b/src/coreclr/jit/lclmorph.cpp
@@ -1974,7 +1974,7 @@ PhaseStatus Compiler::fgMarkAddressExposedLocals()
 
         madeChanges = visitor.MadeChanges();
 
-        fgExposeUnpropagatedLocals(visitor.PropagatedAnyAddresses(), &assertions);
+        madeChanges |= fgExposeUnpropagatedLocals(visitor.PropagatedAnyAddresses(), &assertions);
     }
 
     return madeChanges ? PhaseStatus::MODIFIED_EVERYTHING : PhaseStatus::MODIFIED_NOTHING;

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1198,6 +1198,7 @@ void SsaBuilder::RenameVariables()
         assert(varDsc->lvTracked);
 
         if (varDsc->lvIsParam || m_pCompiler->info.compInitMem || varDsc->lvMustInit ||
+            (varTypeIsGC(varDsc) && !varDsc->lvHasExplicitInit) ||
             VarSetOps::IsMember(m_pCompiler, m_pCompiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex))
         {
             unsigned ssaNum = varDsc->lvPerSsaData.AllocSsaNum(m_allocator);

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -10007,7 +10007,7 @@ PhaseStatus Compiler::fgValueNumber()
             ssaDef->m_vnPair.SetBoth(initVal);
             ssaDef->SetBlock(fgFirstBB);
         }
-        else if (info.compInitMem || varDsc->lvMustInit ||
+        else if (info.compInitMem || varDsc->lvMustInit || (varTypeIsGC(varDsc) && !varDsc->lvHasExplicitInit) ||
                  VarSetOps::IsMember(this, fgFirstBB->bbLiveIn, varDsc->lvVarIndex))
         {
             // The last clause covers the use-before-def variables (the ones that are live-in to the first block),

--- a/src/tests/JIT/opt/AssertionPropagation/LocalMorphBackedge.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/LocalMorphBackedge.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public unsafe class LocalMorphBackedge
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        int x = 1234;
+        int y = 5678;
+        int* px;
+        int** ppx = null;
+
+        for (int i = 100; i < GetUpper(); i++)
+        {
+            px = &x;
+
+            if (ppx != null)
+            {
+                *ppx = &y;
+            }
+
+            *px = i;
+            ppx = &px;
+        }
+
+        return x;
+    }
+	
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int GetUpper() => 102;
+}

--- a/src/tests/JIT/opt/AssertionPropagation/LocalMorphBackedge.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/LocalMorphBackedge.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This changes local morph to run in RPO when optimizations are enabled. It adds infrastructure to track and propagate LCL_ADDR values assigned to locals during local morph. This allows us to avoid address exposure in cases where the destination local does not actually end up escaping in any way.

Example:
```csharp
public struct Awaitable
{
    public int Opts;

    public Awaitable(bool value)
    {
        Opts = value ? 1 : 2;
    }
}

[MethodImpl(MethodImplOptions.NoInlining)]
public static int Test() => new Awaitable(false).Opts;
```

Before:
```asm
G_M59043_IG01:  ;; offset=0x0000
       push     rax
						;; size=1 bbWeight=1 PerfScore 1.00

G_M59043_IG02:  ;; offset=0x0001
       xor      eax, eax
       mov      dword ptr [rsp], eax
       mov      dword ptr [rsp], 2
       mov      eax, dword ptr [rsp]
						;; size=15 bbWeight=1 PerfScore 3.25

G_M59043_IG03:  ;; offset=0x0010
       add      rsp, 8
       ret
						;; size=5 bbWeight=1 PerfScore 1.25
; Total bytes of code: 21

```

After:
```asm
G_M59043_IG02:  ;; offset=0x0000
       mov      eax, 2
						;; size=5 bbWeight=1 PerfScore 0.25

G_M59043_IG03:  ;; offset=0x0005
       ret
```

Propagating the addresses works much like local assertion prop in morph does. Proving that the locals that were stored to do not escape afterwards is done with a simplistic approach: we check globally that no reads of the locals exists, and if so, we replace the `LCL_ADDR` stored to them by a constant 0. We leave it up to liveness to clean up the stores themselves.

If we were able to remove any `LCL_ADDR` in this way then we run an additional pass over the locals of the IR to compute the final set of exposed locals.

This could be more sophisticated, but in practice this handles the reported cases just fine.

Fix #87072
Fix #102273
Fix #102518

This is still not sufficient to handle #69254. To handle that we would need more support around tracking the values of struct fields, and handling of promoted fields. This PR currently does not handle promoted fields at all; we use `lvHasLdAddrOp` as a conservative approximation of address exposure on the destination locals, and promoted structs almost always have this set. If we were to handle promoted fields we would need some other way to determine that a destination holding a local address couldn't be exposed.