### PR TITLE
Fix sending ICMP echo request when host is unreachable

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs
@@ -243,7 +243,6 @@ namespace System.Net.NetworkInformation
             SocketConfig socketConfig = GetSocketConfig(address, buffer, timeout, options);
             using (Socket socket = GetRawSocket(socketConfig))
             {
-                Span<byte> socketAddress = stackalloc byte[SocketAddress.GetMaximumAddressSize(address.AddressFamily)];
                 int ipHeaderLength = socketConfig.IsIpv4 ? MinIpHeaderLengthInBytes : 0;
                 try
                 {
@@ -281,29 +280,34 @@ namespace System.Net.NetworkInformation
                 {
                     // This happens on Linux where we explicitly subscribed to error messages
                     // We should be able to get more info by getting extended socket error from error queue.
-
-                    Interop.Sys.MessageHeader header = default;
-
-                    SocketError result;
-                    fixed (byte* sockAddr = &MemoryMarshal.GetReference(socketAddress))
-                    {
-                        header.SocketAddress = sockAddr;
-                        header.SocketAddressLen = socketAddress.Length;
-                        header.IOVectors = null;
-                        header.IOVectorCount = 0;
-
-                        result = Interop.Sys.ReceiveSocketError(socket.SafeHandle, &header);
-                    }
-
-                    if (result == SocketError.Success && header.SocketAddressLen > 0)
-                    {
-                        return CreatePingReply(IPStatus.TtlExpired, IPEndPointExtensions.GetIPAddress(socketAddress.Slice(0, header.SocketAddressLen)));
-                    }
+                    return CreatePingReplyForUnreachableHost(address, socket);
                 }
 
                 // We have exceeded our timeout duration, and no reply has been received.
                 return CreatePingReply(IPStatus.TimedOut);
             }
+        }
+
+        private static PingReply CreatePingReplyForUnreachableHost(IPAddress address, Socket socket)
+        {
+            Span<byte> socketAddress = stackalloc byte[SocketAddress.GetMaximumAddressSize(address.AddressFamily)];
+            unsafe
+            {
+                Interop.Sys.MessageHeader header = default;
+
+                SocketError result;
+                fixed (byte* sockAddr = &MemoryMarshal.GetReference(socketAddress))
+                {
+                    header.SocketAddress = sockAddr;
+                    header.SocketAddressLen = socketAddress.Length;
+                    result = Interop.Sys.ReceiveSocketError(socket.SafeHandle, &header);
+                }
+                if (result == SocketError.Success && header.SocketAddressLen > 0)
+                {
+                     return CreatePingReply(IPStatus.TtlExpired, IPEndPointExtensions.GetIPAddress(socketAddress.Slice(0, header.SocketAddressLen)));
+                }
+            }
+            return CreatePingReply(IPStatus.TimedOut);
         }
 
         private async Task<PingReply> SendIcmpEchoRequestOverRawSocketAsync(IPAddress address, byte[] buffer, int timeout, PingOptions? options)
@@ -359,6 +363,12 @@ namespace System.Net.NetworkInformation
             }
             catch (OperationCanceledException) when (!_canceled)
             {
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.HostUnreachable)
+            {
+                // This happens on Linux where we explicitly subscribed to error messages
+                // We should be able to get more info by getting extended socket error from error queue.
+                return CreatePingReplyForUnreachableHost(address, socket);
             }
 
             // We have exceeded our timeout duration, and no reply has been received.

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -64,6 +64,7 @@
 #endif
 #if HAVE_LINUX_ERRQUEUE_H
 #include <linux/errqueue.h>
+#include <linux/icmp.h>
 #endif
 
 
@@ -1406,8 +1407,17 @@ int32_t SystemNative_ReceiveSocketError(intptr_t socket, MessageHeader* messageH
     messageHeader->ControlBuffer = (void*)buffer;
 
     struct msghdr header;
+    struct icmphdr icmph;
+    struct iovec iov;
     ConvertMessageHeaderToMsghdr(&header, messageHeader, fd);
 
+    if (header.msg_iovlen == 0 || !header.msg_iov)
+    {
+        iov.iov_base = &icmph;
+        iov.iov_len = sizeof(icmph);
+        header.msg_iov = &iov;
+        header.msg_iovlen = 1;
+    }
     while ((res = recvmsg(fd, &header, SocketFlags_MSG_DONTWAIT | SocketFlags_MSG_ERRQUEUE)) < 0 && errno == EINTR);
 
     struct cmsghdr *cmsg;


### PR DESCRIPTION
Before this change we get following failure from PingTest.SendPingToExternalHostWithLowTtlTest:
```
 System.Net.NetworkInformation.PingException : An exception occurred during a Ping request.
      ---- System.Net.Sockets.SocketException : No route to host
      Stack Trace:
        /runtime/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs(729,0): at System.Net.NetworkInformation.Ping.SendPingAsyncInternal[TArg](TArg getAddressArg, Func`3 getAddress, Int32 timeout, Byte[] buffer, PingOptions options, CancellationToken cancellationToken)
        /home/d.jurczak2/runtime/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs(743,0): at System.Net.NetworkInformation.Tests.PingTest.SendPingToExternalHostWithLowTtlTest()
        --- End of stack trace from previous location ---
        ----- Inner Stack Trace -----
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs(1395,0): at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.CreateException(SocketError error, Boolean forAsyncThrow)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs(1097,0): at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ReceiveFromAsync(Socket socket, CancellationToken cancellationToken)
        /runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs(423,0): at System.Net.Sockets.Socket.ReceiveFromAsync(Memory`1 buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken)
        /runtime/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.RawSocket.cs(334,0): at System.Net.NetworkInformation.Ping.SendIcmpEchoRequestOverRawSocketAsync(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
        /runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncMethodBuilderCore.cs(38,0): at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
           at System.Net.NetworkInformation.Ping.SendIcmpEchoRequestOverRawSocketAsync(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
        /runtime/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs(32,0): at System.Net.NetworkInformation.Ping.SendPingAsyncCore(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
        /runtime/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs(721,0): at System.Net.NetworkInformation.Ping.SendPingAsyncInternal[TArg](TArg getAddressArg, Func`3 getAddress, Int32 timeout, Byte[] buffer, PingOptions options, CancellationToken cancellationToken)
        /runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs(292,0): at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncS
```
In this patch we add HostUnreachable handling to SendIcmpEchoRequestOverRawSocketAsync and fix getting empty message from error queue.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung @wfurt
