### PR TITLE
Adding a default IEnumerable.GetEnumerator implementation to IEnumerable<T>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEnumerable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/IEnumerable.cs
@@ -17,5 +17,7 @@ namespace System.Collections.Generic
         [DynamicDependency(nameof(Array.InternalArray__IEnumerable_GetEnumerator) + "``1 ", typeof(Array))]
 #endif
         new IEnumerator<T> GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }


### PR DESCRIPTION
Minor QOL improvement for .NET developers.  I'm honestly surprised that this was not literally the very first thing anyone ever did with the Default Interface Implementation feature.