### PR TITLE
[LoongArch64] Fix some failed CoreRoot R2R testcases.

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -2203,11 +2203,6 @@ void emitter::emitIns_J(instruction ins, BasicBlock* dst, int instrCount)
     emitCounts_INS_OPTS_J++;
     id->idAddr()->iiaBBlabel = dst;
 
-    if (emitComp->opts.compReloc)
-    {
-        id->idSetIsDspReloc();
-    }
-
     id->idjShort = false;
 
     // TODO-LoongArch64: maybe deleted this.

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5610,7 +5610,7 @@ struct GenTreeCall final : public GenTree
             return WellKnownArg::VirtualStubCell;
         }
 
-#if defined(TARGET_ARMARCH) || defined(TARGET_RISCV64)
+#if defined(TARGET_ARMARCH) || defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
         // For ARM architectures, we always use an indirection cell for R2R calls.
         if (IsR2RRelativeIndir() && !IsDelegateInvoke())
         {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6351,7 +6351,7 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         else
         {
             bool shouldOptimizeVirtualStubCall = false;
-#if defined(TARGET_ARMARCH) || defined(TARGET_AMD64)
+#if defined(TARGET_ARMARCH) || defined(TARGET_AMD64) || defined(TARGET_LOONGARCH64)
             // Skip inserting the indirection node to load the address that is already
             // computed in the VSD stub arg register as a hidden parameter. Instead during the
             // codegen, just load the call target from there.


### PR DESCRIPTION
Fix some failed CoreRoot R2R testcases for LoongArch64.
* Mainly fix the valuenum.cpp:12681:Assertion failed 'curArg == nullptr || generateUniqueVN' within mainv1.sh, etc.