### PR TITLE
Better createdump error message for single-file apps for heap or triage dump types.

### DIFF
--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -321,9 +321,7 @@ CrashInfo::InitializeDAC(DumpType dumpType)
     {
         if (m_appModel == AppModelType::SingleFile)
         {
-            printf_error("Only full dumps are supported by single file apps without the DAC module. Either copy %s to %s or change the dump type to full (DOTNET_DbgMiniDumpType=4)\n",
-                MAKEDLLNAME_A("mscordaccore"),
-                dacPath.c_str());
+            printf_error("Only full dumps are supported by single file apps. Change the dump type to full (DOTNET_DbgMiniDumpType=4)\n");
         }
         else
         {

--- a/src/coreclr/debug/createdump/crashinfo.cpp
+++ b/src/coreclr/debug/createdump/crashinfo.cpp
@@ -319,7 +319,16 @@ CrashInfo::InitializeDAC(DumpType dumpType)
     m_dacModule = dlopen(dacPath.c_str(), RTLD_LAZY);
     if (m_dacModule == nullptr)
     {
-        printf_error("InitializeDAC: dlopen(%s) FAILED %s\n", dacPath.c_str(), dlerror());
+        if (m_appModel == AppModelType::SingleFile)
+        {
+            printf_error("Only full dumps are supported by single file apps without the DAC module. Either copy %s to %s or change the dump type to full (DOTNET_DbgMiniDumpType=4)\n",
+                MAKEDLLNAME_A("mscordaccore"),
+                dacPath.c_str());
+        }
+        else
+        {
+            printf_error("InitializeDAC: dlopen(%s) FAILED %s\n", dacPath.c_str(), dlerror());
+        }
         goto exit;
     }
     pfnDllMain = (PFN_DLLMAIN)dlsym(m_dacModule, "DllMain");

--- a/src/coreclr/debug/createdump/createdumpmain.cpp
+++ b/src/coreclr/debug/createdump/createdumpmain.cpp
@@ -229,6 +229,7 @@ int createdump_main(const int argc, const char* argv[])
         exitCode = -1;
     }
 
+    fflush(stderr);
     fflush(g_stdout);
 
     if (g_logfile != nullptr)
@@ -352,7 +353,7 @@ GetTimeStamp()
 #ifdef HOST_UNIX
 
 static void
-trace_prefix()
+trace_prefix(const char* format, va_list args)
 {
     // Only add this prefix if logging to the console
     if (g_logfile == nullptr)
@@ -360,6 +361,8 @@ trace_prefix()
         fprintf(g_stdout, "[createdump] ");
     }
     fprintf(g_stdout, "%08" PRIx64 " ", GetTimeStamp());
+    vfprintf(g_stdout, format, args);
+    fflush(g_stdout);
 }
 
 void
@@ -369,9 +372,7 @@ trace_printf(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
-        trace_prefix();
-        vfprintf(g_stdout, format, args);
-        fflush(g_stdout);
+        trace_prefix(format, args);
         va_end(args);
     }
 }
@@ -383,9 +384,7 @@ trace_verbose_printf(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
-        trace_prefix();
-        vfprintf(g_stdout, format, args);
-        fflush(g_stdout);
+        trace_prefix(format, args);
         va_end(args);
     }
 }
@@ -397,9 +396,7 @@ CrashInfo::Trace(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
-        trace_prefix();
-        vfprintf(g_stdout, format, args);
-        fflush(g_stdout);
+        trace_prefix(format, args);
         va_end(args);
     }
 }
@@ -411,9 +408,7 @@ CrashInfo::TraceVerbose(const char* format, ...)
     {
         va_list args;
         va_start(args, format);
-        trace_prefix();
-        vfprintf(g_stdout, format, args);
-        fflush(g_stdout);
+        trace_prefix(format, args);
         va_end(args);
     }
 }


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/101957

Cleanup printf/trace functions and make sure error messages are flushed.