### PR TITLE
Baseline failing JIT/Regression pri1 tests

### DIFF
--- a/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16423/b16423.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16423/b16423.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28927/b28927.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28927/b28927.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows, uses native varargs -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- The test has a static field of unresolvable type on the class that defines Main() and native AOT makes Main() uncallable -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b88793/b88793.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b88793/b88793.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b91248/b91248.csproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b91248/b91248.csproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b138117/b138117.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1.2-M02/b138117/b138117.ilproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Modifies a value of an initonly field outside of cctor -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.ilproj
@@ -5,6 +5,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows, uses native varargs -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Test uses varargs -->
+    <NativeAotIncompatible>true</NativeAotIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>


### PR DESCRIPTION
Mostly known things. I considered filing a bug on b32879 but I don't know if we really need to be bug-for-bug compatible.

cc @dotnet/ilc-contrib 