### PR TITLE
Fix Http 1.1's read-ahead task management

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -205,7 +205,7 @@ namespace System.Net.Http
                 return true;
             }
 
-            // The read-ahead task has started, and we failed to transition back to CompletionReserved.
+            // The read-ahead task has started, and we failed to transition back to Started.
             // This means that the read-ahead task has completed, and we can't reuse the connection. The caller must dispose it.
             // We're still responsible for observing potential exceptions thrown by the read-ahead task to avoid leaking unobserved exceptions.
             LogExceptions(_readAheadTask.AsTask());

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -57,6 +57,7 @@ namespace System.Net.Http
         private const int ReadAheadTask_NotStarted = 0;
         private const int ReadAheadTask_Started = 1;
         private const int ReadAheadTask_CompletionReserved = 2;
+        private const int ReadAheadTask_Completed = 3;
         private int _readAheadTaskStatus;
         private ValueTask<int> _readAheadTask;
         private ArrayBuffer _readBuffer;
@@ -118,8 +119,11 @@ namespace System.Net.Http
             }
         }
 
+        private bool ReadAheadTaskHasStarted =>
+            _readAheadTaskStatus != ReadAheadTask_NotStarted;
+
         /// <summary>Prepare an idle connection to be used for a new request.
-        /// The caller MUST call SendAsync afterwards if this method returns true.</summary>
+        /// The caller MUST call SendAsync afterwards if this method returns true, or dispose the connection if it returns false.</summary>
         /// <param name="async">Indicates whether the coming request will be sync or async.</param>
         /// <returns>True if connection can be used, false if it is invalid due to a timeout or receiving EOF or unexpected data.</returns>
         public bool PrepareForReuse(bool async)
@@ -133,7 +137,9 @@ namespace System.Net.Http
             // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
             if (ReadAheadTaskHasStarted)
             {
-                return TryOwnReadAheadTaskCompletion();
+                Debug.Assert(_readAheadTaskStatus is ReadAheadTask_Started or ReadAheadTask_Completed);
+
+                return Interlocked.Exchange(ref _readAheadTaskStatus, ReadAheadTask_CompletionReserved) == ReadAheadTask_Started;
             }
 
             // Check to see if we've received anything on the connection; if we have, that's
@@ -177,6 +183,35 @@ namespace System.Net.Http
             }
         }
 
+        /// <summary>Takes ownership of the scavenging task completion if it was started.
+        /// The caller MUST call either SendAsync or return the completion ownership afterwards if this method returns true, or dispose the connection if it returns false.</summary>
+        public bool TryOwnScavengingTaskCompletion()
+        {
+            Debug.Assert(_readAheadTaskStatus != ReadAheadTask_CompletionReserved);
+
+            return !ReadAheadTaskHasStarted
+                || Interlocked.Exchange(ref _readAheadTaskStatus, ReadAheadTask_CompletionReserved) == ReadAheadTask_Started;
+        }
+
+        /// <summary>Returns ownership of the scavenging task completion if it was started.
+        /// The caller MUST Dispose the connection afterwards if this method returns false.</summary>
+        public bool TryReturnScavengingTaskCompletionOwnership()
+        {
+            Debug.Assert(_readAheadTaskStatus != ReadAheadTask_Started);
+
+            if (!ReadAheadTaskHasStarted ||
+                Interlocked.Exchange(ref _readAheadTaskStatus, ReadAheadTask_Started) == ReadAheadTask_CompletionReserved)
+            {
+                return true;
+            }
+
+            // The read-ahead task has started, and we failed to transition back to CompletionReserved.
+            // This means that the read-ahead task has completed, and we can't reuse the connection. The caller must dispose it.
+            // We're still responsible for observing potential exceptions thrown by the read-ahead task to avoid leaking unobserved exceptions.
+            LogExceptions(_readAheadTask.AsTask());
+            return false;
+        }
+
         /// <summary>Check whether a currently idle connection is still usable, or should be scavenged.</summary>
         /// <returns>True if connection can be used, false if it is invalid due to a timeout or receiving EOF or unexpected data.</returns>
         public override bool CheckUsabilityOnScavenge()
@@ -187,21 +222,7 @@ namespace System.Net.Http
             }
 
             // We may already have a read-ahead task if we did a previous scavenge and haven't used the connection since.
-            EnsureReadAheadTaskHasStarted();
-
-            // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
-            return !_readAheadTask.IsCompleted;
-        }
-
-        private bool ReadAheadTaskHasStarted =>
-            _readAheadTaskStatus != ReadAheadTask_NotStarted;
-
-        private bool TryOwnReadAheadTaskCompletion() =>
-            Interlocked.CompareExchange(ref _readAheadTaskStatus, ReadAheadTask_CompletionReserved, ReadAheadTask_Started) == ReadAheadTask_Started;
-
-        private void EnsureReadAheadTaskHasStarted()
-        {
-            if (_readAheadTaskStatus == ReadAheadTask_NotStarted)
+            if (!ReadAheadTaskHasStarted)
             {
                 Debug.Assert(_readAheadTask == default);
 
@@ -211,6 +232,9 @@ namespace System.Net.Http
                 _readAheadTask = ReadAheadWithZeroByteReadAsync();
 #pragma warning restore CA2012
             }
+
+            // If the read-ahead task is completed, then we've received either EOF or erroneous data the connection, so it's not usable.
+            return !_readAheadTask.IsCompleted;
 
             async ValueTask<int> ReadAheadWithZeroByteReadAsync()
             {
@@ -231,18 +255,25 @@ namespace System.Net.Http
                     // PrepareForReuse will check TryOwnReadAheadTaskCompletion before calling into SendAsync.
                     // If we can own the completion from within the read-ahead task, it means that PrepareForReuse hasn't been called yet.
                     // In that case we've received EOF/erroneous data before we sent the request headers, and the connection can't be reused.
-                    if (TryOwnReadAheadTaskCompletion())
+                    if (TransitionToCompletedAndTryOwnCompletion())
                     {
                         if (NetEventSource.Log.IsEnabled()) Trace("Read-ahead task observed data before the request was sent.");
                     }
 
                     return read;
                 }
-                catch (Exception error) when (TryOwnReadAheadTaskCompletion())
+                catch (Exception error) when (TransitionToCompletedAndTryOwnCompletion())
                 {
                     if (NetEventSource.Log.IsEnabled()) Trace($"Error performing read ahead: {error}");
 
                     return 0;
+                }
+
+                bool TransitionToCompletedAndTryOwnCompletion()
+                {
+                    Debug.Assert(_readAheadTaskStatus is ReadAheadTask_Started or ReadAheadTask_CompletionReserved);
+
+                    return Interlocked.Exchange(ref _readAheadTaskStatus, ReadAheadTask_Completed) == ReadAheadTask_Started;
                 }
             }
         }
@@ -497,7 +528,8 @@ namespace System.Net.Http
         {
             Debug.Assert(_currentRequest == null, $"Expected null {nameof(_currentRequest)}.");
             Debug.Assert(_readBuffer.ActiveLength == 0, "Unexpected data in read buffer");
-            Debug.Assert(_readAheadTaskStatus != ReadAheadTask_Started);
+            Debug.Assert(_readAheadTaskStatus != ReadAheadTask_Started,
+                "The caller should have called PrepareForReuse or TryOwnScavengingTaskCompletion if the connection was idle on the pool.");
 
             MarkConnectionAsNotIdle();
 


### PR DESCRIPTION
Fixes #100616

Every HTTP/1.1 connection has a `ValueTask<int> _readAheadTask` field that gets set either:
- from `PrepareForReuse` right before the call to `SendAsync`, or
- by the connection pool every N seconds as part of its scavenging logic that looks for dead connections to clean up (those that have received EOF)

As a result of the latter, if a connection is added to the connection pool at any point (the shared `_http11Connections` stack), we must assume that the read-ahead may have been set.

When "consuming" connections, we carefully manage who may consume the read-ahead task to ensure that we don't leak unobserved task exceptions.
To achieve this, we're using an `int _readAheadTaskStatus` flag to signal which thread will observe the result / whether the exception should be suppressed.

The problem with the current state (before this PR) is that a connection may be briefly added to the connection pool and taken out right after to handle a pending request from the request queue.
Because we know that the connection was freshly added and therefore still good, we don't bother calling into `PrepareForReuse`, which means we weren't updating the `_readAheadTaskStatus` as expected. This results in hitting a debug assert in `HttpConnection.SendAsync` that checks that someone claimed ownership of the read-ahead completion before sending the request (#100616).

---

Why don't we always call `PrepareForReuse` then?

`PrepareForReuse` expects its caller to immediately call into `SendAsync` if the check is successful. This allows it to store the `stream.ReadAsync` into `_readAheadTask` directly, without any extra wrapping logic.
https://github.com/dotnet/runtime/blob/0686ce61ed1e1cb3cb420281a0154efa5d0d00d5/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L166

But at this point in the connection management, we're not 100% certain that we will have a request for the connection yet - we have waiters that may get canceled at any point.
If we did call `PrepareForReuse` and then had no waiter to signal, we'd have to throw away the connection.

`PrepareForReuse` also uses different logic based on a `bool async` argument which we don't yet have at this point.

---

Why don't we give the connection to the waiter and have the consuming code call `PrepareForReuse`?

While not super likely, if the connection was already bad, it would mean that we now took a request from the head of the queue and pushed it back to the tail to retry.
It would also potentially mean needing an extra flag to remember if this is the first request on the connection to match how we currently handle new connections that are immediately bad. Without that, we could end up doing more connect retries to a faulty server than we currently do (maybe that'd be fine, but it's not an obvious consequence).

It should be a possible approach, but I found the following simpler to follow:

---

This PR:

I changed how we handle read-ahead completion ownership, allowing a thread to return its completion ownership:
- When we take a connection from the pool, we check if a scavenging read-ahead was started, and if so try to take ownership of its completion.
- If we then fail to signal a request waiter, we try to hand back the completion ownership.

If `TryOwnScavengingTaskCompletion` fails, the read-ahead already completed and any potential exceptions got ignored => the connection is not usable and we try again.
If `TryReturnScavengingTaskCompletionOwnership` fails, the read-ahead completed between us taking ownership and trying to return it => the connection is not usable and we try again.