### PR TITLE
Fix `UnsafeAccessor`s with enum fields

### DIFF
--- a/src/coreclr/vm/field.cpp
+++ b/src/coreclr/vm/field.cpp
@@ -138,6 +138,7 @@ TypeHandle FieldDesc::LookupFieldTypeHandle(ClassLoadLevel level, BOOL dropGener
              type == ELEMENT_TYPE_STRING ||
              type == ELEMENT_TYPE_TYPEDBYREF ||
              type == ELEMENT_TYPE_SZARRAY ||
+             type == ELEMENT_TYPE_ARRAY ||
              type == ELEMENT_TYPE_VAR
              );
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1185,10 +1185,8 @@ namespace
             return false;
         }
 
-        BYTE callConvDecl = *pSig1;
-        BYTE callConvMethod = *pSig2;
-        pSig1++;
-        pSig2++;
+        ULONG callConvDecl = CorSigUncompressCallingConv(pSig1);
+        ULONG callConvMethod = CorSigUncompressCallingConv(pSig2);
 
         // Handle generic param count
         DWORD declGenericCount = 0;
@@ -1402,10 +1400,72 @@ namespace
         return cxt.TargetMethod != NULL;
     }
 
+    bool DoesFieldMatchUnsafeAccessorDeclaration(
+        GenerationContext& cxt,
+        FieldDesc* field,
+        MetaSig::CompareState& state)
+    {
+        STANDARD_VM_CONTRACT;
+        _ASSERTE(field != NULL);
+
+        PCCOR_SIGNATURE pSig1;
+        DWORD cSig1;
+        cxt.Declaration->GetSig(&pSig1, &cSig1);
+        PCCOR_SIGNATURE pEndSig1 = pSig1 + cSig1;
+        ModuleBase* pModule1 = cxt.Declaration->GetModule();
+        const Substitution* pSubst1 = NULL;
+
+        PCCOR_SIGNATURE pSig2;
+        DWORD cSig2;
+        field->GetSig(&pSig2, &cSig2);
+        PCCOR_SIGNATURE pEndSig2 = pSig2 + cSig2;
+        ModuleBase* pModule2 = field->GetModule();
+        const Substitution* pSubst2 = NULL;
+
+        //
+        // Parsing the signature follows details defined in ECMA-335 - II.23.2.1 (MethodDefSig) and II.23.2.4 (FieldSig)
+        // The intent here is to compare the return type in the MethodDefSig with the type in the FieldSig
+        //
+
+        // Consume calling convention
+        ULONG callConvDecl = CorSigUncompressCallingConv(pSig1);
+        _ASSERTE(*pSig2 == IMAGE_CEE_CS_CALLCONV_FIELD);
+        (void)CorSigUncompressCallingConv(pSig2);
+
+        // Consume parts of the method signature until we get to the return type.
+        DWORD declGenericCount = 0;
+        if (callConvDecl & IMAGE_CEE_CS_CALLCONV_GENERIC)
+            IfFailThrow(CorSigUncompressData_EndPtr(pSig1, pEndSig1, &declGenericCount));
+
+        DWORD declArgCount;
+        IfFailThrow(CorSigUncompressData_EndPtr(pSig1, pEndSig1, &declArgCount));
+
+        // UnsafeAccessors for fields require return types be byref.
+        // This was explictly checked in TryGenerateUnsafeAccessor().
+        _ASSERTE(*pSig1 == ELEMENT_TYPE_BYREF);
+        (void)CorSigUncompressElementType(pSig1);
+
+        // Compare the types
+        if (FALSE == MetaSig::CompareElementType(
+            pSig1,
+            pSig2,
+            pEndSig1,
+            pEndSig2,
+            pModule1,
+            pModule2,
+            pSubst1,
+            pSubst2,
+            &state))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     bool TrySetTargetField(
         GenerationContext& cxt,
-        LPCUTF8 fieldName,
-        TypeHandle fieldType)
+        LPCUTF8 fieldName)
     {
         STANDARD_VM_CONTRACT;
         _ASSERTE(fieldName != NULL);
@@ -1417,7 +1477,6 @@ namespace
 
         MethodTable* pMT = targetType.AsMethodTable();
 
-        CorElementType elemType = fieldType.GetVerifierCorElementType();
         ApproxFieldDescIterator fdIterator(
             pMT,
             (cxt.IsTargetStatic ? ApproxFieldDescIterator::STATIC_FIELDS : ApproxFieldDescIterator::INSTANCE_FIELDS));
@@ -1428,20 +1487,11 @@ namespace
             if (strcmp(fieldName, pField->GetName()) != 0)
                 continue;
 
-            // We check if the possible field is class or valuetype
-            // since generic fields need resolution.
-            CorElementType fieldTypeMaybe = pField->GetFieldType();
-            if (fieldTypeMaybe == ELEMENT_TYPE_CLASS
-                || fieldTypeMaybe == ELEMENT_TYPE_VALUETYPE)
-            {
-                if (fieldType != pField->LookupFieldTypeHandle())
-                    continue;
-            }
-            else
-            {
-                if (elemType != fieldTypeMaybe)
-                    continue;
-            }
+            TokenPairList list { nullptr };
+            MetaSig::CompareState state{ &list };
+            state.IgnoreCustomModifiers = false;
+            if (!DoesFieldMatchUnsafeAccessorDeclaration(cxt, pField, state))
+                continue;
 
             if (cxt.Kind == UnsafeAccessorKind::StaticField && pMT->HasGenericsStaticsInfo())
             {
@@ -1769,7 +1819,7 @@ bool MethodDesc::TryGenerateUnsafeAccessor(DynamicResolver** resolver, COR_ILMET
 
         context.TargetType = ValidateTargetType(firstArgType, firstArgCorType);
         context.IsTargetStatic = kind == UnsafeAccessorKind::StaticField;
-        if (!TrySetTargetField(context, name.GetUTF8(), retType.GetTypeParam()))
+        if (!TrySetTargetField(context, name.GetUTF8()))
             MemberLoader::ThrowMissingFieldException(context.TargetType.AsMethodTable(), name.GetUTF8());
         break;
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1417,7 +1417,7 @@ namespace
 
         MethodTable* pMT = targetType.AsMethodTable();
 
-        CorElementType elemType = fieldType.GetSignatureCorElementType();
+        CorElementType elemType = fieldType.GetVerifierCorElementType();
         ApproxFieldDescIterator fdIterator(
             pMT,
             (cxt.IsTargetStatic ? ApproxFieldDescIterator::STATIC_FIELDS : ApproxFieldDescIterator::INSTANCE_FIELDS));

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1183,6 +1183,8 @@ namespace
         uint32_t callConvMethod;
         IfFailThrow(CorSigUncompressCallingConv(pSig1, cSig1, &callConvDecl));
         IfFailThrow(CorSigUncompressCallingConv(pSig2, cSig2, &callConvMethod));
+        pSig1++;
+        pSig2++;
 
         // Validate calling convention
         if ((callConvDecl & IMAGE_CEE_CS_CALLCONV_MASK) != (callConvMethod & IMAGE_CEE_CS_CALLCONV_MASK))
@@ -1435,6 +1437,8 @@ namespace
         IfFailThrow(CorSigUncompressCallingConv(pSig1, cSig1, &callConvDecl));
         IfFailThrow(CorSigUncompressCallingConv(pSig2, cSig2, &callConvField));
         _ASSERTE(callConvField == IMAGE_CEE_CS_CALLCONV_FIELD);
+        pSig1++;
+        pSig2++;
 
         // Consume parts of the method signature until we get to the return type.
         DWORD declGenericCount = 0;
@@ -1445,9 +1449,9 @@ namespace
         IfFailThrow(CorSigUncompressData_EndPtr(pSig1, pEndSig1, &declArgCount));
 
         // UnsafeAccessors for fields require return types be byref.
-        // This was explictly checked in TryGenerateUnsafeAccessor().
+        // This was explicitly checked in TryGenerateUnsafeAccessor().
         if (pSig1 >= pEndSig1)
-            return META_E_BAD_SIGNATURE;
+            ThrowHR(META_E_BAD_SIGNATURE);
         CorElementType byRefType = CorSigUncompressElementType(pSig1);
         _ASSERTE(byRefType == ELEMENT_TYPE_BYREF);
 

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.Generics.cs
@@ -13,11 +13,17 @@ struct Struct { }
 
 public static unsafe class UnsafeAccessorsTestsGenerics
 {
+    class ClassWithEnum<T>
+    {
+        public enum Enum { }
+    }
+
     class MyList<T>
     {
         public const string StaticGenericFieldName = nameof(_GF);
         public const string StaticFieldName = nameof(_F);
         public const string GenericFieldName = nameof(_list);
+        public const string GenericEnumFieldName = nameof(_enum);
 
         static MyList()
         {
@@ -29,6 +35,7 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         private static string _F;
 
         private List<T> _list;
+        private ClassWithEnum<T>.Enum _enum;
 
         public MyList() => _list = new();
 
@@ -62,6 +69,57 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         public int Capacity => _list.Capacity;
     }
 
+    static class Accessors<V>
+    {
+        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+        public extern static MyList<V> Create(int a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+        public extern static MyList<V> CreateWithList(List<V> a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = ".ctor")]
+        public extern static void CallCtorAsMethod(MyList<V> l, List<V> a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
+        public extern static void AddInt(MyList<V> l, int a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
+        public extern static void AddString(MyList<V> l, string a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
+        public extern static void AddStruct(MyList<V> l, Struct a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Clear")]
+        public extern static void Clear(MyList<V> l);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
+        public extern static void Add(MyList<V> l, V element);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "AddWithIgnore")]
+        public extern static void AddWithIgnore<W>(MyList<V> l, V element, W ignore);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CanCastToElementType")]
+        public extern static bool CanCastToElementType<W>(MyList<V> l, W element);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CreateMessage")]
+        public extern static string CreateMessage(GenericBase<V> b, V v);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "ElementType")]
+        public extern static Type ElementType(MyList<V> l);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CanUseElementType")]
+        public extern static bool CanUseElementType<W>(MyList<V> l, W element);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name=MyList<object>.GenericFieldName)]
+        public extern static ref List<V> GetPrivateField(MyList<V> a);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name=MyList<int>.GenericEnumFieldName)]
+        public extern static ref ClassWithEnum<V>.Enum GetPrivateEnumField(MyList<V> d);
+
+        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticGenericFieldName)]
+        public extern static ref V GetPrivateStaticField(MyList<V> d);
+    }
+
     [Fact]
     public static void Verify_Generic_AccessStaticFieldClass()
     {
@@ -76,12 +134,12 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         {
             int expected = 10;
             MyList<int>.SetStaticGenericField(expected);
-            Assert.Equal(expected, GetPrivateStaticField((MyList<int>)null));
+            Assert.Equal(expected, Accessors<int>.GetPrivateStaticField((MyList<int>)null));
         }
         {
             string expected = "abc";
             MyList<string>.SetStaticGenericField(expected);
-            Assert.Equal(expected, GetPrivateStaticField((MyList<string>)null));
+            Assert.Equal(expected, Accessors<string>.GetPrivateStaticField((MyList<string>)null));
         }
 
         [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticFieldName)]
@@ -92,9 +150,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
 
         [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<Struct>.StaticFieldName)]
         extern static ref string GetPrivateStaticFieldStruct(MyList<Struct> d);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticField, Name=MyList<int>.StaticGenericFieldName)]
-        extern static ref V GetPrivateStaticField<V>(MyList<V> d);
     }
 
     [Fact]
@@ -103,19 +158,19 @@ public static unsafe class UnsafeAccessorsTestsGenerics
         Console.WriteLine($"Running {nameof(Verify_Generic_AccessFieldClass)}");
         {
             MyList<int> a = new();
-            Assert.NotNull(GetPrivateField(a));
+            Assert.NotNull(Accessors<int>.GetPrivateField(a));
+            Accessors<int>.GetPrivateEnumField(a) = default;
         }
         {
             MyList<string> a = new();
-            Assert.NotNull(GetPrivateField(a));
+            Assert.NotNull(Accessors<string>.GetPrivateField(a));
+            Accessors<string>.GetPrivateEnumField(a) = default;
         }
         {
             MyList<Struct> a = new();
-            Assert.NotNull(GetPrivateField(a));
+            Assert.NotNull(Accessors<Struct>.GetPrivateField(a));
+            Accessors<Struct>.GetPrivateEnumField(a) = default;
         }
-
-        [UnsafeAccessor(UnsafeAccessorKind.Field, Name=MyList<object>.GenericFieldName)]
-        extern static ref List<V> GetPrivateField<V>(MyList<V> a);
     }
 
     class Base
@@ -184,48 +239,6 @@ public static unsafe class UnsafeAccessorsTestsGenerics
 
         [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CreateMessageGeneric")]
         extern static string CreateMessage<W>(Base b, W w);
-    }
-
-    sealed class Accessors<V>
-    {
-        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
-        public extern static MyList<V> Create(int a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
-        public extern static MyList<V> CreateWithList(List<V> a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = ".ctor")]
-        public extern static void CallCtorAsMethod(MyList<V> l, List<V> a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
-        public extern static void AddInt(MyList<V> l, int a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
-        public extern static void AddString(MyList<V> l, string a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
-        public extern static void AddStruct(MyList<V> l, Struct a);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Clear")]
-        public extern static void Clear(MyList<V> l);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "Add")]
-        public extern static void Add(MyList<V> l, V element);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "AddWithIgnore")]
-        public extern static void AddWithIgnore<W>(MyList<V> l, V element, W ignore);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CanCastToElementType")]
-        public extern static bool CanCastToElementType<W>(MyList<V> l, W element);
-
-        [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "CreateMessage")]
-        public extern static string CreateMessage(GenericBase<V> b, V v);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "ElementType")]
-        public extern static Type ElementType(MyList<V> l);
-
-        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "CanUseElementType")]
-        public extern static bool CanUseElementType<W>(MyList<V> l, W element);
     }
 
     [Fact]

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
@@ -215,28 +215,28 @@ public static unsafe class UnsafeAccessorsTests
         extern static ref string GetPrivateField(ref UserDataValue d);
     }
 
-    unsafe ref struct AllFields
+    unsafe struct AllFields
     {
-        bool _bool;
-        char _char;
-        byte _byte;
-        sbyte _sbyte;
-        short _short;
-        ushort _ushort;
-        int _int;
-        uint _uint;
-        long _long;
-        ulong _ulong;
-        string _string;
-        AttributeTargets _enum;
-        void* _ptr;
-        Guid _guid;
-        object _object;
-        int[] _array;
-        int[,] _mdarray;
-        IntPtr _intptr;
-        UIntPtr _uintptr;
-        delegate*<void> _fptr;
+        private bool _bool;
+        private char _char;
+        private byte _byte;
+        private sbyte _sbyte;
+        private short _short;
+        private ushort _ushort;
+        private int _int;
+        private uint _uint;
+        private long _long;
+        private ulong _ulong;
+        private string _string;
+        private AttributeTargets _enum;
+        private void* _ptr;
+        private Guid _guid;
+        private object _object;
+        private int[] _array;
+        private int[,] _mdarray;
+        private IntPtr _intptr;
+        private UIntPtr _uintptr;
+        private delegate*<void> _fptr;
     }
 
     [Fact]

--- a/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
+++ b/src/tests/baseservices/compilerservices/UnsafeAccessors/UnsafeAccessorsTests.cs
@@ -215,6 +215,119 @@ public static unsafe class UnsafeAccessorsTests
         extern static ref string GetPrivateField(ref UserDataValue d);
     }
 
+    unsafe ref struct AllFields
+    {
+        bool _bool;
+        char _char;
+        byte _byte;
+        sbyte _sbyte;
+        short _short;
+        ushort _ushort;
+        int _int;
+        uint _uint;
+        long _long;
+        ulong _ulong;
+        string _string;
+        AttributeTargets _enum;
+        void* _ptr;
+        Guid _guid;
+        object _object;
+        int[] _array;
+        int[,] _mdarray;
+        IntPtr _intptr;
+        UIntPtr _uintptr;
+        delegate*<void> _fptr;
+    }
+
+    [Fact]
+    public static void Verify_AccessAllFields_CorElementType()
+    {
+        Console.WriteLine($"Running {nameof(Verify_AccessAllFields_CorElementType)}");
+
+        AllFields allFields = default;
+
+        GetBool(ref allFields) = default;
+        GetChar(ref allFields) = default;
+        GetByte(ref allFields) = default;
+        GetSByte(ref allFields) = default;
+        GetShort(ref allFields) = default;
+        GetUShort(ref allFields) = default;
+        GetInt(ref allFields) = default;
+        GetUInt(ref allFields) = default;
+        GetLong(ref allFields) = default;
+        GetULong(ref allFields) = default;
+        GetString(ref allFields) = default;
+        GetEnum(ref allFields) = default;
+        GetPtr(ref allFields) = default;
+        GetGuid(ref allFields) = default;
+        GetObject(ref allFields) = default;
+        GetArray(ref allFields) = default;
+        GetMDArray(ref allFields) = default;
+        GetIntPtr(ref allFields) = default;
+        GetUIntPtr(ref allFields) = default;
+        GetFPtr(ref allFields) = default;
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_bool")]
+        extern static ref bool GetBool(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_char")]
+        extern static ref char GetChar(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_byte")]
+        extern static ref byte GetByte(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_sbyte")]
+        extern static ref sbyte GetSByte(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_short")]
+        extern static ref short GetShort(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_ushort")]
+        extern static ref ushort GetUShort(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_int")]
+        extern static ref int GetInt(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_uint")]
+        extern static ref uint GetUInt(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_long")]
+        extern static ref long GetLong(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_ulong")]
+        extern static ref ulong GetULong(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_string")]
+        extern static ref string GetString(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_enum")]
+        extern static ref AttributeTargets GetEnum(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_ptr")]
+        extern static ref void* GetPtr(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_guid")]
+        extern static ref Guid GetGuid(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_object")]
+        extern static ref object GetObject(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_array")]
+        extern static ref int[] GetArray(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_mdarray")]
+        extern static ref int[,] GetMDArray(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_intptr")]
+        extern static ref IntPtr GetIntPtr(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_uintptr")]
+        extern static ref UIntPtr GetUIntPtr(ref AllFields f);
+
+        [UnsafeAccessor(UnsafeAccessorKind.Field, Name="_fptr")]
+        extern static ref delegate*<void> GetFPtr(ref AllFields f);
+    }
+
     [Fact]
     public static void Verify_AccessStaticMethodClass()
     {


### PR DESCRIPTION
Instead of using naive `CorElementType` and `TypeHandle` comparrisons for Fields, we now use signature comparrisons. This is both more reliable and fixes issues with Enums and previously untested scenarios with generics.

Add tests for all support `CorElementType`s.
Add test for generic enums.

Fixes https://github.com/dotnet/runtime/issues/102792