### PR TITLE
Fix CET - remove writing to shadow stack

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -7865,7 +7865,6 @@ extern "C" void * QCALLTYPE CallCatchFunclet(QCall::ObjectHandleOnStack exceptio
         if (targetSSP != 0)
         {
             targetSSP -= sizeof(size_t);
-            _wrssq(pvRegDisplay->pCurrentContext->Rip, (void*)targetSSP);
         }
 #endif // HOST_WINDOWS
 #elif defined(HOST_X86)


### PR DESCRIPTION
In my recent fix for failures with CET enabled, I have also added a call to the `_wrssq` intrinsic to push an address to shadow stack. It turns out that instruction is privileged and cannot be used by user code. Moreover, I have realized that it is not needed at all there, so I am removing it.