### PR TITLE
fix NetworkInterface properties on Windows

### DIFF
--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -85,6 +85,8 @@ namespace System.Net.NetworkInformation
             List<SystemNetworkInterface> interfaceList = new List<SystemNetworkInterface>();
 
             Interop.IpHlpApi.GetAdaptersAddressesFlags flags =
+                Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeGateways |
+                Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeWins |
                 Interop.IpHlpApi.GetAdaptersAddressesFlags.IncludeAllInterfaces;
 
             // Figure out the right buffer size for the adapter information.


### PR DESCRIPTION
fixes https://github.com/dotnet/runtime/issues/101710
It is regression from  #100824. It did _replaced_ original flags with `IncludeAllInterfaces`. But the interaction to include all interfaces does not guarantied that all of them would have all properties populated. 
Strangely, on my dev box it would still show gateway even with the change but some Windows instances would not. 
So this change brings all flags together and OR them with the new one to get superset. 

Tested on system @Junjun-zhao  kindly provided.  