### PR TITLE
Block System.Numerics.Tensors tests on native AOT

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -536,6 +536,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests\NlsTests\System.Runtime.Nls.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.Xml\tests\System.Security.Cryptography.Xml.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Tensors\tests\System.Numerics.Tensors.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Failing in the native AOT outerloops. These use the xUnit generic test method that xUnit will MakeGenericMethod at runtime. Needs someone to write RD.XML:

```
Running assembly:System.Numerics.Tensors.Tests, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
[FAIL] System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsTwoSpanInSpanOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsTwoSpanInSpanOut[System.Single](System.Numerics.Tensors.Tests.TensorTests+PerformCalculationTwoSpanInSpanOut`1[System.Single],System.Func`3[System.Numerics.Tensors.Tensor`1[System.Single],System.Numerics.Tensors.Tensor`1[System.Single],System.Numerics.Tensors.Tensor`1[System.Single]])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsSpanInSpanOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsSpanInSpanOut[System.Single](System.Numerics.Tensors.Tests.TensorTests+PerformCalculationSpanInSpanOut`1[System.Single],System.Func`2[System.Numerics.Tensors.Tensor`1[System.Single],System.Numerics.Tensors.Tensor`1[System.Single]])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsTwoSpanInFloatOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsTwoSpanInFloatOut[System.Single](System.Numerics.Tensors.Tests.TensorTests+PerformCalculationTwoSpanInFloatOut`1[System.Single],System.Func`3[System.Numerics.Tensors.Tensor`1[System.Single],System.Numerics.Tensors.Tensor`1[System.Single],System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsSpanInTOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorTests.TensorExtensionsSpanInTOut[System.Single](System.Numerics.Tensors.Tests.TensorTests+PerformCalculationSpanInTOut`1[System.Single],System.Func`2[System.Numerics.Tensors.Tensor`1[System.Single],System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsTwoSpanInFloatOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsTwoSpanInFloatOut[System.Single](System.Numerics.Tensors.Tests.TensorSpanTests+TensorPrimitivesTwoSpanInTOut`1[System.Single],System.Numerics.Tensors.Tests.TensorSpanTests+TensorTwoSpanInTOut`1[System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsSpanInTOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsSpanInTOut[System.Single](System.Numerics.Tensors.Tests.TensorSpanTests+TensorPrimitivesSpanInTOut`1[System.Single],System.Numerics.Tensors.Tests.TensorSpanTests+TensorSpanInTOut`1[System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsSpanInSpanOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsSpanInSpanOut[System.Single](System.Numerics.Tensors.Tests.TensorSpanTests+TensorPrimitivesSpanInSpanOut`1[System.Single],System.Numerics.Tensors.Tests.TensorSpanTests+TensorSpanInSpanOut`1[System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
[FAIL] System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsTwoSpanInSpanOut
System.NotSupportedException : 'System.Numerics.Tensors.Tests.TensorSpanTests.TensorExtensionsTwoSpanInSpanOut[System.Single](System.Numerics.Tensors.Tests.TensorSpanTests+TensorPrimitivesTwoSpanInSpanOut`1[System.Single],System.Numerics.Tensors.Tests.TensorSpanTests+TensorTwoSpanInSpanOut`1[System.Single])' is missing native code. MethodInfo.MakeGenericMethod() is not compatible with AOT compilation. Inspect and fix AOT related warnings that were generated when the app was published. For more information see https://aka.ms/nativeaot-compatibility
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.GetUncachedMethodInvoker(RuntimeTypeInfo[], MemberInfo) + 0x29
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) + 0x1f8
Finished System.Numerics.Tensors.Tests, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
```

Cc @dotnet/ilc-contrib 