### PR TITLE
Avoid a few allocations in StringContent

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/StringContentTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -72,14 +73,57 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
-        public void Ctor_PassNullStringForMediaType_DefaultMediaTypeUsed()
+        public void Ctor_SetsDefaultContentTypeHeader()
         {
-            string sourceString = "\u00C4\u00E4\u00FC\u00DC";
-            Encoding defaultStringEncoding = Encoding.GetEncoding("utf-8");
-            var content = new StringContent(sourceString, defaultStringEncoding, ((string)null)!);
+            var content = new StringContent("Foo");
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
 
-            // If no media is passed-in, the default is used
-            Assert.Equal("text/plain", content.Headers.ContentType.MediaType);
+            content = new StringContent("Foo", (Encoding)null);
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", Encoding.UTF8);
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", Encoding.UTF8, "text/plain");
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", null, "text/plain");
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", Encoding.UTF8, (string)null);
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", null, (string)null);
+            Assert.Equal("text/plain; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("Foo", (MediaTypeHeaderValue)null);
+            Assert.Null(content.Headers.ContentType);
+
+            content = new StringContent("Foo", null, (MediaTypeHeaderValue)null);
+            Assert.Null(content.Headers.ContentType);
+        }
+
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("application/json")]
+        [InlineData("application/xml")]
+        [InlineData("foo/bar")]
+        public void Ctor_SetsContentTypeHeader(string mediaType)
+        {
+            var content = new StringContent("foo", Encoding.UTF8, mediaType);
+            Assert.Equal($"{mediaType}; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("foo", null, mediaType);
+            Assert.Equal($"{mediaType}; charset=utf-8", content.Headers.ContentType.ToString());
+
+            content = new StringContent("foo", Encoding.ASCII, mediaType);
+            Assert.Equal($"{mediaType}; charset=us-ascii", content.Headers.ContentType.ToString());
+
+            content = new StringContent("foo", new MediaTypeHeaderValue(mediaType));
+            Assert.Equal(mediaType, content.Headers.ContentType.ToString());
+
+            content = new StringContent("foo", Encoding.UTF8, new MediaTypeHeaderValue(mediaType, "ascii"));
+            Assert.Equal($"{mediaType}; charset=ascii", content.Headers.ContentType.ToString());
         }
 
         [Fact]


### PR DESCRIPTION
Same idea as #102859, but for `StringContent`. Saves the 5 smaller allocations each time.

AFAICT UTF-8 is practically the only encoding used here, with `text/plain` (default) and `application/json` being by far the most common media types. This PR special-cases these two combinations.

```c#
[Benchmark]
public void Test()
{
    var content = new StringContent("Foo", Encoding.UTF8, "application/json");
    foreach (var header in content.Headers.NonValidated)
    {
        _ = header.Value.ToString();
    }
}
```

| Method | Toolchain | Mean     | Error   | Ratio | Allocated | Alloc Ratio |
|------- |---------- |---------:|--------:|------:|----------:|------------:|
| Test   | main      | 296.5 ns | 2.95 ns |  1.00 |     520 B |        1.00 |
| Test   | pr        | 147.2 ns | 0.55 ns |  0.50 |     304 B |        0.58 |