### PR TITLE
Make span args to SearchValues.Create be params

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -23,7 +23,7 @@ namespace System.Buffers
         /// </summary>
         /// <param name="values">The set of values.</param>
         /// <returns>The optimized representation of <paramref name="values"/> used for efficient searching.</returns>
-        public static SearchValues<byte> Create(ReadOnlySpan<byte> values)
+        public static SearchValues<byte> Create(params ReadOnlySpan<byte> values)
         {
             if (values.IsEmpty)
             {
@@ -66,7 +66,7 @@ namespace System.Buffers
         /// </summary>
         /// <param name="values">The set of values.</param>
         /// /// <returns>The optimized representation of <paramref name="values"/> used for efficient searching.</returns>
-        public static SearchValues<char> Create(ReadOnlySpan<char> values)
+        public static SearchValues<char> Create(params ReadOnlySpan<char> values)
         {
             if (values.IsEmpty)
             {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7501,8 +7501,8 @@ namespace System.Buffers
     public delegate void ReadOnlySpanAction<T, in TArg>(System.ReadOnlySpan<T> span, TArg arg);
     public static partial class SearchValues
     {
-        public static System.Buffers.SearchValues<byte> Create(System.ReadOnlySpan<byte> values) { throw null; }
-        public static System.Buffers.SearchValues<char> Create(System.ReadOnlySpan<char> values) { throw null; }
+        public static System.Buffers.SearchValues<byte> Create(params System.ReadOnlySpan<byte> values) { throw null; }
+        public static System.Buffers.SearchValues<char> Create(params System.ReadOnlySpan<char> values) { throw null; }
         public static System.Buffers.SearchValues<string> Create(System.ReadOnlySpan<string> values, System.StringComparison comparisonType) { throw null; }
     }
     public partial class SearchValues<T> where T : System.IEquatable<T>?


### PR DESCRIPTION
We missed these in our initial scouring of APIs where adding params to existing spans would make sense.

Most of our own usage just passes in `"..."` or `"..."u8`, but it'd be reasonable for folks to prefer individual chars/bytes as well rather than using string syntax.