### PR TITLE
Fix compiling methods with explicit this

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -883,6 +883,7 @@ namespace Internal.JitInterface
                 ThrowHelper.ThrowBadImageFormatException();
 
             if (!signature.IsStatic) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_HASTHIS;
+            if (signature.IsExplicitThis) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_EXPLICITTHIS;
 
             TypeDesc returnType = signature.ReturnType;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -22,6 +22,7 @@ namespace Internal.TypeSystem
         UnmanagedCallingConvention           = 0x0009,
 
         Static = 0x0010,
+        ExplicitThis = 0x0020,
     }
 
     public enum EmbeddedSignatureDataKind
@@ -126,6 +127,14 @@ namespace Internal.TypeSystem
             get
             {
                 return (_flags & MethodSignatureFlags.Static) != 0;
+            }
+        }
+
+        public bool IsExplicitThis
+        {
+            get
+            {
+                return (_flags & MethodSignatureFlags.ExplicitThis) != 0;
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -380,6 +380,9 @@ namespace Internal.TypeSystem.Ecma
             if (!header.IsInstance)
                 flags |= MethodSignatureFlags.Static;
 
+            if (header.HasExplicitThis)
+                flags |= MethodSignatureFlags.ExplicitThis;
+
             int arity = header.IsGeneric ? _reader.ReadCompressedInteger() : 0;
 
             int count = _reader.ReadCompressedInteger();

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.Method.cs
@@ -241,6 +241,10 @@ namespace ILCompiler.Metadata
             {
                 callingConvention |= SignatureCallingConvention.HasThis;
             }
+            if ((signature.Flags & Cts.MethodSignatureFlags.ExplicitThis) != 0)
+            {
+                callingConvention |= SignatureCallingConvention.ExplicitThis;
+            }
             return callingConvention;
         }
 


### PR DESCRIPTION
One of the pri1 JIT tests hits asserts because we forget to set the bit.

Cc @dotnet/ilc-contrib 