### PR TITLE
Disable HAS_MORE_THAN_64_REGISTERS until we add complete support

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1725,13 +1725,15 @@ private:
 #endif
     PhasedVar<SingleTypeRegSet>* availableRegs[TYP_COUNT];
 
-#if defined(TARGET_XARCH)
-#define allAvailableRegs regMaskTP(availableIntRegs | availableFloatRegs | availableMaskRegs)
-#elif defined(TARGET_ARM64)
+#if defined(TARGET_XARCH) || defined(TARGET_ARM64)
+#ifdef HAS_MORE_THAN_64_REGISTERS
 #define allAvailableRegs regMaskTP(availableIntRegs | availableFloatRegs, availableMaskRegs)
 #else
+#define allAvailableRegs regMaskTP(availableIntRegs | availableFloatRegs | availableMaskRegs)
+#endif // HAS_MORE_THAN_64_REGISTERS
+#else
 #define allAvailableRegs regMaskTP(availableIntRegs | availableFloatRegs)
-#endif
+#endif // defined(TARGET_XARCH) || defined(TARGET_ARM64)
 
     // Register mask of argument registers currently occupied because we saw a
     // PUTARG_REG node. Tracked between the PUTARG_REG and its corresponding

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -230,7 +230,7 @@ typedef uint64_t regMaskSmall;
 #endif
 
 #ifdef TARGET_ARM64
-//#define HAS_MORE_THAN_64_REGISTERS 1
+// #define HAS_MORE_THAN_64_REGISTERS 1
 #endif // TARGET_ARM64
 
 #ifdef HAS_MORE_THAN_64_REGISTERS

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -230,7 +230,7 @@ typedef uint64_t regMaskSmall;
 #endif
 
 #ifdef TARGET_ARM64
-#define HAS_MORE_THAN_64_REGISTERS 1
+//#define HAS_MORE_THAN_64_REGISTERS 1
 #endif // TARGET_ARM64
 
 #ifdef HAS_MORE_THAN_64_REGISTERS


### PR DESCRIPTION
We should just disable this until we add complete support for more than 64 registers because we might start operating on `high` although we do not have corresponding registers.