### PR TITLE
[RISC-V] Fix Interop/StructPacking/StructPacking.dll Failure

### DIFF
--- a/src/tests/Interop/StructPacking/StructPacking.cs
+++ b/src/tests/Interop/StructPacking/StructPacking.cs
@@ -1326,9 +1326,9 @@ public unsafe partial class Program
                 expectedOffsetValue: 8
             );
         }
-        else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+        else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 || RuntimeInformation.ProcessArchitecture == Architecture.RiscV64)
         {
-            // The Procedure Call Standard for ARM64 defines this type as having 16-byte alignment
+            // The Procedure Call Standard for ARM64 and RiscV64 defines this type as having 16-byte alignment
 
             succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
                 expectedSize: 48,


### PR DESCRIPTION
Fix Vector size mismatch in Interop/StructPacking/StructPacking.dll caused by https://github.com/dotnet/runtime/pull/99589 PR.
It missed updating the test because of false positive problem of the test.
Currently, RISC-V has the same size of Arm64, it can be splitted later.

It fixes only test error in https://github.com/dotnet/runtime/issues/102768.
Part of #84834, cc @dotnet/samsung