### PR TITLE
[Release/6.0-staging] Fix issue where the IPC server can fully consume a CPU core and prevent incoming connections #102530

### DIFF
--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -194,15 +194,17 @@ ds_ipc_reset (DiagnosticsIpc *ipc)
 		return;
 
 	if (ipc->pipe != INVALID_HANDLE_VALUE) {
+		DisconnectNamedPipe (ipc->pipe);
 		CloseHandle (ipc->pipe);
 		ipc->pipe = INVALID_HANDLE_VALUE;
 	}
 
 	if (ipc->overlap.hEvent != INVALID_HANDLE_VALUE) {
 		CloseHandle (ipc->overlap.hEvent);
-		ipc->overlap.hEvent = INVALID_HANDLE_VALUE;
 	}
 
+	memset(&ipc->overlap, 0, sizeof(OVERLAPPED)); // clear the overlapped objects state
+	ipc->overlap.hEvent = INVALID_HANDLE_VALUE;
 	ipc->is_listening = false;
 }
 

--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -187,6 +187,25 @@ ds_ipc_free (DiagnosticsIpc *ipc)
 	ep_rt_object_free (ipc);
 }
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc)
+{
+	if (!ipc)
+		return;
+
+	if (ipc->pipe != INVALID_HANDLE_VALUE) {
+		CloseHandle (ipc->pipe);
+		ipc->pipe = INVALID_HANDLE_VALUE;
+	}
+
+	if (ipc->overlap.hEvent != INVALID_HANDLE_VALUE) {
+		CloseHandle (ipc->overlap.hEvent);
+		ipc->overlap.hEvent = INVALID_HANDLE_VALUE;
+	}
+
+	ipc->is_listening = false;
+}
+
 int32_t
 ds_ipc_poll (
 	DiagnosticsIpcPollHandle *poll_handles_data,
@@ -206,6 +225,10 @@ ds_ipc_poll (
 			// SERVER
 			EP_ASSERT (poll_handles_data [i].ipc->mode == DS_IPC_CONNECTION_MODE_LISTEN);
 			handles [i] = poll_handles_data [i].ipc->overlap.hEvent;
+			if (handles [i] == INVALID_HANDLE_VALUE) {
+				// Invalid handle, wait will fail. Signal error
+				poll_handles_data [i].events = DS_IPC_POLL_EVENTS_ERR;
+			}
 		} else {
 			// CLIENT
 			bool success = true;

--- a/src/native/eventpipe/ds-ipc-pal-socket.c
+++ b/src/native/eventpipe/ds-ipc-pal-socket.c
@@ -1061,6 +1061,11 @@ ds_ipc_free (DiagnosticsIpc *ipc)
 	ep_rt_object_free (ipc);
 }
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc)
+{
+}
+
 int32_t
 ds_ipc_poll (
 	DiagnosticsIpcPollHandle *poll_handles_data,

--- a/src/native/eventpipe/ds-ipc-pal.h
+++ b/src/native/eventpipe/ds-ipc-pal.h
@@ -35,6 +35,9 @@ ds_ipc_alloc (
 void
 ds_ipc_free (DiagnosticsIpc *ipc);
 
+void
+ds_ipc_reset (DiagnosticsIpc *ipc);
+
 // Poll
 // Parameters:
 // - IpcPollHandle * poll_handles_data: Array of IpcPollHandles to poll

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -850,7 +850,11 @@ listen_port_reset (
 	ds_ipc_error_callback_func callback)
 {
 	EP_ASSERT (object != NULL);
-	return;
+#ifdef _WIN32
+	DiagnosticsListenPort *listen_port = (DiagnosticsListenPort *)object;
+	ds_ipc_reset (listen_port->port.ipc);
+	ds_ipc_listen (listen_port->port.ipc, callback);
+#endif // _WIN32
 }
 
 static DiagnosticsPortVtable listen_port_vtable = {


### PR DESCRIPTION
Backport of #102413 to release/6.0

If the call to CreateNamedPipe fails here: https://github.com/dotnet/runtime/blob/af11dbc1a34538d9a38d39a7c96ddd5e7fc6907b/src/native/eventpipe/ds-ipc-pal-namedpipe.c#L372-L387

We will end up with an invalid handle for the pipe and the overlapped IO event. There currently is no code that tries to reset the connection and we will repeatedly try to poll an invalid handle, leading to one core being pegged as the wait fails due to an invalid handle and we keep waiting.

This PR makes it so we will call `ds_ipc_listen` when we run in to an error, which will reconnect to the named pipe. It also adds a delay when we detect an error, so if there are undetected cases that cause the same issue we will at least not consume the whole core we are running on.

## Customer Impact

- [X] Customer reported
- [] Found internally

The IPC server can fully consume a CPU core and prevent incoming connections. 

## Regression

- [] Yes
- [X] No

## Testing

Fix was verified in the customer's environment that it prevents the CPU issue

## Risk

Low to Medium - The fix itself is small and reasonable, but this area of the code is hard to reason about all possible code paths due to the async nature of the named pipe APIs.

