### PR TITLE
Disable binder tracing test under jitstress

### DIFF
--- a/src/tests/Loader/binding/tracing/BinderTracingTest.targets
+++ b/src/tests/Loader/binding/tracing/BinderTracingTest.targets
@@ -10,6 +10,8 @@
     <NativeAotIncompatible>true</NativeAotIncompatible>
     <!-- Tracing tests routinely time out with gcstress -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <!-- And they also time out with jitstress modes -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.cs" />


### PR DESCRIPTION
This test routinely times out under jitstress.

Fix #97735

