### PR TITLE
Don't needlessly track the method handle for hwintrinsics when optimizations are disabled

### DIFF
--- a/src/coreclr/jit/hwintrinsic.cpp
+++ b/src/coreclr/jit/hwintrinsic.cpp
@@ -1312,6 +1312,12 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             {
                 return impNonConstFallback(intrinsic, retType, simdBaseJitType);
             }
+            else if (!opts.OptimizationEnabled())
+            {
+                // Only enable late stage rewriting if optimizations are enabled
+                // as we won't otherwise encounter a constant at the later point
+                return nullptr;
+            }
             else
             {
                 setMethodHandle = true;
@@ -1342,6 +1348,12 @@ GenTree* Compiler::impHWIntrinsic(NamedIntrinsic        intrinsic,
             if (useFallback)
             {
                 return impNonConstFallback(intrinsic, retType, simdBaseJitType);
+            }
+            else if (!opts.OptimizationEnabled())
+            {
+                // Only enable late stage rewriting if optimizations are enabled
+                // as we won't otherwise encounter a constant at the later point
+                return nullptr;
             }
             else
             {

--- a/src/coreclr/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/jit/hwintrinsicarm64.cpp
@@ -1877,6 +1877,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs == 2);
 
+                if (!opts.OptimizationEnabled())
+                {
+                    // Only enable late stage rewriting if optimizations are enabled
+                    // as we won't otherwise encounter a constant at the later point
+                    return nullptr;
+                }
+
                 op2 = impSIMDPopStack();
                 op1 = impSIMDPopStack();
 
@@ -2215,6 +2222,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             if (!indexOp->OperIsConst())
             {
+                if (!opts.OptimizationEnabled())
+                {
+                    // Only enable late stage rewriting if optimizations are enabled
+                    // as we won't otherwise encounter a constant at the later point
+                    return nullptr;
+                }
+
                 op3 = impPopStack().val;
                 op2 = impPopStack().val;
                 op1 = impSIMDPopStack();

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -2903,6 +2903,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             {
                 assert(sig->numArgs == 2);
 
+                if (!opts.OptimizationEnabled())
+                {
+                    // Only enable late stage rewriting if optimizations are enabled
+                    // as we won't otherwise encounter a constant at the later point
+                    return nullptr;
+                }
+
                 op2 = impSIMDPopStack();
                 op1 = impSIMDPopStack();
 
@@ -3215,6 +3222,13 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
 
             if (!indexOp->OperIsConst())
             {
+                if (!opts.OptimizationEnabled())
+                {
+                    // Only enable late stage rewriting if optimizations are enabled
+                    // as we won't otherwise encounter a constant at the later point
+                    return nullptr;
+                }
+
                 op3 = impPopStack().val;
                 op2 = impPopStack().val;
                 op1 = impSIMDPopStack();


### PR DESCRIPTION
This should fix the minopts pessimization from https://github.com/dotnet/runtime/pull/102827

There is still opportunity to improve the codegen further for fullopts, when it does need to stay a call, but that's less common and so less meaningful to fix.