### PR TITLE
[release/9.0-preview5] [workloads] Releases moved

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,8 +7,8 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
-    <PackageVersionNet8>8.0.7</PackageVersionNet8>
-    <PackageVersionNet7>7.0.20</PackageVersionNet7>
+    <PackageVersionNet8>8.0.6</PackageVersionNet8>
+    <PackageVersionNet7>7.0.19</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet8)').Build),25))</PackageVersionNet6>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>5</PreReleaseVersionIteration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
     <PatchVersion>0</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
     <PackageVersionNet8>8.0.6</PackageVersionNet8>
-    <PackageVersionNet7>7.0.19</PackageVersionNet7>
+    <PackageVersionNet7>7.0.20</PackageVersionNet7>
     <PackageVersionNet6>6.0.$([MSBuild]::Add($([System.Version]::Parse('$(PackageVersionNet8)').Build),25))</PackageVersionNet6>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>5</PreReleaseVersionIteration>


### PR DESCRIPTION
Are these the right versions?
8.0.6, 7.0.20 and 6.0.31