### PR TITLE
Add regression test for assembly origin for event marking

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
@@ -14,6 +14,10 @@ using Mono.Linker.Tests.Cases.Expectations.Assertions;
 [assembly: AccessesMembers(typeof(AssemblyAttributeAccessesMembers.TypeWithMembers))]
 namespace Mono.Linker.Tests.Cases.Attributes
 {
+	/// <summary>
+	/// A regression test for the issue that was fixed by https://github.com/dotnet/runtime/pull/102613.
+	/// Events were assumed to always have a MemberDefinition or Descriptor file as the warning origin, but it also can occur from an assembly attribute.
+	/// </summary>
 	[Kept]
 	class AssemblyAttributeAccessesMembers
 	{

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Attributes;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 
-[assembly: KeptAttributeAttribute(typeof(AccessesMembersAttribute))]
-[assembly: AccessesMembers(typeof(AssemblyAttributeAccessesMembers.TypeWithMembers))]
+[assembly: KeptAttributeAttribute (typeof (AccessesMembersAttribute))]
+[assembly: AccessesMembers (typeof (AssemblyAttributeAccessesMembers.TypeWithMembers))]
 namespace Mono.Linker.Tests.Cases.Attributes
 {
 	/// <summary>
@@ -22,7 +22,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	class AssemblyAttributeAccessesMembers
 	{
 		[Kept]
-		public static void Main()
+		public static void Main ()
 		{
 			typeof (AssemblyAttributeAccessesMembers).Assembly.GetCustomAttributes (false);
 		}
@@ -41,7 +41,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
 			[Kept]
 			[KeptBackingField]
-			public int Property { [Kept]get; [Kept]set; }
+			public int Property { [Kept] get; [Kept] set; }
 
 			[Kept]
 			[KeptEventAddMethod]
@@ -52,11 +52,14 @@ namespace Mono.Linker.Tests.Cases.Attributes
 	}
 
 	[Kept]
-	[KeptBaseType(typeof(Attribute))]
-	public class AccessesMembersAttribute: Attribute
+	[KeptBaseType (typeof (Attribute))]
+	public class AccessesMembersAttribute : Attribute
 	{
 		[Kept]
-		public AccessesMembersAttribute([KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))][DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type type)
+		public AccessesMembersAttribute (
+			[KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)]
+			Type type)
 		{
 		}
 	}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/AssemblyAttributeAccessesMembers.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Mono.Linker.Tests.Cases.Attributes;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+[assembly: KeptAttributeAttribute(typeof(AccessesMembersAttribute))]
+[assembly: AccessesMembers(typeof(AssemblyAttributeAccessesMembers.TypeWithMembers))]
+namespace Mono.Linker.Tests.Cases.Attributes
+{
+	[Kept]
+	class AssemblyAttributeAccessesMembers
+	{
+		[Kept]
+		public static void Main()
+		{
+			typeof (AssemblyAttributeAccessesMembers).Assembly.GetCustomAttributes (false);
+		}
+
+		[Kept]
+		public class TypeWithMembers
+		{
+			[Kept]
+			public TypeWithMembers () { }
+
+			[Kept]
+			public void Method () { }
+
+			[Kept]
+			public int Field;
+
+			[Kept]
+			[KeptBackingField]
+			public int Property { [Kept]get; [Kept]set; }
+
+			[Kept]
+			[KeptEventAddMethod]
+			[KeptEventRemoveMethod]
+			[KeptBackingField]
+			public event EventHandler Event;
+		}
+	}
+
+	[Kept]
+	[KeptBaseType(typeof(Attribute))]
+	public class AccessesMembersAttribute: Attribute
+	{
+		[Kept]
+		public AccessesMembersAttribute([KeptAttributeAttribute(typeof(DynamicallyAccessedMembersAttribute))][DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type type)
+		{
+		}
+	}
+}


### PR DESCRIPTION
Adds a regression test for the issue that was fixed in https://github.com/dotnet/runtime/pull/102613.

The assembly level attribute marks the members on the referenced type, and the assembly is the MessageOrigin for the marking.

I confirmed this fails with before https://github.com/dotnet/runtime/pull/102613.