### PR TITLE
[LoongArch64] Fix the `ArgIteratorTemplate::GetNextOffset()` return argOfs for 'ELEMENT_TYPE_VALUETYPE' which is flattened liking struct{Arr[], float}.

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1390,7 +1390,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                     _hasArgLocDescForStructInRegs = true;
                                     _argLocDescForStructInRegs.m_floatFlags = floatFieldFlags;
 
-                                    int argOfsInner = _transitionBlock.OffsetOfFloatArgumentRegisters + _loongarch64IdxFPReg * 8;
+                                    int argOfsInner = 0;
+                                    if ((floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND) != 0)
+                                    {
+                                        argOfsInner = _transitionBlock.OffsetOfArgumentRegisters + _loongarch64IdxGenReg * 8;
+                                    }
+                                    else
+                                    {
+                                        argOfsInner = _transitionBlock.OffsetOfFloatArgumentRegisters + _loongarch64IdxFPReg * 8;
+                                    }
+
                                     _loongarch64IdxFPReg++;
                                     _loongarch64IdxGenReg++;
                                     return argOfsInner;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -311,10 +311,7 @@ struct TransitionBlock
     #elif defined(TARGET_LOONGARCH64)
         if (argLocDescForStructInRegs != NULL)
         {
-            if (argLocDescForStructInRegs->m_structFields & STRUCT_FLOAT_FIELD_SECOND)
-            {
-                return argLocDescForStructInRegs->m_cFloatReg > 0;
-            }
+            return argLocDescForStructInRegs->m_cFloatReg > 0;
         }
     #endif
         return offset < 0;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -308,6 +308,14 @@ struct TransitionBlock
         {
             return argLocDescForStructInRegs->m_cFloatReg > 0;
         }
+    #elif defined(TARGET_LOONGARCH64)
+        if (argLocDescForStructInRegs != NULL)
+        {
+            if (argLocDescForStructInRegs->m_structFields & STRUCT_FLOAT_FIELD_SECOND)
+            {
+                return argLocDescForStructInRegs->m_cFloatReg > 0;
+            }
+        }
     #endif
         return offset < 0;
     }
@@ -1719,16 +1727,24 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
             if ((1 + m_idxFPReg <= NUM_ARGUMENT_REGISTERS) && (m_idxGenReg + 1 <= NUM_ARGUMENT_REGISTERS))
             {
+                int argOfs = 0;
                 m_argLocDescForStructInRegs.Init();
                 m_argLocDescForStructInRegs.m_idxFloatReg = m_idxFPReg;
                 m_argLocDescForStructInRegs.m_cFloatReg = 1;
-                int argOfs = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
-                m_idxFPReg += 1;
-
-                m_argLocDescForStructInRegs.m_structFields = flags;
-
                 m_argLocDescForStructInRegs.m_idxGenReg = m_idxGenReg;
                 m_argLocDescForStructInRegs.m_cGenReg = 1;
+                m_argLocDescForStructInRegs.m_structFields = flags;
+
+                if (flags & STRUCT_FLOAT_FIELD_SECOND)
+                {
+                    argOfs = TransitionBlock::GetOffsetOfArgumentRegisters() + m_idxGenReg * 8;
+                }
+                else
+                {
+                    argOfs = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
+                }
+
+                m_idxFPReg  += 1;
                 m_idxGenReg += 1;
 
                 m_hasArgLocDescForStructInRegs = true;


### PR DESCRIPTION
[LoongArch64] Fix the `ArgIteratorTemplate::GetNextOffset()` return argOfs for 'ELEMENT_TYPE_VALUETYPE' which is flattened liking struct{Arr[], float}.
* The 'ELEMENT_TYPE_VALUETYPE' is marked to 'TYPE_GC_OTHER' and the first flattened element Arr[] should be GC.
* This also fixed the assert failure "!CREATE_CHECK_STRING(pMT && pMT->Validate())" under GC=8 of MarshalStructAsLayoutSeq.sh.