### PR TITLE
[browser] Chrome bump reviewers update

### DIFF
--- a/.github/workflows/bump-chrome-version.yml
+++ b/.github/workflows/bump-chrome-version.yml
@@ -70,6 +70,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pullRequest.number,
-              reviewers: ["lewing", "pavelsavara", "maraf", "ilonatommy", "radical"]
+              reviewers: ["lewing", "pavelsavara", "maraf", "ilonatommy", "akoeplinger"]
             });
             return pullRequest.number;


### PR DESCRIPTION
Chrome bump PRs still have the old set of reviewers, see: https://github.com/dotnet/runtime/pull/103204