### PR TITLE
[release/8.0-staging] Remove cached cgroup values (#102971)

### DIFF
--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -417,7 +417,7 @@ public:
     // Remarks:
     //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
     //  specified, it returns amount of actual physical memory.
-    static uint64_t GetPhysicalMemoryLimit(bool* is_restricted=NULL);
+    static uint64_t GetPhysicalMemoryLimit(bool* is_restricted=NULL, bool refresh=false);
 
     // Get memory status
     // Parameters:

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -52808,7 +52808,7 @@ int gc_heap::refresh_memory_limit()
     size_t old_heap_hard_limit_poh = heap_hard_limit_oh[poh];
     bool old_hard_limit_config_p = hard_limit_config_p;
 
-    total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted_physical_mem);
+    total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted_physical_mem, true);
 
     bool succeed = true;
 

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1121,14 +1121,13 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
 // Remarks:
 //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
 //  specified, it returns amount of actual physical memory.
-uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted)
+uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted, bool refresh)
 {
     size_t restricted_limit;
     if (is_restricted)
         *is_restricted = false;
 
-    // The limit was not cached
-    if (g_RestrictedPhysicalMemoryLimit == 0)
+    if (g_RestrictedPhysicalMemoryLimit == 0 || refresh)
     {
         restricted_limit = GetRestrictedPhysicalMemoryLimit();
         VolatileStore(&g_RestrictedPhysicalMemoryLimit, restricted_limit);

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -960,7 +960,7 @@ size_t GCToOSInterface::GetVirtualMemoryLimit()
 // Remarks:
 //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
 //  specified, it returns amount of actual physical memory.
-uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted)
+uint64_t GCToOSInterface::GetPhysicalMemoryLimit(bool* is_restricted, bool refresh)
 {
     if (is_restricted)
         *is_restricted = false;


### PR DESCRIPTION
main PR https://github.com/dotnet/runtime/pull/102971

# Description

Make sure we do not rely on cached cgroup when we `RefreshMemoryLimit`.

# Customer Impact

See the comments from @paulbatum below.

# Regression

No

# Testing

Manual validation of the `RefreshMemoryLimit` scenario when the underlying container changes.

# Risk

Low - it only impacts the case when `RefreshMemoryLimit` is called.