### PR TITLE
Avoid long busy-waiting between hijack retries.

### DIFF
--- a/src/coreclr/minipal/Unix/CMakeLists.txt
+++ b/src/coreclr/minipal/Unix/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     doublemapping.cpp
     dn-u16.cpp
+    ${CLR_SRC_NATIVE_DIR}/minipal/time.c
 )
 
 if(NOT CLR_CROSS_COMPONENTS_BUILD)

--- a/src/coreclr/minipal/Windows/CMakeLists.txt
+++ b/src/coreclr/minipal/Windows/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     doublemapping.cpp
     dn-u16.cpp
     ${CLR_SRC_NATIVE_DIR}/minipal/utf8.c
+    ${CLR_SRC_NATIVE_DIR}/minipal/time.c
 )
 
 if(NOT CLR_CROSS_COMPONENTS_BUILD)

--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -51,6 +51,7 @@ set(COMMON_RUNTIME_SOURCES
     ${GC_DIR}/softwarewritewatch.cpp
 
     ${CLR_SRC_NATIVE_DIR}/minipal/cpufeatures.c
+    ${CLR_SRC_NATIVE_DIR}/minipal/time.c
 )
 
 set(SERVER_GC_SOURCES

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -276,12 +276,12 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
         if (remaining < prevRemaining || !observeOnly)
         {
             // 5 usec delay, then check for more progress
-            minipal_microsleep(5, &usecsSinceYield);
+            minipal_microdelay(5, &usecsSinceYield);
             observeOnly = true;
         }
         else
         {
-            minipal_microsleep(rehijackDelay, &usecsSinceYield);
+            minipal_microdelay(rehijackDelay, &usecsSinceYield);
             observeOnly = false;
 
             // double up rehijack delay in case we are rehjacking too often

--- a/src/coreclr/nativeaot/Runtime/threadstore.cpp
+++ b/src/coreclr/nativeaot/Runtime/threadstore.cpp
@@ -22,6 +22,7 @@
 #include "RuntimeInstance.h"
 #include "TargetPtrs.h"
 #include "yieldprocessornormalized.h"
+#include <minipal/time.h>
 
 #include "slist.inl"
 
@@ -224,30 +225,6 @@ void ThreadStore::UnlockThreadStore()
     m_Lock.Leave();
 }
 
-// exponential spinwait with an approximate time limit for waiting in microsecond range.
-// when iteration == -1, only usecLimit is used
-void SpinWait(int iteration, int usecLimit)
-{
-    int64_t startTicks = PalQueryPerformanceCounter();
-    int64_t ticksPerSecond = PalQueryPerformanceFrequency();
-    int64_t endTicks = startTicks + (usecLimit * ticksPerSecond) / 1000000;
-
-    int l = iteration >= 0 ? min(iteration, 30): 30;
-    for (int i = 0; i < l; i++)
-    {
-        for (int j = 0; j < (1 << i); j++)
-        {
-            System_YieldProcessor();
-        }
-
-        int64_t currentTicks = PalQueryPerformanceCounter();
-        if (currentTicks > endTicks)
-        {
-            break;
-        }
-    }
-}
-
 void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
 {
     Thread * pThisThread = GetCurrentThreadIfAvailable();
@@ -265,16 +242,14 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
     // reason for this is that we essentially implement Dekker's algorithm, which requires write ordering.
     PalFlushProcessWriteBuffers();
 
-    int retries = 0;
-    int prevRemaining = 0;
-    int remaining = 0;
-    bool observeOnly = false;
+    int prevRemaining = INT32_MAX;
+    bool observeOnly = true;
+    uint32_t rehijackDelay = 8;
+    uint32_t usecsSinceYield = 0;
 
     while(true)
     {
-        prevRemaining = remaining;
-        remaining = 0;
-
+        int remaining = 0;
         FOREACH_THREAD(pTargetThread)
         {
             if (pTargetThread == pThisThread)
@@ -293,7 +268,7 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
         }
         END_FOREACH_THREAD
 
-        if (!remaining)
+        if (remaining == 0)
             break;
 
         // if we see progress or have just done a hijacking pass
@@ -301,21 +276,33 @@ void ThreadStore::SuspendAllThreads(bool waitForGCEvent)
         if (remaining < prevRemaining || !observeOnly)
         {
             // 5 usec delay, then check for more progress
-            SpinWait(-1, 5);
+            minipal_microsleep(5, &usecsSinceYield);
             observeOnly = true;
         }
         else
         {
-            SpinWait(retries++, 100);
+            minipal_microsleep(rehijackDelay, &usecsSinceYield);
             observeOnly = false;
 
-            // make sure our spining is not starving other threads, but not too often,
-            // this can cause a 1-15 msec delay, depending on OS, and that is a lot while
-            // very rarely needed, since threads are supposed to be releasing their CPUs
-            if ((retries & 127) == 0)
+            // double up rehijack delay in case we are rehjacking too often
+            // up to 100 usec, as that should be enough to make progress.
+            if (rehijackDelay < 100)
             {
-                PalSwitchToThread();
+                rehijackDelay *= 2;
             }
+        }
+
+        prevRemaining = remaining;
+
+        // If we see 1 msec of uninterrupted wait, it is a concern.
+        // Since we are stopping threads, there should be free cores to run on. Perhaps
+        // some thread that we need to stop needs to run on the same core as ours.
+        // Let's yield the timeslice to make sure such threads can run.
+        // We will not do this often though, since this can introduce arbitrary delays.
+        if (usecsSinceYield > 1000)
+        {
+            PalSwitchToThread();
+            usecsSinceYield = 0;
         }
     }
 

--- a/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalRedhawkUnix.cpp
@@ -1049,7 +1049,6 @@ REDHAWK_PALEXPORT void REDHAWK_PALAPI PalHijack(HANDLE hThread, _In_opt_ void* p
     // stack overflow too. Those are held in the sigsegv_handler with blocked signals until
     // the process exits.
     // ESRCH may happen on some OSes when the thread is exiting.
-    // The thread should leave cooperative mode, but we could have seen it in its earlier state.
     if ((status == EAGAIN)
      || (status == ESRCH)
 #ifdef __APPLE__

--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -893,7 +893,13 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
     }
 #endif
 
-    if ((status != 0) && (status != EAGAIN))
+    // ESRCH may happen on some OSes when the thread is exiting.
+    if (status == EAGAIN || status == ESRCH)
+    {
+        return ERROR_CANCELLED;
+    }
+
+    if (status != 0)
     {
         // Failure to send the signal is fatal. There are only two cases when sending
         // the signal can fail. First, if the signal ID is invalid and second,

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -3332,12 +3332,12 @@ void ThreadSuspend::SuspendAllThreads()
         if (remaining < prevRemaining || !observeOnly)
         {
             // 5 usec delay, then check for more progress
-            minipal_microsleep(5, &usecsSinceYield);
+            minipal_microdelay(5, &usecsSinceYield);
             observeOnly = true;
         }
         else
         {
-            minipal_microsleep(rehijackDelay, &usecsSinceYield);
+            minipal_microdelay(rehijackDelay, &usecsSinceYield);
             observeOnly = false;
 
             // double up rehijack delay in case we are rehjacking too often

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -14,6 +14,7 @@
 
 #include "finalizerthread.h"
 #include "dbginterface.h"
+#include <minipal/time.h>
 
 #define HIJACK_NONINTERRUPTIBLE_THREADS
 
@@ -2188,6 +2189,8 @@ void Thread::RareDisablePreemptiveGC()
 #if defined(FEATURE_HIJACK) && !defined(TARGET_UNIX)
             ResetThreadState(Thread::TS_GCSuspendRedirected);
 #endif
+            // make sure this is cleared - in case a signal is lost or somehow we did not act on it
+            m_hasPendingActivation = false;
 
             DWORD status = GCHeapUtilities::GetGCHeap()->WaitUntilGCComplete();
             if (status != S_OK)
@@ -3207,44 +3210,6 @@ COR_PRF_SUSPEND_REASON GCSuspendReasonToProfSuspendReason(ThreadSuspend::SUSPEND
 }
 #endif // PROFILING_SUPPORTED
 
-static int64_t QueryPerformanceCounter()
-{
-    LARGE_INTEGER ts;
-    QueryPerformanceCounter(&ts);
-    return ts.QuadPart;
-}
-
-static int64_t QueryPerformanceFrequency()
-{
-    LARGE_INTEGER ts;
-    QueryPerformanceFrequency(&ts);
-    return ts.QuadPart;
-}
-
-// exponential spinwait with an approximate time limit for waiting in microsecond range.
-// when iteration == -1, only usecLimit is used
-void SpinWait(int iteration, int usecLimit)
-{
-    int64_t startTicks = QueryPerformanceCounter();
-    int64_t ticksPerSecond = QueryPerformanceFrequency();
-    int64_t endTicks = startTicks + (usecLimit * ticksPerSecond) / 1000000;
-
-    int l = iteration >= 0 ? min(iteration, 30): 30;
-    for (int i = 0; i < l; i++)
-    {
-        for (int j = 0; j < (1 << i); j++)
-        {
-            System_YieldProcessor();
-        }
-
-        int64_t currentTicks = QueryPerformanceCounter();
-        if (currentTicks > endTicks)
-        {
-            break;
-        }
-    }
-}
-
 //************************************************************************************
 //
 // SuspendRuntime is responsible for ensuring that all managed threads reach a
@@ -3335,16 +3300,14 @@ void ThreadSuspend::SuspendAllThreads()
     // See VSW 475315 and 488918 for details.
     ::FlushProcessWriteBuffers();
 
-    int retries = 0;
-    int prevRemaining = 0;
-    int remaining = 0;
-    bool observeOnly = false;
+    int prevRemaining = INT32_MAX;
+    bool observeOnly = true;
+    uint32_t rehijackDelay = 8;
+    uint32_t usecsSinceYield = 0;
 
     while(true)
     {
-        prevRemaining = remaining;
-        remaining = 0;
-
+        int remaining = 0;
         Thread* pTargetThread = NULL;
         while ((pTargetThread = ThreadStore::GetThreadList(pTargetThread)) != NULL)
         {
@@ -3361,7 +3324,7 @@ void ThreadSuspend::SuspendAllThreads()
             }
         }
 
-        if (!remaining)
+        if (remaining == 0)
             break;
 
         // if we see progress or have just done a hijacking pass
@@ -3369,21 +3332,33 @@ void ThreadSuspend::SuspendAllThreads()
         if (remaining < prevRemaining || !observeOnly)
         {
             // 5 usec delay, then check for more progress
-            SpinWait(-1, 5);
+            minipal_microsleep(5, &usecsSinceYield);
             observeOnly = true;
         }
         else
         {
-            SpinWait(retries++, 100);
+            minipal_microsleep(rehijackDelay, &usecsSinceYield);
             observeOnly = false;
 
-            // make sure our spining is not starving other threads, but not too often,
-            // this can cause a 1-15 msec delay, depending on OS, and that is a lot while
-            // very rarely needed, since threads are supposed to be releasing their CPUs
-            if ((retries & 127) == 0)
+            // double up rehijack delay in case we are rehjacking too often
+            // up to 100 usec, as that should be enough to make progress.
+            if (rehijackDelay < 100)
             {
-                SwitchToThread();
+                rehijackDelay *= 2;
             }
+        }
+
+        prevRemaining = remaining;
+
+        // If we see 1 msec of uninterrupted wait, it is a concern.
+        // Since we are stopping threads, there should be free cores to run on. Perhaps
+        // some thread that we need to stop needs to run on the same core as ours.
+        // Let's yield the timeslice to make sure such threads can run.
+        // We will not do this often though, since this can introduce arbitrary delays.
+        if (usecsSinceYield > 1000)
+        {
+            SwitchToThread();
+            usecsSinceYield = 0;
         }
     }
 
@@ -5930,7 +5905,13 @@ bool Thread::InjectActivation(ActivationReason reason)
         if (hThread != INVALID_HANDLE_VALUE)
         {
             m_hasPendingActivation = true;
-            return ::PAL_InjectActivation(hThread);
+            BOOL success = ::PAL_InjectActivation(hThread);
+            if (!success)
+            {
+                m_hasPendingActivation = false;
+            }
+
+            return success;
         }
     }
 

--- a/src/native/minipal/configure.cmake
+++ b/src/native/minipal/configure.cmake
@@ -8,4 +8,9 @@ check_function_exists(sysctlbyname HAVE_SYSCTLBYNAME)
 check_symbol_exists(arc4random_buf "stdlib.h" HAVE_ARC4RANDOM_BUF)
 check_symbol_exists(O_CLOEXEC fcntl.h HAVE_O_CLOEXEC)
 
+check_symbol_exists(
+    clock_gettime_nsec_np
+    time.h
+    HAVE_CLOCK_GETTIME_NSEC_NP)
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/minipalconfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/minipalconfig.h)

--- a/src/native/minipal/minipalconfig.h.in
+++ b/src/native/minipal/minipalconfig.h.in
@@ -5,5 +5,6 @@
 #cmakedefine01 HAVE_AUXV_HWCAP_H
 #cmakedefine01 HAVE_O_CLOEXEC
 #cmakedefine01 HAVE_SYSCTLBYNAME
+#cmakedefine01 HAVE_CLOCK_GETTIME_NSEC_NP
 
 #endif

--- a/src/native/minipal/time.c
+++ b/src/native/minipal/time.c
@@ -68,7 +68,6 @@ int64_t minipal_hires_ticks()
     if (result != 0)
     {
         assert(!"clock_gettime(CLOCK_MONOTONIC) failed");
-        __builtin_unreachable();
     }
 
     return ((int64_t)(ts.tv_sec) * (int64_t)(tccSecondsToNanoSeconds)) + (int64_t)(ts.tv_nsec);

--- a/src/native/minipal/time.c
+++ b/src/native/minipal/time.c
@@ -77,7 +77,7 @@ int64_t minipal_hires_ticks()
 
 #endif // !HOST_WINDOWS
 
-void minipal_microsleep(uint32_t usecs, uint32_t* usecsSinceYield)
+void minipal_microdelay(uint32_t usecs, uint32_t* usecsSinceYield)
 {
 #ifdef HOST_WINDOWS
     if (usecs > 1000)
@@ -116,9 +116,9 @@ void minipal_microsleep(uint32_t usecs, uint32_t* usecsSinceYield)
     int64_t ticksPerSecond = minipal_hires_tick_frequency();
     int64_t endTicks = startTicks + (usecs * ticksPerSecond) / 1000000;
 
-    // start with 4 nops/pauses and then double up until we hit the limit
+    // start with 1 nop/pause and then double up until we hit the limit
     // this way we should not overshoot by more than 2x.
-    for (int i = 2; i < 30; i++)
+    for (int i = 0; i < 30; i++)
     {
         for (int j = 0; j < (1 << i); j++)
         {

--- a/src/native/minipal/time.c
+++ b/src/native/minipal/time.c
@@ -1,0 +1,139 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <assert.h>
+#include <minipal/time.h>
+
+#ifdef HOST_WINDOWS
+
+#include <Windows.h>
+
+int64_t minipal_hires_ticks()
+{
+    LARGE_INTEGER ts;
+    QueryPerformanceCounter(&ts);
+    return ts.QuadPart;
+}
+
+int64_t minipal_hires_tick_frequency()
+{
+    LARGE_INTEGER ts;
+    QueryPerformanceFrequency(&ts);
+    return ts.QuadPart;
+}
+
+#else // HOST_WINDOWS
+
+#include "minipalconfig.h"
+
+#include <time.h> // nanosleep
+#include <errno.h>
+
+inline static void YieldProcessor()
+{
+#if defined(HOST_X86) || defined(HOST_AMD64)
+    __asm__ __volatile__(
+        "rep\n"
+        "nop");
+#elif defined(HOST_ARM)
+    __asm__ __volatile__( "yield");
+#elif defined(HOST_ARM64)
+    __asm__ __volatile__(
+        "dmb ishst\n"
+        "yield"
+        );
+#elif defined(HOST_LOONGARCH64)
+    __asm__ volatile( "dbar 0;  \n");
+#elif defined(HOST_RISCV64)
+    // TODO-RISCV64-CQ: When Zihintpause is supported, replace with `pause` instruction.
+    __asm__ __volatile__(".word 0x0100000f");
+#else
+    return;
+#endif
+}
+
+#define tccSecondsToNanoSeconds 1000000000      // 10^9
+int64_t minipal_hires_tick_frequency()
+{
+    return tccSecondsToNanoSeconds;
+}
+
+int64_t minipal_hires_ticks()
+{
+#if HAVE_CLOCK_GETTIME_NSEC_NP
+    return (int64_t)clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+#else
+    struct timespec ts;
+    int result = clock_gettime(CLOCK_MONOTONIC, &ts);
+    if (result != 0)
+    {
+        assert(!"clock_gettime(CLOCK_MONOTONIC) failed");
+        __builtin_unreachable();
+    }
+
+    return ((int64_t)(ts.tv_sec) * (int64_t)(tccSecondsToNanoSeconds)) + (int64_t)(ts.tv_nsec);
+#endif
+}
+
+#endif // !HOST_WINDOWS
+
+void minipal_microsleep(uint32_t usecs, uint32_t* usecsSinceYield)
+{
+#ifdef HOST_WINDOWS
+    if (usecs > 1000)
+    {
+        SleepEx(usecs / 1000, FALSE);
+        if (usecsSinceYield)
+        {
+            usecsSinceYield = 0;
+        }
+
+        return;
+    }
+#else
+    if (usecs > 10)
+    {
+        struct timespec requested;
+        requested.tv_sec = usecs / 1000;
+        requested.tv_nsec = (usecs - requested.tv_sec * 1000) * 1000;
+
+        struct timespec remaining;
+        while (nanosleep(&requested, &remaining) == EINTR)
+        {
+            requested = remaining;
+        }
+
+        if (usecsSinceYield)
+        {
+            usecsSinceYield = 0;
+        }
+
+        return;
+    }
+#endif
+
+    int64_t startTicks = minipal_hires_ticks();
+    int64_t ticksPerSecond = minipal_hires_tick_frequency();
+    int64_t endTicks = startTicks + (usecs * ticksPerSecond) / 1000000;
+
+    // start with 4 nops/pauses and then double up until we hit the limit
+    // this way we should not overshoot by more than 2x.
+    for (int i = 2; i < 30; i++)
+    {
+        for (int j = 0; j < (1 << i); j++)
+        {
+            YieldProcessor();
+        }
+
+        int64_t currentTicks = minipal_hires_ticks();
+        if (currentTicks > endTicks)
+        {
+            break;
+        }
+    }
+
+    if (usecsSinceYield)
+    {
+        *usecsSinceYield += usecs;
+    }
+}

--- a/src/native/minipal/time.h
+++ b/src/native/minipal/time.h
@@ -23,7 +23,7 @@ extern "C"
     //
     // If not NULL, `usecsSinceYield` keeps track of busy-waiting time, so that
     // the containing algorithm could handle cases when busy-waiting time is too high.
-    void minipal_microsleep(uint32_t usecs, uint32_t* usecsSinceYield);
+    void minipal_microdelay(uint32_t usecs, uint32_t* usecsSinceYield);
 
 #ifdef __cplusplus
 }

--- a/src/native/minipal/time.h
+++ b/src/native/minipal/time.h
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#ifndef HAVE_MINIPAL_TIME_H
+#define HAVE_MINIPAL_TIME_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+    // Returns current count of high resolution monotonically increasing timer ticks
+    int64_t minipal_hires_ticks();
+
+    // Returns the frequency of high resolution timer ticks in Hz
+    int64_t minipal_hires_tick_frequency();
+
+    // Delays execution of current thread by `usecs` microseconds.
+    // The delay is best-effort and may take longer than desired.
+    // Some delays, depending on OS and duration, could be implemented via busy waiting.
+    //
+    // If not NULL, `usecsSinceYield` keeps track of busy-waiting time, so that
+    // the containing algorithm could handle cases when busy-waiting time is too high.
+    void minipal_microsleep(uint32_t usecs, uint32_t* usecsSinceYield);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
+#endif /* HAVE_MINIPAL_TIME_H */


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/102832

- refactors the pause routine into `minipal_microdelay` - to have the same implementation for CoreCLR and NativeAOT
- use sub-millisecond sleep API, when available, for long(ish) pauses.
- couple minor fixes around sending suspension signals. 
(not responsible for the regression, just possible corner cases noticed while investigating)


