### PR TITLE
Add missing includes for FreeBSD 14 in pal_networkstatistics.c

### DIFF
--- a/src/native/libs/System.Native/pal_networkstatistics.c
+++ b/src/native/libs/System.Native/pal_networkstatistics.c
@@ -59,6 +59,10 @@
 #elif HAVE_IOS_NETINET_IP_VAR_H
 #include "ios/netinet/ip_var.h"
 #endif
+#ifdef __FreeBSD__
+#include <sys/callout.h>
+#include <sys/osd.h>
+#endif
 #include <netinet/tcp_var.h>
 #include <netinet/tcp.h>
 #if HAVE_TCP_FSM_H

--- a/src/native/libs/System.Native/pal_networkstatistics.c
+++ b/src/native/libs/System.Native/pal_networkstatistics.c
@@ -59,6 +59,10 @@
 #elif HAVE_IOS_NETINET_IP_VAR_H
 #include "ios/netinet/ip_var.h"
 #endif
+#ifdef (__FreeBSD__)
+#include <sys/callout.h>
+#include <sys/osd.h>
+#endif
 #include <netinet/tcp_var.h>
 #include <netinet/tcp.h>
 #if HAVE_TCP_FSM_H


### PR DESCRIPTION
This [patch](https://github.com/freebsd/freebsd-ports/blob/1e59715b75bc96492d56c09cc1cbf0612f1d5235/lang/dotnet/files/patch-src_runtime_src_native_libs_System.Native_pal__networkstatistics.c) is already in ports version of `dotnet` for FreeBSD. 

This PR upstreams the patch with a FreeBSD ifdef

```
  In file included from /runtime/src/native/libs/System.Native/pal_networkstatistics.c:61:
  /crossrootfs/x64/usr/include/netinet/tcp_var.h:310:17: error: field has incomplete type 'struct callout'
          struct callout t_callout;
                         ^
  /crossrootfs/x64/usr/include/netinet/tcp_var.h:310:9: note: forward declaration of 'struct callout'
          struct callout t_callout;
                 ^
  /crossrootfs/x64/usr/include/netinet/tcp_var.h:471:13: error: field has incomplete type 'struct osd'
          struct osd      t_osd;          /* storage for Khelp module data */
                          ^
  /crossrootfs/x64/usr/include/netinet/tcp_var.h:471:9: note: forward declaration of 'struct osd'
          struct osd      t_osd;          /* storage for Khelp module data */
                 ^
```