### PR TITLE
Enable reflection-based serialization in `System.Net.ServerSentEvents.Tests` on Apple mobile

### DIFF
--- a/src/libraries/System.Net.ServerSentEvents/tests/System.Net.ServerSentEvents.Tests.csproj
+++ b/src/libraries/System.Net.ServerSentEvents/tests/System.Net.ServerSentEvents.Tests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkMinimum)</TargetFrameworks>
+    <!-- The JsonSerializerIsReflectionEnabledByDefault feature switch is turned off automatically in projects that enable the PublishTrimmed property.
+         Enable reflection and preserve required assemblies -->
+    <JsonSerializerIsReflectionEnabledByDefault Condition="'$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true'">true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

This PR enables reflection-based serialization in `System.Net.ServerSentEvents.Tests` which should resolve trimming-related errors on Apple mobile platforms. The tests report the following exception:
```
Exception messages: System.InvalidOperationException : Reflection-based serialization has been disabled for this application. Either use the source generator APIs or explicitly configure the 'JsonSerializerOptions.TypeInfoResolver' property.   Exception stack traces:    at System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()
[06:00:34.9598940]    at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions , Type )
[06:00:34.9599000]    at System.Text.Json.JsonSerializer.GetTypeInfo[JsonElement](JsonSerializerOptions )
```

## Changes

The `JsonSerializerIsReflectionEnabledByDefault` feature switch is turned off automatically when `PublishTrimmed` property is set.

## Validation

The tests should pass in the ioslike pipeline https://dev.azure.com/dnceng-public/public/_build?definitionId=225&_a=summary.