### PR TITLE
Baseline failing pri-1 JIT tests

### DIFF
--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_32BIT_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_32BIT_unaligned_1.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_64BIT_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_64BIT_unaligned_1.ilproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist64.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_ARM_unaligned_1.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist_Target_ARM_unaligned_1.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglistARM.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_32BIT_unaligned_2.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_32BIT_unaligned_2.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_64BIT_unaligned_2.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_64BIT_unaligned_2.ilproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist64.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_ARM_unaligned_2.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist_Target_ARM_unaligned_2.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglistARM.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_32BIT_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_32BIT_unaligned_4.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_64BIT_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_64BIT_unaligned_4.ilproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist64.il" />

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_ARM_unaligned_4.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist_Target_ARM_unaligned_4.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglistARM.il" />

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_32BIT_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_32BIT_volatile.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist.il" />

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_64BIT_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_64BIT_volatile.ilproj
@@ -7,6 +7,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' != '64'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglist64.il" />

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_ARM_volatile.ilproj
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/arglist_Target_ARM_volatile.ilproj
@@ -8,6 +8,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'armel'">true</CLRTestTargetUnsupported>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arglistARM.il" />

--- a/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.csproj
+++ b/src/tests/JIT/IL_Conformance/Convert/TestConvertFromIntegral.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <!-- Test uses Reflection.Emit -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/JIT/Methodical/Coverage/arglist_pos.ilproj
+++ b/src/tests/JIT/Methodical/Coverage/arglist_pos.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/refany/seq_d.ilproj
+++ b/src/tests/JIT/Methodical/refany/seq_d.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/refany/seq_r.ilproj
+++ b/src/tests/JIT/Methodical/refany/seq_r.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b36472/b36472.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b36472/b36472.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b37598/b37598.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b37598/b37598.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41391/b41391.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41391/b41391.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b46867/b46867.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b46867/b46867.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31745/b31745.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31745/b31745.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31746/b31746.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31746/b31746.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b37646/b37646.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b37646/b37646.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b41852/b41852.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b41852/b41852.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/b399444.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Hits CodeView implementation limitations -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/gc/misc/funclet.csproj
+++ b/src/tests/JIT/jit64/gc/misc/funclet.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i00.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i00.ilproj
@@ -3,6 +3,8 @@
     <!-- Needed for CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i01.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i01.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i02.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i02.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i03.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i03.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i10.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i10.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i11.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i11.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i12.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i12.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i13.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i13.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i30.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i30.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i31.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i31.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i32.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i32.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i33.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i33.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i50.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i50.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i51.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i51.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i52.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i52.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i53.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i53.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i60.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i60.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows uses native varargs -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i61.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i61.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i62.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i62.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i63.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i63.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i70.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i70.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i71.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i71.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i72.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i72.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i73.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i73.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i80.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i80.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i81.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i81.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i82.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i82.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/jit64/mcc/interop/mcc_i83.ilproj
+++ b/src/tests/JIT/jit64/mcc/interop/mcc_i83.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1101,10 +1101,20 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_r8_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_struct_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_u8_r\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_b_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_i4_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_objref_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_r4_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_r8_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge\huge_struct_d\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge\huge_struct\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\huge\huge_u8_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\address_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\ldelem_get_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\address_r\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\arrres_il_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\gcarr_il_r\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\gcarr_il_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\misc\ldelem_get_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\range\float64_range1_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\range\float64_range2_d\*" />
@@ -1121,6 +1131,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\range\int32_range1_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\Arrays\range\int32_range2_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\int64\arrays\hugedim_r\*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\int64\arrays\hugedim_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\refany\array3_d\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\refany\array3_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\tailcall\deep_array_nz_d\*" />
@@ -1129,6 +1140,7 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical\VT\port\huge_gcref_r\*" />
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/Benchstones/MDBenchI/MDGeneralArray/MDGeneralArray/*" />
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/regressions/GitHub_93597/GitHub_93597/*" />
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b59899/b59899/*" />
 
         <!-- Covariant returns -->
         <!-- https://github.com/dotnet/runtimelab/issues/205 -->


### PR DESCRIPTION
Also known things - varargs, Ref.Emit, arrays with non-zero lower bounds, etc.

Cc @dotnet/ilc-contrib 