### PR TITLE
[LoongArch64] Fix the TestVector256() size alignment within `src/tests/Interop/StructPacking/StructPacking.cs`.

### DIFF
--- a/src/tests/Interop/StructPacking/StructPacking.cs
+++ b/src/tests/Interop/StructPacking/StructPacking.cs
@@ -1326,9 +1326,10 @@ public unsafe partial class Program
                 expectedOffsetValue: 8
             );
         }
-        else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 || RuntimeInformation.ProcessArchitecture == Architecture.RiscV64)
+        else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64 || RuntimeInformation.ProcessArchitecture == Architecture.RiscV64
+                || RuntimeInformation.ProcessArchitecture == Architecture.LoongArch64)
         {
-            // The Procedure Call Standard for ARM64 and RiscV64 defines this type as having 16-byte alignment
+            // The Procedure Call Standard for ARM64, RiscV64, LoongArch64 defines this type as having 16-byte alignment
 
             succeeded &= Test<DefaultLayoutDefaultPacking<Vector256<byte>>>(
                 expectedSize: 48,


### PR DESCRIPTION
Fix the TestVector256() size alignment within `src/tests/Interop/StructPacking/StructPacking.cs`.
* Mainly fix the size and offset mismatch for the testcase: Interop.sh - global::Program.TestEntryPoint().
* Maybe we will adjust it in the future according to https://github.com/dotnet/runtime/pull/94400 .