### PR TITLE
Add MIT license header to DotnetProxyTrustManager.java

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetProxyTrustManager.java
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/net/dot/android/crypto/DotnetProxyTrustManager.java
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 package net.dot.android.crypto;
 
 import java.security.cert.CertificateException;


### PR DESCRIPTION
Noticed while working on #103016. 