### PR TITLE
[vm] fix confusing use of m_pCanonMT (NFC)

### DIFF
--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -39,7 +39,8 @@ FORCEINLINE PTR_EEClass MethodTable::GetClassWithPossibleAV()
     {
         // pointer to canonical MethodTable.
         TADDR canonicalMethodTable = union_getPointer(addr);
-        return PTR_EEClass(PTR_MethodTable(canonicalMethodTable)->m_pCanonMT);
+        // a canonical method table always points at its EEClass, and m_pEEClass has no mask bit, so just return it
+        return PTR_MethodTable(canonicalMethodTable)->m_pEEClass;
     }
 }
 


### PR DESCRIPTION
`m_pCanonMT` and `m_pEEClass` are union members so they're the same value where the lowest bit is used as a flag to indicate which one you have.  In a canonical method table, you always have `m_pEEClass`. `m_pEEClass` has the lowest bit cleared.  So to get the actual pointer, just return it.

This just cleans up hard to read code, there is no functional change at runtime.