### PR TITLE
enable ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed test

### DIFF
--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1587,8 +1587,6 @@ namespace System.Net.Tests
             Assert.NotNull(request.Proxy);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31380")]
-        [OuterLoop("Uses external servers")]
         [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public async Task ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed()


### PR DESCRIPTION
followup on #49348, fixes #31380.
Since it does not use external servers, I also removed the `outerloop` tag. 

This is very old issue and I was not able to reproduce it locally. 
Enabling the offending test once again, we should watch it.  