### PR TITLE
[interp] handle box + brtrue/brfalse and box+isinst+unbox.any patterns up front

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Sum.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Sum.cs
@@ -60,11 +60,11 @@ namespace System.Linq
 
                 if (typeof(T) == typeof(long))
                 {
-                    return (TResult)(object)SumSignedIntegersVectorized(MemoryMarshal.Cast<T, long>(span));
+                    return (TResult)(object)SumSignedIntegersVectorized(Unsafe.BitCast<ReadOnlySpan<T>, ReadOnlySpan<long>>(span));
                 }
                 if (typeof(T) == typeof(int))
                 {
-                    return (TResult)(object)SumSignedIntegersVectorized(MemoryMarshal.Cast<T, int>(span));
+                    return (TResult)(object)SumSignedIntegersVectorized(Unsafe.BitCast<ReadOnlySpan<T>, ReadOnlySpan<int>>(span));
                 }
             }
 

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Helpers.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Helpers.cs
@@ -36,7 +36,11 @@ namespace System.Numerics.Tensors
         private static unsafe Span<TTo> Rename<TFrom, TTo>(Span<TFrom> span)
         {
             Debug.Assert(sizeof(TFrom) == sizeof(TTo));
+#if NET9_0_OR_GREATER
+            return Unsafe.BitCast<Span<TFrom>, Span<TTo>>(span);
+#else
             return *(Span<TTo>*)(&span);
+#endif
         }
 
         /// <summary>Creates a span of <typeparamref name="TTo"/> from a <typeparamref name="TFrom"/> when they're the same type.</summary>
@@ -48,7 +52,11 @@ namespace System.Numerics.Tensors
         private static unsafe ReadOnlySpan<TTo> Rename<TFrom, TTo>(ReadOnlySpan<TFrom> span)
         {
             Debug.Assert(sizeof(TFrom) == sizeof(TTo));
+#if NET9_0_OR_GREATER
+            return Unsafe.BitCast<ReadOnlySpan<TFrom>, ReadOnlySpan<TTo>>(span);
+#else
             return *(ReadOnlySpan<TTo>*)(&span);
+#endif
         }
 
         /// <summary>Mask used to handle alignment elements before vectorized handling of the input.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -763,12 +763,12 @@ namespace System
         {
             if (typeof(TChar) == typeof(char))
             {
-                result.Append(MemoryMarshal.Cast<char, TChar>(s));
+                result.Append(Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(s));
             }
             else
             {
                 Debug.Assert(typeof(TChar) == typeof(byte));
-                Encoding.UTF8.GetBytes(s, MemoryMarshal.Cast<TChar, byte>(result.AppendSpan(Encoding.UTF8.GetByteCount(s))));
+                Encoding.UTF8.GetBytes(s, Unsafe.BitCast<Span<TChar>, Span<byte>>(result.AppendSpan(Encoding.UTF8.GetByteCount(s))));
             }
         }
 
@@ -777,8 +777,8 @@ namespace System
             Span<TChar> chars = stackalloc TChar[11];
             int charCount;
             bool formatted = typeof(TChar) == typeof(char) ?
-                fraction.TryFormat(MemoryMarshal.Cast<TChar, char>(chars), out charCount, fractionFormat, CultureInfo.InvariantCulture) :
-                fraction.TryFormat(MemoryMarshal.Cast<TChar, byte>(chars), out charCount, fractionFormat, CultureInfo.InvariantCulture);
+                fraction.TryFormat(Unsafe.BitCast<Span<TChar>, Span<char>>(chars), out charCount, fractionFormat, CultureInfo.InvariantCulture) :
+                fraction.TryFormat(Unsafe.BitCast<Span<TChar>, Span<byte>>(chars), out charCount, fractionFormat, CultureInfo.InvariantCulture);
             Debug.Assert(charCount != 0);
             result.Append(chars.Slice(0, charCount));
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -358,8 +358,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(AMDesignator) :
-                MemoryMarshal.Cast<byte, TChar>(amDesignatorUtf8 ??= Encoding.UTF8.GetBytes(AMDesignator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(AMDesignator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(amDesignatorUtf8 ??= Encoding.UTF8.GetBytes(AMDesignator));
         }
 
         public Calendar Calendar
@@ -607,8 +607,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(DateSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(dateSeparatorUtf8 ??= Encoding.UTF8.GetBytes(DateSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(DateSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(dateSeparatorUtf8 ??= Encoding.UTF8.GetBytes(DateSeparator));
         }
 
         public DayOfWeek FirstDayOfWeek
@@ -810,8 +810,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(PMDesignator) :
-                MemoryMarshal.Cast<byte, TChar>(pmDesignatorUtf8 ??= Encoding.UTF8.GetBytes(PMDesignator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(PMDesignator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(pmDesignatorUtf8 ??= Encoding.UTF8.GetBytes(PMDesignator));
         }
 
         public string RFC1123Pattern => rfc1123Pattern;
@@ -992,8 +992,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(TimeSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(timeSeparatorUtf8 ??= Encoding.UTF8.GetBytes(TimeSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(TimeSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(timeSeparatorUtf8 ??= Encoding.UTF8.GetBytes(TimeSeparator));
         }
 
         public string UniversalSortableDateTimePattern => universalSortableDateTimePattern;
@@ -1731,8 +1731,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(DecimalSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_decimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(DecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(DecimalSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_decimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(DecimalSeparator));
         }
 
         // Positive TimeSpan Pattern

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/NumberFormatInfo.cs
@@ -269,8 +269,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_currencyDecimalSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_currencyDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencyDecimalSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencyDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyDecimalSeparator));
         }
 
         public bool IsReadOnly => _isReadOnly;
@@ -361,8 +361,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_currencyGroupSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_currencyGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencyGroupSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencyGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_currencyGroupSeparator));
         }
 
         public string CurrencySymbol
@@ -383,8 +383,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_currencySymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_currencySymbolUtf8 ??= Encoding.UTF8.GetBytes(_currencySymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_currencySymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_currencySymbolUtf8 ??= Encoding.UTF8.GetBytes(_currencySymbol));
         }
 
         internal byte[]? CurrencySymbolUtf8 => _currencySymbolUtf8 ??= Encoding.UTF8.GetBytes(_currencySymbol);
@@ -429,8 +429,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_nanSymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_nanSymbolUtf8 ??= Encoding.UTF8.GetBytes(_nanSymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_nanSymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_nanSymbolUtf8 ??= Encoding.UTF8.GetBytes(_nanSymbol));
         }
 
         public int CurrencyNegativePattern
@@ -514,8 +514,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_negativeInfinitySymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_negativeInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_negativeInfinitySymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_negativeInfinitySymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_negativeInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_negativeInfinitySymbol));
         }
 
         public string NegativeSign
@@ -537,8 +537,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_negativeSign) :
-                MemoryMarshal.Cast<byte, TChar>(_negativeSignUtf8 ??= Encoding.UTF8.GetBytes(_negativeSign));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_negativeSign) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_negativeSignUtf8 ??= Encoding.UTF8.GetBytes(_negativeSign));
         }
 
         public int NumberDecimalDigits
@@ -573,8 +573,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_numberDecimalSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_numberDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_numberDecimalSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_numberDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberDecimalSeparator));
         }
 
         public string NumberGroupSeparator
@@ -594,8 +594,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_numberGroupSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_numberGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_numberGroupSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_numberGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_numberGroupSeparator));
         }
 
         public int CurrencyPositivePattern
@@ -631,8 +631,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_positiveInfinitySymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_positiveInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_positiveInfinitySymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_positiveInfinitySymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_positiveInfinitySymbolUtf8 ??= Encoding.UTF8.GetBytes(_positiveInfinitySymbol));
         }
 
         public string PositiveSign
@@ -654,8 +654,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_positiveSign) :
-                MemoryMarshal.Cast<byte, TChar>(_positiveSignUtf8 ??= Encoding.UTF8.GetBytes(_positiveSign));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_positiveSign) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_positiveSignUtf8 ??= Encoding.UTF8.GetBytes(_positiveSign));
         }
 
         public int PercentDecimalDigits
@@ -690,8 +690,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_percentDecimalSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_percentDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentDecimalSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentDecimalSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentDecimalSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentDecimalSeparator));
         }
 
         public string PercentGroupSeparator
@@ -711,8 +711,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_percentGroupSeparator) :
-                MemoryMarshal.Cast<byte, TChar>(_percentGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentGroupSeparator));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentGroupSeparator) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentGroupSeparatorUtf8 ??= Encoding.UTF8.GetBytes(_percentGroupSeparator));
         }
 
         public string PercentSymbol
@@ -732,8 +732,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_percentSymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_percentSymbolUtf8 ??= Encoding.UTF8.GetBytes(_percentSymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_percentSymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_percentSymbolUtf8 ??= Encoding.UTF8.GetBytes(_percentSymbol));
         }
 
         public string PerMilleSymbol
@@ -754,8 +754,8 @@ namespace System.Globalization
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
             return typeof(TChar) == typeof(char) ?
-                MemoryMarshal.Cast<char, TChar>(_perMilleSymbol) :
-                MemoryMarshal.Cast<byte, TChar>(_perMilleSymbolUtf8 ??= Encoding.UTF8.GetBytes(_perMilleSymbol));
+                Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(_perMilleSymbol) :
+                Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(_perMilleSymbolUtf8 ??= Encoding.UTF8.GetBytes(_perMilleSymbol));
         }
 
         public string[] NativeDigits

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -621,7 +621,7 @@ namespace System
 
             if (typeof(TChar) == typeof(char))
             {
-                if (source.TryCopyTo(MemoryMarshal.Cast<TChar, char>(destination)))
+                if (source.TryCopyTo(Unsafe.BitCast<Span<TChar>, Span<char>>(destination)))
                 {
                     charsWritten = source.Length;
                     return true;
@@ -632,7 +632,7 @@ namespace System
             }
             else
             {
-                return Encoding.UTF8.TryGetBytes(source, MemoryMarshal.Cast<TChar, byte>(destination), out charsWritten);
+                return Encoding.UTF8.TryGetBytes(source, Unsafe.BitCast<Span<TChar>, Span<byte>>(destination), out charsWritten);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Parsing.cs
@@ -895,16 +895,16 @@ namespace System
         {
             if (typeof(TChar) == typeof(char))
             {
-                ReadOnlySpan<char> typedSpan = MemoryMarshal.Cast<TChar, char>(span);
-                ReadOnlySpan<char> typedValue = MemoryMarshal.Cast<TChar, char>(value);
+                ReadOnlySpan<char> typedSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(span);
+                ReadOnlySpan<char> typedValue = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(value);
                 return typedSpan.StartsWith(typedValue, comparisonType);
             }
             else
             {
                 Debug.Assert(typeof(TChar) == typeof(byte));
 
-                ReadOnlySpan<byte> typedSpan = MemoryMarshal.Cast<TChar, byte>(span);
-                ReadOnlySpan<byte> typedValue = MemoryMarshal.Cast<TChar, byte>(value);
+                ReadOnlySpan<byte> typedSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(span);
+                ReadOnlySpan<byte> typedValue = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(value);
                 return typedSpan.StartsWithUtf8(typedValue, comparisonType);
             }
         }
@@ -915,13 +915,13 @@ namespace System
         {
             if (typeof(TChar) == typeof(char))
             {
-                return MemoryMarshal.Cast<char, TChar>(MemoryMarshal.Cast<TChar, char>(span).Trim());
+                return Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<TChar>>(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(span).Trim());
             }
             else
             {
                 Debug.Assert(typeof(TChar) == typeof(byte));
 
-                return MemoryMarshal.Cast<byte, TChar>(MemoryMarshal.Cast<TChar, byte>(span).TrimUtf8());
+                return Unsafe.BitCast<ReadOnlySpan<byte>, ReadOnlySpan<TChar>>(Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(span).TrimUtf8());
             }
         }
 
@@ -931,16 +931,16 @@ namespace System
         {
             if (typeof(TChar) == typeof(char))
             {
-                ReadOnlySpan<char> typedSpan = MemoryMarshal.Cast<TChar, char>(span);
-                ReadOnlySpan<char> typedValue = MemoryMarshal.Cast<TChar, char>(value);
+                ReadOnlySpan<char> typedSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(span);
+                ReadOnlySpan<char> typedValue = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<char>>(value);
                 return typedSpan.EqualsOrdinalIgnoreCase(typedValue);
             }
             else
             {
                 Debug.Assert(typeof(TChar) == typeof(byte));
 
-                ReadOnlySpan<byte> typedSpan = MemoryMarshal.Cast<TChar, byte>(span);
-                ReadOnlySpan<byte> typedValue = MemoryMarshal.Cast<TChar, byte>(value);
+                ReadOnlySpan<byte> typedSpan = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(span);
+                ReadOnlySpan<byte> typedValue = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(value);
                 return typedSpan.EqualsOrdinalIgnoreCaseUtf8(typedValue);
             }
         }
@@ -1053,7 +1053,7 @@ namespace System
                 // It's possible after we check the bytes for validity that they could be concurrently
                 // mutated, but if that's happening, all bets are off, anyway, and it simply impacts
                 // which exception is thrown.
-                ReadOnlySpan<byte> bytes = MemoryMarshal.Cast<TChar, byte>(value);
+                ReadOnlySpan<byte> bytes = Unsafe.BitCast<ReadOnlySpan<TChar>, ReadOnlySpan<byte>>(value);
                 errorMessage = Utf8.IsValid(bytes) ?
                     SR.Format(SR.Format_InvalidStringWithValue, Encoding.UTF8.GetString(bytes)) :
                     SR.Format_InvalidString;

--- a/src/libraries/System.Private.CoreLib/src/System/Version.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Version.cs
@@ -249,8 +249,8 @@ namespace System
 
                 int valueCharsWritten;
                 bool formatted = typeof(TChar) == typeof(char) ?
-                    ((uint)value).TryFormat(MemoryMarshal.Cast<TChar, char>(destination), out valueCharsWritten) :
-                    ((uint)value).TryFormat(MemoryMarshal.Cast<TChar, byte>(destination), out valueCharsWritten, default, CultureInfo.InvariantCulture);
+                    ((uint)value).TryFormat(Unsafe.BitCast<Span<TChar>, Span<char>>(destination), out valueCharsWritten) :
+                    ((uint)value).TryFormat(Unsafe.BitCast<Span<TChar>, Span<byte>>(destination), out valueCharsWritten, default, CultureInfo.InvariantCulture);
 
                 if (!formatted)
                 {

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -2241,8 +2241,8 @@ namespace System.Numerics
             {
                 int realChars;
                 if (typeof(TChar) == typeof(char) ?
-                    m_real.TryFormat(MemoryMarshal.Cast<TChar, char>(destination.Slice(1)), out realChars, format, provider) :
-                    m_real.TryFormat(MemoryMarshal.Cast<TChar, byte>(destination.Slice(1)), out realChars, format, provider))
+                    m_real.TryFormat(Unsafe.BitCast<Span<TChar>, Span<char>>(destination.Slice(1)), out realChars, format, provider) :
+                    m_real.TryFormat(Unsafe.BitCast<Span<TChar>, Span<byte>>(destination.Slice(1)), out realChars, format, provider))
                 {
                     destination[0] = TChar.CreateTruncating('<');
                     destination = destination.Slice(1 + realChars); // + 1 for <
@@ -2252,8 +2252,8 @@ namespace System.Numerics
                     {
                         int imaginaryChars;
                         if (typeof(TChar) == typeof(char) ?
-                            m_imaginary.TryFormat(MemoryMarshal.Cast<TChar, char>(destination.Slice(2)), out imaginaryChars, format, provider) :
-                            m_imaginary.TryFormat(MemoryMarshal.Cast<TChar, byte>(destination.Slice(2)), out imaginaryChars, format, provider))
+                            m_imaginary.TryFormat(Unsafe.BitCast<Span<TChar>, Span<char>>(destination.Slice(2)), out imaginaryChars, format, provider) :
+                            m_imaginary.TryFormat(Unsafe.BitCast<Span<TChar>, Span<byte>>(destination.Slice(2)), out imaginaryChars, format, provider))
                         {
                             // We have 1 more character for: >
                             if ((uint)(2 + imaginaryChars) < (uint)destination.Length)

--- a/src/libraries/System.Runtime/tests/System.Runtime.CompilerServices.Unsafe.Tests/UnsafeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.CompilerServices.Unsafe.Tests/UnsafeTests.cs
@@ -1263,10 +1263,9 @@ namespace System.Runtime.CompilerServices
 
             // Conversion between same sized ref structs should succeed
 
-            // TODO https://github.com/dotnet/runtime/issues/102988: Uncomment once this works on mono
-            //int i = 42;
-            //Span<int> span = Unsafe.BitCast<ReadOnlySpan<int>, Span<int>>(new ReadOnlySpan<int>(&i, 1));
-            //Assert.Equal(42, span[0]);
+            int i = 42;
+            Span<int> span = Unsafe.BitCast<ReadOnlySpan<int>, Span<int>>(new ReadOnlySpan<int>(&i, 1));
+            Assert.Equal(42, span[0]);
 
             // Conversion from runtime SIMD type to a custom struct should succeed
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4905,20 +4905,17 @@ interp_handle_box_patterns (TransformData *td, MonoClass *box_class, const unsig
 					if (isinst) {
 						// leave the original value unchanged on the stack
 						interp_add_ins (td, MINT_NOP);
+						td->ip = second_ip + 5;
+						// skip over all three opcodes, continue with the next opcode;
+						return TRUE;
 					} else {
-						// pop the original value, throw a NullReferenceException
-						td->sp--;
-						interp_add_ins (td, MINT_LDNULL);
-						push_simple_type (td, STACK_TYPE_O);
-						interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
-						interp_add_ins (td, MINT_CKNULL);
-						interp_ins_set_sreg (td->last_ins, td->sp->var);
-						set_simple_type_and_var (td, td->sp, td->sp->type);
-						interp_ins_set_dreg (td->last_ins, td->sp->var);
+						// box !T ; isinst S ; unbox.any S should always be
+						// under a box !T ; isinst S ; brtrue/brfalse branch
+						// where the types match.  So if they don't, that's
+						// an invalid program.  In that case compile the
+						// code sequence as is, and allow "box ByRefLike" to
+						// throw InvalidProgramException at execution-time
 					}
-					td->ip = second_ip + 5;
-					// skip over all three opcodes, continue with the next opcode;
-					return TRUE;
 				}
 			}
 	    }

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4827,6 +4827,25 @@ interp_handle_box_patterns (TransformData *td, MonoClass *box_class, const unsig
 		td->ip = next_ip + 5;
 		return TRUE;
 	}
+	if (m_class_is_byreflike (box_class)) {
+	    if (*next_ip == CEE_BRTRUE || *next_ip == CEE_BRTRUE_S || *next_ip == CEE_BRFALSE || *next_ip == CEE_BRFALSE_S) {
+		// replace
+		//  box ByRefLike
+		//  brtrue/brfalse
+		//
+		// by
+		//
+		// ldc.i4.s 1
+		// brtrue/brfalse
+		td->sp--;
+		interp_add_ins (td, MINT_LDC_I4_S);
+		td->last_ins->data[0] = (guint16) 1;
+		push_simple_type (td, STACK_TYPE_I4);
+		interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+		td->ip += 5;
+		return TRUE;
+	    }
+	}
 	return FALSE;
 }
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -7177,14 +7177,6 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 				/* already boxed, do nothing. */
 				td->ip += 5;
 			} else {
-				if (G_UNLIKELY (m_class_is_byreflike (klass)) && !td->optimized) {
-					if (td->verbose_level)
-						g_print ("Box byreflike detected. Retry compilation with full optimization.\n");
-					td->retry_compilation = TRUE;
-					td->retry_with_inlining = TRUE;
-					goto exit;
-				}
-
 				const gboolean vt = mono_mint_type (m_class_get_byval_arg (klass)) == MINT_TYPE_VT;
 
 				if (td->sp [-1].type == STACK_TYPE_R8 && m_class_get_byval_arg (klass)->type == MONO_TYPE_R4)

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -4803,6 +4803,15 @@ interp_emit_sfld_access (TransformData *td, MonoClassField *field, MonoClass *fi
 	}
 }
 
+static MonoClass*
+get_class_from_token (MonoGenericContext *generic_context, MonoMethod *cur_method, uint32_t token)
+{
+	if (cur_method->wrapper_type != MONO_WRAPPER_NONE)
+		return (MonoClass *)mono_method_get_wrapper_data (cur_method, token);
+	else
+		return mini_get_class (cur_method, token, generic_context);
+}
+
 static gboolean
 interp_handle_box_patterns (TransformData *td, MonoClass *box_class, const unsigned char *end, MonoImage *image, MonoGenericContext *generic_context, MonoError *error)
 {
@@ -4828,24 +4837,93 @@ interp_handle_box_patterns (TransformData *td, MonoClass *box_class, const unsig
 		return TRUE;
 	}
 	if (m_class_is_byreflike (box_class)) {
-	    if (*next_ip == CEE_BRTRUE || *next_ip == CEE_BRTRUE_S || *next_ip == CEE_BRFALSE || *next_ip == CEE_BRFALSE_S) {
-		// replace
-		//  box ByRefLike
-		//  brtrue/brfalse
-		//
-		// by
-		//
-		// ldc.i4.s 1
-		// brtrue/brfalse
-		td->sp--;
-		interp_add_ins (td, MINT_LDC_I4_S);
-		td->last_ins->data[0] = (guint16) 1;
-		push_simple_type (td, STACK_TYPE_I4);
-		interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
-		td->ip += 5;
-		return TRUE;
+		if (*next_ip == CEE_BRTRUE || *next_ip == CEE_BRTRUE_S || *next_ip == CEE_BRFALSE || *next_ip == CEE_BRFALSE_S) {
+			// replace
+			//  box ByRefLike
+			//  [brtrue/brfalse]
+			//
+			// by
+			//
+			// ldc.i4.s 1
+			// [brtrue/brfalse]
+			td->sp--;
+			interp_add_ins (td, MINT_LDC_I4_S);
+			td->last_ins->data[0] = (guint16) 1;
+			push_simple_type (td, STACK_TYPE_I4);
+			interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+			td->ip += 5;
+			// skip over box, continue with the branch opcode
+			return TRUE;
+		}
+		if (*next_ip == CEE_ISINST) {
+			// box !!T
+			// isinst S
+			// [brtrue/brfalse]
+			//
+			// turns into
+			// ldc.i4.s (0 or 1)
+			// [brtrue/brfalse]
+
+			// and
+
+			// box !!T
+			// isinst S
+			// unbox.any S
+			//
+			// turns into
+			// nop
+			//   -or-
+			// ldnull
+			// cknull
+			const unsigned char *second_ip = next_ip + 5;
+			if (second_ip >= end || !interp_ip_in_cbb (td, GPTRDIFF_TO_INT (second_ip - td->il_code))) {
+				return FALSE;
+			}
+
+			uint32_t isinst_token = read32 (next_ip + 1);
+			MonoClass *isinst_klass = get_class_from_token (generic_context, method, isinst_token);
+
+			CHECK_TYPELOAD (isinst_klass);
+
+			gboolean isinst = mono_class_is_assignable_from_internal (isinst_klass, box_class);
+
+			if (*second_ip == CEE_BRTRUE || *second_ip == CEE_BRTRUE_S || *second_ip == CEE_BRFALSE || *second_ip == CEE_BRFALSE_S) {
+				td->sp--;
+				interp_add_ins (td, MINT_LDC_I4_S);
+				td->last_ins->data[0] = (guint16) (isinst ? 1 : 0);
+				push_simple_type (td, STACK_TYPE_I4);
+				interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+				td->ip = next_ip + 5;
+				// skip over the box and isinst opcodes, continue with the branch opcode
+				return TRUE;
+			}
+			if (*second_ip == CEE_UNBOX_ANY) {
+				uint32_t unbox_any_token = read32 (second_ip + 1);
+				MonoClass *unbox_klass = get_class_from_token (generic_context, method, unbox_any_token);
+				CHECK_TYPELOAD (unbox_klass);
+				if (unbox_klass == isinst_klass) {
+					if (isinst) {
+						// leave the original value unchanged on the stack
+						interp_add_ins (td, MINT_NOP);
+					} else {
+						// pop the original value, throw a NullReferenceException
+						td->sp--;
+						interp_add_ins (td, MINT_LDNULL);
+						push_simple_type (td, STACK_TYPE_O);
+						interp_ins_set_dreg (td->last_ins, td->sp [-1].var);
+						interp_add_ins (td, MINT_CKNULL);
+						interp_ins_set_sreg (td->last_ins, td->sp->var);
+						set_simple_type_and_var (td, td->sp, td->sp->type);
+						interp_ins_set_dreg (td->last_ins, td->sp->var);
+					}
+					td->ip = second_ip + 5;
+					// skip over all three opcodes, continue with the next opcode;
+					return TRUE;
+				}
+			}
 	    }
 	}
+exit:
 	return FALSE;
 }
 

--- a/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.il
+++ b/src/tests/Loader/classloader/generics/ByRefLike/InvalidCSharp.il
@@ -238,6 +238,20 @@
     }
 
     .method public hidebysig
+        instance bool BoxIsinstUnboxAny_Mismatch(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType2
+            unbox.any ByRefLikeType2
+        // End sequence
+        pop
+        ldc.i4.0
+        ret
+    }
+
+    .method public hidebysig
         instance bool BoxIsinstBranch(!T) cil managed
     {
         ldarg.1
@@ -436,6 +450,14 @@
 }
 
 .class public sequential ansi sealed beforefieldinit ByRefLikeType
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+}
+
+.class public sequential ansi sealed beforefieldinit ByRefLikeType2
     extends [System.Runtime]System.ValueType
 {
     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
@@ -752,6 +774,22 @@
         ldloc 0
         ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
         call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstUnboxAny(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxIsinstUnboxAny_Mismatch() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstUnboxAny_Mismatch(!0)
         ret
     }
 

--- a/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
@@ -68,6 +68,16 @@ public class Validate
     }
 
     [Fact]
+    public static void Validate_RecognizedOpCodeSequences_Mismatch()
+    {
+        Console.WriteLine($"{nameof(Validate_RecognizedOpCodeSequences_Mismatch)}...");
+
+        // box !T ; isinst S ; unbox.any S should always be guarded by a box !T ; isinst S;
+        // brtrue/brfalse branch, so if it's ever executed and the types aren't equal that's invalid
+        Assert.Throws<InvalidProgramException>(() => { Exec.BoxIsinstUnboxAny_Mismatch(); });
+    }
+
+    [Fact]
     public static void Validate_InvalidOpCode_Scenarios()
     {
         Console.WriteLine($"{nameof(Validate_InvalidOpCode_Scenarios)}...");
@@ -81,6 +91,7 @@ public class Validate
 
         // Test that explicitly tries to box a ByRefLike type.
         Assert.Throws<InvalidProgramException>(() => { Exec.BoxAsObject(); });
+
     }
 
     [Fact]

--- a/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
+++ b/src/tests/Loader/classloader/generics/ByRefLike/Validate.cs
@@ -91,7 +91,6 @@ public class Validate
 
         // Test that explicitly tries to box a ByRefLike type.
         Assert.Throws<InvalidProgramException>(() => { Exec.BoxAsObject(); });
-
     }
 
     [Fact]


### PR DESCRIPTION
In cases where we don't do cprop and deadce (for example if `mono_interp_opt` is 0 because we're debugging) don't emit a box_vt opcode before a branch.  Instead just emit a constant true

Fixes https://github.com/dotnet/runtime/issues/102988

Also reverts the changes from https://github.com/dotnet/runtime/pull/102998