### PR TITLE
Update osx-arm64, osx-x64, and linux-arm Helix queues

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -24,13 +24,9 @@
 # 4.  For benchmarks collections, a specialized script is called to set up the benchmarks collection.
 # 5.  Lastly, it sets the pipeline variables.
 #
-# Below are the helix queues and images it sets depending on the OS/architecture (accepted format by Helix is either "QueueName" or "(DisplayName)QueueName@Image")
-# | Arch  | windows                 | Linux                                                                                                                                | macOS          |
-# |-------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------|----------------|
-# | x86   | Windows.10.Amd64.X86.Rt | -                                                                                                                                    | -              |
-# | x64   | Windows.10.Amd64.X86.Rt | Ubuntu.2204.Amd64                                                                                                                    | OSX.1014.Amd64 |
-# | arm   | -                       | (Ubuntu.1804.Arm32)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7                        | -              |
-# | arm64 | Windows.11.Arm64        | (Ubuntu.1804.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8                        | OSX.1100.ARM64 |
+# The helix queues used are defined below in the code, in the `helix_queue` variable.
+# Note that this is unfortunate as it doesn't get updated when the common code in
+# eng/pipelines/coreclr/templates/helix-queues-setup.yml is updated.
 #
 ################################################################################
 ################################################################################
@@ -457,17 +453,18 @@ def main(main_args):
     ci = True
 
     # Determine the Helix queue name to use when running jobs.
+    # Note that we run in the 'internal', not 'public', instance, so we must use 'internal' queues.
     if platform_name == "windows":
         helix_queue = "Windows.11.Arm64" if arch == "arm64" else "Windows.10.Amd64.X86.Rt"
     elif platform_name == "linux":
         if arch == "arm":
-            helix_queue = "(Ubuntu.1804.Arm32)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm32v7"
+            helix_queue = "(Debian.12.Arm32)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-12-helix-arm32v7"
         elif arch == "arm64":
             helix_queue = "(Ubuntu.1804.Arm64)Ubuntu.2004.ArmArch@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-helix-arm64v8"
         else:
             helix_queue = "Ubuntu.2204.Amd64"
     elif platform_name == "osx":
-        helix_queue = "OSX.1100.ARM64" if arch == "arm64" else "OSX.1014.Amd64"
+        helix_queue = "OSX.1200.ARM64" if arch == "arm64" else "OSX.1200.Amd64"
 
     # Copy the superpmi scripts
 


### PR DESCRIPTION
Match the current Helix queues specified in
eng/pipelines/coreclr/templates/helix-queues-setup.yml.