### PR TITLE
Avoid a few allocations in JsonContent

### DIFF
--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -29,7 +29,15 @@ namespace System.Net.Http.Json
 
             Value = inputValue;
             _typeInfo = jsonTypeInfo;
-            Headers.ContentType = mediaType ?? JsonHelpers.GetDefaultMediaType();
+
+            if (mediaType is not null)
+            {
+                Headers.ContentType = mediaType;
+            }
+            else
+            {
+                Headers.TryAddWithoutValidation("Content-Type", JsonHelpers.DefaultMediaType);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonHelpers.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http.Json
             return options.GetTypeInfo(type);
         }
 
-        internal static MediaTypeHeaderValue GetDefaultMediaType() => new("application/json") { CharSet = "utf-8" };
+        internal const string DefaultMediaType = "application/json; charset=utf-8";
 
         internal static Encoding? GetEncoding(HttpContent content)
         {


### PR DESCRIPTION
Functionally the same, but avoids allocating all of this on every request
![image](https://github.com/dotnet/runtime/assets/25307628/8c8fc30c-6b9d-47b1-b9a6-7f2f611f94fc)
