### PR TITLE
ConfigXmlReader is an IDisposable; Dispose it

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/AppSettingsSection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/AppSettingsSection.cs
@@ -127,7 +127,7 @@ namespace System.Configuration
                 }
             }
 
-            ConfigXmlReader internalReader = new ConfigXmlReader(rawXml, sourceFileFullPath, lineOffset);
+            using ConfigXmlReader internalReader = new ConfigXmlReader(rawXml, sourceFileFullPath, lineOffset);
             internalReader.Read();
 
             if (internalReader.MoveToNextAttribute())


### PR DESCRIPTION
This was flagged by a static analysis tool. Is this necessary? Is this safe to do?