### PR TITLE
remove unnecessary Avx512VL ISA flags.

### DIFF
--- a/src/coreclr/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
+++ b/src/coreclr/tools/Common/Compiler/HardwareIntrinsicHelpers.cs
@@ -74,8 +74,7 @@ namespace ILCompiler
             public const int Avx512Vbmi = 0x10000;
             public const int Serialize = 0x20000;
             public const int Avx10v1 = 0x40000;
-            public const int Avx10v1_v512 = 0x80000;
-            public const int Evex = 0x100000;
+            public const int Evex = 0x80000;
 
             public static void AddToBuilder(InstructionSetSupportBuilder builder, int flags)
             {
@@ -129,7 +128,7 @@ namespace ILCompiler
                     builder.AddSupportedInstructionSet("serialize");
                 if ((flags & Avx10v1) != 0)
                     builder.AddSupportedInstructionSet("avx10v1");
-                if ((flags & Avx10v1_v512) != 0)
+                if (((flags & Avx10v1) != 0) && ((flags & Avx512) != 0))
                     builder.AddSupportedInstructionSet("avx10v1_v512");
                 if ((flags & Evex) != 0)
                     builder.AddSupportedInstructionSet("evex");
@@ -198,8 +197,8 @@ namespace ILCompiler
                     InstructionSet.X64_X86Serialize_X64 => Serialize,
                     InstructionSet.X64_AVX10v1 => Avx10v1,
                     InstructionSet.X64_AVX10v1_X64 => Avx10v1,
-                    InstructionSet.X64_AVX10v1_V512 => Avx10v1_v512,
-                    InstructionSet.X64_AVX10v1_V512_X64 => Avx10v1_v512,
+                    InstructionSet.X64_AVX10v1_V512 => (Avx10v1 | Avx512),
+                    InstructionSet.X64_AVX10v1_V512_X64 => (Avx10v1 | Avx512),
                     InstructionSet.X64_EVEX => Evex,
                     InstructionSet.X64_EVEX_X64 => Evex,
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1433,12 +1433,12 @@ void EEJitManager::SetCpuInfo()
         {
             CPUCompileFlags.Set(InstructionSet_EVEX);
             CPUCompileFlags.Set(InstructionSet_AVX10v1);
-        }
-    }
 
-    if ((cpuFeatures & XArchIntrinsicConstants_Avx10v1_V512) != 0)
-    {
-        CPUCompileFlags.Set(InstructionSet_AVX10v1_V512);
+            if((cpuFeatures & XArchIntrinsicConstants_Avx512) != 0)
+            {
+                CPUCompileFlags.Set(InstructionSet_AVX10v1_V512);
+            }
+        }
     }
 #elif defined(TARGET_ARM64)
 

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -263,6 +263,11 @@ int minipal_getcpufeatures(void)
                                         {
                                             result |= XArchIntrinsicConstants_Evex;
                                             result |= XArchIntrinsicConstants_Avx10v1;
+                                            
+                                            // We assume that the Avx10/V512 support can be inferred from
+                                            // both Avx10v1 and Avx512 being present.
+                                            assert(((cpuidInfo[CPUID_EBX] & (1 << 18)) != 0) ==                 // Avx10/V512
+                                                ((result & XArchIntrinsicConstants_Avx512) != 0));
                                         }
                                     }
                                 }

--- a/src/native/minipal/cpufeatures.c
+++ b/src/native/minipal/cpufeatures.c
@@ -263,13 +263,6 @@ int minipal_getcpufeatures(void)
                                         {
                                             result |= XArchIntrinsicConstants_Evex;
                                             result |= XArchIntrinsicConstants_Avx10v1;
-
-                                            bool isV512Supported = (cpuidInfo[CPUID_EBX] & (1 << 18)) != 0;     // Avx10/V512
-
-                                            if (isV512Supported)
-                                            {
-                                                result |= XArchIntrinsicConstants_Avx10v1_V512;
-                                            }
                                         }
                                     }
                                 }

--- a/src/native/minipal/cpufeatures.h
+++ b/src/native/minipal/cpufeatures.h
@@ -30,8 +30,7 @@ enum XArchIntrinsicConstants
     XArchIntrinsicConstants_Avx512Vbmi = 0x10000,
     XArchIntrinsicConstants_Serialize = 0x20000,
     XArchIntrinsicConstants_Avx10v1 = 0x40000,
-    XArchIntrinsicConstants_Avx10v1_V512 = 0x80000,
-    XArchIntrinsicConstants_Evex = 0x100000,
+    XArchIntrinsicConstants_Evex = 0x80000,
 };
 #endif // HOST_X86 || HOST_AMD64
 


### PR DESCRIPTION
More context in https://github.com/dotnet/runtime/pull/103019#discussion_r1625346678

To save some space in `XArchIntrinsicConstants`, this PR turns `Avx512*_VL` ISA flags per  subset into a converged flag: `Avx512F_VL`, such that we can hold more ISAs within this enum, this will be the pre-work for the ongoing APX project.