### PR TITLE
Add test for invalid trim annotations in top-level method

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TopLevelStatementsTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TopLevelStatementsTests.cs
@@ -13,5 +13,11 @@ namespace ILLink.RoslynAnalyzer.Tests
 		{
 			return RunTest ();
 		}
+
+		[Fact]
+		public Task InvalidAnnotations ()
+		{
+			return RunTest ();
+		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/FieldDataFlow.cs
@@ -338,13 +338,13 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[ExpectedWarning ("IL2077", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2077", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			static void TestFlowOutOfField ()
 			{
 				RequirePublicFields (unsupportedTypeInstance);
 			}
 
-			[ExpectedWarning ("IL2074", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2074", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			public static void Test () {
 				var t = GetUnsupportedTypeInstance ();
 				unsupportedTypeInstance = t;

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodParametersDataFlow.cs
@@ -244,7 +244,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			static UnsupportedType GetUnsupportedTypeInstance () => null;
 
 			[ExpectedWarning ("IL2098", nameof (UnsupportedType))]
-			[ExpectedWarning ("IL2067", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2067", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			static void RequirePublicMethods (
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 				UnsupportedType unsupportedTypeInstance)
@@ -259,7 +259,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 			{
 			}
 
-			[ExpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			public static void Test () {
 				var t = GetUnsupportedTypeInstance ();
 				RequirePublicMethods (t);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodReturnParameterDataFlow.cs
@@ -220,7 +220,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				RequirePublicFields (t);
 			}
 
-			[ExpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			static void TestCtorReturnValue () {
 				var t = new UnsupportedType ();
 				RequirePublicFields (t);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MethodThisDataFlow.cs
@@ -122,7 +122,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods)]
 				UnsupportedType unsupportedTypeInstance) { }
 
-			[ExpectedWarning ("IL2075", nameof (UnsupportedType), nameof (UnsupportedType.GetMethod), Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+			[UnexpectedWarning ("IL2075", nameof (UnsupportedType), nameof (UnsupportedType.GetMethod), Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
 			static void TestMethodThisParameter () {
 				var t = GetUnsupportedTypeInstance ();
 				t.GetMethod ("foo");

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TopLevelStatements/InvalidAnnotations/InvalidAnnotations.csproj
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TopLevelStatements/InvalidAnnotations/InvalidAnnotations.csproj
@@ -1,0 +1,1 @@
+<Project Sdk="Microsoft.NET.Sdk" />

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TopLevelStatements/InvalidAnnotations/Program.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TopLevelStatements/InvalidAnnotations/Program.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+[assembly: ExpectedNoWarnings]
+
+Test ();
+
+[UnexpectedWarning ("IL2072", Tool.Analyzer, "https://github.com/dotnet/runtime/issues/101211")]
+[Kept]
+static void Test () {
+    RequireAll (GetUnsupportedType ());
+}
+
+[ExpectedWarning ("IL2098", Tool.Trimmer | Tool.NativeAot, "https://github.com/dotnet/runtime/issues/101215")]
+[Kept]
+static void RequireAll(
+    [KeptAttributeAttribute (typeof (DynamicallyAccessedMembersAttribute))]
+    [DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.All)] UnsupportedType f) {}
+
+[Kept]
+static UnsupportedType GetUnsupportedType () => new UnsupportedType ();
+
+[Kept]
+[KeptMember (".ctor()")]
+class UnsupportedType {}


### PR DESCRIPTION
Adds a testcase for https://github.com/dotnet/runtime/issues/101215.
