### PR TITLE
Improve Json flushing

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -56,7 +56,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     state.Current.EndCollectionElement();
 
-                    if (ShouldFlush(ref state))
+                    if (ShouldFlush(ref state, writer))
                     {
                         state.Current.EnumeratorIndex = ++index;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -45,7 +45,7 @@ namespace System.Text.Json.Serialization.Converters
 
             do
             {
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -61,7 +61,7 @@ namespace System.Text.Json.Serialization.Converters
             {
                 do
                 {
-                    if (ShouldFlush(ref state))
+                    if (ShouldFlush(ref state, writer))
                     {
                         state.Current.CollectionEnumerator = enumerator;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
@@ -107,7 +107,7 @@ namespace System.Text.Json.Serialization.Converters
                     return true;
                 }
 
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     return false;
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -60,7 +60,7 @@ namespace System.Text.Json.Serialization.Converters
 
             do
             {
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonConverter<object?> converter = GetElementConverter(ref state);
             do
             {
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonConverter<TElement> converter = GetElementConverter(ref state);
             do
             {
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -65,7 +65,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     state.Current.EndCollectionElement();
 
-                    if (ShouldFlush(ref state))
+                    if (ShouldFlush(ref state, writer))
                     {
                         state.Current.EnumeratorIndex = ++index;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -62,7 +62,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     state.Current.EndCollectionElement();
 
-                    if (ShouldFlush(ref state))
+                    if (ShouldFlush(ref state, writer))
                     {
                         state.Current.EnumeratorIndex = ++index;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ReadOnlyMemoryConverter.cs
@@ -74,7 +74,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     state.Current.EndCollectionElement();
 
-                    if (ShouldFlush(ref state))
+                    if (ShouldFlush(ref state, writer))
                     {
                         state.Current.EnumeratorIndex = ++index;
                         return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOrQueueConverter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Converters
             JsonConverter<object?> converter = GetElementConverter(ref state);
             do
             {
-                if (ShouldFlush(ref state))
+                if (ShouldFlush(ref state, writer))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -403,7 +403,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.Current.EndProperty();
                         state.Current.EnumeratorIndex++;
 
-                        if (ShouldFlush(ref state))
+                        if (ShouldFlush(ref state, writer))
                         {
                             return false;
                         }
@@ -432,7 +432,7 @@ namespace System.Text.Json.Serialization.Converters
                         state.Current.EndProperty();
                         state.Current.EnumeratorIndex++;
 
-                        if (ShouldFlush(ref state))
+                        if (ShouldFlush(ref state, writer))
                         {
                             return false;
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -180,7 +180,7 @@ namespace System.Text.Json.Serialization
             // If surpassed flush threshold then return true which will flush stream.
             if (state.PipeWriter is { } pipeWriter)
             {
-                return state.FlushThreshold > 0 && pipeWriter.UnflushedBytes + writer.BytesPending > state.FlushThreshold;
+                return state.FlushThreshold > 0 && pipeWriter.UnflushedBytes > state.FlushThreshold - writer.BytesPending;
             }
 
             return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -173,14 +173,14 @@ namespace System.Text.Json.Serialization
         /// </summary>
         internal bool IsInternalConverterForNumberType { get; init; }
 
-        internal static bool ShouldFlush(ref WriteStack state)
+        internal static bool ShouldFlush(ref WriteStack state, Utf8JsonWriter writer)
         {
             Debug.Assert(state.FlushThreshold == 0 || (state.PipeWriter is { CanGetUnflushedBytes: true }),
                 "ShouldFlush should only be called by resumable serializers, all of which use the PipeWriter abstraction with CanGetUnflushedBytes == true.");
             // If surpassed flush threshold then return true which will flush stream.
             if (state.PipeWriter is { } pipeWriter)
             {
-                return state.FlushThreshold > 0 && pipeWriter.UnflushedBytes > state.FlushThreshold;
+                return state.FlushThreshold > 0 && pipeWriter.UnflushedBytes + writer.BytesPending > state.FlushThreshold;
             }
 
             return false;


### PR DESCRIPTION
Realized that when calculating if we should flush we weren't accounting for bytes pending in the writer (Advance hasn't been called on the PipeWriter yet). This could result in excess buffering and larger buffers being allocated (rented). Added test coverage for this scenario too.

Also fixes https://github.com/dotnet/runtime/issues/102532