### PR TITLE
[CI][aot] Do not overwrite `scenarios` argument if they were passed

### DIFF
--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -32,12 +32,12 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-        - ${{ if not(empty(parameters.scenarios)) }}:
+        ${{ if not(empty(parameters.scenarios)) }}:
           - ${{ parameters.scenarios }}
-        - ${{ else }}:
-          - ${{ if eq(platform, 'browser_wasm') }}:
+        ${{ else }}:
+          ${{ if eq(platform, 'browser_wasm') }}:
             - WasmTestOnV8
-          - ${{ if eq(platform, 'browser_wasm_win') }}:
+          ${{ if eq(platform, 'browser_wasm_win') }}:
             - WasmTestOnChrome
-          - ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
+          ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
             - WasmTestOnWasmtime

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -32,12 +32,12 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-      - ${{ if not(empty(parameters.scenarios)) }}:
-        - ${{ parameters.scenarios }}
-      - ${{ else }}:
-        - ${{ if eq(platform, 'browser_wasm') }}:
-          - WasmTestOnV8
-        - ${{ if eq(platform, 'browser_wasm_win') }}:
-          - WasmTestOnChrome
-        - ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
-          - WasmTestOnWasmtime
+        - ${{ if not(empty(parameters.scenarios)) }}:
+          - ${{ parameters.scenarios }}
+        - ${{ else }}:
+          - ${{ if eq(platform, 'browser_wasm') }}:
+            - WasmTestOnV8
+          - ${{ if eq(platform, 'browser_wasm_win') }}:
+            - WasmTestOnChrome
+          - ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
+            - WasmTestOnWasmtime

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -31,6 +31,9 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
+      - ${{ if not(empty(parameters.scenarios)) }}:
+        - ${{ parameters.scenarios }}
+      - ${{ if empty(parameters.scenarios) }}:
         - ${{ if eq(platform, 'browser_wasm') }}:
           - WasmTestOnV8
         - ${{ if eq(platform, 'browser_wasm_win') }}:

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -32,12 +32,12 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-        ${{ if not(empty(parameters.scenarios)) }}:
+        - ${{ if not(empty(parameters.scenarios)) }}:
           - ${{ parameters.scenarios }}
-        ${{ else }}:
-          ${{ if eq(platform, 'browser_wasm') }}:
+        - ${{ else }}:
+          - ${{ if eq(platform, 'browser_wasm') }}:
             - WasmTestOnV8
-          ${{ if eq(platform, 'browser_wasm_win') }}:
+          - ${{ if eq(platform, 'browser_wasm_win') }}:
             - WasmTestOnChrome
-          ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
+          - ${{ if or(eq(platform, 'wasi_wasm_win'), eq(platform, 'wasi_wasm')) }}:
             - WasmTestOnWasmtime

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -32,7 +32,7 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-        - ${{ if (parameters.scenarios != '') }}:
+        - ${{ if eq(parameters.scenarios, '') }}:
           - ${{ parameters.scenarios }}
         - ${{ else }}:
           - ${{ if eq(platform, 'browser_wasm') }}:

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -10,6 +10,7 @@ parameters:
   runAOT: false
   shouldRunSmokeOnly: false
   shouldContinueOnError: false
+  scenarios: ''
 
 jobs:
 
@@ -33,7 +34,7 @@ jobs:
       scenarios:
       - ${{ if not(empty(parameters.scenarios)) }}:
         - ${{ parameters.scenarios }}
-      - ${{ if empty(parameters.scenarios) }}:
+      - ${{ else }}:
         - ${{ if eq(platform, 'browser_wasm') }}:
           - WasmTestOnV8
         - ${{ if eq(platform, 'browser_wasm_win') }}:

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -32,7 +32,7 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-        - ${{ if not(empty(parameters.scenarios)) }}:
+        - ${{ if (parameters.scenarios != '') }}:
           - ${{ parameters.scenarios }}
         - ${{ else }}:
           - ${{ if eq(platform, 'browser_wasm') }}:

--- a/eng/pipelines/common/templates/wasm-library-aot-tests.yml
+++ b/eng/pipelines/common/templates/wasm-library-aot-tests.yml
@@ -10,7 +10,7 @@ parameters:
   runAOT: false
   shouldRunSmokeOnly: false
   shouldContinueOnError: false
-  scenarios: ''
+  scenarios: []
 
 jobs:
 
@@ -32,7 +32,7 @@ jobs:
       shouldRunSmokeOnly: ${{ parameters.shouldRunSmokeOnly }}
       shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
       scenarios:
-        - ${{ if eq(parameters.scenarios, '') }}:
+        - ${{ if ne(parameters.scenarios[0], '') }}:
           - ${{ parameters.scenarios }}
         - ${{ else }}:
           - ${{ if eq(platform, 'browser_wasm') }}:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml
@@ -201,21 +201,22 @@ jobs:
         - WasmTestOnFirefox
         - WasmTestOnNodeJS
 
-  # Hybrid Globalization AOT tests
-  - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
-    parameters:
-      platforms:
-        - browser_wasm
-        - browser_wasm_win
-      nameSuffix: _HybridGlobalization_AOT
-      extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:HybridGlobalization=true
-      runAOT: true
-      isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-      isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
-      alwaysRun: true
-      scenarios:
-        - WasmTestOnChrome
-        - WasmTestOnNodeJS
+  # # Hybrid Globalization AOT tests
+  # # ActiveIssue: https://github.com/dotnet/runtime/issues/51746
+  # - template: /eng/pipelines/common/templates/wasm-library-aot-tests.yml
+  #   parameters:
+  #     platforms:
+  #       - browser_wasm
+  #       - browser_wasm_win
+  #     nameSuffix: _HybridGlobalization_AOT
+  #     extraBuildArgs: /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS) /p:HybridGlobalization=true
+  #     runAOT: true
+  #     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+  #     isWasmOnlyBuild: ${{ parameters.isWasmOnlyBuild }}
+  #     alwaysRun: true
+  #     scenarios:
+  #       - WasmTestOnChrome
+  #       - WasmTestOnNodeJS
 
 - ${{ if and(ne(parameters.isRollingBuild, true), ne(parameters.excludeNonLibTests, true), ne(parameters.debuggerTestsOnly, true)) }}:
   # Builds only

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.WebAssembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.WebAssembly.cs
@@ -10,7 +10,7 @@ namespace System.Globalization
     {
         internal unsafe void JsChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool toUpper)
         {
-            Debug.Assert(!GlobalizationMode.Invariant);
+            Debug.Assert(!GlobalizationMode.Invariant); // dummy change - to be removed
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(GlobalizationMode.Hybrid);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.WebAssembly.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.WebAssembly.cs
@@ -10,7 +10,7 @@ namespace System.Globalization
     {
         internal unsafe void JsChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool toUpper)
         {
-            Debug.Assert(!GlobalizationMode.Invariant); // dummy change - to be removed
+            Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(GlobalizationMode.Hybrid);
 


### PR DESCRIPTION
Continuation of switching off HybridGlobalization tests on v8. `HybridGlobalization_AOT` lane on CI was still running V8 because it was overwriting the `scenarios` argument passed here:
https://github.com/dotnet/runtime/blob/e6c2e536b85e3d8412c3b669a81b7baaf329fcb3/eng/pipelines/extra-platforms/runtime-extra-platforms-wasm.yml#L216

Example of run with v8 on:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=702059&view=logs&j=2c5d15bf-ca52-57a8-9a4e-bb898fb954b8

Now we don't overwrite if `scenarios` is already defined.