### PR TITLE
Add fast path for linq count with predicate

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/libraries/System.Linq/src/System/Linq/AnyAll.cs
@@ -55,11 +55,24 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            foreach (TSource element in source)
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
-                if (predicate(element))
+                foreach (TSource element in span)
                 {
-                    return true;
+                    if (predicate(element))
+                    {
+                        return true;
+                    }
+                }
+            }
+            else
+            {
+                foreach (TSource element in source)
+                {
+                    if (predicate(element))
+                    {
+                        return true;
+                    }
                 }
             }
 
@@ -78,11 +91,24 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            foreach (TSource element in source)
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
-                if (!predicate(element))
+                foreach (TSource element in span)
                 {
-                    return false;
+                    if (!predicate(element))
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                foreach (TSource element in source)
+                {
+                    if (!predicate(element))
+                    {
+                        return false;
+                    }
                 }
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -69,17 +69,14 @@ namespace System.Linq
                         count++;
                     }
                 }
-
-                return count;
             }
-
-            foreach (TSource element in source)
+            else
             {
-                checked
+                foreach (TSource element in source)
                 {
                     if (predicate(element))
                     {
-                        count++;
+                        checked { count++; }
                     }
                 }
             }
@@ -149,15 +146,15 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
             }
 
+            // TryGetSpan isn't used here because if it's expected that there are more than int.MaxValue elements,
+            // the source can't possibly be something from which we can extract a span.
+
             long count = 0;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                checked
+                while (e.MoveNext())
                 {
-                    while (e.MoveNext())
-                    {
-                        count++;
-                    }
+                    checked { count++; }
                 }
             }
 
@@ -176,15 +173,15 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
+            // TryGetSpan isn't used here because if it's expected that there are more than int.MaxValue elements,
+            // the source can't possibly be something from which we can extract a span.
+
             long count = 0;
             foreach (TSource element in source)
             {
-                checked
+                if (predicate(element))
                 {
-                    if (predicate(element))
-                    {
-                        count++;
-                    }
+                    checked { count++; }
                 }
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Count.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Count.cs
@@ -60,6 +60,19 @@ namespace System.Linq
             }
 
             int count = 0;
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
+            {
+                foreach (TSource element in span)
+                {
+                    if (predicate(element))
+                    {
+                        count++;
+                    }
+                }
+
+                return count;
+            }
+
             foreach (TSource element in source)
             {
                 checked

--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -114,12 +114,26 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            foreach (TSource element in source)
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
-                if (predicate(element))
+                foreach (TSource element in span)
                 {
-                    found = true;
-                    return element;
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
+                }
+            }
+            else
+            {
+                foreach (TSource element in source)
+                {
+                    if (predicate(element))
+                    {
+                        found = true;
+                        return element;
+                    }
                 }
             }
 

--- a/src/libraries/System.Linq/src/System/Linq/Single.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Single.cs
@@ -117,8 +117,30 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            if (source.TryGetSpan(out ReadOnlySpan<TSource> span))
             {
+                for (int i = 0; i < span.Length; i++)
+                {
+                    TSource result = span[i];
+                    if (predicate(result))
+                    {
+                        for (i++; (uint)i < (uint)span.Length; i++)
+                        {
+                            if (predicate(span[i]))
+                            {
+                                ThrowHelper.ThrowMoreThanOneMatchException();
+                            }
+                        }
+
+                        found = true;
+                        return result;
+                    }
+                }
+            }
+            else
+            {
+                using IEnumerator<TSource> e = source.GetEnumerator();
+
                 while (e.MoveNext())
                 {
                     TSource result = e.Current;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/102696

A simple change to take fast path when the source is span-able. Also move non-span loop to a local function to make it easier for the JIT to inline the method alongside the lambda, when available, per callsite, avoiding a single lambda only devirtualization due to the loop not being inlined.