### PR TITLE
[android] Don't include `JNI_OnLoad` in `libSystem.Security.Cryptography.Native.Android.a`

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -33,7 +33,7 @@ set(NATIVECRYPTO_SOURCES
 
 add_library(System.Security.Cryptography.Native.Android
     SHARED
-    ${NATIVECRYPTO_SOURCES}
+    ${NATIVECRYPTO_SOURCES} pal_jni_onload.c
     ${VERSION_FILE_PATH}
 )
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -692,7 +692,7 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
 jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 {
     (void)reserved;
-    LOG_DEBUG(__PRETTY_FUNCTION__);
+    LOG_DEBUG("%s in %s", __PRETTY_FUNCTION__, __FILE__);
     gJvm = vm;
 
     JNIEnv* env = GetJNIEnv();

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -692,7 +692,7 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
 jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 {
     (void)reserved;
-    LOG_INFO("JNI_OnLoad in pal_jni.c");
+    LOG_DEBUG("JNI_OnLoad in pal_jni.c");
     gJvm = vm;
 
     JNIEnv* env = GetJNIEnv();

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -692,7 +692,7 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
 jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 {
     (void)reserved;
-    LOG_DEBUG("JNI_OnLoad in pal_jni.c");
+    LOG_DEBUG(__PRETTY_FUNCTION__);
     gJvm = vm;
 
     JNIEnv* env = GetJNIEnv();

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -689,8 +689,7 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
     return value;
 }
 
-JNIEXPORT jint JNICALL
-JNI_OnLoad(JavaVM *vm, void *reserved)
+jint init_library_on_load (JavaVM *vm, void *reserved)
 {
     (void)reserved;
     LOG_INFO("JNI_OnLoad in pal_jni.c");

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -689,7 +689,7 @@ int GetEnumAsInt(JNIEnv *env, jobject enumObj)
     return value;
 }
 
-jint init_library_on_load (JavaVM *vm, void *reserved)
+jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 {
     (void)reserved;
     LOG_INFO("JNI_OnLoad in pal_jni.c");

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -604,7 +604,7 @@ jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 jfieldID GetOptionalField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 JNIEnv* GetJNIEnv(void);
-jint init_library_on_load (JavaVM *vm, void *reserved);
+jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved);
 
 int GetEnumAsInt(JNIEnv *env, jobject enumObj) ARGS_NON_NULL_ALL;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -604,6 +604,10 @@ jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 jfieldID GetOptionalField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 JNIEnv* GetJNIEnv(void);
+
+// This is supposed to be called by embedders who link the **static** archive of this library.
+// The function must be called from the embedder's `JNI_OnLoad` function prior to using any
+// APIs in this library.
 jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved);
 
 int GetEnumAsInt(JNIEnv *env, jobject enumObj) ARGS_NON_NULL_ALL;

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -604,6 +604,7 @@ jmethodID GetOptionalMethod(JNIEnv *env, bool isStatic, jclass klass, const char
 jfieldID GetField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 jfieldID GetOptionalField(JNIEnv *env, bool isStatic, jclass klass, const char* name, const char* sig) ARGS_NON_NULL_ALL;
 JNIEnv* GetJNIEnv(void);
+jint init_library_on_load (JavaVM *vm, void *reserved);
 
 int GetEnumAsInt(JNIEnv *env, jobject enumObj) ARGS_NON_NULL_ALL;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 #include "pal_jni.h"
 
 JNIEXPORT jint JNICALL

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
@@ -3,5 +3,5 @@
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
 {
-	return init_library_on_load (vm, reserved);
+	return AndroidCryptoNative_InitLibraryOnLoad (vm, reserved);
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni_onload.c
@@ -1,0 +1,7 @@
+#include "pal_jni.h"
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+	return init_library_on_load (vm, reserved);
+}


### PR DESCRIPTION
I'm working on a feature in .NET For Android which will allow us to link
all the native bits into a single shared library at application build
time.  In order to make it possible, no archive (`.a`) may contain any
`JNI_OnLoad` functions (called by `JavaVM` when initializing a Java
extension DSO), because our runtime already contains one and there Can
be Only One(tm).

`libSystem.Security.Cryptography.Native.Android` is currently the only
BCL support native library which contains `JNI_OnLoad` and thus it
prevents us from linking it into our runtime.  This PR changes things
a bit my moving the initialization code to a separate
function (`AndroidCryptoNative_InitLibraryOnLoad `) which remains in the `.a` archive and
can be called by `.NET For Android` runtime from its own `JNI_OnLoad` as
well as by the `libSystem.Security.Cryptography.Native.Android.so` from
its `JNI_OnLoad`, which this PR moves to a separate source file that is
compiled only into the shared version of the crypto support library.