### PR TITLE
Revert "Content-Length header not always returned when enumerating HttpContentHeaders"

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -20,7 +20,6 @@ namespace System.Net.Http
 
             _content = content;
             _count = content.Length;
-            Headers.ContentLength = _count;
         }
 
         public ByteArrayContent(byte[] content, int offset, int count)
@@ -36,7 +35,6 @@ namespace System.Net.Http
             _content = content;
             _offset = offset;
             _count = count;
-            Headers.ContentLength = _count;
         }
 
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
@@ -11,11 +11,8 @@ namespace System.Net.Http
     {
         private readonly ReadOnlyMemory<byte> _content;
 
-        public ReadOnlyMemoryContent(ReadOnlyMemory<byte> content)
-        {
+        public ReadOnlyMemoryContent(ReadOnlyMemory<byte> content) =>
             _content = content;
-            Headers.ContentLength = content.Length;
-        }
 
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -23,11 +23,6 @@ namespace System.Net.Http
 
             // Indicate that we should use default buffer size by setting size to 0.
             InitializeContent(content, 0);
-
-            if (TryComputeLength(out long contentLength))
-            {
-                Headers.ContentLength = contentLength;
-            }
         }
 
         public StreamContent(Stream content, int bufferSize)
@@ -36,11 +31,6 @@ namespace System.Net.Http
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
 
             InitializeContent(content, bufferSize);
-
-            if (TryComputeLength(out long contentLength))
-            {
-                Headers.ContentLength = contentLength;
-            }
         }
 
         [MemberNotNull(nameof(_content))]

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ByteArrayContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ByteArrayContentTest.cs
@@ -66,9 +66,6 @@ namespace System.Net.Http.Functional.Tests
             var contentData = new byte[10];
             var content = new ByteArrayContent(contentData);
 
-            Assert.Contains("Content-Length", content.Headers.ToString());
-            Assert.Contains(content.Headers, h => h.Key == "Content-Length");
-            Assert.Contains(content.Headers.NonValidated, h => h.Key == "Content-Length");
             Assert.Equal(contentData.Length, content.Headers.ContentLength);
         }
 
@@ -78,9 +75,6 @@ namespace System.Net.Http.Functional.Tests
             var contentData = new byte[10];
             var content = new ByteArrayContent(contentData, 5, 3);
 
-            Assert.Contains("Content-Length", content.Headers.ToString());
-            Assert.Contains(content.Headers, h => h.Key == "Content-Length");
-            Assert.Contains(content.Headers.NonValidated, h => h.Key == "Content-Length");
             Assert.Equal(3, content.Headers.ContentLength);
         }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpRequestMessageTest.cs
@@ -210,7 +210,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(
                 "Method: PUT, RequestUri: 'http://a.com/', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:" + Environment.NewLine +
                 $"{{{Environment.NewLine}" +
-                "  Content-Length: 7" + Environment.NewLine +
                 "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                 "}", rm.ToString());
 
@@ -229,7 +228,6 @@ namespace System.Net.Http.Functional.Tests
                     "  Accept: text/xml; q=0.1" + Environment.NewLine +
                     "  Accept-Language: en-US,en;q=0.5" + Environment.NewLine +
                     "  Custom-Request-Header: value1" + Environment.NewLine +
-                    "  Content-Length: 7" + Environment.NewLine +
                     "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                     "  Custom-Content-Header: value2" + Environment.NewLine +
                     "}", rm.ToString());

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpResponseMessageTest.cs
@@ -312,7 +312,6 @@ namespace System.Net.Http.Functional.Tests
                 Assert.Equal(
                     "StatusCode: 400, ReasonPhrase: 'Bad Request', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:" + Environment.NewLine +
                     "{" + Environment.NewLine +
-                    "  Content-Length: 7" + Environment.NewLine +
                     "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                     "}", rm.ToString());
 
@@ -327,7 +326,6 @@ namespace System.Net.Http.Functional.Tests
                     "  Accept-Ranges: bytes" + Environment.NewLine +
                     "  Accept-Ranges: pages" + Environment.NewLine +
                     "  Custom-Response-Header: value1" + Environment.NewLine +
-                    "  Content-Length: 7" + Environment.NewLine +
                     "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                     "  Custom-Content-Header: value2" + Environment.NewLine +
                     "}", rm.ToString());
@@ -341,7 +339,6 @@ namespace System.Net.Http.Functional.Tests
                     "  Accept-Ranges: bytes" + Environment.NewLine +
                     "  Accept-Ranges: pages" + Environment.NewLine +
                     "  Custom-Response-Header: value1" + Environment.NewLine +
-                    "  Content-Length: 7" + Environment.NewLine +
                     "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                     "  Custom-Content-Header: value2" + Environment.NewLine +
                     "}, Trailing Headers:" + Environment.NewLine +

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MultipartContentTest.cs
@@ -160,7 +160,6 @@ namespace System.Net.Http.Functional.Tests
 
             Assert.Equal(
                 "--theBoundary\r\n" +
-                "Content-Length: 26\r\n" +
                 "someHeaderName: andSomeHeaderValue\r\n" +
                 "someOtherHeaderName: withNotOne, ButTwoValues\r\n" +
                 "oneMoreHeader: withNotOne, AndNotTwo, butThreeValues\r\n" +
@@ -183,11 +182,9 @@ namespace System.Net.Http.Functional.Tests
 
             Assert.Equal(
                 "--theBoundary\r\n" +
-                "Content-Length: 26\r\n" +
                 "\r\n" +
                 "This is a ByteArrayContent\r\n" +
                 "--theBoundary\r\n" +
-                "Content-Length: 23\r\n" +
                 "Content-Type: text/plain; charset=utf-8\r\n" +
                 "\r\n" +
                 "This is a StringContent\r\n" +
@@ -480,31 +477,28 @@ namespace System.Net.Http.Functional.Tests
 
             byte[] expected = Concat(
                 "--fooBoundary\r\n"u8.ToArray(),
-                "Content-Length: 4\r\n"u8.ToArray(),
                 "Content-Type: text/plain; charset=utf-8\r\n"u8.ToArray(),
                 "latin1: "u8.ToArray(),
                 Encoding.Latin1.GetBytes("\U0001F600"),
                 "\r\n\r\n"u8.ToArray(),
                 "bar1"u8.ToArray(),
                 "\r\n--fooBoundary\r\n"u8.ToArray(),
-                "Content-Length: 4\r\n"u8.ToArray(),
                 "utf8: "u8.ToArray(),
                 "\U0001F600"u8.ToArray(),
                 "\r\n\r\n"u8.ToArray(),
                 "bar2"u8.ToArray(),
                 "\r\n--fooBoundary\r\n"u8.ToArray(),
-                "Content-Length: 4\r\n"u8.ToArray(),
                 "ascii: "u8.ToArray(),
                 Encoding.ASCII.GetBytes("\U0001F600"),
                 "\r\n\r\n"u8.ToArray(),
                 "bar3"u8.ToArray(),
                 "\r\n--fooBoundary\r\n"u8.ToArray(),
-                "Content-Length: 4\r\n"u8.ToArray(),
                 "default: "u8.ToArray(),
                 Encoding.Latin1.GetBytes("\U0001F600"),
                 "\r\n\r\n"u8.ToArray(),
                 "bar4"u8.ToArray(),
                 "\r\n--fooBoundary--\r\n"u8.ToArray());
+
             Assert.Equal(expected, ms.ToArray());
 
             static byte[] Concat(params byte[][] arrays) => arrays.SelectMany(b => b).ToArray();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MultipartFormDataContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MultipartFormDataContentTest.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data\r\n\r\nHello World\r\n--test_boundary--\r\n",
                 result);
         }
@@ -110,7 +110,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=test_name\r\n\r\nHello World\r\n--test_boundary--\r\n",
                 result);
         }
@@ -128,7 +128,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=test_name; "
                 + "filename=test_file_name; filename*=utf-8\'\'test_file_name\r\n\r\n"
                 + "Hello World\r\n--test_boundary--\r\n",
@@ -148,7 +148,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=\"test name\"\r\n\r\nHello World\r\n--test_boundary--\r\n",
                 result);
         }
@@ -166,7 +166,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\""
                 + "\r\n\r\nHello World\r\n--test_boundary--\r\n",
                 result);
@@ -185,7 +185,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\""
                 + "\r\n\r\nHello World\r\n--test_boundary--\r\n",
                 result);
@@ -204,7 +204,7 @@ namespace System.Net.Http.Functional.Tests
             string result = new StreamReader(output).ReadToEnd();
 
             Assert.Equal(
-                "--test_boundary\r\nContent-Length: 11\r\nContent-Type: text/plain; charset=utf-8\r\n"
+                "--test_boundary\r\nContent-Type: text/plain; charset=utf-8\r\n"
                 + "Content-Disposition: form-data; name=\"=?utf-8?B?dGVzdOOCrw0KIG5hbcOp?=\";"
                 + " filename=\"=?utf-8?B?ZmlsZeOCrw0KIG5hbcOp?=\"; filename*=utf-8\'\'file%E3%82%AF%0D%0A%20nam%C3%A9"
                 + "\r\n\r\nHello World\r\n--test_boundary--\r\n",

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/StreamContentTest.cs
@@ -32,21 +32,6 @@ namespace System.Net.Http.Functional.Tests
             var source = new MockStream(new byte[10], true, true); // Supports seeking.
             var content = new StreamContent(source);
 
-            Assert.Contains("Content-Length", content.Headers.ToString());
-            Assert.Contains(content.Headers, h => h.Key == "Content-Length");
-            Assert.Contains(content.Headers.NonValidated, h => h.Key == "Content-Length");
-            Assert.Equal(source.Length, content.Headers.ContentLength);
-        }
-
-        [Fact]
-        public void ContentLength_SetStreamSupportingSeekingWithBuffering_StreamLengthMatchesHeaderValue()
-        {
-            var source = new MockStream(new byte[10], true, true); // Supports seeking.
-            var content = new StreamContent(source, 5);
-
-            Assert.Contains("Content-Length", content.Headers.ToString());
-            Assert.Contains(content.Headers, h => h.Key == "Content-Length");
-            Assert.Contains(content.Headers.NonValidated, h => h.Key == "Content-Length");
             Assert.Equal(source.Length, content.Headers.ContentLength);
         }
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/HttpRequestMessageTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/HttpRequestMessageTest.cs
@@ -336,7 +336,6 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
             Assert.Equal(
                 $"Method: PUT, RequestUri: '{uriData}', Version: 1.0, Content: " + typeof(StringContent).ToString() + ", Headers:" + Environment.NewLine +
                 $"{{{Environment.NewLine}" +
-                "  Content-Length: 7" + Environment.NewLine +
                 "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                 "}", rm.ToString());
         }
@@ -362,7 +361,6 @@ namespace System.Runtime.InteropServices.JavaScript.Http.Tests
                 "  Accept: text/plain; q=0.2" + Environment.NewLine +
                 "  Accept: text/xml; q=0.1" + Environment.NewLine +
                 "  Custom-Request-Header: value1" + Environment.NewLine +
-                "  Content-Length: 7" + Environment.NewLine +
                 "  Content-Type: text/plain; charset=utf-8" + Environment.NewLine +
                 "  Custom-Content-Header: value2" + Environment.NewLine +
                 "}", rm.ToString());


### PR DESCRIPTION
Reverts dotnet/runtime#102416

The change broke outerloop tests in `System.Net.Tests.SyncWebClientTest`. Seems like it sends bogus Content-Length:
![image](https://github.com/dotnet/runtime/assets/11718369/6f644ffc-3a5a-491a-bcd6-19ae4e845fd5)


cc @pedrobsaila @MihaZupan 