### PR TITLE
[RISC-V] Fix ArgIteratorTemplate::GetNextOffset() for struct{Arr[], float}

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1512,7 +1512,11 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                     _hasArgLocDescForStructInRegs = true;
                                     _argLocDescForStructInRegs.m_floatFlags = floatFieldFlags;
 
-                                    int argOfsInner = _transitionBlock.OffsetOfFloatArgumentRegisters + _riscv64IdxFPReg * 8;
+                                    int argOfsInner =
+                                        ((floatFieldFlags & (uint)StructFloatFieldInfoFlags.STRUCT_FLOAT_FIELD_SECOND) != 0)
+                                            ? _transitionBlock.OffsetOfArgumentRegisters + _riscv64IdxGenReg * 8
+                                            : _transitionBlock.OffsetOfFloatArgumentRegisters + _riscv64IdxFPReg * 8;
+
                                     _riscv64IdxFPReg++;
                                     _riscv64IdxGenReg++;
                                     return argOfsInner;

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -308,6 +308,11 @@ struct TransitionBlock
         {
             return argLocDescForStructInRegs->m_cFloatReg > 0;
         }
+    #elif defined(TARGET_RISCV64)
+        if (argLocDescForStructInRegs != NULL)
+        {
+            return argLocDescForStructInRegs->m_cFloatReg > 0;
+        }
     #endif
         return offset < 0;
     }
@@ -1836,7 +1841,9 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
                 m_argLocDescForStructInRegs.Init();
                 m_argLocDescForStructInRegs.m_idxFloatReg = m_idxFPReg;
                 m_argLocDescForStructInRegs.m_cFloatReg = 1;
-                int argOfs = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
+                int argOfs = (flags & STRUCT_FLOAT_FIELD_SECOND)
+                    ? TransitionBlock::GetOffsetOfArgumentRegisters() + m_idxGenReg * 8
+                    : TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
                 m_idxFPReg += 1;
 
                 m_argLocDescForStructInRegs.m_structFields = flags;


### PR DESCRIPTION
Change analogous to #103108. I eschewed the profiler patch as ProfileArgIterator::CopyStructFromRegisters already handles this case on RISC-V.

Part of #84834, cc @dotnet/samsung