### PR TITLE
Re-write Android PBKDF2 one shot in Java

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.cs
@@ -38,6 +38,52 @@ internal static partial class Interop
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "CryptoNative_GetMaxMdSize")]
         private static partial int GetMaxMdSize();
 
+        [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_Pbkdf2", StringMarshalling = StringMarshalling.Utf8)]
+        private static partial int Pbkdf2(
+            string algorithmName,
+            ReadOnlySpan<byte> pPassword,
+            int passwordLength,
+            ReadOnlySpan<byte> pSalt,
+            int saltLength,
+            int iterations,
+            Span<byte> pDestination,
+            int destinationLength);
+
+        internal static void Pbkdf2(
+            string algorithmName,
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            int iterations,
+            Span<byte> destination)
+        {
+            const int Success = 1;
+            const int UnsupportedAlgorithm = -1;
+            const int Failed = 0;
+
+            int result = Pbkdf2(
+                algorithmName,
+                password,
+                password.Length,
+                salt,
+                salt.Length,
+                iterations,
+                destination,
+                destination.Length);
+
+            switch (result)
+            {
+                case Success:
+                    return;
+                case UnsupportedAlgorithm:
+                    throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, algorithmName));
+                case Failed:
+                    throw new CryptographicException();
+                default:
+                    Debug.Fail($"Unexpected result {result}");
+                    throw new CryptographicException();
+            }
+        }
+
         internal static unsafe int EvpDigestFinalXOF(SafeEvpMdCtxHandle ctx, Span<byte> destination)
         {
             // The partial needs to match the OpenSSL parameters.

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1017,7 +1017,7 @@
     <Compile Include="System\Security\Cryptography\OpenSslCipher.cs" />
     <Compile Include="System\Security\Cryptography\OpenSslCipherLite.cs" />
     <Compile Include="System\Security\Cryptography\PasswordDeriveBytes.NotSupported.cs" />
-    <Compile Include="System\Security\Cryptography\Pbkdf2Implementation.Managed.cs" />
+    <Compile Include="System\Security\Cryptography\Pbkdf2Implementation.Android.cs" />
     <Compile Include="System\Security\Cryptography\PinAndClear.cs" />
     <Compile Include="System\Security\Cryptography\RandomNumberGeneratorImplementation.OpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\RC2CryptoServiceProvider.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Pbkdf2Implementation.Android.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    internal static partial class Pbkdf2Implementation
+    {
+        public static unsafe void Fill(
+            ReadOnlySpan<byte> password,
+            ReadOnlySpan<byte> salt,
+            int iterations,
+            HashAlgorithmName hashAlgorithmName,
+            Span<byte> destination)
+        {
+            Debug.Assert(!destination.IsEmpty);
+            Debug.Assert(hashAlgorithmName.Name is not null);
+            Interop.Crypto.Pbkdf2(hashAlgorithmName.Name, password, salt, iterations, destination);
+        }
+    }
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -20,6 +20,7 @@ set(NATIVECRYPTO_SOURCES
     pal_lifetime.c
     pal_memory.c
     pal_misc.c
+    pal_pbkdf2.c
     pal_rsa.c
     pal_signature.c
     pal_ssl.c

--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/PalPbkdf2.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/PalPbkdf2.java
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+package net.dot.android.crypto;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Mac;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.SecretKeySpec;
+
+public final class PalPbkdf2 {
+    private static final int ERROR_UNSUPPORTED_ALGORITHM = -1;
+    private static final int SUCCESS = 1;
+
+    public static int pbkdf2OneShot(String algorithmName, byte[] password, byte[] salt, int iterations, byte[] destination)
+        throws ShortBufferException, InvalidKeyException {
+
+        // We do not ever expect a ShortBufferException to ever get thrown since the buffer destination length is always
+        // checked. Let it go through the checked exception and JNI will handle it as a generic failure.
+        // InvalidKeyException should not throw except the the case of an empty key, which we already handle. Let JNI
+        // handle it as a generic failure.
+
+        // We use a custom implementation of PBKDF2 instead of the one provided by the Android platform for two reasons:
+        // The first is that Android only added support for PBKDF2 + SHA-2 family of agorithms in API level 26, and we
+        // need to support SHA-2 prior to that.
+        // The second is that PBEKeySpec only supports char-based passwords, whereas .NET supports arbitrary byte keys.
+
+        assert algorithmName != null;
+        assert password != null;
+        assert salt != null;
+        assert iterations > 0;
+        assert destination != null;
+
+        // The .NET side already validates the hash algorithm name inputs.
+        String javaAlgorithmName = "Hmac" + algorithmName;
+        Mac mac;
+
+        try {
+            mac = Mac.getInstance(javaAlgorithmName);
+        }
+        catch (NoSuchAlgorithmException nsae) {
+            assert false : "The algorithm was checked before, so it should be available.";
+            return ERROR_UNSUPPORTED_ALGORITHM;
+        }
+
+        if (password.length == 0) {
+            // SecretKeySpec does not permit empty keys. Since HMAC just zero extends the key, a single zero byte key is
+            // the same as an empty key.
+            password = new byte[] { 0 };
+        }
+
+        SecretKeySpec key = new SecretKeySpec(password, javaAlgorithmName);
+        mac.init(key);
+
+        // Since this is a one-shot, it should not be possible to exceed the extract limit since the .NET side is
+        // limited to the length of a span (2^31 - 1 bytes). It would only take ~128 million SHA-1 blocks to fill an entire
+        // span, and 128 million fits in a signed 32-bit integer.
+        int blockCounter = 1;
+        int destinationOffset = 0;
+        byte[] blockCounterBuffer = new byte[4]; // Big-endian 32-bit integer
+        byte[] block = new byte[mac.getMacLength()];
+        byte[] u = new byte[block.length];
+
+        while (destinationOffset < destination.length) {
+            assert blockCounter > 0; // Given the comment above, this should never overflow.
+
+            writeBigEndianInt(blockCounter, blockCounterBuffer);
+
+            mac.update(salt);
+            mac.update(blockCounterBuffer);
+            mac.doFinal(u, 0);
+
+            System.arraycopy(u, 0, block, 0, block.length);
+
+            // Start at 2 since we did the first iteration above.
+            for (int i = 2; i <= iterations; i++) {
+                mac.reset();
+                mac.update(u);
+                mac.doFinal(u, 0);
+
+                for (int j = 0; j < u.length; j++) {
+                    block[j] ^= u[j];
+                }
+            }
+
+            System.arraycopy(block, 0, destination, destinationOffset, Math.min(block.length, destination.length - destinationOffset));
+            destinationOffset += block.length;
+            blockCounter++;
+        }
+
+        return SUCCESS;
+    }
+
+    private static void writeBigEndianInt(int value, byte[] destination) {
+        destination[0] = (byte)((value >> 24) & 0xFF);
+        destination[1] = (byte)((value >> 16) & 0xFF);
+        destination[2] = (byte)((value >> 8) & 0xFF);
+        destination[3] = (byte)(value & 0xFF);
+    }
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/PalPbkdf2.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/PalPbkdf2.java
@@ -70,7 +70,6 @@ public final class PalPbkdf2 {
 
             // Start at 2 since we did the first iteration above.
             for (int i = 2; i <= iterations; i++) {
-                mac.reset();
                 mac.update(u);
                 mac.doFinal(u, 0);
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -489,6 +489,10 @@ jclass g_TrustManager;
 jclass    g_DotnetProxyTrustManager;
 jmethodID g_DotnetProxyTrustManagerCtor;
 
+// net/dot/android/crypto/PalPbkdf2
+jclass    g_PalPbkdf2;
+jmethodID g_PalPbkdf2Pbkdf2OneShot;
+
 jobject ToGRef(JNIEnv *env, jobject lref)
 {
     if (lref)
@@ -1095,6 +1099,9 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 
     g_DotnetProxyTrustManager =     GetClassGRef(env, "net/dot/android/crypto/DotnetProxyTrustManager");
     g_DotnetProxyTrustManagerCtor = GetMethod(env, false, g_DotnetProxyTrustManager, "<init>", "(J)V");
+
+    g_PalPbkdf2              = GetClassGRef(env, "net/dot/android/crypto/PalPbkdf2");
+    g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[B[BI[B)I");
 
     return JNI_VERSION_1_6;
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -1101,7 +1101,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_DotnetProxyTrustManagerCtor = GetMethod(env, false, g_DotnetProxyTrustManager, "<init>", "(J)V");
 
     g_PalPbkdf2              = GetClassGRef(env, "net/dot/android/crypto/PalPbkdf2");
-    g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[B[BI[B)I");
+    g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[BLjava/nio/ByteBuffer;I[B)I");
 
     return JNI_VERSION_1_6;
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -1101,7 +1101,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
     g_DotnetProxyTrustManagerCtor = GetMethod(env, false, g_DotnetProxyTrustManager, "<init>", "(J)V");
 
     g_PalPbkdf2              = GetClassGRef(env, "net/dot/android/crypto/PalPbkdf2");
-    g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[BLjava/nio/ByteBuffer;I[B)I");
+    g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[BLjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;)I");
 
     return JNI_VERSION_1_6;
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -503,6 +503,10 @@ extern jclass g_TrustManager;
 extern jclass    g_DotnetProxyTrustManager;
 extern jmethodID g_DotnetProxyTrustManagerCtor;
 
+// net/dot/android/crypto/PalPbkdf2
+extern jclass    g_PalPbkdf2;
+extern jmethodID g_PalPbkdf2Pbkdf2OneShot;
+
 // Compatibility macros
 #if !defined (__mallocfunc)
 #if defined (__clang__) || defined (__GNUC__)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.c
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "pal_pbkdf2.h"
+#include "pal_utilities.h"
+
+
+int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
+                                   const uint8_t* password,
+                                   int32_t passwordLength,
+                                   const uint8_t* salt,
+                                   int32_t saltLength,
+                                   int32_t iterations,
+                                   uint8_t* destination,
+                                   int32_t destinationLength)
+{
+    JNIEnv* env = GetJNIEnv();
+
+    jstring javaAlgorithmName = make_java_string(env, algorithmName);
+    jbyteArray passwordBytes = make_java_byte_array(env, passwordLength);
+    jbyteArray saltBytes = make_java_byte_array(env, saltLength);
+    jbyteArray destinationBytes = make_java_byte_array(env, destinationLength);
+
+    if (password && passwordLength > 0)
+    {
+        (*env)->SetByteArrayRegion(env, passwordBytes, 0, passwordLength, (const jbyte*)password);
+    }
+
+    if (salt && saltLength > 0)
+    {
+        (*env)->SetByteArrayRegion(env, saltBytes, 0, saltLength, (const jbyte*)salt);
+    }
+
+    jint ret = (*env)->CallStaticIntMethod(env, g_PalPbkdf2, g_PalPbkdf2Pbkdf2OneShot,
+        javaAlgorithmName, passwordBytes, saltBytes, iterations, destinationBytes);
+
+    if (CheckJNIExceptions(env))
+    {
+        ret = FAIL;
+    }
+    else if (ret == SUCCESS)
+    {
+        (*env)->GetByteArrayRegion(env, destinationBytes, 0, destinationLength, (jbyte*)destination);
+    }
+
+    (*env)->DeleteLocalRef(env, javaAlgorithmName);
+    (*env)->DeleteLocalRef(env, passwordBytes);
+    (*env)->DeleteLocalRef(env, saltBytes);
+    (*env)->DeleteLocalRef(env, destinationBytes);
+
+    return ret;
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.c
@@ -4,11 +4,10 @@
 #include "pal_pbkdf2.h"
 #include "pal_utilities.h"
 
-
 int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
                                    const uint8_t* password,
                                    int32_t passwordLength,
-                                   const uint8_t* salt,
+                                   uint8_t* salt,
                                    int32_t saltLength,
                                    int32_t iterations,
                                    uint8_t* destination,
@@ -18,8 +17,8 @@ int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
 
     jstring javaAlgorithmName = make_java_string(env, algorithmName);
     jbyteArray passwordBytes = make_java_byte_array(env, passwordLength);
-    jbyteArray saltBytes = make_java_byte_array(env, saltLength);
     jbyteArray destinationBytes = make_java_byte_array(env, destinationLength);
+    jobject saltByteBuffer = NULL;
 
     if (password && passwordLength > 0)
     {
@@ -28,11 +27,11 @@ int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
 
     if (salt && saltLength > 0)
     {
-        (*env)->SetByteArrayRegion(env, saltBytes, 0, saltLength, (const jbyte*)salt);
+        saltByteBuffer = (*env)->NewDirectByteBuffer(env, salt, saltLength);
     }
 
     jint ret = (*env)->CallStaticIntMethod(env, g_PalPbkdf2, g_PalPbkdf2Pbkdf2OneShot,
-        javaAlgorithmName, passwordBytes, saltBytes, iterations, destinationBytes);
+        javaAlgorithmName, passwordBytes, saltByteBuffer, iterations, destinationBytes);
 
     if (CheckJNIExceptions(env))
     {
@@ -45,7 +44,7 @@ int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
 
     (*env)->DeleteLocalRef(env, javaAlgorithmName);
     (*env)->DeleteLocalRef(env, passwordBytes);
-    (*env)->DeleteLocalRef(env, saltBytes);
+    (*env)->DeleteLocalRef(env, saltByteBuffer);
     (*env)->DeleteLocalRef(env, destinationBytes);
 
     return ret;

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.h
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "pal_jni.h"
+#include "pal_compiler.h"
+#include "pal_types.h"
+
+
+PALEXPORT int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
+                                             const uint8_t* password,
+                                             int32_t passwordLength,
+                                             const uint8_t* salt,
+                                             int32_t saltLength,
+                                             int32_t iterations,
+                                             uint8_t* destination,
+                                             int32_t destinationLength);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_pbkdf2.h
@@ -11,7 +11,7 @@
 PALEXPORT int32_t AndroidCryptoNative_Pbkdf2(const char* algorithmName,
                                              const uint8_t* password,
                                              int32_t passwordLength,
-                                             const uint8_t* salt,
+                                             uint8_t* salt,
                                              int32_t saltLength,
                                              int32_t iterations,
                                              uint8_t* destination,


### PR DESCRIPTION
This re-writes the `Pbkdf2` one shot from .NET primitives to Java to improve performance.

PBKDF2 works by doing many HMAC calls, anywhere from thousands to hundreds of thousands or even millions. With the managed implementation, each HMAC invocation incurs small overhead, but with the number of them needed, it adds up.

1. 3 P/invokes (Update + Final + Reset) per iteration.
2. Two of the  p/invokes must copy data in (`SetByteArrayRegion`) and data out (`GetByteArrayRegion`) between JNI and .NET.

The Java VM itself is allocating potentially millions of byte arrays during this process.

Building off of https://github.com/dotnet/runtime/pull/77386, now that we have the ability to write real Java, this re-writes the PBKDF2 implementation for Android in Java. This

1. Brings the P/Invoke count down to 1, total.
2. Since this is a one shot, we can re-use Java buffers. In this implementation, `doFinal` can write to an existing buffer. So instead of creating tons of small byte arrays and copying them in and out, the Java implementation only needs to allocate two buffers (`u` and `u-previous` in PBKDF2 terms) and a Java buffer of the final result to get the array back over to JNI.

Performance improvements are favorable for small and large work factors.

For SHA-2-256 with a 64-byte output:

| Iterations | Before           | After            |
|------------|------------------|------------------|
| 1000       | 00:00:00.0211213 | 00:00:00.0130257 |
| 100,000    | 00:00:02.1599356 | 00:00:01.3113251 |
| 600,000    | 00:00:12.9551999 | 00:00:08.0959086 |

Closes #102406