### PR TITLE
Weaken assert around folding constants

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -9426,7 +9426,8 @@ DONE_MORPHING_CHILDREN:
             }
 
             /* Any constant cases should have been folded earlier */
-            noway_assert(!op1->OperIsConst() || opts.OptimizationDisabled() || optValnumCSE_phase);
+            noway_assert(!op1->OperIsConst() || op1->IsIconHandle() || opts.OptimizationDisabled() ||
+                         optValnumCSE_phase);
             break;
 
         case GT_CKFINITE:


### PR DESCRIPTION
I ran into this assert with native AOT. It seems to be too strong - we are not allowed to fold IconHandle constants with prejit so this feels expected for that.

The test that runs into this is [handleMath.ilproj](https://github.com/dotnet/runtime/blob/main/src/tests/JIT/Regression/JitBlue/DevDiv_206786/handleMath.il) from the pri 1 test suite. We don't currently run pri1 suite with native AOT, I'm in the process of unblocking it.

Cc @dotnet/ilc-contrib 
@dotnet/jit-contrib PTAL