### PR TITLE
Set csharp_indent_case_contents_when_block to false

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,7 +31,7 @@ csharp_new_line_between_query_expression_clauses = true
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
+csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 


### PR DESCRIPTION
The VS default and therefore our default is `csharp_indent_case_contents_when_block = true` which is that way for historical reasons:
```csharp
// csharp_indent_case_contents_when_block = true
case 0:
    {
        Console.WriteLine("Hello");
        break;
    }

// csharp_indent_case_contents_when_block = false
case 0:
{
    Console.WriteLine("Hello");
    break;
}
```

But this default is inconsistent with the indentation used for block expressions given `if`, `else`, `for`, `foreach`, `do`, `while`, `switch` itself, etc. So this makes `case` consistent with all other scenarios, makes the code more readable, and avoids devs needing to fight formatting with VS.