### PR TITLE
Adding latency numbers for serialize instruction.

### DIFF
--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1921,6 +1921,7 @@ protected:
 #define PERFSCORE_LATENCY_26C  26.0f
 #define PERFSCORE_LATENCY_62C  62.0f
 #define PERFSCORE_LATENCY_69C  69.0f
+#define PERFSCORE_LATENCY_105C 105.0f
 #define PERFSCORE_LATENCY_140C 140.0f
 #define PERFSCORE_LATENCY_400C 400.0f // Intel microcode issue with these instructions
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -20056,6 +20056,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         case INS_serialize:
         {
             result.insThroughput = PERFSCORE_THROUGHPUT_50C;
+            result.insLatency = PERFSCORE_LATENCY_105C;
             break;
         }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -20056,7 +20056,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         case INS_serialize:
         {
             result.insThroughput = PERFSCORE_THROUGHPUT_50C;
-            result.insLatency = PERFSCORE_LATENCY_105C;
+            result.insLatency    = PERFSCORE_LATENCY_105C;
             break;
         }
 


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/68917.
