### PR TITLE
Remove `Thread::TSNC_IgnoreUnhandledExceptions`

### DIFF
--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -507,11 +507,6 @@ FCIMPL1(void, ThreadNative::Initialize, ThreadBaseObject* pThisUNSAFE)
 
     PREFIX_ASSUME(unstarted != NULL);
 
-    if (AppDomain::GetCurrentDomain()->IgnoreUnhandledExceptions())
-    {
-        unstarted->SetThreadStateNC(Thread::TSNC_IgnoreUnhandledExceptions);
-    }
-
     pThis->SetInternal(unstarted);
     pThis->SetManagedThreadId(unstarted->GetThreadId());
     unstarted->SetExposedObject(pThis);

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -4720,20 +4720,10 @@ LONG InternalUnhandledExceptionFilter_Worker(
 
         if (pParam->pThread != NULL)
         {
-            BOOL fIsProcessTerminating = TRUE;
 
-            // In CoreCLR, we can be asked to not let an exception go unhandled on managed threads in a given AppDomain.
+            // In CoreCLR, we can be asked to not let an exception go unhandled on managed threads.
             // If the exception reaches the top of the thread's stack, we simply deliver AppDomain's UnhandledException event and
             // return back to the filter, instead of letting the process terminate because of unhandled exception.
-
-            // Below is how we perform the check:
-            //
-            // 1) The flag is specified on the AD when it is created by the host and all managed threads created
-            //    in such an AD will inherit the flag. For non-finalizer and non-threadpool threads, we check the flag against the thread.
-            // 2) The finalizer thread always switches to the AD of the object that is going to be finalized. Thus,
-            //    while it wont have the flag specified, the AD it switches to will.
-            // 3) The threadpool thread also switches to the correct AD before executing the request. The thread wont have the
-            //    flag specified, but the AD it switches to will.
 
             // This code must only be exercised when running as a normal filter; returning
             // EXCEPTION_EXECUTE_HANDLER is not valid if this code is being invoked from
@@ -4741,10 +4731,7 @@ LONG InternalUnhandledExceptionFilter_Worker(
             // Fortunately, we should never get into this case, since the thread flag about
             // ignoring unhandled exceptions cannot be set on the default domain.
 
-            if (IsFinalizerThread() || (pParam->pThread->IsThreadPoolThread()))
-                fIsProcessTerminating = !(AppDomain::GetCurrentDomain()->IgnoreUnhandledExceptions());
-            else
-                fIsProcessTerminating = !(pParam->pThread->HasThreadStateNC(Thread::TSNC_IgnoreUnhandledExceptions));
+            BOOL fIsProcessTerminating = !(AppDomain::GetCurrentDomain()->IgnoreUnhandledExceptions());
 
 #ifndef TARGET_UNIX
             // Setup the watson bucketing details for UE processing.

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -537,8 +537,6 @@ class Thread
     friend BOOL NTGetThreadContext(Thread *pThread, T_CONTEXT *pContext);
     friend BOOL NTSetThreadContext(Thread *pThread, const T_CONTEXT *pContext);
 
-    friend void CommonTripThread();
-
 #ifdef FEATURE_HIJACK
     // MapWin32FaultToCOMPlusException needs access to Thread::IsAddrOfRedirectFunc()
     friend DWORD MapWin32FaultToCOMPlusException(EXCEPTION_RECORD *pExceptionRecord);
@@ -551,8 +549,6 @@ class Thread
 #endif // FEATURE_HIJACK
 
     friend void         InitThreadManager();
-
-    friend void CallFinalizerOnThreadObject(Object *obj);
 
     // Debug and Profiler caches ThreadHandle.
     friend class Debugger;                  // void Debugger::ThreadStarted(Thread* pRuntimeThread, BOOL fAttaching);
@@ -706,11 +702,10 @@ public:
                                                       // at the beginning of wait.
         // unused                       = 0x00040000,
         // unused                       = 0x00080000,
-        TSNC_RaiseUnloadEvent           = 0x00100000, // Finalize thread is raising managed unload event which
-                                                      // may call AppDomain.Unload.
+        // unused                       = 0x00100000,
         // unused                       = 0x00200000,
         // unused                       = 0x00400000,
-        TSNC_IgnoreUnhandledExceptions  = 0x00800000, // Set for a managed thread born inside an appdomain created with the APPDOMAIN_IGNORE_UNHANDLED_EXCEPTIONS flag.
+        // unused                       = 0x00800000,
         TSNC_ProcessedUnhandledException = 0x01000000,// Set on a thread on which we have done unhandled exception processing so that
                                                       // we dont perform it again when OS invokes our UEF. Currently, applicable threads include:
                                                       // 1) entry point thread of a managed app


### PR DESCRIPTION
The IgnoreUnhandledExceptions behaviour is set at the app domain level. Since we only have the one app domain now, the flag on the thread (`TSNC_IgnoreUnhandledExceptions`) can go away.