### PR TITLE
Replace legacy __sync intrinsics with __atomic ones

### DIFF
--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -205,17 +205,17 @@ typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
 
 #if defined(__arm__) || defined(__aarch64__)
  #define YieldProcessor() asm volatile ("yield")
- #define MemoryBarrier __sync_synchronize
+ #define MemoryBarrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 #endif // __arm__ || __aarch64__
 
 #ifdef __loongarch64
- #define YieldProcessor() __asm__ volatile( "dbar 0; \n")
- #define MemoryBarrier __sync_synchronize
+ #define YieldProcessor() __asm__ volatile("dbar 0; \n")
+ #define MemoryBarrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 #endif // __loongarch64
 
 #ifdef __riscv
- #define YieldProcessor() asm volatile( ".word 0x0100000f");
- #define MemoryBarrier __sync_synchronize
+ #define YieldProcessor() asm volatile(".word 0x0100000f")
+ #define MemoryBarrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 #endif // __riscv
 
 #endif // _MSC_VER

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -461,7 +461,7 @@ void GCToOSInterface::FlushProcessWriteBuffers()
 
         // Ensure that the page is dirty before we change the protection so that
         // we prevent the OS from skipping the global TLB flush.
-        __sync_add_and_fetch((size_t*)g_helperPage, 1);
+        __atomic_add_fetch((size_t*)g_helperPage, 1, __ATOMIC_SEQ_CST);
 
         status = mprotect(g_helperPage, OS_PAGE_SIZE, PROT_NONE);
         assert(status == 0 && "Failed to change helper page protection to no access");

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -3439,7 +3439,13 @@ Define_InterlockMethod(
     LONGLONG,
     InterlockedAdd64(IN OUT LONGLONG volatile *lpAddend, IN LONGLONG value),
     InterlockedAdd64(lpAddend, value),
+#ifdef HOST_X86
+    __attribute__((aligned(8))) LONGLONG alignedAddend = *lpAddend;
+    LONGLONG result = __atomic_add_fetch(&alignedAddend, value, __ATOMIC_SEQ_CST);
+    *lpAddend = alignedAddend;,
+#else
     LONGLONG result = __atomic_add_fetch(lpAddend, value, __ATOMIC_SEQ_CST),
+#endif
     result
 )
 
@@ -3474,7 +3480,13 @@ Define_InterlockMethod(
     LONGLONG,
     InterlockedIncrement64(IN OUT LONGLONG volatile *lpAddend),
     InterlockedIncrement64(lpAddend),
+#ifdef HOST_X86
+    __attribute__((aligned(8))) LONGLONG alignedAddend = *lpAddend;
+    LONGLONG result = __atomic_add_fetch(&alignedAddend, 1, __ATOMIC_SEQ_CST);
+    *lpAddend = alignedAddend;,
+#else
     LONGLONG result = __atomic_add_fetch(lpAddend, 1, __ATOMIC_SEQ_CST),
+#endif
     result
 )
 
@@ -3511,7 +3523,13 @@ Define_InterlockMethod(
     LONGLONG,
     InterlockedDecrement64(IN OUT LONGLONG volatile *lpAddend),
     InterlockedDecrement64(lpAddend),
+#ifdef HOST_X86
+    __attribute__((aligned(8))) LONGLONG alignedAddend = *lpAddend;
+    LONGLONG result = __atomic_sub_fetch(&alignedAddend, 1, __ATOMIC_SEQ_CST);
+    *lpAddend = alignedAddend;,
+#else
     LONGLONG result = __atomic_sub_fetch(lpAddend, 1, __ATOMIC_SEQ_CST),
+#endif
     result
 )
 
@@ -3616,6 +3634,17 @@ Define_InterlockMethod(
     LONGLONG,
     InterlockedCompareExchange64(IN OUT LONGLONG volatile *Destination, IN LONGLONG Exchange, IN LONGLONG Comperand),
     InterlockedCompareExchange64(Destination, Exchange, Comperand),
+#ifdef HOST_X86
+    __attribute__((aligned(8))) LONGLONG alignedDestination = *Destination;
+    __atomic_compare_exchange_n(
+        &alignedDestination, /* Pointer to a variable whose value is to be compared with. */
+        &Comperand, /* Pointer to the value to be compared */
+        Exchange, /* The value to be stored */
+        false, /* Whether the comparison should be made equal to exchange */
+        __ATOMIC_SEQ_CST, /* Memory order for both success and failure */
+        __ATOMIC_SEQ_CST); /* Memory order for both success and failure */
+    *Destination = alignedDestination;,
+#else
     __atomic_compare_exchange_n(
         Destination, /* Pointer to a variable whose value is to be compared with. */
         &Comperand, /* Pointer to the value to be compared */
@@ -3623,6 +3652,7 @@ Define_InterlockMethod(
         false, /* Whether the comparison should be made equal to exchange */
         __ATOMIC_SEQ_CST, /* Memory order for both success and failure */
         __ATOMIC_SEQ_CST), /* Memory order for both success and failure */
+#endif
     Comperand
 )
 
@@ -3655,7 +3685,13 @@ Define_InterlockMethod(
     LONGLONG,
     InterlockedExchangeAdd64(IN OUT LONGLONG volatile *Addend, IN LONGLONG Value),
     InterlockedExchangeAdd64(Addend, Value),
+#ifdef HOST_X86
+    __attribute__((aligned(8))) LONGLONG alignedAddend = *Addend;
+    LONGLONG result = __atomic_fetch_add(&alignedAddend, Value, __ATOMIC_SEQ_CST);
+    *Addend = alignedAddend;,
+#else
     LONGLONG result = __atomic_fetch_add(Addend, Value, __ATOMIC_SEQ_CST),
+#endif
     result
 )
 

--- a/src/coreclr/pal/src/CMakeLists.txt
+++ b/src/coreclr/pal/src/CMakeLists.txt
@@ -308,6 +308,10 @@ if(CLR_CMAKE_TARGET_LINUX)
     target_link_libraries(coreclrpal PUBLIC ucontext)
   endif(CLR_CMAKE_TARGET_LINUX_MUSL AND (CLR_CMAKE_TARGET_ARCH_I386 OR CLR_CMAKE_TARGET_ARCH_POWERPC64))
 
+  if(CLR_CMAKE_TARGET_ARCH_I386)
+      target_link_libraries(coreclrpal PUBLIC atomic)
+  endif(CLR_CMAKE_TARGET_ARCH_I386)
+
 endif(CLR_CMAKE_TARGET_LINUX)
 
 if(CLR_CMAKE_TARGET_NETBSD)

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -578,7 +578,8 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
         {
             if (GetCurrentPalThread())
             {
-                size_t handlerStackTop = __sync_val_compare_and_swap((size_t*)&g_stackOverflowHandlerStack, (size_t)g_stackOverflowHandlerStack, 0);
+                size_t handlerStackTop = (size_t)g_stackOverflowHandlerStack;
+                __atomic_compare_exchange_n(&g_stackOverflowHandlerStack, &handlerStackTop, 0, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
                 if (handlerStackTop == 0)
                 {
                     // We have only one stack for handling stack overflow preallocated. We let only the first thread that hits stack overflow to

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -579,7 +579,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
             if (GetCurrentPalThread())
             {
                 size_t handlerStackTop = (size_t)g_stackOverflowHandlerStack;
-                __atomic_compare_exchange_n(&g_stackOverflowHandlerStack, &handlerStackTop, 0, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+                __atomic_compare_exchange_n(&g_stackOverflowHandlerStack, (volatile void **)&handlerStackTop, 0, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
                 if (handlerStackTop == 0)
                 {
                     // We have only one stack for handling stack overflow preallocated. We let only the first thread that hits stack overflow to


### PR DESCRIPTION
From: https://gcc.gnu.org/onlinedocs/gcc/_005f_005fsync-Builtins.html

> These functions are implemented in terms of the ‘__atomic’ builtins (see [Built-in Functions for Memory Model Aware Atomic Operations](https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)). They should not be used for new code which should use the ‘__atomic’ builtins instead.