### PR TITLE
Fix retry loop around Process.Kill

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -311,6 +311,7 @@ namespace CoreclrTestLib
                     try
                     {
                         createdump.Kill(entireProcessTree: true);
+                        break;
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
We do not need to be retrying after Process.Kill succeeds