### PR TITLE
Fix Microsoft.NET.ILLink package

### DIFF
--- a/src/tools/illink/src/linker/Mono.Linker.csproj
+++ b/src/tools/illink/src/linker/Mono.Linker.csproj
@@ -77,7 +77,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.DependencyAnalysisFramework\ILCompiler.DependencyAnalysisFramework.csproj" />
+    <!-- PrivateAssets prevents ILCompiler.DependencyAnalysisFramework from becoming a dependency of the Microsoft.NET.ILLink package, which is designed to
+         be referenced by custom step authors as the public surface available to custom steps (which should not use the dependency analysis framework). -->
+    <ProjectReference Include="$(CoreClrProjectRoot)tools\aot\ILCompiler.DependencyAnalysisFramework\ILCompiler.DependencyAnalysisFramework.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By removing dependency on ILCompiler.DependencyAnalysisFramework.

Fixes https://github.com/dotnet/runtime/issues/103249.