### PR TITLE
Add native ARM64 popcount for sizeof(T) above 1 to TensorPrimitives

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.PopCount.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.PopCount.cs
@@ -38,20 +38,40 @@ namespace System.Numerics.Tensors
                 // This relies on 64-bit shifts for sizeof(T) == 8, and such shifts aren't accelerated on today's hardware.
                 // Alternative approaches, such as doing two 32-bit operations and combining them were observed to not
                 // provide any meaningfuls speedup over scalar. So for now, we don't vectorize when sizeof(T) == 8.
-                sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4;
+                (sizeof(T) is 1 or 2 or 4) || (AdvSimd.IsSupported && sizeof(T) == 8);
 
             public static T Invoke(T x) => T.PopCount(x);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector128<T> Invoke(Vector128<T> x)
             {
-                if (sizeof(T) == 1)
+                if (AdvSimd.IsSupported)
                 {
-                    if (AdvSimd.IsSupported)
+                    Vector128<byte> cnt = AdvSimd.PopCount(x.AsByte());
+
+                    if (sizeof(T) == 1)
                     {
-                        return AdvSimd.PopCount(x.AsByte()).As<byte, T>();
+                        return cnt.As<byte, T>();
                     }
 
+                    if (sizeof(T) == 2)
+                    {
+                        return AdvSimd.AddPairwiseWidening(cnt).As<ushort, T>();
+                    }
+
+                    if (sizeof(T) == 4)
+                    {
+                        return AdvSimd.AddPairwiseWidening(AdvSimd.AddPairwiseWidening(cnt)).As<uint, T>();
+                    }
+
+                    if (sizeof(T) == 8)
+                    {
+                        return AdvSimd.AddPairwiseWidening(AdvSimd.AddPairwiseWidening(AdvSimd.AddPairwiseWidening(cnt))).As<ulong, T>();
+                    }
+                }
+
+                if (sizeof(T) == 1)
+                {
                     if (PackedSimd.IsSupported)
                     {
                         return PackedSimd.PopCount(x.AsByte()).As<byte, T>();


### PR DESCRIPTION
I validated that the codegen before and after the change for `sizeof(T) is 1` in `InvokeSpanIntoSpan.Vectorized128` is identical so whatever difference there is, it is likely the noise (from non-temporal stores? I found the numbers unstable even at 256KiB of data).

For `sizeof(T) is 8` I also tested Vector128 into Vector64x2 with `vaddvq_u32`and back into V128 but it was slower than continuing to bruteforce.

Environment:
```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.5 (23F79) [Darwin 23.5.0]
Apple M1 Pro, 1 CPU, 8 logical and 8 physical cores
.NET SDK 9.0.100-preview.6.24307.18
  [Host]     : .NET 9.0.0 (9.0.24.30702), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 9.0.0 (9.0.24.30702), Arm64 RyuJIT AdvSIMD
  ```

Benchmark:
```cs
public class TensorPopCount
{
    const int Length = 262_144;
    static readonly byte[] sink = new byte[Length];
    static readonly byte[] bytes = Enumerable.Repeat((byte)0b10101010, Length).ToArray();
    static readonly ushort[] shorts = MemoryMarshal.Cast<byte, ushort>(bytes).ToArray();
    static readonly uint[] ints = MemoryMarshal.Cast<byte, uint>(bytes).ToArray();
    static readonly ulong[] longs = MemoryMarshal.Cast<byte, ulong>(bytes).ToArray();

    [Benchmark]
    public void Bytes() => TensorPrimitives.PopCount<byte>(bytes, sink);

    [Benchmark]
    public void Shorts() => TensorPrimitives.PopCount(shorts, MemoryMarshal.Cast<byte, ushort>(sink));

    [Benchmark]
    public void Ints() => TensorPrimitives.PopCount(ints, MemoryMarshal.Cast<byte, uint>(sink));

    [Benchmark]
    public void Longs() => TensorPrimitives.PopCount(longs, MemoryMarshal.Cast<byte, ulong>(sink));
}
```

Current:

| Method | Mean      | Error     | StdDev    |
|------- |----------:|----------:|----------:|
| Bytes  |  5.689 us | 0.0738 us | 0.0690 us |
| Shorts | 19.246 us | 0.0215 us | 0.0190 us |
| Ints   | 19.368 us | 0.0264 us | 0.0221 us |
| Longs  | 71.893 us | 0.1026 us | 0.0960 us |

PR:

| Method | Mean     | Error     | StdDev    |
|------- |---------:|----------:|----------:|
| Bytes  | 5.809 us | 0.1144 us | 0.1447 us |
| Shorts | 3.660 us | 0.0237 us | 0.0185 us |
| Ints   | 4.297 us | 0.0463 us | 0.0387 us |
| Longs  | 5.360 us | 0.0150 us | 0.0117 us |