### PR TITLE
Don't run the new System.Net.ServerSentEvents test with NAOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -536,6 +536,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\NlsTests\System.Runtime.Nls.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Xml\tests\System.Security.Cryptography.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.ServerSentEvents\tests\System.Net.ServerSentEvents.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Uses reflection-based JSON so it's unsupportable without someone writing a trimming descriptor.