### PR TITLE
Tweak the fuzzing readme

### DIFF
--- a/src/libraries/Fuzzing/README.md
+++ b/src/libraries/Fuzzing/README.md
@@ -31,17 +31,6 @@ dotnet tool install --global SharpFuzz.CommandLine
 > The project uses a checked runtime + debug libraries configuration by default.
 > If you want to use a different configuration, make sure to also adjust the artifact paths in `nuget.config`.
 
-### Running against a sample input
-
-The program accepts two arguments: the name of the fuzzer and the path to a sample input file / directory.
-To run the HttpHeaders target against the `inputs` directory, use the following command:
-
-```cmd
-cd src/libraries/Fuzzing/DotnetFuzzing
-
-dotnet run HttpHeadersFuzzer inputs
-```
-
 ### Fuzzing locally
 
 The `prepare-onefuzz` command will create separate directories for each fuzzing target, instrument the relevant assemblies, and generate a helper script for running them locally.
@@ -50,7 +39,7 @@ Note that this command must be ran on the published artifacts (won't work with `
 ```cmd
 cd src/libraries/Fuzzing/DotnetFuzzing
 
-dotnet publish -o publish && publish/DotnetFuzzing.exe prepare-onefuzz deployment
+dotnet publish -o publish; publish/DotnetFuzzing.exe prepare-onefuzz deployment
 ```
 
 You can now start fuzzing by running the `local-run.bat` script in the folder of the fuzzer you are interested in.
@@ -92,3 +81,16 @@ internal sealed class IPAddressFuzzer : IFuzzer
 
 Once you've created the new target, you can follow instructions above to run it locally.
 Targets are discovered via reflection, so they will automatically become available for local runs and continuous fuzzing in CI.
+
+### Running against a sample input
+
+The program accepts two arguments: the name of the fuzzer and the path to a sample input file / directory.
+To run the HttpHeaders target against the `inputs` directory, use the following command:
+
+```cmd
+cd src/libraries/Fuzzing/DotnetFuzzing
+
+dotnet run HttpHeadersFuzzer inputs
+```
+
+This can be useful when debugging a crash, or running the fuzzer over existing inputs to collect code coverage.


### PR DESCRIPTION
`command1 && command2` isn't supported by older versions of Powershell - switching the doc to `;`.

Moved "Running against a sample input" to the bottom of the document since it's less likely you'd want to do that first.