### PR TITLE
Dispose IDisposables in RegexGenerator

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -140,7 +140,7 @@ namespace System.Text.RegularExpressions.Generator
                 }
 
                 // At this point we'll be emitting code.  Create a writer to hold it all.
-                using var sw = new StringWriter();
+                using StringWriter sw = new();
                 using IndentedTextWriter writer = new(sw);
 
                 // Add file headers and required usings.

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.cs
@@ -140,8 +140,8 @@ namespace System.Text.RegularExpressions.Generator
                 }
 
                 // At this point we'll be emitting code.  Create a writer to hold it all.
-                var sw = new StringWriter();
-                IndentedTextWriter writer = new(sw);
+                using var sw = new StringWriter();
+                using IndentedTextWriter writer = new(sw);
 
                 // Add file headers and required usings.
                 foreach (string header in s_headers)


### PR DESCRIPTION
The StringWriter and IndentedTextWriter are IDisposable classes, so we should dispose them when we are done with them.