### PR TITLE
Optimize HttpUtility.JavaScriptStringEncode by using SearchValues

### DIFF
--- a/src/libraries/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
+++ b/src/libraries/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
@@ -17,6 +17,8 @@
              Link="Common\System\HexConverter.cs" />
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.AppendSpanFormattable.cs"
+             Link="Common\System\Text\ValueStringBuilder.AppendSpanFormattable.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
+++ b/src/libraries/System.Web.HttpUtility/src/System.Web.HttpUtility.csproj
@@ -15,6 +15,8 @@
     <Compile Include="System\Web\Util\Utf16StringValidator.cs" />
     <Compile Include="$(CommonPath)System\HexConverter.cs"
              Link="Common\System\HexConverter.cs" />
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
+             Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/HttpUtility.cs
@@ -237,12 +237,8 @@ namespace System.Web
         [return: NotNullIfNotNull(nameof(bytes))]
         public static byte[]? UrlDecodeToBytes(byte[]? bytes, int offset, int count) => HttpEncoder.UrlDecode(bytes, offset, count);
 
-        public static string JavaScriptStringEncode(string? value) => HttpEncoder.JavaScriptStringEncode(value);
+        public static string JavaScriptStringEncode(string? value) => HttpEncoder.JavaScriptStringEncode(value, false);
 
-        public static string JavaScriptStringEncode(string? value, bool addDoubleQuotes)
-        {
-            string encoded = HttpEncoder.JavaScriptStringEncode(value);
-            return addDoubleQuotes ? "\"" + encoded + "\"" : encoded;
-        }
+        public static string JavaScriptStringEncode(string? value, bool addDoubleQuotes) => HttpEncoder.JavaScriptStringEncode(value, addDoubleQuotes);
     }
 }

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -130,15 +130,10 @@ namespace System.Web.Util
 
         internal static string JavaScriptStringEncode(string? value, bool addDoubleQuotes)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return addDoubleQuotes ? @"""""" : string.Empty;
-            }
-
             int i = value.AsSpan().IndexOfAny(s_invalidJavaScriptChars);
             if (i < 0)
             {
-                return addDoubleQuotes ? $"\"{value}\"" : value;
+                return addDoubleQuotes ? $"\"{value}\"" : value ?? string.Empty;
             }
 
             return EncodeCore(value, i, addDoubleQuotes);

--- a/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
+++ b/src/libraries/System.Web.HttpUtility/src/System/Web/Util/HttpEncoder.cs
@@ -140,7 +140,7 @@ namespace System.Web.Util
 
             static string EncodeCore(ReadOnlySpan<char> value, int i, bool addDoubleQuotes)
             {
-                var vsb = new ValueStringBuilder(stackalloc char[512]);
+                var vsb = new ValueStringBuilder(stackalloc char[StackallocThreshold]);
                 if (addDoubleQuotes)
                 {
                     vsb.Append('"');

--- a/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -310,8 +310,7 @@ namespace System.Web.Tests
                 yield return new object[] { "", "" };
                 yield return new object[] {"No escaping needed.", "No escaping needed."};
                 yield return new object[] {"The \t and \n will need to be escaped.", "The \\t and \\n will need to be escaped."};
-                yield return new object[] { "The \t and \n will need to be escaped.", "The \\t and \\n will need to be escaped." };
-                yield return new object[] { "The \t and \n will need to be escaped.>", "The \\t and \\n will need to be escaped.\\u003e" };
+                yield return new object[] {"The \t and \n will need to be escaped.>", "The \\t and \\n will need to be escaped.\\u003e" };
                 for (char c = char.MinValue; c < TestMaxChar; c++)
                 {
                     if (c >= 0 && c <= 7 || c == 11 || c >= 14 && c <= 31 || c == 38 || c == 39 || c == 60 || c == 62 || c == 133 || c == 8232 || c == 8233)

--- a/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
+++ b/src/libraries/System.Web.HttpUtility/tests/HttpUtility/HttpUtilityTest.cs
@@ -310,6 +310,8 @@ namespace System.Web.Tests
                 yield return new object[] { "", "" };
                 yield return new object[] {"No escaping needed.", "No escaping needed."};
                 yield return new object[] {"The \t and \n will need to be escaped.", "The \\t and \\n will need to be escaped."};
+                yield return new object[] { "The \t and \n will need to be escaped.", "The \\t and \\n will need to be escaped." };
+                yield return new object[] { "The \t and \n will need to be escaped.>", "The \\t and \\n will need to be escaped.\\u003e" };
                 for (char c = char.MinValue; c < TestMaxChar; c++)
                 {
                     if (c >= 0 && c <= 7 || c == 11 || c >= 14 && c <= 31 || c == 38 || c == 39 || c == 60 || c == 62 || c == 133 || c == 8232 || c == 8233)


### PR DESCRIPTION
Optimize HttpUtility.JavaScriptStringEncode by using SearchValues for invalid JavaScript characters.

Benchmark
``` C#
[MemoryDiagnoser]
public class HttpUtilityBenchmarks
{
	[Params(true, false)]
	public bool AddQuotes { get; set; }

	[Benchmark(Baseline = true)]
	public string JavaScriptStringEncode_NoEscape() => HttpUtility.JavaScriptStringEncode("No escaping needed.", AddQuotes);

	[Benchmark]
	public string JavaScriptStringEncode_NoEscape_PR() => MyHttpUtility.JavaScriptStringEncode("No escaping needed.", AddQuotes);

	[Benchmark]
	public string JavaScriptStringEncode_Escape() => HttpUtility.JavaScriptStringEncode("The \t and \n will need to be escaped.", AddQuotes);

	[Benchmark]
	public string JavaScriptStringEncode_Escape_PR() => MyHttpUtility.JavaScriptStringEncode("The \t and \n will need to be escaped.", AddQuotes);
}
```

Results:
| Method                             | AddQuotes | Mean      | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|----------------------------------- |---------- |----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| JavaScriptStringEncode_NoEscape    | False     | 27.485 ns | 0.2172 ns | 0.2032 ns |  1.00 |    0.00 |      - |         - |          NA |
| JavaScriptStringEncode_NoEscape_PR | False     |  2.558 ns | 0.0873 ns | 0.0857 ns |  0.09 |    0.00 |      - |         - |          NA |
| JavaScriptStringEncode_Escape      | False     | 75.264 ns | 0.7011 ns | 0.5854 ns |  2.74 |    0.02 | 0.0315 |     264 B |          NA |
| JavaScriptStringEncode_Escape_PR   | False     | 36.093 ns | 0.5054 ns | 0.3945 ns |  1.31 |    0.02 | 0.0315 |     264 B |          NA |
|                                    |           |           |           |           |       |         |        |           |             |
| JavaScriptStringEncode_NoEscape    | True      | 35.001 ns | 0.4262 ns | 0.3778 ns |  1.00 |    0.00 | 0.0076 |      64 B |        1.00 |
| JavaScriptStringEncode_NoEscape_PR | True      |  8.809 ns | 0.2115 ns | 0.3100 ns |  0.26 |    0.01 | 0.0076 |      64 B |        1.00 |
| JavaScriptStringEncode_Escape      | True      | 86.737 ns | 1.7250 ns | 1.6136 ns |  2.48 |    0.04 | 0.0440 |     368 B |        5.75 |
| JavaScriptStringEncode_Escape_PR   | True      | 37.486 ns | 0.7770 ns | 1.4971 ns |  1.10 |    0.03 | 0.0315 |     264 B |        4.12 |