### PR TITLE
Enable escape analysis and use in vn

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4717,9 +4717,17 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     // local variable allocation on the stack.
     ObjectAllocator objectAllocator(this); // PHASE_ALLOCATE_OBJECTS
 
-    if (compObjectStackAllocation() && opts.OptimizationEnabled())
+    if (opts.OptimizationEnabled())
     {
-        objectAllocator.EnableObjectStackAllocation();
+        if (JitConfig.JitObjectStackAllocationAnalysis() > 0)
+        {
+            objectAllocator.EnableObjectStackAllocationAnalysis();
+        }
+
+        if (compObjectStackAllocation())
+        {
+            objectAllocator.EnableObjectStackAllocation();
+        }
     }
 
     objectAllocator.Run();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6497,7 +6497,7 @@ private:
 
     GenTree* fgMorphCastIntoHelper(GenTree* tree, int helper, GenTree* oper);
 
-    GenTree* fgMorphIntoHelperCall(
+    GenTreeCall* fgMorphIntoHelperCall(
         GenTree* tree, int helper, bool morphArgs, GenTree* arg1 = nullptr, GenTree* arg2 = nullptr);
 
     // A "MorphAddrContext" carries information from the surrounding context.  If we are evaluating a byref address,

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4171,6 +4171,7 @@ enum GenTreeCallFlags : unsigned int
     GTF_CALL_M_CAST_CAN_BE_EXPANDED    = 0x04000000, // this cast (helper call) can be expanded if it's profitable. To be removed.
     GTF_CALL_M_CAST_OBJ_NONNULL        = 0x08000000, // if we expand this specific cast we don't need to check the input object for null
                                                      // NOTE: if needed, this flag can be removed, and we can introduce new _NONNUL cast helpers
+    GTF_CALL_M_NO_ESCAPE               = 0x10000000, // the object allocated by this call does not escape allocating thread
 };
 
 inline constexpr GenTreeCallFlags operator ~(GenTreeCallFlags a)

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -651,6 +651,7 @@ RELEASE_CONFIG_INTEGER(JitExtDefaultPolicyProfScale, W("JitExtDefaultPolicyProfS
 RELEASE_CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 RELEASE_CONFIG_INTEGER(JitInlinePolicyProfile, W("JitInlinePolicyProfile"), 0)
 RELEASE_CONFIG_INTEGER(JitInlinePolicyProfileThreshold, W("JitInlinePolicyProfileThreshold"), 40)
+RELEASE_CONFIG_INTEGER(JitObjectStackAllocationAnalysis, W("JitObjectStackAllocationAnalysis"), 1)
 RELEASE_CONFIG_INTEGER(JitObjectStackAllocation, W("JitObjectStackAllocation"), 0)
 
 RELEASE_CONFIG_INTEGER(JitEECallTimingInfo, W("JitEECallTimingInfo"), 0)

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -71,6 +71,8 @@ JITMETADATAMETRIC(ProfileInconsistentInlineeScale,       int,              0)
 JITMETADATAMETRIC(ProfileInconsistentInlinee,            int,              0)
 JITMETADATAMETRIC(ProfileInconsistentNoReturnInlinee,    int,              0)
 JITMETADATAMETRIC(ProfileInconsistentMayThrowInlinee,    int,              0)
+JITMETADATAMETRIC(NewHelperCalls,                        int,              0)
+JITMETADATAMETRIC(NonEscapingNewHelperCalls,             int,              0)
 
 #undef JITMETADATA
 #undef JITMETADATAINFO

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -71,8 +71,10 @@ JITMETADATAMETRIC(ProfileInconsistentInlineeScale,       int,              0)
 JITMETADATAMETRIC(ProfileInconsistentInlinee,            int,              0)
 JITMETADATAMETRIC(ProfileInconsistentNoReturnInlinee,    int,              0)
 JITMETADATAMETRIC(ProfileInconsistentMayThrowInlinee,    int,              0)
-JITMETADATAMETRIC(NewHelperCalls,                        int,              0)
-JITMETADATAMETRIC(NonEscapingNewHelperCalls,             int,              0)
+JITMETADATAMETRIC(NewRefClassHelperCalls,                int,              0)
+JITMETADATAMETRIC(NonEscapingNewRefClassHelperCalls,     int,              0)
+JITMETADATAMETRIC(NewBoxedValueClassHelperCalls,         int,              0)
+JITMETADATAMETRIC(NonEscapingNewBoxedValueClassHelperCalls, int,              0)
 
 #undef JITMETADATA
 #undef JITMETADATAINFO

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -180,7 +180,7 @@ public:
 // Return value:
 //   The call (which is the same as `tree`).
 //
-GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, bool morphArgs, GenTree* arg1, GenTree* arg2)
+GenTreeCall* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, bool morphArgs, GenTree* arg1, GenTree* arg2)
 {
     // The helper call ought to be semantically equivalent to the original node, so preserve its VN.
     tree->ChangeOper(GT_CALL, GenTree::PRESERVE_VN);
@@ -250,10 +250,10 @@ GenTree* Compiler::fgMorphIntoHelperCall(GenTree* tree, int helper, bool morphAr
     if (morphArgs)
     {
         SharedTempsScope scope(this);
-        tree = fgMorphArgs(call);
+        call = fgMorphArgs(call);
     }
 
-    return tree;
+    return call;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -417,17 +417,20 @@ bool ObjectAllocator::MorphAllocObjNodes()
 
                     // Some new helpers directly cause escape (eg add to finalizer queue)
                     //
-                    const bool         doesNotEscape = !CanLclVarEscape(lclNum) && !asAllocObj->gtHelperHasSideEffects;
-                    GenTreeCall* const helper        = MorphAllocObjNodeIntoHelperCall(asAllocObj);
 
+                    GenTreeCall* const helper        = MorphAllocObjNodeIntoHelperCall(asAllocObj);
                     data                         = helper;
                     stmtExpr->AsLclVar()->Data() = data;
                     stmtExpr->AddAllEffectsFlags(data);
 
-                    if (doesNotEscape)
+                    if (IsObjectStackAllocationAnalysisEnabled())
                     {
-                        JITDUMP("ALLOCOBJ at [%06u] does not escape\n", comp->dspTreeID(asAllocObj));
-                        helper->gtCallMoreFlags |= GTF_CALL_M_NO_ESCAPE;
+                        const bool doesNotEscape = !CanLclVarEscape(lclNum) && !asAllocObj->gtHelperHasSideEffects;
+                        if (doesNotEscape)
+                        {
+                            JITDUMP("ALLOCOBJ at [%06u] does not escape\n", comp->dspTreeID(asAllocObj));
+                            helper->gtCallMoreFlags |= GTF_CALL_M_NO_ESCAPE;
+                        }
                     }
                 }
             }

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -393,7 +393,8 @@ bool ObjectAllocator::MorphAllocObjNodes()
                 unsigned int         lclNum     = stmtExpr->AsLclVar()->GetLclNum();
                 CORINFO_CLASS_HANDLE clsHnd     = data->AsAllocObj()->gtAllocObjClsHnd;
 
-                DWORD      classAttribs = comp->info.compCompHnd->getClassAttribs(clsHnd);
+                DWORD classAttribs = 0;
+                // comp->info.compCompHnd->getClassAttribs(clsHnd);
                 const bool isValueClass = (classAttribs & CORINFO_FLG_VALUECLASS) != 0;
 
                 if (isValueClass)

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -751,6 +751,7 @@ void ObjectAllocator::UpdateAncestorTypes(GenTree* tree, ArrayStack<GenTree*>* p
                 break;
 
             case GT_IND:
+            case GT_CALL:
                 break;
 
             default:

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -418,7 +418,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
                     // Some new helpers directly cause escape (eg add to finalizer queue)
                     //
 
-                    GenTreeCall* const helper        = MorphAllocObjNodeIntoHelperCall(asAllocObj);
+                    GenTreeCall* const helper    = MorphAllocObjNodeIntoHelperCall(asAllocObj);
                     data                         = helper;
                     stmtExpr->AsLclVar()->Data() = data;
                     stmtExpr->AddAllEffectsFlags(data);

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -380,6 +380,8 @@ bool ObjectAllocator::MorphAllocObjNodes()
             if (canonicalAllocObjFound)
             {
                 assert(basicBlockHasNewObj);
+
+                comp->Metrics.NewHelperCalls++;
                 //------------------------------------------------------------------------
                 // We expect the following expression tree at this point
                 //  STMTx (IL 0x... ???)
@@ -430,6 +432,7 @@ bool ObjectAllocator::MorphAllocObjNodes()
                         {
                             JITDUMP("ALLOCOBJ at [%06u] does not escape\n", comp->dspTreeID(asAllocObj));
                             helper->gtCallMoreFlags |= GTF_CALL_M_NO_ESCAPE;
+                            comp->Metrics.NonEscapingNewHelperCalls++;
                         }
                     }
                 }

--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -25,6 +25,7 @@ class ObjectAllocator final : public Phase
 
     //===============================================================================
     // Data members
+    bool         m_IsObjectStackAllocationAnalysisEnabled;
     bool         m_IsObjectStackAllocationEnabled;
     bool         m_AnalysisDone;
     BitVecTraits m_bitVecTraits;
@@ -41,7 +42,9 @@ class ObjectAllocator final : public Phase
 public:
     ObjectAllocator(Compiler* comp);
     bool IsObjectStackAllocationEnabled() const;
+    bool IsObjectStackAllocationAnalysisEnabled() const;
     void EnableObjectStackAllocation();
+    void EnableObjectStackAllocationAnalysis();
 
 protected:
     virtual PhaseStatus DoPhase() override;
@@ -61,7 +64,7 @@ private:
     void         ComputeStackObjectPointers(BitVecTraits* bitVecTraits);
     bool         MorphAllocObjNodes();
     void         RewriteUses();
-    GenTree*     MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* allocObj);
+    GenTreeCall* MorphAllocObjNodeIntoHelperCall(GenTreeAllocObj* allocObj);
     unsigned int MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* allocObj, BasicBlock* block, Statement* stmt);
     struct BuildConnGraphVisitorCallbackData;
     bool CanLclVarEscapeViaParentStack(ArrayStack<GenTree*>* parentStack, unsigned int lclNum);
@@ -74,6 +77,7 @@ private:
 
 inline ObjectAllocator::ObjectAllocator(Compiler* comp)
     : Phase(comp, PHASE_ALLOCATE_OBJECTS)
+    , m_IsObjectStackAllocationAnalysisEnabled(false)
     , m_IsObjectStackAllocationEnabled(false)
     , m_AnalysisDone(false)
     , m_bitVecTraits(comp->lvaCount, comp)
@@ -97,11 +101,31 @@ inline bool ObjectAllocator::IsObjectStackAllocationEnabled() const
 }
 
 //------------------------------------------------------------------------
+// IsObjectStackAllocationAnalysisEnabled: Returns true iff object stack allocation analysis is enabled
+//
+// Return Value:
+//    Returns true iff object stack allocation analysis is enabled
+
+inline bool ObjectAllocator::IsObjectStackAllocationAnalysisEnabled() const
+{
+    return m_IsObjectStackAllocationAnalysisEnabled;
+}
+
+//------------------------------------------------------------------------
+// EnableObjectStackAllocationAnalysis:       Enable object stack allocation analysis.
+
+inline void ObjectAllocator::EnableObjectStackAllocationAnalysis()
+{
+    m_IsObjectStackAllocationAnalysisEnabled = true;
+}
+
+//------------------------------------------------------------------------
 // EnableObjectStackAllocation:       Enable object stack allocation.
 
 inline void ObjectAllocator::EnableObjectStackAllocation()
 {
-    m_IsObjectStackAllocationEnabled = true;
+    m_IsObjectStackAllocationEnabled         = true;
+    m_IsObjectStackAllocationAnalysisEnabled = true;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1665,6 +1665,7 @@ void HelperCallProperties::init()
 
                 // These throw for a failing cast
                 // But if given a null input arg will return null
+                // if they throw they cause the object to escape
                 isPure = true;
                 break;
 

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -1520,6 +1520,7 @@ void HelperCallProperties::init()
         bool isAllocator   = false; // true if the result is usually a newly created heap item, or may throw OutOfMemory
         bool mutatesHeap   = false; // true if any previous heap objects [are|can be] modified
         bool mayRunCctor   = false; // true if the helper call may cause a static constructor to be run.
+        bool isNoEscape    = false; // true if none of the GC ref arguments can escape
 
         switch (helper)
         {
@@ -1644,8 +1645,9 @@ void HelperCallProperties::init()
             case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE:
             case CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE:
 
-                isPure  = true;
-                noThrow = true; // These return null for a failing cast
+                isNoEscape = true;
+                isPure     = true;
+                noThrow    = true; // These return null for a failing cast
                 break;
 
             case CORINFO_HELP_GETCURRENTMANAGEDTHREADID:
@@ -1669,8 +1671,8 @@ void HelperCallProperties::init()
             // helpers returning addresses, these can also throw
             case CORINFO_HELP_UNBOX:
             case CORINFO_HELP_LDELEMA_REF:
-
-                isPure = true;
+                isNoEscape = true;
+                isPure     = true;
                 break;
 
             // GETREFANY is pure up to the value of the struct argument. We
@@ -1742,7 +1744,6 @@ void HelperCallProperties::init()
             case CORINFO_HELP_ASSIGN_REF_ENSURE_NONHEAP:
             case CORINFO_HELP_ASSIGN_BYREF:
             case CORINFO_HELP_BULK_WRITEBARRIER:
-
                 mutatesHeap = true;
                 break;
 
@@ -1821,6 +1822,7 @@ void HelperCallProperties::init()
         m_isAllocator[helper]   = isAllocator;
         m_mutatesHeap[helper]   = mutatesHeap;
         m_mayRunCctor[helper]   = mayRunCctor;
+        m_isNoEscape[helper]    = isNoEscape;
     }
 }
 

--- a/src/coreclr/jit/utils.h
+++ b/src/coreclr/jit/utils.h
@@ -590,6 +590,7 @@ private:
     bool m_isAllocator[CORINFO_HELP_COUNT];
     bool m_mutatesHeap[CORINFO_HELP_COUNT];
     bool m_mayRunCctor[CORINFO_HELP_COUNT];
+    bool m_isNoEscape[CORINFO_HELP_COUNT];
 
     void init();
 
@@ -646,6 +647,13 @@ public:
         assert(helperId > CORINFO_HELP_UNDEF);
         assert(helperId < CORINFO_HELP_COUNT);
         return m_mayRunCctor[helperId];
+    }
+
+    bool IsNoEscape(CorInfoHelpFunc helperId)
+    {
+        assert(helperId > CORINFO_HELP_UNDEF);
+        assert(helperId < CORINFO_HELP_COUNT);
+        return m_isNoEscape[helperId];
     }
 };
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12766,11 +12766,11 @@ void Compiler::fgValueNumberCall(GenTreeCall* call)
 
         if (modHeap)
         {
-            if ((call->gtCallMoreFlags & GTF_CALL_M_NO_ESCAPE) != 0)
-            {
-                // zero obj??
-            }
-            else
+            // if ((call->gtCallMoreFlags & GTF_CALL_M_NO_ESCAPE) != 0)
+            //{
+            //     // zero obj??
+            // }
+            //  else
             {
                 // For now, arbitrary side effect on GcHeap/ByrefExposed.
                 fgMutateGcHeap(call DEBUGARG("HELPER - modifies heap"));

--- a/src/coreclr/jit/valuenumfuncs.h
+++ b/src/coreclr/jit/valuenumfuncs.h
@@ -147,6 +147,7 @@ ValueNumFuncDef(ReadyToRunGenericHandle, 2, false, true, false, false)
 ValueNumFuncDef(GetStaticAddrTLS, 1, false, true, false, false)
 
 ValueNumFuncDef(JitNew, 2, false, true, false, false)
+ValueNumFuncDef(JitNewNoEscape, 2, false, true, false, false)
 ValueNumFuncDef(JitNewArr, 3, false, true, false, false)
 ValueNumFuncDef(JitNewMdArr, 4, false, true, false, false)
 ValueNumFuncDef(JitReadyToRunNew, 2, false, true, false, false)

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
@@ -152,13 +152,14 @@ namespace ObjectStackAllocation
 
             CallTestAndVerifyAllocation(AllocateClassWithGcFieldAndInt, 5, expectedAllocationKind);
 
-            // The remaining tests currently never allocate on the stack
-            if (expectedAllocationKind == AllocationKind.Stack) {
-                expectedAllocationKind = AllocationKind.Heap;
-            }
-
             // This test calls CORINFO_HELP_ISINSTANCEOFCLASS
             CallTestAndVerifyAllocation(AllocateSimpleClassAndCheckTypeHelper, 1, expectedAllocationKind);
+
+            // The remaining tests currently never allocate on the stack
+            if (expectedAllocationKind == AllocationKind.Stack)
+            {
+                expectedAllocationKind = AllocationKind.Heap;
+            }
 
             // This test calls CORINFO_HELP_CHKCASTCLASS_SPECIAL
             CallTestAndVerifyAllocation(AllocateSimpleClassAndCast, 7, expectedAllocationKind);


### PR DESCRIPTION
Note this does not enable stack allocation of ref classes&mdash;the aim is to let downstream phases treat the memory from non-escaping objects more aggressively, since it's not exposed cross-thread.