### PR TITLE
Scan intrinsic methods if we're taking address

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -387,14 +387,17 @@ namespace Internal.IL
                     return;
                 }
 
-                if (IsRuntimeHelpersIsReferenceOrContainsReferences(method))
+                if (opcode != ILOpcode.ldftn)
                 {
-                    return;
-                }
+                    if (IsRuntimeHelpersIsReferenceOrContainsReferences(method))
+                    {
+                        return;
+                    }
 
-                if (IsMemoryMarshalGetArrayDataReference(method))
-                {
-                    return;
+                    if (IsMemoryMarshalGetArrayDataReference(method))
+                    {
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
These can be address taken and if they are, we still need to scan them. Fixes pri-0 outerloop test build break.

Cc @dotnet/ilc-contrib 