### PR TITLE
Removes the redundant external condition

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -118,12 +118,9 @@ namespace System.Text.Json.Serialization.Metadata
                     }
 
                     FlushResult result = await pipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
-                    if (result.IsCanceled || result.IsCompleted)
+                    if (result.IsCanceled)
                     {
-                        if (result.IsCanceled)
-                        {
-                            ThrowHelper.ThrowOperationCanceledException_PipeWriteCanceled();
-                        }
+                        ThrowHelper.ThrowOperationCanceledException_PipeWriteCanceled();
                     }
                 }
                 finally


### PR DESCRIPTION
This PR introduces a tiny refactor addressing a _possible_ redundancy introduced in a condition very recently. Since we're anyway verifying only for `isCancelled`, I see no reason why we're checking for `isCompleted` externally, especially given that it's an OR check.