### PR TITLE
JIT: Reset `optReachability` bitvec traits in IV opts

### DIFF
--- a/src/coreclr/jit/inductionvariableopts.cpp
+++ b/src/coreclr/jit/inductionvariableopts.cpp
@@ -1169,8 +1169,9 @@ PhaseStatus Compiler::optInductionVariables()
 
     bool changed = false;
 
-    m_dfsTree = fgComputeDfs();
-    m_loops   = FlowGraphNaturalLoops::Find(m_dfsTree);
+    optReachableBitVecTraits = nullptr;
+    m_dfsTree                = fgComputeDfs();
+    m_loops                  = FlowGraphNaturalLoops::Find(m_dfsTree);
 
     LoopLocalOccurrences loopLocals(m_loops);
 


### PR DESCRIPTION
IV opts relied on the RBO phase to reset these bitvec traits, which would cause problems if the RBO phase was disabled.

Fix #102978