### PR TITLE
Micro-optimize type check in GVMDependenciesNode.SearchDynamicDependencies

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ConstructedEETypeNode.cs
@@ -8,7 +8,7 @@ using Internal.TypeSystem;
 
 namespace ILCompiler.DependencyAnalysis
 {
-    public class ConstructedEETypeNode : EETypeNode
+    public sealed class ConstructedEETypeNode : EETypeNode
     {
         public ConstructedEETypeNode(NodeFactory factory, TypeDesc type) : base(factory, type)
         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using System.Collections.Generic;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -70,7 +70,7 @@ namespace ILCompiler.DependencyAnalysis
             bool methodIsShared = _method.IsSharedByGenericInstantiations;
 
             TypeSystemContext context = _method.Context;
-            Type uninterestingType = typeof(ScannedMethodNode);
+            object lastUninterestingObject = null;
 
             for (int i = firstNode; i < markedNodes.Count; i++)
             {
@@ -81,13 +81,13 @@ namespace ILCompiler.DependencyAnalysis
                 // would be rejected by the `entry is EETypeNode` check below. However,
                 // that check has to walk the whole class hierarchy and can get rather
                 // expensive, so take a shortcut here as micro optimization.
-                if (entry.GetType() == uninterestingType)
+                if (lastUninterestingObject is not null && entry.GetType() == lastUninterestingObject.GetType())
                     continue;
 
                 EETypeNode entryAsEETypeNode = entry as EETypeNode;
                 if (entryAsEETypeNode == null)
                 {
-                    uninterestingType = entry.GetType();
+                    lastUninterestingObject = entry;
                     continue;
                 }
 


### PR DESCRIPTION
When compiling a large project, there is a considerable amount of time spent in `GVMDependenciesNode.SearchDynamicDependencies` on a type check in a loop. The whole compilation takes 4m 9s with this patch, and 4m 31s without the patch (with other unrelated optimizations in ILC). Profiler shows slightly smaller improvement of about ~15s which is still quite measurable.

Profile before:
```
  100%   SearchDynamicDependencies  •  46,057 ms  •  ILCompiler.DependencyAnalysis.GVMDependenciesNode.SearchDynamicDependencies(List, Int32, NodeFactory)
    79.9%   IsInstanceOfClass  •  36,779 ms  •  System.Runtime.CompilerServices.CastHelpers.IsInstanceOfClass(Void*, Object)
    0.97%   GetTypeDefinition  •  446 ms  •  Internal.TypeSystem.InstantiatedType.GetTypeDefinition()
```

Profile after:
```
  100%   SearchDynamicDependencies  •  31,337 ms  •  ILCompiler.DependencyAnalysis.GVMDependenciesNode.SearchDynamicDependencies(List, Int32, NodeFactory)
  ► 1.64%   GetTypeDefinition  •  515 ms  •  Internal.TypeSystem.InstantiatedType.GetTypeDefinition()
    0.75%   IsInstanceOfClass  •  236 ms  •  System.Runtime.CompilerServices.CastHelpers.IsInstanceOfClass(Void*, Object)
```