### PR TITLE
Dispose XmlReader in CreateRuntimeRootDescriptorFile

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
+++ b/src/tools/illink/src/ILLink.Tasks/CreateRuntimeRootDescriptorFile.cs
@@ -302,7 +302,7 @@ namespace ILLink.Tasks
 		{
 			XmlDocument doc = new XmlDocument ();
 			using (var sr = new StreamReader (iLLinkTrimXmlFilePath)) {
-				XmlReader reader = XmlReader.Create (sr, new XmlReaderSettings () { XmlResolver = null });
+				using XmlReader reader = XmlReader.Create (sr, new XmlReaderSettings () { XmlResolver = null });
 				doc.Load (reader);
 			}
 


### PR DESCRIPTION
It's an IDisposable, so we should Dispose it manually or use a `using` to auto-Dispose it.