### PR TITLE
[browser] Increase timeout for System.Memory.Tests and System.Private.Xml.Tests

### DIFF
--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -5,6 +5,13 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <XunitShowProgress>true</XunitShowProgress>
+    <!-- This WASM test is problematic and slow right now. This sets the xharness timeout but there is also override in sendtohelix-browser.targets -->
+    <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
+  </PropertyGroup>
+  
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>

--- a/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/System.Private.Xml.Tests.csproj
@@ -4,6 +4,12 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
+    <XunitShowProgress>true</XunitShowProgress>
+    <!-- This WASM test is problematic and slow right now. This sets the xharness timeout but there is also override in sendtohelix-browser.targets -->
+    <WasmXHarnessTestsTimeout>01:15:00</WasmXHarnessTestsTimeout>
+  </PropertyGroup>
+
   <ItemGroup>
     <RdXmlFile Include="default.rd.xml" />
   </ItemGroup>

--- a/src/libraries/sendtohelix-browser.targets
+++ b/src/libraries/sendtohelix-browser.targets
@@ -282,6 +282,8 @@
         <Timeout Condition="'%(FileName)' == 'System.Collections.Immutable.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Net.WebSockets.Client.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Net.Http.Functional.Tests'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Memory.Tests'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Private.Xml.Tests'">01:20:00</Timeout>
       </HelixWorkItem>
 
     </ItemGroup>

--- a/src/libraries/sendtohelix-browser.targets
+++ b/src/libraries/sendtohelix-browser.targets
@@ -250,6 +250,7 @@
         <Timeout Condition="'%(FileName)' == 'System.Collections.Immutable.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Net.WebSockets.Client.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Net.Http.Functional.Tests'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Memory.Tests'">01:20:00</Timeout>
       </HelixWorkItem>
     </ItemGroup>
 

--- a/src/libraries/sendtohelix-browser.targets
+++ b/src/libraries/sendtohelix-browser.targets
@@ -251,6 +251,7 @@
         <Timeout Condition="'%(FileName)' == 'System.Net.WebSockets.Client.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Net.Http.Functional.Tests'">01:20:00</Timeout>
         <Timeout Condition="'%(FileName)' == 'System.Memory.Tests'">01:20:00</Timeout>
+        <Timeout Condition="'%(FileName)' == 'System.Private.Xml.Tests'">01:20:00</Timeout>
       </HelixWorkItem>
     </ItemGroup>
 


### PR DESCRIPTION
There doesn't seem to be any relevant change in tests directly. Trying to increase timeout

Related to https://github.com/dotnet/runtime/issues/102955
Related to https://github.com/dotnet/runtime/issues/102957
Related to https://github.com/dotnet/runtime/issues/103060
Related to https://github.com/dotnet/runtime/issues/103061
Related to https://github.com/dotnet/runtime/issues/103246