### PR TITLE
Fix computing new EH ranges in SubstitutedILProvider

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -415,7 +415,8 @@ namespace ILCompiler
                 return method;
 
             // Maps instruction offsets in original method body to offsets in rewritten method body.
-            var offsetMap = new int[methodBytes.Length];
+            // Do a + 1 to length because exception handlers might refer to offset at the end of last instruction.
+            var offsetMap = new int[methodBytes.Length + 1];
 #if DEBUG
             Array.Fill(offsetMap, -1);
 #endif
@@ -469,6 +470,7 @@ namespace ILCompiler
                     dstPos += 2;
                 }
             }
+            offsetMap[methodBytes.Length] = dstPos;
 
             // Now generate the new body
             var newBody = new byte[dstPos];


### PR DESCRIPTION
There was an IL test that was running into out of range access.

Cc @dotnet/ilc-contrib 