### PR TITLE
Enable sending activation to dispatch queue threads

### DIFF
--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1047,10 +1047,10 @@ REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalRegisterHijackCallback(_In_ PalH
     g_pHijackCallback = callback;
 
 #ifdef __APPLE__
-    void *libdispatch = dlopen("/usr/lib/system/libdispatch.dylib", RTLD_LAZY);
-    if (libdispatch != NULL)
+    void *libSystem = dlopen("/usr/lib/libSystem.dylib", RTLD_LAZY);
+    if (libSystem != NULL)
     {
-        int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libdispatch, "dispatch_allow_send_signals");
+        int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libSystem, "dispatch_allow_send_signals");
         if (dispatch_allow_send_signals_ptr != NULL)
         {
             int status = dispatch_allow_send_signals_ptr(INJECT_ACTIVATION_SIGNAL);

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -90,6 +90,16 @@ extern "C" void RaiseFailFastException(PEXCEPTION_RECORD arg1, PCONTEXT arg2, ui
     abort();
 }
 
+static void UnmaskActivationSignal()
+{
+    sigset_t signal_set;
+    sigemptyset(&signal_set);
+    sigaddset(&signal_set, INJECT_ACTIVATION_SIGNAL);
+
+    int sigmaskRet = pthread_sigmask(SIG_UNBLOCK, &signal_set, NULL);
+    _ASSERTE(sigmaskRet != 0);
+}
+
 static void TimeSpecAdd(timespec* time, uint32_t milliseconds)
 {
     uint64_t nsec = time->tv_nsec + (uint64_t)milliseconds * tccMilliSecondsToNanoSeconds;
@@ -501,6 +511,8 @@ extern "C" void PalAttachThread(void* thread)
 #else
     tls_destructionMonitor.SetThread(thread);
 #endif
+
+    UnmaskActivationSignal();
 }
 
 // Detach thread from OS notifications.
@@ -1034,6 +1046,27 @@ REDHAWK_PALEXPORT UInt32_BOOL REDHAWK_PALAPI PalRegisterHijackCallback(_In_ PalH
     ASSERT(g_pHijackCallback == NULL);
     g_pHijackCallback = callback;
 
+#ifdef __APPLE__
+    void *libdispatch = dlopen("/usr/lib/system/libdispatch.dylib", RTLD_LAZY);
+    if (libdispatch != NULL)
+    {
+        int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libdispatch, "dispatch_allow_send_signals");
+        if (dispatch_allow_send_signals_ptr != NULL)
+        {
+            int status = dispatch_allow_send_signals_ptr(INJECT_ACTIVATION_SIGNAL);
+            _ASSERTE(status == 0);
+        }
+    }
+
+    // TODO: Once our CI tools can get upgraded to xcode >= 15.3, replace the code above by this:
+    // if (__builtin_available(macOS 14.4, iOS 17.4, tvOS 17.4, *))
+    // {
+    //    // Allow sending the activation signal to dispatch queue threads
+    //    int status = dispatch_allow_send_signals(INJECT_ACTIVATION_SIGNAL);
+    //    _ASSERTE(status == 0);
+    // }
+#endif // __APPLE__
+
     return AddSignalHandler(INJECT_ACTIVATION_SIGNAL, ActivationHandler, &g_previousActivationHandler);
 }
 
@@ -1053,7 +1086,7 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_opt_ void* p
     if ((status == EAGAIN)
      || (status == ESRCH)
 #ifdef __APPLE__
-        // On Apple, pthread_kill is not allowed to be sent to dispatch queue threads
+        // On Apple, pthread_kill is not allowed to be sent to dispatch queue threads on macOS older than 14.4 or iOS/tvOS older than 17.4
      || (status == ENOTSUP)
 #endif
        )

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -97,7 +97,7 @@ static void UnmaskActivationSignal()
     sigaddset(&signal_set, INJECT_ACTIVATION_SIGNAL);
 
     int sigmaskRet = pthread_sigmask(SIG_UNBLOCK, &signal_set, NULL);
-    _ASSERTE(sigmaskRet != 0);
+    _ASSERTE(sigmaskRet == 0);
 }
 
 static void TimeSpecAdd(timespec* time, uint32_t milliseconds)

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -509,6 +509,19 @@ void UnmaskActivationSignal()
     }
 }
 
+void MaskActivationSignal()
+{
+    sigset_t signal_set;
+    sigemptyset(&signal_set);
+    sigaddset(&signal_set, INJECT_ACTIVATION_SIGNAL);
+
+    int sigmaskRet = pthread_sigmask(SIG_BLOCK, &signal_set, NULL);
+    if (sigmaskRet != 0)
+    {
+        ASSERT("pthread_sigmask failed; error number is %d\n", sigmaskRet);
+    }
+}
+
 #if !HAVE_MACH_EXCEPTIONS
 
 /*++
@@ -536,11 +549,7 @@ extern "C" void signal_handler_worker(int code, siginfo_t *siginfo, void *contex
     returnPoint->returnFromHandler = common_signal_handler(code, siginfo, context, 2, (size_t)0, (size_t)siginfo->si_addr);
 
     // We are going to return to the alternate stack, so block the activation signal again
-    sigmaskRet = pthread_sigmask(SIG_BLOCK, &signal_set, NULL);
-    if (sigmaskRet != 0)
-    {
-        ASSERT("pthread_sigmask failed; error number is %d\n", sigmaskRet);
-    }
+    MaskActivationSignal();
 
     RtlRestoreContext(&returnPoint->context, NULL);
 }

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -244,10 +244,10 @@ BOOL SEHInitializeSignals(CorUnix::CPalThread *pthrCurrent, DWORD flags)
     if (flags & PAL_INITIALIZE_REGISTER_ACTIVATION_SIGNAL)
     {
 #ifdef __APPLE__
-        void *libdispatch = dlopen("/usr/lib/system/libdispatch.dylib", RTLD_LAZY);
-        if (libdispatch != NULL)
+        void *libSystem = dlopen("/usr/lib/libSystem.dylib", RTLD_LAZY);
+        if (libSystem != NULL)
         {
-            int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libdispatch, "dispatch_allow_send_signals");
+            int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libSystem, "dispatch_allow_send_signals");
             if (dispatch_allow_send_signals_ptr != NULL)
             {
                 int st = dispatch_allow_send_signals_ptr(INJECT_ACTIVATION_SIGNAL);

--- a/src/coreclr/pal/src/include/pal/signal.hpp
+++ b/src/coreclr/pal/src/include/pal/signal.hpp
@@ -117,4 +117,14 @@ Function :
 --*/
 void SEHCleanupSignals();
 
+/*++
+Function :
+    UnmaskActivationSignal
+
+    Unmask the INJECT_ACTIVATION_SIGNAL for the current thread
+
+    (no parameters, no return value)
+--*/
+void UnmaskActivationSignal();
+
 #endif /* _PAL_SIGNAL_HPP_ */

--- a/src/coreclr/pal/src/init/sxs.cpp
+++ b/src/coreclr/pal/src/init/sxs.cpp
@@ -91,6 +91,9 @@ AllocatePalThread(CPalThread **ppThread)
 
     PROCAddThread(pThread, pThread);
 
+    // Unmask the activation signal so that GC can suspend this thread
+    UnmaskActivationSignal();
+
 exit:
     *ppThread = pThread;
     return palError;

--- a/src/tests/Regressions/coreclr/GitHub_102887/CMakeLists.txt
+++ b/src/tests/Regressions/coreclr/GitHub_102887/CMakeLists.txt
@@ -1,6 +1,9 @@
-include_directories(${INC_PLATFORM_DIR})
+# The test is valid only on Apple
+if (CLR_CMAKE_TARGET_APPLE)
+  include_directories(${INC_PLATFORM_DIR})
 
-add_library(nativetest102887 SHARED nativetest102887.cpp)
+  add_library(nativetest102887 SHARED nativetest102887.cpp)
 
-# add the install targets
-install (TARGETS nativetest102887 DESTINATION bin)
+  # add the install targets
+  install (TARGETS nativetest102887 DESTINATION bin)
+endif ()

--- a/src/tests/Regressions/coreclr/GitHub_102887/CMakeLists.txt
+++ b/src/tests/Regressions/coreclr/GitHub_102887/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories(${INC_PLATFORM_DIR})
+
+add_library(nativetest102887 SHARED nativetest102887.cpp)
+
+# add the install targets
+install (TARGETS nativetest102887 DESTINATION bin)

--- a/src/tests/Regressions/coreclr/GitHub_102887/nativetest102887.cpp
+++ b/src/tests/Regressions/coreclr/GitHub_102887/nativetest102887.cpp
@@ -3,6 +3,7 @@
 
 #include <platformdefines.h>
 
+#include <dlfcn.h>
 #include <dispatch/dispatch.h>
 #include <dispatch/queue.h>
 
@@ -10,4 +11,17 @@ extern "C" DLL_EXPORT void StartDispatchQueueThread(void (*work)(void* args))
 {
     dispatch_queue_global_t q = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
     dispatch_async_f(q, NULL, work);
+}
+
+extern "C" DLL_EXPORT bool SupportsSendingSignalsToDispatchQueueThread()
+{
+    void *libSystem = dlopen("/usr/lib/libSystem.dylib", RTLD_LAZY);
+    bool result = false;
+    if (libSystem != NULL)
+    {
+        int (*dispatch_allow_send_signals_ptr)(int) = (int (*)(int))dlsym(libSystem, "dispatch_allow_send_signals");
+        result = (dispatch_allow_send_signals_ptr != NULL);
+    }
+
+    return result;
 }

--- a/src/tests/Regressions/coreclr/GitHub_102887/nativetest102887.cpp
+++ b/src/tests/Regressions/coreclr/GitHub_102887/nativetest102887.cpp
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <platformdefines.h>
+
+#include <dispatch/dispatch.h>
+#include <dispatch/queue.h>
+
+extern "C" DLL_EXPORT void StartDispatchQueueThread(void (*work)(void* args))
+{
+    dispatch_queue_global_t q = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0);
+    dispatch_async_f(q, NULL, work);
+}

--- a/src/tests/Regressions/coreclr/GitHub_102887/test102887.cs
+++ b/src/tests/Regressions/coreclr/GitHub_102887/test102887.cs
@@ -11,6 +11,10 @@ public class Test102887
     [DllImport("nativetest102887")]
     private static extern void StartDispatchQueueThread(DispatchQueueWork start);
 
+    [DllImport("nativetest102887")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SupportsSendingSignalsToDispatchQueueThread();
+
     static volatile int s_cnt;
     static ManualResetEvent s_workStarted = new ManualResetEvent(false);
 
@@ -26,12 +30,17 @@ public class Test102887
     [Fact]
     public static void TestEntryPoint()
     {
-        StartDispatchQueueThread(RunOnDispatchQueueThread);
-        s_workStarted.WaitOne();
-
-        for (int i = 0; i < 100; i++)
+        // Skip the test if the current OS doesn't support sending signals to the dispatch queue threads
+        if (SupportsSendingSignalsToDispatchQueueThread())
         {
-            GC.Collect(2);
+            Console.WriteLine("Sending signals to dispatch queue thread is supported, testing it now");
+            StartDispatchQueueThread(RunOnDispatchQueueThread);
+            s_workStarted.WaitOne();
+
+            for (int i = 0; i < 100; i++)
+            {
+                GC.Collect(2);
+            }
         }
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_102887/test102887.cs
+++ b/src/tests/Regressions/coreclr/GitHub_102887/test102887.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Xunit;
+
+public class Test102887
+{
+    delegate void DispatchQueueWork(IntPtr args);
+    [DllImport("nativetest102887")]
+    private static extern void StartDispatchQueueThread(DispatchQueueWork start);
+
+    static volatile int s_cnt;
+    static ManualResetEvent s_workStarted = new ManualResetEvent(false);
+
+    private static void RunOnDispatchQueueThread(IntPtr args)
+    {
+        s_workStarted.Set();
+        while (true)
+        {
+            s_cnt++;
+        }
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        StartDispatchQueueThread(RunOnDispatchQueueThread);
+        s_workStarted.WaitOne();
+
+        for (int i = 0; i < 100; i++)
+        {
+            GC.Collect(2);
+        }
+    }
+}
+

--- a/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
+    <!-- Needed for CLRTestTargetUnsupported -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test102887.cs" />

--- a/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test102887.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestSourceDir)Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <CMakeProjectReference Include="CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_102887/test102887.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test102887.cs" />


### PR DESCRIPTION
Until recently, it was not possible to send activation signal to Apple dispatch queue threads using pthread_kill. So in case a .NET code was running on such a thread, it could end up blocking runtime suspension in some cases. Recently, Apple has implemented a new API to enable sending specific signals to the dispatch queues, the dispatch_allow_send_signals.

This change adds a call to that API to the PAL initialization code.