### PR TITLE
[NativeAOT] Enable `-dead_strip` linker optimization by default on Apple platforms 

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -341,6 +341,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CustomLinkerArg Include="-exported_symbols_list /dev/null" Condition="'$(OutputType)' == 'exe' and '$(_IsApplePlatform)' == 'true' and '$(ExportsFile)' == ''" />
       <CustomLinkerArg Include="-Wl,--version-script=$(ExportsFile)" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
       <CustomLinkerArg Include="-Wl,--export-dynamic" Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true' and '$(ExportsFile)' != ''" />
+      <CustomLinkerArg Include="-Wl,-dead_strip" Condition="'$(_IsApplePlatform)' == 'true'" />
       <CustomLinkerArg Include="@(LinkerArg)" />
     </ItemGroup>
     <ItemGroup Condition="'$(_targetOS)' != 'win' and '$(_IsApplePlatform)' != 'true'">

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/MachObjectWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/MachObjectWriter.cs
@@ -475,12 +475,15 @@ namespace ILCompiler.ObjectWriter
             foreach ((string name, SymbolDefinition definition) in definedSymbols)
             {
                 MachSection section = _sections[definition.SectionIndex];
+                // Sections in our object file should not be altered during native linking as the runtime
+                // depends on the layout generated during compilation. For this reason we mark all symbols
+                // with N_NO_DEAD_STRIP to prevent breaking up sections into subsections during linking.
                 sortedDefinedSymbols.Add(new MachSymbol
                 {
                     Name = name,
                     Section = section,
                     Value = section.VirtualAddress + (ulong)definition.Value,
-                    Descriptor = 0,
+                    Descriptor = N_NO_DEAD_STRIP,
                     Type = N_SECT | N_EXT,
                 });
             }


### PR DESCRIPTION
## Description

This PR: 
- Enables `-dead_strip` linker optimization by default.
- Marks all symbols as non-deadstrippable to ensure that the sections are not split/reorganized/removed by the platform linker.

## Background

When Xcode 15 got released we started hitting issues with NAOT executables as the new linker was producing incorrect unwind tables causing crashes during GC or on first stack walk. 
We got this fixed by marking the ILC output and our libs with `.subsections_via_symbols` in: 
- https://github.com/dotnet/llvm-project/pull/471 
- https://github.com/dotnet/runtime/pull/92520

In the meantime we started using managed object writer in .NET9 but we still mark our object Mach-O files with `.subsections_via_symbols`:
https://github.com/dotnet/runtime/blob/9fca0c3dbd3874ed0245b1bdb10547d0ba769d66/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/MachObjectWriter.cs#L197

Regarding the `-dead_strip` flag we disabled it for iOS platforms as the build was crashing the old Apple linker: https://github.com/dotnet/runtime/issues/88032

## Current state

The `.subsections_via_symbols` fixes solved us some problems but unfortunately they did not seem to completely solve the compatibility with the new linker as from: https://github.com/dotnet/runtime/issues/97745 we started noticing similar problems which in the end resulted with falling back to using the old linker `ld_classic` https://github.com/dotnet/runtime/pull/98726 (backport: https://github.com/dotnet/runtime/pull/97856)

@filipnavara also opened a [ticket to Apple](https://github.com/dotnet/runtime/issues/97745#issuecomment-1925915381) regarding the new linker issues which still have not been resolved.

Additionally, our customers started reporting startup crashes when linker optimizations switches are enabled (`-dead_strip` and `-flto`):

- https://github.com/dotnet/runtime/issues/96663
- https://github.com/dotnet/runtime/issues/97501

## Dead stripping and the `.subsections_via_symbols` flag

Apple's linking is based on atoms - indivisible chunks of code or data which is different to traditional section-based linkers. This means that linker operates at a finer grain but it also means that it gives the linker freedom to break up the sections and reorganize their subsections to achieve better optimization. This is particularly useful for dead code stripping (ref: https://github.com/apple-oss-distributions/ld64/blob/main/doc/design/linker.html). To enable an object file to be split into atoms and qualify it for dead stripping by the linker, it needs to be marked with a `.subsections_via_symbols` flag (ref: https://opensource.apple.com/source/cctools/cctools-622.5.1/RelNotes/CompilerTools.html).
However, NAOT codegen/runtime has many assumptions about the layout of the generated code/data which shouldn't be altered once object file is produced. For this reason we need to mark all symbols as non-deadstrippable to avoid problems with the platform linker.

<details>
  <summary>Click here to expand the case study used to asses the behaviour of dead stripping on a macOS console app </summary>
  
### Case study: NAOT hello world console app with `-dead_strip` enabled on macOS

1. Build the runtime `./build.sh clr+clr.aot+libs+packs -c Release`
2. Create a hello world template `dotnet new console`
3. Adjust the project file with:
```xml
  <PropertyGroup>
    <PublishAot>true</PublishAot>
    <RestoreAdditionalProjectSources>_path_to_the_shipping_folder_</RestoreAdditionalProjectSources>
  </PropertyGroup>

  <ItemGroup>
    <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="9.0.0-dev" />
    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="9.0.0-dev" />
  </ItemGroup>

  <ItemGroup>
    <LinkerArg Include="-Wl,-dead_strip" />
  </ItemGroup>
```
4. Publish the app and run it

- The first problem: The app will crash due to dehydrated/hydrated data being partially or completely stripped out
- The second problem: If we workaround the first problem by passing `-p:IlcDehydrate=false` the app then crashes in: `StartupCodeHelpers.InitializeModules` because the module count is 0 as the whole `__modules` section gets stripped
- The third problem: If we workaround the second problem by explicitly marking the `__modules` section with `S_ATTR_NO_DEAD_STRIP` the app will crash in: `StartupCodeHelpers.InitializeStatics` due to stripping and reordering of the GCStatic MethodTables which causes `RhAllocateNewObject` allocation to fail as `blockAddr` points to a nonexistent location.

NOTE: Kudos to @anatawa12 as the first two problems were called out in: https://github.com/dotnet/runtime/pull/96743 

### Questions

- What problem would we hit next? 
- Is it possible to mark every possible scenario where the codegen/runtime makes assumption about the program layout or should we just define that our object file is not compatible for splitting into subsections?

</details>

## Size savings

| console macOS app | main  (b)                                                               | this PR (b)                                                             | diff (%)  |
|------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|--------|
| app size       | 1538384                                                              | 1417792                                                              | -7,84% |
| symbols list    | [syms.lst](https://gist.github.com/ivanpovazan/821cd1adf6888cfcb38776c646c567e8) | [syms.lst](https://gist.github.com/ivanpovazan/d3bc9073d2e6ca744af1afa0a8ed2beb) |

| MAUI iOS Recipes app | main  (b)                                                               | this PR (b)                                                             | diff (%)  |
|------------------|----------------------------------------------------------------------|----------------------------------------------------------------------|--------|
| app size       | 12834881                                                              | 12645649                                                              | -1,47% |

The savings are coming from dead stripping other native dependencies so are not related to the size of the managed code.

---
Fixes: https://github.com/dotnet/runtime/issues/96663 

PS Manually tested that both `-dead_strip` and `-flto` are now working properly
