### PR TITLE
Remove cached cgroup values

### DIFF
--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -422,7 +422,7 @@ public:
     // Remarks:
     //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
     //  specified, it returns amount of actual physical memory.
-    static uint64_t GetPhysicalMemoryLimit(bool* is_restricted=NULL);
+    static uint64_t GetPhysicalMemoryLimit(bool* is_restricted=NULL, bool refresh=false);
 
     // Get memory status
     // Parameters:

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -52832,7 +52832,7 @@ int gc_heap::refresh_memory_limit()
     size_t old_heap_hard_limit_poh = heap_hard_limit_oh[poh];
     bool old_hard_limit_config_p = hard_limit_config_p;
 
-    total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted_physical_mem);
+    total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted_physical_mem, true);
 
     bool succeed = true;
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1212,14 +1212,14 @@ size_t GCToOSInterface::GetVirtualMemoryMaxAddress()
 // Remarks:
 //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
 //  specified, it returns amount of actual physical memory.
-uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted)
+uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted, bool refresh)
 {
     size_t restricted_limit;
     if (is_restricted)
         *is_restricted = false;
 
     // The limit was not cached
-    if (g_RestrictedPhysicalMemoryLimit == 0)
+    if (g_RestrictedPhysicalMemoryLimit == 0 || refresh)
     {
         restricted_limit = GetRestrictedPhysicalMemoryLimit();
         VolatileStore(&g_RestrictedPhysicalMemoryLimit, restricted_limit);

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1218,7 +1218,6 @@ uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted, bool refre
     if (is_restricted)
         *is_restricted = false;
 
-    // The limit was not cached
     if (g_RestrictedPhysicalMemoryLimit == 0 || refresh)
     {
         restricted_limit = GetRestrictedPhysicalMemoryLimit();

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -969,7 +969,7 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
 // Remarks:
 //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
 //  specified, it returns amount of actual physical memory.
-uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted)
+uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted, bool refresh)
 {
     if (is_restricted)
         *is_restricted = false;


### PR DESCRIPTION
This will make `RefreshMemoryLimit` works when the actual cgroup value changes.