### PR TITLE
Fix handling of corrupting state exceptions

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -6527,6 +6527,8 @@ static LONG HandleManagedFaultFilter(EXCEPTION_POINTERS* ep, LPVOID pv)
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
+void FirstChanceExceptionNotification();
+
 void HandleManagedFaultNew(EXCEPTION_RECORD* pExceptionRecord, CONTEXT* pContext)
 {
     WRAPPER_NO_CONTRACT;
@@ -6556,6 +6558,8 @@ void HandleManagedFaultNew(EXCEPTION_RECORD* pExceptionRecord, CONTEXT* pContext
     DECLARE_ARGHOLDER_ARRAY(args, 2);
     args[ARGNUM_0] = DWORD_TO_ARGHOLDER(exceptionCode);
     args[ARGNUM_1] = PTR_TO_ARGHOLDER(&exInfo);
+
+    FirstChanceExceptionNotification();
 
     pThread->IncPreventAbort();
 

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -6527,8 +6527,6 @@ static LONG HandleManagedFaultFilter(EXCEPTION_POINTERS* ep, LPVOID pv)
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-void FirstChanceExceptionNotification();
-
 void HandleManagedFaultNew(EXCEPTION_RECORD* pExceptionRecord, CONTEXT* pContext)
 {
     WRAPPER_NO_CONTRACT;
@@ -6558,8 +6556,6 @@ void HandleManagedFaultNew(EXCEPTION_RECORD* pExceptionRecord, CONTEXT* pContext
     DECLARE_ARGHOLDER_ARRAY(args, 2);
     args[ARGNUM_0] = DWORD_TO_ARGHOLDER(exceptionCode);
     args[ARGNUM_1] = PTR_TO_ARGHOLDER(&exInfo);
-
-    FirstChanceExceptionNotification();
 
     pThread->IncPreventAbort();
 


### PR DESCRIPTION
The new EH is not correctly handling corrupting state exceptions. Instead of failing fast, the exceptions are actually handled like other exceptions and can be caught by the user code.

This change fixes it. Besides fixing the issue, I had to introduce a way to trim exception handling code frames from the stack trace reported by the failfast, otherwise the output would be confusing.

As an additional change, I've noticed that hardware exceptions under WinDbg don't trigger the WinDbg first chance exception mechanism. I've recently fixed the same for software exceptions, this adds the same for hardware ones.

Close #103018