### PR TITLE
Fix shadow stack handling during exception handling

### DIFF
--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -8170,12 +8170,15 @@ void Thread::InitializeSpecialUserModeApc()
 EXTERN_C void STDCALL ClrRestoreNonvolatileContextWorker(PCONTEXT ContextRecord, DWORD64 ssp);
 #endif
 
-void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord)
+void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord, size_t targetSSP)
 {
 #if defined(TARGET_AMD64)
-    DWORD64 ssp = GetSSP(ContextRecord);
+    if (targetSSP == 0)
+    {
+        targetSSP = GetSSP(ContextRecord);
+    }
     __asan_handle_no_return();
-    ClrRestoreNonvolatileContextWorker(ContextRecord, ssp);
+    ClrRestoreNonvolatileContextWorker(ContextRecord, targetSSP);
 #else
     __asan_handle_no_return();
     // Falling back to RtlRestoreContext() for now, though it should be possible to have simpler variants for these cases

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -5776,7 +5776,7 @@ private:
 #if defined(TARGET_WINDOWS) && defined(TARGET_AMD64)
 EXTERN_C void STDCALL ClrRestoreNonvolatileContextWorker(PCONTEXT ContextRecord, DWORD64 ssp);
 #endif
-void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord);
+void ClrRestoreNonvolatileContext(PCONTEXT ContextRecord, size_t targetSSP = 0);
 #endif // DACCESS_COMPILE
 
 #endif //__threads_h__


### PR DESCRIPTION
The shadow stack pointer was not updated when resuming execution after a catch handler. That was causing stack overflow crashes in some of the coreclr tests when running with CET enabled.

This change adds proper updating of the shadow stack pointer in a similar way to what RtlRestoreContext does.