### PR TITLE
Fix OpenSSL stores refreshing too frequently

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedDirectoryStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedDirectoryStoreProvider.cs
@@ -46,6 +46,8 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     _storeDirectoryInfo.Refresh();
                     DirectoryInfo info = _storeDirectoryInfo;
+                    ret = _nativeCollection;
+                    elapsed = _recheckStopwatch.Elapsed;
 
                     if (ret == null ||
                         _forceRefresh ||

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCachedSystemStoreProvider.cs
@@ -93,6 +93,9 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 lock (s_recheckStopwatch)
                 {
+                    ret = s_nativeCollections;
+                    elapsed = s_recheckStopwatch.Elapsed;
+
                     if (ret == null ||
                         elapsed > s_assumeInvalidInterval ||
                         LastWriteTimesHaveChanged())
@@ -214,7 +217,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (processedFiles.Contains(fileId))
                 {
-                   return true;
+                    return true;
                 }
 
                 using (SafeBioHandle fileBio = Interop.Crypto.BioNewFile(file, "rb"))


### PR DESCRIPTION
Background: OpenSSL stores refresh themselves, either on-demand or periodically (assumed stale). The way it was written, a thread checks to see if the store needs to be refreshed. If it does, it takes a lock, and refreshes it.

If you have multiple threads waiting on the lock, then the lock is released, the next thread will proceed. However, the "does the store need to be refreshed?" information is stored in a local. So after a thread has acquired the lock, it appears that the store needs to be refreshed. So each thread that arrives at the lock patiently waits its turn, thinks the store needs to be refreshed, and refreshes it.

This refreshes the locals after the lock has been take to see if another thread updated the information after the thread got a hold of the lock.