### PR TITLE
Add a regression test for double Content-Length header in HttpWebRequest

### DIFF
--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -2120,9 +2120,11 @@ namespace System.Net.Tests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task SendHttpPostRequest_WhenBufferingChanges_Success(bool buffering)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task SendHttpPostRequest_WhenBufferingChanges_Success(bool buffering, bool setContentLength)
         {
             byte[] randomData = Encoding.ASCII.GetBytes("Hello World!!!!\n");
             await LoopbackServer.CreateClientAndServerAsync(
@@ -2132,6 +2134,12 @@ namespace System.Net.Tests
                     HttpWebRequest request = WebRequest.CreateHttp(uri);
                     request.Method = "POST";
                     request.AllowWriteStreamBuffering = buffering;
+
+                    if (setContentLength)
+                    {
+                        request.Headers.Add("content-length", size.ToString());
+                    }
+
                     using var stream = await request.GetRequestStreamAsync();
                     for (int i = 0; i < size / randomData.Length; i++)
                     {


### PR DESCRIPTION
~~Replaces #102986~~

Adds a test for the impacted scenario.

