### PR TITLE
Run System.Diagnostics.StackTrace tests with NAOT

### DIFF
--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -110,14 +110,26 @@ namespace System.Diagnostics
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private void BuildStackFrame(int frameIndex, bool needFileInfo)
         {
+            IntPtr ipAddress;
+
             const int SystemDiagnosticsStackDepth = 2;
 
-            frameIndex += SystemDiagnosticsStackDepth;
-            IntPtr[] frameArray = new IntPtr[frameIndex + 1];
-            int returnedFrameCount = RuntimeImports.RhGetCurrentThreadStackTrace(frameArray);
-            int realFrameCount = (returnedFrameCount >= 0 ? returnedFrameCount : frameArray.Length);
+            // Unreasonably high or negative frameIndex could lead to overflows or failures to allocate
+            // the frameArray below so spot check it's sane.
+            RuntimeImports.RhGetCurrentThreadStackBounds(out IntPtr stackLow, out IntPtr stackHigh);
+            if (frameIndex >= -SystemDiagnosticsStackDepth && frameIndex < ((stackHigh - stackLow) / IntPtr.Size))
+            {
+                frameIndex += SystemDiagnosticsStackDepth;
+                IntPtr[] frameArray = new IntPtr[frameIndex + 1];
+                int returnedFrameCount = RuntimeImports.RhGetCurrentThreadStackTrace(frameArray);
+                int realFrameCount = (returnedFrameCount >= 0 ? returnedFrameCount : frameArray.Length);
 
-            IntPtr ipAddress = (frameIndex < realFrameCount) ? frameArray[frameIndex] : IntPtr.Zero;
+                ipAddress = (frameIndex < realFrameCount) ? frameArray[frameIndex] : IntPtr.Zero;
+            }
+            else
+            {
+                ipAddress = IntPtr.Zero;
+            }
             InitializeForIpAddress(ipAddress, needFileInfo);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackFrame.NativeAot.cs
@@ -110,26 +110,14 @@ namespace System.Diagnostics
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private void BuildStackFrame(int frameIndex, bool needFileInfo)
         {
-            IntPtr ipAddress;
-
             const int SystemDiagnosticsStackDepth = 2;
 
-            // Unreasonably high or negative frameIndex could lead to overflows or failures to allocate
-            // the frameArray below so spot check it's sane.
-            RuntimeImports.RhGetCurrentThreadStackBounds(out IntPtr stackLow, out IntPtr stackHigh);
-            if (frameIndex >= -SystemDiagnosticsStackDepth && frameIndex < ((stackHigh - stackLow) / IntPtr.Size))
-            {
-                frameIndex += SystemDiagnosticsStackDepth;
-                IntPtr[] frameArray = new IntPtr[frameIndex + 1];
-                int returnedFrameCount = RuntimeImports.RhGetCurrentThreadStackTrace(frameArray);
-                int realFrameCount = (returnedFrameCount >= 0 ? returnedFrameCount : frameArray.Length);
+            frameIndex += SystemDiagnosticsStackDepth;
+            IntPtr[] frameArray = new IntPtr[frameIndex + 1];
+            int returnedFrameCount = RuntimeImports.RhGetCurrentThreadStackTrace(frameArray);
+            int realFrameCount = (returnedFrameCount >= 0 ? returnedFrameCount : frameArray.Length);
 
-                ipAddress = (frameIndex < realFrameCount) ? frameArray[frameIndex] : IntPtr.Zero;
-            }
-            else
-            {
-                ipAddress = IntPtr.Zero;
-            }
+            IntPtr ipAddress = (frameIndex < realFrameCount) ? frameArray[frameIndex] : IntPtr.Zero;
             InitializeForIpAddress(ipAddress, needFileInfo);
         }
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackTrace.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Diagnostics/StackTrace.NativeAot.cs
@@ -80,18 +80,19 @@ namespace System.Diagnostics
 #if !TARGET_WASM
         internal void ToString(TraceFormat traceFormat, StringBuilder builder)
         {
-            if (_stackFrames == null)
+            if (_stackFrames != null)
             {
-                return;
-            }
-
-            foreach (StackFrame frame in _stackFrames)
-            {
-                frame.AppendToStackTrace(builder);
+                foreach (StackFrame frame in _stackFrames)
+                {
+                    frame?.AppendToStackTrace(builder);
+                }
             }
 
             if (traceFormat == TraceFormat.Normal && builder.Length >= Environment.NewLine.Length)
                 builder.Length -= Environment.NewLine.Length;
+
+            if (traceFormat == TraceFormat.TrailingNewLine && builder.Length == 0)
+                builder.AppendLine();
         }
 #endif
     }

--- a/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/MethodNameFormatter.cs
+++ b/src/coreclr/nativeaot/System.Private.StackTraceMetadata/src/Internal/StackTraceMetadata/MethodNameFormatter.cs
@@ -403,9 +403,10 @@ namespace Internal.StackTraceMetadata
         /// <summary>
         /// Emit function pointer type.
         /// </summary>
-        private void EmitFunctionPointerTypeName()
+        private static void EmitFunctionPointerTypeName()
         {
-            _outputBuilder.Append("IntPtr");
+            // Function pointer types have no textual representation and we have tests making sure
+            // they show up as empty strings in stack traces, so deliberately do nothing.
         }
 
         /// <summary>

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -172,6 +172,7 @@ namespace System
         public static bool IsAsyncFileIOSupported => !IsBrowser && !IsWasi;
 
         public static bool IsLineNumbersSupported => !IsNativeAot;
+        public static bool IsILOffsetsSupported => !IsNativeAot;
 
         public static bool IsInContainer => GetIsInContainer();
         public static bool IsNotInContainer => !IsInContainer;

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
@@ -16,21 +16,21 @@ namespace System.Diagnostics.Tests
             yield return new object[] { new StackFrame(int.MaxValue) };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(StackFrame_TestData))]
         public void HasNativeImage_StackFrame_ReturnsFalse(StackFrame stackFrame)
         {
             Assert.False(stackFrame.HasNativeImage());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(StackFrame_TestData))]
         public void GetNativeIP_StackFrame_ReturnsZero(StackFrame stackFrame)
         {
             Assert.Equal(IntPtr.Zero, stackFrame.GetNativeIP());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNativeAot))]
         [MemberData(nameof(StackFrame_TestData))]
         public void GetNativeImageBase_StackFrame_ReturnsZero(StackFrame stackFrame)
         {
@@ -43,7 +43,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { new StackFrame(int.MaxValue), false };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsILOffsetsSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
         [MemberData(nameof(HasMethod_TestData))]
         public void HasILOffset_Invoke_ReturnsExpected(StackFrame stackFrame, bool expected)

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
@@ -59,6 +59,7 @@ namespace System.Diagnostics.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50957", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsMonoAOT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103218", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [MemberData(nameof(HasMethod_TestData))]
         public void HasMethod_Invoke_ReturnsExpected(StackFrame stackFrame, bool expected)
         {
@@ -79,6 +80,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103218", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [MemberData(nameof(HasSource_TestData))]
         public void HasSource_Invoke_ReturnsExpected(StackFrame stackFrame, bool expected)
         {

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -123,6 +123,7 @@ namespace System.Diagnostics.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/mono/mono/issues/15186", TestRuntimes.Mono)]
+        [ActiveIssue("TODOTODOTODO", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [MemberData(nameof(ToString_TestData))]
         public void ToString_Invoke_ReturnsExpected(StackFrame stackFrame, string expectedToString)
         {
@@ -168,7 +169,10 @@ namespace System.Diagnostics.Tests
             }
             else
             {
-                Assert.True(stackFrame.GetILOffset() >= 0, $"Expected GetILOffset() {stackFrame.GetILOffset()} for {stackFrame} to be greater or equal to zero.");
+                if (PlatformDetection.IsILOffsetsSupported)
+                {
+                    Assert.True(stackFrame.GetILOffset() >= 0, $"Expected GetILOffset() {stackFrame.GetILOffset()} for {stackFrame} to be greater or equal to zero.");
+                }
             }
 
             // GetMethod returns null for unknown frames.

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -75,6 +75,7 @@ namespace System.Diagnostics.Tests
         [Theory]
         [InlineData(int.MinValue)]
         [InlineData(int.MaxValue)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103218", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         public void SkipFrames_ManyFrames_HasNoMethod(int skipFrames)
         {
             var stackFrame = new StackFrame(skipFrames);

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -123,7 +123,7 @@ namespace System.Diagnostics.Tests
 
         [Theory]
         [ActiveIssue("https://github.com/mono/mono/issues/15186", TestRuntimes.Mono)]
-        [ActiveIssue("TODOTODOTODO", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/103156", typeof(PlatformDetection), nameof(PlatformDetection.IsNativeAot))]
         [MemberData(nameof(ToString_TestData))]
         public void ToString_Invoke_ReturnsExpected(StackFrame stackFrame, string expectedToString)
         {

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics.SymbolStore.Tests
 {
     public class StackTraceSymbolsTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/51399", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void StackTraceSymbolsDoNotLockFile()
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -517,7 +517,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common\tests\System.Data.Common.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.PerformanceCounter\tests\System.Diagnostics.PerformanceCounter.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TraceSource\tests\System.Diagnostics.TraceSource.Config.Tests\System.Diagnostics.TraceSource.Config.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Cbor\tests\System.Formats.Cbor.Tests.csproj" />


### PR DESCRIPTION
Also fixes some corner case issues, like whether an empty stacktrace should stringify into a newline.

Cc @dotnet/ilc-contrib 