### PR TITLE
Dispose XMLReader after using in Xml/Utils.cs

### DIFF
--- a/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/Utils.cs
@@ -212,7 +212,7 @@ namespace System.Security.Cryptography.Xml
                 settings.DtdProcessing = DtdProcessing.Parse;
                 settings.MaxCharactersFromEntities = MaxCharactersFromEntities;
                 settings.MaxCharactersInDocument = MaxCharactersInDocument;
-                XmlReader reader = XmlReader.Create(stringReader, settings, baseUri);
+                using XmlReader reader = XmlReader.Create(stringReader, settings, baseUri);
                 doc.Load(reader);
             }
             return doc;
@@ -235,7 +235,7 @@ namespace System.Security.Cryptography.Xml
                 settings.DtdProcessing = DtdProcessing.Parse;
                 settings.MaxCharactersFromEntities = MaxCharactersFromEntities;
                 settings.MaxCharactersInDocument = MaxCharactersInDocument;
-                XmlReader reader = XmlReader.Create(stringReader, settings, baseUri);
+                using XmlReader reader = XmlReader.Create(stringReader, settings, baseUri);
                 doc.Load(reader);
             }
             return doc;


### PR DESCRIPTION
They are IDisposables and should be Dispose()d after being used to avoid resource leaks.